### PR TITLE
perf(linter): finish indexed fact arenas

### DIFF
--- a/crates/shuck-benchmark/examples/linter_memory.rs
+++ b/crates/shuck-benchmark/examples/linter_memory.rs
@@ -1,0 +1,335 @@
+use std::cell::RefCell;
+use std::process;
+
+use serde::Serialize;
+use shuck_benchmark::{benchmark_cases, parse_fixture};
+use shuck_indexer::Indexer;
+use shuck_linter::{Checker, LinterFacts, LinterSettings, ShellDialect, classify_file_context};
+use shuck_parser::parser::{ParseResult, ParseStatus};
+use shuck_semantic::SemanticModel;
+
+#[global_allocator]
+static GLOBAL: CountingAllocator<std::alloc::System> = CountingAllocator(std::alloc::System);
+
+const MAX_MEASURE_DEPTH: usize = 8;
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Frame {
+    allocation_count: u64,
+    reallocation_count: u64,
+    total_allocated_bytes: u64,
+    total_reallocated_bytes: u64,
+    current_live_bytes: i64,
+    peak_live_bytes: u64,
+}
+
+impl Frame {
+    fn on_alloc(&mut self, size: usize) {
+        self.allocation_count += 1;
+        self.total_allocated_bytes += size as u64;
+        self.current_live_bytes += size as i64;
+        self.peak_live_bytes = self
+            .peak_live_bytes
+            .max(self.current_live_bytes.max(0) as u64);
+    }
+
+    fn on_dealloc(&mut self, size: usize) {
+        self.current_live_bytes -= size as i64;
+    }
+
+    fn on_realloc(&mut self, old_size: usize, new_size: usize) {
+        self.reallocation_count += 1;
+        self.total_reallocated_bytes += new_size as u64;
+        self.current_live_bytes += new_size as i64 - old_size as i64;
+        self.peak_live_bytes = self
+            .peak_live_bytes
+            .max(self.current_live_bytes.max(0) as u64);
+    }
+}
+
+#[derive(Debug, Default)]
+struct CounterState {
+    depth: usize,
+    frames: [Frame; MAX_MEASURE_DEPTH],
+}
+
+thread_local! {
+    static COUNTER_STATE: RefCell<CounterState> = RefCell::new(CounterState::default());
+}
+
+struct CountingAllocator<A>(A);
+
+unsafe impl<A: std::alloc::GlobalAlloc> std::alloc::GlobalAlloc for CountingAllocator<A> {
+    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+        let ptr = unsafe { self.0.alloc(layout) };
+        if !ptr.is_null() {
+            record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+        record_dealloc(layout.size());
+        unsafe { self.0.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: std::alloc::Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { self.0.realloc(ptr, layout, new_size) };
+        if !new_ptr.is_null() {
+            record_realloc(layout.size(), new_size);
+        }
+        new_ptr
+    }
+}
+
+fn record_alloc(size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_alloc(size);
+        }
+    });
+}
+
+fn record_dealloc(size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_dealloc(size);
+        }
+    });
+}
+
+fn record_realloc(old_size: usize, new_size: usize) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        if depth == 0 {
+            return;
+        }
+        for frame in &mut state.frames[1..=depth] {
+            frame.on_realloc(old_size, new_size);
+        }
+    });
+}
+
+fn measure<T>(f: impl FnOnce() -> T) -> (Frame, T) {
+    COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        assert!(
+            state.depth + 1 < MAX_MEASURE_DEPTH,
+            "measurement nesting too deep"
+        );
+        state.depth += 1;
+        let depth = state.depth;
+        state.frames[depth] = Frame::default();
+    });
+
+    let result = f();
+
+    let frame = COUNTER_STATE.with(|state| {
+        let mut state = state.borrow_mut();
+        let depth = state.depth;
+        let frame = state.frames[depth];
+        state.frames[depth] = Frame::default();
+        state.depth -= 1;
+        frame
+    });
+
+    (frame, result)
+}
+
+#[derive(Debug, Serialize)]
+struct MemoryMetrics {
+    allocation_count: u64,
+    reallocation_count: u64,
+    total_allocated_bytes: u64,
+    total_reallocated_bytes: u64,
+    peak_live_bytes: u64,
+    final_live_bytes: u64,
+}
+
+impl From<Frame> for MemoryMetrics {
+    fn from(frame: Frame) -> Self {
+        Self {
+            allocation_count: frame.allocation_count,
+            reallocation_count: frame.reallocation_count,
+            total_allocated_bytes: frame.total_allocated_bytes,
+            total_reallocated_bytes: frame.total_reallocated_bytes,
+            peak_live_bytes: frame.peak_live_bytes,
+            final_live_bytes: frame.current_live_bytes.max(0) as u64,
+        }
+    }
+}
+
+struct PreparedInput {
+    source: &'static str,
+    output: ParseResult,
+    indexer: Indexer,
+    semantic: SemanticModel,
+    shell: ShellDialect,
+    file_context: shuck_linter::FileContext,
+}
+
+impl PreparedInput {
+    fn new(source: &'static str) -> Self {
+        let output = parse_fixture(source);
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let shell = ShellDialect::infer(source, None);
+        let file_context = classify_file_context(source, None, shell);
+
+        Self {
+            source,
+            output,
+            indexer,
+            semantic,
+            shell,
+            file_context,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CaseReport {
+    case: String,
+    files: usize,
+    recovered_files: usize,
+    command_count: usize,
+    fact_count: usize,
+    diagnostic_count: usize,
+    facts_metrics: MemoryMetrics,
+    check_metrics: MemoryMetrics,
+}
+
+fn facts_size(input: &PreparedInput) -> usize {
+    let facts = LinterFacts::build_with_shell_and_ambient_shell_options(
+        &input.output.file,
+        input.source,
+        &input.semantic,
+        &input.indexer,
+        &input.file_context,
+        input.shell,
+        Default::default(),
+    );
+
+    facts.commands().len()
+        + facts.word_facts().count()
+        + facts.single_quoted_fragments().len()
+        + facts.backtick_fragments().len()
+        + facts.pattern_charclass_spans().len()
+        + facts.substring_expansion_fragments().len()
+        + facts.case_modification_fragments().len()
+        + facts.replacement_expansion_fragments().len()
+}
+
+fn check_diagnostics(input: &PreparedInput, settings: &LinterSettings) -> usize {
+    let checker = Checker::new(
+        &input.output.file,
+        input.source,
+        &input.semantic,
+        &input.indexer,
+        &settings.rules,
+        input.shell,
+        settings.ambient_shell_options,
+        settings.report_environment_style_names,
+        settings.rule_options.clone(),
+        &input.file_context,
+        None,
+        None,
+    );
+    checker.check().len()
+}
+
+fn single_case_report(case_name: &str) -> Option<CaseReport> {
+    let cases = benchmark_cases();
+    let case = cases.into_iter().find(|case| case.name == case_name)?;
+    let inputs = case
+        .files
+        .iter()
+        .map(|file| PreparedInput::new(file.source))
+        .collect::<Vec<_>>();
+    let settings = LinterSettings::default();
+
+    let recovered_files = inputs
+        .iter()
+        .filter(|input| input.output.status != ParseStatus::Clean)
+        .count();
+    let command_count = inputs
+        .iter()
+        .map(|input| input.output.file.body.len())
+        .sum();
+
+    let (facts_frame, fact_count) = measure(|| inputs.iter().map(facts_size).sum());
+    let (check_frame, diagnostic_count) = measure(|| {
+        inputs
+            .iter()
+            .map(|input| check_diagnostics(input, &settings))
+            .sum()
+    });
+
+    Some(CaseReport {
+        case: case.name.to_string(),
+        files: case.files.len(),
+        recovered_files,
+        command_count,
+        fact_count,
+        diagnostic_count,
+        facts_metrics: facts_frame.into(),
+        check_metrics: check_frame.into(),
+    })
+}
+
+fn parse_case_arg() -> Option<String> {
+    let mut args = std::env::args().skip(1);
+    let arg = args.next()?;
+
+    match arg.as_str() {
+        "--case" => {
+            let value = args.next();
+            if let Some(extra) = args.next() {
+                eprintln!("unknown argument `{extra}`");
+                process::exit(2);
+            }
+            value
+        }
+        "--help" | "-h" => {
+            eprintln!(
+                "usage: cargo run -p shuck-benchmark --example linter_memory -- [--case NAME]"
+            );
+            process::exit(0);
+        }
+        _ => {
+            eprintln!("unknown argument `{arg}`");
+            process::exit(2);
+        }
+    }
+}
+
+fn main() -> serde_json::Result<()> {
+    let requested_case = parse_case_arg();
+    let reports = if let Some(case_name) = requested_case {
+        let Some(report) = single_case_report(&case_name) else {
+            eprintln!("unknown benchmark case `{case_name}`");
+            process::exit(2);
+        };
+        vec![report]
+    } else {
+        benchmark_cases()
+            .into_iter()
+            .filter_map(|case| single_case_report(case.name))
+            .collect::<Vec<_>>()
+    };
+
+    serde_json::to_writer_pretty(std::io::stdout().lock(), &reports)?;
+    println!();
+    Ok(())
+}

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -190,6 +190,168 @@ impl<'a> Checker<'a> {
         }
     }
 
+    pub fn report_iter<V, I>(&mut self, spans: I, violation: impl Fn() -> V)
+    where
+        V: Violation,
+        I: IntoIterator<Item = Span>,
+    {
+        for span in spans {
+            self.report(violation(), span);
+        }
+    }
+
+    pub fn report_iter_dedup<V, I>(&mut self, spans: I, violation: impl Fn() -> V)
+    where
+        V: Violation,
+        I: IntoIterator<Item = Span>,
+    {
+        for span in spans {
+            self.report_dedup(violation(), span);
+        }
+    }
+
+    pub fn report_fact_spans<V>(
+        &mut self,
+        collect: impl FnOnce(&LinterFacts<'a>, &mut dyn FnMut(Span)),
+        violation: impl Fn() -> V,
+    ) where
+        V: Violation,
+    {
+        let facts = self.facts.get_or_init(|| {
+            LinterFacts::build_with_shell_and_ambient_shell_options(
+                self.file,
+                self.source,
+                self.semantic,
+                self.indexer,
+                self.file_context,
+                self.shell,
+                self.ambient_shell_options,
+            )
+        });
+        let diagnostics = &mut self.diagnostics;
+        let reported = &mut self.reported;
+        let mut report = |span| {
+            let diagnostic = Diagnostic::new(violation(), span);
+            reported.insert(DiagnosticKey::new(diagnostic.rule, diagnostic.span));
+            diagnostics.push(diagnostic);
+        };
+        collect(facts, &mut report);
+    }
+
+    pub fn report_fact_spans_dedup<V>(
+        &mut self,
+        collect: impl FnOnce(&LinterFacts<'a>, &mut dyn FnMut(Span)),
+        violation: impl Fn() -> V,
+    ) where
+        V: Violation,
+    {
+        let facts = self.facts.get_or_init(|| {
+            LinterFacts::build_with_shell_and_ambient_shell_options(
+                self.file,
+                self.source,
+                self.semantic,
+                self.indexer,
+                self.file_context,
+                self.shell,
+                self.ambient_shell_options,
+            )
+        });
+        let diagnostics = &mut self.diagnostics;
+        let reported = &mut self.reported;
+        let mut report = |span| {
+            let diagnostic = Diagnostic::new(violation(), span);
+            let key = DiagnosticKey::new(diagnostic.rule, diagnostic.span);
+            if reported.insert(key) {
+                diagnostics.push(diagnostic);
+            }
+        };
+        collect(facts, &mut report);
+    }
+
+    pub fn report_fact_slice<V>(
+        &mut self,
+        spans: impl for<'facts> FnOnce(&'facts LinterFacts<'a>) -> &'facts [Span],
+        violation: impl Fn() -> V,
+    ) where
+        V: Violation,
+    {
+        self.report_fact_spans(
+            |facts, report| {
+                for span in spans(facts).iter().copied() {
+                    report(span);
+                }
+            },
+            violation,
+        );
+    }
+
+    pub fn report_fact_slice_dedup<V>(
+        &mut self,
+        spans: impl for<'facts> FnOnce(&'facts LinterFacts<'a>) -> &'facts [Span],
+        violation: impl Fn() -> V,
+    ) where
+        V: Violation,
+    {
+        self.report_fact_spans_dedup(
+            |facts, report| {
+                for span in spans(facts).iter().copied() {
+                    report(span);
+                }
+            },
+            violation,
+        );
+    }
+
+    pub fn report_fact_diagnostics_dedup(
+        &mut self,
+        collect: impl FnOnce(&LinterFacts<'a>, &mut dyn FnMut(Diagnostic)),
+    ) {
+        let facts = self.facts.get_or_init(|| {
+            LinterFacts::build_with_shell_and_ambient_shell_options(
+                self.file,
+                self.source,
+                self.semantic,
+                self.indexer,
+                self.file_context,
+                self.shell,
+                self.ambient_shell_options,
+            )
+        });
+        let diagnostics = &mut self.diagnostics;
+        let reported = &mut self.reported;
+        let mut report = |diagnostic: Diagnostic| {
+            let key = DiagnosticKey::new(diagnostic.rule, diagnostic.span);
+            if reported.insert(key) {
+                diagnostics.push(diagnostic);
+            }
+        };
+        collect(facts, &mut report);
+    }
+
+    pub fn report_fact_diagnostics(
+        &mut self,
+        collect: impl FnOnce(&LinterFacts<'a>, &mut dyn FnMut(Diagnostic)),
+    ) {
+        let facts = self.facts.get_or_init(|| {
+            LinterFacts::build_with_shell_and_ambient_shell_options(
+                self.file,
+                self.source,
+                self.semantic,
+                self.indexer,
+                self.file_context,
+                self.shell,
+                self.ambient_shell_options,
+            )
+        });
+        let diagnostics = &mut self.diagnostics;
+        let reported = &mut self.reported;
+        let mut report = |diagnostic: Diagnostic| {
+            reported.insert(DiagnosticKey::new(diagnostic.rule, diagnostic.span));
+            diagnostics.push(diagnostic);
+        };
+        collect(facts, &mut report);
+    }
+
     pub fn check(mut self) -> Vec<Diagnostic> {
         if self.rules.is_empty() {
             return self.diagnostics;

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -213,7 +213,7 @@ fn bare_command_name_assignment_span<'a>(
     }
 
     let text = occurrence_static_text(word_nodes, fact, source)?;
-    if !is_bare_command_name_assignment_value(text) {
+    if !is_bare_command_name_assignment_value(&text) {
         return None;
     }
 

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -2,6 +2,7 @@ fn build_literal_brace_spans(
     nodes: &[WordNode<'_>],
     occurrences: &[WordOccurrence],
     commands: CommandFacts<'_, '_>,
+    fact_store: &FactStore<'_>,
     source: &str,
     heredoc_ranges: &[TextRange],
 ) -> Vec<Span> {
@@ -26,7 +27,7 @@ fn build_literal_brace_spans(
         }
         processed_word_nodes[node_index] = true;
 
-        collect_literal_brace_spans_for_word(nodes, fact, source, &mut spans);
+        collect_literal_brace_spans_for_word(nodes, fact, fact_store, source, &mut spans);
     }
 
     spans.extend(uncovered_command_brace_spans(
@@ -49,6 +50,7 @@ fn build_literal_brace_spans(
 fn collect_literal_brace_spans_for_word(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
+    fact_store: &FactStore<'_>,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
@@ -82,7 +84,9 @@ fn collect_literal_brace_spans_for_word(
             .flat_map(|brace| brace_character_spans(brace.span, source))
             .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
             .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-            .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source)),
+            .filter(|span| {
+                !word_span_is_inside_command_substitution(nodes, fact, fact_store, *span)
+            }),
     );
 
     spans.extend(
@@ -90,25 +94,30 @@ fn collect_literal_brace_spans_for_word(
             .into_iter()
             .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
             .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-            .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source)),
+            .filter(|span| {
+                !word_span_is_inside_command_substitution(nodes, fact, fact_store, *span)
+            }),
     );
     spans.extend(
         unclassified_literal_brace_spans(word, source, &mut dynamic_exclusions)
             .into_iter()
             .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
             .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-            .filter(|span| !word_span_is_inside_command_substitution(nodes, fact, *span, source)),
+            .filter(|span| {
+                !word_span_is_inside_command_substitution(nodes, fact, fact_store, *span)
+            }),
     );
 }
 
 fn word_span_is_inside_command_substitution(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
+    fact_store: &FactStore<'_>,
     span: Span,
-    source: &str,
 ) -> bool {
-    word_node_derived(&nodes[fact.node_id.index()], source)
-        .command_substitution_spans
+    let derived = word_node_derived(&nodes[fact.node_id.index()]);
+    fact_store
+        .word_spans(derived.command_substitution_spans)
         .iter()
         .copied()
         .any(|substitution| contains_span(substitution, span))

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -34,10 +34,6 @@ struct HeredocFactSummary {
     spaced_tabstrip_close_spans: Vec<Span>,
 }
 
-fn total_child_len<T>(lists: &[Vec<T>]) -> usize {
-    lists.iter().map(Vec::len).sum()
-}
-
 fn estimate_fact_build_capacity(file: &File) -> FactBuildCapacity {
     let mut capacity = FactBuildCapacity::default();
     walk_commands(
@@ -100,6 +96,8 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut comma_array_assignment_spans = Vec::new();
         let mut ifs_literal_backslash_assignment_value_spans = Vec::new();
         let mut word_nodes = Vec::with_capacity(estimated_word_nodes);
+        let mut word_spans = ListArena::with_capacity(estimated_word_nodes.saturating_mul(2));
+        let mut word_span_scratch = Vec::new();
         let mut word_node_ids_by_span =
             FxHashMap::with_capacity_and_hasher(estimated_word_nodes, Default::default());
         let mut word_occurrences = Vec::with_capacity(estimated_word_occurrences);
@@ -195,6 +193,8 @@ impl<'a> LinterFactsBuilder<'a> {
                     command_zsh_options.clone(),
                     WordFactOutputs {
                         word_nodes: &mut word_nodes,
+                        word_spans: &mut word_spans,
+                        word_span_scratch: &mut word_span_scratch,
                         word_node_ids_by_span: &mut word_node_ids_by_span,
                         word_occurrences: &mut word_occurrences,
                         pending_arithmetic_word_occurrences:
@@ -388,22 +388,17 @@ impl<'a> LinterFactsBuilder<'a> {
         arithmetic_update_operator_spans.dedup();
 
         let mut fact_store = FactStore::empty();
-        fact_store.redirect_facts = redirect_fact_store.into_vec();
-        fact_store.declaration_assignment_probes = declaration_assignment_probe_store.into_vec();
+        fact_store.redirect_facts = redirect_fact_store;
+        fact_store.declaration_assignment_probes = declaration_assignment_probe_store;
+        fact_store.word_spans = word_spans;
 
         populate_linebreak_in_test_facts(&mut commands, self.source);
-        let substitution_facts = build_substitution_facts(
-            CommandFacts::new(&commands, &fact_store),
+        populate_substitution_fact_ranges(
+            &mut commands,
+            &mut fact_store,
             &command_ids_by_span,
             self.source,
         );
-        let mut substitution_fact_store = ListArena::with_capacity(total_child_len(
-            &substitution_facts,
-        ));
-        for (fact, substitutions) in commands.iter_mut().zip(substitution_facts) {
-            fact.substitution_facts = substitution_fact_store.push_many(substitutions);
-        }
-        fact_store.substitution_facts = substitution_fact_store.into_vec();
 
         let presence_tested_names =
             build_presence_tested_names(&commands, self.source, self.semantic);
@@ -449,40 +444,13 @@ impl<'a> LinterFactsBuilder<'a> {
         let case_pattern_impossible_spans =
             build_case_pattern_impossible_spans(&commands, self.source);
         let pipelines = build_pipeline_facts(&commands, &command_ids_by_span);
-        let command_facts = CommandFacts::new(&commands, &fact_store);
-        let scope_read_source_words = build_scope_read_source_words(
-            command_facts,
+        populate_scope_fact_ranges(
+            &mut commands,
+            &mut fact_store,
             &pipelines,
             &if_condition_command_ids,
             source,
         );
-        let (scope_name_read_uses, scope_heredoc_name_read_uses, scope_name_write_uses) =
-            build_scope_name_uses(command_facts, &pipelines, source);
-        let mut scope_read_source_word_store =
-            ListArena::with_capacity(total_child_len(&scope_read_source_words));
-        let mut scope_name_read_use_store =
-            ListArena::with_capacity(total_child_len(&scope_name_read_uses));
-        let mut scope_heredoc_name_read_use_store =
-            ListArena::with_capacity(total_child_len(&scope_heredoc_name_read_uses));
-        let mut scope_name_write_use_store =
-            ListArena::with_capacity(total_child_len(&scope_name_write_uses));
-        for ((((fact, words), name_reads), heredoc_name_reads), name_writes) in commands
-            .iter_mut()
-            .zip(scope_read_source_words)
-            .zip(scope_name_read_uses)
-            .zip(scope_heredoc_name_read_uses)
-            .zip(scope_name_write_uses)
-        {
-            fact.scope_read_source_words = scope_read_source_word_store.push_many(words);
-            fact.scope_name_read_uses = scope_name_read_use_store.push_many(name_reads);
-            fact.scope_heredoc_name_read_uses =
-                scope_heredoc_name_read_use_store.push_many(heredoc_name_reads);
-            fact.scope_name_write_uses = scope_name_write_use_store.push_many(name_writes);
-        }
-        fact_store.scope_read_source_words = scope_read_source_word_store.into_vec();
-        fact_store.scope_name_read_uses = scope_name_read_use_store.into_vec();
-        fact_store.scope_heredoc_name_read_uses = scope_heredoc_name_read_use_store.into_vec();
-        fact_store.scope_name_write_uses = scope_name_write_use_store.into_vec();
         let lists = build_list_facts(&commands, &command_ids_by_span, self.source);
         let completion_registered_function_command_flags =
             build_completion_registered_function_command_flags(
@@ -538,6 +506,7 @@ impl<'a> LinterFactsBuilder<'a> {
             &word_nodes,
             &word_occurrences,
             CommandFacts::new(&commands, &fact_store),
+            &fact_store,
             source,
             self._indexer.region_index().heredoc_ranges(),
         );
@@ -632,7 +601,7 @@ impl<'a> LinterFactsBuilder<'a> {
                     runtime_literal: RuntimeLiteralAnalysis::default(),
                     operand_class: None,
                     enclosing_expansion_context: Some(pending.enclosing_expansion_context),
-                    array_assignment_split_scalar_expansion_spans: OnceCell::new(),
+                    array_assignment_split_scalar_expansion_spans: IdRange::empty(),
                 }),
         );
         let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
@@ -664,8 +633,23 @@ impl<'a> LinterFactsBuilder<'a> {
             word_occurrence_ids[offset] = id;
             word_occurrence_offsets_by_command[command_index] += 1;
         }
-        fact_store.word_occurrence_ids = word_occurrence_ids;
+        let mut word_occurrence_id_store = ListArena::with_capacity(word_occurrence_ids.len());
+        let all_word_occurrence_ids = word_occurrence_id_store.push_many(word_occurrence_ids);
+        debug_assert_eq!(all_word_occurrence_ids.start_index(), 0);
+        debug_assert_eq!(
+            all_word_occurrence_ids.end_index(),
+            next_word_occurrence_offset
+        );
+        fact_store.word_occurrence_ids = word_occurrence_id_store;
         fact_store.word_occurrence_ids_by_command = word_occurrence_ids_by_command;
+        populate_array_assignment_split_scalar_expansion_spans(
+            self.shell,
+            &commands,
+            &word_nodes,
+            &mut word_occurrences,
+            &mut fact_store,
+            &array_assignment_split_word_ids,
+        );
         let echo_to_sed_substitution_spans = build_echo_to_sed_substitution_spans(
             CommandFacts::new(&commands, &fact_store),
             &pipelines,
@@ -673,6 +657,7 @@ impl<'a> LinterFactsBuilder<'a> {
             &word_nodes,
             &word_occurrences,
             &word_index,
+            &fact_store,
             source,
         );
         let assignment_like_command_name_spans =
@@ -693,6 +678,7 @@ impl<'a> LinterFactsBuilder<'a> {
             build_brace_variable_before_bracket_spans(&word_nodes, &word_occurrences, source);
         let alias_definition_expansion_spans = build_alias_definition_expansion_spans(
             &commands,
+            &fact_store,
             &word_nodes,
             &word_occurrences,
             &word_index,
@@ -714,7 +700,6 @@ impl<'a> LinterFactsBuilder<'a> {
 
         LinterFacts {
             source,
-            shell: self.shell,
             commands,
             structural_command_ids,
             command_ids_by_span,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -654,11 +654,13 @@ impl<'a> LinterFactsBuilder<'a> {
             CommandFacts::new(&commands, &fact_store),
             &pipelines,
             &backticks,
-            &word_nodes,
-            &word_occurrences,
-            &word_index,
-            &fact_store,
-            source,
+            WordFactLookup {
+                nodes: &word_nodes,
+                occurrences: &word_occurrences,
+                word_index: &word_index,
+                fact_store: &fact_store,
+                source,
+            },
         );
         let assignment_like_command_name_spans =
             build_assignment_like_command_name_spans(&commands, self.source);

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -656,154 +656,226 @@ fn background_semicolon_span(
     Some(Span::from_positions(start, end))
 }
 
-fn build_scope_read_source_words<'a>(
+fn populate_scope_fact_ranges<'a>(
+    commands: &mut [CommandFact<'a>],
+    fact_store: &mut FactStore<'a>,
+    pipelines: &[PipelineFact<'a>],
+    if_condition_command_ids: &FxHashSet<CommandId>,
+    source: &str,
+) {
+    let (pipeline_summaries, pipeline_summary_ids_by_writer) = {
+        let command_facts = CommandFacts::new(commands, fact_store);
+        build_pipeline_scope_summaries(
+            command_facts,
+            pipelines,
+            if_condition_command_ids,
+            source,
+        )
+    };
+    let mut source_words = Vec::new();
+    let mut name_reads = Vec::new();
+    let mut heredoc_name_reads = Vec::new();
+    let mut name_writes = Vec::new();
+
+    for index in 0..commands.len() {
+        {
+            let command_facts = CommandFacts::new(commands, fact_store);
+            let command = command_facts
+                .get(index)
+                .expect("command index should resolve while populating scope facts");
+            collect_scope_read_source_words_for_command(
+                command_facts,
+                command,
+                &pipeline_summaries,
+                &pipeline_summary_ids_by_writer[index],
+                if_condition_command_ids,
+                source,
+                &mut source_words,
+            );
+            collect_scope_name_read_uses_for_command(
+                command_facts,
+                command,
+                &pipeline_summaries,
+                &pipeline_summary_ids_by_writer[index],
+                source,
+                &mut name_reads,
+            );
+            collect_scope_heredoc_name_read_uses_for_command(
+                command_facts,
+                command,
+                &pipeline_summaries,
+                &pipeline_summary_ids_by_writer[index],
+                source,
+                &mut heredoc_name_reads,
+            );
+            collect_scope_name_write_uses_for_command(
+                command_facts,
+                command,
+                source,
+                &mut name_writes,
+            );
+        }
+
+        commands[index].scope_read_source_words =
+            fact_store.scope_read_source_words.push_many(source_words.drain(..));
+        commands[index].scope_name_read_uses =
+            fact_store.scope_name_read_uses.push_many(name_reads.drain(..));
+        commands[index].scope_heredoc_name_read_uses = fact_store
+            .scope_heredoc_name_read_uses
+            .push_many(heredoc_name_reads.drain(..));
+        commands[index].scope_name_write_uses =
+            fact_store.scope_name_write_uses.push_many(name_writes.drain(..));
+    }
+}
+
+struct PipelineScopeSummary<'a> {
+    source_words: Vec<PathWordFact<'a>>,
+    name_reads: Vec<ComparableNameUse>,
+    heredoc_name_reads: Vec<ComparableNameUse>,
+}
+
+fn build_pipeline_scope_summaries<'a>(
     commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
-) -> Vec<Vec<PathWordFact<'a>>> {
-    let mut words_by_command = vec![Vec::new(); commands.len()];
+) -> (Vec<PipelineScopeSummary<'a>>, Vec<SmallVec<[usize; 1]>>) {
+    let mut summaries = Vec::new();
+    let mut summary_ids_by_writer = vec![SmallVec::<[usize; 1]>::new(); commands.len()];
 
-    for command in commands {
-        let scope_words = &mut words_by_command[command.id().index()];
-        collect_own_scope_read_source_words(command, if_condition_command_ids, source, scope_words);
-        if command_has_file_output_redirect(command) {
-            collect_nested_scope_read_source_words(
-                commands,
+    for pipeline in pipelines {
+        let writer_ids = pipeline
+            .segments()
+            .iter()
+            .map(|segment| segment.command_id())
+            .filter(|id| {
+                commands
+                    .get(id.index())
+                    .is_some_and(command_has_file_output_redirect)
+            })
+            .collect::<SmallVec<[_; 4]>>();
+        if writer_ids.is_empty() {
+            continue;
+        }
+
+        let mut source_words = Vec::new();
+        let mut name_reads = Vec::new();
+        let mut heredoc_name_reads = Vec::new();
+        for command in commands
+            .iter()
+            .filter(|command| contains_span(pipeline.span(), command.span()))
+        {
+            collect_own_scope_read_source_words(
                 command,
                 if_condition_command_ids,
                 source,
-                scope_words,
+                &mut source_words,
             );
+            collect_own_scope_name_read_uses(command, source, &mut name_reads);
+            collect_own_scope_heredoc_name_read_uses(command, source, &mut heredoc_name_reads);
         }
-        dedup_path_words(scope_words);
-    }
+        dedup_path_words(&mut source_words);
+        dedup_name_uses(&mut name_reads);
+        dedup_name_uses(&mut heredoc_name_reads);
 
-    for pipeline in pipelines {
-        let writer_ids = pipeline
-            .segments()
-            .iter()
-            .map(|segment| segment.command_id())
-            .filter(|id| {
-                commands
-                    .get(id.index())
-                    .is_some_and(command_has_file_output_redirect)
-            })
-            .collect::<SmallVec<[_; 4]>>();
-        if writer_ids.is_empty() {
-            continue;
-        }
-
-        let mut pipeline_words = commands
-            .iter()
-            .filter(|command| contains_span(pipeline.span(), command.span()))
-            .flat_map(|command| own_scope_read_source_words(command, if_condition_command_ids, source))
-            .collect::<Vec<_>>();
-        dedup_path_words(&mut pipeline_words);
-
+        let summary_id = summaries.len();
+        summaries.push(PipelineScopeSummary {
+            source_words,
+            name_reads,
+            heredoc_name_reads,
+        });
         for writer_id in writer_ids {
-            words_by_command[writer_id.index()].extend(pipeline_words.iter().cloned());
-            dedup_path_words(&mut words_by_command[writer_id.index()]);
+            summary_ids_by_writer[writer_id.index()].push(summary_id);
         }
     }
 
-    words_by_command
+    (summaries, summary_ids_by_writer)
 }
 
-type ScopeNameUseBuckets = Vec<Vec<ComparableNameUse>>;
-type ScopeNameUseSets = (
-    ScopeNameUseBuckets,
-    ScopeNameUseBuckets,
-    ScopeNameUseBuckets,
-);
-
-fn build_scope_name_uses<'a>(
+fn collect_scope_read_source_words_for_command<'a>(
     commands: CommandFacts<'_, 'a>,
-    pipelines: &[PipelineFact<'a>],
-    source: &str,
-) -> ScopeNameUseSets {
-    let mut reads_by_command = vec![Vec::new(); commands.len()];
-    let mut heredoc_reads_by_command = vec![Vec::new(); commands.len()];
-    let mut writes_by_command = vec![Vec::new(); commands.len()];
-
-    for command in commands {
-        let read_uses = &mut reads_by_command[command.id().index()];
-        collect_own_scope_name_read_uses(command, source, read_uses);
-        if command_has_file_output_redirect(command) {
-            collect_nested_scope_name_read_uses(commands, command, source, read_uses);
-        }
-        dedup_name_uses(read_uses);
-
-        let heredoc_read_uses = &mut heredoc_reads_by_command[command.id().index()];
-        collect_own_scope_heredoc_name_read_uses(command, source, heredoc_read_uses);
-        if command_has_file_output_redirect(command) || command_has_file_input_redirect(command) {
-            collect_nested_scope_heredoc_name_read_uses(
-                commands, command, source,
-                heredoc_read_uses,
-            );
-        }
-        dedup_name_uses(heredoc_read_uses);
-
-        let write_uses = &mut writes_by_command[command.id().index()];
-        collect_own_scope_name_write_uses(command, source, write_uses);
-        if command_has_file_input_redirect(command) {
-            collect_nested_scope_name_write_uses(commands, command, source, write_uses);
-        }
-        dedup_name_uses(write_uses);
-    }
-
-    for pipeline in pipelines {
-        let writer_ids = pipeline
-            .segments()
-            .iter()
-            .map(|segment| segment.command_id())
-            .filter(|id| {
-                commands
-                    .get(id.index())
-                    .is_some_and(command_has_file_output_redirect)
-            })
-            .collect::<SmallVec<[_; 4]>>();
-        if writer_ids.is_empty() {
-            continue;
-        }
-
-        let mut pipeline_reads = commands
-            .iter()
-            .filter(|command| contains_span(pipeline.span(), command.span()))
-            .flat_map(|command| own_scope_name_read_uses(command, source))
-            .collect::<Vec<_>>();
-        dedup_name_uses(&mut pipeline_reads);
-        let mut pipeline_heredoc_reads = commands
-            .iter()
-            .filter(|command| contains_span(pipeline.span(), command.span()))
-            .flat_map(|command| own_scope_heredoc_name_read_uses(command, source))
-            .collect::<Vec<_>>();
-        dedup_name_uses(&mut pipeline_heredoc_reads);
-
-        for writer_id in writer_ids {
-            reads_by_command[writer_id.index()].extend(pipeline_reads.iter().cloned());
-            dedup_name_uses(&mut reads_by_command[writer_id.index()]);
-            heredoc_reads_by_command[writer_id.index()]
-                .extend(pipeline_heredoc_reads.iter().cloned());
-            dedup_name_uses(&mut heredoc_reads_by_command[writer_id.index()]);
-        }
-    }
-
-    (
-        reads_by_command,
-        heredoc_reads_by_command,
-        writes_by_command,
-    )
-}
-
-fn own_scope_read_source_words<'a>(
     command: CommandFactRef<'_, 'a>,
+    pipeline_summaries: &[PipelineScopeSummary<'a>],
+    pipeline_summary_ids: &[usize],
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
-) -> Vec<PathWordFact<'a>> {
-    let mut words = Vec::new();
-    collect_own_scope_read_source_words(command, if_condition_command_ids, source, &mut words);
-    words
+    words: &mut Vec<PathWordFact<'a>>,
+) {
+    collect_own_scope_read_source_words(command, if_condition_command_ids, source, words);
+    if command_has_file_output_redirect(command) {
+        collect_nested_scope_read_source_words(
+            commands,
+            command,
+            if_condition_command_ids,
+            source,
+            words,
+        );
+        for summary_id in pipeline_summary_ids {
+            words.extend(
+                pipeline_summaries[*summary_id]
+                    .source_words
+                    .iter()
+                    .cloned(),
+            );
+        }
+    }
+    dedup_path_words(words);
+}
+
+fn collect_scope_name_read_uses_for_command(
+    commands: CommandFacts<'_, '_>,
+    command: CommandFactRef<'_, '_>,
+    pipeline_summaries: &[PipelineScopeSummary<'_>],
+    pipeline_summary_ids: &[usize],
+    source: &str,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    collect_own_scope_name_read_uses(command, source, uses);
+    if command_has_file_output_redirect(command) {
+        collect_nested_scope_name_read_uses(commands, command, source, uses);
+        for summary_id in pipeline_summary_ids {
+            uses.extend(pipeline_summaries[*summary_id].name_reads.iter().cloned());
+        }
+    }
+    dedup_name_uses(uses);
+}
+
+fn collect_scope_heredoc_name_read_uses_for_command(
+    commands: CommandFacts<'_, '_>,
+    command: CommandFactRef<'_, '_>,
+    pipeline_summaries: &[PipelineScopeSummary<'_>],
+    pipeline_summary_ids: &[usize],
+    source: &str,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    collect_own_scope_heredoc_name_read_uses(command, source, uses);
+    if command_has_file_output_redirect(command) || command_has_file_input_redirect(command) {
+        collect_nested_scope_heredoc_name_read_uses(commands, command, source, uses);
+    }
+    if command_has_file_output_redirect(command) {
+        for summary_id in pipeline_summary_ids {
+            uses.extend(
+                pipeline_summaries[*summary_id]
+                    .heredoc_name_reads
+                    .iter()
+                    .cloned(),
+            );
+        }
+    }
+    dedup_name_uses(uses);
+}
+
+fn collect_scope_name_write_uses_for_command(
+    commands: CommandFacts<'_, '_>,
+    command: CommandFactRef<'_, '_>,
+    source: &str,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    collect_own_scope_name_write_uses(command, source, uses);
+    if command_has_file_input_redirect(command) {
+        collect_nested_scope_name_write_uses(commands, command, source, uses);
+    }
+    dedup_name_uses(uses);
 }
 
 fn collect_own_scope_read_source_words<'a>(
@@ -825,17 +897,11 @@ fn collect_own_scope_read_source_words<'a>(
             )
         })
     );
-    words.extend(command_redirect_read_source_words(command, source));
-    words.extend(command_simple_test_path_words(command, source));
+    collect_command_redirect_read_source_words(command, source, words);
+    collect_command_simple_test_path_words(command, source, words);
     if !if_condition_command_ids.contains(&command.id()) {
-        words.extend(command_conditional_path_words(command, source));
+        collect_command_conditional_path_words(command, source, words);
     }
-}
-
-fn own_scope_name_read_uses(command: CommandFactRef<'_, '_>, _source: &str) -> Vec<ComparableNameUse> {
-    let mut uses = Vec::new();
-    collect_own_scope_name_read_uses(command, _source, &mut uses);
-    uses
 }
 
 fn collect_own_scope_name_read_uses(
@@ -859,15 +925,6 @@ fn collect_own_scope_name_read_uses(
             | RedirectKind::OutputBoth => {}
         }
     }
-}
-
-fn own_scope_heredoc_name_read_uses(
-    command: CommandFactRef<'_, '_>,
-    source: &str,
-) -> Vec<ComparableNameUse> {
-    let mut uses = Vec::new();
-    collect_own_scope_heredoc_name_read_uses(command, source, &mut uses);
-    uses
 }
 
 fn collect_own_scope_heredoc_name_read_uses(
@@ -992,45 +1049,45 @@ fn command_has_file_input_redirect(command: CommandFactRef<'_, '_>) -> bool {
     })
 }
 
-fn command_redirect_read_source_words<'a>(
+fn collect_command_redirect_read_source_words<'a>(
     command: CommandFactRef<'_, 'a>,
     source: &str,
-) -> Vec<PathWordFact<'a>> {
-    command
-        .redirect_facts()
-        .iter()
-        .filter_map(|redirect| {
-            if !matches!(
-                redirect.redirect().kind,
-                RedirectKind::Input | RedirectKind::ReadWrite | RedirectKind::HereString
-            ) {
-                return None;
-            }
+    words: &mut Vec<PathWordFact<'a>>,
+) {
+    for redirect in command.redirect_facts() {
+        if !matches!(
+            redirect.redirect().kind,
+            RedirectKind::Input | RedirectKind::ReadWrite | RedirectKind::HereString
+        ) {
+            continue;
+        }
 
-            let word = redirect.redirect().word_target()?;
-            let context = match ExpansionContext::from_redirect_kind(redirect.redirect().kind) {
-                Some(context) => context,
-                None => unreachable!("input redirects should carry a word target context"),
-            };
-            Some(PathWordFact::new(
-                word,
-                context,
-                source,
-                command.zsh_options(),
-            ))
-        })
-        .collect()
+        let Some(word) = redirect.redirect().word_target() else {
+            continue;
+        };
+        let context = match ExpansionContext::from_redirect_kind(redirect.redirect().kind) {
+            Some(context) => context,
+            None => unreachable!("input redirects should carry a word target context"),
+        };
+        words.push(PathWordFact::new(
+            word,
+            context,
+            source,
+            command.zsh_options(),
+        ));
+    }
 }
 
-fn command_simple_test_path_words<'a>(
+fn collect_command_simple_test_path_words<'a>(
     command: CommandFactRef<'_, 'a>,
     source: &str,
-) -> Vec<PathWordFact<'a>> {
+    words: &mut Vec<PathWordFact<'a>>,
+) {
     let Some(simple_test) = command.simple_test() else {
-        return Vec::new();
+        return;
     };
 
-    simple_test
+    words.extend(simple_test
         .operator_expression_operand_words(source)
         .into_iter()
         .map(|word| {
@@ -1040,16 +1097,14 @@ fn command_simple_test_path_words<'a>(
                 source,
                 command.zsh_options(),
             )
-        })
-        .collect()
+        }));
 }
 
-fn command_conditional_path_words<'a>(
+fn collect_command_conditional_path_words<'a>(
     command: CommandFactRef<'_, 'a>,
     source: &str,
-) -> Vec<PathWordFact<'a>> {
-    let mut words = Vec::new();
-
+    words: &mut Vec<PathWordFact<'a>>,
+) {
     if let Some(conditional) = command.conditional() {
         for node in conditional.nodes() {
             match node {
@@ -1079,8 +1134,6 @@ fn command_conditional_path_words<'a>(
             }
         }
     }
-
-    words
 }
 
 fn contains_span(outer: Span, inner: Span) -> bool {

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -121,71 +121,77 @@ type CommandLookupIndex = FxHashMap<FactSpan, SmallVec<[CommandLookupEntry; 1]>>
 
 #[derive(Debug, Clone)]
 struct FactStore<'a> {
-    redirect_facts: Vec<RedirectFact<'a>>,
-    substitution_facts: Vec<SubstitutionFact>,
-    scope_read_source_words: Vec<PathWordFact<'a>>,
-    scope_name_read_uses: Vec<ComparableNameUse>,
-    scope_heredoc_name_read_uses: Vec<ComparableNameUse>,
-    scope_name_write_uses: Vec<ComparableNameUse>,
-    declaration_assignment_probes: Vec<DeclarationAssignmentProbe>,
-    word_occurrence_ids: Vec<WordOccurrenceId>,
+    redirect_facts: ListArena<RedirectFact<'a>>,
+    substitution_facts: ListArena<SubstitutionFact>,
+    scope_read_source_words: ListArena<PathWordFact<'a>>,
+    scope_name_read_uses: ListArena<ComparableNameUse>,
+    scope_heredoc_name_read_uses: ListArena<ComparableNameUse>,
+    scope_name_write_uses: ListArena<ComparableNameUse>,
+    declaration_assignment_probes: ListArena<DeclarationAssignmentProbe>,
+    word_occurrence_ids: ListArena<WordOccurrenceId>,
     word_occurrence_ids_by_command: Vec<IdRange<WordOccurrenceId>>,
+    word_spans: ListArena<Span>,
 }
 
 impl<'a> FactStore<'a> {
     fn empty() -> Self {
         Self {
-            redirect_facts: Vec::new(),
-            substitution_facts: Vec::new(),
-            scope_read_source_words: Vec::new(),
-            scope_name_read_uses: Vec::new(),
-            scope_heredoc_name_read_uses: Vec::new(),
-            scope_name_write_uses: Vec::new(),
-            declaration_assignment_probes: Vec::new(),
-            word_occurrence_ids: Vec::new(),
+            redirect_facts: ListArena::new(),
+            substitution_facts: ListArena::new(),
+            scope_read_source_words: ListArena::new(),
+            scope_name_read_uses: ListArena::new(),
+            scope_heredoc_name_read_uses: ListArena::new(),
+            scope_name_write_uses: ListArena::new(),
+            declaration_assignment_probes: ListArena::new(),
+            word_occurrence_ids: ListArena::new(),
             word_occurrence_ids_by_command: Vec::new(),
+            word_spans: ListArena::new(),
         }
     }
 
     fn redirect_facts(&self, range: IdRange<RedirectFact<'a>>) -> &[RedirectFact<'a>] {
-        range.slice(&self.redirect_facts)
+        self.redirect_facts.get(range)
     }
 
     fn substitution_facts(&self, range: IdRange<SubstitutionFact>) -> &[SubstitutionFact] {
-        range.slice(&self.substitution_facts)
+        self.substitution_facts.get(range)
     }
 
     fn scope_read_source_words(&self, range: IdRange<PathWordFact<'a>>) -> &[PathWordFact<'a>] {
-        range.slice(&self.scope_read_source_words)
+        self.scope_read_source_words.get(range)
     }
 
     fn scope_name_read_uses(&self, range: IdRange<ComparableNameUse>) -> &[ComparableNameUse] {
-        range.slice(&self.scope_name_read_uses)
+        self.scope_name_read_uses.get(range)
     }
 
     fn scope_heredoc_name_read_uses(
         &self,
         range: IdRange<ComparableNameUse>,
     ) -> &[ComparableNameUse] {
-        range.slice(&self.scope_heredoc_name_read_uses)
+        self.scope_heredoc_name_read_uses.get(range)
     }
 
     fn scope_name_write_uses(&self, range: IdRange<ComparableNameUse>) -> &[ComparableNameUse] {
-        range.slice(&self.scope_name_write_uses)
+        self.scope_name_write_uses.get(range)
     }
 
     fn declaration_assignment_probes(
         &self,
         range: IdRange<DeclarationAssignmentProbe>,
     ) -> &[DeclarationAssignmentProbe] {
-        range.slice(&self.declaration_assignment_probes)
+        self.declaration_assignment_probes.get(range)
     }
 
     fn word_occurrence_ids_for_command(&self, id: CommandId) -> &[WordOccurrenceId] {
         self.word_occurrence_ids_by_command
             .get(id.index())
             .copied()
-            .map_or(&[], |range| range.slice(&self.word_occurrence_ids))
+            .map_or(&[], |range| self.word_occurrence_ids.get(range))
+    }
+
+    fn word_spans(&self, range: IdRange<Span>) -> &[Span] {
+        self.word_spans.get(range)
     }
 }
 

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -61,7 +61,7 @@ use shuck_semantic::{
     ReferenceId, ReferenceKind, ScopeId, SemanticModel, ZshOptionState,
 };
 use smallvec::SmallVec;
-use std::{borrow::Cow, cell::OnceCell, ops::ControlFlow};
+use std::{borrow::Cow, ops::ControlFlow};
 
 pub use self::conditional_portability::ConditionalPortabilityFacts;
 pub(crate) use self::escape_scan::{EscapeScanMatch, EscapeScanSourceKind};

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1,6 +1,5 @@
 pub struct LinterFacts<'a> {
     source: &'a str,
-    shell: ShellDialect,
     commands: Vec<CommandFact<'a>>,
     structural_command_ids: Vec<CommandId>,
     #[cfg_attr(not(test), allow(dead_code))]
@@ -441,61 +440,12 @@ impl<'a> LinterFacts<'a> {
         &self.word_occurrences[id.index()]
     }
 
-    fn word_occurrence_ids_for_command(&self, id: CommandId) -> &[WordOccurrenceId] {
-        self.fact_store.word_occurrence_ids_for_command(id)
-    }
-
     fn word_node(&self, id: WordNodeId) -> &WordNode<'a> {
         &self.word_nodes[id.index()]
     }
 
-    fn word_node_derived(&self, id: WordNodeId) -> &WordNodeDerived {
-        word_node_derived(self.word_node(id), self.source)
-    }
-
-    fn compute_array_assignment_split_scalar_expansion_spans(
-        &self,
-        id: WordOccurrenceId,
-    ) -> Box<[Span]> {
-        let fact = self.word_occurrence_ref(id);
-        let word = occurrence_word(&self.word_nodes, self.word_occurrence(id));
-        let mut split_sensitive_spans = fact.unquoted_scalar_expansion_spans().to_vec();
-        let use_replacement_spans = collect_array_assignment_use_replacement_expansion_spans(word);
-        let brace_expansion_spans = word
-            .brace_syntax()
-            .iter()
-            .copied()
-            .filter(|_| shell_has_brace_expansion(self.shell))
-            .filter(|brace| brace.expands())
-            .map(|brace| brace.span)
-            .collect::<Vec<_>>();
-        let unquoted_command_substitution_spans = fact.unquoted_command_substitution_spans();
-
-        for command in &self.commands {
-            if contains_span_strictly(fact.span(), command.span())
-                && unquoted_command_substitution_spans
-                    .iter()
-                    .any(|span| contains_span_strictly(*span, command.span()))
-            {
-                for nested_id in self.word_occurrence_ids_for_command(command.id()) {
-                    split_sensitive_spans.extend(
-                        self.word_occurrence_ref(*nested_id)
-                            .scalar_expansion_spans()
-                            .iter()
-                            .copied(),
-                    );
-                }
-            }
-        }
-
-        split_sensitive_spans.retain(|span| {
-            !use_replacement_spans.contains(span)
-                && !brace_expansion_spans
-                    .iter()
-                    .any(|brace_span| contains_span(*brace_span, *span))
-        });
-        sort_and_dedup_spans(&mut split_sensitive_spans);
-        split_sensitive_spans.into_boxed_slice()
+    fn word_node_derived(&self, id: WordNodeId) -> &WordNodeDerived<'a> {
+        word_node_derived(self.word_node(id))
     }
 
     pub fn brace_variable_before_bracket_spans(&self) -> &[Span] {
@@ -908,6 +858,90 @@ impl<'a> LinterFacts<'a> {
         }
         uses
     }
+}
+
+fn populate_array_assignment_split_scalar_expansion_spans(
+    shell: ShellDialect,
+    commands: &[CommandFact<'_>],
+    word_nodes: &[WordNode<'_>],
+    word_occurrences: &mut [WordOccurrence],
+    fact_store: &mut FactStore<'_>,
+    word_ids: &[WordOccurrenceId],
+) {
+    let mut scratch = Vec::new();
+    for id in word_ids.iter().copied() {
+        collect_array_assignment_split_scalar_expansion_spans(
+            shell,
+            id,
+            commands,
+            word_nodes,
+            word_occurrences,
+            fact_store,
+            &mut scratch,
+        );
+        word_occurrences[id.index()].array_assignment_split_scalar_expansion_spans =
+            fact_store.word_spans.push_many(scratch.drain(..));
+    }
+}
+
+fn collect_array_assignment_split_scalar_expansion_spans(
+    shell: ShellDialect,
+    id: WordOccurrenceId,
+    commands: &[CommandFact<'_>],
+    word_nodes: &[WordNode<'_>],
+    word_occurrences: &[WordOccurrence],
+    fact_store: &FactStore<'_>,
+    split_sensitive_spans: &mut Vec<Span>,
+) {
+    split_sensitive_spans.clear();
+    let fact = &word_occurrences[id.index()];
+    let word = occurrence_word(word_nodes, fact);
+    let derived = word_node_derived(&word_nodes[fact.node_id.index()]);
+    split_sensitive_spans.extend(
+        fact_store
+            .word_spans(derived.unquoted_scalar_expansion_spans)
+            .iter()
+            .copied(),
+    );
+    let use_replacement_spans = collect_array_assignment_use_replacement_expansion_spans(word);
+    let brace_expansion_spans = word
+        .brace_syntax()
+        .iter()
+        .copied()
+        .filter(|_| shell_has_brace_expansion(shell))
+        .filter(|brace| brace.expands())
+        .map(|brace| brace.span)
+        .collect::<Vec<_>>();
+    let fact_span = occurrence_span(word_nodes, fact);
+    let unquoted_command_substitution_spans =
+        fact_store.word_spans(derived.unquoted_command_substitution_spans);
+
+    for command in commands {
+        if contains_span_strictly(fact_span, command.span())
+            && unquoted_command_substitution_spans
+                .iter()
+                .any(|span| contains_span_strictly(*span, command.span()))
+        {
+            for nested_id in fact_store.word_occurrence_ids_for_command(command.id()) {
+                let nested = &word_occurrences[nested_id.index()];
+                let nested_derived = word_node_derived(&word_nodes[nested.node_id.index()]);
+                split_sensitive_spans.extend(
+                    fact_store
+                        .word_spans(nested_derived.scalar_expansion_spans)
+                        .iter()
+                        .copied(),
+                );
+            }
+        }
+    }
+
+    split_sensitive_spans.retain(|span| {
+        !use_replacement_spans.contains(span)
+            && !brace_expansion_spans
+                .iter()
+                .any(|brace_span| contains_span(*brace_span, *span))
+    });
+    sort_and_dedup_spans(split_sensitive_spans);
 }
 
 fn source_compat_name_use(

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -148,15 +148,22 @@ impl SubstitutionFact {
     }
 }
 
-pub(super) fn build_substitution_facts<'a>(
-    commands: CommandFacts<'_, 'a>,
+fn populate_substitution_fact_ranges<'a>(
+    commands: &mut [CommandFact<'a>],
+    fact_store: &mut FactStore<'a>,
     command_ids_by_span: &CommandLookupIndex,
     source: &str,
-) -> Vec<Vec<SubstitutionFact>> {
-    commands
-        .iter()
-        .map(|fact| build_command_substitution_facts(fact, commands, command_ids_by_span, source))
-        .collect()
+) {
+    for index in 0..commands.len() {
+        let substitutions = {
+            let command_facts = CommandFacts::new(commands, fact_store);
+            let fact = command_facts
+                .get(index)
+                .expect("command index should resolve while populating substitution facts");
+            build_command_substitution_facts(fact, command_facts, command_ids_by_span, source)
+        };
+        commands[index].substitution_facts = fact_store.substitution_facts.push_many(substitutions);
+    }
 }
 
 fn build_command_substitution_facts<'a>(

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1,6 +1,30 @@
 use super::*;
 
 #[test]
+fn word_static_text_preserves_multi_part_literals() {
+    let source = "echo foo\"bar\" 'baz'qux\n";
+    with_facts(source, None, |_output, facts| {
+        let mut static_args = facts
+            .expansion_word_facts(ExpansionContext::CommandArgument)
+            .map(|fact| {
+                (
+                    fact.span().slice(source),
+                    fact.static_text()
+                        .expect("expected static argument text")
+                        .into_owned(),
+                )
+            });
+
+        assert_eq!(
+            static_args.next(),
+            Some(("foo\"bar\"", "foobar".to_owned()))
+        );
+        assert_eq!(static_args.next(), Some(("'baz'qux", "bazqux".to_owned())));
+        assert_eq!(static_args.next(), None);
+    });
+}
+
+#[test]
 fn summarizes_command_options_and_invokers() {
     let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\nsed 's/foo/bar/'\nsed -e 's/foo/bar/'\nsed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\1:'\nsed 's/[]\\[^$.*/]/\\\\&/g'\nsed 's/\\([/&]\\)/\\\\\\1/g'\nsed -n 's/foo/bar/p'\nsed --expression 's/foo/bar/'\nsed -r 's/foo/bar/'\nsed \\\"s/foo/bar/\\\"\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -type d -name CVS | xargs -iX rm -rf X\nfind . -type d -name CVS | xargs --replace rm -rf {}\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eETo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
     let output = Parser::new(source).parse().unwrap();

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -2297,6 +2297,30 @@ param_hash=\"$AWK '\"\\
 }
 
 #[test]
+fn builds_word_facts_for_reopened_quote_line_join_after_word_span() {
+    let source = "\
+#!/bin/bash
+value=\"foo\"\\
+\"bar\"
+";
+
+    with_facts(source, None, |_, facts| {
+        let spans = facts
+            .expansion_word_facts(ExpansionContext::AssignmentValue)
+            .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
+            .flat_map(|fact| {
+                fact.unquoted_literal_between_double_quoted_segments_spans()
+                    .iter()
+                    .map(|span| span.slice(source).to_owned())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(spans, vec!["\\\n"]);
+    });
+}
+
+#[test]
 fn builds_word_facts_ignore_comment_text_in_nested_fragment_scan() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/word_spans.rs
+++ b/crates/shuck-linter/src/facts/word_spans.rs
@@ -14,10 +14,18 @@ pub fn command_substitution_part_spans(word: &Word) -> Vec<Span> {
 }
 
 pub fn command_substitution_part_spans_in_source(word: &Word, source: &str) -> Vec<Span> {
-    command_substitution_part_spans(word)
-        .into_iter()
-        .map(|span| normalize_command_substitution_span(span, source))
-        .collect()
+    let mut spans = Vec::new();
+    collect_command_substitution_part_spans_in_source(word, source, &mut spans);
+    spans
+}
+
+pub fn collect_command_substitution_part_spans_in_source(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_command_substitution_spans(&word.parts, spans);
+    normalize_command_substitution_spans(spans, source);
 }
 
 pub fn arithmetic_expansion_part_spans(word: &Word) -> Vec<Span> {
@@ -39,10 +47,18 @@ pub fn unquoted_command_substitution_part_spans(word: &Word) -> Vec<Span> {
 }
 
 pub fn unquoted_command_substitution_part_spans_in_source(word: &Word, source: &str) -> Vec<Span> {
-    unquoted_command_substitution_part_spans(word)
-        .into_iter()
-        .map(|span| normalize_command_substitution_span(span, source))
-        .collect()
+    let mut spans = Vec::new();
+    collect_unquoted_command_substitution_part_spans_in_source(word, source, &mut spans);
+    spans
+}
+
+pub fn collect_unquoted_command_substitution_part_spans_in_source(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_unquoted_command_substitution_spans(&word.parts, false, spans);
+    normalize_command_substitution_spans(spans, source);
 }
 
 pub fn unquoted_dollar_paren_command_substitution_part_spans_in_source(
@@ -50,11 +66,19 @@ pub fn unquoted_dollar_paren_command_substitution_part_spans_in_source(
     source: &str,
 ) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_unquoted_dollar_paren_command_substitution_spans(&word.parts, false, &mut spans);
+    collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
+        word, source, &mut spans,
+    );
     spans
-        .into_iter()
-        .map(|span| normalize_command_substitution_span(span, source))
-        .collect()
+}
+
+pub fn collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_unquoted_dollar_paren_command_substitution_spans(&word.parts, false, spans);
+    normalize_command_substitution_spans(spans, source);
 }
 
 pub fn unescaped_backtick_command_substitution_span(span: Span, source: &str) -> Option<Span> {
@@ -82,14 +106,26 @@ pub(crate) fn shellcheck_collapsed_backtick_part_span_in_source(span: Span, sour
 
 pub fn array_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_array_expansion_spans(&word.parts, false, false, &mut spans);
+    collect_array_expansion_part_spans(word, &mut spans);
     spans
+}
+
+pub fn collect_array_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
+    collect_array_expansion_spans(&word.parts, false, false, spans);
 }
 
 pub fn all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_all_elements_array_expansion_spans(&word.parts, source, &mut spans);
+    collect_all_elements_array_expansion_part_spans(word, source, &mut spans);
     spans
+}
+
+pub fn collect_all_elements_array_expansion_part_spans(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_all_elements_array_expansion_spans(&word.parts, source, spans);
 }
 
 pub fn word_has_all_elements_array_expansion_syntax(word: &Word) -> bool {
@@ -98,14 +134,30 @@ pub fn word_has_all_elements_array_expansion_syntax(word: &Word) -> bool {
 
 pub fn direct_all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_direct_all_elements_array_expansion_spans(&word.parts, source, &mut spans);
+    collect_direct_all_elements_array_expansion_part_spans(word, source, &mut spans);
     spans
+}
+
+pub fn collect_direct_all_elements_array_expansion_part_spans(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_direct_all_elements_array_expansion_spans(&word.parts, source, spans);
 }
 
 pub fn unquoted_all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_unquoted_all_elements_array_expansion_spans(&word.parts, false, source, &mut spans);
+    collect_unquoted_all_elements_array_expansion_part_spans(word, source, &mut spans);
     spans
+}
+
+pub fn collect_unquoted_all_elements_array_expansion_part_spans(
+    word: &Word,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_unquoted_all_elements_array_expansion_spans(&word.parts, false, source, spans);
 }
 
 pub fn word_all_elements_array_slice_spans(word: &Word) -> Vec<Span> {
@@ -142,8 +194,12 @@ pub fn word_quoted_unindexed_bash_source_span_in_source(word: &Word, source: &st
 
 pub fn unquoted_array_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_array_expansion_spans(&word.parts, false, true, &mut spans);
+    collect_unquoted_array_expansion_part_spans(word, &mut spans);
     spans
+}
+
+pub fn collect_unquoted_array_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
+    collect_array_expansion_spans(&word.parts, false, true, spans);
 }
 
 pub fn expansion_part_spans(word: &Word) -> Vec<Span> {
@@ -153,10 +209,14 @@ pub fn expansion_part_spans(word: &Word) -> Vec<Span> {
 }
 
 pub fn active_expansion_spans_in_source(word: &Word, source: &str) -> Vec<Span> {
-    let mut spans = expansion_part_spans(word)
-        .into_iter()
-        .map(|span| normalize_command_substitution_span(span, source))
-        .collect::<Vec<_>>();
+    let mut spans = Vec::new();
+    collect_active_expansion_spans_in_source(word, source, &mut spans);
+    spans
+}
+
+pub fn collect_active_expansion_spans_in_source(word: &Word, source: &str, spans: &mut Vec<Span>) {
+    collect_expansion_spans(&word.parts, spans);
+    normalize_command_substitution_spans(spans, source);
     spans.extend(
         word.brace_syntax()
             .iter()
@@ -166,19 +226,26 @@ pub fn active_expansion_spans_in_source(word: &Word, source: &str) -> Vec<Span> 
     );
     spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
     spans.dedup();
-    spans
 }
 
 pub fn scalar_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_scalar_expansion_spans(&word.parts, false, false, &mut spans);
+    collect_scalar_expansion_part_spans(word, &mut spans);
     spans
+}
+
+pub fn collect_scalar_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
+    collect_scalar_expansion_spans(&word.parts, false, false, spans);
 }
 
 pub fn unquoted_scalar_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_scalar_expansion_spans(&word.parts, false, true, &mut spans);
+    collect_unquoted_scalar_expansion_part_spans(word, &mut spans);
     spans
+}
+
+pub fn collect_unquoted_scalar_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
+    collect_scalar_expansion_spans(&word.parts, false, true, spans);
 }
 
 pub fn double_quoted_scalar_affix_span(word: &Word) -> Option<Span> {
@@ -1477,6 +1544,12 @@ fn normalize_command_substitution_span(span: Span, source: &str) -> Span {
     }
 
     span
+}
+
+fn normalize_command_substitution_spans(spans: &mut [Span], source: &str) {
+    for span in spans {
+        *span = normalize_command_substitution_span(*span, source);
+    }
 }
 
 fn collapse_backtick_continuation_span(

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2853,6 +2853,17 @@ fn mixed_quote_following_line_join_between_double_quotes_span(
     word: &Word,
     source: &str,
 ) -> Option<Span> {
+    let suffix = mixed_quote_following_line_join_suffix_after_word(word, source)?;
+    Some(Span::from_positions(
+        word.span.end,
+        word.span.end.advanced_by(suffix),
+    ))
+}
+
+fn mixed_quote_following_line_join_suffix_after_word(
+    word: &Word,
+    source: &str,
+) -> Option<&'static str> {
     if !matches!(
         word.parts.first().map(|part| &part.kind),
         Some(WordPart::DoubleQuoted { .. })
@@ -2860,22 +2871,17 @@ fn mixed_quote_following_line_join_between_double_quotes_span(
         return None;
     }
 
+    let tail = &source[word.span.end.offset..];
+    let suffix = tail
+        .strip_prefix("\\\r\n\"")
+        .map(|_| "\\\r\n")
+        .or_else(|| tail.strip_prefix("\\\n\"").map(|_| "\\\n"))?;
+
     if !mixed_quote_text_ends_with_unescaped_double_quote(word.span.slice(source)) {
         return None;
     }
 
-    let suffix = source[word.span.end.offset..]
-        .strip_prefix("\\\r\n\"")
-        .map(|_| "\\\r\n")
-        .or_else(|| {
-            source[word.span.end.offset..]
-                .strip_prefix("\\\n\"")
-                .map(|_| "\\\n")
-        })?;
-    Some(Span::from_positions(
-        word.span.end,
-        word.span.end.advanced_by(suffix),
-    ))
+    Some(suffix)
 }
 
 fn mixed_quote_chained_line_join_between_double_quotes_spans(
@@ -3511,7 +3517,7 @@ fn word_may_have_unquoted_literal_between_double_quoted_segments_spans(
     word: &Word,
     source: &str,
 ) -> bool {
-    word.parts.windows(3).any(|window| {
+    let has_reopened_literal = word.parts.windows(3).any(|window| {
         matches!(
             window,
             [
@@ -3529,11 +3535,22 @@ fn word_may_have_unquoted_literal_between_double_quoted_segments_spans(
                 },
             ]
         )
-    }) || (matches!(
+    });
+    if has_reopened_literal {
+        return true;
+    }
+
+    if !matches!(
         word.parts.first().map(|part| &part.kind),
         Some(WordPart::DoubleQuoted { .. })
-    ) && word.span.slice(source).contains("\\\n"))
-        || word.span.slice(source).contains("\\\r\n")
+    ) {
+        return false;
+    }
+
+    let text = word.span.slice(source);
+    text.contains("\\\n")
+        || text.contains("\\\r\n")
+        || mixed_quote_following_line_join_suffix_after_word(word, source).is_some()
 }
 
 fn borrowed_static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<&'a str> {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1268,12 +1268,17 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.occurrence().operand_class
     }
 
-    pub fn static_text(self) -> Option<&'a str> {
-        self.derived().static_text
+    pub fn static_text(self) -> Option<Cow<'a, str>> {
+        self.static_text_from_source(self.facts.source)
     }
 
     pub fn static_text_cow(self, source: &'a str) -> Option<Cow<'a, str>> {
-        self.static_text()
+        self.static_text_from_source(source)
+    }
+
+    fn static_text_from_source(self, source: &'a str) -> Option<Cow<'a, str>> {
+        self.derived()
+            .static_text
             .map(Cow::Borrowed)
             .or_else(|| static_word_text(self.word(), source))
     }
@@ -2088,30 +2093,26 @@ fn text_contains_echo_backslash_escape(text: &str, is_sensitive: fn(u8) -> bool)
     false
 }
 
+#[derive(Clone, Copy)]
+struct WordFactLookup<'facts, 'a> {
+    nodes: &'facts [WordNode<'a>],
+    occurrences: &'facts [WordOccurrence],
+    word_index: &'facts FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+    fact_store: &'facts FactStore<'a>,
+    source: &'a str,
+}
+
 fn build_echo_to_sed_substitution_spans<'a>(
     commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
     backticks: &[BacktickFragmentFact],
-    nodes: &[WordNode<'a>],
-    occurrences: &[WordOccurrence],
-    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
-    fact_store: &FactStore<'a>,
-    source: &str,
+    lookup: WordFactLookup<'_, 'a>,
 ) -> Vec<Span> {
     let mut spans = Vec::new();
     let mut pipeline_sed_command_ids = FxHashSet::default();
 
     for pipeline in pipelines {
-        if let Some(span) = sc2001_like_pipeline_span(
-            commands,
-            pipeline,
-            backticks,
-            nodes,
-            occurrences,
-            word_index,
-            fact_store,
-            source,
-        ) {
+        if let Some(span) = sc2001_like_pipeline_span(commands, pipeline, backticks, lookup) {
             spans.push(span);
             if let Some(last_segment) = pipeline.last_segment() {
                 pipeline_sed_command_ids.insert(last_segment.command_id());
@@ -2121,7 +2122,7 @@ fn build_echo_to_sed_substitution_spans<'a>(
 
     spans.extend(commands.iter().filter_map(|command| {
         (!pipeline_sed_command_ids.contains(&command.id()))
-            .then(|| sc2001_like_here_string_span(command, backticks, source))
+            .then(|| sc2001_like_here_string_span(command, backticks, lookup.source))
             .flatten()
     }));
 
@@ -2133,11 +2134,7 @@ fn sc2001_like_pipeline_span<'a>(
     commands: CommandFacts<'_, 'a>,
     pipeline: &PipelineFact<'a>,
     backticks: &[BacktickFragmentFact],
-    nodes: &[WordNode<'a>],
-    occurrences: &[WordOccurrence],
-    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
-    fact_store: &FactStore<'a>,
-    source: &str,
+    lookup: WordFactLookup<'_, 'a>,
 ) -> Option<Span> {
     let [left_segment, right_segment] = pipeline.segments() else {
         return None;
@@ -2159,7 +2156,7 @@ fn sc2001_like_pipeline_span<'a>(
         return None;
     }
 
-    if !command_has_sc2001_like_sed_script(right, backticks, source) {
+    if !command_has_sc2001_like_sed_script(right, backticks, lookup.source) {
         return None;
     }
 
@@ -2168,18 +2165,18 @@ fn sc2001_like_pipeline_span<'a>(
     };
 
     let word_fact = word_occurrence_with_context(
-        nodes,
-        occurrences,
-        word_index,
+        lookup.nodes,
+        lookup.occurrences,
+        lookup.word_index,
         argument.span,
         WordFactContext::Expansion(ExpansionContext::CommandArgument),
     )?;
 
-    if occurrence_static_text(nodes, word_fact, source).is_some() {
+    if occurrence_static_text(lookup.nodes, word_fact, lookup.source).is_some() {
         return None;
     }
 
-    let derived = word_node_derived(&nodes[word_fact.node_id.index()]);
+    let derived = word_node_derived(&lookup.nodes[word_fact.node_id.index()]);
     if derived.scalar_expansion_spans.is_empty()
         && derived.array_expansion_spans.is_empty()
         && derived.command_substitution_spans.is_empty()
@@ -2188,21 +2185,31 @@ fn sc2001_like_pipeline_span<'a>(
     }
 
     if derived.has_literal_affixes
-        && !word_occurrence_is_pure_quoted_dynamic(nodes, word_fact, fact_store, source)
+        && !word_occurrence_is_pure_quoted_dynamic(
+            lookup.nodes,
+            word_fact,
+            lookup.fact_store,
+            lookup.source,
+        )
     {
         return None;
     }
 
     if command_is_inside_backtick_fragment(right, backticks)
         && word_occurrence_is_backtick_escaped_double_quoted_dynamic(
-            nodes, word_fact, fact_store, source,
+            lookup.nodes,
+            word_fact,
+            lookup.fact_store,
+            lookup.source,
         )
     {
-        return sc2001_like_backtick_pipeline_span(commands, pipeline, right, source);
+        return sc2001_like_backtick_pipeline_span(commands, pipeline, right, lookup.source);
     }
 
     Some(pipeline_span_with_shellcheck_tail(
-        commands, pipeline, source,
+        commands,
+        pipeline,
+        lookup.source,
     ))
 }
 

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1058,29 +1058,29 @@ pub struct WordNode<'a> {
     key: FactSpan,
     word: &'a Word,
     analysis: ExpansionAnalysis,
-    derived: OnceCell<WordNodeDerived>,
+    derived: WordNodeDerived<'a>,
 }
 
 #[derive(Debug)]
-pub(crate) struct WordNodeDerived {
-    static_text: Option<Box<str>>,
+pub(crate) struct WordNodeDerived<'a> {
+    static_text: Option<&'a str>,
     trailing_literal_char: Option<char>,
     starts_with_extglob: bool,
     has_literal_affixes: bool,
     contains_shell_quoting_literals: bool,
-    active_expansion_spans: Box<[Span]>,
-    scalar_expansion_spans: Box<[Span]>,
-    unquoted_scalar_expansion_spans: Box<[Span]>,
-    array_expansion_spans: Box<[Span]>,
-    all_elements_array_expansion_spans: Box<[Span]>,
-    direct_all_elements_array_expansion_spans: Box<[Span]>,
-    unquoted_all_elements_array_expansion_spans: Box<[Span]>,
-    unquoted_array_expansion_spans: Box<[Span]>,
-    command_substitution_spans: Box<[Span]>,
-    unquoted_command_substitution_spans: Box<[Span]>,
-    unquoted_dollar_paren_command_substitution_spans: Box<[Span]>,
-    double_quoted_expansion_spans: Box<[Span]>,
-    unquoted_literal_between_double_quoted_segments_spans: Box<[Span]>,
+    active_expansion_spans: IdRange<Span>,
+    scalar_expansion_spans: IdRange<Span>,
+    unquoted_scalar_expansion_spans: IdRange<Span>,
+    array_expansion_spans: IdRange<Span>,
+    all_elements_array_expansion_spans: IdRange<Span>,
+    direct_all_elements_array_expansion_spans: IdRange<Span>,
+    unquoted_all_elements_array_expansion_spans: IdRange<Span>,
+    unquoted_array_expansion_spans: IdRange<Span>,
+    command_substitution_spans: IdRange<Span>,
+    unquoted_command_substitution_spans: IdRange<Span>,
+    unquoted_dollar_paren_command_substitution_spans: IdRange<Span>,
+    double_quoted_expansion_spans: IdRange<Span>,
+    unquoted_literal_between_double_quoted_segments_spans: IdRange<Span>,
 }
 
 #[derive(Debug)]
@@ -1093,7 +1093,7 @@ pub struct WordOccurrence {
     runtime_literal: RuntimeLiteralAnalysis,
     operand_class: Option<TestOperandClass>,
     enclosing_expansion_context: Option<ExpansionContext>,
-    array_assignment_split_scalar_expansion_spans: OnceCell<Box<[Span]>>,
+    array_assignment_split_scalar_expansion_spans: IdRange<Span>,
 }
 
 #[derive(Clone, Copy)]
@@ -1195,7 +1195,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.facts.word_node(self.occurrence().node_id)
     }
 
-    fn derived(self) -> &'facts WordNodeDerived {
+    fn derived(self) -> &'facts WordNodeDerived<'a> {
         self.facts.word_node_derived(self.occurrence().node_id)
     }
 
@@ -1268,8 +1268,14 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.occurrence().operand_class
     }
 
-    pub fn static_text(self) -> Option<&'facts str> {
-        self.derived().static_text.as_deref()
+    pub fn static_text(self) -> Option<&'a str> {
+        self.derived().static_text
+    }
+
+    pub fn static_text_cow(self, source: &'a str) -> Option<Cow<'a, str>> {
+        self.static_text()
+            .map(Cow::Borrowed)
+            .or_else(|| static_word_text(self.word(), source))
     }
 
     pub fn trailing_literal_char(self) -> Option<char> {
@@ -1317,63 +1323,75 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     }
 
     pub fn active_expansion_spans(self) -> &'facts [Span] {
-        &self.derived().active_expansion_spans
+        self.facts.fact_store.word_spans(self.derived().active_expansion_spans)
     }
 
     pub fn scalar_expansion_spans(self) -> &'facts [Span] {
-        &self.derived().scalar_expansion_spans
+        self.facts.fact_store.word_spans(self.derived().scalar_expansion_spans)
     }
 
     pub fn unquoted_scalar_expansion_spans(self) -> &'facts [Span] {
-        &self.derived().unquoted_scalar_expansion_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().unquoted_scalar_expansion_spans)
     }
 
     pub fn array_assignment_split_scalar_expansion_spans(self) -> &'facts [Span] {
-        self.occurrence()
-            .array_assignment_split_scalar_expansion_spans
-            .get_or_init(|| {
-                self.facts
-                    .compute_array_assignment_split_scalar_expansion_spans(self.id)
-            })
-            .as_ref()
+        self.facts
+            .fact_store
+            .word_spans(self.occurrence().array_assignment_split_scalar_expansion_spans)
     }
 
     pub fn array_expansion_spans(self) -> &'facts [Span] {
-        &self.derived().array_expansion_spans
+        self.facts.fact_store.word_spans(self.derived().array_expansion_spans)
     }
 
     pub fn all_elements_array_expansion_spans(self) -> &'facts [Span] {
-        &self.derived().all_elements_array_expansion_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().all_elements_array_expansion_spans)
     }
 
     pub fn direct_all_elements_array_expansion_spans(self) -> &'facts [Span] {
-        &self.derived().direct_all_elements_array_expansion_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().direct_all_elements_array_expansion_spans)
     }
 
     pub fn unquoted_all_elements_array_expansion_spans(self) -> &'facts [Span] {
