### PR TITLE
fix(linter): remove project-specific ambient contracts

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -40,28 +40,10 @@ pub(crate) fn file_entry_contract(
 }
 
 fn providers() -> &'static [AmbientContractProvider] {
-    &[
-        AmbientContractProvider {
-            matches: matches_void_packages_build_style_contract,
-            build: build_void_packages_build_style_contract,
-        },
-        AmbientContractProvider {
-            matches: matches_void_packages_pre_pkg_hook_contract,
-            build: build_void_packages_pre_pkg_hook_contract,
-        },
-        AmbientContractProvider {
-            matches: matches_void_packages_xbps_src_framework_contract,
-            build: build_void_packages_xbps_src_framework_contract,
-        },
-        AmbientContractProvider {
-            matches: matches_void_packages_pycompile_trigger_contract,
-            build: build_void_packages_pycompile_trigger_contract,
-        },
-        AmbientContractProvider {
-            matches: matches_sourced_runtime_contract,
-            build: build_sourced_runtime_contract,
-        },
-    ]
+    &[AmbientContractProvider {
+        matches: matches_sourced_runtime_contract,
+        build: build_sourced_runtime_contract,
+    }]
 }
 
 fn merge_contract(merged: &mut FileContract, contract: FileContract) {
@@ -75,189 +57,6 @@ fn merge_contract(merged: &mut FileContract, contract: FileContract) {
     for function in contract.provided_functions {
         merged.add_provided_function(function);
     }
-}
-
-fn matches_void_packages_build_style_contract(
-    source: &str,
-    path: &Path,
-    _shell: ShellDialect,
-    _file_context: &FileContext,
-) -> bool {
-    let lower = lower_path(path);
-    (path_matches_any(
-        &lower,
-        &[
-            "void-packages/common/build-style/",
-            "void-packages/common/environment/build-style/",
-            "void-packages__common__build-style__",
-            "void-packages__common__environment__build-style__",
-        ],
-    )) && has_probable_function_definition(source)
-        && source_mentions_any(source, &["wrksrc", "XBPS_SRCPKGDIR"])
-}
-
-fn matches_void_packages_pre_pkg_hook_contract(
-    source: &str,
-    path: &Path,
-    _shell: ShellDialect,
-    _file_context: &FileContext,
-) -> bool {
-    let lower = lower_path(path);
-    path_matches_any(
-        &lower,
-        &[
-            "void-packages/common/hooks/pre-pkg/",
-            "void-packages__common__hooks__pre-pkg__",
-        ],
-    ) && (lower.contains("/99-pkglint") || lower.contains("__99-pkglint"))
-        && lower.ends_with(".sh")
-        && has_named_function_definition(source, "hook")
-        && source.contains("PKGDESTDIR")
-}
-
-fn matches_void_packages_xbps_src_framework_contract(
-    source: &str,
-    path: &Path,
-    _shell: ShellDialect,
-    _file_context: &FileContext,
-) -> bool {
-    let lower = lower_path(path);
-    let libexec_path = path_matches_any(
-        &lower,
-        &[
-            "void-packages/common/xbps-src/libexec/",
-            "void-packages__common__xbps-src__libexec__",
-        ],
-    );
-    let shutils_path = path_matches_any(
-        &lower,
-        &[
-            "void-packages/common/xbps-src/shutils/",
-            "void-packages__common__xbps-src__shutils__",
-        ],
-    );
-    (libexec_path || shutils_path)
-        && lower.ends_with(".sh")
-        && xbps_src_framework_has_shell_shape(source, libexec_path)
-        && source.matches("XBPS_").count() >= 3
-}
-
-fn matches_void_packages_pycompile_trigger_contract(
-    source: &str,
-    path: &Path,
-    _shell: ShellDialect,
-    _file_context: &FileContext,
-) -> bool {
-    let lower = lower_path(path);
-    (lower.ends_with("/void-packages/srcpkgs/xbps-triggers/files/pycompile")
-        || lower.ends_with("__void-packages__srcpkgs__xbps-triggers__files__pycompile"))
-        && (source.contains("ACTION=\"$1\"")
-            || source.contains("TARGET=\"$2\"")
-            || source.contains("case \"$ACTION\""))
-}
-
-fn build_void_packages_build_style_contract(
-    _source: &str,
-    _path: &Path,
-    _shell: ShellDialect,
-    _file_context: &FileContext,
-) -> FileContract {
-    runtime_variable_contract(&[
-        "build_style",
-        "distfiles",
-        "metapackage",
-        "pkgname",
-        "pkgver",
-        "version",
-        "pycompile_version",
-        "XBPS_SRCPKGDIR",
-        "XBPS_SRCDISTDIR",
-        "XBPS_TARGET_WORDSIZE",
-        "configure_args",
-        "makejobs",
-        "cross_binutils_configure_args",
-        "cross_gcc_bootstrap_configure_args",
-        "cross_gcc_configure_args",
-        "cross_glibc_configure_args",
-        "cross_musl_configure_args",
-        "wrksrc",
-    ])
-}
-
-fn build_void_packages_pre_pkg_hook_contract(
-    _source: &str,
-    _path: &Path,
-    _shell: ShellDialect,
-    _file_context: &FileContext,
-) -> FileContract {
-    runtime_variable_contract(&[
-        "PKGDESTDIR",
-        "pkgname",
-        "pkgver",
-        "metapackage",
-        "conf_files",
-        "provides",
-        "XBPS_COMMONDIR",
-        "XBPS_STATEDIR",
-        "XBPS_TARGET_MACHINE",
-        "XBPS_QUERY_XCMD",
-        "XBPS_UHELPER_CMD",
-    ])
-}
-
-fn build_void_packages_xbps_src_framework_contract(
-    _source: &str,
-    _path: &Path,
-    _shell: ShellDialect,
-    _file_context: &FileContext,
-) -> FileContract {
-    runtime_variable_contract(&[
-        "XBPS_COMMONDIR",
-        "XBPS_SRCPKGDIR",
-        "XBPS_SRCDISTDIR",
-        "XBPS_BUILDSTYLEDIR",
-        "XBPS_LIBEXECDIR",
-        "XBPS_STATEDIR",
-        "XBPS_MACHINE",
-        "XBPS_TARGET",
-        "XBPS_TARGET_MACHINE",
-        "XBPS_TARGET_PKG",
-        "XBPS_CROSS_BUILD",
-        "pkgname",
-        "pkgver",
-        "build_style",
-        "sourcepkg",
-        "subpackages",
-        "wrksrc",
-        "build_option_",
-        "NOCOLORS",
-        "XBPS_CFLAGS",
-        "XBPS_CPPFLAGS",
-        "XBPS_CXXFLAGS",
-        "XBPS_FFLAGS",
-        "XBPS_LDFLAGS",
-    ])
-}
-
-fn build_void_packages_pycompile_trigger_contract(
-    _source: &str,
-    _path: &Path,
-    _shell: ShellDialect,
-    _file_context: &FileContext,
-) -> FileContract {
-    runtime_variable_contract(&["pycompile_dirs", "pycompile_module", "pycompile_version"])
-}
-
-fn runtime_variable_contract(names: &[&str]) -> FileContract {
-    let mut contract = FileContract::default();
-    for name in names {
-        contract.add_provided_binding(ProvidedBinding::new(
-            Name::from(*name),
-            ProvidedBindingKind::Variable,
-            ContractCertainty::Definite,
-        ));
-    }
-    contract
 }
 
 fn matches_sourced_runtime_contract(
@@ -304,33 +103,19 @@ fn sourced_runtime_path_shape(lower: &str) -> bool {
             "/completions/",
             ".completion.",
             "bash_autocomplete",
-            "__completion__",
-            "__completions-",
-            "__completions__",
             "/themes/",
             ".theme.",
-            "__themes__",
             "/plugins/",
             "/plugin/",
-            "__plugins__",
             "/modules/",
-            "__modules__",
             "/scriptmodules/",
-            "__scriptmodules__",
             "/scripts/functions/",
-            "__scripts__functions__",
             "/rvm/scripts/",
-            "__rvm__scripts__",
             "/lgsm/modules/",
-            "__lgsm__modules__",
             "/common/environment/setup/",
-            "__common__environment__setup__",
             "/common/chroot-style/",
-            "__common__chroot-style__",
             "/common/hooks/",
-            "__common__hooks__",
             "termux-packages/packages/",
-            "termux-packages__packages__",
         ],
     )
 }
