### PR TITLE
fix(linter): improve S001 ShellCheck parity

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -847,39 +847,11 @@ reviewed_divergences:
     end_column: 19
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
-    path_suffix: "megastep__makeself__makeself.sh"
-    line: 401
-    end_line: 401
-    column: 36
-    end_column: 38
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "megastep__makeself__makeself.sh"
-    line: 401
-    end_line: 401
-    column: 38
-    end_column: 40
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
     path_suffix: "megastep__makeself__test__variabletest"
     line: 15
     end_line: 15
     column: 56
     end_column: 60
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "moovweb__gvm__examples__native__depcomp"
-    line: 126
-    end_line: 126
-    column: 19
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "moovweb__gvm__examples__native__depcomp"
-    line: 126
-    end_line: 126
-    column: 20
-    end_column: 35
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__nvm.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -3,13 +3,6 @@ reviewed_divergences:
     path_suffix: "233boy__v2ray__src__core.sh"
     line: 1254
     end_line: 1254
-    column: 26
-    end_column: 38
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "233boy__v2ray__src__core.sh"
-    line: 1254
-    end_line: 1254
     column: 39
     end_column: 43
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
@@ -47,13 +40,6 @@ reviewed_divergences:
     end_line: 83
     column: 14
     end_column: 21
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__network__quagga__rc.quagga"
-    line: 18
-    end_line: 18
-    column: 14
-    end_column: 22
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh"
@@ -176,36 +162,8 @@ reviewed_divergences:
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars"
-    line: 149
-    end_line: 149
-    column: 47
-    end_column: 49
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars"
-    line: 155
-    end_line: 155
-    column: 44
-    end_column: 46
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars"
     line: 418
     end_line: 418
-    column: 29
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars"
-    line: 468
-    end_line: 468
-    column: 45
-    end_column: 47
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars"
-    line: 470
-    end_line: 470
     column: 29
     end_column: 31
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
@@ -595,69 +553,6 @@ reviewed_divergences:
     end_column: 25
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__dot-a.sh"
-    line: 249
-    end_line: 249
-    column: 21
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__dot-a.sh"
-    line: 262
-    end_line: 262
-    column: 21
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__dot-a.sh"
-    line: 277
-    end_line: 277
-    column: 21
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__dot-a.sh"
-    line: 290
-    end_line: 290
-    column: 21
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__dot-a.sh"
-    line: 311
-    end_line: 311
-    column: 21
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__dot-a.sh"
-    line: 327
-    end_line: 327
-    column: 21
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__dot-a.sh"
-    line: 345
-    end_line: 345
-    column: 21
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__dot-a.sh"
-    line: 361
-    end_line: 361
-    column: 21
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__dot-a.sh"
-    line: 717
-    end_line: 717
-    column: 42
-    end_column: 51
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "gentoo__gentoo__eclass__tests__toolchain-funcs.sh"
     line: 61
     end_line: 61
@@ -670,34 +565,6 @@ reviewed_divergences:
     end_line: 155
     column: 7
     end_column: 13
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__net-firewall__nftables__files__libexec__nftables.sh"
-    line: 114
-    end_line: 114
-    column: 29
-    end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__net-firewall__nftables__files__libexec__nftables.sh"
-    line: 114
-    end_line: 114
-    column: 36
-    end_column: 55
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__net-firewall__nftables__files__libexec__nftables.sh"
-    line: 116
-    end_line: 116
-    column: 30
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__net-firewall__nftables__files__libexec__nftables.sh"
-    line: 116
-    end_line: 116
-    column: 37
-    end_column: 56
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "gentoo__gentoo__net-vpn__derper__files__derper-pre.sh"
@@ -1230,32 +1097,4 @@ reviewed_divergences:
     end_line: 377
     column: 12
     end_column: 17
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__hooks__pre-configure__02-script-wrapper.sh"
-    line: 182
-    end_line: 182
-    column: 45
-    end_column: 53
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__hooks__pre-configure__02-script-wrapper.sh"
-    line: 183
-    end_line: 183
-    column: 54
-    end_column: 62
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__hooks__pre-configure__02-script-wrapper.sh"
-    line: 188
-    end_line: 188
-    column: 45
-    end_column: 53
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__hooks__pre-configure__02-script-wrapper.sh"
-    line: 189
-    end_line: 189
-    column: 54
-    end_column: 62
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -916,27 +916,6 @@ reviewed_divergences:
     column: 21
     end_column: 39
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
-    line: 226
-    end_line: 226
-    column: 23
-    end_column: 42
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
-    line: 234
-    end_line: 234
-    column: 39
-    end_column: 58
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "romkatv__powerlevel10k__gitstatus__gitstatus.plugin.sh"
-    line: 384
-    end_line: 384
-    column: 61
-    end_column: 79
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__binscripts__rvm-installer"
     line: 89

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -994,34 +994,6 @@ reviewed_divergences:
     end_column: 35
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__set"
-    line: 150
-    end_line: 150
-    column: 26
-    end_column: 41
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__set"
-    line: 150
-    end_line: 150
-    column: 27
-    end_column: 42
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__set"
-    line: 151
-    end_line: 151
-    column: 21
-    end_column: 33
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__set"
-    line: 151
-    end_line: 151
-    column: 23
-    end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "scop__bash-completion__completions-core__geoiplookup.bash"
     line: 29
     end_line: 29

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -728,20 +728,6 @@ reviewed_divergences:
     end_column: 56
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "gentoo__gentoo__net-p2p__freenet__files__run.sh-20090501"
-    line: 132
-    end_line: 132
-    column: 16
-    end_column: 25
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__net-p2p__freenet__files__run.sh-20090501"
-    line: 377
-    end_line: 377
-    column: 25
-    end_column: 33
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "gentoo__gentoo__net-vpn__derper__files__derper-pre.sh"
     line: 44
     end_line: 44
@@ -761,48 +747,6 @@ reviewed_divergences:
     end_line: 329
     column: 17
     end_column: 27
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "google__oss-fuzz__projects__sudoers__build.sh"
-    line: 24
-    end_line: 24
-    column: 21
-    end_column: 28
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "google__oss-fuzz__projects__sudoers__build.sh"
-    line: 24
-    end_line: 24
-    column: 42
-    end_column: 57
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "google__oss-fuzz__projects__sudoers__build.sh"
-    line: 27
-    end_line: 27
-    column: 21
-    end_column: 28
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "google__oss-fuzz__projects__sudoers__build.sh"
-    line: 27
-    end_line: 27
-    column: 42
-    end_column: 58
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "google__oss-fuzz__projects__sudoers__build.sh"
-    line: 34
-    end_line: 34
-    column: 17
-    end_column: 24
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "google__oss-fuzz__projects__sudoers__build.sh"
-    line: 37
-    end_line: 37
-    column: 18
-    end_column: 25
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "google__oss-fuzz__projects__threetenbp__build.sh"
@@ -908,13 +852,6 @@ reviewed_divergences:
     end_line: 30
     column: 11
     end_column: 22
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "kward__shunit2__shunit2"
-    line: 1532
-    end_line: 1532
-    column: 53
-    end_column: 71
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "masonr__yet-another-bench-script__yabs.sh"
@@ -1237,13 +1174,6 @@ reviewed_divergences:
     end_line: 724
     column: 36
     end_column: 57
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "swoodford__aws__ec2-associate-elastic-ip.sh"
-    line: 13
-    end_line: 13
-    column: 21
-    end_column: 36
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "swoodford__aws__vpc-sg-import-rules-cloudflare.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -813,20 +813,6 @@ reviewed_divergences:
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "masonr__yet-another-bench-script__yabs.sh"
-    line: 750
-    end_line: 750
-    column: 10
-    end_column: 12
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "masonr__yet-another-bench-script__yabs.sh"
-    line: 778
-    end_line: 778
-    column: 10
-    end_column: 12
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "masonr__yet-another-bench-script__yabs.sh"
     line: 991
     end_line: 991
     column: 12

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -826,13 +826,6 @@ reviewed_divergences:
     end_column: 24
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "itzg__docker-minecraft-server__scripts__start-autopause"
-    line: 69
-    end_line: 69
-    column: 14
-    end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "juewuy__ShellCrash__scripts__menus__2_settings.sh"
     line: 360
     end_line: 360
@@ -1078,13 +1071,6 @@ reviewed_divergences:
     end_column: 21
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__fetch"
-    line: 73
-    end_line: 73
-    column: 20
-    end_column: 27
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "rvm__rvm__scripts__functions__build_requirements"
     line: 160
     end_line: 160
@@ -1174,13 +1160,6 @@ reviewed_divergences:
     end_line: 74
     column: 17
     end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__migrate"
-    line: 208
-    end_line: 208
-    column: 21
-    end_column: 23
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "rvm__rvm__scripts__set"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -27,33 +27,12 @@ reviewed_divergences:
     column: 56
     end_column: 77
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__emulators__jzintv.sh"
-    line: 59
-    end_line: 59
-    column: 10
-    end_column: 16
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__emulators__px68k.sh"
-    line: 35
-    end_line: 35
-    column: 59
-    end_column: 69
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
     line: 235
     end_line: 235
     column: 32
     end_column: 38
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__development__Xdialog__Xdialog.SlackBuild"
-    line: 83
-    end_line: 83
-    column: 3
-    end_column: 8
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__libraries__libvirt__rc.libvirt"
@@ -89,34 +68,6 @@ reviewed_divergences:
     end_line: 80
     column: 12
     end_column: 19
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__nvidia-kernel__nvidia-kernel.SlackBuild"
-    line: 101
-    end_line: 101
-    column: 12
-    end_column: 18
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__nvidia-kernel__nvidia-kernel.SlackBuild"
-    line: 113
-    end_line: 113
-    column: 22
-    end_column: 28
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__nvidia-legacy580-kernel__nvidia-legacy580-kernel.SlackBuild"
-    line: 103
-    end_line: 103
-    column: 12
-    end_column: 18
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__nvidia-legacy580-kernel__nvidia-legacy580-kernel.SlackBuild"
-    line: 115
-    end_line: 115
-    column: 22
-    end_column: 28
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh"
@@ -302,13 +253,6 @@ reviewed_divergences:
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__db"
-    line: 1207
-    end_line: 1207
-    column: 12
-    end_column: 25
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__db"
     line: 1258
     end_line: 1258
     column: 4
@@ -330,38 +274,10 @@ reviewed_divergences:
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
-    line: 1250
-    end_line: 1250
-    column: 10
-    end_column: 24
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
-    line: 1251
-    end_line: 1251
-    column: 34
-    end_column: 43
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
-    line: 1258
-    end_line: 1258
-    column: 4
-    end_column: 16
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
     line: 2620
     end_line: 2620
     column: 79
     end_column: 81
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__pdf"
-    line: 454
-    end_line: 454
-    column: 5
-    end_column: 17
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__rrd"
@@ -376,13 +292,6 @@ reviewed_divergences:
     end_line: 83
     column: 8
     end_column: 10
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__speedtest"
-    line: 306
-    end_line: 306
-    column: 13
-    end_column: 35
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__speedtest"
@@ -461,26 +370,12 @@ reviewed_divergences:
     column: 9
     end_column: 21
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 1447
-    end_line: 1447
-    column: 23
-    end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
     line: 2096
     end_line: 2096
     column: 10
     end_column: 15
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__wifi"
-    line: 2293
-    end_line: 2293
-    column: 7
-    end_column: 10
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__wifi"
@@ -495,48 +390,6 @@ reviewed_divergences:
     end_line: 11
     column: 33
     end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__usr__sbin__cron.minutely_check_wifi_incoming_multicast.sh"
-    line: 67
-    end_line: 67
-    column: 4
-    end_column: 27
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__usr__sbin__cron.minutely_check_wifi_incoming_multicast.sh"
-    line: 69
-    end_line: 69
-    column: 8
-    end_column: 26
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-build__apply_profile.code"
-    line: 123
-    end_line: 123
-    column: 9
-    end_column: 15
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-build__build.sh"
-    line: 2370
-    end_line: 2370
-    column: 10
-    end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-build__build.sh"
-    line: 2398
-    end_line: 2398
-    column: 12
-    end_column: 25
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-build__mybuild.sh"
-    line: 1192
-    end_line: 1192
-    column: 18
-    end_column: 24
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-build__mybuild.sh"
@@ -593,13 +446,6 @@ reviewed_divergences:
     end_line: 231
     column: 4
     end_column: 6
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__tools__addon__all-templates.sh"
-    line: 160
-    end_line: 160
-    column: 34
-    end_column: 42
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__archlinux-vm.sh"
@@ -873,13 +719,6 @@ reviewed_divergences:
     end_line: 155
     column: 7
     end_column: 13
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__net-firewall__nftables__files__libexec__nftables.sh"
-    line: 41
-    end_line: 41
-    column: 12
-    end_column: 21
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "gentoo__gentoo__net-firewall__nftables__files__libexec__nftables.sh"
@@ -1204,13 +1043,6 @@ reviewed_divergences:
     end_column: 14
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "openvpn__easy-rsa__easyrsa3__easyrsa"
-    line: 4098
-    end_line: 4098
-    column: 4
-    end_column: 18
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh"
     line: 191
     end_line: 191
@@ -1478,13 +1310,6 @@ reviewed_divergences:
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "termux__termux-packages__packages__dart__build.sh"
-    line: 55
-    end_line: 55
-    column: 35
-    end_column: 42
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__dart__build.sh"
     line: 56
     end_line: 56
     column: 25
@@ -1510,34 +1335,6 @@ reviewed_divergences:
     end_line: 15
     column: 5
     end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__nodejs-lts__build.sh"
-    line: 158
-    end_line: 158
-    column: 14
-    end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__nodejs__build.sh"
-    line: 157
-    end_line: 157
-    column: 14
-    end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__godot__build.sh"
-    line: 72
-    end_line: 72
-    column: 8
-    end_column: 14
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__x11-packages__godot__build.sh"
-    line: 89
-    end_line: 89
-    column: 52
-    end_column: 58
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "termux__termux-packages__x11-packages__python-qscintilla__build.sh"
@@ -1589,20 +1386,6 @@ reviewed_divergences:
     end_column: 85
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "tteck__Proxmox__ct__create_lxc.sh"
-    line: 114
-    end_line: 114
-    column: 34
-    end_column: 42
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__misc__all-templates.sh"
-    line: 124
-    end_line: 124
-    column: 34
-    end_column: 42
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "tteck__Proxmox__misc__glances.sh"
     line: 100
     end_line: 100
@@ -1615,13 +1398,6 @@ reviewed_divergences:
     end_line: 100
     column: 73
     end_column: 85
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__turnkey__turnkey.sh"
-    line: 145
-    end_line: 145
-    column: 34
-    end_column: 42
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "tteck__Proxmox__vm__debian-vm.sh"
@@ -1734,13 +1510,6 @@ reviewed_divergences:
     end_line: 16442
     column: 11
     end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__build-style__void-cross.sh"
-    line: 204
-    end_line: 204
-    column: 12
-    end_column: 19
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "void-linux__void-packages__common__build-style__void-cross.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -706,20 +706,6 @@ reviewed_divergences:
     column: 12
     end_column: 19
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "google__oss-fuzz__infra__base-images__base-runner__coverage"
-    line: 115
-    end_line: 115
-    column: 17
-    end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "google__oss-fuzz__infra__base-images__base-runner__coverage"
-    line: 329
-    end_line: 329
-    column: 17
-    end_column: 27
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "google__oss-fuzz__projects__threetenbp__build.sh"
     line: 56
@@ -1349,11 +1335,4 @@ reviewed_divergences:
     end_line: 189
     column: 54
     end_column: 62
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "void-linux__void-packages__srcpkgs__acpid__files__handler.sh"
-    line: 13
-    end_line: 13
-    column: 57
-    end_column: 59
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -56,20 +56,6 @@ reviewed_divergences:
     end_column: 22
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__ntopng__rc.ntopng"
-    line: 54
-    end_line: 54
-    column: 10
-    end_column: 17
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__ntopng__rc.ntopng"
-    line: 80
-    end_line: 80
-    column: 12
-    end_column: 19
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh"
     line: 19
     end_line: 19
