### PR TITLE
perf(linter): reduce facts allocation churn

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1020,11 +1020,12 @@ fn var_ref_name_has_visible_assoc_binding_from_named_callers(
         return false;
     };
 
-    let mut seen = FxHashSet::default();
-    let mut worklist = function_names.to_vec();
+    let mut seen = AssocCallerSeenNames::new();
+    let mut worklist = SmallVec::<[Name; 4]>::new();
+    worklist.extend(function_names.iter().cloned());
 
     while let Some(function_name) = worklist.pop() {
-        if !seen.insert(function_name.clone()) {
+        if !seen.insert(&function_name) {
             continue;
         }
 
@@ -1048,6 +1049,44 @@ fn var_ref_name_has_visible_assoc_binding_from_named_callers(
     }
 
     false
+}
+
+struct AssocCallerSeenNames {
+    inline: SmallVec<[Name; 8]>,
+    hashed: Option<FxHashSet<Name>>,
+}
+
+impl AssocCallerSeenNames {
+    const HASH_THRESHOLD: usize = 32;
+
+    fn new() -> Self {
+        Self {
+            inline: SmallVec::new(),
+            hashed: None,
+        }
+    }
+
+    fn insert(&mut self, name: &Name) -> bool {
+        if let Some(hashed) = &mut self.hashed {
+            return hashed.insert(name.clone());
+        }
+
+        if self.inline.iter().any(|seen_name| seen_name == name) {
+            return false;
+        }
+
+        if self.inline.len() < Self::HASH_THRESHOLD {
+            self.inline.push(name.clone());
+            return true;
+        }
+
+        let mut hashed =
+            FxHashSet::with_capacity_and_hasher(Self::HASH_THRESHOLD * 2, Default::default());
+        hashed.extend(self.inline.drain(..));
+        let inserted = hashed.insert(name.clone());
+        self.hashed = Some(hashed);
+        inserted
+    }
 }
 
 fn named_function_scope_names(semantic: &SemanticModel, offset: usize) -> Option<&[Name]> {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -320,15 +320,10 @@ impl<'a> LinterFacts<'a> {
         &self.presence_tested_names
     }
 
-    pub(crate) fn all_presence_tested_names(&self) -> Vec<&Name> {
-        let mut names = self
-            .presence_test_references_by_name
+    pub(crate) fn presence_tested_candidate_names(&self) -> impl Iterator<Item = &Name> {
+        self.presence_test_references_by_name
             .keys()
             .chain(self.presence_test_names_by_name.keys())
-            .collect::<Vec<_>>();
-        names.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
-        names.dedup_by(|left, right| left.as_str() == right.as_str());
-        names
     }
 
     pub fn is_presence_tested_name(&self, name: &Name, span: Span) -> bool {

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -5152,11 +5152,12 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             return false;
         };
 
-        let mut seen = FxHashSet::default();
-        let mut worklist = function_names.to_vec();
+        let mut seen = AssocCallerSeenNames::new();
+        let mut worklist = SmallVec::<[Name; 4]>::new();
+        worklist.extend(function_names.iter().cloned());
 
         while let Some(function_name) = worklist.pop() {
-            if !seen.insert(function_name.clone()) {
+            if !seen.insert(&function_name) {
                 continue;
             }
 

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -468,8 +468,7 @@ fn preferred_candidate_name(checker: &Checker<'_>, target_name: &str) -> Option<
 fn presence_tested_candidate_name(checker: &Checker<'_>, target_name: &str) -> Option<String> {
     checker
         .facts()
-        .all_presence_tested_names()
-        .into_iter()
+        .presence_tested_candidate_names()
         .filter(|candidate_name| candidate_name.as_str() != target_name)
         .filter_map(|candidate_name| {
             let first_span = first_presence_test_span(checker, candidate_name)?;
@@ -478,12 +477,16 @@ fn presence_tested_candidate_name(checker: &Checker<'_>, target_name: &str) -> O
                     rank,
                     first_span.start.offset,
                     first_span.end.offset,
-                    candidate_name.to_string(),
+                    candidate_name,
                 )
             })
         })
-        .min_by_key(|(rank, start, end, _)| (*rank, *start, *end))
-        .map(|(_, _, _, name)| name)
+        .min_by(|left, right| {
+            (left.0, left.1, left.2)
+                .cmp(&(right.0, right.1, right.2))
+                .then_with(|| left.3.as_str().cmp(right.3.as_str()))
+        })
+        .map(|(_, _, _, name)| name.to_string())
 }
 
 fn first_presence_test_span(checker: &Checker<'_>, candidate_name: &Name) -> Option<Span> {


### PR DESCRIPTION
## Summary

- avoid per-query heap allocations in assoc-binding visibility traversal with an inline visited set for the common case
- lazily upgrade that visited set to `FxHashSet` for larger caller graphs so traversal does not become quadratic
- expose presence-tested candidate names as an iterator so rule code no longer builds and sorts a temporary Vec
- preserve deterministic candidate selection by tie-breaking on candidate name before allocating the final String

## Allocation sample

From `cargo run -p shuck-benchmark --example linter_memory --release --quiet` on this branch after the review fix:

- `nvm` facts: 31,894 allocations, 13,851,094 bytes, peak 11,894,800 bytes
- `all` facts: 63,346 allocations, 29,726,477 bytes, peak 11,981,422 bytes

Compared with the previous baseline from the allocation pass:

- `nvm` facts: 32,132 -> 31,894 allocations; 13,899,686 -> 13,851,094 bytes
- `all` facts: 64,028 -> 63,346 allocations; 29,820,429 -> 29,726,477 bytes

## Verification

- `cargo fmt --check`
- `cargo test -p shuck-ast`
- `cargo test -p shuck-linter`
- `cargo test -p shuck-benchmark --examples`
- `make test`
- `git diff --check`
- search gate: no old `all_presence_tested_names` helper or obvious rule-side collect/to_vec regressions