@@ -383,41 +168,34 @@ fn runtime_names_for_source_path(source: &str, lower: &str) -> &'static [&'stati
 }
 
 fn bash_it_theme_runtime_shape(source: &str, lower: &str) -> bool {
-    path_matches_any(
-        lower,
-        &[
-            "/bash-it/themes/",
-            "/bash-it/theme/",
-            "__bash-it__themes__",
-            "__bash-it__theme__",
-        ],
-    ) && (source.contains("PROMPT_COMMAND")
-        || source.contains("SCM_THEME_PROMPT")
-        || source_mentions_any(
-            source,
-            &[
-                "black",
-                "red",
-                "green",
-                "yellow",
-                "blue",
-                "purple",
-                "cyan",
-                "white",
-                "normal",
-                "default",
-                "reset_color",
-                "bold_black",
-                "bold_red",
-                "bold_green",
-                "bold_yellow",
-                "bold_blue",
-                "bold_purple",
-                "bold_cyan",
-                "bold_white",
-                "italic",
-            ],
-        ))
+    path_matches_any(lower, &["/bash-it/themes/", "/bash-it/theme/"])
+        && (source.contains("PROMPT_COMMAND")
+            || source.contains("SCM_THEME_PROMPT")
+            || source_mentions_any(
+                source,
+                &[
+                    "black",
+                    "red",
+                    "green",
+                    "yellow",
+                    "blue",
+                    "purple",
+                    "cyan",
+                    "white",
+                    "normal",
+                    "default",
+                    "reset_color",
+                    "bold_black",
+                    "bold_red",
+                    "bold_green",
+                    "bold_yellow",
+                    "bold_blue",
+                    "bold_purple",
+                    "bold_cyan",
+                    "bold_white",
+                    "italic",
+                ],
+            ))
 }
 
 fn completion_runtime_shape(source: &str, lower: &str) -> bool {
@@ -430,16 +208,9 @@ fn completion_runtime_path_shape(lower: &str) -> bool {
         &[
             "/bash-completion/",
             "/bash_completion/",
-            "bash-completion__",
-            "bash_completion__",
-            "__bash-completion__",
-            "__bash_completion__",
             "/bash-it/completion/",
             "/bash-it/completions/",
-            "__bash-it__completion__",
-            "__bash-it__completions__",
             "/bash-progcomp/",
-            "__bash-progcomp__",
             "bash_autocomplete",
         ],
     )
@@ -793,13 +564,6 @@ fn has_probable_function_definition(source: &str) -> bool {
         .any(probable_function_definition)
 }
 
-fn has_named_function_definition(source: &str, name: &str) -> bool {
-    source
-        .lines()
-        .map(str::trim)
-        .any(|trimmed| named_function_definition(trimmed, name))
-}
-
 fn has_source_command(source: &str) -> bool {
     source.lines().map(str::trim).any(|trimmed| {
         trimmed.starts_with("source ")
@@ -807,13 +571,6 @@ fn has_source_command(source: &str) -> bool {
             || trimmed.starts_with("\\source ")
             || trimmed.starts_with("\\. ")
     })
-}
-
-fn xbps_src_framework_has_shell_shape(source: &str, libexec_path: bool) -> bool {
-    has_probable_function_definition(source)
-        || (libexec_path
-            && source.contains("readonly XBPS_TARGET")
-            && source.contains("setup_pkg \"$PKGNAME\""))
 }
 
 fn probable_function_definition(trimmed: &str) -> bool {
@@ -826,22 +583,6 @@ fn probable_function_definition(trimmed: &str) -> bool {
     }
 
     trimmed.contains("() {") || trimmed.contains("(){")
-}
-
-fn named_function_definition(trimmed: &str, name: &str) -> bool {
-    if trimmed.starts_with('#') || trimmed.is_empty() {
-        return false;
-    }
-
-    if let Some(rest) = trimmed.strip_prefix("function ") {
-        let rest = rest.trim_start();
-        return rest.starts_with(name) && rest.contains('{');
-    }
-
-    trimmed.starts_with(&format!("{name}()"))
-        || trimmed.starts_with(&format!("{name} ()"))
-        || trimmed.contains(&format!("{name}() {{"))
-        || trimmed.contains(&format!("{name}(){{"))
 }
 
 fn source_mentions_any(source: &str, names: &[&str]) -> bool {
@@ -864,13 +605,6 @@ mod tests {
         file_entry_contract(source, Some(path), ShellDialect::Sh, &context)
     }
 
-    fn has_binding(contract: &FileContract, name: &str) -> bool {
-        contract
-            .provided_bindings
-            .iter()
-            .any(|binding| binding.name == name)
-    }
-
     fn has_initialized_binding(contract: &FileContract, name: &str) -> bool {
         contract.provided_bindings.iter().any(|binding| {
             binding.name == name
@@ -880,99 +614,21 @@ mod tests {
     }
 
     #[test]
-    fn void_packages_build_style_paths_get_an_explicit_contract() {
-        let path = Path::new("/tmp/void-packages/common/build-style/void-cross.sh");
-        let source = "\
+    fn project_specific_paths_do_not_get_ambient_contracts() {
+        let void_path = Path::new("/tmp/void-packages/common/build-style/void-cross.sh");
+        let void_source = "\
 helper() { cd \"${wrksrc}\"; }
 printf '%s\\n' \"$pkgname\" \"$pkgver\" \"$XBPS_SRCPKGDIR\" \"$configure_args\"
 ";
+        assert!(contract_for(void_path, void_source).is_none());
 
-        let contract = contract_for(path, source).unwrap();
-
-        assert!(has_binding(&contract, "pkgname"));
-        assert!(has_binding(&contract, "pkgver"));
-        assert!(has_binding(&contract, "wrksrc"));
-        assert!(has_binding(&contract, "XBPS_SRCPKGDIR"));
-        assert!(has_binding(&contract, "configure_args"));
-        assert!(!has_initialized_binding(&contract, "wrksrc"));
-        assert!(!contract.externally_consumed_bindings);
-    }
-
-    #[test]
-    fn void_packages_pre_pkg_hook_paths_get_an_explicit_contract() {
-        let path = Path::new("/tmp/void-packages/common/hooks/pre-pkg/99-pkglint.sh");
-        let source = "\
-hook() { printf '%s\\n' \"$PKGDESTDIR\"; }
-printf '%s\\n' \"$pkgname\" \"$pkgver\" \"$XBPS_COMMONDIR\"
+        let flattened_path =
+            Path::new("/tmp/scripts/void-linux__void-packages__common__build-style__void-cross.sh");
+        let flattened_source = "\
+helper() { :; }
+printf '%s\\n' \"$XBPS_SRCPKGDIR\" \"$configure_args\" \"$wrksrc\"
 ";
-
-        let contract = contract_for(path, source).unwrap();
-
-        assert!(has_binding(&contract, "PKGDESTDIR"));
-        assert!(has_binding(&contract, "pkgname"));
-        assert!(has_binding(&contract, "pkgver"));
-        assert!(has_binding(&contract, "XBPS_COMMONDIR"));
-        assert!(!has_initialized_binding(&contract, "pkgname"));
-        assert!(!contract.externally_consumed_bindings);
-    }
-
-    #[test]
-    fn void_packages_xbps_src_framework_paths_get_an_explicit_contract() {
-        let path = Path::new("/tmp/void-packages/common/xbps-src/shutils/common.sh");
-        let source = "\
-helper() { printf '%s\\n' \"$XBPS_COMMONDIR\"; }
-printf '%s\\n' \"$XBPS_SRCPKGDIR\" \"$XBPS_STATEDIR\" \"$pkgname\" \"$build_style\"
-";
-
-        let contract = contract_for(path, source).unwrap();
-
-        assert!(has_binding(&contract, "XBPS_COMMONDIR"));
-        assert!(has_binding(&contract, "XBPS_SRCPKGDIR"));
-        assert!(has_binding(&contract, "XBPS_STATEDIR"));
-        assert!(has_binding(&contract, "build_style"));
-        assert!(!has_initialized_binding(&contract, "build_style"));
-        assert!(!contract.externally_consumed_bindings);
-    }
-
-    #[test]
-    fn void_packages_xbps_src_libexec_drivers_get_an_explicit_contract() {
-        let path = Path::new("/tmp/void-packages/common/xbps-src/libexec/build.sh");
-        let source = "\
-readonly XBPS_TARGET=\"$1\"
-setup_pkg \"$PKGNAME\"
-for subpkg in ${subpackages} ${sourcepkg}; do
-  printf '%s\\n' \"$XBPS_LIBEXECDIR\" \"$XBPS_CROSS_BUILD\"
-done
-";
-
-        let contract = contract_for(path, source).unwrap();
-
-        assert!(has_binding(&contract, "sourcepkg"));
-        assert!(has_binding(&contract, "subpackages"));
-        assert!(has_binding(&contract, "XBPS_LIBEXECDIR"));
-        assert!(has_binding(&contract, "XBPS_CROSS_BUILD"));
-        assert!(!has_initialized_binding(&contract, "sourcepkg"));
-        assert!(!contract.externally_consumed_bindings);
-    }
-
-    #[test]
-    fn void_packages_pycompile_trigger_paths_get_an_explicit_contract() {
-        let path = Path::new("/tmp/void-packages/srcpkgs/xbps-triggers/files/pycompile");
-        let source = "\
-ACTION=\"$1\"
-TARGET=\"$2\"
-case \"$ACTION\" in
-run) printf '%s\\n' \"$pycompile_dirs\" \"$pycompile_module\" \"$pycompile_version\" ;;
-esac
-";
-
-        let contract = contract_for(path, source).unwrap();
-
-        assert!(has_binding(&contract, "pycompile_dirs"));
-        assert!(has_binding(&contract, "pycompile_module"));
-        assert!(has_binding(&contract, "pycompile_version"));
-        assert!(!has_initialized_binding(&contract, "pycompile_version"));
-        assert!(!contract.externally_consumed_bindings);
+        assert!(contract_for(flattened_path, flattened_source).is_none());
     }
 
     #[test]
@@ -1194,41 +850,5 @@ printf '%s\\n' \"$pkgname\"
         assert!(context.has_tag(FileContextTag::ProjectClosure));
 
         assert!(file_entry_contract(source, Some(path), ShellDialect::Sh, &context).is_none());
-    }
-
-    #[test]
-    fn void_packages_paths_without_required_source_anchors_do_not_inject_contracts() {
-        let xbps_src_path = Path::new("/tmp/void-packages/common/xbps-src/shutils/common.sh");
-        let xbps_src_source = "printf '%s\\n' \"$XBPS_COMMONDIR\"\n";
-        assert!(contract_for(xbps_src_path, xbps_src_source).is_none());
-
-        let pycompile_path = Path::new("/tmp/void-packages/srcpkgs/xbps-triggers/files/pycompile");
-        let pycompile_source = "printf '%s\\n' \"$pycompile_version\"\n";
-        assert!(contract_for(pycompile_path, pycompile_source).is_none());
-    }
-
-    #[test]
-    fn flattened_large_corpus_void_packages_paths_also_get_contracts() {
-        let build_style_path =
-            Path::new("/tmp/scripts/void-linux__void-packages__common__build-style__void-cross.sh");
-        let build_style_source = "\
-helper() { :; }
-printf '%s\\n' \"$XBPS_SRCPKGDIR\" \"$configure_args\" \"$wrksrc\"
-";
-        let build_style_contract = contract_for(build_style_path, build_style_source).unwrap();
-        assert!(has_binding(&build_style_contract, "wrksrc"));
-        assert!(has_binding(&build_style_contract, "configure_args"));
-
-        let pycompile_path = Path::new(
-            "/tmp/scripts/void-linux__void-packages__srcpkgs__xbps-triggers__files__pycompile",
-        );
-        let pycompile_source = "\
-ACTION=\"$1\"
-case \"$ACTION\" in
-run) printf '%s\\n' \"$pycompile_version\" ;;
-esac
-";
-        let pycompile_contract = contract_for(pycompile_path, pycompile_source).unwrap();
-        assert!(has_binding(&pycompile_contract, "pycompile_version"));
     }
 }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -783,13 +783,12 @@ End
     }
 
     #[test]
-    fn ambient_build_style_contract_keeps_uppercase_context_but_reports_lowercase_reads() {
+    fn project_specific_paths_do_not_suppress_undefined_variables() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/void-packages/common/build-style/void-cross.sh"),
             "\
 build() {
-printf '%s\\n' \"$pkgname\" \"$pkgver\" \"$XBPS_SRCPKGDIR\" \"$configure_args\" \"$cross_gcc_configure_args\"
-printf '%s\\n' \"$wrksrc\"
+printf '%s\\n' \"$XBPS_SRCPKGDIR\" \"$configure_args\" \"$wrksrc\"
 }
 build
 ",
@@ -799,37 +798,17 @@ build
         assert!(
             diagnostics
                 .iter()
-                .any(|diagnostic| diagnostic.message.contains("pkgname"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("pkgver"))
-        );
-        assert!(
-            diagnostics
-                .iter()
                 .any(|diagnostic| diagnostic.message.contains("configure_args"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("cross_gcc_configure_args"))
         );
         assert!(
             diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.message.contains("wrksrc"))
         );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_SRCPKGDIR"))
-        );
     }
 
     #[test]