@@ -999,13 +985,6 @@ reviewed_divergences:
     end_line: 104
     column: 28
     end_column: 53
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "nvm-sh__nvm__nvm.sh"
-    line: 2230
-    end_line: 2230
-    column: 10
-    end_column: 20
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__nvm.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -1120,20 +1120,6 @@ reviewed_divergences:
     end_column: 24
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "tteck__Proxmox__ct__create_lxc.sh"
-    line: 28
-    end_line: 28
-    column: 37
-    end_column: 49
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__ct__create_lxc.sh"
-    line: 28
-    end_line: 28
-    column: 73
-    end_column: 85
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "tteck__Proxmox__misc__glances.sh"
     line: 100
     end_line: 100
@@ -1160,20 +1146,6 @@ reviewed_divergences:
     end_line: 410
     column: 23
     end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__haos-vm.sh"
-    line: 46
-    end_line: 46
-    column: 37
-    end_column: 49
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__haos-vm.sh"
-    line: 46
-    end_line: 46
-    column: 73
-    end_column: 85
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "tteck__Proxmox__vm__haos-vm.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -630,13 +630,6 @@ reviewed_divergences:
     end_column: 109
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "dylanaraps__neofetch__neofetch"
-    line: 7233
-    end_line: 7233
-    column: 28
-    end_column: 33
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "gentoo__gentoo__dev-libs__kpathsea__files__texmf-update-r2"
     line: 28
     end_line: 28

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -90,48 +90,6 @@ reviewed_divergences:
     column: 36
     end_column: 43
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 591
-    end_line: 591
-    column: 19
-    end_column: 26
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 594
-    end_line: 594
-    column: 8
-    end_column: 15
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 594
-    end_line: 594
-    column: 36
-    end_column: 43
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 718
-    end_line: 718
-    column: 45
-    end_column: 52
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 761
-    end_line: 761
-    column: 8
-    end_column: 15
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 852
-    end_line: 852
-    column: 21
-    end_column: 28
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "alpinelinux__aports__main__syslinux__update-extlinux"
     line: 96
@@ -628,20 +586,6 @@ reviewed_divergences:
     end_line: 11
     column: 28
     end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "juewuy__ShellCrash__scripts__menus__subconverter.sh"
-    line: 121
-    end_line: 121
-    column: 48
-    end_column: 58
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "juewuy__ShellCrash__scripts__menus__subconverter.sh"
-    line: 146
-    end_line: 146
-    column: 51
-    end_column: 63
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "juewuy__ShellCrash__tools__tg_bot.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -881,48 +881,6 @@ reviewed_divergences:
     column: 30
     end_column: 50
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__packages__libminizip__build.sh"
-    line: 15
-    end_line: 15
-    column: 5
-    end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__x11-packages__python-qscintilla__build.sh"
-    line: 35
-    end_line: 35
-    column: 16
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__x11-packages__python-qscintilla__build.sh"
-    line: 36
-    end_line: 36
-    column: 11
-    end_column: 21
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__x11-packages__python-qscintilla__build.sh"
-    line: 41
-    end_line: 41
-    column: 41
-    end_column: 51
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__x11-packages__python-qscintilla__build.sh"
-    line: 42
-    end_line: 42
-    column: 13
-    end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__x11-packages__python-qscintilla__build.sh"
-    line: 43
-    end_line: 43
-    column: 14
-    end_column: 24
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "tteck__Proxmox__misc__glances.sh"
     line: 100

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -721,13 +721,6 @@ reviewed_divergences:
     end_column: 47
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "itzg__docker-minecraft-server__scripts__start"
-    line: 24
-    end_line: 24
-    column: 20
-    end_column: 24
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "juewuy__ShellCrash__scripts__menus__2_settings.sh"
     line: 360
     end_line: 360

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -104,34 +104,6 @@ reviewed_divergences:
     column: 36
     end_column: 43
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 132
-    end_line: 132
-    column: 36
-    end_column: 47
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 132
-    end_line: 132
-    column: 58
-    end_column: 67
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 135
-    end_line: 135
-    column: 36
-    end_column: 47
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
-    line: 135
-    end_line: 135
-    column: 58
-    end_column: 67
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "alexanderepstein__Bash-Snippets__gist__gist"
     line: 591

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -87,6 +87,11 @@ impl RegionIndex {
         contains_any(&self.heredocs, offset)
     }
 
+    /// Check if a byte offset falls inside a quoted heredoc body.
+    pub fn is_quoted_heredoc(&self, offset: TextSize) -> bool {
+        contains_any(&self.quoted_heredocs, offset)
+    }
+
     /// Check if a byte offset falls inside a command substitution.
     pub fn is_command_substitution(&self, offset: TextSize) -> bool {
         contains_any(&self.command_substitutions, offset)

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2670,13 +2670,13 @@ fn annotate_conditional_assignment_value_paths<'a>(
             let Some(span) = segment.assignment_span() else {
                 continue;
             };
-            if index > 0 && !prior_assignment_targets.contains(target) {
-                if let Some(binding_id) =
+            if index > 0
+                && !prior_assignment_targets.contains(target)
+                && let Some(binding_id) =
                     binding_value_visible_id_for_name(semantic, &Name::from(target), span)
-                    && let Some(binding_value) = binding_values.get_mut(&binding_id)
-                {
-                    binding_value.mark_one_sided_short_circuit_assignment();
-                }
+                && let Some(binding_value) = binding_values.get_mut(&binding_id)
+            {
+                binding_value.mark_one_sided_short_circuit_assignment();
             }
             prior_assignment_targets.insert(target.to_owned());
         }

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -38,6 +38,7 @@ impl DeclarationAssignmentProbe {
 pub struct BindingValueFact<'a> {
     kind: BindingValueKind<'a>,
     conditional_assignment_shortcut: bool,
+    one_sided_short_circuit_assignment: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -51,6 +52,7 @@ impl<'a> BindingValueFact<'a> {
         Self {
             kind: BindingValueKind::Scalar(word),
             conditional_assignment_shortcut: false,
+            one_sided_short_circuit_assignment: false,
         }
     }
 
@@ -58,6 +60,7 @@ impl<'a> BindingValueFact<'a> {
         Self {
             kind: BindingValueKind::Loop(words),
             conditional_assignment_shortcut: false,
+            one_sided_short_circuit_assignment: false,
         }
     }
 
@@ -79,8 +82,16 @@ impl<'a> BindingValueFact<'a> {
         self.conditional_assignment_shortcut
     }
 
+    pub fn one_sided_short_circuit_assignment(&self) -> bool {
+        self.one_sided_short_circuit_assignment
+    }
+
     fn mark_conditional_assignment_shortcut(&mut self) {
         self.conditional_assignment_shortcut = true;
+    }
+
+    fn mark_one_sided_short_circuit_assignment(&mut self) {
+        self.one_sided_short_circuit_assignment = true;
     }
 }
 
@@ -2620,7 +2631,7 @@ fn binding_value_visible_id_for_name(
         .map(|binding| binding.id)
 }
 
-fn annotate_conditional_assignment_shortcuts<'a>(
+fn annotate_conditional_assignment_value_paths<'a>(
     semantic: &SemanticModel,
     lists: &[ListFact<'a>],
     binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
@@ -2644,6 +2655,30 @@ fn annotate_conditional_assignment_shortcuts<'a>(
             if let Some(binding_value) = binding_values.get_mut(&binding_id) {
                 binding_value.mark_conditional_assignment_shortcut();
             }
+        }
+    }
+
+    for list in lists
+        .iter()
+        .filter(|list| !list_has_conditional_assignment_shortcuts(list))
+    {
+        let mut prior_assignment_targets = FxHashSet::default();
+        for (index, segment) in list.segments().iter().enumerate() {
+            let Some(target) = segment.assignment_target() else {
+                continue;
+            };
+            let Some(span) = segment.assignment_span() else {
+                continue;
+            };
+            if index > 0 && !prior_assignment_targets.contains(target) {
+                if let Some(binding_id) =
+                    binding_value_visible_id_for_name(semantic, &Name::from(target), span)
+                    && let Some(binding_value) = binding_values.get_mut(&binding_id)
+                {
+                    binding_value.mark_one_sided_short_circuit_assignment();
+                }
+            }
+            prior_assignment_targets.insert(target.to_owned());
         }
     }
 }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -491,7 +491,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 &lists,
                 self.source,
             );
-        annotate_conditional_assignment_shortcuts(self.semantic, &lists, &mut binding_values);
+        annotate_conditional_assignment_value_paths(self.semantic, &lists, &mut binding_values);
         let statement_facts =
             build_statement_facts(&commands, &command_ids_by_span, &self.file.body);
         let background_semicolon_spans =

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -708,7 +708,13 @@ impl<'a> LinterFactsBuilder<'a> {
         let command_parent_ids = build_command_parent_ids(&commands);
         let command_dominance_barrier_flags = build_command_dominance_barrier_flags(&commands);
 
-        let backtick_substitution_spans = word_spans::backtick_substitution_spans(source);
+        let mut backtick_substitution_spans = word_spans::backtick_substitution_spans(source);
+        backtick_substitution_spans.retain(|span| {
+            !self
+                ._indexer
+                .region_index()
+                .is_quoted_heredoc(TextSize::new(span.start.offset as u32))
+        });
         let backtick_escaped_parameters =
             word_spans::backtick_escaped_parameters(source, &backtick_substitution_spans);
 

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -154,6 +154,10 @@ impl<'a> SimpleTestFact<'a> {
         simple_test_operator_expression_operand_words(self, source)
     }
 
+    pub fn numeric_binary_expression_operand_words(&self, source: &str) -> Vec<&'a Word> {
+        simple_test_numeric_binary_expression_operand_words(self, source)
+    }
+
     pub fn string_unary_expression_words(&'a self, source: &str) -> Vec<(&'a Word, &'a Word)> {
         simple_test_expressions(self, source)
             .into_iter()
@@ -552,6 +556,39 @@ fn simple_test_operator_expression_operand_words<'a>(
     expression_operands
 }
 
+fn simple_test_numeric_binary_expression_operand_words<'a>(
+    simple_test: &SimpleTestFact<'a>,
+    source: &str,
+) -> Vec<&'a Word> {
+    let operands = simple_test.effective_operands();
+    let mut expression_operands = Vec::new();
+    let mut segment_start = 0;
+
+    for index in 0..=operands.len() {
+        let is_connector = index < operands.len()
+            && simple_test_effective_operand_text(simple_test, index, source)
+                .as_deref()
+                .is_some_and(simple_test_is_logical_connector);
+        let splits_segment = is_connector
+            && simple_test_segment_is_expression(simple_test, segment_start, index, source);
+        if !splits_segment && index != operands.len() {
+            continue;
+        }
+
+        collect_simple_test_numeric_binary_expression_operand_words(
+            simple_test,
+            segment_start,
+            index,
+            source,
+            &mut expression_operands,
+        );
+
+        segment_start = index + 1;
+    }
+
+    expression_operands
+}
+
 fn collect_simple_test_operator_expression_operand_words<'a>(
     simple_test: &SimpleTestFact<'a>,
     start: usize,
@@ -594,6 +631,45 @@ fn collect_simple_test_operator_expression_operand_words<'a>(
             )
             .as_deref()
             .is_some_and(simple_test_is_nonlogical_binary_operator) =>
+        {
+            expression_operands.push(left);
+            expression_operands.push(right);
+        }
+        [..] => {}
+    }
+}
+
+fn collect_simple_test_numeric_binary_expression_operand_words<'a>(
+    simple_test: &SimpleTestFact<'a>,
+    start: usize,
+    end: usize,
+    source: &str,
+    expression_operands: &mut Vec<&'a Word>,
+) {
+    if start >= end {
+        return;
+    }
+
+    let segment = &simple_test.effective_operands()[start..end];
+    let mut expression_start = 0;
+    while expression_start + 1 < segment.len()
+        && simple_test_effective_operand_text(simple_test, start + expression_start, source)
+            .as_deref()
+            == Some("!")
+    {
+        expression_start += 1;
+    }
+
+    let expression = &segment[expression_start..];
+    match expression {
+        [left, operator, right]
+            if simple_test_effective_operand_text(
+                simple_test,
+                start + expression_start + 1,
+                source,
+            )
+            .as_deref()
+            .is_some_and(simple_test_is_numeric_binary_operator) =>
         {
             expression_operands.push(left);
             expression_operands.push(right);
@@ -844,6 +920,10 @@ fn simple_test_logical_connector_span(
 
 fn simple_test_is_nonlogical_binary_operator(text: &str) -> bool {
     simple_test_is_binary_operator(text) && !simple_test_is_logical_connector(text)
+}
+
+fn simple_test_is_numeric_binary_operator(text: &str) -> bool {
+    matches!(text, "-eq" | "-ne" | "-gt" | "-ge" | "-lt" | "-le")
 }
 
 pub(super) fn build_single_test_subshell_spans<'a>(

--- a/crates/shuck-linter/src/facts/tests/assignments.rs
+++ b/crates/shuck-linter/src/facts/tests/assignments.rs
@@ -80,6 +80,8 @@ check() { return 0; }
 true && w='-w' || w=''
 check && opt='-o' || opt=''
 if true; then flag='-f'; else flag=''; fi
+check && one_sided='-x'
+one_sided='-b' || one_sided='-y'
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
@@ -125,6 +127,19 @@ if true; then flag='-f'; else flag=''; fi
         })
         .collect::<Vec<_>>();
     assert_eq!(flag_bindings, vec![false, false]);
+
+    let one_sided_bindings = semantic
+        .bindings_for(&Name::from("one_sided"))
+        .iter()
+        .copied()
+        .map(|binding_id| {
+            facts
+                .binding_value(binding_id)
+                .expect("expected one_sided binding value fact")
+                .one_sided_short_circuit_assignment()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(one_sided_bindings, vec![true, false, false]);
 }
 
 #[test]

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -837,6 +837,7 @@ fn simple_test_fact_tracks_operator_expression_operands() {
 [ lhs -eq rhs ]
 [ -d one -o two = three ]
 [ ! -e four -a five -nt six ]
+[ ! seven -le eight -a -n nine ]
 ";
 
     with_facts(source, None, |_, facts| {
@@ -879,6 +880,14 @@ fn simple_test_fact_tracks_operator_expression_operands() {
                 .collect::<Vec<_>>(),
             vec!["lhs", "rhs"]
         );
+        assert_eq!(
+            binary
+                .numeric_binary_expression_operand_words(source)
+                .into_iter()
+                .map(|word| word.span.slice(source).to_owned())
+                .collect::<Vec<_>>(),
+            vec!["lhs", "rhs"]
+        );
 
         let compound = commands
             .iter()
@@ -893,6 +902,11 @@ fn simple_test_fact_tracks_operator_expression_operands() {
                 .collect::<Vec<_>>(),
             vec!["one", "two", "three"]
         );
+        assert!(
+            compound
+                .numeric_binary_expression_operand_words(source)
+                .is_empty()
+        );
 
         let negated_compound = commands
             .iter()
@@ -906,6 +920,25 @@ fn simple_test_fact_tracks_operator_expression_operands() {
                 .map(|word| word.span.slice(source).to_owned())
                 .collect::<Vec<_>>(),
             vec!["four", "five", "six"]
+        );
+        assert!(
+            negated_compound
+                .numeric_binary_expression_operand_words(source)
+                .is_empty()
+        );
+
+        let mixed_numeric = commands
+            .iter()
+            .find(|(text, _)| text == "[ ! seven -le eight -a -n nine ]")
+            .and_then(|(_, fact)| fact.simple_test())
+            .expect("expected mixed numeric compound test fact");
+        assert_eq!(
+            mixed_numeric
+                .numeric_binary_expression_operand_words(source)
+                .into_iter()
+                .map(|word| word.span.slice(source).to_owned())
+                .collect::<Vec<_>>(),
+            vec!["seven", "eight"]
         );
     });
 }

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1794,6 +1794,31 @@ fn collects_command_substitution_spans_for_wrapped_substring_offset_arithmetic()
 }
 
 #[test]
+fn word_facts_descend_into_arithmetic_command_substitution_bodies() {
+    let source = "\
+#!/bin/bash
+if (( $(du -c $mask | cut -f 1) == 0 )); then
+  :
+fi
+for (( i=$(next $start); i < 3; i++ )); do
+  :
+done
+";
+
+    with_facts(source, None, |_, facts| {
+        let nested_args = facts
+            .word_facts()
+            .filter(|fact| fact.is_nested_word_command())
+            .filter(|fact| fact.host_expansion_context() == Some(ExpansionContext::CommandArgument))
+            .map(|fact| fact.span().slice(source))
+            .collect::<Vec<_>>();
+
+        assert!(nested_args.contains(&"$mask"), "{nested_args:?}");
+        assert!(nested_args.contains(&"$start"), "{nested_args:?}");
+    });
+}
+
+#[test]
 fn ignores_quoted_dollar_words_in_arithmetic_command_contexts() {
     let source = "#!/bin/bash\n(( \"$x\" + 1 ))\nfor (( i=\"$y\"; i < 3; i++ )); do :; done\n";
 

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -218,6 +218,21 @@ fn collect_arithmetic_words<'a>(expression: &'a ArithmeticExprNode, words: &mut 
     }
 }
 
+fn collect_arithmetic_expression_visits<'a, F>(
+    expression: &'a ArithmeticExprNode,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(CommandVisit<'a>, CommandTraversalContext),
+{
+    let mut arithmetic_words = Vec::new();
+    collect_arithmetic_words(expression, &mut arithmetic_words);
+    for word in arithmetic_words {
+        collect_word_visits(word, options, context, visitor);
+    }
+}
+
 fn visit_arithmetic_lvalue_words<'a>(
     target: &'a ArithmeticLvalue,
     visitor: &mut impl FnMut(&'a Word),
@@ -422,6 +437,16 @@ fn collect_compound_visits<'a, F>(
             collect_command_visits(&command.body, options, loop_context(context), visitor);
         }
         CompoundCommand::ArithmeticFor(command) => {
+            for expression in [
+                command.init_ast.as_ref(),
+                command.condition_ast.as_ref(),
+                command.step_ast.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                collect_arithmetic_expression_visits(expression, options, context, visitor);
+            }
             collect_command_visits(&command.body, options, loop_context(context), visitor);
         }
         CompoundCommand::While(command) => {
@@ -462,7 +487,11 @@ fn collect_compound_visits<'a, F>(
             collect_command_visits(&command.body, options, context, visitor);
             collect_command_visits(&command.always_body, options, context, visitor);
         }
