### PR TITLE
fix(linter): generalize C006 build-flag parity

### DIFF
--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -833,41 +833,6 @@ impl<'a> LinterFacts<'a> {
         &self.conditional_portability
     }
 
-    pub(crate) fn possible_variable_misspelling_source_compat_name_uses(
-        &self,
-        source: &str,
-        semantic: &SemanticModel,
-    ) -> Vec<ComparableNameUse> {
-        let mut uses = Vec::new();
-
-        if !has_defining_binding(semantic, "CFLAGS")
-            && source.contains("--conlyopt")
-            && source.contains("--cxxopt")
-            && let Some(name_use) =
-                source_compat_name_use(source, semantic, "${CFLAGS}", "CFLAGS", false, |line| {
-                    line.trim_start().starts_with("for f in ${CFLAGS};")
-                })
-        {
-            uses.push(name_use);
-        }
-
-        if source.contains("LDAP_USER_DC")
-            && source.contains("LDAP_USER_OU=\"${LDAP_USER_OU:-")
-            && let Some(name_use) = source_compat_name_use(
-                source,
-                semantic,
-                "${LDAP_USER_OU/#/ou=}",
-                "LDAP_USER_OU",
-                true,
-                |_| true,
-            )
-        {
-            uses.push(name_use);
-        }
-
-        uses
-    }
-
     pub(crate) fn possible_variable_misspelling_scope_compat_name_uses(
         &self,
     ) -> Vec<ComparableNameUse> {
@@ -884,6 +849,42 @@ impl<'a> LinterFacts<'a> {
                     .filter(|name_use| name_use.kind() == ComparableNameUseKind::Parameter),
             );
         }
+        for command in self.commands() {
+            visit_command_words_for_substitutions(
+                command.command(),
+                command.redirects(),
+                self.source,
+                &mut |word| {
+                    uses.extend(
+                        comparable_name_uses(word, self.source)
+                            .into_vec()
+                            .into_iter()
+                            .filter(|name_use| name_use.kind() == ComparableNameUseKind::Derived),
+                    );
+                },
+            );
+        }
+        for word in self
+            .for_headers()
+            .iter()
+            .flat_map(|header| header.words())
+            .chain(self.select_headers().iter().flat_map(|header| header.words()))
+        {
+            uses.extend(
+                comparable_name_uses(word.word(), self.source)
+                    .into_vec()
+                    .into_iter()
+                    .filter_map(|mut name_use| {
+                        if name_use.kind() == ComparableNameUseKind::Parameter {
+                            name_use.mark_derived();
+                            Some(name_use)
+                        } else {
+                            None
+                        }
+                    }),
+            );
+        }
+        uses.extend(build_flag_for_loop_source_name_uses(self.source));
         uses
     }
 }
@@ -972,41 +973,69 @@ fn collect_array_assignment_split_scalar_expansion_spans(
     sort_and_dedup_spans(split_sensitive_spans);
 }
 
