### PR TITLE
fix(linter): match xargs zero-option parity

### DIFF
--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -260,12 +260,17 @@ impl MapfileCommandFacts {
 pub struct XargsCommandFacts {
     pub uses_null_input: bool,
     max_procs: Option<u64>,
+    zero_digit_option_word: bool,
     inline_replace_option_spans: Box<[Span]>,
 }
 
 impl XargsCommandFacts {
     pub fn max_procs(&self) -> Option<u64> {
         self.max_procs
+    }
+
+    pub fn has_zero_digit_option_word(&self) -> bool {
+        self.zero_digit_option_word
     }
 
     pub fn inline_replace_option_spans(&self) -> &[Span] {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -2955,6 +2955,7 @@ find . | xargs -P1 echo
 find . | xargs -P 0 echo
 find . | xargs --max-procs=10 echo
 find . | xargs --max-procs \"$N\" echo
+find . | xargs -P11 echo
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
@@ -2969,13 +2970,20 @@ find . | xargs --max-procs \"$N\" echo
         .filter_map(|fact| fact.options().xargs())
         .collect::<Vec<_>>();
 
-    assert_eq!(xargs_facts.len(), 5);
+    assert_eq!(xargs_facts.len(), 6);
     assert_eq!(
         xargs_facts
             .iter()
             .map(|xargs| xargs.max_procs())
             .collect::<Vec<_>>(),
-        vec![Some(10), Some(1), Some(0), Some(10), None]
+        vec![Some(10), Some(1), Some(0), Some(10), None, Some(11)]
+    );
+    assert_eq!(
+        xargs_facts
+            .iter()
+            .map(|xargs| xargs.has_zero_digit_option_word())
+            .collect::<Vec<_>>(),
+        vec![true, false, false, true, false, false]
     );
 }
 

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -6707,6 +6707,7 @@ fn mapfile_option_takes_argument(flag: char) -> bool {
 fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
     let mut uses_null_input = false;
     let mut max_procs = None;
+    let mut zero_digit_option_word = false;
     let mut inline_replace_options = Vec::new();
     let mut index = 0usize;
 
@@ -6725,6 +6726,8 @@ fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
         if !text.starts_with('-') || text == "-" {
             break;
         }
+
+        zero_digit_option_word |= text.contains('0');
 
         if let Some(long) = text.strip_prefix("--") {
             if long_name(long) == "null" {
@@ -6803,6 +6806,7 @@ fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
     XargsCommandFacts {
         uses_null_input,
         max_procs,
+        zero_digit_option_word,
         inline_replace_option_spans: inline_replace_option_spans.into_boxed_slice(),
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
@@ -62,9 +62,11 @@ fn unsafe_find_to_xargs_diagnostics(
                 return None;
             }
 
-            if right.options().xargs().is_some_and(|xargs| {
-                xargs.uses_null_input || xargs_uses_shellcheck_parallel_exemption(xargs)
-            }) {
+            if right
+                .options()
+                .xargs()
+                .is_some_and(|xargs| xargs.uses_null_input || xargs.has_zero_digit_option_word())
+            {
                 return None;
             }
 
@@ -137,12 +139,6 @@ fn find_command_span(segment: &PipelineSegmentFact<'_>, fact: CommandFactRef<'_,
     }
 }
 
-fn xargs_uses_shellcheck_parallel_exemption(xargs: &crate::XargsCommandFacts) -> bool {
-    xargs
-        .max_procs()
-        .is_some_and(|max_procs| max_procs == 0 || max_procs >= 10)
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::Path;
@@ -203,17 +199,24 @@ find \"$pkg\" -print1 | xargs -0 file
     }
 
     #[test]
-    fn ignores_parallel_xargs_when_shellcheck_does() {
+    fn follows_shellcheck_zero_digit_xargs_option_exemption() {
         let source = "\
 find \"$dir\" \\( -type f -o -type l \\) -and -not -path \"$dir/plugins/*\" | xargs -I % -P10 bash -c '. /tmp/lib.sh && foo %'
+find . -type f | xargs -P0 rm
+find . -type f | xargs -P 10 rm
+find . -type f | xargs --max-procs=10 rm
+find . -type f -print0 | xargs -P10 rm
+find . -type f | xargs -P11 rm
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FindOutputToXargs));
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "find . -type f");
+        assert_eq!(diagnostics[1].span.slice(source), "find . -type f");
     }
 
     #[test]
-    fn still_reports_replacement_xargs_when_parallelism_does_not_trigger_the_exemption() {
+    fn reports_replacement_xargs_without_null_input() {
         let source = "\
 find \"$dir\" \\( -type f -o -type l \\) -and -not -path \"$dir/plugins/*\" | xargs -I % -P1 bash -c '. /tmp/lib.sh && foo %'
 ";


### PR DESCRIPTION
## Summary
- model ShellCheck SC2038 parity for xargs option words containing `0` before the command operand
- keep the C007 rule on fact-derived xargs option state instead of a corpus-specific divergence
- cover the zero-option behavior and the non-exempt `-P11` case in linter/fact tests

## Validation
- `cargo test -p shuck-linter xargs`
- `cargo test -p shuck-linter rule_modules_avoid_direct_ast_traversal_tokens`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C007`

The targeted large corpus run completed with `implementation_diffs=0` and `reviewed_divergences=0`. 