-        CompoundCommand::Arithmetic(_) => {}
+        CompoundCommand::Arithmetic(command) => {
+            if let Some(expression) = command.expr_ast.as_ref() {
+                collect_arithmetic_expression_visits(expression, options, context, visitor);
+            }
+        }
         CompoundCommand::Time(command) => {
             if let Some(command) = &command.command {
                 collect_command_visit(command, options, context, visitor);
@@ -576,11 +605,7 @@ fn collect_word_part_visits<'a, F>(
             }
             WordPart::ArithmeticExpansion { expression_ast, .. } => {
                 if let Some(expression_ast) = expression_ast.as_ref() {
-                    let mut arithmetic_words = Vec::new();
-                    collect_optional_arithmetic_words(Some(expression_ast), &mut arithmetic_words);
-                    for word in arithmetic_words {
-                        collect_word_visits(word, options, context, visitor);
-                    }
+                    collect_arithmetic_expression_visits(expression_ast, options, context, visitor);
                 }
             }
             WordPart::Parameter(parameter) => {

--- a/crates/shuck-linter/src/facts/word_spans.rs
+++ b/crates/shuck-linter/src/facts/word_spans.rs
@@ -72,7 +72,9 @@ pub(crate) fn shellcheck_collapsed_backtick_part_span(
     source: &str,
     backtick_spans: &[Span],
 ) -> Span {
-    collapse_backtick_continuation_span(span, source, backtick_spans).unwrap_or(span)
+    let deescaped =
+        shellcheck_deescaped_backtick_part_span(span, source, backtick_spans).unwrap_or(span);
+    collapse_backtick_continuation_span(deescaped, source, backtick_spans).unwrap_or(deescaped)
 }
 
 pub(crate) fn shellcheck_collapsed_backtick_part_span_in_source(span: Span, source: &str) -> Span {
@@ -1490,6 +1492,52 @@ fn collapse_backtick_continuation_span(
         shellcheck_collapsed_position(chain_start, span.start, source),
         shellcheck_collapsed_position(chain_start, span.end, source),
     ))
+}
+
+fn shellcheck_deescaped_backtick_part_span(
+    span: Span,
+    source: &str,
+    backtick_spans: &[Span],
+) -> Option<Span> {
+    let containing_span = containing_backtick_substitution_span(span, backtick_spans)?;
+    let content_start = containing_span.start.offset.saturating_add('`'.len_utf8());
+    let start_removed = backtick_removed_escape_count(source, content_start, span.start.offset)?;
+    let end_removed = backtick_removed_escape_count(source, content_start, span.end.offset)?;
+    if start_removed == 0 && end_removed == 0 {
+        return None;
+    }
+
+    Some(Span::from_positions(
+        position_at_offset(source, span.start.offset.checked_sub(start_removed)?)?,
+        position_at_offset(source, span.end.offset.checked_sub(end_removed)?)?,
+    ))
+}
+
+fn backtick_removed_escape_count(source: &str, start: usize, end: usize) -> Option<usize> {
+    let mut removed = 0usize;
+    let mut index = start;
+    while index < end {
+        let ch = source[index..].chars().next()?;
+        let ch_len = ch.len_utf8();
+        if ch != '\\' {
+            index += ch_len;
+            continue;
+        }
+
+        let next_offset = index + ch_len;
+        if next_offset >= end {
+            break;
+        }
+        let escaped = source[next_offset..].chars().next()?;
+        if matches!(escaped, '$' | '`' | '\\') {
+            removed += 1;
+            index = next_offset + escaped.len_utf8();
+        } else {
+            index += ch_len;
+        }
+    }
+
+    Some(removed)
 }
 
 fn containing_backtick_substitution_span(target: Span, backtick_spans: &[Span]) -> Option<Span> {
@@ -6072,6 +6120,41 @@ printf '%s\\n' \"${arr[@]}\" \"x${arr[@]}\" \"x${!arr[@]}\" \"x${arr[@]:1}\" \"x
     }
 
     #[test]
+    fn shellcheck_collapsed_backtick_part_span_in_source_counts_removed_backslash_pairs() {
+        let source = r#"echo `sed -e "s/'/'\\\\\''/g" $2`"#;
+        let span = span_for_text(source, "$2");
+
+        let adjusted = shellcheck_collapsed_backtick_part_span_in_source(span, source);
+
+        assert_eq!(adjusted.start.line, span.start.line);
+        assert_eq!(adjusted.end.line, span.end.line);
+        assert_eq!(adjusted.start.column, span.start.column - 2);
+        assert_eq!(adjusted.end.column, span.end.column - 2);
+    }
+
+    #[test]
+    fn shellcheck_collapsed_backtick_part_span_in_source_counts_escaped_dollars() {
+        let source = r#"echo `echo \$x $y`"#;
+        let span = span_for_text(source, "$y");
+
+        let adjusted = shellcheck_collapsed_backtick_part_span_in_source(span, source);
+
+        assert_eq!(adjusted.start.column, span.start.column - 1);
+        assert_eq!(adjusted.end.column, span.end.column - 1);
+    }
+
+    #[test]
+    fn shellcheck_collapsed_backtick_part_span_in_source_keeps_literal_backslashes() {
+        let source = r#"echo `echo \a $x`"#;
+        let span = span_for_text(source, "$x");
+
+        assert_eq!(
+            shellcheck_collapsed_backtick_part_span_in_source(span, source),
+            span
+        );
+    }
+
+    #[test]
     fn backtick_escaped_parameters_keep_quoted_assignment_prefixes_together() {
         let source = "`VAR=\"a b\" OTHER=$(printf '%s\\n' value) \\$cmd arg`";
         let backtick_spans = backtick_substitution_spans(source);
@@ -6099,6 +6182,15 @@ printf '%s\\n' \"${arr[@]}\" \"x${arr[@]}\" \"x${!arr[@]}\" \"x${arr[@]:1}\" \"x
 
         assert_eq!(escaped.len(), 1);
         assert!(escaped[0].standalone_command_name);
+    }
+
+    fn span_for_text(source: &str, text: &str) -> Span {
+        let start_offset = source.find(text).expect("expected text");
+        let end_offset = start_offset + text.len();
+        Span::from_positions(
+            position_at_offset(source, start_offset).expect("expected start position"),
+            position_at_offset(source, end_offset).expect("expected end position"),
+        )
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1248,6 +1248,64 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.context() == WordFactContext::ArithmeticCommand
     }
 
+    pub fn part_is_inside_backtick_escaped_double_quotes(
+        self,
+        part_span: Span,
+        source: &str,
+    ) -> bool {
+        let Some(backtick_span) =
+            self.facts
+                .backtick_substitution_spans()
+                .iter()
+                .copied()
+                .find(|span| {
+                    span.start.offset <= part_span.start.offset
+                        && span.end.offset >= part_span.end.offset
+                })
+        else {
+            return false;
+        };
+
+        let mut index = backtick_span.start.offset.saturating_add('`'.len_utf8());
+        let limit = part_span.start.offset.min(
+            backtick_span
+                .end
+                .offset
+                .saturating_sub('`'.len_utf8()),
+        );
+        let mut in_single_quote = false;
+        let mut in_escaped_double_quote = false;
+
+        while index < limit {
+            let Some(ch) = source[index..].chars().next() else {
+                break;
+            };
+            let ch_len = ch.len_utf8();
+
+            match ch {
+                '\'' if !in_escaped_double_quote => {
+                    in_single_quote = !in_single_quote;
+                    index += ch_len;
+                }
+                '\\' if !in_single_quote => {
+                    let next_index = index + ch_len;
+                    let Some(escaped) = source[next_index..].chars().next() else {
+                        break;
+                    };
+                    if escaped == '"' {
+                        in_escaped_double_quote = !in_escaped_double_quote;
+                    }
+                    index = next_index + escaped.len_utf8();
+                }
+                _ => {
+                    index += ch_len;
+                }
+            }
+        }
+
+        in_escaped_double_quote
+    }
+
     pub fn host_kind(self) -> WordFactHostKind {
         self.occurrence().host_kind
     }

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1477,7 +1477,10 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
                         })
                 }
             }
-            WordPart::Parameter(_) | WordPart::ParameterExpansion { .. } => part_span,
+            WordPart::Parameter(_) | WordPart::ParameterExpansion { .. } => {
+                shellcheck_parameter_span_inside_escaped_quotes(part_span, source)
+                    .unwrap_or(part_span)
+            }
             _ => return part_span,
         };
 
@@ -1590,6 +1593,131 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
             .map(|brace| brace.span)
             .collect()
     }
+}
+
+fn shellcheck_parameter_span_inside_escaped_quotes(span: Span, source: &str) -> Option<Span> {
+    if span.start.line != span.end.line {
+        return None;
+    }
+
+    let search_start = offset_for_line_column(
+        source,
+        span.start.line,
+        span.start.column.saturating_sub(2).max(1),
+    )?;
+    let search_end = offset_for_line_column(
+        source,
+        span.end.line,
+        span.end.column.saturating_add(3),
+    )
+    .or_else(|| line_end_offset(source, span.end.line))?;
+    let window = source.get(search_start..search_end)?;
+    let relative_dollar = window.find('$')?;
+    let start_offset = search_start + relative_dollar;
+    let start = Position::new().advanced_by(&source[..start_offset]);
+    if start.line != span.start.line
+        || start.column < span.start.column
+        || start.column > span.start.column.saturating_add(2)
+    {
+        return None;
+    }
+
+    let span_start_offset = offset_for_line_column(source, span.start.line, span.start.column)?;
+    let prefix = source.get(span_start_offset..start_offset)?;
+    if !prefix.contains('"') && !prefix.contains('\\') {
+        return None;
+    }
+
+    let end_offset = parameter_expansion_end_offset(source, start_offset)?;
+    let end = Position::new().advanced_by(&source[..end_offset]);
+    if end.line != span.end.line
+        || end.column < span.end.column
+        || end.column > span.end.column.saturating_add(3)
+    {
+        return None;
+    }
+
+    if start.column == span.start.column && end.column == span.end.column {
+        return None;
+    }
+
+    Some(Span::from_positions(start, end))
+}
+
+fn offset_for_line_column(source: &str, line: usize, column: usize) -> Option<usize> {
+    if line == 0 || column == 0 {
+        return None;
+    }
+
+    let mut current_line = 1usize;
+    let mut line_start = 0usize;
+    for (offset, ch) in source.char_indices() {
+        if current_line == line {
+            return offset_for_column_in_line(source, line_start, column);
+        }
+        if ch == '\n' {
+            current_line += 1;
+            line_start = offset + ch.len_utf8();
+        }
+    }
+
+    (current_line == line).then(|| offset_for_column_in_line(source, line_start, column))?
+}
+
+fn offset_for_column_in_line(source: &str, line_start: usize, column: usize) -> Option<usize> {
+    let mut current_column = 1usize;
+    for (relative_offset, ch) in source.get(line_start..)?.char_indices() {
+        if ch == '\n' {
+            break;
+        }
+        if current_column == column {
+            return Some(line_start + relative_offset);
+        }
+        current_column += 1;
+    }
+
+    (current_column == column).then_some(
+        line_start
+            + source
+                .get(line_start..)?
+                .find('\n')
+                .unwrap_or(source.len() - line_start),
+    )
+}
+
+fn line_end_offset(source: &str, line: usize) -> Option<usize> {
+    let line_start = offset_for_line_column(source, line, 1)?;
+    Some(
+        line_start
+            + source
+                .get(line_start..)?
+                .find('\n')
+                .unwrap_or(source.len() - line_start),
+    )
+}
+
+fn parameter_expansion_end_offset(source: &str, dollar_offset: usize) -> Option<usize> {
+    let after_dollar = dollar_offset + '$'.len_utf8();
+    let bytes = source.as_bytes();
+    if bytes.get(after_dollar) == Some(&b'{') {
+        let relative_end = source.get(after_dollar..)?.find('}')?;
+        return Some(after_dollar + relative_end + '}'.len_utf8());
+    }
+
+    let first = source.get(after_dollar..)?.chars().next()?;
+    if matches!(first, '@' | '*' | '#' | '?' | '$' | '!' | '-' | '0'..='9') {
+        return Some(after_dollar + first.len_utf8());
+    }
+
+    let mut end = after_dollar;
+    for ch in source.get(after_dollar..)?.chars() {
+        if ch == '_' || ch.is_ascii_alphanumeric() {
+            end += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    (end > after_dollar).then_some(end)
 }
 
 fn build_brace_variable_before_bracket_spans<'a>(

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -3733,9 +3733,14 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                                 &mut self.arithmetic.arithmetic_command_substitution_spans,
                             );
                         }
+                        let word_context = Self::simple_command_argument_expansion_context(
+                            surface_command_name,
+                            word,
+                            self.source,
+                        );
                         let (_, opened) = self.push_word_with_surface(
                             word,
-                            WordFactContext::Expansion(ExpansionContext::CommandArgument),
+                            word_context,
                             WordFactHostKind::Direct,
                             surface_word_context,
                         );
@@ -3837,6 +3842,31 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 );
             }
         }