-fn source_compat_name_use(
-    source: &str,
-    semantic: &SemanticModel,
-    needle: &str,
-    name: &str,
-    require_reference_overlap: bool,
-    line_matches: impl Fn(&str) -> bool,
-) -> Option<ComparableNameUse> {
-    source.match_indices(needle).find_map(|(start, text)| {
-        if !line_matches(source_line_at(source, start)) {
-            return None;
-        }
-
-        let start_position = source_position_at_offset(source, start)?;
-        let end_position = source_position_at_offset(source, start + text.len())?;
-        let span = Span::from_positions(start_position, end_position);
-        let overlaps_reference = !require_reference_overlap
-            || semantic.references().iter().any(|reference| {
-                reference.name.as_str() == name && spans_overlap(reference.span, span)
-            });
-        overlaps_reference.then(|| ComparableNameUse {
-            span,
-            key: ComparableNameKey(name.into()),
-            kind: ComparableNameUseKind::Parameter,
-        })
-    })
+fn shell_has_brace_expansion(shell: ShellDialect) -> bool {
+    matches!(
+        shell,
+        ShellDialect::Bash | ShellDialect::Ksh | ShellDialect::Mksh | ShellDialect::Zsh
+    )
 }
 
-fn has_defining_binding(semantic: &SemanticModel, name: &str) -> bool {
-    semantic.bindings_for(&Name::from(name)).iter().any(|binding_id| {
-        !matches!(
-            semantic.binding(*binding_id).kind,
-            BindingKind::FunctionDefinition | BindingKind::Imported
-        )
-    })
+fn build_flag_for_loop_source_name_uses(source: &str) -> Vec<ComparableNameUse> {
+    let mut uses = Vec::new();
+    let mut line_start = 0;
+    for line in source.split_inclusive('\n') {
+        let line_without_newline = line.trim_end_matches('\n');
+        let trimmed = line_without_newline.trim_start();
+        let leading_whitespace = line_without_newline.len() - trimmed.len();
+        if let Some(after_for) = trimmed.strip_prefix("for ")
+            && let Some(in_offset) = after_for.find(" in ")
+        {
+            let list = &after_for[in_offset + 4..];
+            if let Some(name_start_in_list) = list.find("${") {
+                let name_start = line_start
+                    + leading_whitespace
+                    + "for ".len()
+                    + in_offset
+                    + 4
+                    + name_start_in_list
+                    + 2;
+                let name_text = &source[name_start..];
+                let name_len = name_text
+                    .bytes()
+                    .take_while(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+                    .count();
+                let name = &source[name_start..name_start + name_len];
+                if is_build_flag_source_name(name)
+                    && source
+                        .as_bytes()
+                        .get(name_start + name_len)
+                        .is_some_and(|byte| *byte == b'}')
+                    && let (Some(start), Some(end)) = (
+                        source_position_at_offset(source, name_start - 2),
+                        source_position_at_offset(source, name_start + name_len + 1),
+                    )
+                {
+                    uses.push(ComparableNameUse {
+                        span: Span::from_positions(start, end),
+                        key: ComparableNameKey(name.into()),
+                        kind: ComparableNameUseKind::Derived,
+                    });
+                }
+            }
+        }
+        line_start += line.len();
+    }
+    uses
+}
+
+fn is_build_flag_source_name(name: &str) -> bool {
+    matches!(
+        name,
+        "CFLAGS" | "CXXFLAGS" | "CPPFLAGS" | "LDFLAGS" | "GOFLAGS"
+    ) || name.ends_with("_CFLAGS")
+        || name.ends_with("_CXXFLAGS")
+        || name.ends_with("_CPPFLAGS")
+        || name.ends_with("_LDFLAGS")
 }
 
 fn source_position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
@@ -1018,25 +1047,6 @@ fn source_position_at_offset(source: &str, target_offset: usize) -> Option<Posit
         position.advance(char);
     }
     Some(position)
-}
-
-fn source_line_at(source: &str, offset: usize) -> &str {
-    let start = source[..offset].rfind('\n').map_or(0, |index| index + 1);
-    let end = source[offset..]
-        .find('\n')
-        .map_or(source.len(), |index| offset + index);
-    &source[start..end]
-}
-
-fn spans_overlap(left: Span, right: Span) -> bool {
-    left.start.offset < right.end.offset && right.start.offset < left.end.offset
-}
-
-fn shell_has_brace_expansion(shell: ShellDialect) -> bool {
-    matches!(
-        shell,
-        ShellDialect::Bash | ShellDialect::Ksh | ShellDialect::Mksh | ShellDialect::Zsh
-    )
 }
 
 fn assignment_value_span(value: &AssignmentValue) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -341,6 +341,17 @@ fn collect_command_substitution_comparable_name_uses(
             descend_nested_word_commands: true,
         },
     ) {
+        visit_command_substitution_loop_header_words(visit.command, &mut |word| {
+            if !allow_quoted_derived_words
+                && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
+            {
+                return;
+            }
+            if let Some(mut name_use) = standalone_comparable_name_use(word, source) {
+                name_use.mark_derived();
+                uses.push(name_use);
+            }
+        });
         visit_command_argument_words_for_substitutions(visit.command, source, &mut |word| {
             if !allow_quoted_derived_words
                 && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
@@ -352,6 +363,27 @@ fn collect_command_substitution_comparable_name_uses(
                 uses.push(name_use);
             }
         });
+    }
+}
+
+fn visit_command_substitution_loop_header_words<'a>(
+    command: &'a Command,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    match command {
+        Command::Compound(CompoundCommand::For(command)) => {
+            if let Some(words) = &command.words {
+                for word in words {
+                    visitor(word);
+                }
+            }
+        }
+        Command::Compound(CompoundCommand::Select(command)) => {
+            for word in &command.words {
+                visitor(word);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -154,7 +154,6 @@ pub fn possible_variable_misspelling(checker: &mut Checker) {
         &guarded_name_offsets,
         &suppressed_reference_spans,
     ));
-    findings.extend(source_compat_findings(checker));
 
     findings.sort_by_key(|(span, _, _)| (span.start.offset, span.end.offset));
     let mut reported_names = FxHashSet::default();
@@ -201,9 +200,7 @@ fn heredoc_findings(
                 Some(candidate) => candidate,
                 None => continue,
             };
-            if has_prior_guarded_reference(guarded_name_offsets, reference_name, name_use.span())
-                && !is_ldap_user_ou_dc_pair(reference_name, candidate.as_str())
-            {
+            if has_prior_guarded_reference(guarded_name_offsets, reference_name, name_use.span()) {
                 continue;
             }
             if has_suppressed_reference_span(
@@ -213,9 +210,7 @@ fn heredoc_findings(
             ) {
                 continue;
             }
-            if has_same_name_defining_bindings(checker, &Name::from(reference_name))
-                && !is_ldap_user_ou_dc_pair(reference_name, candidate.as_str())
-            {
+            if has_same_name_defining_bindings(checker, &Name::from(reference_name)) {
                 continue;
             }
             if is_presence_tested_reference_name(checker, reference_name, name_use.span()) {
@@ -271,7 +266,13 @@ fn scope_compat_findings(
         if !seen.insert((reference_name.to_owned(), name_use.span().start.offset)) {
             continue;
         }
-        if !is_scope_compat_reference_name(reference_name) {
+        if !is_scope_compat_reference_name(reference_name, name_use.kind()) {
+            continue;
+        }
+        if name_use.kind() == ComparableNameUseKind::Derived
+            && is_build_flag_family_name(reference_name)
+            && !is_braced_parameter_use(checker.source(), name_use.span())
+        {
             continue;
         }
         if !looks_like_case_mismatch_reference(reference_name) {
@@ -297,7 +298,7 @@ fn scope_compat_findings(
             continue;
         }
 
-        let candidate = match preferred_candidate_name(checker, reference_name) {
+        let candidate = match preferred_scope_compat_candidate_name(checker, reference_name) {
             Some(candidate) => candidate,
             None => continue,
         };
@@ -337,40 +338,80 @@ fn scope_compat_findings(
     findings
 }
 
-fn source_compat_findings(checker: &Checker<'_>) -> Vec<(Span, String, String)> {
-    checker
-        .facts()
-        .possible_variable_misspelling_source_compat_name_uses(checker.source(), checker.semantic())
-        .into_iter()
-        .filter_map(|name_use| {
-            let reference_name = name_use.key().as_str();
-            let candidate = match reference_name {
-                "CFLAGS" => "CXXFLAGS".to_owned(),
-                "LDAP_USER_OU" => "LDAP_USER_DC".to_owned(),
-                _ => preferred_candidate_name(checker, reference_name)?,
-            };
-            Some((name_use.span(), reference_name.to_owned(), candidate))
-        })
-        .collect()
+fn is_scope_compat_reference_name(reference_name: &str, kind: ComparableNameUseKind) -> bool {
+    reference_name == "SHELLSPEC_EXECDIR"
+        || kind == ComparableNameUseKind::Derived && is_build_flag_family_name(reference_name)
 }
 
-fn is_scope_compat_reference_name(reference_name: &str) -> bool {
-    matches!(reference_name, "CFLAGS" | "SHELLSPEC_EXECDIR")
+fn is_braced_parameter_use(source: &str, span: Span) -> bool {
+    source
+        .as_bytes()
+        .get(span.start.offset..span.start.offset + 2)
+        .is_some_and(|prefix| prefix == b"${")
+}
+
+fn preferred_scope_compat_candidate_name(
+    checker: &Checker<'_>,
+    reference_name: &str,
+) -> Option<String> {
+    preferred_candidate_name(checker, reference_name)
+        .or_else(|| build_flag_scope_candidate_name(checker, reference_name))
+}
+
+fn build_flag_scope_candidate_name(checker: &Checker<'_>, reference_name: &str) -> Option<String> {
+    if !is_build_flag_family_name(reference_name) {
+        return None;
+    }
+
+    checker
+        .semantic()
+        .bindings()
+        .iter()
+        .filter_map(|binding| {
+            let candidate_name = binding.name.as_str();
+            if candidate_name == reference_name
+                || !is_build_flag_misspelling_report_pair(reference_name, candidate_name)
+            {
+                return None;
+            }
+            Some((
+                binding.span.start.offset,
+                binding.span.end.offset,
+                candidate_name.to_owned(),
+            ))
+        })
+        .chain(
+            checker
+                .facts()
+                .possible_variable_misspelling_scope_compat_name_uses()
+                .into_iter()
+                .filter_map(|name_use| {
+                    let candidate_name = name_use.key().as_str();
+                    if candidate_name == reference_name
+                        || !is_build_flag_misspelling_report_pair(reference_name, candidate_name)
+                    {
+                        return None;
+                    }
+                    Some((
+                        name_use.span().start.offset,
+                        name_use.span().end.offset,
+                        candidate_name.to_owned(),
+                    ))
+                }),
+        )
+        .min_by_key(|(start, end, _)| (*start, *end))
+        .map(|(_, _, name)| name)
 }
 
 fn is_scope_compat_pair(
-    checker: &Checker<'_>,
+    _checker: &Checker<'_>,
     reference_name: &str,
-    reference_span: Span,
+    _reference_span: Span,
     candidate_name: &str,
 ) -> bool {
     match (reference_name, candidate_name) {
         ("SHELLSPEC_EXECDIR", "SHELLSPEC_SPECDIR") => true,
-        ("CFLAGS", "CXXFLAGS") => {
-            let nearby_lines = source_line_window(checker.source(), reference_span.start.offset, 4);
-            nearby_lines.contains("--conlyopt") && nearby_lines.contains("--cxxopt")
-        }
-        _ => false,
+        _ => is_build_flag_misspelling_report_pair(reference_name, candidate_name),
     }
 }
 
@@ -642,14 +683,41 @@ fn is_build_flag_family_non_report_pair(reference_name: &str, candidate_name: &s
         return false;
     }
 
-    !matches!(
-        (reference_name, candidate_upper.as_str()),
+    !is_build_flag_misspelling_report_pair(reference_name, &candidate_upper)
+}
+
+fn is_build_flag_misspelling_report_pair(reference_name: &str, candidate_name: &str) -> bool {
+    let candidate_upper = canonical_uppercase_name(candidate_name);
+    let Some((reference_prefix, reference_suffix)) = split_build_flag_family_name(reference_name)
+    else {
+        return false;
+    };
+    let Some((candidate_prefix, candidate_suffix)) = split_build_flag_family_name(&candidate_upper)
+    else {
+        return false;
+    };
+    if reference_prefix != candidate_prefix {
+        return false;
+    }
+
+    matches!(
+        (reference_suffix, candidate_suffix),
         ("CFLAGS", "CXXFLAGS" | "CPPFLAGS") | ("CPPFLAGS", "CXXFLAGS") | ("CXXFLAGS", "CPPFLAGS")
     )
 }
 
-fn is_ldap_user_ou_dc_pair(reference_name: &str, candidate_name: &str) -> bool {
-    reference_name == "LDAP_USER_OU" && candidate_name == "LDAP_USER_DC"
+fn split_build_flag_family_name(name: &str) -> Option<(&str, &'static str)> {
+    ["CXXFLAGS", "CPPFLAGS", "CFLAGS", "LDFLAGS", "GOFLAGS"]
+        .into_iter()
+        .find_map(|suffix| {
+            if name == suffix {
+                Some(("", suffix))
+            } else {
+                name.strip_suffix(suffix)
+                    .filter(|prefix| prefix.ends_with('_'))
+                    .map(|prefix| (prefix, suffix))
+            }
+        })
 }
 
 fn is_build_flag_family_name(name: &str) -> bool {
@@ -1226,16 +1294,43 @@ echo \"$OPT\"
     }
 
     #[test]
-    fn reports_cflags_cxxflags_in_split_bazel_option_context() {
+    fn reports_build_flag_family_references_in_loop_headers() {
         let source = "\
 #!/bin/bash
 CXXFLAGS=\"${CXXFLAGS//-stdlib=libc++/}\"
 for f in ${CFLAGS}; do
-  echo \"--conlyopt=${f}\"
+  echo \"c flag: ${f}\"
 done
-for f in ${CXXFLAGS}; do
-  echo \"--cxxopt=${f}\"
+MY_CXXFLAGS=\"${MY_CXXFLAGS:-}\"
+for f in ${MY_CFLAGS}; do
+  echo \"custom c flag: ${f}\"
 done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CFLAGS}", "${MY_CFLAGS}"]
+        );
+    }
+
+    #[test]
+    fn reports_build_flag_family_references_in_declaration_command_substitution_loop_headers() {
+        let source = "\
+#!/bin/bash
+CXXFLAGS=\"${CXXFLAGS//-stdlib=libc++/}\"
+declare -r EXTRA_FLAGS=\"\\
+$(
+for f in ${CFLAGS}; do
+  echo \"c flag: ${f}\"
+done
+)\"
 ";
         let diagnostics = test_snippet(
             source,


### PR DESCRIPTION
## Summary
- remove corpus-shaped C156 compatibility facts for exact Bazel/LDAP source substrings
- derive build-flag typo compatibility from reusable loop/header name-use facts
- cover declaration command-substitution loop headers without LDAP-specific bypasses

## Verification
- cargo fmt --check
- cargo test -q -p shuck-linter possible_variable_misspelling -- --nocapture
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006,C156
