### PR TITLE
fix(linter): generalize xargs inline replace parity

### DIFF
--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -263,6 +263,7 @@ pub struct XargsCommandFacts<'a> {
     zero_digit_option_word: bool,
     inline_replace_options: Box<[XargsInlineReplaceOptionFact]>,
     command_operand_words: Box<[&'a Word]>,
+    sc2267_default_replace_silent_shape: bool,
 }
 
 impl<'a> XargsCommandFacts<'a> {
@@ -286,6 +287,10 @@ impl<'a> XargsCommandFacts<'a> {
 
     pub fn command_operand_words(&self) -> &[&'a Word] {
         &self.command_operand_words
+    }
+
+    pub fn has_sc2267_default_replace_silent_shape(&self) -> bool {
+        self.sc2267_default_replace_silent_shape
     }
 }
 

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -257,14 +257,15 @@ impl MapfileCommandFacts {
 }
 
 #[derive(Debug, Clone)]
-pub struct XargsCommandFacts {
+pub struct XargsCommandFacts<'a> {
     pub uses_null_input: bool,
     max_procs: Option<u64>,
     zero_digit_option_word: bool,
-    inline_replace_option_spans: Box<[Span]>,
+    inline_replace_options: Box<[XargsInlineReplaceOptionFact]>,
+    command_operand_words: Box<[&'a Word]>,
 }
 
-impl XargsCommandFacts {
+impl<'a> XargsCommandFacts<'a> {
     pub fn max_procs(&self) -> Option<u64> {
         self.max_procs
     }
@@ -273,8 +274,34 @@ impl XargsCommandFacts {
         self.zero_digit_option_word
     }
 
-    pub fn inline_replace_option_spans(&self) -> &[Span] {
-        &self.inline_replace_option_spans
+    pub fn inline_replace_options(&self) -> &[XargsInlineReplaceOptionFact] {
+        &self.inline_replace_options
+    }
+
+    pub fn inline_replace_option_spans(&self) -> impl Iterator<Item = Span> + '_ {
+        self.inline_replace_options
+            .iter()
+            .map(XargsInlineReplaceOptionFact::span)
+    }
+
+    pub fn command_operand_words(&self) -> &[&'a Word] {
+        &self.command_operand_words
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct XargsInlineReplaceOptionFact {
+    span: Span,
+    uses_default_replacement: bool,
+}
+
+impl XargsInlineReplaceOptionFact {
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn uses_default_replacement(&self) -> bool {
+        self.uses_default_replacement
     }
 }
 
@@ -555,7 +582,7 @@ pub struct CommandOptionFacts<'a> {
     find_exec: Option<FindExecCommandFacts>,
     find_exec_shell: Option<FindExecShellCommandFacts>,
     mapfile: Option<MapfileCommandFacts>,
-    xargs: Option<XargsCommandFacts>,
+    xargs: Option<XargsCommandFacts<'a>>,
     wait: Option<WaitCommandFacts>,
     grep: Option<GrepCommandFacts<'a>>,
     ps: Option<PsCommandFacts>,
@@ -621,7 +648,7 @@ impl<'a> CommandOptionFacts<'a> {
         self.mapfile.as_ref()
     }
 
-    pub fn xargs(&self) -> Option<&XargsCommandFacts> {
+    pub fn xargs(&self) -> Option<&XargsCommandFacts<'a>> {
         self.xargs.as_ref()
     }
 

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -295,7 +295,7 @@ fn summarizes_command_options_and_invokers() {
         .iter()
         .filter(|fact| fact.effective_name_is("xargs"))
         .filter_map(|fact| fact.options().xargs())
-        .flat_map(|xargs| xargs.inline_replace_option_spans().iter().copied())
+        .flat_map(|xargs| xargs.inline_replace_option_spans())
         .map(|span| span.slice(source))
         .collect::<Vec<_>>();
     assert_eq!(inline_replace_option_spans, vec!["-iX"]);
@@ -2813,7 +2813,7 @@ fn parses_long_xargs_null_mode_and_numeric_exit_status() {
         .and_then(|fact| fact.options().xargs())
         .expect("expected xargs facts");
     assert!(xargs.uses_null_input);
-    assert!(xargs.inline_replace_option_spans().is_empty());
+    assert!(xargs.inline_replace_options().is_empty());
 
     let exit = facts
         .commands()
@@ -2907,14 +2907,31 @@ xargs -i echo \"-----> Configuring {} with $template\"
     assert_eq!(
         xargs_facts[2]
             .inline_replace_option_spans()
-            .iter()
             .map(|span| span.slice(source))
             .collect::<Vec<_>>(),
         vec!["-i0"]
     );
-    assert!(xargs_facts[3].inline_replace_option_spans().is_empty());
-    assert!(xargs_facts[4].inline_replace_option_spans().is_empty());
-    assert!(xargs_facts[5].inline_replace_option_spans().is_empty());
+    assert_eq!(
+        xargs_facts[3]
+            .inline_replace_option_spans()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["-i"]
+    );
+    assert_eq!(
+        xargs_facts[4]
+            .inline_replace_option_spans()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["-0i"]
+    );
+    assert_eq!(
+        xargs_facts[5]
+            .inline_replace_option_spans()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["-i"]
+    );
 }
 
 #[test]
@@ -2961,7 +2978,6 @@ xargs -a inputs -iX echo X
     assert_eq!(
         xargs_facts[1]
             .inline_replace_option_spans()
-            .iter()
             .map(|span| span.slice(source))
             .collect::<Vec<_>>(),
         vec!["-iX"]

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -7171,7 +7171,7 @@ fn mapfile_option_takes_argument(flag: char) -> bool {
     matches!(flag, 'u' | 'C' | 'c' | 'd' | 'n' | 'O' | 's')
 }
 
-fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
+fn parse_xargs_command<'a>(args: &[&'a Word], source: &str) -> XargsCommandFacts<'a> {
     let mut uses_null_input = false;
     let mut max_procs = None;
     let mut zero_digit_option_word = false;
@@ -7222,7 +7222,7 @@ fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
                 uses_null_input = true;
             }
             if flag == 'i' {
-                inline_replace_options.push(XargsInlineReplaceOption {
+                inline_replace_options.push(XargsInlineReplaceOptionFact {
                     span: word.span,
                     uses_default_replacement: chars.peek().is_none(),
                 });
@@ -7260,67 +7260,13 @@ fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
         }
     }
 
-    let suppress_default_replacement_diagnostic =
-        xargs_suppresses_default_inline_replace_diagnostic(&args[index..], source);
-    let inline_replace_option_spans = inline_replace_options
-        .into_iter()
-        .filter(|option| {
-            !option.uses_default_replacement || !suppress_default_replacement_diagnostic
-        })
-        .map(|option| option.span)
-        .collect::<Vec<_>>();
-
     XargsCommandFacts {
         uses_null_input,
         max_procs,
         zero_digit_option_word,
-        inline_replace_option_spans: inline_replace_option_spans.into_boxed_slice(),
+        inline_replace_options: inline_replace_options.into_boxed_slice(),
+        command_operand_words: args[index..].to_vec().into_boxed_slice(),
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct XargsInlineReplaceOption {
-    span: Span,
-    uses_default_replacement: bool,
-}
-
-fn xargs_suppresses_default_inline_replace_diagnostic(args: &[&Word], source: &str) -> bool {
-    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
-        return false;
-    };
-
-    if matches!(
-        command_name.as_ref(),
-        "sh" | "bash" | "dash" | "ksh" | "zsh"
-    ) && args
-        .get(1)
-        .and_then(|word| static_word_text(word, source))
-        .as_deref()
-        == Some("-c")
-    {
-        return true;
-    }
-
-    if command_name.as_ref() == "echo" {
-        for operand in args.iter().skip(1) {
-            if static_word_text(operand, source).as_deref() == Some("--") {
-                return false;
-            }
-            if static_word_text(operand, source).is_some_and(|text| is_echo_option_text(&text)) {
-                continue;
-            }
-            let literal_prefix = leading_literal_word_prefix(operand, source);
-            return literal_prefix.starts_with('-') && literal_prefix != "-";
-        }
-    }
-
-    false
-}
-
-fn is_echo_option_text(text: &str) -> bool {
-    text != "-"
-        && text.starts_with('-')
-        && text[1..].chars().all(|ch| matches!(ch, 'n' | 'e' | 'E'))
 }
 
 fn xargs_long_option_argument(

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -7266,7 +7266,62 @@ fn parse_xargs_command<'a>(args: &[&'a Word], source: &str) -> XargsCommandFacts
         zero_digit_option_word,
         inline_replace_options: inline_replace_options.into_boxed_slice(),
         command_operand_words: args[index..].to_vec().into_boxed_slice(),
+        sc2267_default_replace_silent_shape: xargs_sc2267_default_replace_silent_shape(
+            &args[index..],
+            source,
+        ),
     }
+}
+
+fn xargs_sc2267_default_replace_silent_shape(args: &[&Word], source: &str) -> bool {
+    xargs_command_is_shell_c_wrapper(args, source)
+        || xargs_command_is_echo_leading_dash_replacement(args, source)
+}
+
+fn xargs_command_is_shell_c_wrapper(args: &[&Word], source: &str) -> bool {
+    let args = if args
+        .first()
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("command")
+    {
+        &args[1..]
+    } else {
+        args
+    };
+
+    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
+        return false;
+    };
+
+    matches!(
+        command_basename(command_name.as_ref()),
+        "sh" | "bash" | "dash" | "ksh" | "zsh"
+    ) && args
+        .get(1)
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("-c")
+}
+
+fn xargs_command_is_echo_leading_dash_replacement(args: &[&Word], source: &str) -> bool {
+    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
+        return false;
+    };
+
+    if command_basename(command_name.as_ref()) != "echo" {
+        return false;
+    }
+
+    let Some(first_operand) = args.get(1) else {
+        return false;
+    };
+    let literal_prefix = leading_literal_word_prefix(first_operand, source);
+    literal_prefix.starts_with('-') && literal_prefix != "-" && literal_prefix.contains("{}")
+}
+
+fn command_basename(name: &str) -> &str {
+    name.rsplit('/').next().unwrap_or(name)
 }
 
 fn xargs_long_option_argument(

--- a/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
+++ b/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
@@ -1,5 +1,4 @@
-use crate::{Checker, Rule, ShellDialect, Violation, facts::leading_literal_word_prefix};
-use shuck_ast::{Word, static_word_text};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct XargsWithInlineReplace;
 
@@ -21,7 +20,6 @@ pub fn xargs_with_inline_replace(checker: &mut Checker) {
         return;
     }
 
-    let source = checker.source();
     let spans = checker
         .facts()
         .commands()
@@ -34,66 +32,13 @@ pub fn xargs_with_inline_replace(checker: &mut Checker) {
                 .copied()
                 .filter(move |option| {
                     !option.uses_default_replacement()
-                        || !matches_sc2267_default_replace_silent_shape(
-                            xargs.command_operand_words(),
-                            source,
-                        )
+                        || !xargs.has_sc2267_default_replace_silent_shape()
                 })
                 .map(|option| option.span())
         })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || XargsWithInlineReplace);