-        &self.derived().unquoted_all_elements_array_expansion_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().unquoted_all_elements_array_expansion_spans)
     }
 
     pub fn unquoted_array_expansion_spans(self) -> &'facts [Span] {
-        &self.derived().unquoted_array_expansion_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().unquoted_array_expansion_spans)
     }
 
     pub fn command_substitution_spans(self) -> &'facts [Span] {
-        &self.derived().command_substitution_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().command_substitution_spans)
     }
 
     pub fn unquoted_command_substitution_spans(self) -> &'facts [Span] {
-        &self.derived().unquoted_command_substitution_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().unquoted_command_substitution_spans)
     }
 
     pub fn unquoted_dollar_paren_command_substitution_spans(self) -> &'facts [Span] {
-        &self
-            .derived()
-            .unquoted_dollar_paren_command_substitution_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().unquoted_dollar_paren_command_substitution_spans)
     }
 
     pub fn double_quoted_expansion_spans(self) -> &'facts [Span] {
-        &self.derived().double_quoted_expansion_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().double_quoted_expansion_spans)
     }
 
     pub fn single_quoted_equivalent_if_plain_double_quoted(self, source: &str) -> Option<String> {
@@ -1381,9 +1399,9 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     }
 
     pub fn unquoted_literal_between_double_quoted_segments_spans(self) -> &'facts [Span] {
