### PR TITLE
perf(semantic): reduce CFG allocation churn

### DIFF
--- a/crates/shuck-benchmark/examples/semantic_memory.rs
+++ b/crates/shuck-benchmark/examples/semantic_memory.rs
@@ -175,16 +175,20 @@ struct CaseReport {
     files: usize,
     recovered_files: usize,
     command_count: usize,
+    semantic_item_count: usize,
+    cfg_block_count: usize,
     metrics: MemoryMetrics,
+    cfg_metrics: MemoryMetrics,
 }
 
-fn build_semantic(source: &str) -> (usize, usize, bool) {
+fn build_semantic(source: &str) -> (SemanticModel, usize, usize, bool) {
     let output = parse_fixture(source);
     let indexer = Indexer::new(source, &output);
     let semantic = SemanticModel::build(&output.file, source, &indexer);
     let semantic_count =
         semantic.bindings().len() + semantic.references().len() + semantic.scopes().len();
     (
+        semantic,
         semantic_count,
         output.file.body.len(),
         output.status != ParseStatus::Clean,
@@ -195,20 +199,42 @@ fn single_case_report(case_name: &str) -> Option<CaseReport> {
     let cases = benchmark_cases();
     let case = cases.into_iter().find(|case| case.name == case_name)?;
 
-    let (frame, (recovered_files, command_count)) = measure(|| {
+    let (frame, (models, recovered_files, command_count, semantic_item_count)) = measure(|| {
         let mut recovered_files = 0usize;
         let mut command_count = 0usize;
         let mut semantic_count = 0usize;
+        let mut models = Vec::with_capacity(case.files.len());
 
         for file in case.files {
-            let (file_semantic_count, file_command_count, recovered) = build_semantic(file.source);
+            let (model, file_semantic_count, file_command_count, recovered) =
+                build_semantic(file.source);
             semantic_count += file_semantic_count;
             command_count += file_command_count;
             recovered_files += usize::from(recovered);
+            models.push(model);
         }
 
         std::hint::black_box(semantic_count);
-        (recovered_files, command_count)
+        (models, recovered_files, command_count, semantic_count)
+    });
+
+    let (cfg_frame, cfg_block_count) = measure(|| {
+        let mut cfg_block_count = 0usize;
+        let mut cfg_edge_count = 0usize;
+
+        for model in &models {
+            let analysis = model.analysis();
+            let cfg = analysis.cfg();
+            cfg_block_count += cfg.blocks().len();
+            cfg_edge_count += cfg
+                .blocks()
+                .iter()
+                .map(|block| cfg.successors(block.id).len())
+                .sum::<usize>();
+        }
+
+        std::hint::black_box(cfg_edge_count);
+        cfg_block_count
     });
 
     Some(CaseReport {
@@ -216,7 +242,10 @@ fn single_case_report(case_name: &str) -> Option<CaseReport> {
         files: case.files.len(),
         recovered_files,
         command_count,
+        semantic_item_count,
+        cfg_block_count,
         metrics: frame.into(),
+        cfg_metrics: cfg_frame.into(),
     })
 }
 

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -49,8 +49,8 @@ pub struct FlowContext {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControlFlowGraph {
     blocks: Vec<BasicBlock>,
-    successors: FxHashMap<BlockId, SmallVec<[(BlockId, EdgeKind); 2]>>,
-    predecessors: FxHashMap<BlockId, SmallVec<[BlockId; 2]>>,
+    successors: Vec<SmallVec<[FlowEdge; 2]>>,
+    predecessors: Vec<SmallVec<[BlockId; 2]>>,
     entry: BlockId,
     exits: Vec<BlockId>,
     natural_exits: Vec<BlockId>,
@@ -63,6 +63,8 @@ pub struct ControlFlowGraph {
     pub(crate) unreachable_causes: FxHashMap<BlockId, UnreachableCause>,
 }
 
+type FlowEdge = (BlockId, EdgeKind);
+
 impl ControlFlowGraph {
     pub fn blocks(&self) -> &[BasicBlock] {
         &self.blocks
@@ -74,14 +76,14 @@ impl ControlFlowGraph {
 
     pub fn successors(&self, id: BlockId) -> &[(BlockId, EdgeKind)] {
         self.successors
-            .get(&id)
+            .get(id.index())
             .map(SmallVec::as_slice)
             .unwrap_or(&[])
     }
 
     pub fn predecessors(&self, id: BlockId) -> &[BlockId] {
         self.predecessors
-            .get(&id)
+            .get(id.index())
             .map(SmallVec::as_slice)
             .unwrap_or(&[])
     }
@@ -1355,7 +1357,7 @@ struct GraphBuilder<'a> {
     command_references: &'a FxHashMap<SpanKey, SmallVec<[ReferenceId; 4]>>,
     script_terminating_calls: FxHashSet<SpanKey>,
     blocks: Vec<BasicBlock>,
-    successors: FxHashMap<BlockId, SmallVec<[(BlockId, EdgeKind); 2]>>,
+    successors: Vec<SmallVec<[FlowEdge; 2]>>,
     command_blocks: FxHashMap<SpanKey, SmallVec<[BlockId; 1]>>,
     unreachable_causes: FxHashMap<BlockId, UnreachableCause>,
     scope_entries: FxHashMap<ScopeId, BlockId>,
@@ -1385,7 +1387,7 @@ pub(crate) fn build_control_flow_graph(
         command_references,
         script_terminating_calls,
         blocks: Vec::with_capacity(command_count),
-        successors: FxHashMap::with_capacity_and_hasher(command_count, Default::default()),
+        successors: Vec::with_capacity(command_count),
         command_blocks: FxHashMap::with_capacity_and_hasher(command_count, Default::default()),
         unreachable_causes: FxHashMap::default(),
         scope_entries: FxHashMap::with_capacity_and_hasher(scope_count, Default::default()),
@@ -1429,9 +1431,9 @@ pub(crate) fn build_control_flow_graph(
         exits.extend(function_exits.iter().copied());
     }
 
-    let predecessors = derive_predecessors(&builder.successors);
     let unreachable =
         compute_unreachable(&builder.blocks, &builder.scope_entries, &builder.successors);
+    let predecessors = derive_predecessors(&builder.successors);
 
     ControlFlowGraph {
         blocks: builder.blocks,
@@ -2186,6 +2188,7 @@ impl<'a> GraphBuilder<'a> {
                 .cloned()
                 .unwrap_or_default(),
         });
+        self.successors.push(SmallVec::new());
         self.command_blocks.entry(key).or_default().push(id);
         id
     }
@@ -2198,11 +2201,12 @@ impl<'a> GraphBuilder<'a> {
             bindings: SmallVec::new(),
             references: SmallVec::new(),
         });
+        self.successors.push(SmallVec::new());
         id
     }
 
     fn add_edge(&mut self, from: BlockId, to: BlockId, kind: EdgeKind) {
-        self.successors.entry(from).or_default().push((to, kind));
+        self.successors[from.index()].push((to, kind));
     }
 }
 
@@ -2210,14 +2214,12 @@ fn resolve_break_target(loops: &[LoopTarget], depth: usize) -> Option<&LoopTarge
     loops.iter().rev().nth(depth.saturating_sub(1))
 }
 
-fn derive_predecessors(
-    successors: &FxHashMap<BlockId, SmallVec<[(BlockId, EdgeKind); 2]>>,
-) -> FxHashMap<BlockId, SmallVec<[BlockId; 2]>> {
-    let mut predecessors: FxHashMap<BlockId, SmallVec<[BlockId; 2]>> =
-        FxHashMap::with_capacity_and_hasher(successors.len(), Default::default());
-    for (block, edges) in successors {
+fn derive_predecessors(successors: &[SmallVec<[FlowEdge; 2]>]) -> Vec<SmallVec<[BlockId; 2]>> {
+    let mut predecessors = vec![SmallVec::<[BlockId; 2]>::new(); successors.len()];
+    for (block_index, edges) in successors.iter().enumerate() {
+        let block = BlockId(block_index as u32);
         for (target, _) in edges {
-            predecessors.entry(*target).or_default().push(*block);
+            predecessors[target.index()].push(block);
         }
     }
     predecessors
@@ -2226,7 +2228,7 @@ fn derive_predecessors(
 fn compute_unreachable(
     blocks: &[BasicBlock],
     roots: &FxHashMap<ScopeId, BlockId>,
-    successors: &FxHashMap<BlockId, SmallVec<[(BlockId, EdgeKind); 2]>>,
+    successors: &[SmallVec<[FlowEdge; 2]>],
 ) -> Vec<BlockId> {
     let mut visited = FxHashSet::with_capacity_and_hasher(blocks.len(), Default::default());
     let mut stack: Vec<BlockId> = roots.values().copied().collect();
@@ -2234,10 +2236,8 @@ fn compute_unreachable(
         if !visited.insert(block) {
             continue;
         }
-        if let Some(edges) = successors.get(&block) {
-            for (target, _) in edges {
-                stack.push(*target);
-            }
+        for (target, _) in &successors[block.index()] {
+            stack.push(*target);
         }
     }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -1370,10 +1370,7 @@ fn build_unreachable_block_set(cfg: &ControlFlowGraph) -> DenseBitSet {
 }
 
 fn command_block_for_span(cfg: &ControlFlowGraph, span: Span) -> Option<BlockId> {
-    cfg.command_blocks
-        .get(&SpanKey::new(span))
-        .and_then(|blocks| blocks.last())
-        .copied()
+    cfg.block_ids_for_span(span).last().copied()
 }
 
 fn compute_reaching_definitions_dense(


### PR DESCRIPTION
## Summary

- Store CFG successors and predecessors in `BlockId`-indexed vectors instead of hash maps.
- Keep the existing CFG accessor API intact for callers.
- Extend the semantic memory harness so it forces and reports lazy CFG allocation metrics separately from semantic model construction.

## Allocation Results

Measured with `crates/shuck-benchmark/examples/semantic_memory` against a clean baseline checkout with the same harness changes applied.

| Case | CFG allocated bytes | CFG peak live bytes | CFG allocations |
|---|---:|---:|---:|
| fzf-install | 123,968 -> 108,504 (-12.47%) | 123,752 -> 105,416 (-14.82%) | 129 -> 129 (+0.00%) |
| homebrew-install | 244,556 -> 209,764 (-14.23%) | 238,340 -> 197,976 (-16.94%) | 120 -> 120 (+0.00%) |
| ruby-build | 459,956 -> 380,852 (-17.20%) | 450,336 -> 359,096 (-20.26%) | 198 -> 198 (+0.00%) |
| pyenv-python-build | 775,832 -> 662,480 (-14.61%) | 752,720 -> 615,968 (-18.17%) | 378 -> 378 (+0.00%) |
| nvm | 1,780,172 -> 1,272,788 (-28.50%) | 1,704,460 -> 1,198,420 (-29.69%) | 953 -> 952 (-0.10%) |
| all | 3,384,484 -> 2,634,388 (-22.16%) | 1,704,460 -> 1,198,420 (-29.69%) | 1,778 -> 1,777 (-0.06%) |

A direct hyperfine run on the `nvm` semantic memory case was flat: `16.9 ms` before vs `16.9 ms` after, so this is mainly an allocation and peak-memory improvement.

## Validation

- `cargo test -p shuck-semantic`
- `cargo fmt --check`
- `git diff --check`