-}
-
-fn matches_sc2267_default_replace_silent_shape(args: &[&Word], source: &str) -> bool {
-    matches_shell_c_wrapper(args, source) || matches_echo_leading_dash_replacement(args, source)
-}
-
-fn matches_shell_c_wrapper(args: &[&Word], source: &str) -> bool {
-    let args = if args
-        .first()
-        .and_then(|word| static_word_text(word, source))
-        .as_deref()
-        == Some("command")
-    {
-        &args[1..]
-    } else {
-        args
-    };
-
-    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
-        return false;
-    };
-
-    matches!(
-        command_basename(command_name.as_ref()),
-        "sh" | "bash" | "dash" | "ksh" | "zsh"
-    ) && args
-        .get(1)
-        .and_then(|word| static_word_text(word, source))
-        .as_deref()
-        == Some("-c")
-}
-
-fn matches_echo_leading_dash_replacement(args: &[&Word], source: &str) -> bool {
-    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
-        return false;
-    };
-
-    if command_basename(command_name.as_ref()) != "echo" {
-        return false;
-    }
-
-    let Some(first_operand) = args.get(1) else {
-        return false;
-    };
-    let literal_prefix = leading_literal_word_prefix(first_operand, source);
-    literal_prefix.starts_with('-') && literal_prefix != "-" && literal_prefix.contains("{}")
-}
-
-fn command_basename(name: &str) -> &str {
-    name.rsplit('/').next().unwrap_or(name)
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
+++ b/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
@@ -1,4 +1,5 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Rule, ShellDialect, Violation, facts::leading_literal_word_prefix};
+use shuck_ast::{Word, static_word_text};
 
 pub struct XargsWithInlineReplace;
 