+    }
+
+    fn simple_command_argument_expansion_context(
+        command_name: Option<&str>,
+        word: &Word,
+        source: &str,
+    ) -> WordFactContext {
+        match command_name {
+            Some("let") => WordFactContext::ArithmeticCommand,
+            Some("declare" | "export" | "local" | "readonly" | "typeset")
+                if Self::simple_assignment_like_word(word, source) =>
+            {
+                WordFactContext::Expansion(ExpansionContext::DeclarationAssignmentValue)
+            }
+            _ => WordFactContext::Expansion(ExpansionContext::CommandArgument),
+        }
+    }
+
+    fn simple_assignment_like_word(word: &Word, source: &str) -> bool {
+        let text = word.span.slice(source);
+        let Some((name, _)) = text.split_once('=') else {
+            return false;
+        };
+
+        is_shell_variable_name(name)
     }
 
     fn collect_expansion_assignment_value_words(&mut self, command: &'a Command) {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -877,19 +877,22 @@ impl<'a> SafeValueIndex<'a> {
                 } else {
                     let binding_value = self.facts.binding_value(binding_id);
                     let scalar_word = binding_value.and_then(|value| value.scalar_word());
-                    if case_cli_scope == Some(binding.scope)
+                    let case_cli_status_capture_stays_unsafe = case_cli_scope
+                        == Some(binding.scope)
                         && query.is_field_context()
-                        && scalar_word.is_some_and(word_is_standalone_status_capture)
+                        && scalar_word.is_some_and(word_is_standalone_status_capture);
+                    let conditional_assignment_shortcut_stays_unsafe =
+                        binding_value.is_some_and(|value| {
+                            value.conditional_assignment_shortcut()
+                                && !self.conditional_assignment_shortcut_value_can_stay_safe(
+                                    binding_id,
+                                    scalar_word,
+                                    query,
+                                )
+                        });
+                    if case_cli_status_capture_stays_unsafe
+                        || conditional_assignment_shortcut_stays_unsafe
                     {
-                        false
-                    } else if binding_value.is_some_and(|value| {
-                        value.conditional_assignment_shortcut()
-                            && !self.conditional_assignment_shortcut_value_can_stay_safe(
-                                binding_id,
-                                scalar_word,
-                                query,
-                            )
-                    }) {
                         false
                     } else {
                         scalar_word.is_some_and(|word| {
@@ -2508,9 +2511,11 @@ impl<'a> SafeValueIndex<'a> {
         name: &Name,
         at: Span,
     ) -> bool {
-        let unset_blocks = (!bindings.is_empty())
-            .then(|| self.unset_value_blocks_for_name_before_reference(name, at))
-            .unwrap_or_default();
+        let unset_blocks = if bindings.is_empty() {
+            Default::default()
+        } else {
+            self.unset_value_blocks_for_name_before_reference(name, at)
+        };
         self.value_source_blocks_cover_all_paths_to_reference(bindings, name, at, unset_blocks)
     }
 

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -323,6 +323,7 @@ impl<'a> SafeValueIndex<'a> {
 
         let mut bindings = self.safe_bindings_for_name(name, at);
         self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        self.drop_outer_bindings_shadowed_by_covering_loop_bindings(&mut bindings, at);
         bindings.retain(|binding_id| {
             !self.binding_is_cleared_by_dominating_unset(*binding_id, name, at)
         });
@@ -1268,10 +1269,37 @@ impl<'a> SafeValueIndex<'a> {
         let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset) else {
             return false;
         };
+        self.loop_variable_scope_callers_stay_within_body(
+            definition_span,
+            helper_scope,
+            &mut FxHashSet::default(),
+        )
+    }
+
+    fn loop_variable_scope_callers_stay_within_body(
+        &self,
+        definition_span: Span,
+        helper_scope: ScopeId,
+        seen_scopes: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        if !seen_scopes.insert(helper_scope) {
+            return false;
+        }
+
         let caller_sites = self.named_function_call_sites(helper_scope);
         !caller_sites.is_empty()
             && caller_sites.into_iter().all(|(_, call_span)| {
-                self.loop_variable_reference_stays_within_body(definition_span, call_span)
+                if self.loop_variable_reference_stays_within_body(definition_span, call_span) {
+                    return true;
+                }
+
+                let caller_scope = self.semantic.scope_at(call_span.start.offset);
+                let mut caller_seen = seen_scopes.clone();
+                self.loop_variable_scope_callers_stay_within_body(
+                    definition_span,
+                    caller_scope,
+                    &mut caller_seen,
+                )
             })
     }
 
@@ -1331,7 +1359,16 @@ impl<'a> SafeValueIndex<'a> {
         if !uncalled_function_bindings.is_empty() && !function_local_binding {
             bindings = uncalled_function_bindings;
         }
-        if bindings.is_empty() {
+        if !caller_bindings.is_empty()
+            && self.enclosing_function_scope_at(at.start.offset).is_some()
+            && !function_local_binding
+            && self.bindings_are_static_loop_variables(&caller_bindings)
+        {
+            bindings = caller_bindings;
+            bindings.extend(helper_bindings);
+            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            bindings.dedup();
+        } else if bindings.is_empty() {
             bindings = caller_bindings;
             bindings.extend(helper_bindings);
             bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
@@ -1341,9 +1378,43 @@ impl<'a> SafeValueIndex<'a> {
             bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
             bindings.dedup();
         }
+        if let Some(scope) = self.enclosing_function_scope_at(at.start.offset)
+            && bindings.iter().copied().any(|binding_id| {
+                self.binding_is_in_scope_or_descendant(binding_id, scope)
+                    && self.binding_shadows_outer_scope_values(binding_id)
+            })
+        {
+            bindings
+                .retain(|binding_id| self.binding_is_in_scope_or_descendant(*binding_id, scope));
+        }
+        let reference_scope = self.semantic.scope_at(at.start.offset);
+        bindings.retain(|binding_id| {
+            self.semantic.binding(*binding_id).span.start.offset <= at.start.offset
+                || !self.binding_is_in_scope_or_descendant(*binding_id, reference_scope)
+                || self.future_binding_can_reach_reference(*binding_id, name, at)
+        });
 
         self.retain_value_bindings(&mut bindings);
         bindings
+    }
+
+    fn bindings_are_static_loop_variables(&self, bindings: &[BindingId]) -> bool {
+        !bindings.is_empty()
+            && bindings.iter().copied().all(|binding_id| {
+                matches!(
+                    self.semantic.binding(binding_id).origin,
+                    BindingOrigin::LoopVariable {
+                        items: LoopValueOrigin::StaticWords,
+                        ..
+                    }
+                )
+            })
+    }
+
+    fn binding_shadows_outer_scope_values(&self, binding_id: BindingId) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        binding.attributes.contains(BindingAttributes::LOCAL)
+            || matches!(binding.origin, BindingOrigin::LoopVariable { .. })
     }
 
     fn uncalled_function_outer_bindings_at_end(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
@@ -1395,29 +1466,95 @@ impl<'a> SafeValueIndex<'a> {
         let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset) else {
             return Vec::new();
         };
+        self.caller_bindings_covering_static_scope_call_sites(
+            name,
+            helper_scope,
+            &mut FxHashSet::default(),
+        )
+        .unwrap_or_default()
+    }
+
+    fn caller_bindings_covering_static_scope_call_sites(
+        &mut self,
+        name: &Name,
+        helper_scope: ScopeId,
+        seen_scopes: &mut FxHashSet<ScopeId>,
+    ) -> Option<Vec<BindingId>> {
+        if !seen_scopes.insert(helper_scope) {
+            return None;
+        }
+
         let caller_sites = self.named_function_call_sites(helper_scope);
         if caller_sites.is_empty() {
-            return Vec::new();
+            return None;
         }
 
         let mut bindings = Vec::new();
         for (scope, span) in caller_sites {
-            let branch = self.caller_branch_bindings_before(name, scope, span);
-            if branch.is_empty()
-                || !self.bindings_cover_all_paths_to_callsite(
-                    &branch,
-                    self.command_for_name_word_span(span)
-                        .map_or(span, |command| command.span()),
-                )
+            let caller_scope = self
+                .enclosing_function_scope_at(span.start.offset)
+                .unwrap_or(scope);
+            let mut branch = self.caller_branch_bindings_before(name, caller_scope, span);
+            self.drop_declarations_shadowed_by_covering_loop_bindings(&mut branch, span);
+            if branch
+                .iter()
+                .copied()
+                .any(|binding_id| self.binding_is_in_scope_or_descendant(binding_id, caller_scope))
             {
-                return Vec::new();
+                branch.retain(|binding_id| {
+                    self.binding_is_in_scope_or_descendant(*binding_id, caller_scope)
+                });
             }
-            bindings.extend(branch);
+            let call_span = self
+                .command_for_name_word_span(span)
+                .map_or(span, |command| command.span());
+            let loop_branch = self.loop_bindings_covering_callsite(&branch, call_span);
+            if !loop_branch.is_empty() {
+                bindings.extend(loop_branch);
+                continue;
+            }
+            if !branch.is_empty() && self.bindings_cover_all_paths_to_callsite(&branch, call_span) {
+                bindings.extend(branch);
+                continue;
+            }
+
+            let mut caller_seen = seen_scopes.clone();
+            let transitive = self.caller_bindings_covering_static_scope_call_sites(
+                name,
+                caller_scope,
+                &mut caller_seen,
+            )?;
+            if transitive.is_empty() {
+                return None;
+            }
+            bindings.extend(transitive);
         }
 
         bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         bindings.dedup();
+        Some(bindings)
+    }
+
+    fn loop_bindings_covering_callsite(
+        &self,
+        bindings: &[BindingId],
+        call_span: Span,
+    ) -> Vec<BindingId> {
         bindings
+            .iter()
+            .copied()
+            .filter(|binding_id| {
+                let binding = self.semantic.binding(*binding_id);
+                let BindingOrigin::LoopVariable {
+                    definition_span,
+                    items: LoopValueOrigin::StaticWords,
+                } = &binding.origin
+                else {
+                    return false;
+                };
+                self.loop_variable_reference_stays_within_body(*definition_span, call_span)
+            })
+            .collect()
     }
 
     fn visible_bindings_for_name_without_helpers(&self, name: &Name, at: Span) -> Vec<BindingId> {
@@ -1597,6 +1734,42 @@ impl<'a> SafeValueIndex<'a> {
         false
     }
 
+    fn future_binding_can_reach_reference(
+        &self,
+        binding_id: BindingId,
+        name: &Name,
+        at: Span,
+    ) -> bool {
+        let Some(binding_block) = self.block_for_binding(binding_id) else {
+            return false;
+        };
+        let Some(reference_block) = self.block_for_name_reference_or_virtual_offset(name, at)
+        else {
+            return false;
+        };
+        if binding_block == reference_block {
+            return true;
+        }
+
+        let cfg = self.analysis.cfg();
+        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let mut stack = vec![binding_block];
+        let mut seen = FxHashSet::default();
+        while let Some(block_id) = stack.pop() {
+            if unreachable.contains(&block_id) || !seen.insert(block_id) {
+                continue;
+            }
+            for (successor, _) in cfg.successors(block_id) {
+                if *successor == reference_block {
+                    return true;
+                }
+                stack.push(*successor);
+            }
+        }
+
+        false
+    }
+
     fn current_binding_value_for_name(&self, name: &Name) -> Option<BindingId> {
         self.binding_value_stack
             .iter()
@@ -1642,6 +1815,65 @@ impl<'a> SafeValueIndex<'a> {
                 binding.scope == *scope && binding.span.start.offset <= *loop_start
             })
         });
+    }
+
+    fn drop_outer_bindings_shadowed_by_covering_loop_bindings(
+        &self,
+        bindings: &mut Vec<BindingId>,
+        at: Span,
+    ) {
+        let covering_loop_scopes = bindings
+            .iter()
+            .copied()
+            .filter_map(|binding_id| {
+                let binding = self.semantic.binding(binding_id);
+                let BindingOrigin::LoopVariable {
+                    definition_span,
+                    items: LoopValueOrigin::StaticWords,
+                } = &binding.origin
+                else {
+                    return None;
+                };
+                (self.loop_variable_reference_stays_within_body(*definition_span, at)
+                    || self
+                        .loop_variable_reference_stays_within_static_callers(*definition_span, at))
+                .then_some((binding_id, binding.scope))
+            })
+            .collect::<Vec<_>>();
+        if covering_loop_scopes.is_empty() {
+            return;
+        }
+
+        bindings.retain(|binding_id| {
+            if covering_loop_scopes
+                .iter()
+                .any(|(covering_id, _)| covering_id == binding_id)
+            {
+                return true;
+            }
+
+            let binding = self.semantic.binding(*binding_id);
+            if matches!(
+                binding.origin,
+                BindingOrigin::LoopVariable {
+                    items: LoopValueOrigin::StaticWords,
+                    ..
+                }
+            ) {
+                return false;
+            }
+            !covering_loop_scopes
+                .iter()
+                .any(|(_, loop_scope)| self.scope_is_ancestor(binding.scope, *loop_scope))
+        });
+    }
+
+    fn scope_is_ancestor(&self, ancestor: ScopeId, scope: ScopeId) -> bool {
+        ancestor != scope
+            && self
+                .semantic
+                .ancestor_scopes(scope)
+                .any(|candidate| candidate == ancestor)
     }
 
     fn called_helper_bindings_for_name(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
@@ -1766,7 +1998,20 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         caller_sites.into_iter().all(|(scope, span)| {
-            let branch = self.caller_branch_bindings_before(name, scope, span);
+            let caller_scope = self
+                .enclosing_function_scope_at(span.start.offset)
+                .unwrap_or(scope);
+            let mut branch = self.caller_branch_bindings_before(name, caller_scope, span);
+            self.drop_declarations_shadowed_by_covering_loop_bindings(&mut branch, span);
+            if branch
+                .iter()
+                .copied()
+                .any(|binding_id| self.binding_is_in_scope_or_descendant(binding_id, caller_scope))
+            {
+                branch.retain(|binding_id| {
+                    self.binding_is_in_scope_or_descendant(*binding_id, caller_scope)
+                });
+            }
             if branch.is_empty() {
                 return false;
             }
@@ -1779,13 +2024,15 @@ impl<'a> SafeValueIndex<'a> {
                 .into_iter()
                 .filter(|binding_id| !helper_branch.contains(binding_id))
                 .collect::<Vec<_>>();
+            let call_span = self
+                .command_for_name_word_span(span)
+                .map_or(span, |command| command.span());
 
             direct_branch.is_empty()
-                || self.bindings_cover_all_paths_to_callsite(
-                    &direct_branch,
-                    self.command_for_name_word_span(span)
-                        .map_or(span, |command| command.span()),
-                )
+                || !self
+                    .loop_bindings_covering_callsite(&direct_branch, call_span)
+                    .is_empty()
+                || self.bindings_cover_all_paths_to_callsite(&direct_branch, call_span)
         })
     }
 

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -18,6 +18,7 @@ use crate::{ExpansionContext, FactSpan, LinterFacts};
 pub enum SafeValueQuery {
     Argv,
     RedirectTarget,
+    NumericTestOperand,
     Pattern,
     Regex,
     Quoted,
@@ -49,6 +50,7 @@ impl SafeValueQuery {
     fn operand_context(self) -> Option<ExpansionContext> {
         match self {
             Self::Argv => Some(ExpansionContext::CommandArgument),
+            Self::NumericTestOperand => Some(ExpansionContext::CommandArgument),
             Self::RedirectTarget => Some(ExpansionContext::RedirectTarget(RedirectKind::Output)),
             Self::Pattern => Some(ExpansionContext::CasePattern),
             Self::Regex => Some(ExpansionContext::RegexOperand),
@@ -56,9 +58,18 @@ impl SafeValueQuery {
         }
     }
 
+    fn is_field_context(self) -> bool {
+        matches!(
+            self,
+            Self::Argv | Self::RedirectTarget | Self::NumericTestOperand
+        )
+    }
+
     fn literal_is_safe(self, text: &str) -> bool {
         match self {
-            Self::Argv | Self::RedirectTarget => literal_is_field_safe(text),
+            Self::Argv | Self::RedirectTarget | Self::NumericTestOperand => {
+                literal_is_field_safe(text)
+            }
             Self::Pattern => literal_is_pattern_safe(text),
             Self::Regex => literal_is_regex_safe(text),
             Self::Quoted => true,
@@ -315,12 +326,13 @@ impl<'a> SafeValueIndex<'a> {
         bindings.retain(|binding_id| {
             !self.binding_is_cleared_by_dominating_unset(*binding_id, name, at)
         });
-        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
+        if query.is_field_context() {
             bindings.retain(|binding_id| {
                 !self.binding_is_blocked_by_exit_like_function_call(*binding_id, at)
             });
         }
-        let case_cli_scope = matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+        let case_cli_scope = query
+            .is_field_context()
             .then(|| self.case_cli_dispatch_scope_at(at.start.offset))
             .flatten();
         if bindings.is_empty()
@@ -342,15 +354,14 @@ impl<'a> SafeValueIndex<'a> {
                 .copied()
                 .any(|binding_id| self.binding_is_in_scope_or_descendant(binding_id, scope))
         });
-        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+        if query.is_field_context()
             && case_cli_scope.is_some()
             && !self.case_cli_dispatch_outer_bindings_can_stay_safe(&bindings, at, query)
             && !binding_belongs_to_case_cli_scope
         {
             return safe_numeric_shell_variable(name);
         }
-        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
-            && self.bindings_are_all_plain_empty_static_literals(&bindings)
+        if query.is_field_context() && self.bindings_are_all_plain_empty_static_literals(&bindings)
         {
             return false;
         }
@@ -368,8 +379,7 @@ impl<'a> SafeValueIndex<'a> {
             .called_helper_bindings_for_name(name, at)
             .into_iter()
             .collect::<FxHashSet<_>>();
-        let needs_arg_path_coverage =
-            matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget);
+        let needs_arg_path_coverage = query.is_field_context();
         let bindings_cover_all_paths = helper_bindings.is_empty()
             && needs_arg_path_coverage
             && self.value_sources_cover_all_paths_to_reference(&bindings, name, at);
@@ -468,9 +478,7 @@ impl<'a> SafeValueIndex<'a> {
         at: Span,
         query: SafeValueQuery,
     ) -> bool {
-        if !matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
-            || self.span_is_within_command_name(at)
-        {
+        if !query.is_field_context() || self.span_is_within_command_name(at) {
             return false;
         }
         let Some(scope) = self.case_cli_reachable_function_scope_at(at.start.offset) else {
@@ -753,7 +761,7 @@ impl<'a> SafeValueIndex<'a> {
         bindings: &[BindingId],
         query: SafeValueQuery,
     ) -> bool {
-        if !matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
+        if !query.is_field_context() {
             return false;
         }
 
@@ -825,15 +833,21 @@ impl<'a> SafeValueIndex<'a> {
                 if self.binding_is_name_only_declaration(binding_id) {
                     true
                 } else {
-                    let scalar_word = self
-                        .facts
-                        .binding_value(binding_id)
-                        .filter(|value| !value.conditional_assignment_shortcut())
-                        .and_then(|value| value.scalar_word());
+                    let binding_value = self.facts.binding_value(binding_id);
+                    let scalar_word = binding_value.and_then(|value| value.scalar_word());
                     if case_cli_scope == Some(binding.scope)
-                        && matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+                        && query.is_field_context()
                         && scalar_word.is_some_and(word_is_standalone_status_capture)
                     {
+                        false
+                    } else if binding_value.is_some_and(|value| {
+                        value.conditional_assignment_shortcut()
+                            && !self.conditional_assignment_shortcut_value_can_stay_safe(
+                                binding_id,
+                                scalar_word,
+                                query,
+                            )
+                    }) {
                         false
                     } else {
                         scalar_word.is_some_and(|word| {
@@ -884,6 +898,25 @@ impl<'a> SafeValueIndex<'a> {
         result
     }
 
+    fn conditional_assignment_shortcut_value_can_stay_safe(
+        &mut self,
+        binding_id: BindingId,
+        scalar_word: Option<&Word>,
+        query: SafeValueQuery,
+    ) -> bool {
+        if query != SafeValueQuery::NumericTestOperand {
+            return false;
+        }
+        let Some(word) = scalar_word else {
+            return false;
+        };
+        if word_static_text_is_shell_integer(word, self.source) {
+            return true;
+        }
+        word_has_arithmetic_expansion(word)
+            && self.word_is_safe_for_binding_value(binding_id, word, query)
+    }
+
     fn status_capture_bindings_cover_reference(
         &self,
         bindings: &[BindingId],
@@ -892,7 +925,7 @@ impl<'a> SafeValueIndex<'a> {
         query: SafeValueQuery,
         case_cli_scope: Option<ScopeId>,
     ) -> bool {
-        if !matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
+        if !query.is_field_context() {
             return false;
         }
 
@@ -933,7 +966,7 @@ impl<'a> SafeValueIndex<'a> {
         query: SafeValueQuery,
         case_cli_scope: Option<ScopeId>,
     ) -> bool {
-        if !matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
+        if !query.is_field_context() {
             return false;
         }
 
@@ -1000,7 +1033,7 @@ impl<'a> SafeValueIndex<'a> {
         query: SafeValueQuery,
         case_cli_scope: Option<ScopeId>,
     ) -> bool {
-        if !matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
+        if !query.is_field_context() {
             return false;
         }
 
@@ -1198,7 +1231,7 @@ impl<'a> SafeValueIndex<'a> {
         if prior_bindings.is_empty() {
             return false;
         }
-        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
+        if query.is_field_context() {
             if self.bindings_are_all_plain_empty_static_literals(&prior_bindings) {
                 return false;
             }
@@ -1258,7 +1291,8 @@ impl<'a> SafeValueIndex<'a> {
         if bindings.is_empty() {
             return false;
         }
-        let case_cli_scope = matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+        let case_cli_scope = query
+            .is_field_context()
             .then(|| self.case_cli_dispatch_scope_at(at.start.offset))
             .flatten();
 
@@ -2405,9 +2439,10 @@ impl<'a> SafeValueIndex<'a> {
         source_text_literal_value(text.slice(self.source)).is_some_and(|literal| match literal {
             SourceTextLiteral::Bare(text) => query.literal_is_safe(text),
             SourceTextLiteral::Quoted(text) => match query {
-                SafeValueQuery::Argv | SafeValueQuery::RedirectTarget | SafeValueQuery::Quoted => {
-                    true
-                }
+                SafeValueQuery::Argv
+                | SafeValueQuery::RedirectTarget
+                | SafeValueQuery::NumericTestOperand
+                | SafeValueQuery::Quoted => true,
                 SafeValueQuery::Pattern | SafeValueQuery::Regex => query.literal_is_safe(text),
             },
         })
@@ -2565,6 +2600,30 @@ fn safe_numeric_shell_variable(name: &Name) -> bool {
             | "SECONDS"
             | "UID"
     )
+}
+
+fn word_static_text_is_shell_integer(word: &Word, source: &str) -> bool {
+    static_word_text(word, source).is_some_and(|text| shell_integer_text_is_safe(&text))
+}
+
+fn shell_integer_text_is_safe(text: &str) -> bool {
+    let digits = text
+        .strip_prefix(['+', '-'])
+        .filter(|rest| !rest.is_empty())
+        .unwrap_or(text);
+    !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn word_has_arithmetic_expansion(word: &Word) -> bool {
+    parts_have_arithmetic_expansion(&word.parts)
+}
+
+fn parts_have_arithmetic_expansion(parts: &[WordPartNode]) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::ArithmeticExpansion { .. } => true,
+        WordPart::DoubleQuoted { parts, .. } => parts_have_arithmetic_expansion(parts),
+        _ => false,
+    })
 }
 
 fn word_contains_special_parameter_slice(word: &Word) -> bool {
@@ -3142,6 +3201,43 @@ iptables $flag -t nat -N chain
 
         assert!(!safe_values.word_occurrence_is_safe(short_circuit_word, SafeValueQuery::Argv));
         assert!(safe_values.word_occurrence_is_safe(if_else_word, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn numeric_assignment_ternary_bindings_stay_safe() {
+        let source = "\
+#!/bin/bash
+I=1
+while [ $I -le 3 ]; do
+  [[ -z $SPEED ]] && I=$(( I + 1 )) || I=11
+done
+J=1
+while [ $J -le 3 ]; do
+  [[ -z $SPEED ]] && J=+11 || J=-1
+done
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let loop_words = facts
+            .word_facts()
+            .iter()
+            .filter(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && matches!(fact.span().slice(source), "$I" | "$J")
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(loop_words.len(), 2);
+        for fact in loop_words {
+            assert!(!safe_values.word_occurrence_is_safe(fact, SafeValueQuery::Argv));
+            assert!(safe_values.word_occurrence_is_safe(fact, SafeValueQuery::NumericTestOperand));
+        }
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -35,7 +35,9 @@ impl SafeValueQuery {
             | ExpansionContext::CommandArgument
             | ExpansionContext::HereString
             | ExpansionContext::DeclarationAssignmentValue => Some(Self::Argv),
-            ExpansionContext::RedirectTarget(_) => Some(Self::RedirectTarget),
+            ExpansionContext::RedirectTarget(_) | ExpansionContext::DescriptorDupTarget(_) => {
+                Some(Self::RedirectTarget)
+            }
             ExpansionContext::CasePattern
             | ExpansionContext::ConditionalPattern
             | ExpansionContext::ParameterPattern => Some(Self::Pattern),
@@ -2790,6 +2792,12 @@ mod tests {
         );
         assert_eq!(
             SafeValueQuery::from_context(ExpansionContext::RedirectTarget(RedirectKind::Output)),
+            Some(SafeValueQuery::RedirectTarget)
+        );
+        assert_eq!(
+            SafeValueQuery::from_context(ExpansionContext::DescriptorDupTarget(
+                RedirectKind::DupOutput
+            )),
             Some(SafeValueQuery::RedirectTarget)
         );
         assert_eq!(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1,9 +1,9 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
     BinaryOp, BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand, FunctionDef,
-    Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, RedirectKind, SourceText,
-    Span, Stmt, StmtSeq, StmtTerminator, VarRef, Word, WordPart, WordPartNode, static_word_text,
-    word_is_standalone_status_capture, word_is_standalone_variable_like,
+    Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Position, RedirectKind,
+    SourceText, Span, Stmt, StmtSeq, StmtTerminator, VarRef, Word, WordPart, WordPartNode,
+    static_word_text, word_is_standalone_status_capture, word_is_standalone_variable_like,
 };
 use shuck_semantic::{
     AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, LoopValueOrigin, ScopeId,
@@ -1317,6 +1317,19 @@ impl<'a> SafeValueIndex<'a> {
         helper_bindings.dedup();
         let mut caller_bindings = self.caller_bindings_covering_all_static_call_sites(name, at);
         self.retain_value_bindings(&mut caller_bindings);
+        let mut uncalled_function_bindings = self.uncalled_function_outer_bindings_at_end(name, at);
+        self.retain_value_bindings(&mut uncalled_function_bindings);
+        let function_local_binding = self
+            .enclosing_function_scope_at(at.start.offset)
+            .is_some_and(|scope| {
+                bindings
+                    .iter()
+                    .copied()
+                    .any(|binding_id| self.binding_is_in_scope_or_descendant(binding_id, scope))
+            });
+        if !uncalled_function_bindings.is_empty() && !function_local_binding {
+            bindings = uncalled_function_bindings;
+        }
         if bindings.is_empty() {
             bindings = caller_bindings;
             bindings.extend(helper_bindings);
@@ -1329,6 +1342,47 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         self.retain_value_bindings(&mut bindings);
+        bindings
+    }
+
+    fn uncalled_function_outer_bindings_at_end(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
+        let Some(helper_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+            return Vec::new();
+        };
+        if self
+            .case_cli_reachable_function_scopes
+            .contains(&helper_scope)
+            || !self.named_function_call_sites(helper_scope).is_empty()
+        {
+            return Vec::new();
+        }
+        let Some(file_scope) = self
+            .semantic
+            .ancestor_scopes(helper_scope)
+            .find(|scope| matches!(self.semantic.scope(*scope).kind, ScopeKind::File))
+        else {
+            return Vec::new();
+        };
+
+        let eof = Position::new().advanced_by(self.source);
+        let eof_span = Span::from_positions(eof, eof);
+        let mut bindings = self.caller_branch_bindings_before(name, file_scope, eof_span);
+        bindings.retain(|binding_id| {
+            let binding = self.semantic.binding(*binding_id);
+            binding.scope != helper_scope
+                && !self.binding_is_in_scope_or_descendant(*binding_id, helper_scope)
+        });
+        let latest_unguarded = bindings
+            .iter()
+            .copied()
+            .filter(|binding_id| !self.binding_is_guarded_before_reference(*binding_id, eof_span))
+            .max_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        let Some(latest_unguarded) = latest_unguarded else {
+            return Vec::new();
+        };
+        bindings.retain(|binding_id| *binding_id == latest_unguarded);
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.dedup();
         bindings
     }
 

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -399,6 +399,20 @@ impl<'a> SafeValueIndex<'a> {
         let direct_bindings_cover_all_paths = needs_arg_path_coverage
             && !direct_bindings.is_empty()
             && self.bindings_cover_all_paths_to_reference(&direct_bindings, name, at);
+        if needs_arg_path_coverage
+            && !direct_bindings_cover_all_paths
+            && !bindings.is_empty()
+            && bindings
+                .iter()
+                .copied()
+                .all(|binding_id| helper_bindings.contains(&binding_id))
+            && bindings
+                .iter()
+                .copied()
+                .all(|binding_id| self.binding_is_one_sided_short_circuit_assignment(binding_id))
+        {
+            return false;
+        }
         let direct_bindings_are_status_captures =
             direct_bindings.iter().copied().all(|binding_id| {
                 self.binding_is_standalone_status_capture(binding_id, case_cli_scope)
@@ -2279,6 +2293,12 @@ impl<'a> SafeValueIndex<'a> {
         }
     }
 
+    fn binding_is_one_sided_short_circuit_assignment(&self, binding_id: BindingId) -> bool {
+        self.facts
+            .binding_value(binding_id)
+            .is_some_and(|value| value.one_sided_short_circuit_assignment())
+    }
+
     fn helper_scopes_providing_name(&self, name: &Name) -> Vec<ScopeId> {
         self.semantic
             .bindings_for(name)
@@ -2388,8 +2408,9 @@ impl<'a> SafeValueIndex<'a> {
 
         cover_blocks.extend(bindings.iter().copied().filter_map(|binding_id| {
             let binding_block = self.block_for_binding(binding_id)?;
-            if binding_block == reference_block
-                && self.binding_is_guarded_before_reference(binding_id, at)
+            if (binding_block == reference_block
+                && self.binding_is_guarded_before_reference(binding_id, at))
+                || self.binding_is_one_sided_short_circuit_assignment(binding_id)
             {
                 None
             } else {
@@ -2490,8 +2511,9 @@ impl<'a> SafeValueIndex<'a> {
             .copied()
             .filter_map(|binding_id| {
                 let binding_block = self.block_for_binding(binding_id)?;
-                if call_blocks.contains(&binding_block)
-                    && self.binding_is_guarded_before_reference(binding_id, call_span)
+                if (call_blocks.contains(&binding_block)
+                    && self.binding_is_guarded_before_reference(binding_id, call_span))
+                    || self.binding_is_one_sided_short_circuit_assignment(binding_id)
                 {
                     None
                 } else {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1,8 +1,8 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
-    BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand, FunctionDef, Name,
-    ParameterExpansion, ParameterExpansionSyntax, ParameterOp, RedirectKind, SourceText, Span,
-    Stmt, StmtSeq, StmtTerminator, VarRef, Word, WordPart, WordPartNode, static_word_text,
+    BinaryOp, BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand, FunctionDef,
+    Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, RedirectKind, SourceText,
+    Span, Stmt, StmtSeq, StmtTerminator, VarRef, Word, WordPart, WordPartNode, static_word_text,
     word_is_standalone_status_capture, word_is_standalone_variable_like,
 };
 use shuck_semantic::{
@@ -310,6 +310,9 @@ impl<'a> SafeValueIndex<'a> {
 
         let mut bindings = self.safe_bindings_for_name(name, at);
         self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        bindings.retain(|binding_id| {
+            !self.binding_is_cleared_by_dominating_unset(*binding_id, name, at)
+        });
         if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
             bindings.retain(|binding_id| {
                 !self.binding_is_blocked_by_exit_like_function_call(*binding_id, at)
@@ -361,7 +364,7 @@ impl<'a> SafeValueIndex<'a> {
             matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget);
         let bindings_cover_all_paths = helper_bindings.is_empty()
             && needs_arg_path_coverage
-            && self.bindings_cover_all_paths_to_reference(&bindings, name, at);
+            && self.value_sources_cover_all_paths_to_reference(&bindings, name, at);
         let unset_covers_reference = needs_arg_path_coverage
             && !bindings.is_empty()
             && self.unset_command_covers_reference(name, at);
@@ -702,6 +705,10 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn binding_is_plain_empty_static_literal(&self, binding_id: BindingId) -> bool {
+        if self.binding_is_name_only_declaration(binding_id) {
+            return true;
+        }
+
         matches!(
             self.semantic.binding(binding_id).origin,
             BindingOrigin::Assignment {
@@ -714,6 +721,15 @@ impl<'a> SafeValueIndex<'a> {
             .and_then(|value| value.scalar_word())
             .and_then(|word| static_word_text(word, self.source))
             .is_some_and(|text| text.is_empty())
+    }
+
+    fn binding_is_name_only_declaration(&self, binding_id: BindingId) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        matches!(binding.origin, BindingOrigin::Declaration { .. })
+            && binding.attributes.contains(BindingAttributes::LOCAL)
+            && !binding
+                .attributes
+                .contains(BindingAttributes::DECLARATION_INITIALIZED)
     }
 
     fn bindings_are_all_plain_empty_static_literals(&self, bindings: &[BindingId]) -> bool {
@@ -754,20 +770,24 @@ impl<'a> SafeValueIndex<'a> {
                 ..
             }
             | BindingOrigin::Declaration { .. } => {
-                let scalar_word = self
-                    .facts
-                    .binding_value(binding_id)
-                    .filter(|value| !value.conditional_assignment_shortcut())
-                    .and_then(|value| value.scalar_word());
-                if case_cli_scope == Some(binding.scope)
-                    && matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
-                    && scalar_word.is_some_and(word_is_standalone_status_capture)
-                {
-                    false
+                if self.binding_is_name_only_declaration(binding_id) {
+                    true
                 } else {
-                    scalar_word.is_some_and(|word| {
-                        self.word_is_safe_for_binding_value(binding_id, word, query)
-                    })
+                    let scalar_word = self
+                        .facts
+                        .binding_value(binding_id)
+                        .filter(|value| !value.conditional_assignment_shortcut())
+                        .and_then(|value| value.scalar_word());
+                    if case_cli_scope == Some(binding.scope)
+                        && matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
+                        && scalar_word.is_some_and(word_is_standalone_status_capture)
+                    {
+                        false
+                    } else {
+                        scalar_word.is_some_and(|word| {
+                            self.word_is_safe_for_binding_value(binding_id, word, query)
+                        })
+                    }
                 }
             }
             BindingOrigin::LoopVariable {
@@ -971,6 +991,26 @@ impl<'a> SafeValueIndex<'a> {
             command.span().end.offset <= at.start.offset
                 && self.command_runs_in_persistent_shell_context(command.id())
                 && self.command_runs_in_unconditional_flow(command.id(), at)
+                && command
+                    .options()
+                    .unset()
+                    .is_some_and(|unset| self.unset_targets_variable_name(unset, name))
+                && self.command_blocks_cover_all_paths_to_reference(command, name, at)
+        })
+    }
+
+    fn binding_is_cleared_by_dominating_unset(
+        &self,
+        binding_id: BindingId,
+        name: &Name,
+        at: Span,
+    ) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        self.facts.structural_commands().any(|command| {
+            command.span().start.offset >= binding.span.end.offset
+                && command.span().end.offset <= at.start.offset
+                && self.command_runs_in_persistent_shell_context(command.id())
+                && !self.command_is_in_background_context(command.id())
                 && command
                     .options()
                     .unset()
@@ -1253,9 +1293,12 @@ impl<'a> SafeValueIndex<'a> {
         let binding = self.semantic.binding(binding_id);
         match binding.origin {
             BindingOrigin::FunctionDefinition { .. } => false,
-            BindingOrigin::Declaration { .. } => binding.attributes.intersects(
-                BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
-            ),
+            BindingOrigin::Declaration { .. } => {
+                self.binding_is_name_only_declaration(binding_id)
+                    || binding.attributes.intersects(
+                        BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
+                    )
+            }
             _ => true,
         }
     }
@@ -1877,25 +1920,48 @@ impl<'a> SafeValueIndex<'a> {
         name: &Name,
         at: Span,
     ) -> bool {
+        self.value_source_blocks_cover_all_paths_to_reference(
+            bindings,
+            name,
+            at,
+            FxHashSet::default(),
+        )
+    }
+
+    fn value_sources_cover_all_paths_to_reference(
+        &self,
+        bindings: &[BindingId],
+        name: &Name,
+        at: Span,
+    ) -> bool {
+        let unset_blocks = (!bindings.is_empty())
+            .then(|| self.unset_value_blocks_for_name_before_reference(name, at))
+            .unwrap_or_default();
+        self.value_source_blocks_cover_all_paths_to_reference(bindings, name, at, unset_blocks)
+    }
+
+    fn value_source_blocks_cover_all_paths_to_reference(
+        &self,
+        bindings: &[BindingId],
+        name: &Name,
+        at: Span,
+        mut cover_blocks: FxHashSet<BlockId>,
+    ) -> bool {
         let Some(reference_block) = self.block_for_name_reference_or_virtual_offset(name, at)
         else {
             return true;
         };
 
-        let cover_blocks = bindings
-            .iter()
-            .copied()
-            .filter_map(|binding_id| {
-                let binding_block = self.block_for_binding(binding_id)?;
-                if binding_block == reference_block
-                    && self.binding_is_guarded_before_reference(binding_id, at)
-                {
-                    None
-                } else {
-                    Some(binding_block)
-                }
-            })
-            .collect::<FxHashSet<_>>();
+        cover_blocks.extend(bindings.iter().copied().filter_map(|binding_id| {
+            let binding_block = self.block_for_binding(binding_id)?;
+            if binding_block == reference_block
+                && self.binding_is_guarded_before_reference(binding_id, at)
+            {
+                None
+            } else {
+                Some(binding_block)
+            }
+        }));
         if cover_blocks.contains(&reference_block) {
             return true;
         }
@@ -1926,6 +1992,47 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         true
+    }
+
+    fn unset_value_blocks_for_name_before_reference(
+        &self,
+        name: &Name,
+        at: Span,
+    ) -> FxHashSet<BlockId> {
+        self.facts
+            .structural_commands()
+            .filter(|command| {
+                command.span().end.offset <= at.start.offset
+                    && self.enclosing_function_scope_at(command.span().start.offset)
+                        == self.enclosing_function_scope_at(at.start.offset)
+                    && self.command_runs_in_persistent_shell_context(command.id())
+                    && !self.command_is_in_background_context(command.id())
+                    && !self.command_is_in_boolean_list(command.id())
+                    && command
+                        .options()
+                        .unset()
+                        .is_some_and(|unset| self.unset_targets_variable_name(unset, name))
+            })
+            .flat_map(|command| {
+                self.analysis
+                    .block_ids_for_span(command.span())
+                    .iter()
+                    .copied()
+            })
+            .collect()
+    }
+
+    fn command_is_in_boolean_list(&self, command_id: crate::facts::CommandId) -> bool {
+        let mut current = self.facts.command_parent_id(command_id);
+        while let Some(id) = current {
+            if let Command::Binary(binary) = self.facts.command(id).command()
+                && matches!(binary.op, BinaryOp::And | BinaryOp::Or)
+            {
+                return true;
+            }
+            current = self.facts.command_parent_id(id);
+        }
+        false
     }
 
     fn bindings_cover_all_paths_to_callsite(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1229,7 +1229,8 @@ impl<'a> SafeValueIndex<'a> {
         prior_bindings.dedup();
 
         if prior_bindings.is_empty() {
-            return false;
+            return safe_numeric_shell_variable(&name)
+                && !self.unset_command_covers_reference(&name, binding_span);
         }
         if query.is_field_context() {
             if self.bindings_are_all_plain_empty_static_literals(&prior_bindings) {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1555,7 +1555,12 @@ impl<'a> SafeValueIndex<'a> {
         let Some(latest_unguarded) = latest_unguarded else {
             return Vec::new();
         };
-        bindings.retain(|binding_id| *binding_id == latest_unguarded);
+        let latest_unguarded_offset = self.semantic.binding(latest_unguarded).span.start.offset;
+        bindings.retain(|binding_id| {
+            *binding_id == latest_unguarded
+                || (self.semantic.binding(*binding_id).span.start.offset > latest_unguarded_offset
+                    && self.binding_is_guarded_before_reference(*binding_id, eof_span))
+        });
         bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         bindings.dedup();
         bindings

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -356,6 +356,9 @@ impl<'a> SafeValueIndex<'a> {
         {
             return true;
         }
+        if self.status_capture_subset_covers_reference(&bindings, name, at, query, case_cli_scope) {
+            return true;
+        }
         let helper_bindings = self
             .called_helper_bindings_for_name(name, at)
             .into_iter()
@@ -871,6 +874,52 @@ impl<'a> SafeValueIndex<'a> {
 
         !status_bindings.is_empty()
             && self.bindings_cover_all_paths_to_reference(&status_bindings, name, at)
+    }
+
+    fn status_capture_subset_covers_reference(
+        &self,
+        bindings: &[BindingId],
+        name: &Name,
+        at: Span,
+        query: SafeValueQuery,
+        case_cli_scope: Option<ScopeId>,
+    ) -> bool {
+        if !matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
+            return false;
+        }
+
+        let status_bindings = bindings
+            .iter()
+            .copied()
+            .filter(|binding_id| {
+                self.semantic.binding(*binding_id).span.end.offset <= at.start.offset
+            })
+            .filter(|binding_id| {
+                self.binding_is_standalone_status_capture(*binding_id, case_cli_scope)
+            })
+            .collect::<Vec<_>>();
+        if status_bindings.is_empty()
+            || !self.bindings_cover_all_paths_to_reference(&status_bindings, name, at)
+        {
+            return false;
+        }
+
+        let Some(reference_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+            return true;
+        };
+        let first_status_offset = status_bindings
+            .iter()
+            .map(|binding_id| self.semantic.binding(*binding_id).span.start.offset)
+            .min()
+            .unwrap_or(at.start.offset);
+
+        !bindings.iter().copied().any(|binding_id| {
+            let binding = self.semantic.binding(binding_id);
+            binding.scope == reference_scope
+                && binding.span.start.offset > first_status_offset
+                && binding.span.start.offset < at.start.offset
+                && !self.binding_is_standalone_status_capture(binding_id, case_cli_scope)
+        })
     }
 
     fn binding_is_standalone_status_capture(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -400,6 +400,19 @@ impl<'a> SafeValueIndex<'a> {
             && !direct_bindings.is_empty()
             && self.bindings_cover_all_paths_to_reference(&direct_bindings, name, at);
         if needs_arg_path_coverage
+            && !bindings_cover_all_paths
+            && !direct_bindings_cover_all_paths
+            && self.one_sided_bindings_preserve_safe_base(
+                &bindings,
+                name,
+                at,
+                query,
+                case_cli_scope,
+            )
+        {
+            return true;
+        }
+        if needs_arg_path_coverage
             && !direct_bindings_cover_all_paths
             && !bindings.is_empty()
             && bindings
@@ -412,6 +425,18 @@ impl<'a> SafeValueIndex<'a> {
                 .all(|binding_id| self.binding_is_one_sided_short_circuit_assignment(binding_id))
         {
             return false;
+        }
+        if needs_arg_path_coverage
+            && !direct_bindings_cover_all_paths
+            && bindings
+                .iter()
+                .copied()
+                .all(|binding_id| self.binding_is_one_sided_append_assignment(binding_id))
+        {
+            return bindings
+                .iter()
+                .copied()
+                .all(|binding_id| self.binding_is_safe(binding_id, at, query, case_cli_scope));
         }
         let direct_bindings_are_status_captures =
             direct_bindings.iter().copied().all(|binding_id| {
@@ -845,7 +870,9 @@ impl<'a> SafeValueIndex<'a> {
                 ..
             }
             | BindingOrigin::Declaration { .. } => {
-                if self.binding_is_name_only_declaration(binding_id) {
+                if matches!(binding.kind, BindingKind::AppendAssignment) {
+                    self.append_assignment_preserves_safe_value(binding_id, query, case_cli_scope)
+                } else if self.binding_is_name_only_declaration(binding_id) {
                     true
                 } else {
                     let binding_value = self.facts.binding_value(binding_id);
@@ -930,6 +957,65 @@ impl<'a> SafeValueIndex<'a> {
         }
         word_has_arithmetic_expansion(word)
             && self.word_is_safe_for_binding_value(binding_id, word, query)
+    }
+
+    fn append_assignment_preserves_safe_value(
+        &mut self,
+        binding_id: BindingId,
+        query: SafeValueQuery,
+        _case_cli_scope: Option<ScopeId>,
+    ) -> bool {
+        let (name, binding_span) = {
+            let binding = self.semantic.binding(binding_id);
+            (binding.name.clone(), binding.span)
+        };
+        let Some(word) = self
+            .facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())
+        else {
+            return false;
+        };
+        if !self.word_is_safe_for_binding_value(binding_id, word, query) {
+            return false;
+        }
+
+        self.binding_value_stack.push(binding_id);
+        let prior_value_is_safe = self.name_is_safe(&name, binding_span, query)
+            || self.append_prior_bindings_are_empty_safe(&name, binding_span, query);
+        self.binding_value_stack.pop();
+        prior_value_is_safe
+    }
+
+    fn append_prior_bindings_are_empty_safe(
+        &self,
+        name: &Name,
+        binding_span: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        if !query.is_field_context() {
+            return false;
+        }
+
+        let mut prior_bindings = self.analysis.reaching_bindings_for_name(name, binding_span);
+        self.retain_value_bindings(&mut prior_bindings);
+        if let Some(current_binding) = self.current_binding_value_for_name(name) {
+            prior_bindings.retain(|binding_id| *binding_id != current_binding);
+        }
+        if prior_bindings.is_empty()
+            && let Some(previous) =
+                self.semantic
+                    .previous_visible_binding(name, binding_span, Some(binding_span))
+            && self.binding_can_supply_parameter_value(previous.id)
+        {
+            prior_bindings.push(previous.id);
+        }
+        prior_bindings
+            .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        prior_bindings.dedup();
+
+        self.bindings_are_all_plain_empty_static_literals(&prior_bindings)
+            && self.bindings_cover_all_paths_to_reference(&prior_bindings, name, binding_span)
     }
 
     fn status_capture_bindings_cover_reference(
@@ -2297,6 +2383,40 @@ impl<'a> SafeValueIndex<'a> {
         self.facts
             .binding_value(binding_id)
             .is_some_and(|value| value.one_sided_short_circuit_assignment())
+    }
+
+    fn binding_is_one_sided_append_assignment(&self, binding_id: BindingId) -> bool {
+        matches!(
+            self.semantic.binding(binding_id).kind,
+            BindingKind::AppendAssignment
+        ) && self.binding_is_one_sided_short_circuit_assignment(binding_id)
+    }
+
+    fn one_sided_bindings_preserve_safe_base(
+        &mut self,
+        bindings: &[BindingId],
+        name: &Name,
+        at: Span,
+        query: SafeValueQuery,
+        case_cli_scope: Option<ScopeId>,
+    ) -> bool {
+        let mut base_bindings = Vec::new();
+        let mut saw_one_sided_binding = false;
+        for binding_id in bindings.iter().copied() {
+            if self.binding_is_one_sided_short_circuit_assignment(binding_id) {
+                saw_one_sided_binding = true;
+            } else {
+                base_bindings.push(binding_id);
+            }
+        }
+
+        saw_one_sided_binding
+            && !base_bindings.is_empty()
+            && self.bindings_cover_all_paths_to_reference(&base_bindings, name, at)
+            && bindings
+                .iter()
+                .copied()
+                .all(|binding_id| self.binding_is_safe(binding_id, at, query, case_cli_scope))
     }
 
     fn helper_scopes_providing_name(&self, name: &Name) -> Vec<ScopeId> {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -352,6 +352,9 @@ impl<'a> SafeValueIndex<'a> {
         {
             return false;
         }
+        if self.optional_field_safe_bindings_can_stay_safe(&bindings, query) {
+            return true;
+        }
         if self.status_capture_bindings_cover_reference(&bindings, name, at, query, case_cli_scope)
         {
             return true;
@@ -741,6 +744,50 @@ impl<'a> SafeValueIndex<'a> {
                 .iter()
                 .copied()
                 .all(|binding_id| self.binding_is_plain_empty_static_literal(binding_id))
+    }
+
+    fn optional_field_safe_bindings_can_stay_safe(
+        &self,
+        bindings: &[BindingId],
+        query: SafeValueQuery,
+    ) -> bool {
+        if !matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget) {
+            return false;
+        }
+
+        let mut saw_name_only_declaration = false;
+        let mut saw_field_safe_value = false;
+        for binding_id in bindings.iter().copied() {
+            if self.binding_is_name_only_declaration(binding_id) {
+                saw_name_only_declaration = true;
+                continue;
+            }
+
+            let binding = self.semantic.binding(binding_id);
+            if !matches!(
+                binding.origin,
+                BindingOrigin::Assignment {
+                    value: AssignmentValueOrigin::StaticLiteral,
+                    ..
+                } | BindingOrigin::Declaration { .. }
+            ) {
+                return false;
+            }
+            let Some(text) = self
+                .facts
+                .binding_value(binding_id)
+                .and_then(|value| value.scalar_word())
+                .and_then(|word| static_word_text(word, self.source))
+            else {
+                return false;
+            };
+            if text.is_empty() || !query.literal_is_safe(&text) {
+                return false;
+            }
+            saw_field_safe_value = true;
+        }
+
+        saw_name_only_declaration && saw_field_safe_value
     }
 
     fn binding_is_safe(

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -103,10 +103,12 @@ fn collect_word_fact_reports(
         safe_values,
         source,
         fact,
-        context,
-        colon_command_ids.contains(&fact.command_id()),
-        numeric_test_operand_spans,
-        |_| true,
+        WordReportOptions {
+            context,
+            in_colon_command: colon_command_ids.contains(&fact.command_id()),
+            numeric_test_operand_spans,
+            part_filter: |_| true,
+        },
     );
 }
 
@@ -131,19 +133,21 @@ fn collect_arithmetic_word_fact_reports(
         safe_values,
         source,
         fact,
-        context,
-        colon_command_ids.contains(&fact.command_id()),
-        &[],
-        |part_span| {
-            arithmetic_word_follows_command_substitution(
-                part_span,
-                source,
-                fact_command_substitution_spans,
-            ) || arithmetic_word_follows_command_substitution(
-                part_span,
-                source,
-                arithmetic_command_substitution_spans,
-            )
+        WordReportOptions {
+            context,
+            in_colon_command: colon_command_ids.contains(&fact.command_id()),
+            numeric_test_operand_spans: &[],
+            part_filter: |part_span| {
+                arithmetic_word_follows_command_substitution(
+                    part_span,
+                    source,
+                    fact_command_substitution_spans,
+                ) || arithmetic_word_follows_command_substitution(
+                    part_span,
+                    source,
+                    arithmetic_command_substitution_spans,
+                )
+            },
         },
     );
 }
@@ -268,16 +272,29 @@ fn arithmetic_word_follows_command_substitution(
     })
 }
 
-fn report_word_expansions(
+struct WordReportOptions<'a, F> {
+    context: ExpansionContext,
+    in_colon_command: bool,
+    numeric_test_operand_spans: &'a [Span],
+    part_filter: F,
+}
+
+fn report_word_expansions<F>(
     spans: &mut Vec<Span>,
     safe_values: &mut SafeValueIndex<'_>,
     source: &str,
     fact: WordOccurrenceRef<'_, '_>,
-    context: ExpansionContext,
-    in_colon_command: bool,
-    numeric_test_operand_spans: &[Span],
-    part_filter: impl Fn(Span) -> bool,
-) {
+    options: WordReportOptions<'_, F>,
+) where
+    F: Fn(Span) -> bool,
+{
+    let WordReportOptions {
+        context,
+        in_colon_command,
+        numeric_test_operand_spans,
+        part_filter,
+    } = options;
+
     if !fact.analysis().hazards.field_splitting && !fact.analysis().hazards.pathname_matching {
         return;
     }
@@ -1419,7 +1436,7 @@ cat <<< $here >$out
     }
 
     #[test]
-    fn skips_assignment_values_and_descriptor_dup_targets() {
+    fn skips_assignment_values_and_reports_descriptor_dup_targets() {
         let source = "\
 #!/bin/bash
 value=$name
@@ -1427,7 +1444,13 @@ printf '%s\\n' ok >&$fd
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$fd"]
+        );
     }
 
     #[test]
@@ -1692,36 +1715,54 @@ template=\"${template/IMG_DOWNLOAD_SIZE/$(stat -c %s ${image_file}.xz)}\"
     }
 
     #[test]
-    fn skips_dynamic_values_inside_parameter_replacement_arithmetic_expansions() {
+    fn reports_dynamic_values_inside_parameter_replacement_arithmetic_expansions() {
         let source = "\
 #!/bin/bash
 printf '%s\\n' \"${template/IMG_OFFSET/$(( $(cat file) $1 step ))}\"
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
-        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$1"]
+        );
     }
 
     #[test]
-    fn skips_dynamic_values_inside_parameter_default_arithmetic_expansions() {
+    fn reports_dynamic_values_inside_parameter_default_arithmetic_expansions() {
         let source = "\
 #!/bin/bash
 printf '%s\\n' \"${value:-$(( $(cat file) $1 step ))}\" \"${value:=$(( $2 + 1 ))}\" \"${value:+$(( $3 + 1 ))}\" \"${value:?$(( $4 + 1 ))}\"
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
-        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$1"]
+        );
     }
 
     #[test]
-    fn skips_dynamic_values_inside_arithmetic_shell_words() {
+    fn reports_dynamic_values_inside_arithmetic_shell_words() {
         let source = "\
 #!/bin/sh
 printf '%s' \"$(( $(cat file) $1 step ))\"
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
-        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$1"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -1633,6 +1633,35 @@ printf '%s\\n' `echo \\$1 \\$HOME \\$SAFE \\$PPID`
     }
 
     #[test]
+    fn ignores_escaped_parameters_in_quoted_heredoc_backticks() {
+        let source = "\
+#!/bin/sh
+cat <<'EOF'
+`echo \\$HOME`
+EOF
+cat <<EOF
+`echo \\$HOME`
+EOF
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| {
+                    (
+                        diagnostic.span.start.line,
+                        diagnostic.span.start.column,
+                        diagnostic.span.end.line,
+                        diagnostic.span.end.column,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![(6, 7, 6, 12)]
+        );
+    }
+
+    #[test]
     fn reports_unsafe_escaped_parameters_in_legacy_backticks() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2229,6 +2229,28 @@ demo() {
     }
 
     #[test]
+    fn reports_parameters_shadowing_outer_status_captures() {
+        let source = "\
+#!/bin/bash
+status=$?
+report() {
+  local status=\"$2\"
+  if [ $status -eq 1 ]; then :; fi
+}
+report \"$@\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$status"]
+        );
+    }
+
+    #[test]
     fn uses_static_loop_values_from_static_function_call_sites() {
         let source = "\
 #!/bin/bash
@@ -2325,6 +2347,51 @@ exit $RETVAL
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_status_capture_helpers_called_from_multiple_case_arms() {
+        let source = "\
+#!/bin/sh
+RETVAL=0
+start() {
+  return 0
+  RETVAL=$?
+  if [ $RETVAL -eq 0 ]; then :; fi
+  return $RETVAL
+}
+stop() {
+  RETVAL=$?
+  if [ $RETVAL -eq 0 ]; then :; fi
+  return $RETVAL
+}
+case \"$1\" in
+  start) start ;;
+  stop) stop ;;
+  restart)
+    stop
+    start
+    ;;
+  *) RETVAL=1 ;;
+esac
+exit $RETVAL
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| {
+                    (
+                        diagnostic.span.start.line,
+                        diagnostic.span.start.column,
+                        diagnostic.span.end.line,
+                        diagnostic.span.end.column,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![(6, 8, 6, 15), (7, 10, 7, 17)]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2114,6 +2114,40 @@ printf '%s\\n' -DPACKAGE_VERSION=\\\"$TERMUX_PKG_VERSION\\\"
     }
 
     #[test]
+    fn anchors_braced_parameters_inside_escaped_literal_quotes() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \\\"${items[*]}\\\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${items[*]}"]
+        );
+    }
+
+    #[test]
+    fn anchors_braced_parameters_inside_escaped_literal_quotes_in_substitution() {
+        let source = "\
+#!/bin/bash
+json=\"$(echo \\\"${items[*]}\\\")\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${items[*]}"]
+        );
+    }
+
+    #[test]
     fn reports_decl_assignment_values_in_sh_mode() {
         let source = "\
 local _patch=$TERMUX_PKG_BUILDER_DIR/file.diff

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -158,6 +158,7 @@ fn array_assignment_split_context_is_checked(context: ExpansionContext) -> bool 
             | ExpansionContext::CommandArgument
             | ExpansionContext::HereString
             | ExpansionContext::RedirectTarget(_)
+            | ExpansionContext::DescriptorDupTarget(_)
     )
 }
 
@@ -166,7 +167,8 @@ fn should_check_context(context: ExpansionContext, shell: ShellDialect) -> bool 
         ExpansionContext::CommandName
         | ExpansionContext::CommandArgument
         | ExpansionContext::HereString
-        | ExpansionContext::RedirectTarget(_) => true,
+        | ExpansionContext::RedirectTarget(_)
+        | ExpansionContext::DescriptorDupTarget(_) => true,
         ExpansionContext::DeclarationAssignmentValue => shell != ShellDialect::Bash,
         _ => false,
     }
@@ -289,6 +291,43 @@ flags=\"`echo \\\"$CFLAGS\\\" | sed \\\"s/ $COVERAGE_FLAGS//\\\"`\"
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn treats_brace_fd_redirect_bindings_as_numeric_values() {
+        let source = "\
+#!/bin/bash
+exec {fd}< <(:)
+read -u $fd value
+echo >&$fd
+echo 2>&$fd
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_descriptor_dup_targets_without_visible_fd_bindings() {
+        let source = "\
+#!/bin/bash
+function start() {
+  exec {_GITSTATUS_REQ_FD}>>\"$req_fifo\" {_GITSTATUS_RESP_FD}<\"$resp_fifo\" || return
+  IFS='' read -r -u $_GITSTATUS_RESP_FD GITSTATUS_DAEMON_PID || return
+}
+function query() {
+  echo -nE \"$req_id\"$'\\x1f'\"$dir\"$'\\x1e' >&$_GITSTATUS_REQ_FD || return
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$_GITSTATUS_REQ_FD"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2722,6 +2722,61 @@ main
     }
 
     #[test]
+    fn reports_values_from_guarded_safe_assignments_on_uncovered_paths() {
+        let source = "\
+#!/bin/bash
+source \"$CONFIG\"
+[[ -z $folder || ! -w $(dirname \"$folder\") ]] && folder=~/gist
+mkdir -p $folder
+find $folder -maxdepth 1
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$folder", "$folder"]
+        );
+    }
+
+    #[test]
+    fn reports_helper_values_from_one_sided_short_circuit_assignments() {
+        let source = "\
+#!/bin/bash
+source \"$CONFIG\"
+init_folder() {
+  [[ -z $folder ]] && folder=~/gist
+}
+init_folder
+find $folder -maxdepth 1
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$folder"]
+        );
+    }
+
+    #[test]
+    fn skips_one_sided_short_circuit_assignments_after_covering_safe_values() {
+        let source = "\
+#!/bin/bash
+folder=/var
+[[ -d x ]] && folder=/tmp
+find $folder -maxdepth 1
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn uses_safe_top_level_bindings_at_static_function_call_sites() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -220,6 +220,9 @@ fn report_word_expansions(
         if use_replacement_spans.contains(&part_span) {
             continue;
         }
+        if fact.part_is_inside_backtick_escaped_double_quotes(part_span, source) {
+            continue;
+        }
         if safe_values.part_is_safe(part, part_span, query) {
             continue;
         }
@@ -274,6 +277,18 @@ printf '%s\\n' \"$(echo $name)\"
                 .collect::<Vec<_>>(),
             vec!["$name"]
         );
+    }
+
+    #[test]
+    fn ignores_backtick_escaped_double_quoted_parameters() {
+        let source = "\
+#!/bin/bash
+path=\"`dirname \\\"$REALPATH\\\"`\"
+flags=\"`echo \\\"$CFLAGS\\\" | sed \\\"s/ $COVERAGE_FLAGS//\\\"`\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2,8 +2,8 @@ use rustc_hash::FxHashSet;
 use shuck_ast::Span;
 
 use crate::{
-    Checker, ExpansionContext, Rule, SafeValueIndex, SafeValueQuery, ShellDialect, Violation,
-    WordOccurrenceRef,
+    Checker, ExpansionContext, FactSpan, Rule, SafeValueIndex, SafeValueQuery, ShellDialect,
+    Violation, WordOccurrenceRef,
 };
 
 pub struct UnquotedExpansion;
@@ -34,6 +34,7 @@ pub fn unquoted_expansion(checker: &mut Checker) {
         source,
     );
     let array_assignment_split_spans = collect_array_assignment_split_candidate_spans(checker);
+    let numeric_test_operand_spans = collect_numeric_test_operand_spans(checker, source);
 
     let mut spans = Vec::new();
     for fact in checker.facts().word_facts() {
@@ -44,6 +45,7 @@ pub fn unquoted_expansion(checker: &mut Checker) {
             &mut spans,
             source,
             fact,
+            &numeric_test_operand_spans,
         );
         collect_array_assignment_split_reports(
             &mut safe_values,
@@ -88,6 +90,7 @@ fn collect_word_fact_reports(
     spans: &mut Vec<shuck_ast::Span>,
     source: &str,
     fact: WordOccurrenceRef<'_, '_>,
+    numeric_test_operand_spans: &[Span],
 ) {
     let Some(context) = fact.host_expansion_context() else {
         return;
@@ -102,6 +105,7 @@ fn collect_word_fact_reports(
         fact,
         context,
         colon_command_ids.contains(&fact.command_id()),
+        numeric_test_operand_spans,
         |_| true,
     );
 }
@@ -129,6 +133,7 @@ fn collect_arithmetic_word_fact_reports(
         fact,
         context,
         colon_command_ids.contains(&fact.command_id()),
+        &[],
         |part_span| {
             arithmetic_word_follows_command_substitution(
                 part_span,
@@ -141,6 +146,24 @@ fn collect_arithmetic_word_fact_reports(
             )
         },
     );
+}
+
+fn collect_numeric_test_operand_spans(checker: &Checker, source: &str) -> Vec<Span> {
+    let mut spans = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter_map(|fact| fact.simple_test())
+        .flat_map(|simple_test| {
+            simple_test
+                .numeric_binary_expression_operand_words(source)
+                .into_iter()
+                .map(|word| word.span)
+        })
+        .collect::<Vec<_>>();
+    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.dedup_by_key(|span| FactSpan::new(*span));
+    spans
 }
 
 fn collect_array_assignment_split_candidate_spans(checker: &Checker) -> Vec<Span> {
@@ -252,6 +275,7 @@ fn report_word_expansions(
     fact: WordOccurrenceRef<'_, '_>,
     context: ExpansionContext,
     in_colon_command: bool,
+    numeric_test_operand_spans: &[Span],
     part_filter: impl Fn(Span) -> bool,
 ) {
     if !fact.analysis().hazards.field_splitting && !fact.analysis().hazards.pathname_matching {
@@ -296,12 +320,24 @@ fn report_word_expansions(
         if fact.part_is_inside_backtick_escaped_double_quotes(part_span, source) {
             continue;
         }
+        if part_is_in_numeric_test_operand(part_span, numeric_test_operand_spans)
+            && safe_values.part_is_safe(part, part_span, SafeValueQuery::NumericTestOperand)
+        {
+            continue;
+        }
         if safe_values.part_is_safe(part, part_span, query) {
             continue;
         }
 
         spans.push(fact.diagnostic_part_span(part, part_span, source));
     }
+}
+
+fn part_is_in_numeric_test_operand(part_span: Span, operand_spans: &[Span]) -> bool {
+    operand_spans
+        .iter()
+        .copied()
+        .any(|operand_span| span_contains(operand_span, part_span))
 }
 
 #[cfg(test)]
@@ -1507,6 +1543,49 @@ iptables $flag -t nat -N chain
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$w"]
+        );
+    }
+
+    #[test]
+    fn skips_numeric_short_circuit_assignment_ternaries() {
+        let source = "\
+#!/bin/bash
+I=1
+while [ $I -le 3 ]; do
+  [[ -z $SPEED ]] && I=$(( I + 1 )) || I=11
+done
+J=1
+while [ $J -le 3 ]; do
+  [[ -z $SPEED ]] && J=+11 || J=-1
+done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_numeric_short_circuit_values_outside_numeric_tests() {
+        let source = "\
+#!/bin/bash
+f() {
+  RV=0
+  [[ -z $PID ]] && RV=0 || RV=1
+  return $RV
+}
+[ \"${WITH_POWER_PLANS}\" != \"no\" ] && __INCLUDE_POWER_PLANS=1 || __INCLUDE_POWER_PLANS=0
+make install INCLUDE_POWER_PLANS=${__INCLUDE_POWER_PLANS}
+[ \"${JBIG}\" = \"no\" ] && JBIGOPT=0 || JBIGOPT=1
+make DISABLE_JBIG=$JBIGOPT
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$RV", "${__INCLUDE_POWER_PLANS}", "$JBIGOPT"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -1971,6 +1971,78 @@ f() {
     }
 
     #[test]
+    fn skips_optional_safe_assignments_after_name_only_declarations() {
+        let source = "\
+#!/bin/bash
+f() {
+  local extra
+  if true; then
+    extra=EXTRA=-DPLAT_LINUX_RPI
+  fi
+  make $extra
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_name_only_declarations_without_safe_assignments() {
+        let source = "\
+#!/bin/bash
+f() {
+  local extra
+  make $extra
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$extra"]
+        );
+    }
+
+    #[test]
+    fn skips_safe_assignment_or_unset_branches() {
+        let source = "\
+#!/bin/bash
+if [ \"$GTK2\" = enable ]; then
+  GTK2=--with-gtk2
+else
+  unset GTK2
+fi
+./configure $GTK2
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_values_after_dominating_unsets() {
+        let source = "\
+#!/bin/bash
+opt=-n
+unset opt
+printf '%s\\n' $opt
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$opt"]
+        );
+    }
+
+    #[test]
     fn skips_safe_literal_bindings_inside_nested_command_substitutions() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2371,6 +2371,29 @@ printf '%s\\n' $(ps -o comm= -p $PPID) $UID $EUID $RANDOM $OPTIND $SECONDS $LINE
     }
 
     #[test]
+    fn skips_numeric_shell_variables_after_default_assignment() {
+        let source = "\
+#!/bin/bash
+: \"${UID:=1000}\"
+usermod -u $UID minecraft
+UID='a b'
+usermod -u $UID minecraft
+unset COLUMNS
+: \"${COLUMNS:=$1}\"
+printf '%s\\n' $COLUMNS
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$UID", "$COLUMNS"]
+        );
+    }
+
+    #[test]
     fn reports_unknown_values_in_uncalled_function_bodies() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3288,6 +3288,25 @@ value=\"$1\"
     }
 
     #[test]
+    fn reports_uncalled_function_references_after_guarded_unsafe_global_update() {
+        let source = "\
+#!/bin/bash
+value=abc
+if cond; then value=\"$1\"; fi
+helper() { printf '%s\\n' $value; }
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$value"]
+        );
+    }
+
+    #[test]
     fn reports_uncalled_function_references_after_partial_global_initialization() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -53,6 +53,19 @@ pub fn unquoted_expansion(checker: &mut Checker) {
             &array_assignment_split_spans,
         );
     }
+    let arithmetic_command_substitution_spans =
+        checker.facts().arithmetic_command_substitution_spans();
+    for fact in checker.facts().arithmetic_command_word_facts() {
+        collect_arithmetic_word_fact_reports(
+            checker,
+            &colon_command_ids,
+            &mut safe_values,
+            &mut spans,
+            source,
+            fact,
+            arithmetic_command_substitution_spans,
+        );
+    }
     for escaped in checker.facts().backtick_escaped_parameters() {
         if escaped.standalone_command_name {
             continue;
@@ -89,6 +102,44 @@ fn collect_word_fact_reports(
         fact,
         context,
         colon_command_ids.contains(&fact.command_id()),
+        |_| true,
+    );
+}
+
+fn collect_arithmetic_word_fact_reports(
+    checker: &Checker,
+    colon_command_ids: &FxHashSet<crate::facts::core::CommandId>,
+    safe_values: &mut SafeValueIndex<'_>,
+    spans: &mut Vec<shuck_ast::Span>,
+    source: &str,
+    fact: WordOccurrenceRef<'_, '_>,
+    arithmetic_command_substitution_spans: &[Span],
+) {
+    let Some(context) = fact.host_expansion_context() else {
+        return;
+    };
+    if !should_check_context(context, checker.shell()) {
+        return;
+    }
+    let fact_command_substitution_spans = fact.command_substitution_spans();
+    report_word_expansions(
+        spans,
+        safe_values,
+        source,
+        fact,
+        context,
+        colon_command_ids.contains(&fact.command_id()),
+        |part_span| {
+            arithmetic_word_follows_command_substitution(
+                part_span,
+                source,
+                fact_command_substitution_spans,
+            ) || arithmetic_word_follows_command_substitution(
+                part_span,
+                source,
+                arithmetic_command_substitution_spans,
+            )
+        },
     );
 }
 
@@ -178,6 +229,22 @@ fn span_contains(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
 }
 
+fn arithmetic_word_follows_command_substitution(
+    word_span: Span,
+    source: &str,
+    command_substitution_spans: &[Span],
+) -> bool {
+    command_substitution_spans.iter().copied().any(|span| {
+        if span.end.offset > word_span.start.offset {
+            return false;
+        }
+        let Some(between) = source.get(span.end.offset..word_span.start.offset) else {
+            return false;
+        };
+        !between.contains('\n') && between.chars().all(char::is_whitespace)
+    })
+}
+
 fn report_word_expansions(
     spans: &mut Vec<Span>,
     safe_values: &mut SafeValueIndex<'_>,
@@ -185,6 +252,7 @@ fn report_word_expansions(
     fact: WordOccurrenceRef<'_, '_>,
     context: ExpansionContext,
     in_colon_command: bool,
+    part_filter: impl Fn(Span) -> bool,
 ) {
     if !fact.analysis().hazards.field_splitting && !fact.analysis().hazards.pathname_matching {
         return;
@@ -214,6 +282,9 @@ fn report_word_expansions(
     for (part, part_span) in fact.parts_with_spans() {
         let report_unquoted_star = star_spans.contains(&part_span);
         if !scalar_spans.contains(&part_span) && !report_unquoted_star {
+            continue;
+        }
+        if !part_filter(part_span) {
             continue;
         }
         if assign_default_spans.contains(&part_span) {
@@ -278,6 +349,44 @@ printf '%s\\n' \"$(echo $name)\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$name"]
+        );
+    }
+
+    #[test]
+    fn descends_into_arithmetic_command_substitutions() {
+        let source = "\
+#!/bin/bash
+if (( $(du -c $profraw_file_mask | tail -n 1 | cut -f 1) == 0 )); then
+  :
+fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$profraw_file_mask"]
+        );
+    }
+
+    #[test]
+    fn reports_arithmetic_words_following_command_substitutions() {
+        let source = "\
+#!/bin/bash
+printf '%s\\n' \"$(( $(cat \"$backlight/brightness\") $1 step ))\"
+printf '%s\\n' \"$(( $(cat \"$backlight/brightness\") + $count ))\"
+printf '%s\\n' \"$(( $count + 1 ))\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$1"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2629,6 +2629,99 @@ main
     }
 
     #[test]
+    fn uses_static_loop_values_through_intermediate_helpers() {
+        let source = "\
+#!/bin/bash
+run() {
+  LDFLAGS=\"-fuse-ld=${linker}\"
+  cc ${CFLAGS} ${LDFLAGS}
+}
+dispatch() {
+  run
+}
+main() {
+  local linker
+  for linker in gold bfd lld; do
+    dispatch
+  done
+}
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CFLAGS}"]
+        );
+    }
+
+    #[test]
+    fn reports_static_loop_values_when_intermediate_helpers_have_unsafe_callers() {
+        let source = "\
+#!/bin/bash
+run() {
+  LDFLAGS=\"-fuse-ld=${linker}\"
+  cc ${CFLAGS} ${LDFLAGS}
+}
+dispatch() {
+  run
+}
+main() {
+  local linker
+  for linker in gold bfd lld; do
+    dispatch
+  done
+}
+main
+dispatch
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CFLAGS}", "${LDFLAGS}"]
+        );
+    }
+
+    #[test]
+    fn uses_static_loop_call_values_over_unrelated_prior_loop_bindings() {
+        let source = "\
+#!/bin/bash
+for linker in gold bfd lld; do
+  :
+done
+run() {
+  LDFLAGS=\"-fuse-ld=${linker}\"
+  cc ${CFLAGS} ${LDFLAGS}
+}
+main() {
+  local linker
+  for linker in gold bfd lld; do
+    [[ ${CC} == gcc && ${linker} == lld ]] && continue
+    LDFLAGS=\"-fuse-ld=${linker}\" tc-ld-is-${linker} || continue
+    run
+  done
+}
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CFLAGS}"]
+        );
+    }
+
+    #[test]
     fn uses_safe_top_level_bindings_at_static_function_call_sites() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2251,6 +2251,19 @@ report \"$@\"
     }
 
     #[test]
+    fn skips_arithmetic_and_escaped_declaration_assignment_arguments() {
+        let source = "\
+#!/bin/bash
+let COOLDOWN=$AUTOPAUSE_TIMEOUT_KN/2
+\\typeset counter=${1:-0}
+\\typeset __action=$1
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn uses_static_loop_values_from_static_function_call_sites() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2177,6 +2177,22 @@ exit $?
     }
 
     #[test]
+    fn skips_name_only_local_option_bindings() {
+        let source = "\
+#!/bin/bash
+request() {
+  local header_opt data_opt
+  [[ -n $token ]] && header_opt=--header
+  [[ $method == POST ]] && data_opt=--data
+  curl $header_opt \"$header\" $data_opt \"$payload\"
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_status_capture_declarations_with_initializers() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2950,6 +2950,58 @@ printf '%s\\n' $foo
     }
 
     #[test]
+    fn skips_uncalled_function_references_after_safe_global_initialization() {
+        let source = "\
+#!/bin/bash
+value=\"$1\"
+helper() { printf '%s\\n' $value; }
+value=abc
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_uncalled_function_references_after_unsafe_global_initialization() {
+        let source = "\
+#!/bin/bash
+value=abc
+helper() { printf '%s\\n' $value; }
+value=\"$1\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$value"]
+        );
+    }
+
+    #[test]
+    fn reports_uncalled_function_references_after_partial_global_initialization() {
+        let source = "\
+#!/bin/bash
+helper() { printf '%s\\n' $value; }
+if [ \"$1\" = yes ]; then
+  value=abc
+fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$value"]
+        );
+    }
+
+    #[test]
     fn skips_straight_line_safe_overwrites_in_test_operands() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2262,6 +2262,100 @@ printf '%s\\n' $n $s $glob $split $copy $alias
     }
 
     #[test]
+    fn reports_append_assignments_without_safe_prior_values() {
+        let source = "\
+#!/bin/bash
+var+=ok
+printf '%s\\n' $var
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$var"]
+        );
+    }
+
+    #[test]
+    fn skips_append_assignments_after_safe_prior_values() {
+        let source = "\
+#!/bin/bash
+var=ok
+var+=still_ok
+printf '%s\\n' $var
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_multiple_conditional_appends_after_safe_prior_values() {
+        let source = "\
+#!/bin/bash
+themes=gtk2,gtk3
+type -P gnome-shell >/dev/null && themes+=,gnome-shell
+type -P cinnamon-session >/dev/null && themes+=,cinnamon
+meson -Dthemes=$themes
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_conditional_appends_after_empty_prior_values() {
+        let source = "\
+#!/bin/bash
+options=
+if [ \"$1\" = yes ]; then
+  options+=--enable-experimental
+fi
+./configure $options
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_values_derived_from_unknown_append_assignments() {
+        let source = "\
+#!/bin/bash
+f() {
+  TERMUX_PKG_SRCDIR+=/Python
+  TERMUX_PKG_BUILDDIR=\"$TERMUX_PKG_SRCDIR\"
+  local _bindir=$TERMUX_PKG_BUILDDIR/_wrapper/bin
+  mkdir -p ${_bindir}
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${_bindir}"]
+        );
+    }
+
+    #[test]
+    fn skips_append_assignments_to_numeric_shell_variables() {
+        let source = "\
+#!/bin/bash
+SECONDS+=1
+printf '%s\\n' $SECONDS
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_initialized_declaration_bindings_with_safe_values() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -470,6 +470,25 @@ echo 2>&$fd
     }
 
     #[test]
+    fn reports_descriptor_dup_target_before_new_brace_fd_binding() {
+        let source = "\
+#!/bin/bash
+fd='1 2'
+exec {fd}>&$fd
+printf '%s\\n' \"$fd\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$fd"]
+        );
+    }
+
+    #[test]
     fn reports_descriptor_dup_targets_without_visible_fd_bindings() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1228,6 +1228,19 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
         for redirect in redirects {
+            if let (Some(name), Some(span)) = (&redirect.fd_var, redirect.fd_var_span) {
+                self.add_binding(
+                    name,
+                    BindingKind::Assignment,
+                    self.current_scope(),
+                    span,
+                    BindingOrigin::Assignment {
+                        definition_span: span,
+                        value: AssignmentValueOrigin::StaticLiteral,
+                    },
+                    BindingAttributes::INTEGER,
+                );
+            }
             match redirect.word_target() {
                 Some(word) => {
                     self.visit_word_into(word, WordVisitKind::Expansion, flow, nested_regions)

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1228,24 +1228,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
         for redirect in redirects {
-            if let (Some(name), Some(span)) = (&redirect.fd_var, redirect.fd_var_span) {
-                self.add_binding(
-                    name,
-                    BindingKind::Assignment,
-                    self.current_scope(),
-                    span,
-                    BindingOrigin::Assignment {
-                        definition_span: span,
-                        value: AssignmentValueOrigin::StaticLiteral,
-                    },
-                    BindingAttributes::INTEGER,
-                );
-            }
             match redirect.word_target() {
                 Some(word) => {
-                    self.visit_word_into(word, WordVisitKind::Expansion, flow, nested_regions)
+                    self.visit_word_into(word, WordVisitKind::Expansion, flow, nested_regions);
+                    self.add_redirect_fd_var_binding(redirect);
                 }
                 None => {
+                    self.add_redirect_fd_var_binding(redirect);
                     let Some(heredoc) = redirect.heredoc() else {
                         continue;
                     };
@@ -1259,6 +1248,22 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     }
                 }
             }
+        }
+    }
+
+    fn add_redirect_fd_var_binding(&mut self, redirect: &shuck_ast::Redirect) {
+        if let (Some(name), Some(span)) = (&redirect.fd_var, redirect.fd_var_span) {
+            self.add_binding(
+                name,
+                BindingKind::Assignment,
+                self.current_scope(),
+                span,
+                BindingOrigin::Assignment {
+                    definition_span: span,
+                    value: AssignmentValueOrigin::StaticLiteral,
+                },
+                BindingAttributes::INTEGER,
+            );
         }
     }
 

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -3672,6 +3672,58 @@ mod tests {
     }
 
     #[test]
+    fn brace_fd_redirect_target_resolves_before_new_fd_binding() {
+        let source = "\
+#!/bin/bash
+fd='1 2'
+exec {fd}>&$fd
+printf '%s\\n' \"$fd\"
+";
+        let model = model(source);
+
+        let fd_bindings = model.bindings_for(&Name::from("fd"));
+        assert_eq!(
+            fd_bindings.len(),
+            2,
+            "expected scalar and brace-fd bindings"
+        );
+        let initial_binding = model.binding(fd_bindings[0]);
+        let brace_fd_binding = model.binding(fd_bindings[1]);
+        assert!(
+            brace_fd_binding
+                .attributes
+                .contains(BindingAttributes::INTEGER)
+        );
+
+        let fd_refs = model
+            .references()
+            .iter()
+            .filter(|reference| {
+                reference.kind == ReferenceKind::Expansion && reference.name == "fd"
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(fd_refs.len(), 2);
+
+        let redirect_target_ref = fd_refs
+            .iter()
+            .find(|reference| reference.span.start.line == 3)
+            .unwrap();
+        let later_ref = fd_refs
+            .iter()
+            .find(|reference| reference.span.start.line == 4)
+            .unwrap();
+
+        assert_eq!(
+            model.resolved_binding(redirect_target_ref.id).unwrap().id,
+            initial_binding.id
+        );
+        assert_eq!(
+            model.resolved_binding(later_ref.id).unwrap().id,
+            brace_fd_binding.id
+        );
+    }
+
+    #[test]
     fn declare_plus_g_stays_local_inside_functions() {
         let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- tighten S001 unquoted expansion behavior across arithmetic, backticks, heredocs, file descriptors, optional values, helper callers, guarded assignments, and append assignments
- extend linter facts and safe-value analysis so S001 decisions are based on the same shell execution/value paths covered by the corpus deltas
- remove resolved S001 entries from the corpus metadata as divergences are eliminated

## Verification
- `cargo test -p shuck-linter append -- --nocapture`
- `cargo test -p shuck-linter one_sided_short_circuit -- --nocapture`
- `cargo test -p shuck-linter reports_values_from_guarded_safe_assignments_on_uncovered_paths -- --nocapture`
- `cargo test -p shuck-linter marks_conditional_assignment_shortcuts_on_binding_values -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001`