-        &self
-            .derived()
-            .unquoted_literal_between_double_quoted_segments_spans
+        self.facts
+            .fact_store
+            .word_spans(self.derived().unquoted_literal_between_double_quoted_segments_spans)
     }
 
     pub fn has_single_part(self) -> bool {
@@ -1577,9 +1595,10 @@ pub(crate) fn occurrence_analysis(
     nodes[occurrence.node_id.index()].analysis
 }
 
-pub(crate) fn word_node_derived<'a>(node: &'a WordNode<'_>, source: &str) -> &'a WordNodeDerived {
-    node.derived
-        .get_or_init(|| derive_word_fact_data(node.word, source))
+pub(crate) fn word_node_derived<'node, 'word>(
+    node: &'node WordNode<'word>,
+) -> &'node WordNodeDerived<'word> {
+    &node.derived
 }
 
 fn word_is_plain_scalar_reference(word: &Word) -> bool {
@@ -1687,6 +1706,7 @@ fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source: &str) -> 
 
 fn build_alias_definition_expansion_spans(
     commands: &[CommandFact<'_>],
+    fact_store: &FactStore<'_>,
     nodes: &[WordNode<'_>],
     occurrences: &[WordOccurrence],
     word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
@@ -1712,8 +1732,9 @@ fn build_alias_definition_expansion_spans(
                         })
                 })
                 .flat_map(|fact| {
-                    word_node_derived(&nodes[fact.node_id.index()], source)
-                        .active_expansion_spans
+                    let derived = word_node_derived(&nodes[fact.node_id.index()]);
+                    fact_store
+                        .word_spans(derived.active_expansion_spans)
                         .iter()
                         .copied()
                 })
@@ -2074,6 +2095,7 @@ fn build_echo_to_sed_substitution_spans<'a>(
     nodes: &[WordNode<'a>],
     occurrences: &[WordOccurrence],
     word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+    fact_store: &FactStore<'a>,
     source: &str,
 ) -> Vec<Span> {
     let mut spans = Vec::new();
@@ -2087,6 +2109,7 @@ fn build_echo_to_sed_substitution_spans<'a>(
             nodes,
             occurrences,
             word_index,
+            fact_store,
             source,
         ) {
             spans.push(span);
@@ -2113,6 +2136,7 @@ fn sc2001_like_pipeline_span<'a>(
     nodes: &[WordNode<'a>],
     occurrences: &[WordOccurrence],
     word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+    fact_store: &FactStore<'a>,
     source: &str,
 ) -> Option<Span> {
     let [left_segment, right_segment] = pipeline.segments() else {
@@ -2155,7 +2179,7 @@ fn sc2001_like_pipeline_span<'a>(
         return None;
     }
 
-    let derived = word_node_derived(&nodes[word_fact.node_id.index()], source);
+    let derived = word_node_derived(&nodes[word_fact.node_id.index()]);
     if derived.scalar_expansion_spans.is_empty()
         && derived.array_expansion_spans.is_empty()
         && derived.command_substitution_spans.is_empty()
@@ -2164,13 +2188,15 @@ fn sc2001_like_pipeline_span<'a>(
     }
 
     if derived.has_literal_affixes
-        && !word_occurrence_is_pure_quoted_dynamic(nodes, word_fact, source)
+        && !word_occurrence_is_pure_quoted_dynamic(nodes, word_fact, fact_store, source)
     {
         return None;
     }
 
     if command_is_inside_backtick_fragment(right, backticks)
-        && word_occurrence_is_backtick_escaped_double_quoted_dynamic(nodes, word_fact, source)
+        && word_occurrence_is_backtick_escaped_double_quoted_dynamic(
+            nodes, word_fact, fact_store, source,
+        )
     {
         return sc2001_like_backtick_pipeline_span(commands, pipeline, right, source);
     }
@@ -2395,70 +2421,79 @@ fn word_occurrence_with_context<'a>(
 pub(crate) fn occurrence_static_text<'a>(
     nodes: &'a [WordNode<'a>],
     occurrence: &WordOccurrence,
-    source: &str,
-) -> Option<&'a str> {
-    word_node_derived(&nodes[occurrence.node_id.index()], source)
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    let node = &nodes[occurrence.node_id.index()];
+    word_node_derived(node)
         .static_text
-        .as_deref()
+        .map(Cow::Borrowed)
+        .or_else(|| static_word_text(node.word, source))
 }
 