@@ -20,15 +21,79 @@ pub fn xargs_with_inline_replace(checker: &mut Checker) {
         return;
     }
 
+    let source = checker.source();
     let spans = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|fact| fact.options().xargs())
-        .flat_map(|xargs| xargs.inline_replace_option_spans().iter().copied())
+        .flat_map(|xargs| {
+            xargs
+                .inline_replace_options()
+                .iter()
+                .copied()
+                .filter(move |option| {
+                    !option.uses_default_replacement()
+                        || !matches_sc2267_default_replace_silent_shape(
+                            xargs.command_operand_words(),
+                            source,
+                        )
+                })
+                .map(|option| option.span())
+        })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || XargsWithInlineReplace);
+}
+
+fn matches_sc2267_default_replace_silent_shape(args: &[&Word], source: &str) -> bool {
+    matches_shell_c_wrapper(args, source) || matches_echo_leading_dash_replacement(args, source)
+}
+
+fn matches_shell_c_wrapper(args: &[&Word], source: &str) -> bool {
+    let args = if args
+        .first()
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("command")
+    {
+        &args[1..]
+    } else {
+        args
+    };
+
+    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
+        return false;
+    };
+
+    matches!(
+        command_basename(command_name.as_ref()),
+        "sh" | "bash" | "dash" | "ksh" | "zsh"
+    ) && args
+        .get(1)
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("-c")
+}
+
+fn matches_echo_leading_dash_replacement(args: &[&Word], source: &str) -> bool {
+    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
+        return false;
+    };
+
+    if command_basename(command_name.as_ref()) != "echo" {
+        return false;
+    }
+
+    let Some(first_operand) = args.get(1) else {
+        return false;
+    };
+    let literal_prefix = leading_literal_word_prefix(first_operand, source);
+    literal_prefix.starts_with('-') && literal_prefix != "-" && literal_prefix.contains("{}")
+}
+
+fn command_basename(name: &str) -> &str {
+    name.rsplit('/').next().unwrap_or(name)
 }
 
 #[cfg(test)]
