### PR TITLE
fix(linter): stop ambient contracts initializing runtime names

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -86,7 +86,7 @@ fn build_sourced_runtime_contract(
         ..FileContract::default()
     };
     for name in names {
-        contract.add_provided_binding(ProvidedBinding::new_file_entry_initialized(
+        contract.add_provided_binding(ProvidedBinding::new(
             Name::from(name.as_str()),
             ProvidedBindingKind::Variable,
             ContractCertainty::Definite,
@@ -613,6 +613,14 @@ mod tests {
         })
     }
 
+    fn has_ambient_binding(contract: &FileContract, name: &str) -> bool {
+        contract.provided_bindings.iter().any(|binding| {
+            binding.name == name
+                && binding.file_entry_initialization
+                    == shuck_semantic::FileEntryBindingInitialization::AmbientOnly
+        })
+    }
+
     #[test]
     fn project_specific_paths_do_not_get_ambient_contracts() {
         let void_path = Path::new("/tmp/void-packages/common/build-style/void-cross.sh");
@@ -632,7 +640,7 @@ printf '%s\\n' \"$XBPS_SRCPKGDIR\" \"$configure_args\" \"$wrksrc\"
     }
 
     #[test]
-    fn bash_it_theme_paths_get_palette_initialized_contracts() {
+    fn bash_it_theme_paths_get_palette_ambient_contracts() {
         let path = Path::new("/tmp/Bash-it/themes/example/example.theme.bash");
         let source = "\
 prompt_command() {
@@ -643,8 +651,10 @@ PROMPT_COMMAND=prompt_command
 
         let contract = contract_for(path, source).unwrap();
 
-        assert!(has_initialized_binding(&contract, "green"));
-        assert!(has_initialized_binding(&contract, "reset_color"));
+        assert!(has_ambient_binding(&contract, "green"));
+        assert!(has_ambient_binding(&contract, "reset_color"));
+        assert!(!has_initialized_binding(&contract, "green"));
+        assert!(!has_initialized_binding(&contract, "reset_color"));
         assert!(!contract.externally_consumed_bindings);
     }
 
@@ -715,7 +725,7 @@ _example() {
     }
 
     #[test]
-    fn bash_completion_paths_with_initializer_get_completion_contracts() {
+    fn bash_completion_paths_with_initializer_get_ambient_completion_contracts() {
         let path = Path::new("/tmp/bash-completion/completions/example.bash");
         let source = "\
 _example() {
@@ -726,9 +736,12 @@ _example() {
 
         let contract = contract_for(path, source).unwrap();
 
-        assert!(has_initialized_binding(&contract, "cur"));
-        assert!(has_initialized_binding(&contract, "cword"));
-        assert!(has_initialized_binding(&contract, "comp_args"));
+        assert!(has_ambient_binding(&contract, "cur"));
+        assert!(has_ambient_binding(&contract, "cword"));
+        assert!(has_ambient_binding(&contract, "comp_args"));
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!has_initialized_binding(&contract, "comp_args"));
         assert!(!contract.externally_consumed_bindings);
     }
 

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -833,19 +833,28 @@ build
     }
 
     #[test]
-    fn sourced_theme_contract_suppresses_runtime_color_reads() {
+    fn sourced_theme_contract_does_not_suppress_runtime_color_reads() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/bash-it/themes/minimal/minimal.theme.bash"),
             "\
 prompt_command() {
-  PS1=\"${green?} ${green} ${reset_color?}\"
+  PS1=\"$green $reset_color\"
 }
 PROMPT_COMMAND=prompt_command
 ",
             &LinterSettings::for_rule(Rule::UndefinedVariable),
         );
 
-        assert!(diagnostics.is_empty());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("green"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("reset_color"))
+        );
     }
 
     #[test]
@@ -947,7 +956,7 @@ complete_example() {
     }
 
     #[test]
-    fn bash_completion_directory_with_initializer_suppresses_helper_reads() {
+    fn bash_completion_directory_with_initializer_does_not_suppress_helper_reads() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/bash-completion/completions/example.bash"),
             "\
@@ -959,7 +968,21 @@ complete_example() {
             &LinterSettings::for_rule(Rule::UndefinedVariable),
         );
 
-        assert!(diagnostics.is_empty());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cur"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("cword"))
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("comp_args"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep path/source-derived ambient runtime contracts from marking variables as initialized at file entry
- update bash-it theme and bash-completion regressions to ensure those ambient contracts no longer suppress undefined-variable reads

## Why
The previous ambient contract provider inferred initialized runtime names from repository/path shape plus source tokens. That could hide undefined-variable diagnostics for unrelated files that merely matched the same shape. These contracts now remain ambient imports unless a real write is modeled elsewhere.

## Validation
- `cargo test -p shuck-linter ambient_contracts -- --nocapture`
- `cargo test -p shuck-linter bash_completion_directory -- --nocapture`
- `cargo test -p shuck-linter sourced_theme_contract -- --nocapture`
- `make test-large-corpus` (`implementation_diffs=0`)