-pub(crate) fn word_occurrence_is_pure_quoted_dynamic(
+fn word_occurrence_is_pure_quoted_dynamic(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
+    fact_store: &FactStore<'_>,
     source: &str,
 ) -> bool {
     let word = occurrence_word(nodes, fact);
     !word_spans::word_double_quoted_scalar_only_expansion_spans(word).is_empty()
         || !word_spans::word_quoted_all_elements_array_slice_spans(word).is_empty()
-        || word_occurrence_is_double_quoted_command_substitution_only(nodes, fact, source)
-        || word_occurrence_is_backtick_escaped_double_quoted_dynamic(nodes, fact, source)
+        || word_occurrence_is_double_quoted_command_substitution_only(
+            nodes, fact, fact_store, source,
+        )
+        || word_occurrence_is_backtick_escaped_double_quoted_dynamic(
+            nodes, fact, fact_store, source,
+        )
 }
 
-fn build_unquoted_literal_between_double_quoted_segments_spans(
+fn collect_unquoted_literal_between_double_quoted_segments_spans(
     word: &Word,
     source: &str,
-) -> Vec<Span> {
-    let nested_fragment_parts = mixed_quote_word_parts_inside_nested_shell_fragments(word, source);
+    spans: &mut Vec<Span>,
+) {
+    let mut command_depth = 0i32;
+    let mut parameter_depth = 0i32;
 
-    let mut spans = word
-        .parts
-        .windows(3)
-        .enumerate()
-        .filter_map(|(window_index, window)| {
-            let [left, middle, right] = window else {
-                return None;
-            };
-            let WordPart::DoubleQuoted {
-                parts: left_inner, ..
-            } = &left.kind
-            else {
-                return None;
-            };
-            let WordPart::Literal(text) = &middle.kind else {
-                return None;
-            };
-            let WordPart::DoubleQuoted {
-                parts: right_inner, ..
-            } = &right.kind
-            else {
-                return None;
-            };
+    for index in 0..word.parts.len() {
+        let middle_is_nested = command_depth > 0 || parameter_depth > 0;
 
-            let neighbor_has_literal =
-                mixed_quote_double_quoted_parts_contain_literal_content(left_inner)
-                    || mixed_quote_double_quoted_parts_contain_literal_content(right_inner);
-            let middle_is_nested = nested_fragment_parts
-                .get(window_index + 1)
-                .copied()
-                .unwrap_or(false);
-            (neighbor_has_literal
-                && !middle_is_nested
-                && mixed_quote_literal_is_warnable_between_double_quotes(
-                    text.as_str(source, middle.span),
-                ))
-            .then_some(middle.span)
-        })
-        .collect::<Vec<_>>();
+        if index > 0 && index + 1 < word.parts.len() {
+            let left = &word.parts[index - 1];
+            let middle = &word.parts[index];
+            let right = &word.parts[index + 1];
+
+            if let (
+                WordPart::DoubleQuoted {
+                    parts: left_inner, ..
+                },
+                WordPart::Literal(text),
+                WordPart::DoubleQuoted {
+                    parts: right_inner, ..
+                },
+            ) = (&left.kind, &middle.kind, &right.kind)
+            {
+                let neighbor_has_literal =
+                    mixed_quote_double_quoted_parts_contain_literal_content(left_inner)
+                        || mixed_quote_double_quoted_parts_contain_literal_content(right_inner);
+                if neighbor_has_literal
+                    && !middle_is_nested
+                    && mixed_quote_literal_is_warnable_between_double_quotes(
+                        text.as_str(source, middle.span),
+                    )
+                {
+                    spans.push(middle.span);
+                }
+            }
+        }
+
+        let (command_delta, parameter_delta) =
+            mixed_quote_shell_fragment_balance_delta_for_part(&word.parts[index], source);
+        command_depth += command_delta;
+        parameter_depth += parameter_delta;
+        command_depth = command_depth.max(0);
+        parameter_depth = parameter_depth.max(0);
+    }
 
     for span in mixed_quote_line_join_between_double_quotes_spans(word, source) {
         if !spans.contains(&span) {
@@ -2483,8 +2518,6 @@ fn build_unquoted_literal_between_double_quoted_segments_spans(
     {
         spans.push(span);
     }
-
-    spans
 }
 
 fn mixed_quote_double_quoted_parts_contain_literal_content(parts: &[WordPartNode]) -> bool {
@@ -2561,25 +2594,6 @@ fn mixed_quote_literal_has_shellcheck_skipped_word_operator(text: &str) -> bool 
     text.contains('+') || text.contains('@')
 }
 
-fn mixed_quote_word_parts_inside_nested_shell_fragments(word: &Word, source: &str) -> Vec<bool> {
-    let mut command_depth = 0i32;
-    let mut parameter_depth = 0i32;
-    let mut nested = Vec::with_capacity(word.parts.len());
-
-    for part in &word.parts {
-        nested.push(command_depth > 0 || parameter_depth > 0);
-
-        let (command_delta, parameter_delta) =
-            mixed_quote_shell_fragment_balance_delta_for_part(part, source);
-        command_depth += command_delta;
-        parameter_depth += parameter_delta;
-        command_depth = command_depth.max(0);
-        parameter_depth = parameter_depth.max(0);
-    }
-
-    nested
-}
-
 fn mixed_quote_shell_fragment_balance_delta_for_part(
     part: &WordPartNode,
     source: &str,
@@ -2628,8 +2642,8 @@ fn mixed_quote_shell_fragment_balance_delta(
     let mut in_single_quotes = false;
     let mut in_double_quotes = false;
     let mut in_comment = false;
-    let mut command_frames = Vec::new();
-    let mut parameter_frames = Vec::new();
+    let mut command_frames = SmallVec::<[MixedQuoteShellParenFrame; 4]>::new();
+    let mut parameter_frames = SmallVec::<[bool; 4]>::new();
     let mut previous_char = None;
 
     while let Some(ch) = chars.next() {
@@ -2912,8 +2926,8 @@ fn mixed_quote_closing_double_quote_offset(text: &str) -> Option<usize> {
     let mut escaped = false;
     let mut command_depth = 0i32;
     let mut parameter_depth = 0i32;
-    let mut command_frames = Vec::new();
-    let mut parameter_frames = Vec::new();
+    let mut command_frames = SmallVec::<[MixedQuoteShellParenFrame; 4]>::new();
+    let mut parameter_frames = SmallVec::<[bool; 4]>::new();
     let mut in_backtick_command = false;
     let mut in_single_quotes = false;
     let mut in_double_quotes = false;
@@ -3063,13 +3077,15 @@ fn mixed_quote_text_ends_with_unescaped_double_quote(text: &str) -> bool {
     backslash_count % 2 == 0
 }
 
-pub(crate) fn word_occurrence_is_double_quoted_command_substitution_only(
+fn word_occurrence_is_double_quoted_command_substitution_only(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
+    fact_store: &FactStore<'_>,
     source: &str,
 ) -> bool {
-    let derived = word_node_derived(&nodes[fact.node_id.index()], source);
-    let [command_substitution] = derived.command_substitution_spans.as_ref() else {
+    let derived = word_node_derived(&nodes[fact.node_id.index()]);
+    let command_substitution_spans = fact_store.word_spans(derived.command_substitution_spans);
+    let [command_substitution] = command_substitution_spans else {
         return false;
     };
 
@@ -3084,12 +3100,13 @@ pub(crate) fn word_occurrence_is_double_quoted_command_substitution_only(
         && &word_text[1..word_text.len() - 1] == command_substitution.slice(source)
 }
 
-pub(crate) fn word_occurrence_is_backtick_escaped_double_quoted_dynamic(
+fn word_occurrence_is_backtick_escaped_double_quoted_dynamic(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
+    fact_store: &FactStore<'_>,
     source: &str,
 ) -> bool {
-    let derived = word_node_derived(&nodes[fact.node_id.index()], source);
+    let derived = word_node_derived(&nodes[fact.node_id.index()]);
     let word_text = occurrence_span(nodes, fact).slice(source);
     if !word_text.starts_with("\\\"") || !word_text.ends_with("\\\"") {
         return false;
@@ -3097,9 +3114,9 @@ pub(crate) fn word_occurrence_is_backtick_escaped_double_quoted_dynamic(
 
     let inner = &word_text[2..word_text.len() - 2];
     match (
-        derived.scalar_expansion_spans.as_ref(),
-        derived.array_expansion_spans.as_ref(),
-        derived.command_substitution_spans.as_ref(),
+        fact_store.word_spans(derived.scalar_expansion_spans),
+        fact_store.word_spans(derived.array_expansion_spans),
+        fact_store.word_spans(derived.command_substitution_spans),
     ) {
         ([scalar], [], []) => inner == scalar.slice(source),
         ([], [array], []) => inner == array.slice(source),
@@ -3200,6 +3217,8 @@ pub(crate) fn benchmark_collect_word_facts(
     let mut pending_arithmetic_word_occurrences = Vec::new();
     let mut compound_assignment_value_word_spans = FxHashSet::default();
     let mut array_assignment_split_word_ids = Vec::new();
+    let mut word_spans = ListArena::new();
+    let mut word_span_scratch = Vec::new();
     let mut assoc_binding_visibility_memo = FxHashMap::default();
     let mut case_pattern_expansions = Vec::new();
     let mut pattern_literal_spans = Vec::new();
@@ -3236,6 +3255,8 @@ pub(crate) fn benchmark_collect_word_facts(
                     pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
                     compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
                     array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
+                    word_spans: &mut word_spans,
+                    word_span_scratch: &mut word_span_scratch,
                     assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
                     case_pattern_expansions: &mut case_pattern_expansions,
                     pattern_literal_spans: &mut pattern_literal_spans,
@@ -3278,6 +3299,8 @@ struct WordFactCommandContext {
 
 struct WordFactOutputs<'out, 'a> {
     word_nodes: &'out mut Vec<WordNode<'a>>,
+    word_spans: &'out mut ListArena<Span>,
+    word_span_scratch: &'out mut Vec<Span>,
     word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
     word_occurrences: &'out mut Vec<WordOccurrence>,
     pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
@@ -3298,53 +3321,235 @@ struct PendingArithmeticWordOccurrence {
     enclosing_expansion_context: ExpansionContext,
 }
 
-fn derive_word_fact_data(word: &Word, source: &str) -> WordNodeDerived {
+fn derive_word_fact_data<'a>(
+    word: &'a Word,
+    source: &'a str,
+    span_store: &mut ListArena<Span>,
+    scratch: &mut Vec<Span>,
+) -> WordNodeDerived<'a> {
+    let may_have_runtime_expansion_spans = word_may_have_runtime_expansion_spans(word);
+    let may_have_command_substitution_spans = word_may_have_command_substitution_spans(word);
+    let may_have_mixed_quote_spans =
+        word_may_have_unquoted_literal_between_double_quoted_segments_spans(word, source);
+
     WordNodeDerived {
-        static_text: static_word_text(word, source).map(|text| text.into_owned().into_boxed_str()),
+        static_text: borrowed_static_word_text(word, source),
         trailing_literal_char: word_trailing_literal_char(word, source),
         starts_with_extglob: word_spans::word_starts_with_extglob(word, source),
         has_literal_affixes: word_has_literal_affixes(word),
         contains_shell_quoting_literals: word_contains_shell_quoting_literals(word, source),
-        active_expansion_spans: word_spans::active_expansion_spans_in_source(word, source)
-            .into_boxed_slice(),
-        scalar_expansion_spans: word_spans::scalar_expansion_part_spans(word, source)
-            .into_boxed_slice(),
-        unquoted_scalar_expansion_spans: word_spans::unquoted_scalar_expansion_part_spans(
-            word, source,
+        active_expansion_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_runtime_expansion_spans || word.has_active_brace_expansion(),
+            |spans| {
+                word_spans::collect_active_expansion_spans_in_source(word, source, spans);
+            },
+        ),
+        scalar_expansion_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_runtime_expansion_spans,
+            |spans| {
+                word_spans::collect_scalar_expansion_part_spans(word, spans);
+            },
+        ),
+        unquoted_scalar_expansion_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_runtime_expansion_spans,
+            |spans| {
+                word_spans::collect_unquoted_scalar_expansion_part_spans(word, spans);
+            },
+        ),
+        array_expansion_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_runtime_expansion_spans,
+            |spans| {
+                word_spans::collect_array_expansion_part_spans(word, spans);
+            },
+        ),
+        all_elements_array_expansion_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_runtime_expansion_spans,
+            |spans| {
+                word_spans::collect_all_elements_array_expansion_part_spans(word, source, spans);
+            },
+        ),
+        direct_all_elements_array_expansion_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_runtime_expansion_spans,
+            |spans| {
+                word_spans::collect_direct_all_elements_array_expansion_part_spans(
+                    word, source, spans,
+                );
+            },
+        ),
+        unquoted_all_elements_array_expansion_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_runtime_expansion_spans,
+            |spans| {
+                word_spans::collect_unquoted_all_elements_array_expansion_part_spans(
+                    word, source, spans,
+                );
+            },
+        ),
+        unquoted_array_expansion_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_runtime_expansion_spans,
+            |spans| {
+                word_spans::collect_unquoted_array_expansion_part_spans(word, spans);
+            },
+        ),
+        command_substitution_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_command_substitution_spans,
+            |spans| {
+                word_spans::collect_command_substitution_part_spans_in_source(word, source, spans);
+            },
+        ),
+        unquoted_command_substitution_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_command_substitution_spans,
+            |spans| {
+                word_spans::collect_unquoted_command_substitution_part_spans_in_source(
+                    word, source, spans,
+                );
+            },
+        ),
+        unquoted_dollar_paren_command_substitution_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_command_substitution_spans,
+            |spans| {
+                word_spans::collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
+                    word, source, spans,
+                );
+            },
+        ),
+        double_quoted_expansion_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_runtime_expansion_spans,
+            |spans| {
+                collect_double_quoted_expansion_part_spans(word, spans);
+            },
+        ),
+        unquoted_literal_between_double_quoted_segments_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            may_have_mixed_quote_spans,
+            |spans| {
+                collect_unquoted_literal_between_double_quoted_segments_spans(word, source, spans);
+            },
+        ),
+    }
+}
+
+fn push_word_span_list(
+    span_store: &mut ListArena<Span>,
+    scratch: &mut Vec<Span>,
+    collect: impl FnOnce(&mut Vec<Span>),
+) -> IdRange<Span> {
+    scratch.clear();
+    collect(scratch);
+    span_store.push_many(scratch.drain(..))
+}
+
+fn push_needed_word_span_list(
+    span_store: &mut ListArena<Span>,
+    scratch: &mut Vec<Span>,
+    needed: bool,
+    collect: impl FnOnce(&mut Vec<Span>),
+) -> IdRange<Span> {
+    if needed {
+        push_word_span_list(span_store, scratch, collect)
+    } else {
+        IdRange::empty()
+    }
+}
+
+fn word_may_have_runtime_expansion_spans(word: &Word) -> bool {
+    word_parts_may_have_runtime_expansion_spans(&word.parts)
+}
+
+fn word_parts_may_have_runtime_expansion_spans(parts: &[WordPartNode]) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Literal(_) | WordPart::SingleQuoted { .. } => false,
+        WordPart::DoubleQuoted { parts, .. } => word_parts_may_have_runtime_expansion_spans(parts),
+        _ => true,
+    })
+}
+
+fn word_may_have_command_substitution_spans(word: &Word) -> bool {
+    word_parts_may_have_command_substitution_spans(&word.parts)
+}
+
+fn word_parts_may_have_command_substitution_spans(parts: &[WordPartNode]) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::DoubleQuoted { parts, .. } => word_parts_may_have_command_substitution_spans(parts),
+        WordPart::CommandSubstitution { .. } => true,
+        _ => false,
+    })
+}
+
+fn word_may_have_unquoted_literal_between_double_quoted_segments_spans(
+    word: &Word,
+    source: &str,
+) -> bool {
+    word.parts.windows(3).any(|window| {
+        matches!(
+            window,
+            [
+                WordPartNode {
+                    kind: WordPart::DoubleQuoted { .. },
+                    ..
+                },
+                WordPartNode {
+                    kind: WordPart::Literal(_),
+                    ..
+                },
+                WordPartNode {
+                    kind: WordPart::DoubleQuoted { .. },
+                    ..
+                },
+            ]
         )
-        .into_boxed_slice(),
-        array_expansion_spans: word_spans::array_expansion_part_spans(word, source)
-            .into_boxed_slice(),
-        all_elements_array_expansion_spans: word_spans::all_elements_array_expansion_part_spans(
-            word, source,
-        )
-        .into_boxed_slice(),
-        direct_all_elements_array_expansion_spans:
-            word_spans::direct_all_elements_array_expansion_part_spans(word, source)
-                .into_boxed_slice(),
-        unquoted_all_elements_array_expansion_spans:
-            word_spans::unquoted_all_elements_array_expansion_part_spans(word, source)
-                .into_boxed_slice(),
-        unquoted_array_expansion_spans: word_spans::unquoted_array_expansion_part_spans(
-            word, source,
-        )
-        .into_boxed_slice(),
-        command_substitution_spans: word_spans::command_substitution_part_spans_in_source(
-            word, source,
-        )
-        .into_boxed_slice(),
-        unquoted_command_substitution_spans:
-            word_spans::unquoted_command_substitution_part_spans_in_source(word, source)
-                .into_boxed_slice(),
-        unquoted_dollar_paren_command_substitution_spans:
-            word_spans::unquoted_dollar_paren_command_substitution_part_spans_in_source(
-                word, source,
-            )
-            .into_boxed_slice(),
-        double_quoted_expansion_spans: double_quoted_expansion_part_spans(word).into_boxed_slice(),
-        unquoted_literal_between_double_quoted_segments_spans:
-            build_unquoted_literal_between_double_quoted_segments_spans(word, source)
-                .into_boxed_slice(),
+    }) || (matches!(
+        word.parts.first().map(|part| &part.kind),
+        Some(WordPart::DoubleQuoted { .. })
+    ) && word.span.slice(source).contains("\\\n"))
+        || word.span.slice(source).contains("\\\r\n")
+}
+
+fn borrowed_static_word_text<'a>(word: &'a Word, source: &'a str) -> Option<&'a str> {
+    let [part] = word.parts.as_slice() else {
+        return None;
+    };
+    borrowed_static_word_part_text(part, source)
+}
+
+fn borrowed_static_word_part_text<'a>(
+    part: &'a WordPartNode,
+    source: &'a str,
+) -> Option<&'a str> {
+    match &part.kind {
+        WordPart::Literal(text) => Some(text.as_str(source, part.span)),
+        WordPart::SingleQuoted { value, .. } => Some(value.slice(source)),
+        WordPart::DoubleQuoted { parts, .. } => {
+            let [part] = parts.as_slice() else {
+                return None;
+            };
+            borrowed_static_word_part_text(part, source)
+        }
+        _ => None,
     }
 }
 
