### PR TITLE
perf: speed up large corpus hotspot analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
+.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-large-corpus-hotspots bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
 
 ARGS ?= --help
 BENCH_FILE ?=
@@ -181,6 +181,9 @@ bench-linter:
 
 bench-formatter:
 	cargo bench -p shuck-benchmark --bench formatter
+
+bench-large-corpus-hotspots: ensure-cache
+	cargo bench -p shuck-benchmark --features large-corpus-hotspots --bench large_corpus_hotspots
 
 bench-macro:
 	$(NIX_DEVELOP) ./scripts/benchmarks/setup.sh hyperfine shellcheck

--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["development-tools::profiling"]
 publish = false
 
 [features]
+large-corpus-hotspots = []
 parser-benchmarking = ["shuck-parser/benchmarking"]
 
 [dependencies]
@@ -74,3 +75,4 @@ harness = false
 [[bench]]
 name = "large_corpus_hotspots"
 harness = false
+required-features = ["large-corpus-hotspots"]

--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -349,6 +349,10 @@ fn large_corpus_without_c100_settings() -> LinterSettings {
     settings
 }
 
+fn large_corpus_without_source_closure_settings(fixture: &LargeCorpusFixture) -> LinterSettings {
+    large_corpus_default_settings(fixture).with_resolve_source_closure(false)
+}
+
 fn build_large_corpus_word_facts(input: &PreparedWordFactsInput) -> usize {
     black_box(
         benchmark_collect_word_facts(&input.parse_result.file, &input.source, &input.semantic)
@@ -506,6 +510,55 @@ fn bench_large_corpus_linter_rule_splits(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_large_corpus_linter_source_closure_splits(c: &mut Criterion) {
+    let Ok(fixtures) = large_corpus_fixtures() else {
+        let Err(message) = large_corpus_fixtures() else {
+            unreachable!();
+        };
+        eprintln!("skipping large corpus hotspot benches: {message}");
+        return;
+    };
+
+    let fixture = &fixtures.airgeddon;
+    let mut group = c.benchmark_group("large_corpus_linter_source_closure_splits");
+    group.sample_size(10);
+    group.throughput(Throughput::Bytes(fixture.bytes()));
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter("airgeddon/with_source_closure"),
+        fixture,
+        |b, fixture| {
+            let resolver = fixtures.resolver.clone();
+            let settings = large_corpus_default_settings(fixture);
+            b.iter(|| {
+                lint_large_corpus_fixture_with_settings(
+                    fixture,
+                    Some(resolver.as_ref() as &(dyn SourcePathResolver + Send + Sync)),
+                    settings.clone(),
+                )
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::from_parameter("airgeddon/without_source_closure"),
+        fixture,
+        |b, fixture| {
+            let resolver = fixtures.resolver.clone();
+            let settings = large_corpus_without_source_closure_settings(fixture);
+            b.iter(|| {
+                lint_large_corpus_fixture_with_settings(
+                    fixture,
+                    Some(resolver.as_ref() as &(dyn SourcePathResolver + Send + Sync)),
+                    settings.clone(),
+                )
+            });
+        },
+    );
+
+    group.finish();
+}
+
 fn bench_large_corpus_word_facts(c: &mut Criterion) {
     let Ok(fixtures) = large_corpus_fixtures() else {
         let Err(message) = large_corpus_fixtures() else {
@@ -538,6 +591,7 @@ criterion_group!(
     benches,
     bench_large_corpus_linter,
     bench_large_corpus_linter_rule_splits,
+    bench_large_corpus_linter_source_closure_splits,
     bench_large_corpus_word_facts
 );
 criterion_main!(benches);

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -361,6 +361,11 @@ mod tests {
     }
 
     #[test]
+    fn ignores_single_quoted_literals_split_by_double_quoted_expansions() {
+        assert_eq!(c005("rx=${rx:-'prefix'\"$pkgname\"'suffix'}\n"), 0);
+    }
+
+    #[test]
     fn reports_single_quoted_literals_inside_keyed_array_subscripts() {
         assert_eq!(c005("declare -A map=(['$HOME']=1)\n"), 1);
     }

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -6717,6 +6717,10 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_source_text_as_word(&self, text: &SourceText) -> Word {
+        if let Some(word) = self.simple_source_text_as_word(text) {
+            return word;
+        }
+
         let span = text.span();
         if !text.is_source_backed()
             && span.start.offset <= span.end.offset
@@ -6729,6 +6733,58 @@ impl<'a> Parser<'a> {
         }
 
         Self::parse_word_fragment(self.input, text.slice(self.input), text.span())
+    }
+
+    fn simple_source_text_as_word(&self, text: &SourceText) -> Option<Word> {
+        if !text.is_source_backed() {
+            return None;
+        }
+
+        let span = text.span();
+        let raw = text.slice(self.input);
+        if raw.is_empty() {
+            return Some(Word::literal_with_span("", span));
+        }
+
+        if let Some(word) = self.simple_quoted_source_text_as_word(raw, span) {
+            return Some(word);
+        }
+
+        if Self::word_text_needs_parse(raw)
+            || raw.contains(['\'', '"', '\\'])
+            || self.zsh_glob_qualifiers_enabled_at(span.start.offset)
+        {
+            return None;
+        }
+
+        Some(self.word_with_single_part(self.literal_part_from_text(raw, span, true), span))
+    }
+
+    fn simple_quoted_source_text_as_word(&self, raw: &str, span: Span) -> Option<Word> {
+        if raw.len() < 2 {
+            return None;
+        }
+
+        let quote = raw.as_bytes()[0];
+        if quote != b'\'' && quote != b'"' || raw.as_bytes().last().copied() != Some(quote) {
+            return None;
+        }
+
+        let inner = &raw[1..raw.len() - 1];
+        let inner_start = span.start.advanced_by(&raw[..1]);
+        let inner_end = inner_start.advanced_by(inner);
+        let inner_span = Span::from_positions(inner_start, inner_end);
+        let part = match quote {
+            b'\'' => self.single_quoted_part_from_text(inner, inner_span, span, false),
+            b'"' => {
+                if Self::word_text_needs_parse(inner) || inner.contains(['\\', '"']) {
+                    return None;
+                }
+                self.double_quoted_literal_part_from_text(inner, inner_span, span, true, false)
+            }
+            _ => unreachable!("quote is checked above"),
+        };
+        Some(self.word_with_single_part(part, span))
     }
 
     fn parse_optional_source_text_as_word(&self, text: Option<&SourceText>) -> Option<Word> {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -6771,6 +6771,10 @@ impl<'a> Parser<'a> {
         }
 
         let inner = &raw[1..raw.len() - 1];
+        if quote == b'\'' && inner.contains('\'') {
+            return None;
+        }
+
         let inner_start = span.start.advanced_by(&raw[..1]);
         let inner_end = inner_start.advanced_by(inner);
         let inner_span = Span::from_positions(inner_start, inner_end);

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -4857,6 +4857,17 @@ fn test_parse_parameter_expansion_preserves_quoted_associative_subscripts() {
             .slice(input),
         "\"key\""
     );
+    assert!(matches!(
+        first_subscript
+            .word_ast()
+            .expect("expected subscript word AST")
+            .parts
+            .as_slice(),
+        [WordPartNode {
+            kind: WordPart::DoubleQuoted { .. },
+            ..
+        }]
+    ));
     assert_eq!(command.args[1].render_syntax(input), "${assoc[\"key\"]}");
 
     let second_subscript = expect_subscript_syntax(second, input, "'k'", "k");
@@ -4868,6 +4879,17 @@ fn test_parse_parameter_expansion_preserves_quoted_associative_subscripts() {
             .render_syntax(input),
         "'k'"
     );
+    assert!(matches!(
+        second_subscript
+            .word_ast()
+            .expect("expected subscript word AST")
+            .parts
+            .as_slice(),
+        [WordPartNode {
+            kind: WordPart::SingleQuoted { .. },
+            ..
+        }]
+    ));
     assert_eq!(command.args[2].render_syntax(input), "${assoc['k']}");
 }
 

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -1,3 +1,4 @@
+use std::cell::RefCell;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -47,6 +48,13 @@ struct SourceClosureLookupContext<'a> {
     source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
     analyzed_paths: Option<&'a FxHashSet<PathBuf>>,
     shell_profile: ShellProfile,
+    resolved_helper_paths: RefCell<FxHashMap<HelperPathResolutionKey, Vec<PathBuf>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct HelperPathResolutionKey {
+    source_path: PathBuf,
+    candidate: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -101,6 +109,7 @@ pub(crate) fn collect_source_closure_contracts(
         source_path_resolver,
         analyzed_paths,
         shell_profile: model.shell_profile().clone(),
+        resolved_helper_paths: RefCell::new(FxHashMap::default()),
     };
     let contracts = collect_source_closure_contracts_with_cache(
         model,
@@ -127,11 +136,16 @@ pub(crate) fn collect_source_ref_metadata(
     analyzed_paths: Option<&FxHashSet<PathBuf>>,
 ) -> SourceRefMetadataResult {
     let facts = collect_ast_facts(model);
-    let call_args_by_scope = resolve_literal_call_args_by_scope(model, &facts.calls);
+    let call_args_by_scope = if facts.source_templates_use_positional_args {
+        resolve_literal_call_args_by_scope(model, &facts.calls)
+    } else {
+        FxHashMap::default()
+    };
     let context = SourceClosureLookupContext {
         source_path_resolver,
         analyzed_paths,
         shell_profile: model.shell_profile().clone(),
+        resolved_helper_paths: RefCell::new(FxHashMap::default()),
     };
     let mut source_ref_resolutions = Vec::new();
     let mut source_ref_explicitness = Vec::new();
@@ -172,7 +186,11 @@ fn collect_source_closure_contracts_with_cache(
     context: &SourceClosureLookupContext<'_>,
 ) -> SourceClosureContracts {
     let facts = collect_ast_facts(model);
-    let call_args_by_scope = resolve_literal_call_args_by_scope(model, &facts.calls);
+    let call_args_by_scope = if facts.source_templates_use_positional_args {
+        resolve_literal_call_args_by_scope(model, &facts.calls)
+    } else {
+        FxHashMap::default()
+    };
     let mut synthetic_reads = Vec::new();
     let mut imported_bindings = Vec::new();
     let mut imported_functions = Vec::new();
@@ -288,8 +306,7 @@ fn merge_contracts_for_candidates(
     let mut resolved = false;
     let mut explicit = false;
     for candidate in candidates {
-        let resolved_paths =
-            resolve_helper_paths(source_path, &candidate, context.source_path_resolver);
+        let resolved_paths = resolve_helper_paths_cached(source_path, &candidate, context);
         resolved |= !resolved_paths.is_empty();
         explicit |= resolved_paths
             .iter()
@@ -313,8 +330,7 @@ fn source_ref_metadata_for_candidates(
     let mut resolved = false;
     let mut explicit = false;
     for candidate in candidates {
-        let resolved_paths =
-            resolve_helper_paths(source_path, &candidate, context.source_path_resolver);
+        let resolved_paths = resolve_helper_paths_cached(source_path, &candidate, context);
         resolved |= !resolved_paths.is_empty();
         explicit |= resolved_paths
             .iter()
@@ -588,6 +604,7 @@ fn visible_imported_function_in_scope<'a>(
 #[derive(Debug, Clone)]
 struct AstFacts {
     source_templates: FxHashMap<SpanKey, SourcePathTemplate>,
+    source_templates_use_positional_args: bool,
     calls: Vec<CallInfo>,
 }
 
@@ -615,6 +632,7 @@ pub(crate) enum TemplatePart {
 fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
     let mut facts = AstFacts {
         source_templates: FxHashMap::default(),
+        source_templates_use_positional_args: false,
         calls: Vec::new(),
     };
     let program = model.recorded_program();
@@ -642,12 +660,20 @@ fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
         if matches!(name, "source" | ".")
             && let Some(template) = info.source_path_template.clone()
         {
+            facts.source_templates_use_positional_args |=
+                source_template_uses_positional_args(&template);
             facts
                 .source_templates
                 .insert(SpanKey::new(command.span), template);
         }
     }
     facts
+}
+
+fn source_template_uses_positional_args(template: &SourcePathTemplate) -> bool {
+    match template {
+        SourcePathTemplate::Interpolated(parts) => uses_positional_args(parts),
+    }
 }
 
 pub(crate) fn source_path_template(
@@ -1157,6 +1183,27 @@ fn resolve_helper_paths(
         .collect()
 }
 
+fn resolve_helper_paths_cached(
+    source_path: &Path,
+    candidate: &str,
+    context: &SourceClosureLookupContext<'_>,
+) -> Vec<PathBuf> {
+    let key = HelperPathResolutionKey {
+        source_path: source_path.to_path_buf(),
+        candidate: candidate.to_owned(),
+    };
+    if let Some(paths) = context.resolved_helper_paths.borrow().get(&key) {
+        return paths.clone();
+    }
+
+    let paths = resolve_helper_paths(source_path, candidate, context.source_path_resolver);
+    context
+        .resolved_helper_paths
+        .borrow_mut()
+        .insert(key, paths.clone());
+    paths
+}
+
 fn candidate_path_variants(candidate: &str) -> Vec<PathBuf> {
     #[cfg(not(windows))]
     let variants = vec![PathBuf::from(candidate)];
@@ -1253,6 +1300,7 @@ fn summarize_helper_uncached(
             source_path_resolver,
             analyzed_paths: None,
             shell_profile,
+            resolved_helper_paths: RefCell::new(FxHashMap::default()),
         },
     );
     semantic.apply_source_contracts(
@@ -1465,6 +1513,7 @@ coproc loader { . \"$2\"; }
             source_path_resolver: None,
             analyzed_paths: None,
             shell_profile: ShellProfile::native(ParseShellDialect::Bash),
+            resolved_helper_paths: RefCell::new(FxHashMap::default()),
         };
         let mut summaries = FxHashMap::default();
         let mut active = FxHashSet::default();

--- a/scripts/benchmarks/run_criterion.py
+++ b/scripts/benchmarks/run_criterion.py
@@ -38,6 +38,11 @@ def parse_args() -> argparse.Namespace:
         help="Cargo package that owns the Criterion benches.",
     )
     parser.add_argument(
+        "--features",
+        default="",
+        help="Comma-separated Cargo features to enable for optional benchmark targets.",
+    )
+    parser.add_argument(
         "--noplot",
         action="store_true",
         help="Disable Criterion plot generation.",
@@ -45,7 +50,13 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_bench_names(repo_root: Path) -> list[str]:
+def parse_features(features: str) -> set[str]:
+    return {feature.strip() for feature in features.split(",") if feature.strip()}
+
+
+def load_bench_names(
+    repo_root: Path, package_name: str, enabled_features: set[str]
+) -> list[str]:
     metadata = subprocess.run(
         [
             "cargo",
@@ -65,26 +76,34 @@ def load_bench_names(repo_root: Path) -> list[str]:
     benches: list[str] = []
 
     for package in payload.get("packages", []):
-        if package.get("name") != "shuck-benchmark":
+        if package.get("name") != package_name:
             continue
-        benches = [
-            target["name"]
-            for target in package.get("targets", [])
-            if "bench" in target.get("kind", []) and isinstance(target.get("name"), str)
-        ]
+        for target in package.get("targets", []):
+            if "bench" not in target.get("kind", []):
+                continue
+            name = target.get("name")
+            if not isinstance(name, str):
+                continue
+            required_features = set(target.get("required-features") or [])
+            if required_features and not required_features.issubset(enabled_features):
+                continue
+            benches.append(name)
         break
 
     if not benches:
-        raise SystemExit("no Criterion benches found in cargo metadata for shuck-benchmark")
+        raise SystemExit(f"no Criterion benches found in cargo metadata for {package_name}")
     return benches
 
 
 def main() -> int:
     args = parse_args()
     repo_root = args.repo_root.resolve()
-    bench_names = load_bench_names(repo_root)
+    enabled_features = parse_features(args.features)
+    bench_names = load_bench_names(repo_root, args.package, enabled_features)
 
     command = ["cargo", "bench", "-p", args.package]
+    if enabled_features:
+        command.extend(["--features", ",".join(sorted(enabled_features))])
     for bench_name in bench_names:
         command.extend(["--bench", bench_name])
 
@@ -98,6 +117,8 @@ def main() -> int:
         command.append("--noplot")
 
     print(f"Repository: {repo_root}")
+    if enabled_features:
+        print(f"Features: {', '.join(sorted(enabled_features))}")
     print(f"Benches: {', '.join(bench_names)}")
     print(f"Command: {' '.join(command)}")
     completed = subprocess.run(command, cwd=repo_root)


### PR DESCRIPTION
## Summary
- keep the airgeddon large-corpus hotspot Criterion target optional behind the `large-corpus-hotspots` feature, with a Makefile entry for explicit profiling runs
- cache repeated source-closure helper path resolution and skip function call-argument resolution when sourced templates do not use positional args
- fast-path simple source-backed subscript word AST construction while preserving quoted associative subscript shapes

## Benchmarks
- `cargo bench -p shuck-benchmark --features large-corpus-hotspots --bench large_corpus_hotspots -- --baseline=base --noplot 'large_corpus_linter/(airgeddon|language_strings)'`\n- `large_corpus_linter/airgeddon`: 465.18 ms, about 2.5% faster\n- `large_corpus_linter/language_strings`: 559.35 ms, about 8.4% faster\n- A later source-closure split rerun was discarded because concurrent Rust benchmark workloads were saturating CPU.\n\n## Tests\n- `cargo fmt --check`\n- `git diff --check`\n- `cargo test -p shuck-semantic source_closure -- --nocapture`\n- `cargo test -p shuck-parser subscript -- --nocapture`\n- `cargo test -p shuck-linter visit_var_ref_subscript_words_uses_parser_backed_subscript_words -- --nocapture`