### PR TITLE
perf(linter): reduce facts-layer allocation churn

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1873,33 +1873,44 @@ fn escaped_braced_parameter_names(text: &str) -> Vec<String> {
 fn build_innermost_command_ids_by_offset(
     commands: &[CommandFact<'_>],
     mut offsets: Vec<usize>,
-) -> FxHashMap<usize, Option<CommandId>> {
+) -> CommandOffsetLookup {
     if offsets.is_empty() {
-        return FxHashMap::default();
+        return CommandOffsetLookup::default();
     }
 
     offsets.sort_unstable();
     offsets.dedup();
 
-    let mut command_spans = commands
+    let mut command_order = commands
         .iter()
-        .map(|command| (command.span(), command.id()))
+        .map(CommandFact::id)
         .collect::<Vec<_>>();
-    if command_spans
+    if command_order
         .windows(2)
-        .any(|window| compare_command_offset_entries(window[0], window[1]).is_gt())
+        .any(|window| {
+            compare_command_offset_entries(
+                command_offset_entry(commands, window[0]),
+                command_offset_entry(commands, window[1]),
+            )
+            .is_gt()
+        })
     {
-        command_spans.sort_unstable_by(|left, right| compare_command_offset_entries(*left, *right));
+        command_order.sort_unstable_by(|left, right| {
+            compare_command_offset_entries(
+                command_offset_entry(commands, *left),
+                command_offset_entry(commands, *right),
+            )
+        });
     }
 
-    let mut command_ids_by_offset =
-        FxHashMap::with_capacity_and_hasher(offsets.len(), Default::default());
+    let mut entries = Vec::with_capacity(offsets.len());
     let mut active_commands = Vec::new();
     let mut next_command = 0;
     for offset in offsets {
         pop_finished_commands(&mut active_commands, offset);
 
-        while let Some((span, id)) = command_spans.get(next_command).copied() {
+        while let Some(id) = command_order.get(next_command).copied() {
+            let span = command_fact(commands, id).span();
             if span.start.offset > offset {
                 break;
             }
@@ -1913,10 +1924,26 @@ fn build_innermost_command_ids_by_offset(
         }
 
         pop_finished_commands(&mut active_commands, offset);
-        command_ids_by_offset.insert(offset, active_commands.last().map(|command| command.id));
+        if let Some(command) = active_commands.last() {
+            entries.push(CommandOffsetLookupEntry {
+                offset,
+                id: command.id,
+            });
+        }
     }
 
-    command_ids_by_offset
+    CommandOffsetLookup { entries }
+}
+
+#[derive(Debug, Default, Clone)]
+struct CommandOffsetLookup {
+    entries: Vec<CommandOffsetLookupEntry>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandOffsetLookupEntry {
+    offset: usize,
+    id: CommandId,
 }
 
 fn compare_command_offset_entries(
@@ -1931,11 +1958,19 @@ fn compare_command_offset_entries(
         .then_with(|| right_id.index().cmp(&left_id.index()))
 }
 
+fn command_offset_entry(commands: &[CommandFact<'_>], id: CommandId) -> (Span, CommandId) {
+    (command_fact(commands, id).span(), id)
+}
+
 fn precomputed_command_id_for_offset(
-    command_ids_by_offset: &FxHashMap<usize, Option<CommandId>>,
+    command_ids_by_offset: &CommandOffsetLookup,
     offset: usize,
 ) -> Option<CommandId> {
-    command_ids_by_offset.get(&offset).copied().unwrap_or(None)
+    command_ids_by_offset
+        .entries
+        .binary_search_by_key(&offset, |entry| entry.offset)
+        .ok()
+        .map(|index| command_ids_by_offset.entries[index].id)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -7,7 +7,8 @@ fn build_literal_brace_spans(
     heredoc_ranges: &[TextRange],
 ) -> Vec<Span> {
     let mut spans = Vec::new();
-    let mut processed_word_nodes = vec![false; nodes.len()];
+    let mut scratch = LiteralBraceScratch::default();
+    scratch.processed_word_nodes.resize(nodes.len(), false);
 
     for fact in occurrences {
         if fact.context == WordFactContext::Expansion(ExpansionContext::RegexOperand) {
@@ -22,29 +23,53 @@ fn build_literal_brace_spans(
         }
 
         let node_index = fact.node_id.index();
-        if processed_word_nodes[node_index] {
+        if scratch.processed_word_nodes[node_index] {
             continue;
         }
-        processed_word_nodes[node_index] = true;
+        scratch.processed_word_nodes[node_index] = true;
 
-        collect_literal_brace_spans_for_word(nodes, fact, fact_store, source, &mut spans);
+        collect_literal_brace_spans_for_word(
+            nodes,
+            fact,
+            fact_store,
+            source,
+            &mut spans,
+            &mut scratch,
+        );
     }
 
-    spans.extend(uncovered_command_brace_spans(
+    collect_uncovered_command_brace_spans(
         commands,
         source,
         heredoc_ranges,
-    ));
-    spans.extend(unmatched_command_substitution_brace_spans(
+        &mut spans,
+        &mut scratch,
+    );
+    collect_unmatched_command_substitution_brace_spans(
         commands,
         source,
         heredoc_ranges,
-    ));
+        &mut spans,
+        &mut scratch,
+    );
     spans.retain(|span| !span_is_plain_parameter_expansion_edge_in_source(*span, source));
     spans.retain(|span| !span_is_active_brace_expansion_edge_in_source(*span, source));
     spans.sort_by_key(|span| (span.start.offset, span.end.offset));
     spans.dedup_by_key(|span| (span.start.offset, span.end.offset));
     spans
+}
+
+#[derive(Default)]
+struct LiteralBraceScratch {
+    processed_word_nodes: Vec<bool>,
+    dynamic_exclusions: Vec<DynamicBraceExcludedSpan>,
+    raw_escaped_exclusions: Vec<DynamicBraceExcludedSpan>,
+    relevant_excluded_ranges: Vec<(usize, usize)>,
+    covered_spans: Vec<Span>,
+    unmatched_spans: Vec<Span>,
+    unmatched_offsets: Vec<usize>,
+    literal_stack: Vec<LiteralBraceCandidate>,
+    escaped_parameter_stack: Vec<usize>,
 }
 
 fn collect_literal_brace_spans_for_word(
@@ -53,60 +78,74 @@ fn collect_literal_brace_spans_for_word(
     fact_store: &FactStore<'_>,
     source: &str,
     spans: &mut Vec<Span>,
+    scratch: &mut LiteralBraceScratch,
 ) {
     let word = occurrence_word(nodes, fact);
-    let mut dynamic_exclusions = Vec::new();
+    scratch.dynamic_exclusions.clear();
     collect_dynamic_brace_exclusions(
         &word.parts,
         word.span.start.offset,
         word.span.end.offset,
         source,
-        &mut dynamic_exclusions,
+        &mut scratch.dynamic_exclusions,
     );
-    dynamic_exclusions.sort_by_key(|span| (span.start_offset, span.end_offset));
+    scratch
+        .dynamic_exclusions
+        .sort_by_key(|span| (span.start_offset, span.end_offset));
 
-    spans.extend(
-        word.brace_syntax()
-            .iter()
-            .copied()
-            .filter(|brace| brace.quote_context == BraceQuoteContext::Unquoted)
-            .filter(|brace| !literal_brace_syntax_looks_like_active_expansion(*brace, source))
-            .filter(|brace| {
-                matches!(
-                    brace.kind,
-                    BraceSyntaxKind::Literal | BraceSyntaxKind::TemplatePlaceholder
-                ) || brace_syntax_with_whitespace_is_literal(*brace, source)
-            })
-            .filter(|brace| {
-                brace.span.slice(source) != "{}"
-                    && !brace_span_has_escaped_dollar_prefix(brace.span, source)
-            })
-            .flat_map(|brace| brace_character_spans(brace.span, source))
-            .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
-            .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-            .filter(|span| {
-                !word_span_is_inside_command_substitution(nodes, fact, fact_store, *span)
-            }),
-    );
+    for brace in word
+        .brace_syntax()
+        .iter()
+        .copied()
+        .filter(|brace| brace.quote_context == BraceQuoteContext::Unquoted)
+        .filter(|brace| !literal_brace_syntax_looks_like_active_expansion(*brace, source))
+        .filter(|brace| {
+            matches!(
+                brace.kind,
+                BraceSyntaxKind::Literal | BraceSyntaxKind::TemplatePlaceholder
+            ) || brace_syntax_with_whitespace_is_literal(*brace, source)
+        })
+        .filter(|brace| {
+            brace.span.slice(source) != "{}"
+                && !brace_span_has_escaped_dollar_prefix(brace.span, source)
+        })
+    {
+        collect_brace_character_spans(brace.span, source, spans, |span| {
+            literal_brace_word_span_is_reportable(nodes, fact, fact_store, word, span, source)
+        });
+    }
 
-    spans.extend(
-        escaped_parameter_expansion_brace_edge_spans(word, source, &dynamic_exclusions)
-            .into_iter()
-            .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
-            .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-            .filter(|span| {
-                !word_span_is_inside_command_substitution(nodes, fact, fact_store, *span)
-            }),
+    collect_escaped_parameter_expansion_brace_edge_spans(
+        word,
+        source,
+        &scratch.dynamic_exclusions,
+        &mut scratch.literal_stack,
+        &mut scratch.raw_escaped_exclusions,
+        &mut scratch.escaped_parameter_stack,
+        spans,
+        |span| literal_brace_word_span_is_reportable(nodes, fact, fact_store, word, span, source),
     );
-    spans.extend(
-        unclassified_literal_brace_spans(word, source, &mut dynamic_exclusions)
-            .into_iter()
-            .filter(|span| !span_inside_nested_escaped_parameter_template(word, *span, source))
-            .filter(|span| !brace_span_is_plain_parameter_expansion_edge(word, *span, source))
-            .filter(|span| {
-                !word_span_is_inside_command_substitution(nodes, fact, fact_store, *span)
-            }),
+    collect_unclassified_literal_brace_spans(
+        word,
+        source,
+        &mut scratch.dynamic_exclusions,
+        &mut scratch.unmatched_offsets,
+        spans,
+        |span| literal_brace_word_span_is_reportable(nodes, fact, fact_store, word, span, source),
     );
+}
+
+fn literal_brace_word_span_is_reportable(
+    nodes: &[WordNode<'_>],
+    fact: &WordOccurrence,
+    fact_store: &FactStore<'_>,
+    word: &Word,
+    span: Span,
+    source: &str,
+) -> bool {
+    !span_inside_nested_escaped_parameter_template(word, span, source)
+        && !brace_span_is_plain_parameter_expansion_edge(word, span, source)
+        && !word_span_is_inside_command_substitution(nodes, fact, fact_store, span)
 }
 
 fn word_span_is_inside_command_substitution(
@@ -298,12 +337,10 @@ fn line_has_find_exec_placeholder_context(source: &str, brace_span: Span) -> boo
 
     let prefix = &line_text[..relative_start];
     let suffix = &line_text[relative_end..];
-    let first_word = shellish_words(prefix).into_iter().next();
+    let first_word = shellish_words(prefix).next();
     let has_exec_flag_before = shellish_words(prefix)
-        .into_iter()
         .any(|word| matches!(word, "-exec" | "-execdir" | "-ok" | "-okdir"));
     let has_exec_terminator_after = shellish_words(suffix)
-        .into_iter()
         .any(|word| matches!(word, "+" | "\\;"));
 
     first_word
@@ -328,13 +365,10 @@ fn is_xargs_replacement_word(
         return false;
     }
 
-    xargs_replacement_spans(command.body_args(), source)
-        .into_iter()
-        .any(|span| span == occurrence_span(nodes, fact))
+    xargs_replacement_spans_contain(command.body_args(), source, occurrence_span(nodes, fact))
 }
 
-fn xargs_replacement_spans(args: &[&Word], source: &str) -> Vec<Span> {
-    let mut spans = Vec::new();
+fn xargs_replacement_spans_contain(args: &[&Word], source: &str, target: Span) -> bool {
     let mut index = 0usize;
 
     while let Some(word) = args.get(index) {
@@ -348,8 +382,8 @@ fn xargs_replacement_spans(args: &[&Word], source: &str) -> Vec<Span> {
 
         if let Some(long) = text.strip_prefix("--") {
             if let Some(replacement) = long.strip_prefix("replace=") {
-                if !replacement.is_empty() {
-                    spans.push(word.span);
+                if !replacement.is_empty() && word.span == target {
+                    return true;
                 }
                 index += 1;
                 continue;
@@ -359,7 +393,9 @@ fn xargs_replacement_spans(args: &[&Word], source: &str) -> Vec<Span> {
                 let Some(next_word) = args.get(index + 1) else {
                     break;
                 };
-                spans.push(next_word.span);
+                if next_word.span == target {
+                    return true;
+                }
                 index += 2;
                 continue;
             }
@@ -382,19 +418,23 @@ fn xargs_replacement_spans(args: &[&Word], source: &str) -> Vec<Span> {
         while let Some(flag) = chars.next() {
             match flag {
                 'i' => {
-                    if chars.peek().is_some() {
-                        spans.push(word.span);
+                    if chars.peek().is_some() && word.span == target {
+                        return true;
                     }
                     break;
                 }
                 'I' => {
                     if chars.peek().is_some() {
-                        spans.push(word.span);
+                        if word.span == target {
+                            return true;
+                        }
                     } else {
                         let Some(next_word) = args.get(index + 1) else {
-                            return spans;
+                            return false;
                         };
-                        spans.push(next_word.span);
+                        if next_word.span == target {
+                            return true;
+                        }
                         consume_next_argument = true;
                     }
                     break;
@@ -418,45 +458,69 @@ fn xargs_replacement_spans(args: &[&Word], source: &str) -> Vec<Span> {
         }
     }
 
-    spans
+    false
 }
 
-fn shellish_words(text: &str) -> Vec<&str> {
-    let mut words = Vec::new();
-    let mut start = None;
+struct ShellishWords<'a> {
+    text: &'a str,
+    cursor: usize,
+}
 
-    for (index, ch) in text.char_indices() {
-        let is_word =
-            ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '+' | '/' | '\\' | ';' | '.');
-        if is_word {
-            if start.is_none() {
-                start = Some(index);
+impl<'a> Iterator for ShellishWords<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut start = None;
+
+        for (relative_index, ch) in self.text[self.cursor..].char_indices() {
+            let index = self.cursor + relative_index;
+            let is_word = ch.is_ascii_alphanumeric()
+                || matches!(ch, '_' | '-' | '+' | '/' | '\\' | ';' | '.');
+            if is_word {
+                if start.is_none() {
+                    start = Some(index);
+                }
+            } else if let Some(word_start) = start {
+                self.cursor = index + ch.len_utf8();
+                return Some(&self.text[word_start..index]);
             }
-        } else if let Some(word_start) = start.take() {
-            words.push(&text[word_start..index]);
+        }
+
+        if let Some(word_start) = start {
+            self.cursor = self.text.len();
+            return Some(&self.text[word_start..]);
+        }
+
+        self.cursor = self.text.len();
+        None
+    }
+}
+
+fn shellish_words(text: &str) -> ShellishWords<'_> {
+    ShellishWords { text, cursor: 0 }
+}
+
+fn collect_brace_character_spans(
+    span: Span,
+    source: &str,
+    out: &mut Vec<Span>,
+    mut is_reportable: impl FnMut(Span) -> bool,
+) {
+    let text = span.slice(source);
+    for (offset, ch) in text.char_indices() {
+        if !matches!(ch, '{' | '}') {
+            continue;
+        }
+        let absolute_offset = span.start.offset + offset;
+        if has_odd_backslash_run_before(source, absolute_offset) {
+            continue;
+        }
+        let position = span.start.advanced_by(&text[..offset]);
+        let brace_span = Span::from_positions(position, position);
+        if is_reportable(brace_span) {
+            out.push(brace_span);
         }
     }
-
-    if let Some(word_start) = start {
-        words.push(&text[word_start..]);
-    }
-
-    words
-}
-
-fn brace_character_spans(span: Span, source: &str) -> Vec<Span> {
-    let text = span.slice(source);
-    text.char_indices()
-        .filter(|&(_, ch)| matches!(ch, '{' | '}'))
-        .filter_map(|(offset, _)| {
-            let absolute_offset = span.start.offset + offset;
-            if has_odd_backslash_run_before(source, absolute_offset) {
-                return None;
-            }
-            let position = span.start.advanced_by(&text[..offset]);
-            Some(Span::from_positions(position, position))
-        })
-        .collect()
 }
 
 fn brace_span_has_escaped_dollar_prefix(span: Span, source: &str) -> bool {
@@ -557,11 +621,14 @@ fn word_is_empty_brace_pair_variant(word: &Word, source: &str) -> bool {
     matches!(word.span.slice(source), "{}" | "\\{\\}")
 }
 
-fn unclassified_literal_brace_spans(
+fn collect_unclassified_literal_brace_spans(
     word: &Word,
     source: &str,
     excluded: &mut Vec<DynamicBraceExcludedSpan>,
-) -> Vec<Span> {
+    unmatched_opens: &mut Vec<usize>,
+    out: &mut Vec<Span>,
+    mut is_reportable: impl FnMut(Span) -> bool,
+) {
     let span = word.span;
     let text = span.slice(source);
     excluded.extend(
@@ -575,10 +642,9 @@ fn unclassified_literal_brace_spans(
     );
     excluded.sort_by_key(|span| (span.start_offset, span.end_offset));
 
-    let mut spans = Vec::new();
     let mut excluded_index = 0usize;
     let mut index = 0usize;
-    let mut unmatched_opens = Vec::new();
+    unmatched_opens.clear();
 
     while index < text.len() {
         while let Some(excluded_span) = excluded.get(excluded_index).copied() {
@@ -623,100 +689,118 @@ fn unclassified_literal_brace_spans(
             unmatched_opens.push(index);
         } else if ch == '}' && unmatched_opens.pop().is_none() {
             let position = span.start.advanced_by(&text[..index]);
-            spans.push(Span::from_positions(position, position));
+            let brace_span = Span::from_positions(position, position);
+            if is_reportable(brace_span) {
+                out.push(brace_span);
+            }
         }
 
         index += ch_len;
     }
 
-    spans.extend(unmatched_opens.into_iter().map(|offset| {
+    for offset in unmatched_opens.drain(..) {
         let position = span.start.advanced_by(&text[..offset]);
-        Span::from_positions(position, position)
-    }));
-
-    spans
+        let brace_span = Span::from_positions(position, position);
+        if is_reportable(brace_span) {
+            out.push(brace_span);
+        }
+    }
 }
 
-fn uncovered_command_brace_spans(
+fn collect_uncovered_command_brace_spans(
     commands: CommandFacts<'_, '_>,
     source: &str,
     heredoc_ranges: &[TextRange],
-) -> Vec<Span> {
-    let mut spans = Vec::new();
-
+    out: &mut Vec<Span>,
+    scratch: &mut LiteralBraceScratch,
+) {
     for command in commands {
         let Command::Simple(simple) = command.command() else {
             continue;
         };
         let command_span = command.span();
-        let mut covered = Vec::new();
+        scratch.covered_spans.clear();
 
         if !simple.name.span.slice(source).is_empty() {
-            covered.push(simple.name.span);
+            scratch.covered_spans.push(simple.name.span);
         }
-        covered.extend(simple.args.iter().map(|word| word.span));
-        covered.extend(simple.assignments.iter().map(|assignment| assignment.span));
-        covered.extend(command.redirects().iter().map(|redirect| redirect.span));
-        covered.extend(command.substitution_facts().iter().map(|fact| fact.span()));
-        covered.extend(
+        scratch
+            .covered_spans
+            .extend(simple.args.iter().map(|word| word.span));
+        scratch
+            .covered_spans
+            .extend(simple.assignments.iter().map(|assignment| assignment.span));
+        scratch
+            .covered_spans
+            .extend(command.redirects().iter().map(|redirect| redirect.span));
+        scratch
+            .covered_spans
+            .extend(command.substitution_facts().iter().map(|fact| fact.span()));
+        scratch.covered_spans.extend(
             command
                 .redirects()
                 .iter()
                 .filter_map(|redirect| redirect.fd_var_span),
         );
-        covered.extend(
+        scratch.covered_spans.extend(
             command
                 .redirects()
                 .iter()
                 .filter_map(|redirect| redirect_fd_var_brace_span(redirect, source)),
         );
-        covered.extend(
+        scratch.covered_spans.extend(
             command
                 .redirects()
                 .iter()
                 .filter_map(|redirect| redirect.heredoc().map(|heredoc| heredoc.body.span)),
         );
-        covered.extend(
+        scratch.covered_spans.extend(
             command
                 .redirects()
                 .iter()
                 .filter_map(|redirect| redirect.fd_var_span),
         );
 
-        if covered.is_empty() {
+        if scratch.covered_spans.is_empty() {
             continue;
         }
 
-        covered.sort_by_key(|span| (span.start.offset, span.end.offset));
+        scratch
+            .covered_spans
+            .sort_by_key(|span| (span.start.offset, span.end.offset));
 
         let mut cursor = command_span.start.offset;
-        for span in covered {
+        for span in scratch.covered_spans.iter().copied() {
             if span.start.offset > cursor {
-                spans.extend(raw_literal_brace_spans(
+                collect_raw_literal_brace_spans(
                     command_span,
                     cursor,
                     span.start.offset,
                     source,
                     RawLiteralBraceScanMode::All,
                     heredoc_ranges,
-                ));
+                    out,
+                    &mut scratch.relevant_excluded_ranges,
+                    &mut scratch.unmatched_spans,
+                );
             }
             cursor = cursor.max(span.end.offset);
         }
 
         if command_span.end.offset > cursor {
-            spans.extend(raw_literal_brace_spans(
+            collect_raw_literal_brace_spans(
                 command_span,
                 cursor,
                 command_span.end.offset,
                 source,
                 RawLiteralBraceScanMode::All,
                 heredoc_ranges,
-            ));
+                out,
+                &mut scratch.relevant_excluded_ranges,
+                &mut scratch.unmatched_spans,
+            );
         }
     }
-
-    spans
 }
 
 fn redirect_fd_var_brace_span(redirect: &Redirect, source: &str) -> Option<Span> {
@@ -756,15 +840,19 @@ enum RawLiteralBraceQuoteState {
     Double,
 }
 
-fn raw_literal_brace_spans(
+fn collect_raw_literal_brace_spans(
     container_span: Span,
     scan_start: usize,
     scan_end: usize,
     source: &str,
     mode: RawLiteralBraceScanMode,
     excluded_ranges: &[TextRange],
-) -> Vec<Span> {
-    let mut relevant_excluded = excluded_ranges
+    out: &mut Vec<Span>,
+    relevant_excluded: &mut Vec<(usize, usize)>,
+    unmatched_opens: &mut Vec<Span>,
+) {
+    relevant_excluded.clear();
+    relevant_excluded.extend(excluded_ranges
         .iter()
         .filter_map(|range| {
             let start = usize::from(range.start());
@@ -773,61 +861,59 @@ fn raw_literal_brace_spans(
                 return None;
             }
             Some((start.max(scan_start), end.min(scan_end)))
-        })
-        .collect::<Vec<_>>();
+        }));
     relevant_excluded.sort_unstable_by_key(|&(start, end)| (start, end));
 
-    let mut spans = Vec::new();
-    let mut unmatched_opens = Vec::new();
+    unmatched_opens.clear();
     let mut cursor = scan_start;
-    for (start, end) in relevant_excluded {
+    for (start, end) in relevant_excluded.iter().copied() {
         if start > cursor {
-            spans.extend(raw_literal_brace_spans_without_exclusions(
+            collect_raw_literal_brace_spans_without_exclusions(
                 container_span,
                 cursor,
                 start,
                 source,
                 mode,
-                &mut unmatched_opens,
-            ));
+                unmatched_opens,
+                out,
+            );
         }
         cursor = cursor.max(end);
     }
 
     if scan_end > cursor {
-        spans.extend(raw_literal_brace_spans_without_exclusions(
+        collect_raw_literal_brace_spans_without_exclusions(
             container_span,
             cursor,
             scan_end,
             source,
             mode,
-            &mut unmatched_opens,
-        ));
+            unmatched_opens,
+            out,
+        );
     }
 
     if mode == RawLiteralBraceScanMode::UnmatchedOnly {
-        spans.extend(unmatched_opens);
+        out.extend(unmatched_opens.drain(..));
     }
-
-    spans
 }
 
-fn raw_literal_brace_spans_without_exclusions(
+fn collect_raw_literal_brace_spans_without_exclusions(
     _container_span: Span,
     scan_start: usize,
     scan_end: usize,
     source: &str,
     mode: RawLiteralBraceScanMode,
     unmatched_opens: &mut Vec<Span>,
-) -> Vec<Span> {
+    out: &mut Vec<Span>,
+) {
     let Some(text) = source.get(scan_start..scan_end) else {
-        return Vec::new();
+        return;
     };
     if text.is_empty() {
-        return Vec::new();
+        return;
     }
 
-    let mut spans = Vec::new();
     let mut index = 0usize;
     let mut quote_state = None;
     let mut in_comment = false;
@@ -919,12 +1005,12 @@ fn raw_literal_brace_spans_without_exclusions(
             };
             let span = Span::from_positions(position, position);
             match mode {
-                RawLiteralBraceScanMode::All => spans.push(span),
+                RawLiteralBraceScanMode::All => out.push(span),
                 RawLiteralBraceScanMode::UnmatchedOnly => {
                     if ch == '{' {
                         unmatched_opens.push(span);
                     } else if unmatched_opens.pop().is_none() {
-                        spans.push(span);
+                        out.push(span);
                     }
                 }
             }
@@ -932,8 +1018,6 @@ fn raw_literal_brace_spans_without_exclusions(
 
         index += ch_len;
     }
-
-    spans
 }
 
 fn brace_at_command_start(text: &str, index: usize, ch: char) -> bool {
@@ -1023,13 +1107,13 @@ fn closing_brace_ends_shell_group(text: &str, index: usize) -> bool {
     }
 }
 
-fn unmatched_command_substitution_brace_spans(
+fn collect_unmatched_command_substitution_brace_spans(
     commands: CommandFacts<'_, '_>,
     source: &str,
     heredoc_ranges: &[TextRange],
-) -> Vec<Span> {
-    let mut spans = Vec::new();
-
+    out: &mut Vec<Span>,
+    scratch: &mut LiteralBraceScratch,
+) {
     for substitution in commands
         .iter()
         .flat_map(|command| command.substitution_facts())
@@ -1041,18 +1125,19 @@ fn unmatched_command_substitution_brace_spans(
         };
 
         if body_end > body_start {
-            spans.extend(raw_literal_brace_spans(
+            collect_raw_literal_brace_spans(
                 container_span,
                 body_start,
                 body_end,
                 source,
                 RawLiteralBraceScanMode::UnmatchedOnly,
                 heredoc_ranges,
-            ));
+                out,
+                &mut scratch.relevant_excluded_ranges,
+                &mut scratch.unmatched_spans,
+            );
         }
     }
-
-    spans
 }
 
 fn command_substitution_body_offsets(span: Span, source: &str) -> Option<(Span, usize, usize)> {
@@ -1096,15 +1181,19 @@ struct DynamicBraceExcludedSpan {
     kind: DynamicBraceExcludedSpanKind,
 }
 
-fn escaped_parameter_expansion_brace_edge_spans(
+fn collect_escaped_parameter_expansion_brace_edge_spans(
     word: &Word,
     source: &str,
     excluded: &[DynamicBraceExcludedSpan],
-) -> Vec<Span> {
+    literal_stack: &mut Vec<LiteralBraceCandidate>,
+    raw_escaped_exclusions: &mut Vec<DynamicBraceExcludedSpan>,
+    escaped_parameter_stack: &mut Vec<usize>,
+    out: &mut Vec<Span>,
+    mut is_reportable: impl FnMut(Span) -> bool,
+) {
     let span = word.span;
     let text = span.slice(source);
-    let mut spans = Vec::new();
-    let mut literal_stack: Vec<LiteralBraceCandidate> = Vec::new();
+    literal_stack.clear();
     let mut excluded_index = 0usize;
     let mut index = 0usize;
     let mut previous_char = None;
@@ -1152,8 +1241,14 @@ fn escaped_parameter_expansion_brace_edge_spans(
                     let close = span
                         .start
                         .advanced_by(&text[..excluded_span.end_offset - '}'.len_utf8()]);
-                    spans.push(Span::from_positions(open, open));
-                    spans.push(Span::from_positions(close, close));
+                    let open_span = Span::from_positions(open, open);
+                    let close_span = Span::from_positions(close, close);
+                    if is_reportable(open_span) {
+                        out.push(open_span);
+                    }
+                    if is_reportable(close_span) {
+                        out.push(close_span);
+                    }
                 }
             }
             previous_char = None;
@@ -1213,8 +1308,14 @@ fn escaped_parameter_expansion_brace_edge_spans(
         {
             let open = span.start.advanced_by(&text[..candidate.open_offset]);
             let close = span.start.advanced_by(&text[..index]);
-            spans.push(Span::from_positions(open, open));
-            spans.push(Span::from_positions(close, close));
+            let open_span = Span::from_positions(open, open);
+            let close_span = Span::from_positions(close, close);
+            if is_reportable(open_span) {
+                out.push(open_span);
+            }
+            if is_reportable(close_span) {
+                out.push(close_span);
+            }
         }
 
         previous_char = Some(ch);
@@ -1222,8 +1323,14 @@ fn escaped_parameter_expansion_brace_edge_spans(
         index += ch_len;
     }
 
-    spans.extend(raw_escaped_parameter_brace_edge_spans(word, source));
-    spans
+    collect_raw_escaped_parameter_brace_edge_spans(
+        word,
+        source,
+        raw_escaped_exclusions,
+        escaped_parameter_stack,
+        out,
+        &mut is_reportable,
+    );
 }
 
 fn excluded_runtime_syntax_has_escaped_dollar_prefix(
@@ -1409,19 +1516,25 @@ fn find_runtime_parameter_closing_brace(text: &str, start_offset: usize) -> Opti
     None
 }
 
-fn raw_escaped_parameter_brace_edge_spans(word: &Word, source: &str) -> Vec<Span> {
+fn collect_raw_escaped_parameter_brace_edge_spans(
+    word: &Word,
+    source: &str,
+    excluded: &mut Vec<DynamicBraceExcludedSpan>,
+    escaped_parameter_stack: &mut Vec<usize>,
+    out: &mut Vec<Span>,
+    mut is_reportable: impl FnMut(Span) -> bool,
+) {
     let span = word.span;
     let text = span.slice(source);
-    let mut excluded = Vec::new();
-    collect_raw_escaped_parameter_exclusions(&word.parts, span.start.offset, source, &mut excluded);
+    excluded.clear();
+    collect_raw_escaped_parameter_exclusions(&word.parts, span.start.offset, source, excluded);
     excluded.sort_by_key(|span| (span.start_offset, span.end_offset));
 
-    let mut spans = Vec::new();
     let mut excluded_index = 0usize;
     let mut index = 0usize;
     let mut previous_char = None;
     let mut previous_char_escaped = false;
-    let mut escaped_parameter_stack: Vec<usize> = Vec::new();
+    escaped_parameter_stack.clear();
     let mut parameter_depth = 0usize;
 
     while index < text.len() {
@@ -1476,8 +1589,14 @@ fn raw_escaped_parameter_brace_edge_spans(word: &Word, source: &str) -> Vec<Span
             {
                 let open = span.start.advanced_by(&text[..open_offset]);
                 let close = span.start.advanced_by(&text[..index]);
-                spans.push(Span::from_positions(open, open));
-                spans.push(Span::from_positions(close, close));
+                let open_span = Span::from_positions(open, open);
+                let close_span = Span::from_positions(close, close);
+                if is_reportable(open_span) {
+                    out.push(open_span);
+                }
+                if is_reportable(close_span) {
+                    out.push(close_span);
+                }
             }
         }
 
@@ -1485,8 +1604,6 @@ fn raw_escaped_parameter_brace_edge_spans(word: &Word, source: &str) -> Vec<Span
         previous_char_escaped = false;
         index += ch_len;
     }
-
-    spans
 }
 
 fn brace_pair_matches_nonliteral_syntax(

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -119,9 +119,11 @@ fn collect_literal_brace_spans_for_word(
         word,
         source,
         &scratch.dynamic_exclusions,
-        &mut scratch.literal_stack,
-        &mut scratch.raw_escaped_exclusions,
-        &mut scratch.escaped_parameter_stack,
+        EscapedParameterBraceEdgeScratch {
+            literal_stack: &mut scratch.literal_stack,
+            raw_escaped_exclusions: &mut scratch.raw_escaped_exclusions,
+            escaped_parameter_stack: &mut scratch.escaped_parameter_stack,
+        },
         spans,
         |span| literal_brace_word_span_is_reportable(nodes, fact, fact_store, word, span, source),
     );
@@ -773,12 +775,14 @@ fn collect_uncovered_command_brace_spans(
         for span in scratch.covered_spans.iter().copied() {
             if span.start.offset > cursor {
                 collect_raw_literal_brace_spans(
-                    command_span,
+                    RawLiteralBraceScan {
+                        container_span: command_span,
+                        source,
+                        mode: RawLiteralBraceScanMode::All,
+                        excluded_ranges: heredoc_ranges,
+                    },
                     cursor,
                     span.start.offset,
-                    source,
-                    RawLiteralBraceScanMode::All,
-                    heredoc_ranges,
                     out,
                     &mut scratch.relevant_excluded_ranges,
                     &mut scratch.unmatched_spans,
@@ -789,12 +793,14 @@ fn collect_uncovered_command_brace_spans(
 
         if command_span.end.offset > cursor {
             collect_raw_literal_brace_spans(
-                command_span,
+                RawLiteralBraceScan {
+                    container_span: command_span,
+                    source,
+                    mode: RawLiteralBraceScanMode::All,
+                    excluded_ranges: heredoc_ranges,
+                },
                 cursor,
                 command_span.end.offset,
-                source,
-                RawLiteralBraceScanMode::All,
-                heredoc_ranges,
                 out,
                 &mut scratch.relevant_excluded_ranges,
                 &mut scratch.unmatched_spans,
@@ -840,19 +846,24 @@ enum RawLiteralBraceQuoteState {
     Double,
 }
 
-fn collect_raw_literal_brace_spans(
+#[derive(Debug, Clone, Copy)]
+struct RawLiteralBraceScan<'a> {
     container_span: Span,
+    source: &'a str,
+    mode: RawLiteralBraceScanMode,
+    excluded_ranges: &'a [TextRange],
+}
+
+fn collect_raw_literal_brace_spans(
+    scan: RawLiteralBraceScan<'_>,
     scan_start: usize,
     scan_end: usize,
-    source: &str,
-    mode: RawLiteralBraceScanMode,
-    excluded_ranges: &[TextRange],
     out: &mut Vec<Span>,
     relevant_excluded: &mut Vec<(usize, usize)>,
     unmatched_opens: &mut Vec<Span>,
 ) {
     relevant_excluded.clear();
-    relevant_excluded.extend(excluded_ranges
+    relevant_excluded.extend(scan.excluded_ranges
         .iter()
         .filter_map(|range| {
             let start = usize::from(range.start());
@@ -869,11 +880,11 @@ fn collect_raw_literal_brace_spans(
     for (start, end) in relevant_excluded.iter().copied() {
         if start > cursor {
             collect_raw_literal_brace_spans_without_exclusions(
-                container_span,
+                scan.container_span,
                 cursor,
                 start,
-                source,
-                mode,
+                scan.source,
+                scan.mode,
                 unmatched_opens,
                 out,
             );
@@ -883,18 +894,18 @@ fn collect_raw_literal_brace_spans(
 
     if scan_end > cursor {
         collect_raw_literal_brace_spans_without_exclusions(
-            container_span,
+            scan.container_span,
             cursor,
             scan_end,
-            source,
-            mode,
+            scan.source,
+            scan.mode,
             unmatched_opens,
             out,
         );
     }
 
-    if mode == RawLiteralBraceScanMode::UnmatchedOnly {
-        out.extend(unmatched_opens.drain(..));
+    if scan.mode == RawLiteralBraceScanMode::UnmatchedOnly {
+        out.append(unmatched_opens);
     }
 }
 
@@ -1126,12 +1137,14 @@ fn collect_unmatched_command_substitution_brace_spans(
 
         if body_end > body_start {
             collect_raw_literal_brace_spans(
-                container_span,
+                RawLiteralBraceScan {
+                    container_span,
+                    source,
+                    mode: RawLiteralBraceScanMode::UnmatchedOnly,
+                    excluded_ranges: heredoc_ranges,
+                },
                 body_start,
                 body_end,
-                source,
-                RawLiteralBraceScanMode::UnmatchedOnly,
-                heredoc_ranges,
                 out,
                 &mut scratch.relevant_excluded_ranges,
                 &mut scratch.unmatched_spans,
@@ -1181,19 +1194,23 @@ struct DynamicBraceExcludedSpan {
     kind: DynamicBraceExcludedSpanKind,
 }
 
+struct EscapedParameterBraceEdgeScratch<'a> {
+    literal_stack: &'a mut Vec<LiteralBraceCandidate>,
+    raw_escaped_exclusions: &'a mut Vec<DynamicBraceExcludedSpan>,
+    escaped_parameter_stack: &'a mut Vec<usize>,
+}
+
 fn collect_escaped_parameter_expansion_brace_edge_spans(
     word: &Word,
     source: &str,
     excluded: &[DynamicBraceExcludedSpan],
-    literal_stack: &mut Vec<LiteralBraceCandidate>,
-    raw_escaped_exclusions: &mut Vec<DynamicBraceExcludedSpan>,
-    escaped_parameter_stack: &mut Vec<usize>,
+    scratch: EscapedParameterBraceEdgeScratch<'_>,
     out: &mut Vec<Span>,
     mut is_reportable: impl FnMut(Span) -> bool,
 ) {
     let span = word.span;
     let text = span.slice(source);
-    literal_stack.clear();
+    scratch.literal_stack.clear();
     let mut excluded_index = 0usize;
     let mut index = 0usize;
     let mut previous_char = None;
@@ -1211,11 +1228,11 @@ fn collect_escaped_parameter_expansion_brace_edge_spans(
             }
 
             if excluded_span.kind == DynamicBraceExcludedSpanKind::RuntimeShellSyntax
-                && let Some(current) = literal_stack.last_mut()
+                && let Some(current) = scratch.literal_stack.last_mut()
             {
                 current.has_runtime_shell_sigil_inside = true;
             }
-            if let Some(current) = literal_stack.last_mut() {
+            if let Some(current) = scratch.literal_stack.last_mut() {
                 current.has_excluded_content_inside = true;
             }
             if excluded_span.kind == DynamicBraceExcludedSpanKind::RuntimeShellSyntax
@@ -1280,7 +1297,7 @@ fn collect_escaped_parameter_expansion_brace_edge_spans(
         }
 
         if ch == '{' {
-            literal_stack.push(LiteralBraceCandidate {
+            scratch.literal_stack.push(LiteralBraceCandidate {
                 open_offset: index,
                 after_escaped_dollar: previous_char == Some('$') && previous_char_escaped,
                 has_excluded_content_inside: false,
@@ -1288,17 +1305,17 @@ fn collect_escaped_parameter_expansion_brace_edge_spans(
                 has_brace_expansion_delimiter: false,
             });
         } else if ch == ','
-            && let Some(candidate) = literal_stack.last_mut()
+            && let Some(candidate) = scratch.literal_stack.last_mut()
         {
             candidate.has_brace_expansion_delimiter = true;
         } else if ch == '.'
             && previous_char == Some('.')
             && !previous_char_escaped
-            && let Some(candidate) = literal_stack.last_mut()
+            && let Some(candidate) = scratch.literal_stack.last_mut()
         {
             candidate.has_brace_expansion_delimiter = true;
         } else if ch == '}'
-            && let Some(candidate) = literal_stack.pop()
+            && let Some(candidate) = scratch.literal_stack.pop()
             && index > candidate.open_offset + 1
             && (candidate.after_escaped_dollar
                 || candidate.has_excluded_content_inside
@@ -1326,8 +1343,8 @@ fn collect_escaped_parameter_expansion_brace_edge_spans(
     collect_raw_escaped_parameter_brace_edge_spans(
         word,
         source,
-        raw_escaped_exclusions,
-        escaped_parameter_stack,
+        scratch.raw_escaped_exclusions,
+        scratch.escaped_parameter_stack,
         out,
         &mut is_reportable,
     );

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -106,6 +106,8 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut compound_assignment_value_word_spans = FxHashSet::default();
         let mut array_assignment_split_word_ids =
             Vec::with_capacity(capacity.commands.saturating_div(8));
+        let mut seen_word_occurrences = FxHashSet::default();
+        let mut seen_pending_arithmetic_word_occurrences = FxHashSet::default();
         let mut assoc_binding_visibility_memo = FxHashMap::default();
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut case_pattern_expansions = Vec::new();
@@ -202,6 +204,9 @@ impl<'a> LinterFactsBuilder<'a> {
                         compound_assignment_value_word_spans:
                             &mut compound_assignment_value_word_spans,
                         array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
+                        seen_word_occurrences: &mut seen_word_occurrences,
+                        seen_pending_arithmetic_word_occurrences:
+                            &mut seen_pending_arithmetic_word_occurrences,
                         assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
                         case_pattern_expansions: &mut case_pattern_expansions,
                         pattern_literal_spans: &mut pattern_literal_spans,
@@ -859,7 +864,7 @@ impl<'a> LinterFactsBuilder<'a> {
 fn build_c006_suppressing_reference_offsets_by_name(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
-    innermost_command_ids_by_offset: &FxHashMap<usize, Option<CommandId>>,
+    innermost_command_ids_by_offset: &CommandOffsetLookup,
     subscript_later_suppression_reference_spans: &FxHashSet<FactSpan>,
 ) -> FxHashMap<Name, Vec<usize>> {
     let mut offsets_by_name = FxHashMap::<Name, Vec<usize>>::default();
@@ -890,7 +895,7 @@ fn build_c006_suppressing_reference_offsets_by_name(
 fn c006_reference_suppresses_later_references(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
-    innermost_command_ids_by_offset: &FxHashMap<usize, Option<CommandId>>,
+    innermost_command_ids_by_offset: &CommandOffsetLookup,
     subscript_later_suppression_reference_spans: &FxHashSet<FactSpan>,
     reference: &Reference,
 ) -> bool {
@@ -906,7 +911,7 @@ fn c006_reference_suppresses_later_references(
 
 fn c006_subscript_reference_suppresses_later_references(
     commands: &[CommandFact<'_>],
-    innermost_command_ids_by_offset: &FxHashMap<usize, Option<CommandId>>,
+    innermost_command_ids_by_offset: &CommandOffsetLookup,
     subscript_later_suppression_reference_spans: &FxHashSet<FactSpan>,
     reference: &Reference,
 ) -> bool {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -4,7 +4,7 @@ pub struct LinterFacts<'a> {
     structural_command_ids: Vec<CommandId>,
     #[cfg_attr(not(test), allow(dead_code))]
     command_ids_by_span: CommandLookupIndex,
-    innermost_command_ids_by_offset: FxHashMap<usize, Option<CommandId>>,
+    innermost_command_ids_by_offset: CommandOffsetLookup,
     command_parent_ids: Vec<Option<CommandId>>,
     command_dominance_barrier_flags: Vec<bool>,
     if_condition_command_ids: FxHashSet<CommandId>,

--- a/crates/shuck-linter/src/facts/presence.rs
+++ b/crates/shuck-linter/src/facts/presence.rs
@@ -55,12 +55,16 @@ pub(super) fn build_presence_tested_names(
     let mut names_by_name = FxHashMap::<Name, Vec<PresenceTestNameFact>>::default();
     let outermost_nested_scopes = build_outermost_nested_presence_scopes(commands);
     let sorted_reference_indices = sorted_presence_reference_indices(semantic.references());
+    let mut command_names = FxHashSet::default();
+    let mut c006_command_names = FxHashSet::default();
+    let mut command_reference_ids = FxHashSet::default();
+    let mut command_name_spans = Vec::<(Name, Span)>::new();
 
     for command in commands {
-        let mut command_names = FxHashSet::default();
-        let mut c006_command_names = FxHashSet::default();
-        let mut command_reference_ids = FxHashSet::default();
-        let mut command_name_spans = Vec::<(Name, Span)>::new();
+        command_names.clear();
+        c006_command_names.clear();
+        command_reference_ids.clear();
+        command_name_spans.clear();
 
         if let Some(simple_test) = command.simple_test() {
             let mut simple_test_names = FxHashSet::default();
@@ -94,7 +98,7 @@ pub(super) fn build_presence_tested_names(
             command_names.extend(conditional_names);
         }
 
-        for reference_id in command_reference_ids {
+        for reference_id in command_reference_ids.drain() {
             let reference = semantic.reference(reference_id);
             references_by_name
                 .entry(reference.name.clone())
@@ -105,7 +109,7 @@ pub(super) fn build_presence_tested_names(
                 });
         }
 
-        for (name, tested_span) in command_name_spans {
+        for (name, tested_span) in command_name_spans.drain(..) {
             names_by_name
                 .entry(name)
                 .or_default()
@@ -118,21 +122,21 @@ pub(super) fn build_presence_tested_names(
         if command.is_nested_word_command() {
             let span =
                 outermost_nested_scopes[command.id().index()].unwrap_or_else(|| command.span());
-            for name in command_names {
+            for name in command_names.drain() {
                 nested_command_spans_by_name
                     .entry(name)
                     .or_default()
                     .push(span);
             }
-            for name in c006_command_names {
+            for name in c006_command_names.drain() {
                 c006_nested_command_spans_by_name
                     .entry(name)
                     .or_default()
                     .push(span);
             }
         } else {
-            global_names.extend(command_names);
-            c006_global_names.extend(c006_command_names);
+            global_names.extend(command_names.drain());
+            c006_global_names.extend(c006_command_names.drain());
         }
     }
 
@@ -181,23 +185,20 @@ pub(super) fn build_presence_tested_names(
 }
 
 fn build_outermost_nested_presence_scopes(commands: &[CommandFact<'_>]) -> Vec<Option<Span>> {
-    let mut ordered_commands = commands
-        .iter()
-        .map(|command| {
-            (
-                command.span(),
-                command.id(),
-                command.is_nested_word_command(),
-            )
-        })
-        .collect::<Vec<_>>();
+    let mut ordered_commands = commands.iter().map(CommandFact::id).collect::<Vec<_>>();
     ordered_commands.sort_unstable_by(|left, right| {
-        compare_command_offset_entries((left.0, left.1), (right.0, right.1))
+        compare_command_offset_entries(
+            command_offset_entry(commands, *left),
+            command_offset_entry(commands, *right),
+        )
     });
 
     let mut outermost_scopes = vec![None; commands.len()];
     let mut active_nested_scopes = Vec::<Span>::new();
-    for (span, id, is_nested) in ordered_commands {
+    for id in ordered_commands {
+        let command = command_fact(commands, id);
+        let span = command.span();
+        let is_nested = command.is_nested_word_command();
         pop_finished_nested_presence_scopes(&mut active_nested_scopes, span.start.offset);
         outermost_scopes[id.index()] = active_nested_scopes
             .first()

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -378,6 +378,10 @@ impl<'a> SurfaceScanContext<'a> {
 pub(super) struct SurfaceFragmentSink<'a> {
     source: &'a str,
     facts: SurfaceFragmentFacts,
+    zsh_parameter_index_flag_scratch: Vec<Span>,
+    parameter_special_target_word_scratch: Vec<Span>,
+    open_double_quote_scratch: Vec<(Span, Span)>,
+    split_suspect_closing_quote_scratch: Vec<Span>,
 }
 
 impl<'a> SurfaceFragmentSink<'a> {
@@ -385,6 +389,10 @@ impl<'a> SurfaceFragmentSink<'a> {
         Self {
             source,
             facts: SurfaceFragmentFacts::default(),
+            zsh_parameter_index_flag_scratch: Vec::new(),
+            parameter_special_target_word_scratch: Vec::new(),
+            open_double_quote_scratch: Vec::new(),
+            split_suspect_closing_quote_scratch: Vec::new(),
         }
     }
 
@@ -547,8 +555,14 @@ impl<'a> SurfaceFragmentSink<'a> {
             false,
             &mut self.facts.unicode_smart_quote_spans,
         );
-        for span in zsh_parameter_index_flag_spans_in_word(word.span.slice(self.source), word.span)
-        {
+        self.zsh_parameter_index_flag_scratch.clear();
+        collect_zsh_parameter_index_flag_spans_in_word(
+            word.span.slice(self.source),
+            word.span,
+            &mut self.zsh_parameter_index_flag_scratch,
+        );
+        for index in 0..self.zsh_parameter_index_flag_scratch.len() {
+            let span = self.zsh_parameter_index_flag_scratch[index];
             self.record_zsh_parameter_index_flag(span);
         }
         if context.collect_open_double_quotes {
@@ -582,15 +596,22 @@ impl<'a> SurfaceFragmentSink<'a> {
         command_name: Option<&str>,
         assignment_target: Option<&str>,
     ) {
-        let fragments =
-            suspect_double_quote_spans(word, self.source, command_name, assignment_target);
-        if fragments.is_empty() {
+        self.open_double_quote_scratch.clear();
+        collect_suspect_double_quote_spans(
+            word,
+            self.source,
+            command_name,
+            assignment_target,
+            &mut self.open_double_quote_scratch,
+        );
+        if self.open_double_quote_scratch.is_empty() {
             return;
         }
 
         let replacement =
             rewrite_word_as_single_double_quoted_string(word, self.source, assignment_target);
-        for (opening_span, closing_span) in fragments {
+        for index in 0..self.open_double_quote_scratch.len() {
+            let (opening_span, closing_span) = self.open_double_quote_scratch[index];
             self.facts
                 .open_double_quotes
                 .push(OpenDoubleQuoteFragmentFact {
@@ -607,7 +628,15 @@ impl<'a> SurfaceFragmentSink<'a> {
     pub(super) fn collect_split_suspect_closing_quote_fragment_in_words(&mut self, words: &[Word]) {
         for (index, word) in words.iter().enumerate() {
             let has_later_words = index + 1 < words.len();
-            for span in split_suspect_closing_quote_spans(word, self.source, has_later_words) {
+            self.split_suspect_closing_quote_scratch.clear();
+            collect_split_suspect_closing_quote_spans(
+                word,
+                self.source,
+                has_later_words,
+                &mut self.split_suspect_closing_quote_scratch,
+            );
+            for index in 0..self.split_suspect_closing_quote_scratch.len() {
+                let span = self.split_suspect_closing_quote_scratch[index];
                 if self
                     .facts
                     .suspect_closing_quotes
@@ -763,7 +792,13 @@ impl<'a> SurfaceFragmentSink<'a> {
                         self.record_array_reference(part.span, false);
                     }
                     if parameter_pattern_target_is_special(reference, operator) {
-                        for pattern_span in parameter_operator_special_target_word_spans(operator) {
+                        self.parameter_special_target_word_scratch.clear();
+                        collect_parameter_operator_special_target_word_spans(
+                            operator,
+                            &mut self.parameter_special_target_word_scratch,
+                        );
+                        for index in 0..self.parameter_special_target_word_scratch.len() {
+                            let pattern_span = self.parameter_special_target_word_scratch[index];
                             self.record_parameter_pattern_special_target(pattern_span);
                         }
                     }
@@ -1157,7 +1192,13 @@ impl<'a> SurfaceFragmentSink<'a> {
                     ..
                 } => {
                     if parameter_pattern_target_is_special(reference, operator) {
-                        for pattern_span in parameter_operator_special_target_word_spans(operator) {
+                        self.parameter_special_target_word_scratch.clear();
+                        collect_parameter_operator_special_target_word_spans(
+                            operator,
+                            &mut self.parameter_special_target_word_scratch,
+                        );
+                        for index in 0..self.parameter_special_target_word_scratch.len() {
+                            let pattern_span = self.parameter_special_target_word_scratch[index];
                             self.record_parameter_pattern_special_target(pattern_span);
                         }
                     }
@@ -1452,8 +1493,7 @@ fn quoted_parameter_target_len(text: &str) -> Option<usize> {
     }
 }
 
-fn zsh_parameter_index_flag_spans_in_word(text: &str, span: Span) -> Vec<Span> {
-    let mut spans = Vec::new();
+fn collect_zsh_parameter_index_flag_spans_in_word(text: &str, span: Span, spans: &mut Vec<Span>) {
     let mut search_from = 0usize;
 
     while let Some(start) = next_live_parameter_expansion_start(text, search_from) {
@@ -1472,8 +1512,6 @@ fn zsh_parameter_index_flag_spans_in_word(text: &str, span: Span) -> Vec<Span> {
         spans.push(Span::from_positions(target_start, target_end));
         search_from = start + 2 + target_len;
     }
-
-    spans
 }
 
 fn next_live_parameter_expansion_start(text: &str, search_from: usize) -> Option<usize> {
@@ -1866,14 +1904,19 @@ fn parameter_operator_is_trim(operator: &ParameterOp) -> bool {
     )
 }
 
-fn parameter_operator_special_target_word_spans(operator: &ParameterOp) -> Vec<Span> {
+fn collect_parameter_operator_special_target_word_spans(
+    operator: &ParameterOp,
+    spans: &mut Vec<Span>,
+) {
     match operator {
         ParameterOp::RemovePrefixShort { pattern }
         | ParameterOp::RemovePrefixLong { pattern }
         | ParameterOp::RemoveSuffixShort { pattern }
         | ParameterOp::RemoveSuffixLong { pattern }
         | ParameterOp::ReplaceFirst { pattern, .. }
-        | ParameterOp::ReplaceAll { pattern, .. } => pattern_special_target_word_spans(pattern),
+        | ParameterOp::ReplaceAll { pattern, .. } => {
+            collect_pattern_special_target_word_spans(pattern, spans);
+        }
         ParameterOp::UseDefault
         | ParameterOp::AssignDefault
         | ParameterOp::UseReplacement
@@ -1881,14 +1924,8 @@ fn parameter_operator_special_target_word_spans(operator: &ParameterOp) -> Vec<S
         | ParameterOp::UpperFirst
         | ParameterOp::UpperAll
         | ParameterOp::LowerFirst
-        | ParameterOp::LowerAll => Vec::new(),
+        | ParameterOp::LowerAll => {}
     }
-}
-
-fn pattern_special_target_word_spans(pattern: &Pattern) -> Vec<Span> {
-    let mut spans = Vec::new();
-    collect_pattern_special_target_word_spans(pattern, &mut spans);
-    spans
 }
 
 fn collect_pattern_special_target_word_spans(pattern: &Pattern, spans: &mut Vec<Span>) {
@@ -2390,32 +2427,32 @@ fn word_looks_like_unset_array_target(word: &Word, source: &str) -> bool {
     text.ends_with(']') && is_shell_variable_name(name)
 }
 
-fn suspect_double_quote_spans(
+fn collect_suspect_double_quote_spans(
     word: &Word,
     source: &str,
     _command_name: Option<&str>,
     assignment_target: Option<&str>,
-) -> Vec<(Span, Span)> {
-    word.parts
-        .iter()
-        .enumerate()
-        .filter_map(|(index, current)| {
-            if !suspicious_open_quote_fragment(
-                word,
-                source,
-                index,
-                current,
-                assignment_target.is_some(),
-            ) {
-                return None;
-            }
+    spans: &mut Vec<(Span, Span)>,
+) {
+    for (index, current) in word.parts.iter().enumerate() {
+        if !suspicious_open_quote_fragment(
+            word,
+            source,
+            index,
+            current,
+            assignment_target.is_some(),
+        ) {
+            continue;
+        }
 
-            Some((
-                opening_quote_span(current, source)?,
-                closing_quote_span(current, source)?,
-            ))
-        })
-        .collect()
+        let Some(opening_span) = opening_quote_span(current, source) else {
+            continue;
+        };
+        let Some(closing_span) = closing_quote_span(current, source) else {
+            continue;
+        };
+        spans.push((opening_span, closing_span));
+    }
 }
 
 pub(super) fn rewrite_word_as_single_double_quoted_string(
@@ -2551,7 +2588,20 @@ pub(super) fn word_has_reopened_double_quote_window(
     source: &str,
     command_name: Option<&str>,
 ) -> bool {
-    !suspect_double_quote_spans(word, source, command_name, None).is_empty()
+    word_has_suspect_double_quote_span(word, source, command_name, None)
+}
+
+fn word_has_suspect_double_quote_span(
+    word: &Word,
+    source: &str,
+    _command_name: Option<&str>,
+    assignment_target: Option<&str>,
+) -> bool {
+    word.parts.iter().enumerate().any(|(index, current)| {
+        suspicious_open_quote_fragment(word, source, index, current, assignment_target.is_some())
+            && opening_quote_span(current, source).is_some()
+            && closing_quote_span(current, source).is_some()
+    })
 }
 
 fn suspicious_open_quote_fragment(
@@ -2724,45 +2774,42 @@ fn double_quoted_part_is_empty(part: &WordPartNode, source: &str) -> bool {
     })
 }
 
-fn split_suspect_closing_quote_spans(
+fn collect_split_suspect_closing_quote_spans(
     word: &Word,
     source: &str,
     has_later_words: bool,
-) -> Vec<Span> {
-    word.parts
-        .windows(2)
-        .enumerate()
-        .filter_map(|window| {
-            let (index, [current, next]) = window else {
-                return None;
-            };
-            let WordPart::DoubleQuoted { .. } = &current.kind else {
-                return None;
-            };
-            let WordPart::Literal(text) = &next.kind else {
-                return None;
-            };
-            if !current.span.slice(source).contains('\n') {
-                return None;
-            }
+    spans: &mut Vec<Span>,
+) {
+    for (index, window) in word.parts.windows(2).enumerate() {
+        let [current, next] = window else {
+            continue;
+        };
+        let WordPart::DoubleQuoted { .. } = &current.kind else {
+            continue;
+        };
+        let WordPart::Literal(text) = &next.kind else {
+            continue;
+        };
+        if !current.span.slice(source).contains('\n') {
+            continue;
+        }
 
-            let tail = text.as_str(source, next.span);
-            if !split_quote_tail_is_suspicious(tail) {
-                return None;
-            }
+        let tail = text.as_str(source, next.span);
+        if !split_quote_tail_is_suspicious(tail) {
+            continue;
+        }
 
-            let span = closing_quote_span(current, source)?;
-            if span.start.column == 1
-                || (index > 0
-                    && double_quoted_part_is_empty(&word.parts[index - 1], source)
-                    && has_later_words)
-            {
-                Some(span)
-            } else {
-                None
-            }
-        })
-        .collect()
+        let Some(span) = closing_quote_span(current, source) else {
+            continue;
+        };
+        if span.start.column == 1
+            || (index > 0
+                && double_quoted_part_is_empty(&word.parts[index - 1], source)
+                && has_later_words)
+        {
+            spans.push(span);
+        }
+    }
 }
 
 fn split_quote_tail_is_suspicious(text: &str) -> bool {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -3416,6 +3416,8 @@ pub(crate) fn benchmark_collect_word_facts(
     let mut pending_arithmetic_word_occurrences = Vec::new();
     let mut compound_assignment_value_word_spans = FxHashSet::default();
     let mut array_assignment_split_word_ids = Vec::new();
+    let mut seen_word_occurrences = FxHashSet::default();
+    let mut seen_pending_arithmetic_word_occurrences = FxHashSet::default();
     let mut word_spans = ListArena::new();
     let mut word_span_scratch = Vec::new();
     let mut assoc_binding_visibility_memo = FxHashMap::default();
@@ -3454,6 +3456,9 @@ pub(crate) fn benchmark_collect_word_facts(
                     pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
                     compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
                     array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
+                    seen_word_occurrences: &mut seen_word_occurrences,
+                    seen_pending_arithmetic_word_occurrences:
+                        &mut seen_pending_arithmetic_word_occurrences,
                     word_spans: &mut word_spans,
                     word_span_scratch: &mut word_span_scratch,
                     assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
@@ -3505,6 +3510,8 @@ struct WordFactOutputs<'out, 'a> {
     pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
+    seen_word_occurrences: &'out mut FxHashSet<WordOccurrenceSeenKey>,
+    seen_pending_arithmetic_word_occurrences: &'out mut FxHashSet<PendingArithmeticSeenKey>,
     assoc_binding_visibility_memo: &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
     pattern_literal_spans: &'out mut Vec<Span>,
@@ -3519,6 +3526,9 @@ struct PendingArithmeticWordOccurrence {
     host_kind: WordFactHostKind,
     enclosing_expansion_context: ExpansionContext,
 }
+
+type WordOccurrenceSeenKey = (FactSpan, WordFactContext, WordFactHostKind);
+type PendingArithmeticSeenKey = (FactSpan, ExpansionContext, WordFactHostKind);
 
 fn derive_word_fact_data<'a>(
     word: &'a Word,
@@ -3808,8 +3818,8 @@ struct WordFactCollector<'out, 'a, 'norm> {
     pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     assoc_binding_visibility_memo: &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
-    seen: FxHashSet<(FactSpan, WordFactContext, WordFactHostKind)>,
-    seen_pending_arithmetic: FxHashSet<(FactSpan, ExpansionContext, WordFactHostKind)>,
+    seen: &'out mut FxHashSet<WordOccurrenceSeenKey>,
+    seen_pending_arithmetic: &'out mut FxHashSet<PendingArithmeticSeenKey>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
     case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
     pattern_literal_spans: &'out mut Vec<Span>,
@@ -3861,8 +3871,14 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             pending_arithmetic_word_occurrences: outputs.pending_arithmetic_word_occurrences,
             array_assignment_split_word_ids: outputs.array_assignment_split_word_ids,
             assoc_binding_visibility_memo: outputs.assoc_binding_visibility_memo,
-            seen: FxHashSet::default(),
-            seen_pending_arithmetic: FxHashSet::default(),
+            seen: {
+                outputs.seen_word_occurrences.clear();
+                outputs.seen_word_occurrences
+            },
+            seen_pending_arithmetic: {
+                outputs.seen_pending_arithmetic_word_occurrences.clear();
+                outputs.seen_pending_arithmetic_word_occurrences
+            },
             compound_assignment_value_word_spans: outputs.compound_assignment_value_word_spans,
             case_pattern_expansions: outputs.case_pattern_expansions,
             pattern_literal_spans: outputs.pattern_literal_spans,


### PR DESCRIPTION
## Summary

- Rework literal-brace fact collection to reuse caller-owned scratch buffers instead of returning short-lived `Vec<Span>` values.
- Replace the old offset-sized innermost-command lookup with a compact sorted command-offset table.
- Reuse facts-layer scratch sets and buffers in presence, word fact, and surface fragment collection paths while keeping the existing arena-native APIs.

## Allocation results

Measured with `cargo run -p shuck-benchmark --example linter_memory --release --quiet` on this branch after rebasing onto `main`.

- `nvm` facts: `13,899,686` bytes / `32,132` allocations, diagnostics `56`.
- `all` facts: `29,820,429` bytes / `64,028` allocations, diagnostics `144`.

Compared with the starting local baseline for this work:

- `nvm` facts improved from `16,106,673` bytes / `43,533` allocations.
- `all` facts improved from `34,419,496` bytes / `87,842` allocations.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p shuck-linter`
- `cargo test -p shuck-benchmark --examples`
- `cargo run -p shuck-benchmark --example linter_memory --release --quiet`
- `make test`