@@ -3386,6 +3591,8 @@ struct WordFactCollector<'out, 'a, 'norm> {
     surface_command_name: Option<&'norm str>,
     command_zsh_options: Option<ZshOptionState>,
     word_nodes: &'out mut Vec<WordNode<'a>>,
+    word_spans: &'out mut ListArena<Span>,
+    word_span_scratch: &'out mut Vec<Span>,
     word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
     word_occurrences: &'out mut Vec<WordOccurrence>,
     pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
@@ -3437,6 +3644,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             surface_command_name: normalized.effective_or_literal_name(),
             command_zsh_options,
             word_nodes: outputs.word_nodes,
+            word_spans: outputs.word_spans,
+            word_span_scratch: outputs.word_span_scratch,
             word_node_ids_by_span: outputs.word_node_ids_by_span,
             word_occurrences: outputs.word_occurrences,
             pending_arithmetic_word_occurrences: outputs.pending_arithmetic_word_occurrences,
@@ -4277,11 +4486,13 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
 
         let id = WordNodeId::new(self.word_nodes.len());
         let analysis = analyze_word(word, self.source, self.command_zsh_options.as_ref());
+        let derived =
+            derive_word_fact_data(word, self.source, self.word_spans, self.word_span_scratch);
         self.word_nodes.push(WordNode {
             key,
             word,
             analysis,
-            derived: OnceCell::new(),
+            derived,
         });
         self.word_node_ids_by_span.insert(key, id);
         id