@@ -66,9 +131,12 @@ sudo xargs -i echo {}
 #!/bin/sh
 find . -type f | xargs -i bash -c 'echo {}'
 find . -type f | xargs -0i sh -c 'echo {}'
+find . -type f | xargs -i /bin/sh -c 'echo {}'
+find . -type f | xargs -i command sh -c 'echo {}'
 xargs -i echo '-----> Configuring {}'
 xargs -0i echo '-----> Configuring {}'
 xargs -i echo \"-----> Configuring {} with $template\"
+xargs -i /bin/echo '-----> Configuring {}'
 ";
         let diagnostics = test_snippet(
             source,
@@ -76,6 +144,34 @@ xargs -i echo \"-----> Configuring {} with $template\"
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_default_replace_outside_silent_sc2267_shapes() {
+        let source = "\
+#!/bin/sh
+xargs -i env sh -c 'echo {}'
+xargs -i sudo sh -c 'echo {}'
+xargs -i sh -ec 'echo {}'
+xargs -i echo '{}'
+xargs -i echo -n '-x {}'
+xargs -i echo -- '-x {}'
+xargs -i command echo '-----> Configuring {}'
+xargs -i printf -- '-x %s\n' '{}'
+xargs -i{} sh -c 'echo {}'
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::XargsWithInlineReplace),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-i", "-i", "-i", "-i", "-i", "-i", "-i", "-i", "-i{}"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Keep xargs option facts raw by preserving default `-i` occurrences and the parsed command operand words.
- Move the SC2267 compatibility carveout into the S064 rule with generic shell-wrapper and echo-leading-dash shape predicates.
- Add focused unit coverage for silent and reported default-replacement shapes.

## Verification

- `cargo test -p shuck-linter xargs_with_inline_replace -- --nocapture`
- `cargo test -p shuck-linter xargs -- --nocapture`
- `make ensure-cache && make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S064`
- `git diff --check`