-    fn ambient_build_style_contract_reports_lowercase_reads_on_flattened_corpus_paths() {
+    fn flattened_corpus_paths_do_not_suppress_undefined_variables() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/scripts/void-linux__void-packages__common__build-style__void-cross.sh"),
             "\
@@ -850,197 +829,6 @@ build
             diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.message.contains("wrksrc"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_SRCPKGDIR"))
-        );
-    }
-
-    #[test]
-    fn ambient_pre_pkg_hook_contract_keeps_uppercase_context_but_reports_lowercase_reads() {
-        let diagnostics = lint_named_source(
-            Path::new("/tmp/void-packages/common/hooks/pre-pkg/99-pkglint.sh"),
-            "\
-hook() {
-for f in lib; do
-if [ \"${pkgname}\" = \"base-files\" ]; then
-  :
-else
-  msg_red \"${pkgver}: /${f} must not exist.\\n\"
-fi
-done
-if [ -d ${PKGDESTDIR}/usr/lib/libexec ]; then
-  msg_red \"${pkgver}: /usr/lib/libexec directory is not allowed!\\n\"
-fi
-printf '%s\\n' \"$XBPS_COMMONDIR\" \"$XBPS_QUERY_XCMD\"
-}
-hook
-",
-            &LinterSettings::for_rule(Rule::UndefinedVariable),
-        );
-
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("pkgname"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("pkgver"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_COMMONDIR"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_QUERY_XCMD"))
-        );
-    }
-
-    #[test]
-    fn ambient_xbps_src_shutils_contract_keeps_uppercase_context_but_reports_lowercase_reads() {
-        let diagnostics = lint_named_source(
-            Path::new("/tmp/void-packages/common/xbps-src/shutils/common.sh"),
-            "\
-helper() {
-printf '%s\\n' \"$XBPS_COMMONDIR\" \"$XBPS_SRCPKGDIR\" \"$XBPS_STATEDIR\" \"$pkgname\" \"$build_style\" \"$NOCOLORS\"
-}
-helper
-",
-            &LinterSettings::for_rule(Rule::UndefinedVariable),
-        );
-
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("pkgname"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("build_style"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_COMMONDIR"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_SRCPKGDIR"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_STATEDIR"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("NOCOLORS"))
-        );
-    }
-
-    #[test]
-    fn ambient_xbps_src_libexec_contract_keeps_uppercase_context_but_reports_lowercase_reads() {
-        let diagnostics = lint_named_source(
-            Path::new("/tmp/void-packages/common/xbps-src/libexec/build.sh"),
-            "\
-readonly XBPS_TARGET=\"$1\"
-setup_pkg \"$PKGNAME\"
-for subpkg in ${subpackages} ${sourcepkg}; do
-  $XBPS_LIBEXECDIR/xbps-src-prepkg.sh $subpkg $XBPS_CROSS_BUILD || exit 1
-done
-printf '' > ${XBPS_STATEDIR}/.${sourcepkg}_register_pkg
-printf '%s\\n' \"$XBPS_TARGET\" \"$pkgname\"
-",
-            &LinterSettings::for_rule(Rule::UndefinedVariable),
-        );
-
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("subpackages"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("sourcepkg"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("pkgname"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_LIBEXECDIR"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_CROSS_BUILD"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_STATEDIR"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .all(|diagnostic| !diagnostic.message.contains("XBPS_TARGET"))
-        );
-    }
-
-    #[test]
-    fn ambient_pycompile_trigger_contract_reports_lowercase_reads() {
-        let diagnostics = lint_named_source(
-            Path::new("/tmp/void-packages/srcpkgs/xbps-triggers/files/pycompile"),
-            "\
-ACTION=\"$1\"
-TARGET=\"$2\"
-compile() {
-for f in ${pycompile_dirs}; do
-  python${pycompile_version} -m compileall -f -q ./${f}
-done
-for f in ${pycompile_module}; do
-  echo \"Byte-compiling python${pycompile_version} code for module ${f}...\"
-  if [ -d \"usr/lib/python${pycompile_version}/site-packages/${f}\" ]; then
-    python${pycompile_version} -O -m compileall -f -q \
-      usr/lib/python${pycompile_version}/site-packages/${f}
-  fi
-done
-}
-case \"$ACTION\" in
-run) compile ;;
-esac
-",
-            &LinterSettings::for_rule(Rule::UndefinedVariable),
-        );
-
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("pycompile_dirs"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("pycompile_module"))
-        );
-        assert!(
-            diagnostics
-                .iter()
-                .any(|diagnostic| diagnostic.message.contains("pycompile_version"))
         );
     }
 


### PR DESCRIPTION
## Summary
- remove Void package and flattened large-corpus path ambient contract providers
- stop treating flattened corpus path shapes as production runtime-contract signals
- add regression coverage that project-specific paths do not inject ambient bindings or suppress undefined-variable diagnostics

## Why
The previous ambient providers encoded project-specific corpus knowledge in production lint behavior. That could suppress undefined-variable or unused-assignment diagnostics for any repository with matching paths or content. Conformance should come from general shell analysis, sourced-file modeling, or reviewed corpus divergences instead.

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p shuck-linter ambient_contracts -- --nocapture
- cargo test -p shuck-linter do_not_suppress_undefined_variables -- --nocapture
- cargo test -p shuck-linter --lib
- make test-large-corpus

Large corpus summary: blocking=0, implementation_diffs=0, mapping_issues=0, harness_failures=0, reviewed_divergences=359.