@@ -4344,7 +4555,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             runtime_literal,
             operand_class,
             enclosing_expansion_context: None,
-            array_assignment_split_scalar_expansion_spans: OnceCell::new(),
+            array_assignment_split_scalar_expansion_spans: IdRange::empty(),
         });
         if let WordFactContext::Expansion(enclosing_expansion_context) = context {
             self.collect_pending_arithmetic_word_occurrences(
@@ -4900,19 +5111,17 @@ fn text_contains_shell_quoting_literals(
         return true;
     }
 
-    let chars = text.chars().collect::<Vec<_>>();
-    let mut index = 0usize;
-    while index < chars.len() {
-        if chars[index] != '\\' {
-            index += 1;
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
             continue;
         }
 
-        let mut end = index + 1;
-        while end < chars.len() && chars[end] == '\\' {
-            end += 1;
+        while chars.peek().is_some_and(|next| *next == '\\') {
+            chars.next();
         }
-        if chars.get(end).is_some_and(|next| {
+
+        if chars.peek().is_some_and(|next| {
             matches!(next, '"' | '\'')
                 || (next.is_whitespace()
                     && (matches!(
@@ -4922,8 +5131,6 @@ fn text_contains_shell_quoting_literals(
         }) {
             return true;
         }
-
-        index = end;
     }
 
     false
@@ -6455,8 +6662,12 @@ fn word_classification_from_analysis(analysis: ExpansionAnalysis) -> WordClassif
 
 fn double_quoted_expansion_part_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_double_quoted_expansion_spans(&word.parts, false, &mut spans);
+    collect_double_quoted_expansion_part_spans(word, &mut spans);
     spans
+}
+
+fn collect_double_quoted_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
+    collect_double_quoted_expansion_spans(&word.parts, false, spans);
 }
 
 fn single_quoted_equivalent_if_plain_double_quoted_word(

--- a/crates/shuck-linter/src/rules/correctness/backtick_in_command_position.rs
+++ b/crates/shuck-linter/src/rules/correctness/backtick_in_command_position.rs
@@ -13,8 +13,8 @@ impl Violation for BacktickInCommandPosition {
 }
 
 pub fn backtick_in_command_position(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().backtick_command_name_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.backtick_command_name_spans(),
         || BacktickInCommandPosition,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/broken_assoc_key.rs
+++ b/crates/shuck-linter/src/rules/correctness/broken_assoc_key.rs
@@ -13,9 +13,7 @@ impl Violation for BrokenAssocKey {
 }
 
 pub fn broken_assoc_key(checker: &mut Checker) {
-    checker.report_all_dedup(checker.facts().broken_assoc_key_spans().to_vec(), || {
-        BrokenAssocKey
-    });
+    checker.report_fact_slice_dedup(|facts| facts.broken_assoc_key_spans(), || BrokenAssocKey);
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -13,8 +13,8 @@ impl Violation for CommaArrayElements {
 }
 
 pub fn comma_array_elements(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().comma_array_assignment_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.comma_array_assignment_spans(),
         || CommaArrayElements,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/commented_continuation_line.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CommentedContinuationLine;
 
@@ -19,22 +19,20 @@ impl Violation for CommentedContinuationLine {
 }
 
 pub fn commented_continuation_line(checker: &mut Checker) {
-    let spans = checker
-        .facts()
-        .commented_continuation_comment_spans()
-        .to_vec();
-    for span in spans {
-        let backslash_offset = span
-            .start
-            .offset
-            .checked_sub(1)
-            .expect("commented continuation anchors should follow a trailing backslash");
-        checker.report_diagnostic_dedup(
-            crate::Diagnostic::new(CommentedContinuationLine, span).with_fix(Fix::unsafe_edit(
-                Edit::deletion_at(backslash_offset, span.start.offset),
-            )),
-        );
-    }
+    checker.report_fact_diagnostics_dedup(|facts, report| {
+        for span in facts.commented_continuation_comment_spans().iter().copied() {
+            let backslash_offset = span
+                .start
+                .offset
+                .checked_sub(1)
+                .expect("commented continuation anchors should follow a trailing backslash");
+            report(
+                Diagnostic::new(CommentedContinuationLine, span).with_fix(Fix::unsafe_edit(
+                    Edit::deletion_at(backslash_offset, span.start.offset),
+                )),
+            );
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/dollar_question_after_command.rs
@@ -13,11 +13,8 @@ impl Violation for DollarQuestionAfterCommand {
 }
 
 pub fn dollar_question_after_command(checker: &mut Checker) {
-    checker.report_all(
-        checker
-            .facts()
-            .dollar_question_after_command_spans()
-            .to_vec(),
+    checker.report_fact_slice(
+        |facts| facts.dollar_question_after_command_spans(),
         || DollarQuestionAfterCommand,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
+++ b/crates/shuck-linter/src/rules/correctness/double_paren_grouping.rs
@@ -19,12 +19,15 @@ impl Violation for DoubleParenGrouping {
 }
 
 pub fn double_paren_grouping(checker: &mut Checker) {
-    let spans = checker.facts().double_paren_grouping_spans().to_vec();
-    for span in spans {
-        checker.report_diagnostic_dedup(Diagnostic::new(DoubleParenGrouping, span).with_fix(
-            Fix::unsafe_edit(Edit::insertion(span.start.offset + 1, " ")),
-        ));
-    }
+    checker.report_fact_diagnostics_dedup(|facts, report| {
+        for span in facts.double_paren_grouping_spans().iter().copied() {
+            report(
+                Diagnostic::new(DoubleParenGrouping, span).with_fix(Fix::unsafe_edit(
+                    Edit::insertion(span.start.offset + 1, " "),
+                )),
+            );
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/env_prefix_expansion_only.rs
+++ b/crates/shuck-linter/src/rules/correctness/env_prefix_expansion_only.rs
@@ -13,8 +13,8 @@ impl Violation for EnvPrefixExpansionOnly {
 }
 
 pub fn env_prefix_expansion_only(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().env_prefix_expansion_scope_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.env_prefix_expansion_scope_spans(),
         || EnvPrefixExpansionOnly,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/heredoc_closer_not_alone.rs
+++ b/crates/shuck-linter/src/rules/correctness/heredoc_closer_not_alone.rs
@@ -13,8 +13,8 @@ impl Violation for HeredocCloserNotAlone {
 }
 
 pub fn heredoc_closer_not_alone(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().heredoc_closer_not_alone_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.heredoc_closer_not_alone_spans(),
         || HeredocCloserNotAlone,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/heredoc_missing_end.rs
+++ b/crates/shuck-linter/src/rules/correctness/heredoc_missing_end.rs
@@ -13,9 +13,10 @@ impl Violation for HeredocMissingEnd {
 }
 
 pub fn heredoc_missing_end(checker: &mut Checker) {
-    checker.report_all_dedup(checker.facts().heredoc_missing_end_spans().to_vec(), || {
-        HeredocMissingEnd
-    });
+    checker.report_fact_slice_dedup(
+        |facts| facts.heredoc_missing_end_spans(),
+        || HeredocMissingEnd,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
@@ -14,11 +14,8 @@ impl Violation for IfDollarCommand {
 }
 
 pub fn if_dollar_command(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker
-            .facts()
-            .command_substitution_command_spans()
-            .to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.command_substitution_command_spans(),
         || IfDollarCommand,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/ifs_set_to_literal_backslash_n.rs
+++ b/crates/shuck-linter/src/rules/correctness/ifs_set_to_literal_backslash_n.rs
@@ -13,11 +13,8 @@ impl Violation for IfsSetToLiteralBackslashN {
 }
 
 pub fn ifs_set_to_literal_backslash_n(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker
-            .facts()
-            .ifs_literal_backslash_assignment_value_spans()
-            .to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.ifs_literal_backslash_assignment_value_spans(),
         || IfsSetToLiteralBackslashN,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/malformed_arithmetic_in_condition.rs
+++ b/crates/shuck-linter/src/rules/correctness/malformed_arithmetic_in_condition.rs
@@ -128,7 +128,10 @@ fn simple_test_word_is_bare_operator(
 
     fact.classification().quote == WordQuote::Unquoted
         && fact.classification().is_fixed_literal()
-        && fact.static_text().is_some_and(predicate)
+        && fact
+            .static_text_cow(checker.source())
+            .as_deref()
+            .is_some_and(predicate)
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
+++ b/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
@@ -13,8 +13,8 @@ impl Violation for MisquotedHeredocClose {
 }
 
 pub fn misquoted_heredoc_close(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().misquoted_heredoc_close_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.misquoted_heredoc_close_spans(),
         || MisquotedHeredocClose,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -13,11 +13,8 @@ impl Violation for PlusPrefixInAssignment {
 }
 
 pub fn plus_prefix_in_assignment(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker
-            .facts()
-            .assignment_like_command_name_spans()
-            .to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.assignment_like_command_name_spans(),
         || PlusPrefixInAssignment,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
+++ b/crates/shuck-linter/src/rules/correctness/positional_param_as_operator.rs
@@ -13,12 +13,10 @@ impl Violation for PositionalParamAsOperator {
 }
 
 pub fn positional_param_as_operator(checker: &mut Checker) {
-    let spans = checker
-        .facts()
-        .positional_parameter_operator_spans()
-        .to_vec();
-
-    checker.report_all_dedup(spans, || PositionalParamAsOperator);
+    checker.report_fact_slice_dedup(
+        |facts| facts.positional_parameter_operator_spans(),
+        || PositionalParamAsOperator,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
@@ -44,7 +44,8 @@ fn collect_simple_test_spans(
 ) -> Vec<Span> {
     simple_test_condition_operand(simple_test)
         .and_then(|word| {
-            simple_test_word_looks_like_quoted_pipeline(checker, word.span).then_some(word.span)
+            simple_test_word_looks_like_quoted_pipeline(checker, word.span, checker.source())
+                .then_some(word.span)
         })
         .into_iter()
         .collect()
@@ -150,21 +151,29 @@ fn conditional_unary_checks_literal_string(unary: &crate::ConditionalUnaryFact<'
         || unary.op() == ConditionalUnaryOp::Not
 }
 
-fn simple_test_word_looks_like_quoted_pipeline(checker: &Checker<'_>, span: Span) -> bool {
+fn simple_test_word_looks_like_quoted_pipeline(
+    checker: &Checker<'_>,
+    span: Span,
+    source: &str,
+) -> bool {
     checker
         .facts()
         .word_fact(
             span,
             WordFactContext::Expansion(ExpansionContext::CommandArgument),
         )
-        .is_some_and(word_fact_looks_like_quoted_pipeline)
+        .is_some_and(|fact| word_fact_looks_like_quoted_pipeline(fact, source))
 }
 
-fn word_fact_looks_like_quoted_pipeline(fact: crate::WordOccurrenceRef<'_, '_>) -> bool {
+fn word_fact_looks_like_quoted_pipeline(
+    fact: crate::WordOccurrenceRef<'_, '_>,
+    source: &str,
+) -> bool {
     fact.classification().quote == WordQuote::FullyQuoted
         && fact.classification().is_fixed_literal()
         && fact
-            .static_text()
+            .static_text_cow(source)
+            .as_deref()
             .is_some_and(looks_like_quoted_pipeline_literal)
 }
 

--- a/crates/shuck-linter/src/rules/correctness/status_capture_after_branch_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/status_capture_after_branch_test.rs
@@ -13,8 +13,8 @@ impl Violation for StatusCaptureAfterBranchTest {
 }
 
 pub fn status_capture_after_branch_test(checker: &mut Checker) {
-    checker.report_all(
-        checker.facts().condition_status_capture_spans().to_vec(),
+    checker.report_fact_slice(
+        |facts| facts.condition_status_capture_spans(),
         || StatusCaptureAfterBranchTest,
     );
 }

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Rule, Violation};
 
 pub struct SubshellLocalAssignment {
     pub name: String,
@@ -18,16 +18,16 @@ impl Violation for SubshellLocalAssignment {
 }
 
 pub fn subshell_local_assignment(checker: &mut Checker) {
-    let sites = checker.facts().subshell_assignment_sites().to_vec();
-
-    for site in sites {
-        checker.report(
-            SubshellLocalAssignment {
-                name: site.name.to_string(),
-            },
-            site.span,
-        );
-    }
+    checker.report_fact_diagnostics(|facts, report| {
+        for site in facts.subshell_assignment_sites() {
+            report(Diagnostic::new(
+                SubshellLocalAssignment {
+                    name: site.name.to_string(),
+                },
+                site.span,
+            ));
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Rule, Violation};
 
 pub struct SubshellSideEffect {
     pub name: String,
@@ -18,16 +18,16 @@ impl Violation for SubshellSideEffect {
 }
 
 pub fn subshell_side_effect(checker: &mut Checker) {
-    let sites = checker.facts().subshell_later_use_sites().to_vec();
-
-    for site in sites {
-        checker.report(
-            SubshellSideEffect {
-                name: site.name.to_string(),
-            },
-            site.span,
-        );
-    }
+    checker.report_fact_diagnostics(|facts, report| {
+        for site in facts.subshell_later_use_sites() {
+            report(Diagnostic::new(
+                SubshellSideEffect {
+                    name: site.name.to_string(),
+                },
+                site.span,
+            ));
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/unicode_quote_in_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/unicode_quote_in_string.rs
@@ -20,15 +20,15 @@ impl Violation for UnicodeQuoteInString {
 
 pub fn unicode_quote_in_string(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker.facts().unicode_smart_quote_spans().to_vec();
-    for span in spans {
-        checker.report_diagnostic_dedup(Diagnostic::new(UnicodeQuoteInString, span).with_fix(
-            Fix::unsafe_edit(Edit::replacement(
-                ascii_quote_replacement(span.slice(source)),
-                span,
-            )),
-        ));
-    }
+    checker.report_fact_diagnostics_dedup(|facts, report| {
+        for span in facts.unicode_smart_quote_spans().iter().copied() {
+            report(
+                Diagnostic::new(UnicodeQuoteInString, span).with_fix(Fix::unsafe_edit(
+                    Edit::replacement(ascii_quote_replacement(span.slice(source)), span),
+                )),
+            );
+        }
+    });
 }
 
 fn ascii_quote_replacement(quote: &str) -> &'static str {

--- a/crates/shuck-linter/src/rules/correctness/unused_heredoc.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_heredoc.rs
@@ -13,9 +13,7 @@ impl Violation for UnusedHeredoc {
 }
 
 pub fn unused_heredoc(checker: &mut Checker) {
-    checker.report_all_dedup(checker.facts().unused_heredoc_spans().to_vec(), || {
-        UnusedHeredoc
-    });
+    checker.report_fact_slice_dedup(|facts| facts.unused_heredoc_spans(), || UnusedHeredoc);
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
+++ b/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
@@ -13,8 +13,10 @@ impl Violation for SingleTestSubshell {
 }
 
 pub fn single_test_subshell(checker: &mut Checker) {
-    let spans = checker.facts().single_test_subshell_spans().to_vec();
-    checker.report_all_dedup(spans, || SingleTestSubshell);
+    checker.report_fact_slice_dedup(
+        |facts| facts.single_test_subshell_spans(),
+        || SingleTestSubshell,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
@@ -17,8 +17,10 @@ pub fn base_prefix_in_arithmetic(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker.facts().base_prefix_arithmetic_spans().to_vec();
-    checker.report_all_dedup(spans, || BasePrefixInArithmetic);
+    checker.report_fact_slice_dedup(
+        |facts| facts.base_prefix_arithmetic_spans(),
+        || BasePrefixInArithmetic,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -17,9 +17,10 @@ pub fn c_style_for_arithmetic_in_sh(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker.facts().arithmetic_update_operator_spans().to_vec();
-
-    checker.report_all(spans, || CStyleForArithmeticInSh);
+    checker.report_fact_slice(
+        |facts| facts.arithmetic_update_operator_spans(),
+        || CStyleForArithmeticInSh,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/portability/conditional_portability.rs
+++ b/crates/shuck-linter/src/rules/portability/conditional_portability.rs
@@ -177,12 +177,14 @@ macro_rules! cached_portability_rule {
                 return;
             }
 
-            let spans = checker
-                .facts()
-                .conditional_portability()
-                .$accessor()
-                .to_vec();
-            checker.report_all_dedup(spans, || $violation);
+            checker.report_fact_spans_dedup(
+                |facts, report| {
+                    for span in facts.conditional_portability().$accessor().iter().copied() {
+                        report(span);
+                    }
+                },
+                || $violation,
+            );
         }
     };
 }
@@ -219,12 +221,19 @@ pub fn extglob_in_test(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
-        .facts()
-        .conditional_portability()
-        .extglob_in_test()
-        .to_vec();
-    checker.report_all_dedup(spans, || ExtglobInTest);
+    checker.report_fact_spans_dedup(
+        |facts, report| {
+            for span in facts
+                .conditional_portability()
+                .extglob_in_test()
+                .iter()
+                .copied()
+            {
+                report(span);
+            }
+        },
+        || ExtglobInTest,
+    );
 }
 cached_portability_rule!(
     lexical_comparison_in_double_bracket,

--- a/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
+++ b/crates/shuck-linter/src/rules/portability/echo_backslash_escapes.rs
@@ -20,8 +20,8 @@ pub fn echo_backslash_escapes(checker: &mut Checker) {
         return;
     }
 
-    checker.report_all_dedup(
-        checker.facts().echo_backslash_escape_word_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.echo_backslash_escape_word_spans(),
         || EchoBackslashEscapes,
     );
 }

--- a/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_params_in_sh.rs
@@ -20,8 +20,8 @@ pub fn function_params_in_sh(checker: &mut Checker) {
         return;
     }
 
-    checker.report_all_dedup(
-        checker.facts().function_parameter_fallback_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.function_parameter_fallback_spans(),
         || FunctionParamsInSh,
     );
 }

--- a/crates/shuck-linter/src/rules/portability/plus_equals_append.rs
+++ b/crates/shuck-linter/src/rules/portability/plus_equals_append.rs
@@ -20,8 +20,10 @@ pub fn plus_equals_append(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker.facts().plus_equals_assignment_spans().to_vec();
-    checker.report_all_dedup(spans, || PlusEqualsAppend);
+    checker.report_fact_slice_dedup(
+        |facts| facts.plus_equals_assignment_spans(),
+        || PlusEqualsAppend,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/portability/zsh_array_subscript_in_case.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_array_subscript_in_case.rs
@@ -18,8 +18,8 @@ pub fn zsh_array_subscript_in_case(checker: &mut Checker) {
         return;
     }
 
-    checker.report_all_dedup(
-        checker.facts().case_pattern_impossible_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.case_pattern_impossible_spans(),
         || ZshArraySubscriptInCase,
     );
 }

--- a/crates/shuck-linter/src/rules/style/ampersand_semicolon.rs
+++ b/crates/shuck-linter/src/rules/style/ampersand_semicolon.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct AmpersandSemicolon;
 
@@ -19,13 +19,14 @@ impl Violation for AmpersandSemicolon {
 }
 
 pub fn ampersand_semicolon(checker: &mut Checker) {
-    let spans = checker.facts().background_semicolon_spans().to_vec();
-    for span in spans {
-        checker.report_diagnostic_dedup(
-            crate::Diagnostic::new(AmpersandSemicolon, span)
-                .with_fix(Fix::safe_edit(Edit::deletion(span))),
-        );
-    }
+    checker.report_fact_diagnostics_dedup(|facts, report| {
+        for span in facts.background_semicolon_spans().iter().copied() {
+            report(
+                Diagnostic::new(AmpersandSemicolon, span)
+                    .with_fix(Fix::safe_edit(Edit::deletion(span))),
+            );
+        }
+    });
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/arithmetic_score_line.rs
+++ b/crates/shuck-linter/src/rules/style/arithmetic_score_line.rs
@@ -13,9 +13,10 @@ impl Violation for ArithmeticScoreLine {
 }
 
 pub fn arithmetic_score_line(checker: &mut Checker) {
-    let spans = checker.facts().arithmetic_score_line_spans().to_vec();
-
-    checker.report_all_dedup(spans, || ArithmeticScoreLine);
+    checker.report_fact_slice_dedup(
+        |facts| facts.arithmetic_score_line_spans(),
+        || ArithmeticScoreLine,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/array_index_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/array_index_arithmetic.rs
@@ -13,9 +13,10 @@ impl Violation for ArrayIndexArithmetic {
 }
 
 pub fn array_index_arithmetic(checker: &mut Checker) {
-    let spans = checker.facts().array_index_arithmetic_spans().to_vec();
-
-    checker.report_all_dedup(spans, || ArrayIndexArithmetic);
+    checker.report_fact_slice_dedup(
+        |facts| facts.array_index_arithmetic_spans(),
+        || ArrayIndexArithmetic,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
+++ b/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
@@ -14,12 +14,10 @@ impl Violation for BareCommandNameAssignment {
 }
 
 pub fn bare_command_name_assignment(checker: &mut Checker) {
-    let spans = checker
-        .facts()
-        .bare_command_name_assignment_spans()
-        .to_vec();
-
-    checker.report_all_dedup(spans, || BareCommandNameAssignment);
+    checker.report_fact_slice_dedup(
+        |facts| facts.bare_command_name_assignment_spans(),
+        || BareCommandNameAssignment,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
+++ b/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
@@ -17,11 +17,8 @@ pub fn brace_variable_before_bracket(checker: &mut Checker) {
         return;
     }
 
-    checker.report_all_dedup(
-        checker
-            .facts()
-            .brace_variable_before_bracket_spans()
-            .to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.brace_variable_before_bracket_spans(),
         || BraceVariableBeforeBracket,
     );
 }

--- a/crates/shuck-linter/src/rules/style/command_substitution_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/command_substitution_in_alias.rs
@@ -13,8 +13,8 @@ impl Violation for CommandSubstitutionInAlias {
 }
 
 pub fn command_substitution_in_alias(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().alias_definition_expansion_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.alias_definition_expansion_spans(),
         || CommandSubstitutionInAlias,
     );
 }

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -13,9 +13,10 @@ impl Violation for DollarInArithmetic {
 }
 
 pub fn dollar_in_arithmetic(checker: &mut Checker) {
-    let spans = checker.facts().dollar_in_arithmetic_spans().to_vec();
-
-    checker.report_all_dedup(spans, || DollarInArithmetic);
+    checker.report_fact_slice_dedup(
+        |facts| facts.dollar_in_arithmetic_spans(),
+        || DollarInArithmetic,
+    );
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/echo_here_doc.rs
+++ b/crates/shuck-linter/src/rules/style/echo_here_doc.rs
@@ -13,9 +13,7 @@ impl Violation for EchoHereDoc {
 }
 
 pub fn echo_here_doc(checker: &mut Checker) {
-    checker.report_all_dedup(checker.facts().echo_here_doc_spans().to_vec(), || {
-        EchoHereDoc
-    });
+    checker.report_fact_slice_dedup(|facts| facts.echo_here_doc_spans(), || EchoHereDoc);
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/echo_to_sed_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/echo_to_sed_substitution.rs
@@ -17,8 +17,8 @@ pub fn echo_to_sed_substitution(checker: &mut Checker) {
         return;
     }
 
-    checker.report_all_dedup(
-        checker.facts().echo_to_sed_substitution_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.echo_to_sed_substitution_spans(),
         || EchoToSedSubstitution,
     );
 }

--- a/crates/shuck-linter/src/rules/style/env_prefix_command_only.rs
+++ b/crates/shuck-linter/src/rules/style/env_prefix_command_only.rs
@@ -14,8 +14,8 @@ impl Violation for EnvPrefixCommandOnly {
 }
 
 pub fn env_prefix_command_only(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().env_prefix_assignment_scope_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.env_prefix_assignment_scope_spans(),
         || EnvPrefixCommandOnly,
     );
 }

--- a/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
+++ b/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
@@ -20,11 +20,8 @@ pub fn function_body_without_braces(checker: &mut Checker) {
         return;
     }
 
-    checker.report_all_dedup(
-        checker
-            .facts()
-            .function_body_without_braces_spans()
-            .to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.function_body_without_braces_spans(),
         || FunctionBodyWithoutBraces,
     );
 }

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -13,8 +13,7 @@ impl Violation for FunctionInAlias {
 }
 
 pub fn function_in_alias(checker: &mut Checker) {
-    let spans = checker.facts().function_in_alias_spans().to_vec();
-    checker.report_all_dedup(spans, || FunctionInAlias);
+    checker.report_fact_slice_dedup(|facts| facts.function_in_alias_spans(), || FunctionInAlias);
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
+++ b/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
@@ -13,9 +13,7 @@ impl Violation for HeredocEndSpace {
 }
 
 pub fn heredoc_end_space(checker: &mut Checker) {
-    checker.report_all_dedup(checker.facts().heredoc_end_space_spans().to_vec(), || {
-        HeredocEndSpace
-    });
+    checker.report_fact_slice_dedup(|facts| facts.heredoc_end_space_spans(), || HeredocEndSpace);
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -13,9 +13,7 @@ impl Violation for LiteralBraces {
 }
 
 pub fn literal_braces(checker: &mut Checker) {
-    checker.report_all_dedup(checker.facts().literal_brace_spans().to_vec(), || {
-        LiteralBraces
-    });
+    checker.report_fact_slice_dedup(|facts| facts.literal_brace_spans(), || LiteralBraces);
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/redundant_return_status.rs
+++ b/crates/shuck-linter/src/rules/style/redundant_return_status.rs
@@ -13,8 +13,8 @@ impl Violation for RedundantReturnStatus {
 }
 
 pub fn redundant_return_status(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().redundant_return_status_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.redundant_return_status_spans(),
         || RedundantReturnStatus,
     );
 }

--- a/crates/shuck-linter/src/rules/style/spaced_tabstrip_close.rs
+++ b/crates/shuck-linter/src/rules/style/spaced_tabstrip_close.rs
@@ -13,8 +13,8 @@ impl Violation for SpacedTabstripClose {
 }
 
 pub fn spaced_tabstrip_close(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().spaced_tabstrip_close_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.spaced_tabstrip_close_spans(),
         || SpacedTabstripClose,
     );
 }

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -13,8 +13,8 @@ impl Violation for TrailingDirective {
 }
 
 pub fn trailing_directive(checker: &mut Checker) {
-    checker.report_all_dedup(
-        checker.facts().trailing_directive_comment_spans().to_vec(),
+    checker.report_fact_slice_dedup(
+        |facts| facts.trailing_directive_comment_spans(),
         || TrailingDirective,
     );
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
@@ -17,39 +17,42 @@ impl Violation for UnquotedVariableInTest {
 }
 
 pub fn unquoted_variable_in_test(checker: &mut Checker) {
-    let spans = checker
-        .facts()
-        .commands()
-        .iter()
-        .flat_map(|fact| {
-            let Some(simple_test) = fact.simple_test() else {
-                return Vec::new();
-            };
-            if simple_test.syntax() != SimpleTestSyntax::Bracket {
-                return Vec::new();
+    let source = checker.source();
+    checker.report_fact_spans_dedup(
+        |facts, report| {
+            for fact in facts.commands() {
+                let Some(simple_test) = fact.simple_test() else {
+                    continue;
+                };
+                if simple_test.syntax() != SimpleTestSyntax::Bracket {
+                    continue;
+                }
+                if simple_test.shape() != SimpleTestShape::Unary
+                    || simple_test.operands().len() != 2
+                {
+                    continue;
+                }
+
+                let operator = simple_test.operands()[0];
+                if static_word_text(operator, source).as_deref() != Some("-n") {
+                    continue;
+                }
+
+                let operand = simple_test.operands()[1];
+                let Some(word_fact) = facts.word_fact(
+                    operand.span,
+                    WordFactContext::Expansion(ExpansionContext::CommandArgument),
+                ) else {
+                    continue;
+                };
+
+                for span in word_fact.unquoted_scalar_expansion_spans().iter().copied() {
+                    report(span);
+                }
             }
-            if simple_test.shape() != SimpleTestShape::Unary || simple_test.operands().len() != 2 {
-                return Vec::new();
-            }
-
-            let operator = simple_test.operands()[0];
-            if static_word_text(operator, checker.source()).as_deref() != Some("-n") {
-                return Vec::new();
-            }
-
-            let operand = simple_test.operands()[1];
-            let Some(word_fact) = checker.facts().word_fact(
-                operand.span,
-                WordFactContext::Expansion(ExpansionContext::CommandArgument),
-            ) else {
-                return Vec::new();
-            };
-
-            word_fact.unquoted_scalar_expansion_spans().to_vec()
-        })
-        .collect::<Vec<_>>();
-
-    checker.report_all_dedup(spans, || UnquotedVariableInTest);
+        },
+        || UnquotedVariableInTest,
+    );
 }
 
 #[cfg(test)]

--- a/scripts/benchmarks/run_linter_memory.py
+++ b/scripts/benchmarks/run_linter_memory.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+PRIMARY_METRIC_GROUPS = ["facts_metrics", "check_metrics"]
+PRIMARY_METRICS = [
+    "total_allocated_bytes",
+    "total_reallocated_bytes",
+    "allocation_count",
+    "reallocation_count",
+    "peak_live_bytes",
+    "final_live_bytes",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run linter memory benchmarks with explicit save/compare baseline modes."
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        required=True,
+        help="Path to the shuck repository checkout to benchmark.",
+    )
+
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--save-baseline",
+        metavar="NAME",
+        help="Save linter memory results into the named baseline.",
+    )
+    mode.add_argument(
+        "--baseline",
+        metavar="NAME",
+        help="Compare linter memory results against the named baseline.",
+    )
+
+    parser.add_argument(
+        "--package",
+        default="shuck-benchmark",
+        help="Cargo package that owns the linter memory example.",
+    )
+    parser.add_argument(
+        "--example",
+        default="linter_memory",
+        help="Example target that emits linter memory JSON.",
+    )
+    parser.add_argument(
+        "--release",
+        action="store_true",
+        help="Run the memory harness in release mode.",
+    )
+    return parser.parse_args()
+
+
+def target_dir(repo_root: Path) -> Path:
+    cargo_target_dir = os.environ.get("CARGO_TARGET_DIR")
+    if cargo_target_dir:
+        target = Path(cargo_target_dir)
+        if not target.is_absolute():
+            target = repo_root / target
+        return target
+    return repo_root / "target"
+
+
+def run_example(repo_root: Path, package: str, example: str, release: bool) -> list[dict]:
+    command = ["cargo", "run", "-p", package, "--example", example]
+    if release:
+        command.append("--release")
+    command.append("--quiet")
+
+    completed = subprocess.run(
+        command,
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def baseline_path(repo_root: Path, baseline_name: str) -> Path:
+    return target_dir(repo_root) / "linter-memory-baselines" / f"{baseline_name}.json"
+
+
+def metric_change(current: int, baseline: int) -> str:
+    if baseline == 0:
+        return "n/a" if current == 0 else "inf"
+    change = ((current / baseline) - 1.0) * 100.0
+    sign = "+" if change > 0 else ""
+    return f"{sign}{change:.2f}%"
+
+
+def index_cases(payload: list[dict]) -> dict[str, dict]:
+    return {entry["case"]: entry for entry in payload}
+
+
+def print_comparison(current: list[dict], baseline: list[dict]) -> None:
+    current_cases = index_cases(current)
+    baseline_cases = index_cases(baseline)
+
+    missing_in_current = sorted(set(baseline_cases) - set(current_cases))
+    missing_in_baseline = sorted(set(current_cases) - set(baseline_cases))
+    if missing_in_current or missing_in_baseline:
+        raise SystemExit(
+            "case mismatch between current and baseline: "
+            f"missing_in_current={missing_in_current}, missing_in_baseline={missing_in_baseline}"
+        )
+
+    for case_name in sorted(current_cases):
+        current_case = current_cases[case_name]
+        baseline_case = baseline_cases[case_name]
+        for count_name in ["command_count", "fact_count", "diagnostic_count"]:
+            if current_case[count_name] != baseline_case[count_name]:
+                raise SystemExit(
+                    f"{count_name} mismatch for {case_name}: "
+                    f"{baseline_case[count_name]} != {current_case[count_name]}"
+                )
+        print(
+            f"{case_name}: commands={baseline_case['command_count']} "
+            f"facts={baseline_case['fact_count']} diagnostics={baseline_case['diagnostic_count']}"
+        )
+        for group_name in PRIMARY_METRIC_GROUPS:
+            print(f"  {group_name}:")
+            for metric_name in PRIMARY_METRICS:
+                baseline_value = baseline_case[group_name][metric_name]
+                current_value = current_case[group_name][metric_name]
+                print(
+                    f"    {metric_name}: {baseline_value} -> {current_value} "
+                    f"({metric_change(current_value, baseline_value)})"
+                )
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    current = run_example(repo_root, args.package, args.example, args.release)
+
+    if args.save_baseline is not None:
+        path = baseline_path(repo_root, args.save_baseline)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(current, indent=2) + "\n")
+        print(f"saved linter memory baseline `{args.save_baseline}` to {path}")
+        return 0
+
+    path = baseline_path(repo_root, args.baseline)
+    if not path.is_file():
+        raise SystemExit(f"missing linter memory baseline: {path}")
+
+    baseline = json.loads(path.read_text())
+    print_comparison(current, baseline)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- finish the indexed `LinterFacts` arena migration end to end
- pack high-churn fact lists into arena-backed ranges and migrate production rules to consume fact slices/iterators directly
- remove old compatibility allocation paths and add a `linter_memory` benchmark harness

## Performance
- `hyperfine` release CLI: 82.5 ms -> 79.5 ms, 1.04x faster
- DHAT total allocated bytes: 174,009,174 -> 170,122,283 (-2.23%)
- DHAT allocation blocks: 521,336 -> 482,111 (-7.52%)
- `linter_memory` all check bytes: 61,300,418 -> 57,471,151 (-6.25%)
- `linter_memory` nvm check bytes: 31,239,691 -> 29,011,539 (-7.13%)
- Criterion `linter/nvm`: -10.60%

## Validation
- `cargo test -p shuck-ast`
- `cargo test -p shuck-linter`
- `cargo test -p shuck-benchmark --examples`
- `make test`
- `cargo fmt --check`
- `git diff --check`
- compatibility-helper search gates for removed fact arena shims

Profile artifact: `.cache/profiles/current-samply-final/linter/nvm.json.gz`