### PR TITLE
refactor(ast): add arena-backed parse sidecar

### DIFF
--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -1063,7 +1063,9 @@ impl AstStoreBuilder {
             DeclOperand::Assignment(assignment) => {
                 self.collect_assignment(assignment, words, child_sequences)
             }
-            DeclOperand::Name(_) => {}
+            DeclOperand::Name(reference) => {
+                self.collect_var_ref_words(reference, words, child_sequences);
+            }
         }
     }
 
@@ -1234,8 +1236,10 @@ impl AstStoreBuilder {
                 WordPart::Literal(_)
                 | WordPart::SingleQuoted { .. }
                 | WordPart::Variable(_)
-                | WordPart::PrefixMatch { .. }
-                | WordPart::Transformation { .. } => {}
+                | WordPart::PrefixMatch { .. } => {}
+                WordPart::Transformation { reference, .. } => {
+                    self.collect_var_ref_words(reference, words, child_sequences);
+                }
             }
         }
     }
@@ -1303,7 +1307,10 @@ impl AstStoreBuilder {
                     crate::ZshExpansionTarget::Word(word) => {
                         self.collect_word(word, words, child_sequences);
                     }
-                    crate::ZshExpansionTarget::Reference(_) | crate::ZshExpansionTarget::Empty => {}
+                    crate::ZshExpansionTarget::Reference(reference) => {
+                        self.collect_var_ref_words(reference, words, child_sequences);
+                    }
+                    crate::ZshExpansionTarget::Empty => {}
                 }
                 for modifier in &expansion.modifiers {
                     if let Some(word) = &modifier.argument_word_ast {
@@ -1552,11 +1559,12 @@ mod tests {
     use crate::{
         ArenaFile, ArithmeticCommand, ArithmeticExpr, ArithmeticExprNode, ArrayElem, ArrayExpr,
         ArrayKind, ArrayValueWord, Assignment, AssignmentValue, BourneParameterExpansion, Command,
-        CommandSubstitutionSyntax, CompoundCommand, ConditionalCommand, ConditionalExpr, Heredoc,
-        HeredocBody, HeredocBodyMode, HeredocBodyPart, HeredocBodyPartNode, HeredocDelimiter, Name,
-        ParameterExpansion, ParameterExpansionSyntax, Pattern, PatternPart, PatternPartNode,
-        Redirect, RedirectKind, RedirectTarget, SimpleCommand, Span, Stmt, StmtSeq, Subscript,
-        SubscriptInterpretation, SubscriptKind, Word, WordPart, WordPartNode, ZshGlobSegment,
+        CommandSubstitutionSyntax, CompoundCommand, ConditionalCommand, ConditionalExpr,
+        DeclClause, DeclOperand, Heredoc, HeredocBody, HeredocBodyMode, HeredocBodyPart,
+        HeredocBodyPartNode, HeredocDelimiter, Name, ParameterExpansion, ParameterExpansionSyntax,
+        Pattern, PatternPart, PatternPartNode, Redirect, RedirectKind, RedirectTarget,
+        SimpleCommand, Span, Stmt, StmtSeq, Subscript, SubscriptInterpretation, SubscriptKind,
+        Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment, ZshParameterExpansion,
         ZshQualifiedGlob,
     };
 
@@ -1821,27 +1829,14 @@ mod tests {
     fn bourne_parameter_subscript_words_are_command_words() {
         let expansion = ParameterExpansion {
             syntax: ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access {
-                reference: crate::VarRef {
-                    name: Name::new("arr"),
-                    name_span: Span::new(),
-                    subscript: Some(Box::new(dynamic_subscript())),
-                    span: Span::new(),
-                },
+                reference: var_ref_with_dynamic_subscript("arr"),
             }),
             span: Span::new(),
             raw_body: crate::SourceText::cooked(Span::new(), "arr[$(idx)]"),
         };
-        let word = Word {
-            parts: vec![WordPartNode::new(
-                WordPart::Parameter(expansion),
-                Span::new(),
-            )],
-            span: Span::new(),
-            brace_syntax: Vec::new(),
-        };
         let file = file_with_command(Command::Simple(SimpleCommand {
             name: Word::literal("echo"),
-            args: vec![word],
+            args: vec![word(vec![WordPart::Parameter(expansion)])],
             assignments: Box::new([]),
             span: Span::new(),
         }));
@@ -1851,6 +1846,68 @@ mod tests {
 
         assert_eq!(command.child_sequence_ids().len(), 1);
         assert!(command.word_ids().len() >= 3);
+    }
+
+    #[test]
+    fn declaration_name_subscript_words_are_command_words() {
+        let file = file_with_command(Command::Decl(DeclClause {
+            variant: Name::new("declare"),
+            variant_span: Span::new(),
+            operands: vec![DeclOperand::Name(var_ref_with_dynamic_subscript("arr"))],
+            assignments: Box::new([]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        assert!(!command.word_ids().is_empty());
+    }
+
+    #[test]
+    fn zsh_reference_target_subscript_words_are_command_words() {
+        let expansion = ParameterExpansion {
+            syntax: ParameterExpansionSyntax::Zsh(ZshParameterExpansion {
+                target: ZshExpansionTarget::Reference(var_ref_with_dynamic_subscript("arr")),
+                modifiers: Vec::new(),
+                length_prefix: None,
+                operation: None,
+            }),
+            span: Span::new(),
+            raw_body: crate::SourceText::cooked(Span::new(), "arr[$(idx)]"),
+        };
+        let file = file_with_command(Command::Simple(SimpleCommand {
+            name: Word::literal("echo"),
+            args: vec![word(vec![WordPart::Parameter(expansion)])],
+            assignments: Box::new([]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        assert!(command.word_ids().len() >= 2);
+    }
+
+    #[test]
+    fn transformation_subscript_words_are_command_words() {
+        let file = file_with_command(Command::Simple(SimpleCommand {
+            name: Word::literal("echo"),
+            args: vec![word(vec![WordPart::Transformation {
+                reference: var_ref_with_dynamic_subscript("arr"),
+                operator: 'Q',
+            }])],
+            assignments: Box::new([]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        assert!(command.word_ids().len() >= 2);
     }
 
     fn file_with_command(command: Command) -> crate::File {
@@ -1902,16 +1959,29 @@ mod tests {
     }
 
     fn word_with_command_substitution() -> Word {
+        word(vec![WordPart::CommandSubstitution {
+            body: simple_sequence("subcmd"),
+            syntax: CommandSubstitutionSyntax::DollarParen,
+        }])
+    }
+
+    fn word(parts: Vec<WordPart>) -> Word {
         Word {
-            parts: vec![WordPartNode::new(
-                WordPart::CommandSubstitution {
-                    body: simple_sequence("subcmd"),
-                    syntax: CommandSubstitutionSyntax::DollarParen,
-                },
-                Span::new(),
-            )],
+            parts: parts
+                .into_iter()
+                .map(|part| WordPartNode::new(part, Span::new()))
+                .collect(),
             span: Span::new(),
             brace_syntax: Vec::new(),
+        }
+    }
+
+    fn var_ref_with_dynamic_subscript(name: &str) -> crate::VarRef {
+        crate::VarRef {
+            name: Name::new(name),
+            name_span: Span::new(),
+            subscript: Some(Box::new(dynamic_subscript())),
+            span: Span::new(),
         }
     }
 

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -70,16 +70,22 @@ pub struct AstStore {
     stmt_id_lists: ListArena<StmtId>,
     stmt_seq_id_lists: ListArena<StmtSeqId>,
     comment_lists: ListArena<Comment>,
-    redirect_lists: ListArena<Redirect>,
-    assignment_lists: ListArena<Assignment>,
-    decl_operand_lists: ListArena<DeclOperand>,
+    redirect_lists: ListArena<RedirectNode>,
+    assignment_lists: ListArena<AssignmentNode>,
+    array_elem_lists: ListArena<ArrayElemNode>,
+    decl_operand_lists: ListArena<DeclOperandNode>,
+    heredoc_body_part_lists: ListArena<ArenaHeredocBodyPartNode>,
+    zsh_modifier_lists: ListArena<ZshModifierNode>,
     function_header_entry_lists: ListArena<FunctionHeaderEntryNode>,
     elif_branch_lists: ListArena<ElifBranchNode>,
     for_target_lists: ListArena<ForTargetNode>,
     case_item_lists: ListArena<CaseItemNode>,
-    pattern_lists: ListArena<Pattern>,
+    pattern_lists: ListArena<PatternNode>,
+    pattern_part_lists: ListArena<PatternPartArenaNode>,
+    zsh_glob_segment_lists: ListArena<ZshGlobSegmentNode>,
+    zsh_glob_qualifier_lists: ListArena<crate::ZshGlobQualifier>,
     word_id_lists: ListArena<WordId>,
-    word_part_lists: ListArena<WordPartNode>,
+    word_part_lists: ListArena<WordPartArenaNode>,
     brace_syntax_lists: ListArena<crate::BraceSyntax>,
 }
 
@@ -96,12 +102,18 @@ impl Default for AstStore {
             comment_lists: ListArena::new(),
             redirect_lists: ListArena::new(),
             assignment_lists: ListArena::new(),
+            array_elem_lists: ListArena::new(),
             decl_operand_lists: ListArena::new(),
+            heredoc_body_part_lists: ListArena::new(),
+            zsh_modifier_lists: ListArena::new(),
             function_header_entry_lists: ListArena::new(),
             elif_branch_lists: ListArena::new(),
             for_target_lists: ListArena::new(),
             case_item_lists: ListArena::new(),
             pattern_lists: ListArena::new(),
+            pattern_part_lists: ListArena::new(),
+            zsh_glob_segment_lists: ListArena::new(),
+            zsh_glob_qualifier_lists: ListArena::new(),
             word_id_lists: ListArena::new(),
             word_part_lists: ListArena::new(),
             brace_syntax_lists: ListArena::new(),
@@ -193,12 +205,576 @@ impl AstStore {
             redirects: self
                 .redirect_lists
                 .get(node.redirects)
-                .to_vec()
+                .iter()
+                .map(|redirect| self.materialize_redirect(redirect))
+                .collect::<Vec<_>>()
                 .into_boxed_slice(),
             terminator: node.terminator,
             terminator_span: node.terminator_span,
             inline_comment: node.inline_comment,
             span: node.span,
+        }
+    }
+
+    fn materialize_redirect(&self, node: &RedirectNode) -> Redirect {
+        Redirect {
+            fd: node.fd,
+            fd_var: node.fd_var.clone(),
+            fd_var_span: node.fd_var_span,
+            kind: node.kind,
+            span: node.span,
+            target: match &node.target {
+                RedirectTargetNode::Word(word) => {
+                    RedirectTarget::Word(self.materialize_word(*word))
+                }
+                RedirectTargetNode::Heredoc(heredoc) => RedirectTarget::Heredoc(crate::Heredoc {
+                    delimiter: crate::HeredocDelimiter {
+                        raw: self.materialize_word(heredoc.delimiter.raw),
+                        cooked: heredoc.delimiter.cooked.clone(),
+                        span: heredoc.delimiter.span,
+                        quoted: heredoc.delimiter.quoted,
+                        expands_body: heredoc.delimiter.expands_body,
+                        strip_tabs: heredoc.delimiter.strip_tabs,
+                    },
+                    body: crate::HeredocBody {
+                        mode: heredoc.body.mode,
+                        source_backed: heredoc.body.source_backed,
+                        parts: self
+                            .heredoc_body_part_lists
+                            .get(heredoc.body.parts)
+                            .iter()
+                            .map(|part| self.materialize_heredoc_body_part(part))
+                            .collect(),
+                        span: heredoc.body.span,
+                    },
+                }),
+            },
+        }
+    }
+
+    fn materialize_heredoc_body_part(
+        &self,
+        node: &ArenaHeredocBodyPartNode,
+    ) -> crate::HeredocBodyPartNode {
+        crate::HeredocBodyPartNode {
+            kind: match &node.kind {
+                ArenaHeredocBodyPart::Literal(text) => HeredocBodyPart::Literal(text.clone()),
+                ArenaHeredocBodyPart::Variable(name) => HeredocBodyPart::Variable(name.clone()),
+                ArenaHeredocBodyPart::CommandSubstitution { body, syntax } => {
+                    HeredocBodyPart::CommandSubstitution {
+                        body: self.materialize_stmt_seq(*body),
+                        syntax: *syntax,
+                    }
+                }
+                ArenaHeredocBodyPart::ArithmeticExpansion {
+                    expression,
+                    expression_ast,
+                    expression_word_ast,
+                    syntax,
+                } => HeredocBodyPart::ArithmeticExpansion {
+                    expression: expression.clone(),
+                    expression_ast: expression_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
+                    expression_word_ast: self.materialize_word(*expression_word_ast),
+                    syntax: *syntax,
+                },
+                ArenaHeredocBodyPart::Parameter(expansion) => HeredocBodyPart::Parameter(Box::new(
+                    self.materialize_parameter_expansion(expansion),
+                )),
+            },
+            span: node.span,
+        }
+    }
+
+    fn materialize_assignment_list(&self, range: IdRange<AssignmentNode>) -> Vec<Assignment> {
+        self.assignment_lists
+            .get(range)
+            .iter()
+            .map(|assignment| self.materialize_assignment(assignment))
+            .collect()
+    }
+
+    fn materialize_decl_operand(&self, node: &DeclOperandNode) -> DeclOperand {
+        match node {
+            DeclOperandNode::Flag(word) => DeclOperand::Flag(self.materialize_word(*word)),
+            DeclOperandNode::Name(reference) => {
+                DeclOperand::Name(self.materialize_var_ref(reference))
+            }
+            DeclOperandNode::Assignment(assignment) => {
+                DeclOperand::Assignment(self.materialize_assignment(assignment))
+            }
+            DeclOperandNode::Dynamic(word) => DeclOperand::Dynamic(self.materialize_word(*word)),
+        }
+    }
+
+    fn materialize_assignment(&self, node: &AssignmentNode) -> Assignment {
+        Assignment {
+            target: self.materialize_var_ref(&node.target),
+            value: match &node.value {
+                AssignmentValueNode::Scalar(word) => {
+                    AssignmentValue::Scalar(self.materialize_word(*word))
+                }
+                AssignmentValueNode::Compound(array) => {
+                    AssignmentValue::Compound(self.materialize_array_expr(array))
+                }
+            },
+            append: node.append,
+            span: node.span,
+        }
+    }
+
+    fn materialize_var_ref(&self, node: &VarRefNode) -> crate::VarRef {
+        crate::VarRef {
+            name: node.name.clone(),
+            name_span: node.name_span,
+            subscript: node
+                .subscript
+                .as_deref()
+                .map(|subscript| Box::new(self.materialize_subscript(subscript))),
+            span: node.span,
+        }
+    }
+
+    fn materialize_subscript(&self, node: &SubscriptNode) -> Subscript {
+        Subscript {
+            text: node.text.clone(),
+            raw: node.raw.clone(),
+            kind: node.kind,
+            interpretation: node.interpretation,
+            word_ast: node.word_ast.map(|word| self.materialize_word(word)),
+            arithmetic_ast: node
+                .arithmetic_ast
+                .as_ref()
+                .map(|expr| self.materialize_arithmetic_expr(expr)),
+        }
+    }
+
+    fn materialize_array_expr(&self, node: &ArrayExprNode) -> crate::ArrayExpr {
+        crate::ArrayExpr {
+            kind: node.kind,
+            elements: self
+                .array_elem_lists
+                .get(node.elements)
+                .iter()
+                .map(|element| self.materialize_array_elem(element))
+                .collect(),
+            span: node.span,
+        }
+    }
+
+    fn materialize_array_elem(&self, node: &ArrayElemNode) -> crate::ArrayElem {
+        match node {
+            ArrayElemNode::Sequential(value) => {
+                crate::ArrayElem::Sequential(self.materialize_array_value_word(value))
+            }
+            ArrayElemNode::Keyed { key, value } => crate::ArrayElem::Keyed {
+                key: self.materialize_subscript(key),
+                value: self.materialize_array_value_word(value),
+            },
+            ArrayElemNode::KeyedAppend { key, value } => crate::ArrayElem::KeyedAppend {
+                key: self.materialize_subscript(key),
+                value: self.materialize_array_value_word(value),
+            },
+        }
+    }
+
+    fn materialize_array_value_word(&self, node: &ArrayValueWordNode) -> crate::ArrayValueWord {
+        crate::ArrayValueWord::new(
+            self.materialize_word(node.word),
+            node.has_top_level_unquoted_comma,
+        )
+    }
+
+    fn materialize_pattern(&self, node: &PatternNode) -> Pattern {
+        Pattern {
+            parts: self
+                .pattern_part_lists
+                .get(node.parts)
+                .iter()
+                .map(|part| self.materialize_pattern_part(part))
+                .collect(),
+            span: node.span,
+        }
+    }
+
+    fn materialize_pattern_part(&self, node: &PatternPartArenaNode) -> crate::PatternPartNode {
+        crate::PatternPartNode {
+            kind: match &node.kind {
+                PatternPartArena::Literal(text) => PatternPart::Literal(text.clone()),
+                PatternPartArena::AnyString => PatternPart::AnyString,
+                PatternPartArena::AnyChar => PatternPart::AnyChar,
+                PatternPartArena::CharClass(text) => PatternPart::CharClass(text.clone()),
+                PatternPartArena::Group { kind, patterns } => PatternPart::Group {
+                    kind: *kind,
+                    patterns: self
+                        .pattern_lists
+                        .get(*patterns)
+                        .iter()
+                        .map(|pattern| self.materialize_pattern(pattern))
+                        .collect(),
+                },
+                PatternPartArena::Word(word) => PatternPart::Word(self.materialize_word(*word)),
+            },
+            span: node.span,
+        }
+    }
+
+    fn materialize_zsh_qualified_glob(
+        &self,
+        node: &ZshQualifiedGlobNode,
+    ) -> crate::ZshQualifiedGlob {
+        crate::ZshQualifiedGlob {
+            span: node.span,
+            segments: self
+                .zsh_glob_segment_lists
+                .get(node.segments)
+                .iter()
+                .map(|segment| match segment {
+                    ZshGlobSegmentNode::Pattern(pattern) => {
+                        crate::ZshGlobSegment::Pattern(self.materialize_pattern(pattern))
+                    }
+                    ZshGlobSegmentNode::InlineControl(control) => {
+                        crate::ZshGlobSegment::InlineControl(*control)
+                    }
+                })
+                .collect(),
+            qualifiers: node
+                .qualifiers
+                .as_ref()
+                .map(|qualifiers| crate::ZshGlobQualifierGroup {
+                    span: qualifiers.span,
+                    kind: qualifiers.kind,
+                    fragments: self
+                        .zsh_glob_qualifier_lists
+                        .get(qualifiers.fragments)
+                        .to_vec(),
+                }),
+        }
+    }
+
+    fn materialize_parameter_expansion(
+        &self,
+        node: &ParameterExpansionNode,
+    ) -> crate::ParameterExpansion {
+        crate::ParameterExpansion {
+            syntax: match &node.syntax {
+                ParameterExpansionSyntaxNode::Bourne(expansion) => {
+                    crate::ParameterExpansionSyntax::Bourne(
+                        self.materialize_bourne_parameter_expansion(expansion),
+                    )
+                }
+                ParameterExpansionSyntaxNode::Zsh(expansion) => {
+                    crate::ParameterExpansionSyntax::Zsh(
+                        self.materialize_zsh_parameter_expansion(expansion),
+                    )
+                }
+            },
+            span: node.span,
+            raw_body: node.raw_body.clone(),
+        }
+    }
+
+    fn materialize_bourne_parameter_expansion(
+        &self,
+        node: &BourneParameterExpansionNode,
+    ) -> crate::BourneParameterExpansion {
+        match node {
+            BourneParameterExpansionNode::Access { reference } => {
+                crate::BourneParameterExpansion::Access {
+                    reference: self.materialize_var_ref(reference),
+                }
+            }
+            BourneParameterExpansionNode::Length { reference } => {
+                crate::BourneParameterExpansion::Length {
+                    reference: self.materialize_var_ref(reference),
+                }
+            }
+            BourneParameterExpansionNode::Indices { reference } => {
+                crate::BourneParameterExpansion::Indices {
+                    reference: self.materialize_var_ref(reference),
+                }
+            }
+            BourneParameterExpansionNode::Indirect {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                colon_variant,
+            } => crate::BourneParameterExpansion::Indirect {
+                reference: self.materialize_var_ref(reference),
+                operator: operator.clone(),
+                operand: operand.clone(),
+                operand_word_ast: operand_word_ast.map(|word| self.materialize_word(word)),
+                colon_variant: *colon_variant,
+            },
+            BourneParameterExpansionNode::PrefixMatch { prefix, kind } => {
+                crate::BourneParameterExpansion::PrefixMatch {
+                    prefix: prefix.clone(),
+                    kind: *kind,
+                }
+            }
+            BourneParameterExpansionNode::Slice {
+                reference,
+                offset,
+                offset_ast,
+                offset_word_ast,
+                length,
+                length_ast,
+                length_word_ast,
+            } => crate::BourneParameterExpansion::Slice {
+                reference: self.materialize_var_ref(reference),
+                offset: offset.clone(),
+                offset_ast: offset_ast
+                    .as_ref()
+                    .map(|expr| self.materialize_arithmetic_expr(expr)),
+                offset_word_ast: self.materialize_word(*offset_word_ast),
+                length: length.clone(),
+                length_ast: length_ast
+                    .as_ref()
+                    .map(|expr| self.materialize_arithmetic_expr(expr)),
+                length_word_ast: length_word_ast.map(|word| self.materialize_word(word)),
+            },
+            BourneParameterExpansionNode::Operation {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                colon_variant,
+            } => crate::BourneParameterExpansion::Operation {
+                reference: self.materialize_var_ref(reference),
+                operator: operator.clone(),
+                operand: operand.clone(),
+                operand_word_ast: operand_word_ast.map(|word| self.materialize_word(word)),
+                colon_variant: *colon_variant,
+            },
+            BourneParameterExpansionNode::Transformation {
+                reference,
+                operator,
+            } => crate::BourneParameterExpansion::Transformation {
+                reference: self.materialize_var_ref(reference),
+                operator: *operator,
+            },
+        }
+    }
+
+    fn materialize_zsh_parameter_expansion(
+        &self,
+        node: &ZshParameterExpansionNode,
+    ) -> crate::ZshParameterExpansion {
+        crate::ZshParameterExpansion {
+            target: self.materialize_zsh_expansion_target(&node.target),
+            modifiers: self
+                .zsh_modifier_lists
+                .get(node.modifiers)
+                .iter()
+                .map(|modifier| self.materialize_zsh_modifier(modifier))
+                .collect(),
+            length_prefix: node.length_prefix,
+            operation: node
+                .operation
+                .as_ref()
+                .map(|operation| self.materialize_zsh_expansion_operation(operation)),
+        }
+    }
+
+    fn materialize_zsh_expansion_target(
+        &self,
+        node: &ZshExpansionTargetNode,
+    ) -> crate::ZshExpansionTarget {
+        match node {
+            ZshExpansionTargetNode::Reference(reference) => {
+                crate::ZshExpansionTarget::Reference(self.materialize_var_ref(reference))
+            }
+            ZshExpansionTargetNode::Nested(expansion) => crate::ZshExpansionTarget::Nested(
+                Box::new(self.materialize_parameter_expansion(expansion)),
+            ),
+            ZshExpansionTargetNode::Word(word) => {
+                crate::ZshExpansionTarget::Word(self.materialize_word(*word))
+            }
+            ZshExpansionTargetNode::Empty => crate::ZshExpansionTarget::Empty,
+        }
+    }
+
+    fn materialize_zsh_modifier(&self, node: &ZshModifierNode) -> crate::ZshModifier {
+        crate::ZshModifier {
+            name: node.name,
+            argument: node.argument.clone(),
+            argument_word_ast: node
+                .argument_word_ast
+                .map(|word| self.materialize_word(word)),
+            argument_delimiter: node.argument_delimiter,
+            span: node.span,
+        }
+    }
+
+    fn materialize_zsh_expansion_operation(
+        &self,
+        node: &ZshExpansionOperationNode,
+    ) -> crate::ZshExpansionOperation {
+        match node {
+            ZshExpansionOperationNode::PatternOperation {
+                kind,
+                operand,
+                operand_word_ast,
+            } => crate::ZshExpansionOperation::PatternOperation {
+                kind: *kind,
+                operand: operand.clone(),
+                operand_word_ast: self.materialize_word(*operand_word_ast),
+            },
+            ZshExpansionOperationNode::Defaulting {
+                kind,
+                operand,
+                operand_word_ast,
+                colon_variant,
+            } => crate::ZshExpansionOperation::Defaulting {
+                kind: *kind,
+                operand: operand.clone(),
+                operand_word_ast: self.materialize_word(*operand_word_ast),
+                colon_variant: *colon_variant,
+            },
+            ZshExpansionOperationNode::TrimOperation {
+                kind,
+                operand,
+                operand_word_ast,
+            } => crate::ZshExpansionOperation::TrimOperation {
+                kind: *kind,
+                operand: operand.clone(),
+                operand_word_ast: self.materialize_word(*operand_word_ast),
+            },
+            ZshExpansionOperationNode::ReplacementOperation {
+                kind,
+                pattern,
+                pattern_word_ast,
+                replacement,
+                replacement_word_ast,
+            } => crate::ZshExpansionOperation::ReplacementOperation {
+                kind: *kind,
+                pattern: pattern.clone(),
+                pattern_word_ast: self.materialize_word(*pattern_word_ast),
+                replacement: replacement.clone(),
+                replacement_word_ast: replacement_word_ast.map(|word| self.materialize_word(word)),
+            },
+            ZshExpansionOperationNode::Slice {
+                offset,
+                offset_word_ast,
+                length,
+                length_word_ast,
+            } => crate::ZshExpansionOperation::Slice {
+                offset: offset.clone(),
+                offset_word_ast: self.materialize_word(*offset_word_ast),
+                length: length.clone(),
+                length_word_ast: length_word_ast.map(|word| self.materialize_word(word)),
+            },
+            ZshExpansionOperationNode::Unknown { text, word_ast } => {
+                crate::ZshExpansionOperation::Unknown {
+                    text: text.clone(),
+                    word_ast: self.materialize_word(*word_ast),
+                }
+            }
+        }
+    }
+
+    fn materialize_conditional_expr(&self, node: &ConditionalExprArena) -> ConditionalExpr {
+        match node {
+            ConditionalExprArena::Binary {
+                left,
+                op,
+                op_span,
+                right,
+            } => ConditionalExpr::Binary(crate::ConditionalBinaryExpr {
+                left: Box::new(self.materialize_conditional_expr(left)),
+                op: *op,
+                op_span: *op_span,
+                right: Box::new(self.materialize_conditional_expr(right)),
+            }),
+            ConditionalExprArena::Unary { op, op_span, expr } => {
+                ConditionalExpr::Unary(crate::ConditionalUnaryExpr {
+                    op: *op,
+                    op_span: *op_span,
+                    expr: Box::new(self.materialize_conditional_expr(expr)),
+                })
+            }
+            ConditionalExprArena::Parenthesized {
+                left_paren_span,
+                expr,
+                right_paren_span,
+            } => ConditionalExpr::Parenthesized(crate::ConditionalParenExpr {
+                left_paren_span: *left_paren_span,
+                expr: Box::new(self.materialize_conditional_expr(expr)),
+                right_paren_span: *right_paren_span,
+            }),
+            ConditionalExprArena::Word(word) => ConditionalExpr::Word(self.materialize_word(*word)),
+            ConditionalExprArena::Pattern(pattern) => {
+                ConditionalExpr::Pattern(self.materialize_pattern(pattern))
+            }
+            ConditionalExprArena::Regex(word) => {
+                ConditionalExpr::Regex(self.materialize_word(*word))
+            }
+            ConditionalExprArena::VarRef(reference) => {
+                ConditionalExpr::VarRef(Box::new(self.materialize_var_ref(reference)))
+            }
+        }
+    }
+
+    fn materialize_arithmetic_expr(&self, node: &ArithmeticExprArenaNode) -> ArithmeticExprNode {
+        ArithmeticExprNode {
+            kind: match &node.kind {
+                ArithmeticExprArena::Number(text) => ArithmeticExpr::Number(text.clone()),
+                ArithmeticExprArena::Variable(name) => ArithmeticExpr::Variable(name.clone()),
+                ArithmeticExprArena::Indexed { name, index } => ArithmeticExpr::Indexed {
+                    name: name.clone(),
+                    index: Box::new(self.materialize_arithmetic_expr(index)),
+                },
+                ArithmeticExprArena::ShellWord(word) => {
+                    ArithmeticExpr::ShellWord(self.materialize_word(*word))
+                }
+                ArithmeticExprArena::Parenthesized { expression } => {
+                    ArithmeticExpr::Parenthesized {
+                        expression: Box::new(self.materialize_arithmetic_expr(expression)),
+                    }
+                }
+                ArithmeticExprArena::Unary { op, expr } => ArithmeticExpr::Unary {
+                    op: *op,
+                    expr: Box::new(self.materialize_arithmetic_expr(expr)),
+                },
+                ArithmeticExprArena::Postfix { expr, op } => ArithmeticExpr::Postfix {
+                    expr: Box::new(self.materialize_arithmetic_expr(expr)),
+                    op: *op,
+                },
+                ArithmeticExprArena::Binary { left, op, right } => ArithmeticExpr::Binary {
+                    left: Box::new(self.materialize_arithmetic_expr(left)),
+                    op: *op,
+                    right: Box::new(self.materialize_arithmetic_expr(right)),
+                },
+                ArithmeticExprArena::Conditional {
+                    condition,
+                    then_expr,
+                    else_expr,
+                } => ArithmeticExpr::Conditional {
+                    condition: Box::new(self.materialize_arithmetic_expr(condition)),
+                    then_expr: Box::new(self.materialize_arithmetic_expr(then_expr)),
+                    else_expr: Box::new(self.materialize_arithmetic_expr(else_expr)),
+                },
+                ArithmeticExprArena::Assignment { target, op, value } => {
+                    ArithmeticExpr::Assignment {
+                        target: self.materialize_arithmetic_lvalue(target),
+                        op: *op,
+                        value: Box::new(self.materialize_arithmetic_expr(value)),
+                    }
+                }
+            },
+            span: node.span,
+        }
+    }
+
+    fn materialize_arithmetic_lvalue(&self, node: &ArithmeticLvalueArena) -> ArithmeticLvalue {
+        match node {
+            ArithmeticLvalueArena::Variable(name) => ArithmeticLvalue::Variable(name.clone()),
+            ArithmeticLvalueArena::Indexed { name, index } => ArithmeticLvalue::Indexed {
+                name: name.clone(),
+                index: Box::new(self.materialize_arithmetic_expr(index)),
+            },
         }
     }
 
@@ -215,9 +791,7 @@ impl AstStore {
                     .map(|id| self.materialize_word(id))
                     .collect(),
                 assignments: self
-                    .assignment_lists
-                    .get(command.assignments)
-                    .to_vec()
+                    .materialize_assignment_list(command.assignments)
                     .into_boxed_slice(),
                 span: node.span,
             }),
@@ -231,9 +805,7 @@ impl AstStore {
                     .map(|id| self.materialize_word(id))
                     .collect();
                 let assignments = self
-                    .assignment_lists
-                    .get(command.assignments)
-                    .to_vec()
+                    .materialize_assignment_list(command.assignments)
                     .into_boxed_slice();
                 let command = match command.kind {
                     BuiltinCommandNodeKind::Break => BuiltinCommand::Break(crate::BreakCommand {
@@ -270,11 +842,14 @@ impl AstStore {
             CommandNodePayload::Decl(command) => Command::Decl(crate::DeclClause {
                 variant: command.variant.clone(),
                 variant_span: command.variant_span,
-                operands: self.decl_operand_lists.get(command.operands).to_vec(),
+                operands: self
+                    .decl_operand_lists
+                    .get(command.operands)
+                    .iter()
+                    .map(|operand| self.materialize_decl_operand(operand))
+                    .collect(),
                 assignments: self
-                    .assignment_lists
-                    .get(command.assignments)
-                    .to_vec()
+                    .materialize_assignment_list(command.assignments)
                     .into_boxed_slice(),
                 span: node.span,
             }),
@@ -339,7 +914,6 @@ impl AstStore {
             CommandNodePayload::Compound(command) => {
                 Command::Compound(self.materialize_compound_command(command, node.span))
             }
-            CommandNodePayload::Legacy => node.legacy.clone(),
         }
     }
 
@@ -435,13 +1009,22 @@ impl AstStore {
                 CompoundCommand::ArithmeticFor(Box::new(crate::ArithmeticForCommand {
                     left_paren_span: command.left_paren_span,
                     init_span: command.init_span,
-                    init_ast: command.init_ast.clone(),
+                    init_ast: command
+                        .init_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
                     first_semicolon_span: command.first_semicolon_span,
                     condition_span: command.condition_span,
-                    condition_ast: command.condition_ast.clone(),
+                    condition_ast: command
+                        .condition_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
                     second_semicolon_span: command.second_semicolon_span,
                     step_span: command.step_span,
-                    step_ast: command.step_ast.clone(),
+                    step_ast: command
+                        .step_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
                     right_paren_span: command.right_paren_span,
                     body: self.materialize_stmt_seq(command.body),
                     span,
@@ -469,7 +1052,12 @@ impl AstStore {
                         .get(*cases)
                         .iter()
                         .map(|case| crate::CaseItem {
-                            patterns: self.pattern_lists.get(case.patterns).to_vec(),
+                            patterns: self
+                                .pattern_lists
+                                .get(case.patterns)
+                                .iter()
+                                .map(|pattern| self.materialize_pattern(pattern))
+                                .collect(),
                             body: self.materialize_stmt_seq(case.body),
                             terminator: case.terminator,
                             terminator_span: case.terminator_span,
@@ -507,7 +1095,10 @@ impl AstStore {
                     span,
                     left_paren_span: command.left_paren_span,
                     expr_span: command.expr_span,
-                    expr_ast: command.expr_ast.clone(),
+                    expr_ast: command
+                        .expr_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
                     right_paren_span: command.right_paren_span,
                 })
             }
@@ -521,7 +1112,7 @@ impl AstStore {
             }),
             CompoundCommandNode::Conditional(command) => {
                 CompoundCommand::Conditional(crate::ConditionalCommand {
-                    expression: command.expression.clone(),
+                    expression: self.materialize_conditional_expr(&command.expression),
                     span,
                     left_bracket_span: command.left_bracket_span,
                     right_bracket_span: command.right_bracket_span,
@@ -558,9 +1149,159 @@ impl AstStore {
     fn materialize_word(&self, id: WordId) -> Word {
         let node = &self.words[id.index()];
         Word {
-            parts: self.word_part_lists.get(node.parts).to_vec(),
+            parts: self
+                .word_part_lists
+                .get(node.parts)
+                .iter()
+                .map(|part| self.materialize_word_part(part))
+                .collect(),
             span: node.span,
             brace_syntax: self.brace_syntax_lists.get(node.brace_syntax).to_vec(),
+        }
+    }
+
+    fn materialize_word_part(&self, node: &WordPartArenaNode) -> WordPartNode {
+        WordPartNode {
+            kind: match &node.kind {
+                WordPartArena::Literal(text) => WordPart::Literal(text.clone()),
+                WordPartArena::ZshQualifiedGlob(glob) => {
+                    WordPart::ZshQualifiedGlob(self.materialize_zsh_qualified_glob(glob))
+                }
+                WordPartArena::SingleQuoted { value, dollar } => WordPart::SingleQuoted {
+                    value: value.clone(),
+                    dollar: *dollar,
+                },
+                WordPartArena::DoubleQuoted { parts, dollar } => WordPart::DoubleQuoted {
+                    parts: self
+                        .word_part_lists
+                        .get(*parts)
+                        .iter()
+                        .map(|part| self.materialize_word_part(part))
+                        .collect(),
+                    dollar: *dollar,
+                },
+                WordPartArena::Variable(name) => WordPart::Variable(name.clone()),
+                WordPartArena::CommandSubstitution { body, syntax } => {
+                    WordPart::CommandSubstitution {
+                        body: self.materialize_stmt_seq(*body),
+                        syntax: *syntax,
+                    }
+                }
+                WordPartArena::ArithmeticExpansion {
+                    expression,
+                    expression_ast,
+                    expression_word_ast,
+                    syntax,
+                } => WordPart::ArithmeticExpansion {
+                    expression: expression.clone(),
+                    expression_ast: expression_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
+                    expression_word_ast: self.materialize_word(*expression_word_ast),
+                    syntax: *syntax,
+                },
+                WordPartArena::Parameter(expansion) => {
+                    WordPart::Parameter(self.materialize_parameter_expansion(expansion))
+                }
+                WordPartArena::ParameterExpansion {
+                    reference,
+                    operator,
+                    operand,
+                    operand_word_ast,
+                    colon_variant,
+                } => WordPart::ParameterExpansion {
+                    reference: self.materialize_var_ref(reference),
+                    operator: operator.clone(),
+                    operand: operand.clone(),
+                    operand_word_ast: operand_word_ast.map(|word| self.materialize_word(word)),
+                    colon_variant: *colon_variant,
+                },
+                WordPartArena::Length(reference) => {
+                    WordPart::Length(self.materialize_var_ref(reference))
+                }
+                WordPartArena::ArrayAccess(reference) => {
+                    WordPart::ArrayAccess(self.materialize_var_ref(reference))
+                }
+                WordPartArena::ArrayLength(reference) => {
+                    WordPart::ArrayLength(self.materialize_var_ref(reference))
+                }
+                WordPartArena::ArrayIndices(reference) => {
+                    WordPart::ArrayIndices(self.materialize_var_ref(reference))
+                }
+                WordPartArena::Substring {
+                    reference,
+                    offset,
+                    offset_ast,
+                    offset_word_ast,
+                    length,
+                    length_ast,
+                    length_word_ast,
+                } => WordPart::Substring {
+                    reference: self.materialize_var_ref(reference),
+                    offset: offset.clone(),
+                    offset_ast: offset_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
+                    offset_word_ast: self.materialize_word(*offset_word_ast),
+                    length: length.clone(),
+                    length_ast: length_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
+                    length_word_ast: length_word_ast.map(|word| self.materialize_word(word)),
+                },
+                WordPartArena::ArraySlice {
+                    reference,
+                    offset,
+                    offset_ast,
+                    offset_word_ast,
+                    length,
+                    length_ast,
+                    length_word_ast,
+                } => WordPart::ArraySlice {
+                    reference: self.materialize_var_ref(reference),
+                    offset: offset.clone(),
+                    offset_ast: offset_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
+                    offset_word_ast: self.materialize_word(*offset_word_ast),
+                    length: length.clone(),
+                    length_ast: length_ast
+                        .as_ref()
+                        .map(|expr| self.materialize_arithmetic_expr(expr)),
+                    length_word_ast: length_word_ast.map(|word| self.materialize_word(word)),
+                },
+                WordPartArena::IndirectExpansion {
+                    reference,
+                    operator,
+                    operand,
+                    operand_word_ast,
+                    colon_variant,
+                } => WordPart::IndirectExpansion {
+                    reference: self.materialize_var_ref(reference),
+                    operator: operator.clone(),
+                    operand: operand.clone(),
+                    operand_word_ast: operand_word_ast.map(|word| self.materialize_word(word)),
+                    colon_variant: *colon_variant,
+                },
+                WordPartArena::PrefixMatch { prefix, kind } => WordPart::PrefixMatch {
+                    prefix: prefix.clone(),
+                    kind: *kind,
+                },
+                WordPartArena::ProcessSubstitution { body, is_input } => {
+                    WordPart::ProcessSubstitution {
+                        body: self.materialize_stmt_seq(*body),
+                        is_input: *is_input,
+                    }
+                }
+                WordPartArena::Transformation {
+                    reference,
+                    operator,
+                } => WordPart::Transformation {
+                    reference: self.materialize_var_ref(reference),
+                    operator: *operator,
+                },
+            },
+            span: node.span,
         }
     }
 }
@@ -597,7 +1338,7 @@ pub struct StmtNode {
     /// Whether this statement was prefixed with `!`.
     pub negated: bool,
     /// Statement redirections.
-    pub redirects: IdRange<Redirect>,
+    pub redirects: IdRange<RedirectNode>,
     /// Words found under statement-level redirections.
     pub redirect_words: IdRange<WordId>,
     /// Nested statement sequences found under statement-level redirections.
@@ -610,6 +1351,205 @@ pub struct StmtNode {
     pub inline_comment: Option<Comment>,
     /// Source span of the full statement.
     pub span: Span,
+}
+
+/// Arena-native statement redirection.
+#[derive(Debug, Clone)]
+pub struct RedirectNode {
+    /// File descriptor (defaulted by redirect kind downstream).
+    pub fd: Option<i32>,
+    /// Variable name for `{var}` fd-variable redirects.
+    pub fd_var: Option<crate::Name>,
+    /// Source span of `{name}` in fd-variable redirects.
+    pub fd_var_span: Option<Span>,
+    /// Type of redirection.
+    pub kind: crate::RedirectKind,
+    /// Source span of this redirection.
+    pub span: Span,
+    /// Redirect operand payload.
+    pub target: RedirectTargetNode,
+}
+
+/// Arena-native redirect operand.
+#[derive(Debug, Clone)]
+pub enum RedirectTargetNode {
+    /// Standard redirect operand.
+    Word(WordId),
+    /// Heredoc delimiter metadata plus decoded body.
+    Heredoc(HeredocNode),
+}
+
+/// Arena-native heredoc metadata and decoded body.
+#[derive(Debug, Clone)]
+pub struct HeredocNode {
+    /// Parsed heredoc delimiter.
+    pub delimiter: HeredocDelimiterNode,
+    /// Parsed heredoc body.
+    pub body: HeredocBodyNode,
+}
+
+/// Arena-native heredoc delimiter metadata.
+#[derive(Debug, Clone)]
+pub struct HeredocDelimiterNode {
+    /// Raw delimiter word with original quoting preserved.
+    pub raw: WordId,
+    /// Cooked delimiter string after quote removal.
+    pub cooked: String,
+    /// Source span of the delimiter token.
+    pub span: Span,
+    /// Whether the delimiter used shell quoting.
+    pub quoted: bool,
+    /// Whether the body should be decoded for expansions.
+    pub expands_body: bool,
+    /// Whether `<<-` tab stripping applies.
+    pub strip_tabs: bool,
+}
+
+/// Arena-native heredoc body.
+#[derive(Debug, Clone)]
+pub struct HeredocBodyNode {
+    /// Expansion mode for the body.
+    pub mode: crate::HeredocBodyMode,
+    /// Whether body text points back into source.
+    pub source_backed: bool,
+    /// Body parts in source order.
+    pub parts: IdRange<ArenaHeredocBodyPartNode>,
+    /// Source span of the body.
+    pub span: Span,
+}
+
+/// Arena-native heredoc body part paired with its source span.
+#[derive(Debug, Clone)]
+pub struct ArenaHeredocBodyPartNode {
+    /// Body part payload.
+    pub kind: ArenaHeredocBodyPart,
+    /// Source span of the body part.
+    pub span: Span,
+}
+
+/// Arena-native heredoc body part payload.
+#[derive(Debug, Clone)]
+pub enum ArenaHeredocBodyPart {
+    /// Literal heredoc text.
+    Literal(crate::LiteralText),
+    /// Simple variable expansion.
+    Variable(crate::Name),
+    /// Command substitution body.
+    CommandSubstitution {
+        body: StmtSeqId,
+        syntax: crate::CommandSubstitutionSyntax,
+    },
+    /// Arithmetic expansion body.
+    ArithmeticExpansion {
+        expression: crate::SourceText,
+        expression_ast: Option<ArithmeticExprArenaNode>,
+        expression_word_ast: WordId,
+        syntax: crate::ArithmeticExpansionSyntax,
+    },
+    /// Parameter expansion payload.
+    Parameter(Box<ParameterExpansionNode>),
+}
+
+/// Arena-native variable assignment.
+#[derive(Debug, Clone)]
+pub struct AssignmentNode {
+    /// Assignment target.
+    pub target: VarRefNode,
+    /// Assignment value.
+    pub value: AssignmentValueNode,
+    /// Whether this is an append assignment.
+    pub append: bool,
+    /// Source span of this assignment.
+    pub span: Span,
+}
+
+/// Arena-native declaration operand.
+#[derive(Debug, Clone)]
+pub enum DeclOperandNode {
+    /// A literal option word such as `-a` or `+x`.
+    Flag(WordId),
+    /// A bare variable name or indexed reference.
+    Name(VarRefNode),
+    /// A typed assignment operand.
+    Assignment(AssignmentNode),
+    /// A word whose runtime expansion may produce a flag, name, or assignment.
+    Dynamic(WordId),
+}
+
+/// Arena-native assignment value.
+#[derive(Debug, Clone)]
+pub enum AssignmentValueNode {
+    /// Scalar assignment value.
+    Scalar(WordId),
+    /// Compound array assignment value.
+    Compound(ArrayExprNode),
+}
+
+/// Arena-native variable reference.
+#[derive(Debug, Clone)]
+pub struct VarRefNode {
+    /// Variable name.
+    pub name: crate::Name,
+    /// Source span of the variable name.
+    pub name_span: Span,
+    /// Optional array subscript.
+    pub subscript: Option<Box<SubscriptNode>>,
+    /// Source span of the full reference.
+    pub span: Span,
+}
+
+/// Arena-native array subscript.
+#[derive(Debug, Clone)]
+pub struct SubscriptNode {
+    /// Cooked subscript text.
+    pub text: crate::SourceText,
+    /// Original subscript syntax when it differs from the cooked semantic text.
+    pub raw: Option<crate::SourceText>,
+    /// Syntactic subscript shape.
+    pub kind: crate::SubscriptKind,
+    /// Downstream interpretation for the subscript.
+    pub interpretation: crate::SubscriptInterpretation,
+    /// Parsed word view of the original subscript syntax.
+    pub word_ast: Option<WordId>,
+    /// Typed arithmetic view of this subscript when available.
+    pub arithmetic_ast: Option<ArithmeticExprArenaNode>,
+}
+
+/// Arena-native compound array literal.
+#[derive(Debug, Clone)]
+pub struct ArrayExprNode {
+    /// Array flavor implied by parse context.
+    pub kind: crate::ArrayKind,
+    /// Array elements.
+    pub elements: IdRange<ArrayElemNode>,
+    /// Source span of the array expression.
+    pub span: Span,
+}
+
+/// Arena-native array value word plus parser-owned surface metadata.
+#[derive(Debug, Clone)]
+pub struct ArrayValueWordNode {
+    /// Array value word.
+    pub word: WordId,
+    /// Whether the value has a top-level unquoted comma.
+    pub has_top_level_unquoted_comma: bool,
+}
+
+/// Arena-native compound array element.
+#[derive(Debug, Clone)]
+pub enum ArrayElemNode {
+    /// Positional array element.
+    Sequential(ArrayValueWordNode),
+    /// Keyed array element.
+    Keyed {
+        key: SubscriptNode,
+        value: ArrayValueWordNode,
+    },
+    /// Append to an existing key.
+    KeyedAppend {
+        key: SubscriptNode,
+        value: ArrayValueWordNode,
+    },
 }
 
 /// Command arena node.
@@ -625,7 +1565,6 @@ pub struct CommandNode {
     pub child_sequences: IdRange<StmtSeqId>,
     /// Native arena payload for command families that have been migrated.
     pub payload: CommandNodePayload,
-    legacy: Command,
 }
 
 /// Arena-native command payloads.
@@ -645,8 +1584,6 @@ pub enum CommandNodePayload {
     AnonymousFunction(AnonymousFunctionCommandNode),
     /// Compound shell command payload.
     Compound(CompoundCommandNode),
-    /// Compatibility payload for command families that still materialize from `legacy`.
-    Legacy,
 }
 
 /// Arena-native simple command payload.
@@ -657,7 +1594,7 @@ pub struct SimpleCommandNode {
     /// Command argument words.
     pub args: IdRange<WordId>,
     /// Prefix assignments.
-    pub assignments: IdRange<Assignment>,
+    pub assignments: IdRange<AssignmentNode>,
 }
 
 /// Arena-native typed builtin command payload.
@@ -670,7 +1607,7 @@ pub struct BuiltinCommandNode {
     /// Additional operands preserved for fidelity.
     pub extra_args: IdRange<WordId>,
     /// Prefix assignments.
-    pub assignments: IdRange<Assignment>,
+    pub assignments: IdRange<AssignmentNode>,
 }
 
 /// Arena-native typed builtin command kind.
@@ -694,9 +1631,9 @@ pub struct DeclCommandNode {
     /// Source span of the declaration builtin name.
     pub variant_span: Span,
     /// Parsed declaration operands.
-    pub operands: IdRange<DeclOperand>,
+    pub operands: IdRange<DeclOperandNode>,
     /// Prefix assignments.
-    pub assignments: IdRange<Assignment>,
+    pub assignments: IdRange<AssignmentNode>,
 }
 
 /// Arena-native binary command payload.
@@ -852,7 +1789,7 @@ pub struct ForTargetNode {
 #[derive(Debug, Clone)]
 pub struct CaseItemNode {
     /// Case patterns.
-    pub patterns: IdRange<Pattern>,
+    pub patterns: IdRange<PatternNode>,
     /// Case body sequence.
     pub body: StmtSeqId,
     /// Case terminator.
@@ -861,12 +1798,50 @@ pub struct CaseItemNode {
     pub terminator_span: Option<Span>,
 }
 
+/// Arena-native shell pattern.
+#[derive(Debug, Clone)]
+pub struct PatternNode {
+    /// Pattern parts in source order.
+    pub parts: IdRange<PatternPartArenaNode>,
+    /// Source span of the full pattern.
+    pub span: Span,
+}
+
+/// Arena-native pattern part paired with its source span.
+#[derive(Debug, Clone)]
+pub struct PatternPartArenaNode {
+    /// Pattern part payload.
+    pub kind: PatternPartArena,
+    /// Source span of this pattern part.
+    pub span: Span,
+}
+
+/// Arena-native pattern part payload.
+#[derive(Debug, Clone)]
+pub enum PatternPartArena {
+    /// Literal pattern text.
+    Literal(crate::LiteralText),
+    /// `*`.
+    AnyString,
+    /// `?`.
+    AnyChar,
+    /// Bracket character class source text.
+    CharClass(crate::SourceText),
+    /// Extended glob group.
+    Group {
+        kind: crate::PatternGroupKind,
+        patterns: IdRange<PatternNode>,
+    },
+    /// Word-backed pattern fragment.
+    Word(WordId),
+}
+
 /// Arena-native arithmetic command.
 #[derive(Debug, Clone)]
 pub struct ArithmeticCommandNode {
     pub left_paren_span: Span,
     pub expr_span: Option<Span>,
-    pub expr_ast: Option<ArithmeticExprNode>,
+    pub expr_ast: Option<ArithmeticExprArenaNode>,
     pub right_paren_span: Span,
 }
 
@@ -875,13 +1850,13 @@ pub struct ArithmeticCommandNode {
 pub struct ArithmeticForCommandNode {
     pub left_paren_span: Span,
     pub init_span: Option<Span>,
-    pub init_ast: Option<ArithmeticExprNode>,
+    pub init_ast: Option<ArithmeticExprArenaNode>,
     pub first_semicolon_span: Span,
     pub condition_span: Option<Span>,
-    pub condition_ast: Option<ArithmeticExprNode>,
+    pub condition_ast: Option<ArithmeticExprArenaNode>,
     pub second_semicolon_span: Span,
     pub step_span: Option<Span>,
-    pub step_ast: Option<ArithmeticExprNode>,
+    pub step_ast: Option<ArithmeticExprArenaNode>,
     pub right_paren_span: Span,
     pub body: StmtSeqId,
 }
@@ -889,9 +1864,91 @@ pub struct ArithmeticForCommandNode {
 /// Arena-native conditional command.
 #[derive(Debug, Clone)]
 pub struct ConditionalCommandNode {
-    pub expression: ConditionalExpr,
+    pub expression: ConditionalExprArena,
     pub left_bracket_span: Span,
     pub right_bracket_span: Span,
+}
+
+/// Arena-native conditional expression.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum ConditionalExprArena {
+    Binary {
+        left: Box<ConditionalExprArena>,
+        op: crate::ConditionalBinaryOp,
+        op_span: Span,
+        right: Box<ConditionalExprArena>,
+    },
+    Unary {
+        op: crate::ConditionalUnaryOp,
+        op_span: Span,
+        expr: Box<ConditionalExprArena>,
+    },
+    Parenthesized {
+        left_paren_span: Span,
+        expr: Box<ConditionalExprArena>,
+        right_paren_span: Span,
+    },
+    Word(WordId),
+    Pattern(PatternNode),
+    Regex(WordId),
+    VarRef(VarRefNode),
+}
+
+/// Arena-native arithmetic expression plus its source span.
+#[derive(Debug, Clone)]
+pub struct ArithmeticExprArenaNode {
+    pub kind: ArithmeticExprArena,
+    pub span: Span,
+}
+
+/// Arena-native arithmetic expression.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum ArithmeticExprArena {
+    Number(crate::SourceText),
+    Variable(crate::Name),
+    Indexed {
+        name: crate::Name,
+        index: Box<ArithmeticExprArenaNode>,
+    },
+    ShellWord(WordId),
+    Parenthesized {
+        expression: Box<ArithmeticExprArenaNode>,
+    },
+    Unary {
+        op: crate::ArithmeticUnaryOp,
+        expr: Box<ArithmeticExprArenaNode>,
+    },
+    Postfix {
+        expr: Box<ArithmeticExprArenaNode>,
+        op: crate::ArithmeticPostfixOp,
+    },
+    Binary {
+        left: Box<ArithmeticExprArenaNode>,
+        op: crate::ArithmeticBinaryOp,
+        right: Box<ArithmeticExprArenaNode>,
+    },
+    Conditional {
+        condition: Box<ArithmeticExprArenaNode>,
+        then_expr: Box<ArithmeticExprArenaNode>,
+        else_expr: Box<ArithmeticExprArenaNode>,
+    },
+    Assignment {
+        target: ArithmeticLvalueArena,
+        op: crate::ArithmeticAssignOp,
+        value: Box<ArithmeticExprArenaNode>,
+    },
+}
+
+/// Arena-native arithmetic assignment target.
+#[derive(Debug, Clone)]
+pub enum ArithmeticLvalueArena {
+    Variable(crate::Name),
+    Indexed {
+        name: crate::Name,
+        index: Box<ArithmeticExprArenaNode>,
+    },
 }
 
 /// Coarse command family stored with command arena nodes.
@@ -917,11 +1974,267 @@ pub enum ArenaFileCommandKind {
 #[derive(Debug, Clone)]
 pub struct WordNode {
     /// Word parts in source order.
-    pub parts: IdRange<WordPartNode>,
+    pub parts: IdRange<WordPartArenaNode>,
     /// Source span of this word.
     pub span: Span,
     /// Brace-syntax facts attached by the parser.
     pub brace_syntax: IdRange<crate::BraceSyntax>,
+}
+
+/// Arena-native word part paired with its source span.
+#[derive(Debug, Clone)]
+pub struct WordPartArenaNode {
+    /// Word part payload.
+    pub kind: WordPartArena,
+    /// Source span of this word part.
+    pub span: Span,
+}
+
+/// Arena-native word part payload.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum WordPartArena {
+    /// Literal text.
+    Literal(crate::LiteralText),
+    /// Zsh glob with one classic trailing qualifier group.
+    ZshQualifiedGlob(ZshQualifiedGlobNode),
+    /// Single-quoted literal content.
+    SingleQuoted {
+        value: crate::SourceText,
+        dollar: bool,
+    },
+    /// Double-quoted content with nested parts.
+    DoubleQuoted {
+        parts: IdRange<WordPartArenaNode>,
+        dollar: bool,
+    },
+    /// Variable expansion.
+    Variable(crate::Name),
+    /// Command substitution.
+    CommandSubstitution {
+        body: StmtSeqId,
+        syntax: crate::CommandSubstitutionSyntax,
+    },
+    /// Arithmetic expansion.
+    ArithmeticExpansion {
+        expression: crate::SourceText,
+        expression_ast: Option<ArithmeticExprArenaNode>,
+        expression_word_ast: WordId,
+        syntax: crate::ArithmeticExpansionSyntax,
+    },
+    /// Unified parameter-expansion family for `${...}` forms.
+    Parameter(ParameterExpansionNode),
+    /// Parameter expansion with operator.
+    ParameterExpansion {
+        reference: VarRefNode,
+        operator: crate::ParameterOp,
+        operand: Option<crate::SourceText>,
+        operand_word_ast: Option<WordId>,
+        colon_variant: bool,
+    },
+    /// Length expansion.
+    Length(VarRefNode),
+    /// Array element access.
+    ArrayAccess(VarRefNode),
+    /// Array length.
+    ArrayLength(VarRefNode),
+    /// Array indices.
+    ArrayIndices(VarRefNode),
+    /// Substring extraction.
+    Substring {
+        reference: VarRefNode,
+        offset: crate::SourceText,
+        offset_ast: Option<ArithmeticExprArenaNode>,
+        offset_word_ast: WordId,
+        length: Option<crate::SourceText>,
+        length_ast: Option<ArithmeticExprArenaNode>,
+        length_word_ast: Option<WordId>,
+    },
+    /// Array slice.
+    ArraySlice {
+        reference: VarRefNode,
+        offset: crate::SourceText,
+        offset_ast: Option<ArithmeticExprArenaNode>,
+        offset_word_ast: WordId,
+        length: Option<crate::SourceText>,
+        length_ast: Option<ArithmeticExprArenaNode>,
+        length_word_ast: Option<WordId>,
+    },
+    /// Indirect expansion.
+    IndirectExpansion {
+        reference: VarRefNode,
+        operator: Option<crate::ParameterOp>,
+        operand: Option<crate::SourceText>,
+        operand_word_ast: Option<WordId>,
+        colon_variant: bool,
+    },
+    /// Prefix matching.
+    PrefixMatch {
+        prefix: crate::Name,
+        kind: crate::PrefixMatchKind,
+    },
+    /// Process substitution.
+    ProcessSubstitution { body: StmtSeqId, is_input: bool },
+    /// Parameter transformation.
+    Transformation {
+        reference: VarRefNode,
+        operator: char,
+    },
+}
+
+/// Arena-native zsh qualified glob.
+#[derive(Debug, Clone)]
+pub struct ZshQualifiedGlobNode {
+    pub span: Span,
+    pub segments: IdRange<ZshGlobSegmentNode>,
+    pub qualifiers: Option<ZshGlobQualifierGroupNode>,
+}
+
+/// Arena-native zsh glob segment.
+#[derive(Debug, Clone)]
+pub enum ZshGlobSegmentNode {
+    Pattern(PatternNode),
+    InlineControl(crate::ZshInlineGlobControl),
+}
+
+/// Arena-native zsh glob qualifier group.
+#[derive(Debug, Clone)]
+pub struct ZshGlobQualifierGroupNode {
+    pub span: Span,
+    pub kind: crate::ZshGlobQualifierKind,
+    pub fragments: IdRange<crate::ZshGlobQualifier>,
+}
+
+/// Arena-native parameter expansion.
+#[derive(Debug, Clone)]
+pub struct ParameterExpansionNode {
+    /// Expansion syntax family.
+    pub syntax: ParameterExpansionSyntaxNode,
+    /// Source span of the expansion.
+    pub span: Span,
+    /// Raw body text.
+    pub raw_body: crate::SourceText,
+}
+
+/// Arena-native parameter expansion syntax.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum ParameterExpansionSyntaxNode {
+    Bourne(BourneParameterExpansionNode),
+    Zsh(ZshParameterExpansionNode),
+}
+
+/// Arena-native Bourne-style parameter expansion.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum BourneParameterExpansionNode {
+    Access {
+        reference: VarRefNode,
+    },
+    Length {
+        reference: VarRefNode,
+    },
+    Indices {
+        reference: VarRefNode,
+    },
+    Indirect {
+        reference: VarRefNode,
+        operator: Option<crate::ParameterOp>,
+        operand: Option<crate::SourceText>,
+        operand_word_ast: Option<WordId>,
+        colon_variant: bool,
+    },
+    PrefixMatch {
+        prefix: crate::Name,
+        kind: crate::PrefixMatchKind,
+    },
+    Slice {
+        reference: VarRefNode,
+        offset: crate::SourceText,
+        offset_ast: Option<ArithmeticExprArenaNode>,
+        offset_word_ast: WordId,
+        length: Option<crate::SourceText>,
+        length_ast: Option<ArithmeticExprArenaNode>,
+        length_word_ast: Option<WordId>,
+    },
+    Operation {
+        reference: VarRefNode,
+        operator: crate::ParameterOp,
+        operand: Option<crate::SourceText>,
+        operand_word_ast: Option<WordId>,
+        colon_variant: bool,
+    },
+    Transformation {
+        reference: VarRefNode,
+        operator: char,
+    },
+}
+
+/// Arena-native zsh parameter expansion.
+#[derive(Debug, Clone)]
+pub struct ZshParameterExpansionNode {
+    pub target: ZshExpansionTargetNode,
+    pub modifiers: IdRange<ZshModifierNode>,
+    pub length_prefix: Option<Span>,
+    pub operation: Option<ZshExpansionOperationNode>,
+}
+
+/// Arena-native zsh expansion target.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum ZshExpansionTargetNode {
+    Reference(VarRefNode),
+    Nested(Box<ParameterExpansionNode>),
+    Word(WordId),
+    Empty,
+}
+
+/// Arena-native zsh modifier.
+#[derive(Debug, Clone)]
+pub struct ZshModifierNode {
+    pub name: char,
+    pub argument: Option<crate::SourceText>,
+    pub argument_word_ast: Option<WordId>,
+    pub argument_delimiter: Option<char>,
+    pub span: Span,
+}
+
+/// Arena-native zsh parameter operation.
+#[derive(Debug, Clone)]
+pub enum ZshExpansionOperationNode {
+    PatternOperation {
+        kind: crate::ZshPatternOp,
+        operand: crate::SourceText,
+        operand_word_ast: WordId,
+    },
+    Defaulting {
+        kind: crate::ZshDefaultingOp,
+        operand: crate::SourceText,
+        operand_word_ast: WordId,
+        colon_variant: bool,
+    },
+    TrimOperation {
+        kind: crate::ZshTrimOp,
+        operand: crate::SourceText,
+        operand_word_ast: WordId,
+    },
+    ReplacementOperation {
+        kind: crate::ZshReplacementOp,
+        pattern: crate::SourceText,
+        pattern_word_ast: WordId,
+        replacement: Option<crate::SourceText>,
+        replacement_word_ast: Option<WordId>,
+    },
+    Slice {
+        offset: crate::SourceText,
+        offset_word_ast: WordId,
+        length: Option<crate::SourceText>,
+        length_word_ast: Option<WordId>,
+    },
+    Unknown {
+        text: crate::SourceText,
+        word_ast: WordId,
+    },
 }
 
 /// Borrowed view of a file node.
@@ -1018,7 +2331,7 @@ impl<'a> StmtView<'a> {
     }
 
     /// Returns this statement's redirections.
-    pub fn redirects(self) -> &'a [Redirect] {
+    pub fn redirects(self) -> &'a [RedirectNode] {
         self.store.redirect_lists.get(self.node().redirects)
     }
 
@@ -1107,8 +2420,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => None,
+            | CommandNodePayload::Compound(_) => None,
         }
     }
 
@@ -1124,8 +2436,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => None,
+            | CommandNodePayload::Compound(_) => None,
         }
     }
 
@@ -1141,8 +2452,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => None,
+            | CommandNodePayload::Compound(_) => None,
         }
     }
 
@@ -1158,8 +2468,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => None,
+            | CommandNodePayload::Compound(_) => None,
         }
     }
 
@@ -1175,8 +2484,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => None,
+            | CommandNodePayload::Compound(_) => None,
         }
     }
 
@@ -1192,8 +2500,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => None,
+            | CommandNodePayload::Compound(_) => None,
         }
     }
 
@@ -1209,8 +2516,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
-            | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Legacy => None,
+            | CommandNodePayload::AnonymousFunction(_) => None,
         }
     }
 
@@ -1219,11 +2525,6 @@ impl<'a> CommandView<'a> {
         self.store
             .stmt_seq_id_lists
             .get(self.node().child_sequences)
-    }
-
-    /// Returns the legacy recursive command payload.
-    pub fn legacy(self) -> &'a Command {
-        &self.node().legacy
     }
 
     fn node(self) -> &'a CommandNode {
@@ -1263,7 +2564,7 @@ impl<'a> SimpleCommandView<'a> {
     }
 
     /// Returns prefix assignments.
-    pub fn assignments(self) -> &'a [Assignment] {
+    pub fn assignments(self) -> &'a [AssignmentNode] {
         self.store.assignment_lists.get(self.node().assignments)
     }
 
@@ -1275,8 +2576,7 @@ impl<'a> SimpleCommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => {
+            | CommandNodePayload::Compound(_) => {
                 unreachable!("simple view requires simple payload")
             }
         }
@@ -1320,7 +2620,7 @@ impl<'a> BuiltinCommandView<'a> {
     }
 
     /// Returns prefix assignments.
-    pub fn assignments(self) -> &'a [Assignment] {
+    pub fn assignments(self) -> &'a [AssignmentNode] {
         self.store.assignment_lists.get(self.node().assignments)
     }
 
@@ -1332,8 +2632,7 @@ impl<'a> BuiltinCommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => {
+            | CommandNodePayload::Compound(_) => {
                 unreachable!("builtin view requires builtin payload")
             }
         }
@@ -1359,12 +2658,12 @@ impl<'a> DeclCommandView<'a> {
     }
 
     /// Returns parsed declaration operands.
-    pub fn operands(self) -> &'a [DeclOperand] {
+    pub fn operands(self) -> &'a [DeclOperandNode] {
         self.store.decl_operand_lists.get(self.node().operands)
     }
 
     /// Returns prefix assignments.
-    pub fn assignments(self) -> &'a [Assignment] {
+    pub fn assignments(self) -> &'a [AssignmentNode] {
         self.store.assignment_lists.get(self.node().assignments)
     }
 
@@ -1376,8 +2675,7 @@ impl<'a> DeclCommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => unreachable!("decl view requires decl payload"),
+            | CommandNodePayload::Compound(_) => unreachable!("decl view requires decl payload"),
         }
     }
 }
@@ -1428,8 +2726,9 @@ impl<'a> BinaryCommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => unreachable!("binary view requires binary payload"),
+            | CommandNodePayload::Compound(_) => {
+                unreachable!("binary view requires binary payload")
+            }
         }
     }
 }
@@ -1477,8 +2776,9 @@ impl<'a> FunctionCommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => unreachable!("function view requires function payload"),
+            | CommandNodePayload::Compound(_) => {
+                unreachable!("function view requires function payload")
+            }
         }
     }
 }
@@ -1527,8 +2827,7 @@ impl<'a> AnonymousFunctionCommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
-            | CommandNodePayload::Compound(_)
-            | CommandNodePayload::Legacy => {
+            | CommandNodePayload::Compound(_) => {
                 unreachable!("anonymous function view requires anonymous function payload")
             }
         }
@@ -1552,8 +2851,9 @@ impl<'a> CompoundCommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
-            | CommandNodePayload::AnonymousFunction(_)
-            | CommandNodePayload::Legacy => unreachable!("compound view requires compound payload"),
+            | CommandNodePayload::AnonymousFunction(_) => {
+                unreachable!("compound view requires compound payload")
+            }
         }
     }
 }
@@ -1572,7 +2872,7 @@ impl<'a> WordView<'a> {
     }
 
     /// Returns this word's parts.
-    pub fn parts(self) -> &'a [WordPartNode] {
+    pub fn parts(self) -> &'a [WordPartArenaNode] {
         self.store.word_part_lists.get(self.node().parts)
     }
 
@@ -1676,24 +2976,8 @@ impl AstStoreBuilder {
             .comment_lists
             .push_many(stmt.leading_comments.iter().copied());
         let command = self.lower_command(&stmt.command);
-        let mut redirect_words = Vec::new();
-        let mut redirect_child_sequences = Vec::new();
-        for redirect in stmt.redirects.iter() {
-            self.collect_redirect_children(
-                redirect,
-                &mut redirect_words,
-                &mut redirect_child_sequences,
-            );
-        }
-        let redirect_words = self.store.word_id_lists.push_many(redirect_words);
-        let redirect_child_sequences = self
-            .store
-            .stmt_seq_id_lists
-            .push_many(redirect_child_sequences);
-        let redirects = self
-            .store
-            .redirect_lists
-            .push_many(stmt.redirects.iter().cloned());
+        let (redirects, redirect_words, redirect_child_sequences) =
+            self.lower_redirects(stmt.redirects.iter());
 
         let id = Idx::new(self.store.stmts.len());
         self.store.stmts.push(StmtNode {
@@ -1714,24 +2998,8 @@ impl AstStoreBuilder {
     fn lower_stmt_owned(&mut self, stmt: Stmt) -> StmtId {
         let leading_comments = self.store.comment_lists.push_many(stmt.leading_comments);
         let command = self.lower_command_owned(stmt.command);
-        let mut redirect_words = Vec::new();
-        let mut redirect_child_sequences = Vec::new();
-        for redirect in stmt.redirects.iter() {
-            self.collect_redirect_children(
-                redirect,
-                &mut redirect_words,
-                &mut redirect_child_sequences,
-            );
-        }
-        let redirect_words = self.store.word_id_lists.push_many(redirect_words);
-        let redirect_child_sequences = self
-            .store
-            .stmt_seq_id_lists
-            .push_many(redirect_child_sequences);
-        let redirects = self
-            .store
-            .redirect_lists
-            .push_many(stmt.redirects.into_vec());
+        let (redirects, redirect_words, redirect_child_sequences) =
+            self.lower_redirects(stmt.redirects.iter());
 
         let id = Idx::new(self.store.stmts.len());
         self.store.stmts.push(StmtNode {
@@ -1763,7 +3031,6 @@ impl AstStoreBuilder {
             words,
             child_sequences,
             payload,
-            legacy: command.clone(),
         });
         id
     }
@@ -1782,16 +3049,17 @@ impl AstStoreBuilder {
             words,
             child_sequences,
             payload,
-            legacy: command,
         });
         id
     }
 
-    fn lower_word(&mut self, word: &Word) -> WordId {
-        let parts = self
-            .store
-            .word_part_lists
-            .push_many(word.parts.iter().cloned());
+    fn lower_word(
+        &mut self,
+        word: &Word,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> WordId {
+        let parts = self.lower_word_parts(word.parts.as_slice(), words, child_sequences);
         let brace_syntax = self
             .store
             .brace_syntax_lists
@@ -1805,24 +3073,13 @@ impl AstStoreBuilder {
         id
     }
 
-    fn collect_word(
-        &mut self,
-        word: &Word,
-        words: &mut Vec<WordId>,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        self.collect_word_part_children(word.parts.as_slice(), words, child_sequences);
-        words.push(self.lower_word(word));
-    }
-
     fn collect_word_id(
         &mut self,
         word: &Word,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) -> WordId {
-        self.collect_word_part_children(word.parts.as_slice(), words, child_sequences);
-        let id = self.lower_word(word);
+        let id = self.lower_word(word, words, child_sequences);
         words.push(id);
         id
     }
@@ -1842,11 +3099,8 @@ impl AstStoreBuilder {
                     .map(|word| self.collect_word_id(word, words, child_sequences))
                     .collect::<Vec<_>>();
                 let args = self.store.word_id_lists.push_many(args);
-                self.collect_assignments(command.assignments.iter(), words, child_sequences);
-                let assignments = self
-                    .store
-                    .assignment_lists
-                    .push_many(command.assignments.iter().cloned());
+                let assignments =
+                    self.lower_assignments(command.assignments.iter(), words, child_sequences);
                 CommandNodePayload::Simple(SimpleCommandNode {
                     name,
                     args,
@@ -1857,18 +3111,14 @@ impl AstStoreBuilder {
                 self.collect_builtin_children(command, words, child_sequences)
             }
             Command::Decl(command) => {
-                for operand in &command.operands {
-                    self.collect_decl_operand(operand, words, child_sequences);
-                }
-                self.collect_assignments(command.assignments.iter(), words, child_sequences);
-                let operands = self
-                    .store
-                    .decl_operand_lists
-                    .push_many(command.operands.iter().cloned());
-                let assignments = self
-                    .store
-                    .assignment_lists
-                    .push_many(command.assignments.iter().cloned());
+                let operands = command
+                    .operands
+                    .iter()
+                    .map(|operand| self.lower_decl_operand(operand, words, child_sequences))
+                    .collect::<Vec<_>>();
+                let operands = self.store.decl_operand_lists.push_many(operands);
+                let assignments =
+                    self.lower_assignments(command.assignments.iter(), words, child_sequences);
                 CommandNodePayload::Decl(DeclCommandNode {
                     variant: command.variant.clone(),
                     variant_span: command.variant_span,
@@ -1948,8 +3198,7 @@ impl AstStoreBuilder {
             .map(|word| self.collect_word_id(word, words, child_sequences))
             .collect::<Vec<_>>();
         let extra_args = self.store.word_id_lists.push_many(extra_args);
-        self.collect_assignments(assignments.clone(), words, child_sequences);
-        let assignments = self.store.assignment_lists.push_many(assignments.cloned());
+        let assignments = self.lower_assignments(assignments, words, child_sequences);
         CommandNodePayload::Builtin(BuiltinCommandNode {
             kind,
             primary,
@@ -2179,21 +3428,30 @@ impl AstStoreBuilder {
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) -> CompoundCommandNode {
-        self.collect_arithmetic_expr_option(command.init_ast.as_ref(), words, child_sequences);
-        self.collect_arithmetic_expr_option(command.condition_ast.as_ref(), words, child_sequences);
-        self.collect_arithmetic_expr_option(command.step_ast.as_ref(), words, child_sequences);
         let body = self.lower_stmt_seq(&command.body);
         child_sequences.push(body);
         CompoundCommandNode::ArithmeticFor(Box::new(ArithmeticForCommandNode {
             left_paren_span: command.left_paren_span,
             init_span: command.init_span,
-            init_ast: command.init_ast.clone(),
+            init_ast: self.lower_arithmetic_expr_option(
+                command.init_ast.as_ref(),
+                words,
+                child_sequences,
+            ),
             first_semicolon_span: command.first_semicolon_span,
             condition_span: command.condition_span,
-            condition_ast: command.condition_ast.clone(),
+            condition_ast: self.lower_arithmetic_expr_option(
+                command.condition_ast.as_ref(),
+                words,
+                child_sequences,
+            ),
             second_semicolon_span: command.second_semicolon_span,
             step_span: command.step_span,
-            step_ast: command.step_ast.clone(),
+            step_ast: self.lower_arithmetic_expr_option(
+                command.step_ast.as_ref(),
+                words,
+                child_sequences,
+            ),
             right_paren_span: command.right_paren_span,
             body,
         }))
@@ -2210,13 +3468,12 @@ impl AstStoreBuilder {
             .cases
             .iter()
             .map(|case| {
-                for pattern in &case.patterns {
-                    self.collect_pattern_words(pattern, words, child_sequences);
-                }
-                let patterns = self
-                    .store
-                    .pattern_lists
-                    .push_many(case.patterns.iter().cloned());
+                let patterns = case
+                    .patterns
+                    .iter()
+                    .map(|pattern| self.lower_pattern(pattern, words, child_sequences))
+                    .collect::<Vec<_>>();
+                let patterns = self.store.pattern_lists.push_many(patterns);
                 let body = self.lower_stmt_seq(&case.body);
                 child_sequences.push(body);
                 CaseItemNode {
@@ -2259,11 +3516,14 @@ impl AstStoreBuilder {
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) -> CompoundCommandNode {
-        self.collect_arithmetic_expr_option(command.expr_ast.as_ref(), words, child_sequences);
         CompoundCommandNode::Arithmetic(ArithmeticCommandNode {
             left_paren_span: command.left_paren_span,
             expr_span: command.expr_span,
-            expr_ast: command.expr_ast.clone(),
+            expr_ast: self.lower_arithmetic_expr_option(
+                command.expr_ast.as_ref(),
+                words,
+                child_sequences,
+            ),
             right_paren_span: command.right_paren_span,
         })
     }
@@ -2274,9 +3534,8 @@ impl AstStoreBuilder {
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) -> CompoundCommandNode {
-        self.collect_conditional_expr(&command.expression, words, child_sequences);
         CompoundCommandNode::Conditional(ConditionalCommandNode {
-            expression: command.expression.clone(),
+            expression: self.lower_conditional_expr(&command.expression, words, child_sequences),
             left_bracket_span: command.left_bracket_span,
             right_bracket_span: command.right_bracket_span,
         })
@@ -2339,464 +3598,930 @@ impl AstStoreBuilder {
         }
     }
 
-    fn collect_decl_operand(
+    fn lower_decl_operand(
         &mut self,
         operand: &DeclOperand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
+    ) -> DeclOperandNode {
         match operand {
-            DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
-                self.collect_word(word, words, child_sequences);
-            }
-            DeclOperand::Assignment(assignment) => {
-                self.collect_assignment(assignment, words, child_sequences)
+            DeclOperand::Flag(word) => {
+                DeclOperandNode::Flag(self.collect_word_id(word, words, child_sequences))
             }
             DeclOperand::Name(reference) => {
-                self.collect_var_ref_words(reference, words, child_sequences);
+                DeclOperandNode::Name(self.lower_var_ref(reference, words, child_sequences))
+            }
+            DeclOperand::Assignment(assignment) => DeclOperandNode::Assignment(
+                self.lower_assignment(assignment, words, child_sequences),
+            ),
+            DeclOperand::Dynamic(word) => {
+                DeclOperandNode::Dynamic(self.collect_word_id(word, words, child_sequences))
             }
         }
     }
 
-    fn collect_assignments<'a>(
+    fn lower_assignments<'a>(
         &mut self,
         assignments: impl Iterator<Item = &'a Assignment>,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        for assignment in assignments {
-            self.collect_assignment(assignment, words, child_sequences);
-        }
+    ) -> IdRange<AssignmentNode> {
+        let assignments = assignments
+            .map(|assignment| self.lower_assignment(assignment, words, child_sequences))
+            .collect::<Vec<_>>();
+        self.store.assignment_lists.push_many(assignments)
     }
 
-    fn collect_assignment(
+    fn lower_assignment(
         &mut self,
         assignment: &Assignment,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        self.collect_var_ref_words(&assignment.target, words, child_sequences);
-        match &assignment.value {
-            AssignmentValue::Scalar(word) => self.collect_word(word, words, child_sequences),
-            AssignmentValue::Compound(array) => {
-                for element in &array.elements {
-                    match element {
-                        crate::ArrayElem::Sequential(value) => {
-                            self.collect_word(&value.word, words, child_sequences);
-                        }
-                        crate::ArrayElem::Keyed { key, value }
-                        | crate::ArrayElem::KeyedAppend { key, value } => {
-                            self.collect_subscript_words(key, words, child_sequences);
-                            self.collect_word(&value.word, words, child_sequences);
-                        }
-                    }
+    ) -> AssignmentNode {
+        AssignmentNode {
+            target: self.lower_var_ref(&assignment.target, words, child_sequences),
+            value: match &assignment.value {
+                AssignmentValue::Scalar(word) => {
+                    AssignmentValueNode::Scalar(self.collect_word_id(word, words, child_sequences))
                 }
-            }
-        }
-    }
-
-    fn collect_redirect_children(
-        &mut self,
-        redirect: &Redirect,
-        words: &mut Vec<WordId>,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        match &redirect.target {
-            RedirectTarget::Word(word) => {
-                self.collect_word(word, words, child_sequences);
-            }
-            RedirectTarget::Heredoc(heredoc) => {
-                self.collect_word(&heredoc.delimiter.raw, words, child_sequences);
-                for part in &heredoc.body.parts {
-                    match &part.kind {
-                        HeredocBodyPart::CommandSubstitution { body, .. } => {
-                            child_sequences.push(self.lower_stmt_seq(body));
-                        }
-                        HeredocBodyPart::ArithmeticExpansion {
-                            expression_word_ast,
-                            ..
-                        } => {
-                            self.collect_word(expression_word_ast, words, child_sequences);
-                        }
-                        HeredocBodyPart::Parameter(expansion) => {
-                            self.collect_parameter_expansion_words(
-                                expansion,
-                                words,
-                                child_sequences,
-                            );
-                        }
-                        HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
-                    }
-                }
-            }
-        }
-    }
-
-    fn collect_word_part_children(
-        &mut self,
-        parts: &[WordPartNode],
-        words: &mut Vec<WordId>,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        for part in parts {
-            match &part.kind {
-                WordPart::DoubleQuoted { parts, .. } => {
-                    self.collect_word_part_children(parts, words, child_sequences)
-                }
-                WordPart::CommandSubstitution { body, .. }
-                | WordPart::ProcessSubstitution { body, .. } => {
-                    child_sequences.push(self.lower_stmt_seq(body));
-                }
-                WordPart::ArithmeticExpansion {
-                    expression_ast,
-                    expression_word_ast,
-                    ..
-                } => {
-                    self.collect_arithmetic_expr_option(
-                        expression_ast.as_ref(),
-                        words,
-                        child_sequences,
-                    );
-                    self.collect_word(expression_word_ast, words, child_sequences);
-                }
-                WordPart::Parameter(expansion) => {
-                    self.collect_parameter_expansion_words(expansion, words, child_sequences);
-                }
-                WordPart::ParameterExpansion {
-                    reference,
-                    operand_word_ast,
-                    ..
-                }
-                | WordPart::IndirectExpansion {
-                    reference,
-                    operand_word_ast,
-                    ..
-                } => {
-                    self.collect_var_ref_words(reference, words, child_sequences);
-                    if let Some(word) = operand_word_ast {
-                        self.collect_word(word, words, child_sequences);
-                    }
-                }
-                WordPart::Length(reference)
-                | WordPart::ArrayAccess(reference)
-                | WordPart::ArrayLength(reference)
-                | WordPart::ArrayIndices(reference) => {
-                    self.collect_var_ref_words(reference, words, child_sequences);
-                }
-                WordPart::Substring {
-                    reference,
-                    offset_ast,
-                    offset_word_ast,
-                    length_ast,
-                    length_word_ast,
-                    ..
-                }
-                | WordPart::ArraySlice {
-                    reference,
-                    offset_ast,
-                    offset_word_ast,
-                    length_ast,
-                    length_word_ast,
-                    ..
-                } => {
-                    self.collect_var_ref_words(reference, words, child_sequences);
-                    self.collect_arithmetic_expr_option(
-                        offset_ast.as_ref(),
-                        words,
-                        child_sequences,
-                    );
-                    self.collect_word(offset_word_ast, words, child_sequences);
-                    self.collect_arithmetic_expr_option(
-                        length_ast.as_ref(),
-                        words,
-                        child_sequences,
-                    );
-                    if let Some(word) = length_word_ast {
-                        self.collect_word(word, words, child_sequences);
-                    }
-                }
-                WordPart::ZshQualifiedGlob(glob) => {
-                    for segment in &glob.segments {
-                        if let crate::ZshGlobSegment::Pattern(pattern) = segment {
-                            self.collect_pattern_words(pattern, words, child_sequences);
-                        }
-                    }
-                }
-                WordPart::Literal(_)
-                | WordPart::SingleQuoted { .. }
-                | WordPart::Variable(_)
-                | WordPart::PrefixMatch { .. } => {}
-                WordPart::Transformation { reference, .. } => {
-                    self.collect_var_ref_words(reference, words, child_sequences);
-                }
-            }
-        }
-    }
-
-    fn collect_parameter_expansion_words(
-        &mut self,
-        expansion: &crate::ParameterExpansion,
-        words: &mut Vec<WordId>,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        match &expansion.syntax {
-            crate::ParameterExpansionSyntax::Bourne(expansion) => match expansion {
-                crate::BourneParameterExpansion::Access { reference }
-                | crate::BourneParameterExpansion::Length { reference }
-                | crate::BourneParameterExpansion::Indices { reference }
-                | crate::BourneParameterExpansion::Transformation { reference, .. } => {
-                    self.collect_var_ref_words(reference, words, child_sequences);
-                }
-                crate::BourneParameterExpansion::Indirect {
-                    reference,
-                    operand_word_ast,
-                    ..
-                }
-                | crate::BourneParameterExpansion::Operation {
-                    reference,
-                    operand_word_ast,
-                    ..
-                } => {
-                    self.collect_var_ref_words(reference, words, child_sequences);
-                    if let Some(word) = operand_word_ast {
-                        self.collect_word(word, words, child_sequences);
-                    }
-                }
-                crate::BourneParameterExpansion::Slice {
-                    reference,
-                    offset_ast,
-                    offset_word_ast,
-                    length_ast,
-                    length_word_ast,
-                    ..
-                } => {
-                    self.collect_var_ref_words(reference, words, child_sequences);
-                    self.collect_arithmetic_expr_option(
-                        offset_ast.as_ref(),
-                        words,
-                        child_sequences,
-                    );
-                    self.collect_word(offset_word_ast, words, child_sequences);
-                    self.collect_arithmetic_expr_option(
-                        length_ast.as_ref(),
-                        words,
-                        child_sequences,
-                    );
-                    if let Some(word) = length_word_ast {
-                        self.collect_word(word, words, child_sequences);
-                    }
-                }
-                crate::BourneParameterExpansion::PrefixMatch { .. } => {}
+                AssignmentValue::Compound(array) => AssignmentValueNode::Compound(
+                    self.lower_array_expr(array, words, child_sequences),
+                ),
             },
-            crate::ParameterExpansionSyntax::Zsh(expansion) => {
-                match &expansion.target {
-                    crate::ZshExpansionTarget::Nested(nested) => {
-                        self.collect_parameter_expansion_words(nested, words, child_sequences);
-                    }
-                    crate::ZshExpansionTarget::Word(word) => {
-                        self.collect_word(word, words, child_sequences);
-                    }
-                    crate::ZshExpansionTarget::Reference(reference) => {
-                        self.collect_var_ref_words(reference, words, child_sequences);
-                    }
-                    crate::ZshExpansionTarget::Empty => {}
-                }
-                for modifier in &expansion.modifiers {
-                    if let Some(word) = &modifier.argument_word_ast {
-                        self.collect_word(word, words, child_sequences);
-                    }
-                }
-                if let Some(operation) = &expansion.operation {
-                    self.collect_zsh_operation_words(operation, words, child_sequences);
-                }
-            }
+            append: assignment.append,
+            span: assignment.span,
         }
     }
 
-    fn collect_zsh_operation_words(
+    fn lower_var_ref(
         &mut self,
-        operation: &crate::ZshExpansionOperation,
+        reference: &crate::VarRef,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        match operation {
-            crate::ZshExpansionOperation::PatternOperation {
-                operand_word_ast, ..
-            }
-            | crate::ZshExpansionOperation::Defaulting {
-                operand_word_ast, ..
-            }
-            | crate::ZshExpansionOperation::TrimOperation {
-                operand_word_ast, ..
-            } => {
-                self.collect_word(operand_word_ast, words, child_sequences);
-            }
-            crate::ZshExpansionOperation::ReplacementOperation {
-                pattern_word_ast,
-                replacement_word_ast,
-                ..
-            } => {
-                self.collect_word(pattern_word_ast, words, child_sequences);
-                if let Some(word) = replacement_word_ast {
-                    self.collect_word(word, words, child_sequences);
-                }
-            }
-            crate::ZshExpansionOperation::Slice {
-                offset_word_ast,
-                length_word_ast,
-                ..
-            } => {
-                self.collect_word(offset_word_ast, words, child_sequences);
-                if let Some(word) = length_word_ast {
-                    self.collect_word(word, words, child_sequences);
-                }
-            }
-            crate::ZshExpansionOperation::Unknown { word_ast, .. } => {
-                self.collect_word(word_ast, words, child_sequences);
-            }
+    ) -> VarRefNode {
+        VarRefNode {
+            name: reference.name.clone(),
+            name_span: reference.name_span,
+            subscript: reference
+                .subscript
+                .as_deref()
+                .map(|subscript| Box::new(self.lower_subscript(subscript, words, child_sequences))),
+            span: reference.span,
         }
     }
 
-    fn collect_pattern_words(
-        &mut self,
-        pattern: &Pattern,
-        words: &mut Vec<WordId>,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        for part in &pattern.parts {
-            match &part.kind {
-                PatternPart::Group { patterns, .. } => {
-                    for pattern in patterns {
-                        self.collect_pattern_words(pattern, words, child_sequences);
-                    }
-                }
-                PatternPart::Word(word) => self.collect_word(word, words, child_sequences),
-                PatternPart::Literal(_)
-                | PatternPart::AnyString
-                | PatternPart::AnyChar
-                | PatternPart::CharClass(_) => {}
-            }
-        }
-    }
-
-    fn collect_conditional_expr(
-        &mut self,
-        expression: &ConditionalExpr,
-        words: &mut Vec<WordId>,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        match expression {
-            ConditionalExpr::Binary(expr) => {
-                self.collect_conditional_expr(&expr.left, words, child_sequences);
-                self.collect_conditional_expr(&expr.right, words, child_sequences);
-            }
-            ConditionalExpr::Unary(expr) => {
-                self.collect_conditional_expr(&expr.expr, words, child_sequences);
-            }
-            ConditionalExpr::Parenthesized(expr) => {
-                self.collect_conditional_expr(&expr.expr, words, child_sequences);
-            }
-            ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
-                self.collect_word(word, words, child_sequences);
-            }
-            ConditionalExpr::Pattern(pattern) => {
-                self.collect_pattern_words(pattern, words, child_sequences);
-            }
-            ConditionalExpr::VarRef(var_ref) => {
-                self.collect_var_ref_words(var_ref, words, child_sequences);
-            }
-        }
-    }
-
-    fn collect_arithmetic_expr_option(
-        &mut self,
-        expression: Option<&ArithmeticExprNode>,
-        words: &mut Vec<WordId>,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        if let Some(expression) = expression {
-            self.collect_arithmetic_expr(expression, words, child_sequences);
-        }
-    }
-
-    fn collect_arithmetic_expr(
-        &mut self,
-        expression: &ArithmeticExprNode,
-        words: &mut Vec<WordId>,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        match &expression.kind {
-            ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
-            ArithmeticExpr::Indexed { index, .. } => {
-                self.collect_arithmetic_expr(index, words, child_sequences);
-            }
-            ArithmeticExpr::ShellWord(word) => {
-                self.collect_word(word, words, child_sequences);
-            }
-            ArithmeticExpr::Parenthesized { expression } => {
-                self.collect_arithmetic_expr(expression, words, child_sequences);
-            }
-            ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
-                self.collect_arithmetic_expr(expr, words, child_sequences);
-            }
-            ArithmeticExpr::Binary { left, right, .. } => {
-                self.collect_arithmetic_expr(left, words, child_sequences);
-                self.collect_arithmetic_expr(right, words, child_sequences);
-            }
-            ArithmeticExpr::Conditional {
-                condition,
-                then_expr,
-                else_expr,
-            } => {
-                self.collect_arithmetic_expr(condition, words, child_sequences);
-                self.collect_arithmetic_expr(then_expr, words, child_sequences);
-                self.collect_arithmetic_expr(else_expr, words, child_sequences);
-            }
-            ArithmeticExpr::Assignment { target, value, .. } => {
-                self.collect_arithmetic_lvalue(target, words, child_sequences);
-                self.collect_arithmetic_expr(value, words, child_sequences);
-            }
-        }
-    }
-
-    fn collect_arithmetic_lvalue(
-        &mut self,
-        lvalue: &ArithmeticLvalue,
-        words: &mut Vec<WordId>,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        match lvalue {
-            ArithmeticLvalue::Variable(_) => {}
-            ArithmeticLvalue::Indexed { index, .. } => {
-                self.collect_arithmetic_expr(index, words, child_sequences);
-            }
-        }
-    }
-
-    fn collect_subscript_words(
+    fn lower_subscript(
         &mut self,
         subscript: &Subscript,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        if let Some(word) = subscript.word_ast() {
-            self.collect_word(word, words, child_sequences);
+    ) -> SubscriptNode {
+        SubscriptNode {
+            text: subscript.text.clone(),
+            raw: subscript.raw.clone(),
+            kind: subscript.kind,
+            interpretation: subscript.interpretation,
+            word_ast: subscript
+                .word_ast
+                .as_ref()
+                .map(|word| self.collect_word_id(word, words, child_sequences)),
+            arithmetic_ast: self.lower_arithmetic_expr_option(
+                subscript.arithmetic_ast.as_ref(),
+                words,
+                child_sequences,
+            ),
         }
-        self.collect_arithmetic_expr_option(
-            subscript.arithmetic_ast.as_ref(),
-            words,
-            child_sequences,
-        );
     }
 
-    fn collect_var_ref_words(
+    fn lower_array_expr(
         &mut self,
-        var_ref: &crate::VarRef,
+        array: &crate::ArrayExpr,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        if let Some(subscript) = var_ref.subscript.as_deref() {
-            self.collect_subscript_words(subscript, words, child_sequences);
+    ) -> ArrayExprNode {
+        let elements = array
+            .elements
+            .iter()
+            .map(|element| self.lower_array_elem(element, words, child_sequences))
+            .collect::<Vec<_>>();
+        let elements = self.store.array_elem_lists.push_many(elements);
+        ArrayExprNode {
+            kind: array.kind,
+            elements,
+            span: array.span,
+        }
+    }
+
+    fn lower_array_elem(
+        &mut self,
+        element: &crate::ArrayElem,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ArrayElemNode {
+        match element {
+            crate::ArrayElem::Sequential(value) => ArrayElemNode::Sequential(
+                self.lower_array_value_word(value, words, child_sequences),
+            ),
+            crate::ArrayElem::Keyed { key, value } => ArrayElemNode::Keyed {
+                key: self.lower_subscript(key, words, child_sequences),
+                value: self.lower_array_value_word(value, words, child_sequences),
+            },
+            crate::ArrayElem::KeyedAppend { key, value } => ArrayElemNode::KeyedAppend {
+                key: self.lower_subscript(key, words, child_sequences),
+                value: self.lower_array_value_word(value, words, child_sequences),
+            },
+        }
+    }
+
+    fn lower_array_value_word(
+        &mut self,
+        value: &crate::ArrayValueWord,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ArrayValueWordNode {
+        ArrayValueWordNode {
+            word: self.collect_word_id(&value.word, words, child_sequences),
+            has_top_level_unquoted_comma: value.has_top_level_unquoted_comma,
+        }
+    }
+
+    fn lower_word_parts(
+        &mut self,
+        parts: &[WordPartNode],
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> IdRange<WordPartArenaNode> {
+        let parts = parts
+            .iter()
+            .map(|part| self.lower_word_part(part, words, child_sequences))
+            .collect::<Vec<_>>();
+        self.store.word_part_lists.push_many(parts)
+    }
+
+    fn lower_word_part(
+        &mut self,
+        part: &WordPartNode,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> WordPartArenaNode {
+        let kind = match &part.kind {
+            WordPart::Literal(text) => WordPartArena::Literal(text.clone()),
+            WordPart::ZshQualifiedGlob(glob) => WordPartArena::ZshQualifiedGlob(
+                self.lower_zsh_qualified_glob(glob, words, child_sequences),
+            ),
+            WordPart::SingleQuoted { value, dollar } => WordPartArena::SingleQuoted {
+                value: value.clone(),
+                dollar: *dollar,
+            },
+            WordPart::DoubleQuoted { parts, dollar } => WordPartArena::DoubleQuoted {
+                parts: self.lower_word_parts(parts, words, child_sequences),
+                dollar: *dollar,
+            },
+            WordPart::Variable(name) => WordPartArena::Variable(name.clone()),
+            WordPart::CommandSubstitution { body, syntax } => {
+                let body = self.lower_stmt_seq(body);
+                child_sequences.push(body);
+                WordPartArena::CommandSubstitution {
+                    body,
+                    syntax: *syntax,
+                }
+            }
+            WordPart::ArithmeticExpansion {
+                expression,
+                expression_ast,
+                expression_word_ast,
+                syntax,
+            } => WordPartArena::ArithmeticExpansion {
+                expression: expression.clone(),
+                expression_ast: self.lower_arithmetic_expr_option(
+                    expression_ast.as_ref(),
+                    words,
+                    child_sequences,
+                ),
+                expression_word_ast: self.collect_word_id(
+                    expression_word_ast,
+                    words,
+                    child_sequences,
+                ),
+                syntax: *syntax,
+            },
+            WordPart::Parameter(expansion) => WordPartArena::Parameter(
+                self.lower_parameter_expansion(expansion, words, child_sequences),
+            ),
+            WordPart::ParameterExpansion {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                colon_variant,
+            } => WordPartArena::ParameterExpansion {
+                reference: self.lower_var_ref(reference, words, child_sequences),
+                operator: operator.clone(),
+                operand: operand.clone(),
+                operand_word_ast: operand_word_ast
+                    .as_ref()
+                    .map(|word| self.collect_word_id(word, words, child_sequences)),
+                colon_variant: *colon_variant,
+            },
+            WordPart::Length(reference) => {
+                WordPartArena::Length(self.lower_var_ref(reference, words, child_sequences))
+            }
+            WordPart::ArrayAccess(reference) => {
+                WordPartArena::ArrayAccess(self.lower_var_ref(reference, words, child_sequences))
+            }
+            WordPart::ArrayLength(reference) => {
+                WordPartArena::ArrayLength(self.lower_var_ref(reference, words, child_sequences))
+            }
+            WordPart::ArrayIndices(reference) => {
+                WordPartArena::ArrayIndices(self.lower_var_ref(reference, words, child_sequences))
+            }
+            WordPart::Substring {
+                reference,
+                offset,
+                offset_ast,
+                offset_word_ast,
+                length,
+                length_ast,
+                length_word_ast,
+            } => WordPartArena::Substring {
+                reference: self.lower_var_ref(reference, words, child_sequences),
+                offset: offset.clone(),
+                offset_ast: self.lower_arithmetic_expr_option(
+                    offset_ast.as_ref(),
+                    words,
+                    child_sequences,
+                ),
+                offset_word_ast: self.collect_word_id(offset_word_ast, words, child_sequences),
+                length: length.clone(),
+                length_ast: self.lower_arithmetic_expr_option(
+                    length_ast.as_ref(),
+                    words,
+                    child_sequences,
+                ),
+                length_word_ast: length_word_ast
+                    .as_ref()
+                    .map(|word| self.collect_word_id(word, words, child_sequences)),
+            },
+            WordPart::ArraySlice {
+                reference,
+                offset,
+                offset_ast,
+                offset_word_ast,
+                length,
+                length_ast,
+                length_word_ast,
+            } => WordPartArena::ArraySlice {
+                reference: self.lower_var_ref(reference, words, child_sequences),
+                offset: offset.clone(),
+                offset_ast: self.lower_arithmetic_expr_option(
+                    offset_ast.as_ref(),
+                    words,
+                    child_sequences,
+                ),
+                offset_word_ast: self.collect_word_id(offset_word_ast, words, child_sequences),
+                length: length.clone(),
+                length_ast: self.lower_arithmetic_expr_option(
+                    length_ast.as_ref(),
+                    words,
+                    child_sequences,
+                ),
+                length_word_ast: length_word_ast
+                    .as_ref()
+                    .map(|word| self.collect_word_id(word, words, child_sequences)),
+            },
+            WordPart::IndirectExpansion {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                colon_variant,
+            } => WordPartArena::IndirectExpansion {
+                reference: self.lower_var_ref(reference, words, child_sequences),
+                operator: operator.clone(),
+                operand: operand.clone(),
+                operand_word_ast: operand_word_ast
+                    .as_ref()
+                    .map(|word| self.collect_word_id(word, words, child_sequences)),
+                colon_variant: *colon_variant,
+            },
+            WordPart::PrefixMatch { prefix, kind } => WordPartArena::PrefixMatch {
+                prefix: prefix.clone(),
+                kind: *kind,
+            },
+            WordPart::ProcessSubstitution { body, is_input } => {
+                let body = self.lower_stmt_seq(body);
+                child_sequences.push(body);
+                WordPartArena::ProcessSubstitution {
+                    body,
+                    is_input: *is_input,
+                }
+            }
+            WordPart::Transformation {
+                reference,
+                operator,
+            } => WordPartArena::Transformation {
+                reference: self.lower_var_ref(reference, words, child_sequences),
+                operator: *operator,
+            },
+        };
+        WordPartArenaNode {
+            kind,
+            span: part.span,
+        }
+    }
+
+    fn lower_redirects<'a>(
+        &mut self,
+        redirects: impl Iterator<Item = &'a Redirect>,
+    ) -> (IdRange<RedirectNode>, IdRange<WordId>, IdRange<StmtSeqId>) {
+        let mut words = Vec::new();
+        let mut child_sequences = Vec::new();
+        let redirects = redirects
+            .map(|redirect| self.lower_redirect(redirect, &mut words, &mut child_sequences))
+            .collect::<Vec<_>>();
+        (
+            self.store.redirect_lists.push_many(redirects),
+            self.store.word_id_lists.push_many(words),
+            self.store.stmt_seq_id_lists.push_many(child_sequences),
+        )
+    }
+
+    fn lower_redirect(
+        &mut self,
+        redirect: &Redirect,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> RedirectNode {
+        let target = self.lower_redirect_target(&redirect.target, words, child_sequences);
+        RedirectNode {
+            fd: redirect.fd,
+            fd_var: redirect.fd_var.clone(),
+            fd_var_span: redirect.fd_var_span,
+            kind: redirect.kind,
+            span: redirect.span,
+            target,
+        }
+    }
+
+    fn lower_redirect_target(
+        &mut self,
+        target: &RedirectTarget,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> RedirectTargetNode {
+        match target {
+            RedirectTarget::Word(word) => {
+                RedirectTargetNode::Word(self.collect_word_id(word, words, child_sequences))
+            }
+            RedirectTarget::Heredoc(heredoc) => {
+                let raw = self.collect_word_id(&heredoc.delimiter.raw, words, child_sequences);
+                let parts = heredoc
+                    .body
+                    .parts
+                    .iter()
+                    .map(|part| self.lower_heredoc_body_part(part, words, child_sequences))
+                    .collect::<Vec<_>>();
+                let parts = self.store.heredoc_body_part_lists.push_many(parts);
+                RedirectTargetNode::Heredoc(HeredocNode {
+                    delimiter: HeredocDelimiterNode {
+                        raw,
+                        cooked: heredoc.delimiter.cooked.clone(),
+                        span: heredoc.delimiter.span,
+                        quoted: heredoc.delimiter.quoted,
+                        expands_body: heredoc.delimiter.expands_body,
+                        strip_tabs: heredoc.delimiter.strip_tabs,
+                    },
+                    body: HeredocBodyNode {
+                        mode: heredoc.body.mode,
+                        source_backed: heredoc.body.source_backed,
+                        parts,
+                        span: heredoc.body.span,
+                    },
+                })
+            }
+        }
+    }
+
+    fn lower_heredoc_body_part(
+        &mut self,
+        part: &crate::HeredocBodyPartNode,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ArenaHeredocBodyPartNode {
+        let kind = match &part.kind {
+            HeredocBodyPart::Literal(text) => ArenaHeredocBodyPart::Literal(text.clone()),
+            HeredocBodyPart::Variable(name) => ArenaHeredocBodyPart::Variable(name.clone()),
+            HeredocBodyPart::CommandSubstitution { body, syntax } => {
+                let body = self.lower_stmt_seq(body);
+                child_sequences.push(body);
+                ArenaHeredocBodyPart::CommandSubstitution {
+                    body,
+                    syntax: *syntax,
+                }
+            }
+            HeredocBodyPart::ArithmeticExpansion {
+                expression,
+                expression_ast,
+                expression_word_ast,
+                syntax,
+            } => ArenaHeredocBodyPart::ArithmeticExpansion {
+                expression: expression.clone(),
+                expression_ast: self.lower_arithmetic_expr_option(
+                    expression_ast.as_ref(),
+                    words,
+                    child_sequences,
+                ),
+                expression_word_ast: self.collect_word_id(
+                    expression_word_ast,
+                    words,
+                    child_sequences,
+                ),
+                syntax: *syntax,
+            },
+            HeredocBodyPart::Parameter(expansion) => ArenaHeredocBodyPart::Parameter(Box::new(
+                self.lower_parameter_expansion(expansion, words, child_sequences),
+            )),
+        };
+        ArenaHeredocBodyPartNode {
+            kind,
+            span: part.span,
+        }
+    }
+
+    fn lower_zsh_qualified_glob(
+        &mut self,
+        glob: &crate::ZshQualifiedGlob,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ZshQualifiedGlobNode {
+        let segments = glob
+            .segments
+            .iter()
+            .map(|segment| match segment {
+                crate::ZshGlobSegment::Pattern(pattern) => {
+                    ZshGlobSegmentNode::Pattern(self.lower_pattern(pattern, words, child_sequences))
+                }
+                crate::ZshGlobSegment::InlineControl(control) => {
+                    ZshGlobSegmentNode::InlineControl(*control)
+                }
+            })
+            .collect::<Vec<_>>();
+        let segments = self.store.zsh_glob_segment_lists.push_many(segments);
+        let qualifiers = glob.qualifiers.as_ref().map(|qualifiers| {
+            let fragments = self
+                .store
+                .zsh_glob_qualifier_lists
+                .push_many(qualifiers.fragments.iter().cloned());
+            ZshGlobQualifierGroupNode {
+                span: qualifiers.span,
+                kind: qualifiers.kind,
+                fragments,
+            }
+        });
+        ZshQualifiedGlobNode {
+            span: glob.span,
+            segments,
+            qualifiers,
+        }
+    }
+
+    fn lower_parameter_expansion(
+        &mut self,
+        expansion: &crate::ParameterExpansion,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ParameterExpansionNode {
+        ParameterExpansionNode {
+            syntax: match &expansion.syntax {
+                crate::ParameterExpansionSyntax::Bourne(expansion) => {
+                    ParameterExpansionSyntaxNode::Bourne(self.lower_bourne_parameter_expansion(
+                        expansion,
+                        words,
+                        child_sequences,
+                    ))
+                }
+                crate::ParameterExpansionSyntax::Zsh(expansion) => {
+                    ParameterExpansionSyntaxNode::Zsh(self.lower_zsh_parameter_expansion(
+                        expansion,
+                        words,
+                        child_sequences,
+                    ))
+                }
+            },
+            span: expansion.span,
+            raw_body: expansion.raw_body.clone(),
+        }
+    }
+
+    fn lower_bourne_parameter_expansion(
+        &mut self,
+        expansion: &crate::BourneParameterExpansion,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> BourneParameterExpansionNode {
+        match expansion {
+            crate::BourneParameterExpansion::Access { reference } => {
+                BourneParameterExpansionNode::Access {
+                    reference: self.lower_var_ref(reference, words, child_sequences),
+                }
+            }
+            crate::BourneParameterExpansion::Length { reference } => {
+                BourneParameterExpansionNode::Length {
+                    reference: self.lower_var_ref(reference, words, child_sequences),
+                }
+            }
+            crate::BourneParameterExpansion::Indices { reference } => {
+                BourneParameterExpansionNode::Indices {
+                    reference: self.lower_var_ref(reference, words, child_sequences),
+                }
+            }
+            crate::BourneParameterExpansion::Indirect {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                colon_variant,
+            } => BourneParameterExpansionNode::Indirect {
+                reference: self.lower_var_ref(reference, words, child_sequences),
+                operator: operator.clone(),
+                operand: operand.clone(),
+                operand_word_ast: operand_word_ast
+                    .as_ref()
+                    .map(|word| self.collect_word_id(word, words, child_sequences)),
+                colon_variant: *colon_variant,
+            },
+            crate::BourneParameterExpansion::PrefixMatch { prefix, kind } => {
+                BourneParameterExpansionNode::PrefixMatch {
+                    prefix: prefix.clone(),
+                    kind: *kind,
+                }
+            }
+            crate::BourneParameterExpansion::Slice {
+                reference,
+                offset,
+                offset_ast,
+                offset_word_ast,
+                length,
+                length_ast,
+                length_word_ast,
+            } => BourneParameterExpansionNode::Slice {
+                reference: self.lower_var_ref(reference, words, child_sequences),
+                offset: offset.clone(),
+                offset_ast: self.lower_arithmetic_expr_option(
+                    offset_ast.as_ref(),
+                    words,
+                    child_sequences,
+                ),
+                offset_word_ast: self.collect_word_id(offset_word_ast, words, child_sequences),
+                length: length.clone(),
+                length_ast: self.lower_arithmetic_expr_option(
+                    length_ast.as_ref(),
+                    words,
+                    child_sequences,
+                ),
+                length_word_ast: length_word_ast
+                    .as_ref()
+                    .map(|word| self.collect_word_id(word, words, child_sequences)),
+            },
+            crate::BourneParameterExpansion::Operation {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                colon_variant,
+            } => BourneParameterExpansionNode::Operation {
+                reference: self.lower_var_ref(reference, words, child_sequences),
+                operator: operator.clone(),
+                operand: operand.clone(),
+                operand_word_ast: operand_word_ast
+                    .as_ref()
+                    .map(|word| self.collect_word_id(word, words, child_sequences)),
+                colon_variant: *colon_variant,
+            },
+            crate::BourneParameterExpansion::Transformation {
+                reference,
+                operator,
+            } => BourneParameterExpansionNode::Transformation {
+                reference: self.lower_var_ref(reference, words, child_sequences),
+                operator: *operator,
+            },
+        }
+    }
+
+    fn lower_zsh_parameter_expansion(
+        &mut self,
+        expansion: &crate::ZshParameterExpansion,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ZshParameterExpansionNode {
+        let modifiers = expansion
+            .modifiers
+            .iter()
+            .map(|modifier| self.lower_zsh_modifier(modifier, words, child_sequences))
+            .collect::<Vec<_>>();
+        let modifiers = self.store.zsh_modifier_lists.push_many(modifiers);
+        ZshParameterExpansionNode {
+            target: self.lower_zsh_expansion_target(&expansion.target, words, child_sequences),
+            modifiers,
+            length_prefix: expansion.length_prefix,
+            operation: expansion.operation.as_ref().map(|operation| {
+                self.lower_zsh_expansion_operation(operation, words, child_sequences)
+            }),
+        }
+    }
+
+    fn lower_zsh_expansion_target(
+        &mut self,
+        target: &crate::ZshExpansionTarget,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ZshExpansionTargetNode {
+        match target {
+            crate::ZshExpansionTarget::Reference(reference) => ZshExpansionTargetNode::Reference(
+                self.lower_var_ref(reference, words, child_sequences),
+            ),
+            crate::ZshExpansionTarget::Nested(expansion) => ZshExpansionTargetNode::Nested(
+                Box::new(self.lower_parameter_expansion(expansion, words, child_sequences)),
+            ),
+            crate::ZshExpansionTarget::Word(word) => {
+                ZshExpansionTargetNode::Word(self.collect_word_id(word, words, child_sequences))
+            }
+            crate::ZshExpansionTarget::Empty => ZshExpansionTargetNode::Empty,
+        }
+    }
+
+    fn lower_zsh_modifier(
+        &mut self,
+        modifier: &crate::ZshModifier,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ZshModifierNode {
+        ZshModifierNode {
+            name: modifier.name,
+            argument: modifier.argument.clone(),
+            argument_word_ast: modifier
+                .argument_word_ast
+                .as_ref()
+                .map(|word| self.collect_word_id(word, words, child_sequences)),
+            argument_delimiter: modifier.argument_delimiter,
+            span: modifier.span,
+        }
+    }
+
+    fn lower_zsh_expansion_operation(
+        &mut self,
+        operation: &crate::ZshExpansionOperation,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ZshExpansionOperationNode {
+        match operation {
+            crate::ZshExpansionOperation::PatternOperation {
+                kind,
+                operand,
+                operand_word_ast,
+            } => ZshExpansionOperationNode::PatternOperation {
+                kind: *kind,
+                operand: operand.clone(),
+                operand_word_ast: self.collect_word_id(operand_word_ast, words, child_sequences),
+            },
+            crate::ZshExpansionOperation::Defaulting {
+                kind,
+                operand,
+                operand_word_ast,
+                colon_variant,
+            } => ZshExpansionOperationNode::Defaulting {
+                kind: *kind,
+                operand: operand.clone(),
+                operand_word_ast: self.collect_word_id(operand_word_ast, words, child_sequences),
+                colon_variant: *colon_variant,
+            },
+            crate::ZshExpansionOperation::TrimOperation {
+                kind,
+                operand,
+                operand_word_ast,
+            } => ZshExpansionOperationNode::TrimOperation {
+                kind: *kind,
+                operand: operand.clone(),
+                operand_word_ast: self.collect_word_id(operand_word_ast, words, child_sequences),
+            },
+            crate::ZshExpansionOperation::ReplacementOperation {
+                kind,
+                pattern,
+                pattern_word_ast,
+                replacement,
+                replacement_word_ast,
+            } => ZshExpansionOperationNode::ReplacementOperation {
+                kind: *kind,
+                pattern: pattern.clone(),
+                pattern_word_ast: self.collect_word_id(pattern_word_ast, words, child_sequences),
+                replacement: replacement.clone(),
+                replacement_word_ast: replacement_word_ast
+                    .as_ref()
+                    .map(|word| self.collect_word_id(word, words, child_sequences)),
+            },
+            crate::ZshExpansionOperation::Slice {
+                offset,
+                offset_word_ast,
+                length,
+                length_word_ast,
+            } => ZshExpansionOperationNode::Slice {
+                offset: offset.clone(),
+                offset_word_ast: self.collect_word_id(offset_word_ast, words, child_sequences),
+                length: length.clone(),
+                length_word_ast: length_word_ast
+                    .as_ref()
+                    .map(|word| self.collect_word_id(word, words, child_sequences)),
+            },
+            crate::ZshExpansionOperation::Unknown { text, word_ast } => {
+                ZshExpansionOperationNode::Unknown {
+                    text: text.clone(),
+                    word_ast: self.collect_word_id(word_ast, words, child_sequences),
+                }
+            }
+        }
+    }
+
+    fn lower_pattern(
+        &mut self,
+        pattern: &Pattern,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> PatternNode {
+        let parts = pattern
+            .parts
+            .iter()
+            .map(|part| self.lower_pattern_part(part, words, child_sequences))
+            .collect::<Vec<_>>();
+        let parts = self.store.pattern_part_lists.push_many(parts);
+        PatternNode {
+            parts,
+            span: pattern.span,
+        }
+    }
+
+    fn lower_pattern_part(
+        &mut self,
+        part: &crate::PatternPartNode,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> PatternPartArenaNode {
+        let kind = match &part.kind {
+            PatternPart::Literal(text) => PatternPartArena::Literal(text.clone()),
+            PatternPart::AnyString => PatternPartArena::AnyString,
+            PatternPart::AnyChar => PatternPartArena::AnyChar,
+            PatternPart::CharClass(text) => PatternPartArena::CharClass(text.clone()),
+            PatternPart::Group { kind, patterns } => {
+                let patterns = patterns
+                    .iter()
+                    .map(|pattern| self.lower_pattern(pattern, words, child_sequences))
+                    .collect::<Vec<_>>();
+                let patterns = self.store.pattern_lists.push_many(patterns);
+                PatternPartArena::Group {
+                    kind: *kind,
+                    patterns,
+                }
+            }
+            PatternPart::Word(word) => {
+                PatternPartArena::Word(self.collect_word_id(word, words, child_sequences))
+            }
+        };
+        PatternPartArenaNode {
+            kind,
+            span: part.span,
+        }
+    }
+
+    fn lower_conditional_expr(
+        &mut self,
+        expression: &ConditionalExpr,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ConditionalExprArena {
+        match expression {
+            ConditionalExpr::Binary(expr) => ConditionalExprArena::Binary {
+                left: Box::new(self.lower_conditional_expr(&expr.left, words, child_sequences)),
+                op: expr.op,
+                op_span: expr.op_span,
+                right: Box::new(self.lower_conditional_expr(&expr.right, words, child_sequences)),
+            },
+            ConditionalExpr::Unary(expr) => ConditionalExprArena::Unary {
+                op: expr.op,
+                op_span: expr.op_span,
+                expr: Box::new(self.lower_conditional_expr(&expr.expr, words, child_sequences)),
+            },
+            ConditionalExpr::Parenthesized(expr) => ConditionalExprArena::Parenthesized {
+                left_paren_span: expr.left_paren_span,
+                expr: Box::new(self.lower_conditional_expr(&expr.expr, words, child_sequences)),
+                right_paren_span: expr.right_paren_span,
+            },
+            ConditionalExpr::Word(word) => {
+                ConditionalExprArena::Word(self.collect_word_id(word, words, child_sequences))
+            }
+            ConditionalExpr::Pattern(pattern) => {
+                ConditionalExprArena::Pattern(self.lower_pattern(pattern, words, child_sequences))
+            }
+            ConditionalExpr::Regex(word) => {
+                ConditionalExprArena::Regex(self.collect_word_id(word, words, child_sequences))
+            }
+            ConditionalExpr::VarRef(var_ref) => {
+                ConditionalExprArena::VarRef(self.lower_var_ref(var_ref, words, child_sequences))
+            }
+        }
+    }
+
+    fn lower_arithmetic_expr_option(
+        &mut self,
+        expression: Option<&ArithmeticExprNode>,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> Option<ArithmeticExprArenaNode> {
+        expression.map(|expression| self.lower_arithmetic_expr(expression, words, child_sequences))
+    }
+
+    fn lower_arithmetic_expr(
+        &mut self,
+        expression: &ArithmeticExprNode,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ArithmeticExprArenaNode {
+        ArithmeticExprArenaNode {
+            kind: match &expression.kind {
+                ArithmeticExpr::Number(text) => ArithmeticExprArena::Number(text.clone()),
+                ArithmeticExpr::Variable(name) => ArithmeticExprArena::Variable(name.clone()),
+                ArithmeticExpr::Indexed { name, index } => ArithmeticExprArena::Indexed {
+                    name: name.clone(),
+                    index: Box::new(self.lower_arithmetic_expr(index, words, child_sequences)),
+                },
+                ArithmeticExpr::ShellWord(word) => ArithmeticExprArena::ShellWord(
+                    self.collect_word_id(word, words, child_sequences),
+                ),
+                ArithmeticExpr::Parenthesized { expression } => {
+                    ArithmeticExprArena::Parenthesized {
+                        expression: Box::new(self.lower_arithmetic_expr(
+                            expression,
+                            words,
+                            child_sequences,
+                        )),
+                    }
+                }
+                ArithmeticExpr::Unary { op, expr } => ArithmeticExprArena::Unary {
+                    op: *op,
+                    expr: Box::new(self.lower_arithmetic_expr(expr, words, child_sequences)),
+                },
+                ArithmeticExpr::Postfix { expr, op } => ArithmeticExprArena::Postfix {
+                    expr: Box::new(self.lower_arithmetic_expr(expr, words, child_sequences)),
+                    op: *op,
+                },
+                ArithmeticExpr::Binary { left, op, right } => ArithmeticExprArena::Binary {
+                    left: Box::new(self.lower_arithmetic_expr(left, words, child_sequences)),
+                    op: *op,
+                    right: Box::new(self.lower_arithmetic_expr(right, words, child_sequences)),
+                },
+                ArithmeticExpr::Conditional {
+                    condition,
+                    then_expr,
+                    else_expr,
+                } => ArithmeticExprArena::Conditional {
+                    condition: Box::new(self.lower_arithmetic_expr(
+                        condition,
+                        words,
+                        child_sequences,
+                    )),
+                    then_expr: Box::new(self.lower_arithmetic_expr(
+                        then_expr,
+                        words,
+                        child_sequences,
+                    )),
+                    else_expr: Box::new(self.lower_arithmetic_expr(
+                        else_expr,
+                        words,
+                        child_sequences,
+                    )),
+                },
+                ArithmeticExpr::Assignment { target, op, value } => {
+                    ArithmeticExprArena::Assignment {
+                        target: self.lower_arithmetic_lvalue(target, words, child_sequences),
+                        op: *op,
+                        value: Box::new(self.lower_arithmetic_expr(value, words, child_sequences)),
+                    }
+                }
+            },
+            span: expression.span,
+        }
+    }
+
+    fn lower_arithmetic_lvalue(
+        &mut self,
+        lvalue: &ArithmeticLvalue,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> ArithmeticLvalueArena {
+        match lvalue {
+            ArithmeticLvalue::Variable(name) => ArithmeticLvalueArena::Variable(name.clone()),
+            ArithmeticLvalue::Indexed { name, index } => ArithmeticLvalueArena::Indexed {
+                name: name.clone(),
+                index: Box::new(self.lower_arithmetic_expr(index, words, child_sequences)),
+            },
         }
     }
 }

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -1,9 +1,11 @@
 use crate::{
-    AlwaysCommand, AnonymousFunctionCommand, Assignment, AssignmentValue, BinaryCommand,
-    BuiltinCommand, CaseCommand, Command, Comment, CompoundCommand, CoprocCommand, DeclOperand,
-    File, ForCommand, FunctionDef, HeredocBodyPart, IdRange, Idx, ListArena, Pattern, PatternPart,
-    Redirect, RedirectTarget, RepeatCommand, SelectCommand, Span, Stmt, StmtSeq, StmtTerminator,
-    TimeCommand, UntilCommand, WhileCommand, Word, WordPart, WordPartNode,
+    AlwaysCommand, AnonymousFunctionCommand, ArithmeticCommand, ArithmeticExpr, ArithmeticExprNode,
+    ArithmeticForCommand, ArithmeticLvalue, Assignment, AssignmentValue, BinaryCommand,
+    BuiltinCommand, CaseCommand, Command, Comment, CompoundCommand, ConditionalCommand,
+    ConditionalExpr, CoprocCommand, DeclOperand, File, ForCommand, FunctionDef, HeredocBodyPart,
+    IdRange, Idx, ListArena, Pattern, PatternPart, Redirect, RedirectTarget, RepeatCommand,
+    SelectCommand, Span, Stmt, StmtSeq, StmtTerminator, Subscript, TimeCommand, UntilCommand,
+    WhileCommand, Word, WordPart, WordPartNode,
 };
 
 /// Stable typed identifier for a parsed file node inside an [`AstStore`].
@@ -211,6 +213,10 @@ pub struct StmtNode {
     pub negated: bool,
     /// Statement redirections.
     pub redirects: IdRange<Redirect>,
+    /// Words found under statement-level redirections.
+    pub redirect_words: IdRange<WordId>,
+    /// Nested statement sequences found under statement-level redirections.
+    pub redirect_child_sequences: IdRange<StmtSeqId>,
     /// Optional statement terminator.
     pub terminator: Option<StmtTerminator>,
     /// Source span of the terminator token when present.
@@ -361,6 +367,18 @@ impl<'a> StmtView<'a> {
     /// Returns this statement's redirections.
     pub fn redirects(self) -> &'a [Redirect] {
         self.store.redirect_lists.get(self.node().redirects)
+    }
+
+    /// Returns IDs for words found under statement redirections.
+    pub fn redirect_word_ids(self) -> &'a [WordId] {
+        self.store.word_id_lists.get(self.node().redirect_words)
+    }
+
+    /// Returns IDs for nested statement sequences found under statement redirections.
+    pub fn redirect_child_sequence_ids(self) -> &'a [StmtSeqId] {
+        self.store
+            .stmt_seq_id_lists
+            .get(self.node().redirect_child_sequences)
     }
 
     /// Returns whether this statement is negated.
@@ -526,9 +544,20 @@ impl AstStoreBuilder {
             .comment_lists
             .push_many(stmt.leading_comments.iter().copied());
         let command = self.lower_command(&stmt.command);
+        let mut redirect_words = Vec::new();
+        let mut redirect_child_sequences = Vec::new();
         for redirect in stmt.redirects.iter() {
-            self.collect_redirect_words(redirect);
+            self.collect_redirect_children(
+                redirect,
+                &mut redirect_words,
+                &mut redirect_child_sequences,
+            );
         }
+        let redirect_words = self.store.word_id_lists.push_many(redirect_words);
+        let redirect_child_sequences = self
+            .store
+            .stmt_seq_id_lists
+            .push_many(redirect_child_sequences);
         let redirects = self
             .store
             .redirect_lists
@@ -540,6 +569,8 @@ impl AstStoreBuilder {
             command,
             negated: stmt.negated,
             redirects,
+            redirect_words,
+            redirect_child_sequences,
             terminator: stmt.terminator,
             terminator_span: stmt.terminator_span,
             inline_comment: stmt.inline_comment,
@@ -567,7 +598,6 @@ impl AstStoreBuilder {
     }
 
     fn lower_word(&mut self, word: &Word) -> WordId {
-        self.collect_word_part_children(word.parts.as_slice());
         let parts = self
             .store
             .word_part_lists
@@ -585,6 +615,16 @@ impl AstStoreBuilder {
         id
     }
 
+    fn collect_word(
+        &mut self,
+        word: &Word,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        self.collect_word_part_children(word.parts.as_slice(), words, child_sequences);
+        words.push(self.lower_word(word));
+    }
+
     fn collect_command_children(
         &mut self,
         command: &Command,
@@ -593,16 +633,20 @@ impl AstStoreBuilder {
     ) {
         match command {
             Command::Simple(command) => {
-                words.push(self.lower_word(&command.name));
-                words.extend(command.args.iter().map(|word| self.lower_word(word)));
-                self.collect_assignments(command.assignments.iter(), words);
+                self.collect_word(&command.name, words, child_sequences);
+                for word in &command.args {
+                    self.collect_word(word, words, child_sequences);
+                }
+                self.collect_assignments(command.assignments.iter(), words, child_sequences);
             }
-            Command::Builtin(command) => self.collect_builtin_children(command, words),
+            Command::Builtin(command) => {
+                self.collect_builtin_children(command, words, child_sequences)
+            }
             Command::Decl(command) => {
                 for operand in &command.operands {
-                    self.collect_decl_operand(operand, words);
+                    self.collect_decl_operand(operand, words, child_sequences);
                 }
-                self.collect_assignments(command.assignments.iter(), words);
+                self.collect_assignments(command.assignments.iter(), words, child_sequences);
             }
             Command::Binary(command) => self.collect_binary_children(command, child_sequences),
             Command::Compound(command) => {
@@ -617,27 +661,36 @@ impl AstStoreBuilder {
         }
     }
 
-    fn collect_builtin_children(&mut self, command: &BuiltinCommand, words: &mut Vec<WordId>) {
+    fn collect_builtin_children(
+        &mut self,
+        command: &BuiltinCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
         match command {
             BuiltinCommand::Break(command) => {
-                words.extend(command.depth.iter().map(|word| self.lower_word(word)));
-                words.extend(command.extra_args.iter().map(|word| self.lower_word(word)));
-                self.collect_assignments(command.assignments.iter(), words);
+                for word in command.depth.iter().chain(command.extra_args.iter()) {
+                    self.collect_word(word, words, child_sequences);
+                }
+                self.collect_assignments(command.assignments.iter(), words, child_sequences);
             }
             BuiltinCommand::Continue(command) => {
-                words.extend(command.depth.iter().map(|word| self.lower_word(word)));
-                words.extend(command.extra_args.iter().map(|word| self.lower_word(word)));
-                self.collect_assignments(command.assignments.iter(), words);
+                for word in command.depth.iter().chain(command.extra_args.iter()) {
+                    self.collect_word(word, words, child_sequences);
+                }
+                self.collect_assignments(command.assignments.iter(), words, child_sequences);
             }
             BuiltinCommand::Return(command) => {
-                words.extend(command.code.iter().map(|word| self.lower_word(word)));
-                words.extend(command.extra_args.iter().map(|word| self.lower_word(word)));
-                self.collect_assignments(command.assignments.iter(), words);
+                for word in command.code.iter().chain(command.extra_args.iter()) {
+                    self.collect_word(word, words, child_sequences);
+                }
+                self.collect_assignments(command.assignments.iter(), words, child_sequences);
             }
             BuiltinCommand::Exit(command) => {
-                words.extend(command.code.iter().map(|word| self.lower_word(word)));
-                words.extend(command.extra_args.iter().map(|word| self.lower_word(word)));
-                self.collect_assignments(command.assignments.iter(), words);
+                for word in command.code.iter().chain(command.extra_args.iter()) {
+                    self.collect_word(word, words, child_sequences);
+                }
+                self.collect_assignments(command.assignments.iter(), words, child_sequences);
             }
         }
     }
@@ -686,11 +739,13 @@ impl AstStoreBuilder {
                 self.collect_repeat_children(command, words, child_sequences);
             }
             CompoundCommand::Foreach(command) => {
-                words.extend(command.words.iter().map(|word| self.lower_word(word)));
+                for word in &command.words {
+                    self.collect_word(word, words, child_sequences);
+                }
                 child_sequences.push(self.lower_stmt_seq(&command.body));
             }
             CompoundCommand::ArithmeticFor(command) => {
-                child_sequences.push(self.lower_stmt_seq(&command.body));
+                self.collect_arithmetic_for_children(command, words, child_sequences);
             }
             CompoundCommand::While(command) => {
                 self.collect_while_children(command, child_sequences)
@@ -707,7 +762,12 @@ impl AstStoreBuilder {
             CompoundCommand::Subshell(sequence) | CompoundCommand::BraceGroup(sequence) => {
                 child_sequences.push(self.lower_stmt_seq(sequence));
             }
-            CompoundCommand::Arithmetic(_) | CompoundCommand::Conditional(_) => {}
+            CompoundCommand::Arithmetic(command) => {
+                self.collect_arithmetic_command_children(command, words, child_sequences);
+            }
+            CompoundCommand::Conditional(command) => {
+                self.collect_conditional_command_children(command, words, child_sequences);
+            }
             CompoundCommand::Time(command) => self.collect_time_children(command, child_sequences),
             CompoundCommand::Coproc(command) => {
                 self.collect_coproc_children(command, child_sequences)
@@ -724,14 +784,13 @@ impl AstStoreBuilder {
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) {
-        words.extend(
-            command
-                .targets
-                .iter()
-                .map(|target| self.lower_word(&target.word)),
-        );
+        for target in &command.targets {
+            self.collect_word(&target.word, words, child_sequences);
+        }
         if let Some(header_words) = &command.words {
-            words.extend(header_words.iter().map(|word| self.lower_word(word)));
+            for word in header_words {
+                self.collect_word(word, words, child_sequences);
+            }
         }
         child_sequences.push(self.lower_stmt_seq(&command.body));
     }
@@ -742,7 +801,19 @@ impl AstStoreBuilder {
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) {
-        words.push(self.lower_word(&command.count));
+        self.collect_word(&command.count, words, child_sequences);
+        child_sequences.push(self.lower_stmt_seq(&command.body));
+    }
+
+    fn collect_arithmetic_for_children(
+        &mut self,
+        command: &ArithmeticForCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        self.collect_arithmetic_expr_option(command.init_ast.as_ref(), words, child_sequences);
+        self.collect_arithmetic_expr_option(command.condition_ast.as_ref(), words, child_sequences);
+        self.collect_arithmetic_expr_option(command.step_ast.as_ref(), words, child_sequences);
         child_sequences.push(self.lower_stmt_seq(&command.body));
     }
 
@@ -770,10 +841,10 @@ impl AstStoreBuilder {
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) {
-        words.push(self.lower_word(&command.word));
+        self.collect_word(&command.word, words, child_sequences);
         for case in &command.cases {
             for pattern in &case.patterns {
-                self.collect_pattern_words(pattern, words);
+                self.collect_pattern_words(pattern, words, child_sequences);
             }
             child_sequences.push(self.lower_stmt_seq(&case.body));
         }
@@ -785,8 +856,28 @@ impl AstStoreBuilder {
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) {
-        words.extend(command.words.iter().map(|word| self.lower_word(word)));
+        for word in &command.words {
+            self.collect_word(word, words, child_sequences);
+        }
         child_sequences.push(self.lower_stmt_seq(&command.body));
+    }
+
+    fn collect_arithmetic_command_children(
+        &mut self,
+        command: &ArithmeticCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        self.collect_arithmetic_expr_option(command.expr_ast.as_ref(), words, child_sequences);
+    }
+
+    fn collect_conditional_command_children(
+        &mut self,
+        command: &ConditionalCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        self.collect_conditional_expr(&command.expression, words, child_sequences);
     }
 
     fn collect_time_children(
@@ -832,13 +923,9 @@ impl AstStoreBuilder {
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) {
-        words.extend(
-            function
-                .header
-                .entries
-                .iter()
-                .map(|entry| self.lower_word(&entry.word)),
-        );
+        for entry in &function.header.entries {
+            self.collect_word(&entry.word, words, child_sequences);
+        }
         child_sequences.push(self.lower_stmt_seq(&StmtSeq {
             leading_comments: Vec::new(),
             stmts: vec![(*function.body).clone()],
@@ -859,15 +946,24 @@ impl AstStoreBuilder {
             trailing_comments: Vec::new(),
             span: function.body.span,
         }));
-        words.extend(function.args.iter().map(|word| self.lower_word(word)));
+        for word in &function.args {
+            self.collect_word(word, words, child_sequences);
+        }
     }
 
-    fn collect_decl_operand(&mut self, operand: &DeclOperand, words: &mut Vec<WordId>) {
+    fn collect_decl_operand(
+        &mut self,
+        operand: &DeclOperand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
         match operand {
             DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
-                words.push(self.lower_word(word));
+                self.collect_word(word, words, child_sequences);
             }
-            DeclOperand::Assignment(assignment) => self.collect_assignment(assignment, words),
+            DeclOperand::Assignment(assignment) => {
+                self.collect_assignment(assignment, words, child_sequences)
+            }
             DeclOperand::Name(_) => {}
         }
     }
@@ -876,22 +972,31 @@ impl AstStoreBuilder {
         &mut self,
         assignments: impl Iterator<Item = &'a Assignment>,
         words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
     ) {
         for assignment in assignments {
-            self.collect_assignment(assignment, words);
+            self.collect_assignment(assignment, words, child_sequences);
         }
     }
 
-    fn collect_assignment(&mut self, assignment: &Assignment, words: &mut Vec<WordId>) {
+    fn collect_assignment(
+        &mut self,
+        assignment: &Assignment,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
         match &assignment.value {
-            AssignmentValue::Scalar(word) => words.push(self.lower_word(word)),
+            AssignmentValue::Scalar(word) => self.collect_word(word, words, child_sequences),
             AssignmentValue::Compound(array) => {
                 for element in &array.elements {
                     match element {
-                        crate::ArrayElem::Sequential(value)
-                        | crate::ArrayElem::Keyed { value, .. }
-                        | crate::ArrayElem::KeyedAppend { value, .. } => {
-                            words.push(self.lower_word(&value.word));
+                        crate::ArrayElem::Sequential(value) => {
+                            self.collect_word(&value.word, words, child_sequences);
+                        }
+                        crate::ArrayElem::Keyed { key, value }
+                        | crate::ArrayElem::KeyedAppend { key, value } => {
+                            self.collect_subscript_words(key, words, child_sequences);
+                            self.collect_word(&value.word, words, child_sequences);
                         }
                     }
                 }
@@ -899,26 +1004,35 @@ impl AstStoreBuilder {
         }
     }
 
-    fn collect_redirect_words(&mut self, redirect: &Redirect) {
+    fn collect_redirect_children(
+        &mut self,
+        redirect: &Redirect,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
         match &redirect.target {
             RedirectTarget::Word(word) => {
-                self.lower_word(word);
+                self.collect_word(word, words, child_sequences);
             }
             RedirectTarget::Heredoc(heredoc) => {
-                self.lower_word(&heredoc.delimiter.raw);
+                self.collect_word(&heredoc.delimiter.raw, words, child_sequences);
                 for part in &heredoc.body.parts {
                     match &part.kind {
                         HeredocBodyPart::CommandSubstitution { body, .. } => {
-                            self.lower_stmt_seq(body);
+                            child_sequences.push(self.lower_stmt_seq(body));
                         }
                         HeredocBodyPart::ArithmeticExpansion {
                             expression_word_ast,
                             ..
                         } => {
-                            self.lower_word(expression_word_ast);
+                            self.collect_word(expression_word_ast, words, child_sequences);
                         }
                         HeredocBodyPart::Parameter(expansion) => {
-                            self.collect_parameter_expansion_words(expansion);
+                            self.collect_parameter_expansion_words(
+                                expansion,
+                                words,
+                                child_sequences,
+                            );
                         }
                         HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
                     }
@@ -927,67 +1041,111 @@ impl AstStoreBuilder {
         }
     }
 
-    fn collect_word_part_children(&mut self, parts: &[WordPartNode]) {
+    fn collect_word_part_children(
+        &mut self,
+        parts: &[WordPartNode],
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
         for part in parts {
             match &part.kind {
-                WordPart::DoubleQuoted { parts, .. } => self.collect_word_part_children(parts),
+                WordPart::DoubleQuoted { parts, .. } => {
+                    self.collect_word_part_children(parts, words, child_sequences)
+                }
                 WordPart::CommandSubstitution { body, .. }
                 | WordPart::ProcessSubstitution { body, .. } => {
-                    self.lower_stmt_seq(body);
+                    child_sequences.push(self.lower_stmt_seq(body));
                 }
                 WordPart::ArithmeticExpansion {
+                    expression_ast,
                     expression_word_ast,
                     ..
                 } => {
-                    self.lower_word(expression_word_ast);
+                    self.collect_arithmetic_expr_option(
+                        expression_ast.as_ref(),
+                        words,
+                        child_sequences,
+                    );
+                    self.collect_word(expression_word_ast, words, child_sequences);
                 }
-                WordPart::Parameter(expansion) => self.collect_parameter_expansion_words(expansion),
+                WordPart::Parameter(expansion) => {
+                    self.collect_parameter_expansion_words(expansion, words, child_sequences);
+                }
                 WordPart::ParameterExpansion {
-                    operand_word_ast, ..
+                    reference,
+                    operand_word_ast,
+                    ..
                 }
                 | WordPart::IndirectExpansion {
-                    operand_word_ast, ..
+                    reference,
+                    operand_word_ast,
+                    ..
                 } => {
+                    self.collect_var_ref_words(reference, words, child_sequences);
                     if let Some(word) = operand_word_ast {
-                        self.lower_word(word);
+                        self.collect_word(word, words, child_sequences);
                     }
                 }
+                WordPart::Length(reference)
+                | WordPart::ArrayAccess(reference)
+                | WordPart::ArrayLength(reference)
+                | WordPart::ArrayIndices(reference) => {
+                    self.collect_var_ref_words(reference, words, child_sequences);
+                }
                 WordPart::Substring {
+                    reference,
+                    offset_ast,
                     offset_word_ast,
+                    length_ast,
                     length_word_ast,
                     ..
                 }
                 | WordPart::ArraySlice {
+                    reference,
+                    offset_ast,
                     offset_word_ast,
+                    length_ast,
                     length_word_ast,
                     ..
                 } => {
-                    self.lower_word(offset_word_ast);
+                    self.collect_var_ref_words(reference, words, child_sequences);
+                    self.collect_arithmetic_expr_option(
+                        offset_ast.as_ref(),
+                        words,
+                        child_sequences,
+                    );
+                    self.collect_word(offset_word_ast, words, child_sequences);
+                    self.collect_arithmetic_expr_option(
+                        length_ast.as_ref(),
+                        words,
+                        child_sequences,
+                    );
                     if let Some(word) = length_word_ast {
-                        self.lower_word(word);
+                        self.collect_word(word, words, child_sequences);
                     }
                 }
                 WordPart::ZshQualifiedGlob(glob) => {
                     for segment in &glob.segments {
                         if let crate::ZshGlobSegment::Pattern(pattern) = segment {
-                            self.collect_pattern_words(pattern, &mut Vec::new());
+                            self.collect_pattern_words(pattern, words, child_sequences);
                         }
                     }
                 }
                 WordPart::Literal(_)
                 | WordPart::SingleQuoted { .. }
                 | WordPart::Variable(_)
-                | WordPart::Length(_)
-                | WordPart::ArrayAccess(_)
-                | WordPart::ArrayLength(_)
-                | WordPart::ArrayIndices(_)
                 | WordPart::PrefixMatch { .. }
                 | WordPart::Transformation { .. } => {}
             }
         }
     }
 
-    fn collect_parameter_expansion_words(&mut self, expansion: &crate::ParameterExpansion) {
+    fn collect_parameter_expansion_words(
+        &mut self,
+        expansion: &crate::ParameterExpansion,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
         match &expansion.syntax {
             crate::ParameterExpansionSyntax::Bourne(expansion) => match expansion {
                 crate::BourneParameterExpansion::Indirect {
@@ -997,17 +1155,29 @@ impl AstStoreBuilder {
                     operand_word_ast, ..
                 } => {
                     if let Some(word) = operand_word_ast {
-                        self.lower_word(word);
+                        self.collect_word(word, words, child_sequences);
                     }
                 }
                 crate::BourneParameterExpansion::Slice {
+                    offset_ast,
                     offset_word_ast,
+                    length_ast,
                     length_word_ast,
                     ..
                 } => {
-                    self.lower_word(offset_word_ast);
+                    self.collect_arithmetic_expr_option(
+                        offset_ast.as_ref(),
+                        words,
+                        child_sequences,
+                    );
+                    self.collect_word(offset_word_ast, words, child_sequences);
+                    self.collect_arithmetic_expr_option(
+                        length_ast.as_ref(),
+                        words,
+                        child_sequences,
+                    );
                     if let Some(word) = length_word_ast {
-                        self.lower_word(word);
+                        self.collect_word(word, words, child_sequences);
                     }
                 }
                 crate::BourneParameterExpansion::Access { .. }
@@ -1019,26 +1189,31 @@ impl AstStoreBuilder {
             crate::ParameterExpansionSyntax::Zsh(expansion) => {
                 match &expansion.target {
                     crate::ZshExpansionTarget::Nested(nested) => {
-                        self.collect_parameter_expansion_words(nested);
+                        self.collect_parameter_expansion_words(nested, words, child_sequences);
                     }
                     crate::ZshExpansionTarget::Word(word) => {
-                        self.lower_word(word);
+                        self.collect_word(word, words, child_sequences);
                     }
                     crate::ZshExpansionTarget::Reference(_) | crate::ZshExpansionTarget::Empty => {}
                 }
                 for modifier in &expansion.modifiers {
                     if let Some(word) = &modifier.argument_word_ast {
-                        self.lower_word(word);
+                        self.collect_word(word, words, child_sequences);
                     }
                 }
                 if let Some(operation) = &expansion.operation {
-                    self.collect_zsh_operation_words(operation);
+                    self.collect_zsh_operation_words(operation, words, child_sequences);
                 }
             }
         }
     }
 
-    fn collect_zsh_operation_words(&mut self, operation: &crate::ZshExpansionOperation) {
+    fn collect_zsh_operation_words(
+        &mut self,
+        operation: &crate::ZshExpansionOperation,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
         match operation {
             crate::ZshExpansionOperation::PatternOperation {
                 operand_word_ast, ..
@@ -1049,16 +1224,16 @@ impl AstStoreBuilder {
             | crate::ZshExpansionOperation::TrimOperation {
                 operand_word_ast, ..
             } => {
-                self.lower_word(operand_word_ast);
+                self.collect_word(operand_word_ast, words, child_sequences);
             }
             crate::ZshExpansionOperation::ReplacementOperation {
                 pattern_word_ast,
                 replacement_word_ast,
                 ..
             } => {
-                self.lower_word(pattern_word_ast);
+                self.collect_word(pattern_word_ast, words, child_sequences);
                 if let Some(word) = replacement_word_ast {
-                    self.lower_word(word);
+                    self.collect_word(word, words, child_sequences);
                 }
             }
             crate::ZshExpansionOperation::Slice {
@@ -1066,31 +1241,157 @@ impl AstStoreBuilder {
                 length_word_ast,
                 ..
             } => {
-                self.lower_word(offset_word_ast);
+                self.collect_word(offset_word_ast, words, child_sequences);
                 if let Some(word) = length_word_ast {
-                    self.lower_word(word);
+                    self.collect_word(word, words, child_sequences);
                 }
             }
             crate::ZshExpansionOperation::Unknown { word_ast, .. } => {
-                self.lower_word(word_ast);
+                self.collect_word(word_ast, words, child_sequences);
             }
         }
     }
 
-    fn collect_pattern_words(&mut self, pattern: &Pattern, words: &mut Vec<WordId>) {
+    fn collect_pattern_words(
+        &mut self,
+        pattern: &Pattern,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
         for part in &pattern.parts {
             match &part.kind {
                 PatternPart::Group { patterns, .. } => {
                     for pattern in patterns {
-                        self.collect_pattern_words(pattern, words);
+                        self.collect_pattern_words(pattern, words, child_sequences);
                     }
                 }
-                PatternPart::Word(word) => words.push(self.lower_word(word)),
+                PatternPart::Word(word) => self.collect_word(word, words, child_sequences),
                 PatternPart::Literal(_)
                 | PatternPart::AnyString
                 | PatternPart::AnyChar
                 | PatternPart::CharClass(_) => {}
             }
+        }
+    }
+
+    fn collect_conditional_expr(
+        &mut self,
+        expression: &ConditionalExpr,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        match expression {
+            ConditionalExpr::Binary(expr) => {
+                self.collect_conditional_expr(&expr.left, words, child_sequences);
+                self.collect_conditional_expr(&expr.right, words, child_sequences);
+            }
+            ConditionalExpr::Unary(expr) => {
+                self.collect_conditional_expr(&expr.expr, words, child_sequences);
+            }
+            ConditionalExpr::Parenthesized(expr) => {
+                self.collect_conditional_expr(&expr.expr, words, child_sequences);
+            }
+            ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
+                self.collect_word(word, words, child_sequences);
+            }
+            ConditionalExpr::Pattern(pattern) => {
+                self.collect_pattern_words(pattern, words, child_sequences);
+            }
+            ConditionalExpr::VarRef(var_ref) => {
+                self.collect_var_ref_words(var_ref, words, child_sequences);
+            }
+        }
+    }
+
+    fn collect_arithmetic_expr_option(
+        &mut self,
+        expression: Option<&ArithmeticExprNode>,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        if let Some(expression) = expression {
+            self.collect_arithmetic_expr(expression, words, child_sequences);
+        }
+    }
+
+    fn collect_arithmetic_expr(
+        &mut self,
+        expression: &ArithmeticExprNode,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        match &expression.kind {
+            ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
+            ArithmeticExpr::Indexed { index, .. } => {
+                self.collect_arithmetic_expr(index, words, child_sequences);
+            }
+            ArithmeticExpr::ShellWord(word) => {
+                self.collect_word(word, words, child_sequences);
+            }
+            ArithmeticExpr::Parenthesized { expression } => {
+                self.collect_arithmetic_expr(expression, words, child_sequences);
+            }
+            ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+                self.collect_arithmetic_expr(expr, words, child_sequences);
+            }
+            ArithmeticExpr::Binary { left, right, .. } => {
+                self.collect_arithmetic_expr(left, words, child_sequences);
+                self.collect_arithmetic_expr(right, words, child_sequences);
+            }
+            ArithmeticExpr::Conditional {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.collect_arithmetic_expr(condition, words, child_sequences);
+                self.collect_arithmetic_expr(then_expr, words, child_sequences);
+                self.collect_arithmetic_expr(else_expr, words, child_sequences);
+            }
+            ArithmeticExpr::Assignment { target, value, .. } => {
+                self.collect_arithmetic_lvalue(target, words, child_sequences);
+                self.collect_arithmetic_expr(value, words, child_sequences);
+            }
+        }
+    }
+
+    fn collect_arithmetic_lvalue(
+        &mut self,
+        lvalue: &ArithmeticLvalue,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        match lvalue {
+            ArithmeticLvalue::Variable(_) => {}
+            ArithmeticLvalue::Indexed { index, .. } => {
+                self.collect_arithmetic_expr(index, words, child_sequences);
+            }
+        }
+    }
+
+    fn collect_subscript_words(
+        &mut self,
+        subscript: &Subscript,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        if let Some(word) = subscript.word_ast() {
+            self.collect_word(word, words, child_sequences);
+        }
+        self.collect_arithmetic_expr_option(
+            subscript.arithmetic_ast.as_ref(),
+            words,
+            child_sequences,
+        );
+    }
+
+    fn collect_var_ref_words(
+        &mut self,
+        var_ref: &crate::VarRef,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        if let Some(subscript) = var_ref.subscript.as_deref() {
+            self.collect_subscript_words(subscript, words, child_sequences);
         }
     }
 }
@@ -1139,7 +1440,15 @@ fn command_span(command: &Command) -> Span {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ArenaFile, Command, Span, Stmt, StmtSeq, Word};
+    use crate::{
+        ArenaFile, ArithmeticCommand, ArithmeticExpr, ArithmeticExprNode, ArrayElem, ArrayExpr,
+        ArrayKind, ArrayValueWord, Assignment, AssignmentValue, Command, CommandSubstitutionSyntax,
+        CompoundCommand, ConditionalCommand, ConditionalExpr, Heredoc, HeredocBody,
+        HeredocBodyMode, HeredocBodyPart, HeredocBodyPartNode, HeredocDelimiter, Name, Pattern,
+        PatternPart, PatternPartNode, Redirect, RedirectKind, RedirectTarget, SimpleCommand, Span,
+        Stmt, StmtSeq, Subscript, SubscriptInterpretation, SubscriptKind, Word, WordPart,
+        WordPartNode, ZshGlobSegment, ZshQualifiedGlob,
+    };
 
     #[test]
     fn arena_file_round_trips_simple_sequence() {
@@ -1182,5 +1491,245 @@ mod tests {
             panic!("expected simple command");
         };
         assert_eq!(command.args.len(), 1);
+    }
+
+    #[test]
+    fn command_substitution_body_is_reachable_from_command() {
+        let file = file_with_command(Command::Simple(SimpleCommand {
+            name: Word::literal("echo"),
+            args: vec![word_with_command_substitution()],
+            assignments: Box::new([]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        assert!(command.word_ids().len() >= 2);
+    }
+
+    #[test]
+    fn heredoc_substitution_body_is_reachable_from_statement_redirects() {
+        let redirect = Redirect {
+            fd: None,
+            fd_var: None,
+            fd_var_span: None,
+            kind: RedirectKind::HereDoc,
+            span: Span::new(),
+            target: RedirectTarget::Heredoc(Heredoc {
+                delimiter: HeredocDelimiter {
+                    raw: Word::literal("EOF"),
+                    cooked: "EOF".to_string(),
+                    span: Span::new(),
+                    quoted: false,
+                    expands_body: true,
+                    strip_tabs: false,
+                },
+                body: HeredocBody {
+                    mode: HeredocBodyMode::Expanding,
+                    source_backed: false,
+                    parts: vec![HeredocBodyPartNode::new(
+                        HeredocBodyPart::CommandSubstitution {
+                            body: simple_sequence("inner"),
+                            syntax: CommandSubstitutionSyntax::DollarParen,
+                        },
+                        Span::new(),
+                    )],
+                    span: Span::new(),
+                },
+            }),
+        };
+        let file = file_with_stmt(Stmt {
+            leading_comments: Vec::new(),
+            command: Command::Simple(SimpleCommand {
+                name: Word::literal("cat"),
+                args: Vec::new(),
+                assignments: Box::new([]),
+                span: Span::new(),
+            }),
+            negated: false,
+            redirects: Box::new([redirect]),
+            terminator: None,
+            terminator_span: None,
+            inline_comment: None,
+            span: Span::new(),
+        });
+
+        let arena = ArenaFile::from_file(&file);
+        let stmt = arena.view().body().stmts().next().unwrap();
+
+        assert_eq!(stmt.redirect_child_sequence_ids().len(), 1);
+        assert!(!stmt.redirect_word_ids().is_empty());
+    }
+
+    #[test]
+    fn zsh_qualified_glob_pattern_words_are_command_words() {
+        let pattern = Pattern {
+            parts: vec![PatternPartNode::new(
+                PatternPart::Word(Word::literal("nested")),
+                Span::new(),
+            )],
+            span: Span::new(),
+        };
+        let glob_word = Word {
+            parts: vec![WordPartNode::new(
+                WordPart::ZshQualifiedGlob(ZshQualifiedGlob {
+                    span: Span::new(),
+                    segments: vec![ZshGlobSegment::Pattern(pattern)],
+                    qualifiers: None,
+                }),
+                Span::new(),
+            )],
+            span: Span::new(),
+            brace_syntax: Vec::new(),
+        };
+        let file = file_with_command(Command::Simple(SimpleCommand {
+            name: Word::literal("print"),
+            args: vec![glob_word],
+            assignments: Box::new([]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+
+        assert_eq!(command.word_ids().len(), 3);
+    }
+
+    #[test]
+    fn conditional_and_arithmetic_words_link_nested_substitutions() {
+        let conditional_file = file_with_command(Command::Compound(CompoundCommand::Conditional(
+            ConditionalCommand {
+                expression: ConditionalExpr::Word(word_with_command_substitution()),
+                span: Span::new(),
+                left_bracket_span: Span::new(),
+                right_bracket_span: Span::new(),
+            },
+        )));
+        let arithmetic_file = file_with_command(Command::Compound(CompoundCommand::Arithmetic(
+            ArithmeticCommand {
+                span: Span::new(),
+                left_paren_span: Span::new(),
+                expr_span: Some(Span::new()),
+                expr_ast: Some(ArithmeticExprNode::new(
+                    ArithmeticExpr::ShellWord(word_with_command_substitution()),
+                    Span::new(),
+                )),
+                right_paren_span: Span::new(),
+            },
+        )));
+
+        for file in [conditional_file, arithmetic_file] {
+            let arena = ArenaFile::from_file(&file);
+            let command = arena.view().body().stmts().next().unwrap().command();
+
+            assert_eq!(command.child_sequence_ids().len(), 1);
+            assert!(!command.word_ids().is_empty());
+        }
+    }
+
+    #[test]
+    fn keyed_array_subscript_words_are_assignment_words() {
+        let key = Subscript {
+            text: crate::SourceText::cooked(Span::new(), "$(key)"),
+            raw: None,
+            kind: SubscriptKind::Ordinary,
+            interpretation: SubscriptInterpretation::Indexed,
+            word_ast: Some(word_with_command_substitution()),
+            arithmetic_ast: None,
+        };
+        let assignment = Assignment {
+            target: crate::VarRef {
+                name: Name::new("arr"),
+                name_span: Span::new(),
+                subscript: None,
+                span: Span::new(),
+            },
+            value: AssignmentValue::Compound(ArrayExpr {
+                kind: ArrayKind::Associative,
+                elements: vec![ArrayElem::Keyed {
+                    key,
+                    value: ArrayValueWord::from(Word::literal("value")),
+                }],
+                span: Span::new(),
+            }),
+            append: false,
+            span: Span::new(),
+        };
+        let file = file_with_command(Command::Simple(SimpleCommand {
+            name: Word::literal("printf"),
+            args: Vec::new(),
+            assignments: Box::new([assignment]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        assert!(command.word_ids().len() >= 3);
+    }
+
+    fn file_with_command(command: Command) -> crate::File {
+        file_with_stmt(Stmt {
+            leading_comments: Vec::new(),
+            command,
+            negated: false,
+            redirects: Box::new([]),
+            terminator: None,
+            terminator_span: None,
+            inline_comment: None,
+            span: Span::new(),
+        })
+    }
+
+    fn file_with_stmt(stmt: Stmt) -> crate::File {
+        crate::File {
+            body: StmtSeq {
+                leading_comments: Vec::new(),
+                stmts: vec![stmt],
+                trailing_comments: Vec::new(),
+                span: Span::new(),
+            },
+            span: Span::new(),
+        }
+    }
+
+    fn simple_sequence(name: &str) -> StmtSeq {
+        StmtSeq {
+            leading_comments: Vec::new(),
+            stmts: vec![Stmt {
+                leading_comments: Vec::new(),
+                command: Command::Simple(SimpleCommand {
+                    name: Word::literal(name),
+                    args: Vec::new(),
+                    assignments: Box::new([]),
+                    span: Span::new(),
+                }),
+                negated: false,
+                redirects: Box::new([]),
+                terminator: None,
+                terminator_span: None,
+                inline_comment: None,
+                span: Span::new(),
+            }],
+            trailing_comments: Vec::new(),
+            span: Span::new(),
+        }
+    }
+
+    fn word_with_command_substitution() -> Word {
+        Word {
+            parts: vec![WordPartNode::new(
+                WordPart::CommandSubstitution {
+                    body: simple_sequence("subcmd"),
+                    syntax: CommandSubstitutionSyntax::DollarParen,
+                },
+                Span::new(),
+            )],
+            span: Span::new(),
+            brace_syntax: Vec::new(),
+        }
     }
 }

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -74,6 +74,7 @@ pub struct AstStore {
     redirect_lists: ListArena<Redirect>,
     assignment_lists: ListArena<Assignment>,
     decl_operand_lists: ListArena<DeclOperand>,
+    function_header_entry_lists: ListArena<FunctionHeaderEntryNode>,
     word_id_lists: ListArena<WordId>,
     word_part_lists: ListArena<WordPartNode>,
     brace_syntax_lists: ListArena<crate::BraceSyntax>,
@@ -93,6 +94,7 @@ impl Default for AstStore {
             redirect_lists: ListArena::new(),
             assignment_lists: ListArena::new(),
             decl_operand_lists: ListArena::new(),
+            function_header_entry_lists: ListArena::new(),
             word_id_lists: ListArena::new(),
             word_part_lists: ListArena::new(),
             brace_syntax_lists: ListArena::new(),
@@ -286,6 +288,47 @@ impl AstStore {
                     span: node.span,
                 })
             }
+            CommandNodePayload::Function(command) => {
+                let mut body = self.materialize_stmt_seq(command.body).stmts.into_iter();
+                let Some(body) = body.next() else {
+                    panic!("function body sequence contains one statement");
+                };
+                Command::Function(crate::FunctionDef {
+                    header: crate::FunctionHeader {
+                        function_keyword_span: command.function_keyword_span,
+                        entries: self
+                            .function_header_entry_lists
+                            .get(command.entries)
+                            .iter()
+                            .map(|entry| crate::FunctionHeaderEntry {
+                                word: self.materialize_word(entry.word),
+                                static_name: entry.static_name.clone(),
+                            })
+                            .collect(),
+                        trailing_parens_span: command.trailing_parens_span,
+                    },
+                    body: Box::new(body),
+                    span: node.span,
+                })
+            }
+            CommandNodePayload::AnonymousFunction(command) => {
+                let mut body = self.materialize_stmt_seq(command.body).stmts.into_iter();
+                let Some(body) = body.next() else {
+                    panic!("anonymous function body sequence contains one statement");
+                };
+                Command::AnonymousFunction(crate::AnonymousFunctionCommand {
+                    surface: command.surface,
+                    body: Box::new(body),
+                    args: self
+                        .word_id_lists
+                        .get(command.args)
+                        .iter()
+                        .copied()
+                        .map(|id| self.materialize_word(id))
+                        .collect(),
+                    span: node.span,
+                })
+            }
             CommandNodePayload::Legacy => node.legacy.clone(),
         }
     }
@@ -374,6 +417,10 @@ pub enum CommandNodePayload {
     Decl(DeclCommandNode),
     /// Binary shell command payload.
     Binary(BinaryCommandNode),
+    /// Function definition command payload.
+    Function(FunctionCommandNode),
+    /// Anonymous zsh function command payload.
+    AnonymousFunction(AnonymousFunctionCommandNode),
     /// Compatibility payload for command families that still materialize from `legacy`.
     Legacy,
 }
@@ -439,6 +486,39 @@ pub struct BinaryCommandNode {
     pub op_span: Span,
     /// Right-hand statement sequence.
     pub right: StmtSeqId,
+}
+
+/// Arena-native named function command payload.
+#[derive(Debug, Clone)]
+pub struct FunctionCommandNode {
+    /// Source span of the `function` keyword when present.
+    pub function_keyword_span: Option<Span>,
+    /// Parsed function header entries.
+    pub entries: IdRange<FunctionHeaderEntryNode>,
+    /// Source span of trailing `()` when present.
+    pub trailing_parens_span: Option<Span>,
+    /// Function body sequence.
+    pub body: StmtSeqId,
+}
+
+/// Arena-native function header entry.
+#[derive(Debug, Clone)]
+pub struct FunctionHeaderEntryNode {
+    /// Header entry word.
+    pub word: WordId,
+    /// Static function name when one could be recovered.
+    pub static_name: Option<crate::Name>,
+}
+
+/// Arena-native anonymous function command payload.
+#[derive(Debug, Clone)]
+pub struct AnonymousFunctionCommandNode {
+    /// Preserved anonymous function surface.
+    pub surface: crate::AnonymousFunctionSurface,
+    /// Anonymous function body sequence.
+    pub body: StmtSeqId,
+    /// Invocation argument words.
+    pub args: IdRange<WordId>,
 }
 
 /// Coarse command family stored with command arena nodes.
@@ -652,6 +732,8 @@ impl<'a> CommandView<'a> {
             CommandNodePayload::Builtin(_)
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -666,6 +748,8 @@ impl<'a> CommandView<'a> {
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -680,6 +764,8 @@ impl<'a> CommandView<'a> {
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Builtin(_)
             | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -694,6 +780,40 @@ impl<'a> CommandView<'a> {
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Builtin(_)
             | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Legacy => None,
+        }
+    }
+
+    /// Returns the native function payload when this command is a named function definition.
+    pub fn function(self) -> Option<FunctionCommandView<'a>> {
+        match &self.node().payload {
+            CommandNodePayload::Function(_) => Some(FunctionCommandView {
+                store: self.store,
+                id: self.id,
+            }),
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
+            | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Legacy => None,
+        }
+    }
+
+    /// Returns the native anonymous function payload when this command is anonymous.
+    pub fn anonymous_function(self) -> Option<AnonymousFunctionCommandView<'a>> {
+        match &self.node().payload {
+            CommandNodePayload::AnonymousFunction(_) => Some(AnonymousFunctionCommandView {
+                store: self.store,
+                id: self.id,
+            }),
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -757,6 +877,8 @@ impl<'a> SimpleCommandView<'a> {
             CommandNodePayload::Builtin(_)
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
             | CommandNodePayload::Legacy => {
                 unreachable!("simple view requires simple payload")
             }
@@ -811,6 +933,8 @@ impl<'a> BuiltinCommandView<'a> {
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
             | CommandNodePayload::Legacy => {
                 unreachable!("builtin view requires builtin payload")
             }
@@ -852,6 +976,8 @@ impl<'a> DeclCommandView<'a> {
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Builtin(_)
             | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
             | CommandNodePayload::Legacy => unreachable!("decl view requires decl payload"),
         }
     }
@@ -901,7 +1027,108 @@ impl<'a> BinaryCommandView<'a> {
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Builtin(_)
             | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
             | CommandNodePayload::Legacy => unreachable!("binary view requires binary payload"),
+        }
+    }
+}
+
+/// Borrowed view of an arena-native function command payload.
+#[derive(Debug, Clone, Copy)]
+pub struct FunctionCommandView<'a> {
+    store: &'a AstStore,
+    id: CommandId,
+}
+
+impl<'a> FunctionCommandView<'a> {
+    /// Returns the source span of the `function` keyword when present.
+    pub fn function_keyword_span(self) -> Option<Span> {
+        self.node().function_keyword_span
+    }
+
+    /// Returns parsed function header entries.
+    pub fn entries(self) -> &'a [FunctionHeaderEntryNode] {
+        self.store
+            .function_header_entry_lists
+            .get(self.node().entries)
+    }
+
+    /// Returns the source span of trailing `()` when present.
+    pub fn trailing_parens_span(self) -> Option<Span> {
+        self.node().trailing_parens_span
+    }
+
+    /// Returns the function body sequence.
+    pub fn body(self) -> StmtSeqView<'a> {
+        self.store.stmt_seq(self.node().body)
+    }
+
+    /// Returns the function body sequence ID.
+    pub fn body_id(self) -> StmtSeqId {
+        self.node().body
+    }
+
+    fn node(self) -> &'a FunctionCommandNode {
+        match &self.store.commands[self.id.index()].payload {
+            CommandNodePayload::Function(command) => command,
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
+            | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Legacy => unreachable!("function view requires function payload"),
+        }
+    }
+}
+
+/// Borrowed view of an arena-native anonymous function command payload.
+#[derive(Debug, Clone, Copy)]
+pub struct AnonymousFunctionCommandView<'a> {
+    store: &'a AstStore,
+    id: CommandId,
+}
+
+impl<'a> AnonymousFunctionCommandView<'a> {
+    /// Returns the preserved anonymous function surface.
+    pub fn surface(self) -> crate::AnonymousFunctionSurface {
+        self.node().surface
+    }
+
+    /// Returns the anonymous function body sequence.
+    pub fn body(self) -> StmtSeqView<'a> {
+        self.store.stmt_seq(self.node().body)
+    }
+
+    /// Returns the anonymous function body sequence ID.
+    pub fn body_id(self) -> StmtSeqId {
+        self.node().body
+    }
+
+    /// Returns invocation argument word IDs.
+    pub fn arg_ids(self) -> &'a [WordId] {
+        self.store.word_id_lists.get(self.node().args)
+    }
+
+    /// Returns invocation argument words.
+    pub fn args(self) -> impl ExactSizeIterator<Item = WordView<'a>> + 'a {
+        self.arg_ids()
+            .iter()
+            .copied()
+            .map(move |id| self.store.word(id))
+    }
+
+    fn node(self) -> &'a AnonymousFunctionCommandNode {
+        match &self.store.commands[self.id.index()].payload {
+            CommandNodePayload::AnonymousFunction(command) => command,
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::Legacy => {
+                unreachable!("anonymous function view requires anonymous function payload")
+            }
         }
     }
 }
@@ -1231,14 +1458,12 @@ impl AstStoreBuilder {
                 self.collect_compound_children(command, words, child_sequences);
                 CommandNodePayload::Legacy
             }
-            Command::Function(function) => {
-                self.collect_function_children(function, words, child_sequences);
-                CommandNodePayload::Legacy
-            }
-            Command::AnonymousFunction(function) => {
-                self.collect_anonymous_function_children(function, words, child_sequences);
-                CommandNodePayload::Legacy
-            }
+            Command::Function(function) => CommandNodePayload::Function(
+                self.collect_function_children(function, words, child_sequences),
+            ),
+            Command::AnonymousFunction(function) => CommandNodePayload::AnonymousFunction(
+                self.collect_anonymous_function_children(function, words, child_sequences),
+            ),
         }
     }
 
@@ -1544,16 +1769,30 @@ impl AstStoreBuilder {
         function: &FunctionDef,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        for entry in &function.header.entries {
-            self.collect_word(&entry.word, words, child_sequences);
-        }
-        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+    ) -> FunctionCommandNode {
+        let entries = function
+            .header
+            .entries
+            .iter()
+            .map(|entry| FunctionHeaderEntryNode {
+                word: self.collect_word_id(&entry.word, words, child_sequences),
+                static_name: entry.static_name.clone(),
+            })
+            .collect::<Vec<_>>();
+        let entries = self.store.function_header_entry_lists.push_many(entries);
+        let body = self.lower_stmt_seq(&StmtSeq {
             leading_comments: Vec::new(),
             stmts: vec![(*function.body).clone()],
             trailing_comments: Vec::new(),
             span: function.body.span,
-        }));
+        });
+        child_sequences.push(body);
+        FunctionCommandNode {
+            function_keyword_span: function.header.function_keyword_span,
+            entries,
+            trailing_parens_span: function.header.trailing_parens_span,
+            body,
+        }
     }
 
     fn collect_anonymous_function_children(
@@ -1561,15 +1800,24 @@ impl AstStoreBuilder {
         function: &AnonymousFunctionCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+    ) -> AnonymousFunctionCommandNode {
+        let body = self.lower_stmt_seq(&StmtSeq {
             leading_comments: Vec::new(),
             stmts: vec![(*function.body).clone()],
             trailing_comments: Vec::new(),
             span: function.body.span,
-        }));
-        for word in &function.args {
-            self.collect_word(word, words, child_sequences);
+        });
+        child_sequences.push(body);
+        let args = function
+            .args
+            .iter()
+            .map(|word| self.collect_word_id(word, words, child_sequences))
+            .collect::<Vec<_>>();
+        let args = self.store.word_id_lists.push_many(args);
+        AnonymousFunctionCommandNode {
+            surface: function.surface,
+            body,
+            args,
         }
     }
 
@@ -2338,6 +2586,73 @@ mod tests {
             panic!("expected binary command");
         };
         assert_eq!(command.op, crate::BinaryOp::And);
+    }
+
+    #[test]
+    fn function_payloads_are_arena_native() {
+        let body = Box::new(Stmt {
+            leading_comments: Vec::new(),
+            command: Command::Simple(SimpleCommand {
+                name: Word::literal("body"),
+                args: Vec::new(),
+                assignments: Box::new([]),
+                span: Span::new(),
+            }),
+            negated: false,
+            redirects: Box::new([]),
+            terminator: None,
+            terminator_span: None,
+            inline_comment: None,
+            span: Span::new(),
+        });
+        let function_file = file_with_command(Command::Function(crate::FunctionDef {
+            header: crate::FunctionHeader {
+                function_keyword_span: Some(Span::new()),
+                entries: vec![crate::FunctionHeaderEntry {
+                    word: Word::literal("fn"),
+                    static_name: Some(Name::new("fn")),
+                }],
+                trailing_parens_span: Some(Span::new()),
+            },
+            body: body.clone(),
+            span: Span::new(),
+        }));
+        let anonymous_file = file_with_command(Command::AnonymousFunction(
+            crate::AnonymousFunctionCommand {
+                surface: crate::AnonymousFunctionSurface::Parens {
+                    parens_span: Span::new(),
+                },
+                body,
+                args: vec![Word::literal("arg")],
+                span: Span::new(),
+            },
+        ));
+
+        let arena = ArenaFile::from_file(&function_file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+        let function = command
+            .function()
+            .expect("expected native function payload");
+        assert_eq!(function.entries().len(), 1);
+        assert_eq!(function.body().stmt_ids().len(), 1);
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        let Command::Function(materialized) = &arena.to_file().body[0].command else {
+            panic!("expected function command");
+        };
+        assert_eq!(materialized.header.entries.len(), 1);
+
+        let arena = ArenaFile::from_file(&anonymous_file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+        let function = command
+            .anonymous_function()
+            .expect("expected native anonymous function payload");
+        assert_eq!(function.arg_ids().len(), 1);
+        assert_eq!(function.body().stmt_ids().len(), 1);
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        let Command::AnonymousFunction(materialized) = &arena.to_file().body[0].command else {
+            panic!("expected anonymous function command");
+        };
+        assert_eq!(materialized.args.len(), 1);
     }
 
     #[test]

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -1084,6 +1084,7 @@ impl AstStoreBuilder {
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
     ) {
+        self.collect_var_ref_words(&assignment.target, words, child_sequences);
         match &assignment.value {
             AssignmentValue::Scalar(word) => self.collect_word(word, words, child_sequences),
             AssignmentValue::Compound(array) => {
@@ -1247,23 +1248,36 @@ impl AstStoreBuilder {
     ) {
         match &expansion.syntax {
             crate::ParameterExpansionSyntax::Bourne(expansion) => match expansion {
+                crate::BourneParameterExpansion::Access { reference }
+                | crate::BourneParameterExpansion::Length { reference }
+                | crate::BourneParameterExpansion::Indices { reference }
+                | crate::BourneParameterExpansion::Transformation { reference, .. } => {
+                    self.collect_var_ref_words(reference, words, child_sequences);
+                }
                 crate::BourneParameterExpansion::Indirect {
-                    operand_word_ast, ..
+                    reference,
+                    operand_word_ast,
+                    ..
                 }
                 | crate::BourneParameterExpansion::Operation {
-                    operand_word_ast, ..
+                    reference,
+                    operand_word_ast,
+                    ..
                 } => {
+                    self.collect_var_ref_words(reference, words, child_sequences);
                     if let Some(word) = operand_word_ast {
                         self.collect_word(word, words, child_sequences);
                     }
                 }
                 crate::BourneParameterExpansion::Slice {
+                    reference,
                     offset_ast,
                     offset_word_ast,
                     length_ast,
                     length_word_ast,
                     ..
                 } => {
+                    self.collect_var_ref_words(reference, words, child_sequences);
                     self.collect_arithmetic_expr_option(
                         offset_ast.as_ref(),
                         words,
@@ -1279,11 +1293,7 @@ impl AstStoreBuilder {
                         self.collect_word(word, words, child_sequences);
                     }
                 }
-                crate::BourneParameterExpansion::Access { .. }
-                | crate::BourneParameterExpansion::Length { .. }
-                | crate::BourneParameterExpansion::Indices { .. }
-                | crate::BourneParameterExpansion::PrefixMatch { .. }
-                | crate::BourneParameterExpansion::Transformation { .. } => {}
+                crate::BourneParameterExpansion::PrefixMatch { .. } => {}
             },
             crate::ParameterExpansionSyntax::Zsh(expansion) => {
                 match &expansion.target {
@@ -1541,12 +1551,13 @@ fn command_span(command: &Command) -> Span {
 mod tests {
     use crate::{
         ArenaFile, ArithmeticCommand, ArithmeticExpr, ArithmeticExprNode, ArrayElem, ArrayExpr,
-        ArrayKind, ArrayValueWord, Assignment, AssignmentValue, Command, CommandSubstitutionSyntax,
-        CompoundCommand, ConditionalCommand, ConditionalExpr, Heredoc, HeredocBody,
-        HeredocBodyMode, HeredocBodyPart, HeredocBodyPartNode, HeredocDelimiter, Name, Pattern,
-        PatternPart, PatternPartNode, Redirect, RedirectKind, RedirectTarget, SimpleCommand, Span,
-        Stmt, StmtSeq, Subscript, SubscriptInterpretation, SubscriptKind, Word, WordPart,
-        WordPartNode, ZshGlobSegment, ZshQualifiedGlob,
+        ArrayKind, ArrayValueWord, Assignment, AssignmentValue, BourneParameterExpansion, Command,
+        CommandSubstitutionSyntax, CompoundCommand, ConditionalCommand, ConditionalExpr, Heredoc,
+        HeredocBody, HeredocBodyMode, HeredocBodyPart, HeredocBodyPartNode, HeredocDelimiter, Name,
+        ParameterExpansion, ParameterExpansionSyntax, Pattern, PatternPart, PatternPartNode,
+        Redirect, RedirectKind, RedirectTarget, SimpleCommand, Span, Stmt, StmtSeq, Subscript,
+        SubscriptInterpretation, SubscriptKind, Word, WordPart, WordPartNode, ZshGlobSegment,
+        ZshQualifiedGlob,
     };
 
     #[test]
@@ -1747,14 +1758,6 @@ mod tests {
 
     #[test]
     fn keyed_array_subscript_words_are_assignment_words() {
-        let key = Subscript {
-            text: crate::SourceText::cooked(Span::new(), "$(key)"),
-            raw: None,
-            kind: SubscriptKind::Ordinary,
-            interpretation: SubscriptInterpretation::Indexed,
-            word_ast: Some(word_with_command_substitution()),
-            arithmetic_ast: None,
-        };
         let assignment = Assignment {
             target: crate::VarRef {
                 name: Name::new("arr"),
@@ -1765,7 +1768,7 @@ mod tests {
             value: AssignmentValue::Compound(ArrayExpr {
                 kind: ArrayKind::Associative,
                 elements: vec![ArrayElem::Keyed {
-                    key,
+                    key: dynamic_subscript(),
                     value: ArrayValueWord::from(Word::literal("value")),
                 }],
                 span: Span::new(),
@@ -1777,6 +1780,69 @@ mod tests {
             name: Word::literal("printf"),
             args: Vec::new(),
             assignments: Box::new([assignment]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        assert!(command.word_ids().len() >= 3);
+    }
+
+    #[test]
+    fn assignment_target_subscript_words_are_assignment_words() {
+        let assignment = Assignment {
+            target: crate::VarRef {
+                name: Name::new("arr"),
+                name_span: Span::new(),
+                subscript: Some(Box::new(dynamic_subscript())),
+                span: Span::new(),
+            },
+            value: AssignmentValue::Scalar(Word::literal("value")),
+            append: false,
+            span: Span::new(),
+        };
+        let file = file_with_command(Command::Simple(SimpleCommand {
+            name: Word::literal("printf"),
+            args: Vec::new(),
+            assignments: Box::new([assignment]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        assert!(command.word_ids().len() >= 3);
+    }
+
+    #[test]
+    fn bourne_parameter_subscript_words_are_command_words() {
+        let expansion = ParameterExpansion {
+            syntax: ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access {
+                reference: crate::VarRef {
+                    name: Name::new("arr"),
+                    name_span: Span::new(),
+                    subscript: Some(Box::new(dynamic_subscript())),
+                    span: Span::new(),
+                },
+            }),
+            span: Span::new(),
+            raw_body: crate::SourceText::cooked(Span::new(), "arr[$(idx)]"),
+        };
+        let word = Word {
+            parts: vec![WordPartNode::new(
+                WordPart::Parameter(expansion),
+                Span::new(),
+            )],
+            span: Span::new(),
+            brace_syntax: Vec::new(),
+        };
+        let file = file_with_command(Command::Simple(SimpleCommand {
+            name: Word::literal("echo"),
+            args: vec![word],
+            assignments: Box::new([]),
             span: Span::new(),
         }));
 
@@ -1846,6 +1912,17 @@ mod tests {
             )],
             span: Span::new(),
             brace_syntax: Vec::new(),
+        }
+    }
+
+    fn dynamic_subscript() -> Subscript {
+        Subscript {
+            text: crate::SourceText::cooked(Span::new(), "$(key)"),
+            raw: None,
+            kind: SubscriptKind::Ordinary,
+            interpretation: SubscriptInterpretation::Indexed,
+            word_ast: Some(word_with_command_substitution()),
+            arithmetic_ast: None,
         }
     }
 }

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -73,6 +73,7 @@ pub struct AstStore {
     comment_lists: ListArena<Comment>,
     redirect_lists: ListArena<Redirect>,
     assignment_lists: ListArena<Assignment>,
+    decl_operand_lists: ListArena<DeclOperand>,
     word_id_lists: ListArena<WordId>,
     word_part_lists: ListArena<WordPartNode>,
     brace_syntax_lists: ListArena<crate::BraceSyntax>,
@@ -91,6 +92,7 @@ impl Default for AstStore {
             comment_lists: ListArena::new(),
             redirect_lists: ListArena::new(),
             assignment_lists: ListArena::new(),
+            decl_operand_lists: ListArena::new(),
             word_id_lists: ListArena::new(),
             word_part_lists: ListArena::new(),
             brace_syntax_lists: ListArena::new(),
@@ -256,6 +258,17 @@ impl AstStore {
                 };
                 Command::Builtin(command)
             }
+            CommandNodePayload::Decl(command) => Command::Decl(crate::DeclClause {
+                variant: command.variant.clone(),
+                variant_span: command.variant_span,
+                operands: self.decl_operand_lists.get(command.operands).to_vec(),
+                assignments: self
+                    .assignment_lists
+                    .get(command.assignments)
+                    .to_vec()
+                    .into_boxed_slice(),
+                span: node.span,
+            }),
             CommandNodePayload::Legacy => node.legacy.clone(),
         }
     }
@@ -340,6 +353,8 @@ pub enum CommandNodePayload {
     Simple(SimpleCommandNode),
     /// Typed builtin command payload.
     Builtin(BuiltinCommandNode),
+    /// Declaration builtin command payload.
+    Decl(DeclCommandNode),
     /// Compatibility payload for command families that still materialize from `legacy`.
     Legacy,
 }
@@ -379,6 +394,19 @@ pub enum BuiltinCommandNodeKind {
     Return,
     /// `exit [N]`.
     Exit,
+}
+
+/// Arena-native declaration command payload.
+#[derive(Debug, Clone)]
+pub struct DeclCommandNode {
+    /// Declaration builtin variant.
+    pub variant: crate::Name,
+    /// Source span of the declaration builtin name.
+    pub variant_span: Span,
+    /// Parsed declaration operands.
+    pub operands: IdRange<DeclOperand>,
+    /// Prefix assignments.
+    pub assignments: IdRange<Assignment>,
 }
 
 /// Coarse command family stored with command arena nodes.
@@ -589,7 +617,9 @@ impl<'a> CommandView<'a> {
                 store: self.store,
                 id: self.id,
             }),
-            CommandNodePayload::Builtin(_) | CommandNodePayload::Legacy => None,
+            CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Legacy => None,
         }
     }
 
@@ -600,7 +630,22 @@ impl<'a> CommandView<'a> {
                 store: self.store,
                 id: self.id,
             }),
-            CommandNodePayload::Simple(_) | CommandNodePayload::Legacy => None,
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Legacy => None,
+        }
+    }
+
+    /// Returns the native declaration payload when this command is a declaration builtin.
+    pub fn decl(self) -> Option<DeclCommandView<'a>> {
+        match &self.node().payload {
+            CommandNodePayload::Decl(_) => Some(DeclCommandView {
+                store: self.store,
+                id: self.id,
+            }),
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Legacy => None,
         }
     }
 
@@ -660,7 +705,9 @@ impl<'a> SimpleCommandView<'a> {
     fn node(self) -> &'a SimpleCommandNode {
         match &self.store.commands[self.id.index()].payload {
             CommandNodePayload::Simple(command) => command,
-            CommandNodePayload::Builtin(_) | CommandNodePayload::Legacy => {
+            CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Legacy => {
                 unreachable!("simple view requires simple payload")
             }
         }
@@ -711,9 +758,49 @@ impl<'a> BuiltinCommandView<'a> {
     fn node(self) -> &'a BuiltinCommandNode {
         match &self.store.commands[self.id.index()].payload {
             CommandNodePayload::Builtin(command) => command,
-            CommandNodePayload::Simple(_) | CommandNodePayload::Legacy => {
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Legacy => {
                 unreachable!("builtin view requires builtin payload")
             }
+        }
+    }
+}
+
+/// Borrowed view of an arena-native declaration command payload.
+#[derive(Debug, Clone, Copy)]
+pub struct DeclCommandView<'a> {
+    store: &'a AstStore,
+    id: CommandId,
+}
+
+impl<'a> DeclCommandView<'a> {
+    /// Returns the declaration builtin variant.
+    pub fn variant(self) -> &'a crate::Name {
+        &self.node().variant
+    }
+
+    /// Returns the source span of the declaration builtin name.
+    pub fn variant_span(self) -> Span {
+        self.node().variant_span
+    }
+
+    /// Returns parsed declaration operands.
+    pub fn operands(self) -> &'a [DeclOperand] {
+        self.store.decl_operand_lists.get(self.node().operands)
+    }
+
+    /// Returns prefix assignments.
+    pub fn assignments(self) -> &'a [Assignment] {
+        self.store.assignment_lists.get(self.node().assignments)
+    }
+
+    fn node(self) -> &'a DeclCommandNode {
+        match &self.store.commands[self.id.index()].payload {
+            CommandNodePayload::Decl(command) => command,
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Legacy => unreachable!("decl view requires decl payload"),
         }
     }
 }
@@ -1021,7 +1108,20 @@ impl AstStoreBuilder {
                     self.collect_decl_operand(operand, words, child_sequences);
                 }
                 self.collect_assignments(command.assignments.iter(), words, child_sequences);
-                CommandNodePayload::Legacy
+                let operands = self
+                    .store
+                    .decl_operand_lists
+                    .push_many(command.operands.iter().cloned());
+                let assignments = self
+                    .store
+                    .assignment_lists
+                    .push_many(command.assignments.iter().cloned());
+                CommandNodePayload::Decl(DeclCommandNode {
+                    variant: command.variant.clone(),
+                    variant_span: command.variant_span,
+                    operands,
+                    assignments,
+                })
             }
             Command::Binary(command) => {
                 self.collect_binary_children(command, child_sequences);
@@ -2033,6 +2133,46 @@ mod tests {
         };
         assert!(command.code.is_some());
         assert_eq!(command.extra_args.len(), 1);
+        assert_eq!(command.assignments.len(), 1);
+    }
+
+    #[test]
+    fn declaration_command_payload_is_arena_native() {
+        let file = file_with_command(Command::Decl(DeclClause {
+            variant: Name::new("declare"),
+            variant_span: Span::new(),
+            operands: vec![
+                DeclOperand::Flag(Word::literal("-a")),
+                DeclOperand::Name(var_ref_with_dynamic_subscript("arr")),
+            ],
+            assignments: Box::new([Assignment {
+                target: crate::VarRef {
+                    name: Name::new("prefix"),
+                    name_span: Span::new(),
+                    subscript: None,
+                    span: Span::new(),
+                },
+                value: AssignmentValue::Scalar(Word::literal("value")),
+                append: false,
+                span: Span::new(),
+            }]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+        let decl = command.decl().expect("expected native declaration payload");
+
+        assert_eq!(decl.variant(), "declare");
+        assert_eq!(decl.operands().len(), 2);
+        assert_eq!(decl.assignments().len(), 1);
+        assert_eq!(command.child_sequence_ids().len(), 1);
+
+        let materialized = arena.to_file();
+        let Command::Decl(command) = &materialized.body[0].command else {
+            panic!("expected declaration command");
+        };
+        assert_eq!(command.operands.len(), 2);
         assert_eq!(command.assignments.len(), 1);
     }
 

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -269,6 +269,23 @@ impl AstStore {
                     .into_boxed_slice(),
                 span: node.span,
             }),
+            CommandNodePayload::Binary(command) => {
+                let mut left_stmts = self.materialize_stmt_seq(command.left).stmts.into_iter();
+                let Some(left) = left_stmts.next() else {
+                    panic!("binary left sequence contains one statement");
+                };
+                let mut right_stmts = self.materialize_stmt_seq(command.right).stmts.into_iter();
+                let Some(right) = right_stmts.next() else {
+                    panic!("binary right sequence contains one statement");
+                };
+                Command::Binary(crate::BinaryCommand {
+                    left: Box::new(left),
+                    op: command.op,
+                    op_span: command.op_span,
+                    right: Box::new(right),
+                    span: node.span,
+                })
+            }
             CommandNodePayload::Legacy => node.legacy.clone(),
         }
     }
@@ -355,6 +372,8 @@ pub enum CommandNodePayload {
     Builtin(BuiltinCommandNode),
     /// Declaration builtin command payload.
     Decl(DeclCommandNode),
+    /// Binary shell command payload.
+    Binary(BinaryCommandNode),
     /// Compatibility payload for command families that still materialize from `legacy`.
     Legacy,
 }
@@ -407,6 +426,19 @@ pub struct DeclCommandNode {
     pub operands: IdRange<DeclOperand>,
     /// Prefix assignments.
     pub assignments: IdRange<Assignment>,
+}
+
+/// Arena-native binary command payload.
+#[derive(Debug, Clone)]
+pub struct BinaryCommandNode {
+    /// Left-hand statement sequence.
+    pub left: StmtSeqId,
+    /// Binary operator.
+    pub op: crate::BinaryOp,
+    /// Source span of the operator token.
+    pub op_span: Span,
+    /// Right-hand statement sequence.
+    pub right: StmtSeqId,
 }
 
 /// Coarse command family stored with command arena nodes.
@@ -619,6 +651,7 @@ impl<'a> CommandView<'a> {
             }),
             CommandNodePayload::Builtin(_)
             | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -632,6 +665,7 @@ impl<'a> CommandView<'a> {
             }),
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -645,6 +679,21 @@ impl<'a> CommandView<'a> {
             }),
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Legacy => None,
+        }
+    }
+
+    /// Returns the native binary payload when this command is a binary shell command.
+    pub fn binary(self) -> Option<BinaryCommandView<'a>> {
+        match &self.node().payload {
+            CommandNodePayload::Binary(_) => Some(BinaryCommandView {
+                store: self.store,
+                id: self.id,
+            }),
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -707,6 +756,7 @@ impl<'a> SimpleCommandView<'a> {
             CommandNodePayload::Simple(command) => command,
             CommandNodePayload::Builtin(_)
             | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
             | CommandNodePayload::Legacy => {
                 unreachable!("simple view requires simple payload")
             }
@@ -760,6 +810,7 @@ impl<'a> BuiltinCommandView<'a> {
             CommandNodePayload::Builtin(command) => command,
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
             | CommandNodePayload::Legacy => {
                 unreachable!("builtin view requires builtin payload")
             }
@@ -800,7 +851,57 @@ impl<'a> DeclCommandView<'a> {
             CommandNodePayload::Decl(command) => command,
             CommandNodePayload::Simple(_)
             | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Binary(_)
             | CommandNodePayload::Legacy => unreachable!("decl view requires decl payload"),
+        }
+    }
+}
+
+/// Borrowed view of an arena-native binary command payload.
+#[derive(Debug, Clone, Copy)]
+pub struct BinaryCommandView<'a> {
+    store: &'a AstStore,
+    id: CommandId,
+}
+
+impl<'a> BinaryCommandView<'a> {
+    /// Returns the left-hand statement sequence.
+    pub fn left(self) -> StmtSeqView<'a> {
+        self.store.stmt_seq(self.node().left)
+    }
+
+    /// Returns the left-hand statement sequence ID.
+    pub fn left_id(self) -> StmtSeqId {
+        self.node().left
+    }
+
+    /// Returns the binary operator.
+    pub fn op(self) -> crate::BinaryOp {
+        self.node().op
+    }
+
+    /// Returns the source span of the operator token.
+    pub fn op_span(self) -> Span {
+        self.node().op_span
+    }
+
+    /// Returns the right-hand statement sequence.
+    pub fn right(self) -> StmtSeqView<'a> {
+        self.store.stmt_seq(self.node().right)
+    }
+
+    /// Returns the right-hand statement sequence ID.
+    pub fn right_id(self) -> StmtSeqId {
+        self.node().right
+    }
+
+    fn node(self) -> &'a BinaryCommandNode {
+        match &self.store.commands[self.id.index()].payload {
+            CommandNodePayload::Binary(command) => command,
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Legacy => unreachable!("binary view requires binary payload"),
         }
     }
 }
@@ -1124,8 +1225,7 @@ impl AstStoreBuilder {
                 })
             }
             Command::Binary(command) => {
-                self.collect_binary_children(command, child_sequences);
-                CommandNodePayload::Legacy
+                CommandNodePayload::Binary(self.collect_binary_children(command, child_sequences))
             }
             Command::Compound(command) => {
                 self.collect_compound_children(command, words, child_sequences);
@@ -1213,19 +1313,27 @@ impl AstStoreBuilder {
         &mut self,
         command: &BinaryCommand,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+    ) -> BinaryCommandNode {
+        let left = self.lower_stmt_seq(&StmtSeq {
             leading_comments: Vec::new(),
             stmts: vec![(*command.left).clone()],
             trailing_comments: Vec::new(),
             span: command.left.span,
-        }));
-        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+        });
+        let right = self.lower_stmt_seq(&StmtSeq {
             leading_comments: Vec::new(),
             stmts: vec![(*command.right).clone()],
             trailing_comments: Vec::new(),
             span: command.right.span,
-        }));
+        });
+        child_sequences.push(left);
+        child_sequences.push(right);
+        BinaryCommandNode {
+            left,
+            op: command.op,
+            op_span: command.op_span,
+            right,
+        }
     }
 
     fn collect_compound_children(
@@ -2174,6 +2282,62 @@ mod tests {
         };
         assert_eq!(command.operands.len(), 2);
         assert_eq!(command.assignments.len(), 1);
+    }
+
+    #[test]
+    fn binary_command_payload_is_arena_native() {
+        let left = Stmt {
+            leading_comments: Vec::new(),
+            command: Command::Simple(SimpleCommand {
+                name: Word::literal("left"),
+                args: Vec::new(),
+                assignments: Box::new([]),
+                span: Span::new(),
+            }),
+            negated: false,
+            redirects: Box::new([]),
+            terminator: None,
+            terminator_span: None,
+            inline_comment: None,
+            span: Span::new(),
+        };
+        let right = Stmt {
+            leading_comments: Vec::new(),
+            command: Command::Simple(SimpleCommand {
+                name: Word::literal("right"),
+                args: Vec::new(),
+                assignments: Box::new([]),
+                span: Span::new(),
+            }),
+            negated: false,
+            redirects: Box::new([]),
+            terminator: None,
+            terminator_span: None,
+            inline_comment: None,
+            span: Span::new(),
+        };
+        let file = file_with_command(Command::Binary(crate::BinaryCommand {
+            left: Box::new(left),
+            op: crate::BinaryOp::And,
+            op_span: Span::new(),
+            right: Box::new(right),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+        let binary = command.binary().expect("expected native binary payload");
+
+        assert_eq!(binary.op(), crate::BinaryOp::And);
+        assert_eq!(binary.left().stmt_ids().len(), 1);
+        assert_eq!(binary.right().stmt_ids().len(), 1);
+        assert_eq!(command.child_sequence_ids().len(), 2);
+
+        let materialized = arena.to_file();
+        let Command::Binary(command) = &materialized.body[0].command else {
+            panic!("expected binary command");
+        };
+        assert_eq!(command.op, crate::BinaryOp::And);
     }
 
     #[test]

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -157,6 +157,11 @@ impl AstStore {
         self.array_elem_lists.get(range)
     }
 
+    /// Returns for-loop target nodes from a list range.
+    pub fn for_targets(&self, range: IdRange<ForTargetNode>) -> &[ForTargetNode] {
+        self.for_target_lists.get(range)
+    }
+
     /// Returns heredoc body part nodes from a list range.
     pub fn heredoc_body_parts(
         &self,
@@ -188,6 +193,11 @@ impl AstStore {
     /// Returns zsh glob segment nodes from a list range.
     pub fn zsh_glob_segments(&self, range: IdRange<ZshGlobSegmentNode>) -> &[ZshGlobSegmentNode] {
         self.zsh_glob_segment_lists.get(range)
+    }
+
+    /// Returns zsh modifier nodes from a list range.
+    pub fn zsh_modifiers(&self, range: IdRange<ZshModifierNode>) -> &[ZshModifierNode] {
+        self.zsh_modifier_lists.get(range)
     }
 
     /// Returns word part nodes from a list range.
@@ -2413,6 +2423,11 @@ impl<'a> StmtView<'a> {
         self.node().terminator
     }
 
+    /// Returns this statement's terminator span.
+    pub fn terminator_span(self) -> Option<Span> {
+        self.node().terminator_span
+    }
+
     /// Returns this statement's inline comment.
     pub fn inline_comment(self) -> Option<Comment> {
         self.node().inline_comment
@@ -2421,11 +2436,6 @@ impl<'a> StmtView<'a> {
     /// Returns this statement's source span.
     pub fn span(self) -> Span {
         self.node().span
-    }
-
-    /// Materializes this statement into the recursive AST representation.
-    pub fn to_stmt(self) -> Stmt {
-        self.store.materialize_stmt(self.id)
     }
 
     fn node(self) -> &'a StmtNode {
@@ -2938,6 +2948,11 @@ impl<'a> WordView<'a> {
     /// Returns this node's ID.
     pub fn id(self) -> WordId {
         self.id
+    }
+
+    /// Returns the arena store that owns this word.
+    pub fn store(self) -> &'a AstStore {
+        self.store
     }
 
     /// Returns this word's parts.

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -39,6 +39,16 @@ impl ArenaFile {
         }
     }
 
+    /// Builds an arena representation from an owned parsed root body.
+    pub fn from_body(body: StmtSeq, span: Span) -> Self {
+        let mut builder = AstStoreBuilder::default();
+        let root = builder.lower_file_body(body, span);
+        Self {
+            root,
+            store: builder.finish(),
+        }
+    }
+
     /// Returns a borrowed view of the root file node.
     pub fn view(&self) -> FileView<'_> {
         self.store.file(self.root)
@@ -512,6 +522,13 @@ impl AstStoreBuilder {
         id
     }
 
+    fn lower_file_body(&mut self, body: StmtSeq, span: Span) -> FileId {
+        let body = self.lower_stmt_seq_owned(body);
+        let id = Idx::new(self.store.files.len());
+        self.store.files.push(FileNode { body, span });
+        id
+    }
+
     fn lower_stmt_seq(&mut self, sequence: &StmtSeq) -> StmtSeqId {
         let leading_comments = self
             .store
@@ -527,6 +544,32 @@ impl AstStoreBuilder {
             .store
             .comment_lists
             .push_many(sequence.trailing_comments.iter().copied());
+
+        let id = Idx::new(self.store.stmt_seqs.len());
+        self.store.stmt_seqs.push(StmtSeqNode {
+            leading_comments,
+            stmts,
+            trailing_comments,
+            span: sequence.span,
+        });
+        id
+    }
+
+    fn lower_stmt_seq_owned(&mut self, sequence: StmtSeq) -> StmtSeqId {
+        let leading_comments = self
+            .store
+            .comment_lists
+            .push_many(sequence.leading_comments);
+        let stmts = sequence
+            .stmts
+            .into_iter()
+            .map(|stmt| self.lower_stmt_owned(stmt))
+            .collect::<Vec<_>>();
+        let stmts = self.store.stmt_id_lists.push_many(stmts);
+        let trailing_comments = self
+            .store
+            .comment_lists
+            .push_many(sequence.trailing_comments);
 
         let id = Idx::new(self.store.stmt_seqs.len());
         self.store.stmt_seqs.push(StmtSeqNode {
@@ -579,6 +622,44 @@ impl AstStoreBuilder {
         id
     }
 
+    fn lower_stmt_owned(&mut self, stmt: Stmt) -> StmtId {
+        let leading_comments = self.store.comment_lists.push_many(stmt.leading_comments);
+        let command = self.lower_command_owned(stmt.command);
+        let mut redirect_words = Vec::new();
+        let mut redirect_child_sequences = Vec::new();
+        for redirect in stmt.redirects.iter() {
+            self.collect_redirect_children(
+                redirect,
+                &mut redirect_words,
+                &mut redirect_child_sequences,
+            );
+        }
+        let redirect_words = self.store.word_id_lists.push_many(redirect_words);
+        let redirect_child_sequences = self
+            .store
+            .stmt_seq_id_lists
+            .push_many(redirect_child_sequences);
+        let redirects = self
+            .store
+            .redirect_lists
+            .push_many(stmt.redirects.into_vec());
+
+        let id = Idx::new(self.store.stmts.len());
+        self.store.stmts.push(StmtNode {
+            leading_comments,
+            command,
+            negated: stmt.negated,
+            redirects,
+            redirect_words,
+            redirect_child_sequences,
+            terminator: stmt.terminator,
+            terminator_span: stmt.terminator_span,
+            inline_comment: stmt.inline_comment,
+            span: stmt.span,
+        });
+        id
+    }
+
     fn lower_command(&mut self, command: &Command) -> CommandId {
         let mut words = Vec::new();
         let mut child_sequences = Vec::new();
@@ -593,6 +674,24 @@ impl AstStoreBuilder {
             words,
             child_sequences,
             legacy: command.clone(),
+        });
+        id
+    }
+
+    fn lower_command_owned(&mut self, command: Command) -> CommandId {
+        let mut words = Vec::new();
+        let mut child_sequences = Vec::new();
+        self.collect_command_children(&command, &mut words, &mut child_sequences);
+
+        let words = self.store.word_id_lists.push_many(words);
+        let child_sequences = self.store.stmt_seq_id_lists.push_many(child_sequences);
+        let id = Idx::new(self.store.commands.len());
+        self.store.commands.push(CommandNode {
+            kind: command_kind(&command),
+            span: command_span(&command),
+            words,
+            child_sequences,
+            legacy: command,
         });
         id
     }
@@ -1491,6 +1590,23 @@ mod tests {
             panic!("expected simple command");
         };
         assert_eq!(command.args.len(), 1);
+    }
+
+    #[test]
+    fn arena_file_builds_from_owned_body() {
+        let file = file_with_command(Command::Simple(SimpleCommand {
+            name: Word::literal("echo"),
+            args: vec![Word::literal("hello")],
+            assignments: Box::new([]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_body(file.body, file.span);
+        let materialized = arena.to_file();
+
+        assert_eq!(arena.store.file_count(), 1);
+        assert_eq!(arena.store.stmt_seq_count(), 1);
+        assert_eq!(materialized.body.len(), 1);
     }
 
     #[test]

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -2423,6 +2423,11 @@ impl<'a> StmtView<'a> {
         self.node().span
     }
 
+    /// Materializes this statement into the recursive AST representation.
+    pub fn to_stmt(self) -> Stmt {
+        self.store.materialize_stmt(self.id)
+    }
+
     fn node(self) -> &'a StmtNode {
         &self.store.stmts[self.id.index()]
     }

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -1,0 +1,1186 @@
+use crate::{
+    AlwaysCommand, AnonymousFunctionCommand, Assignment, AssignmentValue, BinaryCommand,
+    BuiltinCommand, CaseCommand, Command, Comment, CompoundCommand, CoprocCommand, DeclOperand,
+    File, ForCommand, FunctionDef, HeredocBodyPart, IdRange, Idx, ListArena, Pattern, PatternPart,
+    Redirect, RedirectTarget, RepeatCommand, SelectCommand, Span, Stmt, StmtSeq, StmtTerminator,
+    TimeCommand, UntilCommand, WhileCommand, Word, WordPart, WordPartNode,
+};
+
+/// Stable typed identifier for a parsed file node inside an [`AstStore`].
+pub type FileId = Idx<FileNode>;
+/// Stable typed identifier for a statement sequence node inside an [`AstStore`].
+pub type StmtSeqId = Idx<StmtSeqNode>;
+/// Stable typed identifier for a statement node inside an [`AstStore`].
+pub type StmtId = Idx<StmtNode>;
+/// Stable typed identifier for a command node inside an [`AstStore`].
+pub type CommandId = Idx<CommandNode>;
+/// Stable typed identifier for a word node inside an [`AstStore`].
+pub type WordId = Idx<WordNode>;
+
+/// An ID-backed parsed file representation.
+#[derive(Debug, Clone)]
+pub struct ArenaFile {
+    /// Root file node.
+    pub root: FileId,
+    /// Arena storage for the parsed file.
+    pub store: AstStore,
+}
+
+impl ArenaFile {
+    /// Builds an arena representation from the existing recursive AST.
+    pub fn from_file(file: &File) -> Self {
+        let mut builder = AstStoreBuilder::default();
+        let root = builder.lower_file(file);
+        Self {
+            root,
+            store: builder.finish(),
+        }
+    }
+
+    /// Returns a borrowed view of the root file node.
+    pub fn view(&self) -> FileView<'_> {
+        self.store.file(self.root)
+    }
+
+    /// Materializes the arena representation back into the legacy recursive AST.
+    pub fn to_file(&self) -> File {
+        self.store.materialize_file(self.root)
+    }
+}
+
+/// Compact typed AST storage for one parsed file.
+#[derive(Debug, Clone)]
+pub struct AstStore {
+    files: Vec<FileNode>,
+    stmt_seqs: Vec<StmtSeqNode>,
+    stmts: Vec<StmtNode>,
+    commands: Vec<CommandNode>,
+    words: Vec<WordNode>,
+    stmt_id_lists: ListArena<StmtId>,
+    stmt_seq_id_lists: ListArena<StmtSeqId>,
+    comment_lists: ListArena<Comment>,
+    redirect_lists: ListArena<Redirect>,
+    word_id_lists: ListArena<WordId>,
+    word_part_lists: ListArena<WordPartNode>,
+    brace_syntax_lists: ListArena<crate::BraceSyntax>,
+}
+
+impl Default for AstStore {
+    fn default() -> Self {
+        Self {
+            files: Vec::new(),
+            stmt_seqs: Vec::new(),
+            stmts: Vec::new(),
+            commands: Vec::new(),
+            words: Vec::new(),
+            stmt_id_lists: ListArena::new(),
+            stmt_seq_id_lists: ListArena::new(),
+            comment_lists: ListArena::new(),
+            redirect_lists: ListArena::new(),
+            word_id_lists: ListArena::new(),
+            word_part_lists: ListArena::new(),
+            brace_syntax_lists: ListArena::new(),
+        }
+    }
+}
+
+impl AstStore {
+    /// Returns the file view for `id`.
+    pub fn file(&self, id: FileId) -> FileView<'_> {
+        FileView { store: self, id }
+    }
+
+    /// Returns the statement sequence view for `id`.
+    pub fn stmt_seq(&self, id: StmtSeqId) -> StmtSeqView<'_> {
+        StmtSeqView { store: self, id }
+    }
+
+    /// Returns the statement view for `id`.
+    pub fn stmt(&self, id: StmtId) -> StmtView<'_> {
+        StmtView { store: self, id }
+    }
+
+    /// Returns the command view for `id`.
+    pub fn command(&self, id: CommandId) -> CommandView<'_> {
+        CommandView { store: self, id }
+    }
+
+    /// Returns the word view for `id`.
+    pub fn word(&self, id: WordId) -> WordView<'_> {
+        WordView { store: self, id }
+    }
+
+    /// Number of file nodes in this store.
+    pub fn file_count(&self) -> usize {
+        self.files.len()
+    }
+
+    /// Number of statement sequence nodes in this store.
+    pub fn stmt_seq_count(&self) -> usize {
+        self.stmt_seqs.len()
+    }
+
+    /// Number of statement nodes in this store.
+    pub fn stmt_count(&self) -> usize {
+        self.stmts.len()
+    }
+
+    /// Number of command nodes in this store.
+    pub fn command_count(&self) -> usize {
+        self.commands.len()
+    }
+
+    /// Number of word nodes in this store.
+    pub fn word_count(&self) -> usize {
+        self.words.len()
+    }
+
+    fn materialize_file(&self, id: FileId) -> File {
+        let node = &self.files[id.index()];
+        File {
+            body: self.materialize_stmt_seq(node.body),
+            span: node.span,
+        }
+    }
+
+    fn materialize_stmt_seq(&self, id: StmtSeqId) -> StmtSeq {
+        let node = &self.stmt_seqs[id.index()];
+        StmtSeq {
+            leading_comments: self.comment_lists.get(node.leading_comments).to_vec(),
+            stmts: self
+                .stmt_id_lists
+                .get(node.stmts)
+                .iter()
+                .copied()
+                .map(|stmt| self.materialize_stmt(stmt))
+                .collect(),
+            trailing_comments: self.comment_lists.get(node.trailing_comments).to_vec(),
+            span: node.span,
+        }
+    }
+
+    fn materialize_stmt(&self, id: StmtId) -> Stmt {
+        let node = &self.stmts[id.index()];
+        Stmt {
+            leading_comments: self.comment_lists.get(node.leading_comments).to_vec(),
+            command: self.commands[node.command.index()].legacy.clone(),
+            negated: node.negated,
+            redirects: self
+                .redirect_lists
+                .get(node.redirects)
+                .to_vec()
+                .into_boxed_slice(),
+            terminator: node.terminator,
+            terminator_span: node.terminator_span,
+            inline_comment: node.inline_comment,
+            span: node.span,
+        }
+    }
+}
+
+/// File-level arena node.
+#[derive(Debug, Clone)]
+pub struct FileNode {
+    /// Root statement sequence.
+    pub body: StmtSeqId,
+    /// Source span of the file.
+    pub span: Span,
+}
+
+/// Statement-sequence arena node.
+#[derive(Debug, Clone)]
+pub struct StmtSeqNode {
+    /// Comments before the first statement in this sequence.
+    pub leading_comments: IdRange<Comment>,
+    /// Statements in source order.
+    pub stmts: IdRange<StmtId>,
+    /// Comments after the final statement and before the enclosing terminator.
+    pub trailing_comments: IdRange<Comment>,
+    /// Source span covering the full sequence.
+    pub span: Span,
+}
+
+/// Statement arena node.
+#[derive(Debug, Clone)]
+pub struct StmtNode {
+    /// Own-line comments immediately preceding this statement.
+    pub leading_comments: IdRange<Comment>,
+    /// Statement command payload.
+    pub command: CommandId,
+    /// Whether this statement was prefixed with `!`.
+    pub negated: bool,
+    /// Statement redirections.
+    pub redirects: IdRange<Redirect>,
+    /// Optional statement terminator.
+    pub terminator: Option<StmtTerminator>,
+    /// Source span of the terminator token when present.
+    pub terminator_span: Option<Span>,
+    /// Trailing inline comment on the statement line.
+    pub inline_comment: Option<Comment>,
+    /// Source span of the full statement.
+    pub span: Span,
+}
+
+/// Command arena node.
+#[derive(Debug, Clone)]
+pub struct CommandNode {
+    /// Coarse command kind for cheap filtering.
+    pub kind: ArenaFileCommandKind,
+    /// Source span of the command.
+    pub span: Span,
+    /// Words found under this command.
+    pub words: IdRange<WordId>,
+    /// Nested statement sequences found under this command.
+    pub child_sequences: IdRange<StmtSeqId>,
+    legacy: Command,
+}
+
+/// Coarse command family stored with command arena nodes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ArenaFileCommandKind {
+    /// Simple command.
+    Simple,
+    /// Builtin command with a dedicated node.
+    Builtin,
+    /// Declaration builtin clause.
+    Decl,
+    /// Binary shell operator.
+    Binary,
+    /// Compound command.
+    Compound,
+    /// Function definition.
+    Function,
+    /// Anonymous zsh function.
+    AnonymousFunction,
+}
+
+/// Word arena node.
+#[derive(Debug, Clone)]
+pub struct WordNode {
+    /// Word parts in source order.
+    pub parts: IdRange<WordPartNode>,
+    /// Source span of this word.
+    pub span: Span,
+    /// Brace-syntax facts attached by the parser.
+    pub brace_syntax: IdRange<crate::BraceSyntax>,
+}
+
+/// Borrowed view of a file node.
+#[derive(Debug, Clone, Copy)]
+pub struct FileView<'a> {
+    store: &'a AstStore,
+    id: FileId,
+}
+
+impl<'a> FileView<'a> {
+    /// Returns this node's ID.
+    pub fn id(self) -> FileId {
+        self.id
+    }
+
+    /// Returns the root statement sequence.
+    pub fn body(self) -> StmtSeqView<'a> {
+        self.store.stmt_seq(self.store.files[self.id.index()].body)
+    }
+
+    /// Returns the file source span.
+    pub fn span(self) -> Span {
+        self.store.files[self.id.index()].span
+    }
+}
+
+/// Borrowed view of a statement sequence node.
+#[derive(Debug, Clone, Copy)]
+pub struct StmtSeqView<'a> {
+    store: &'a AstStore,
+    id: StmtSeqId,
+}
+
+impl<'a> StmtSeqView<'a> {
+    /// Returns this node's ID.
+    pub fn id(self) -> StmtSeqId {
+        self.id
+    }
+
+    /// Returns the raw statement IDs in this sequence.
+    pub fn stmt_ids(self) -> &'a [StmtId] {
+        self.store.stmt_id_lists.get(self.node().stmts)
+    }
+
+    /// Returns the statements in this sequence.
+    pub fn stmts(self) -> impl ExactSizeIterator<Item = StmtView<'a>> + 'a {
+        self.stmt_ids()
+            .iter()
+            .copied()
+            .map(move |id| self.store.stmt(id))
+    }
+
+    /// Returns leading comments for this sequence.
+    pub fn leading_comments(self) -> &'a [Comment] {
+        self.store.comment_lists.get(self.node().leading_comments)
+    }
+
+    /// Returns trailing comments for this sequence.
+    pub fn trailing_comments(self) -> &'a [Comment] {
+        self.store.comment_lists.get(self.node().trailing_comments)
+    }
+
+    /// Returns this sequence's source span.
+    pub fn span(self) -> Span {
+        self.node().span
+    }
+
+    fn node(self) -> &'a StmtSeqNode {
+        &self.store.stmt_seqs[self.id.index()]
+    }
+}
+
+/// Borrowed view of a statement node.
+#[derive(Debug, Clone, Copy)]
+pub struct StmtView<'a> {
+    store: &'a AstStore,
+    id: StmtId,
+}
+
+impl<'a> StmtView<'a> {
+    /// Returns this node's ID.
+    pub fn id(self) -> StmtId {
+        self.id
+    }
+
+    /// Returns this statement's command.
+    pub fn command(self) -> CommandView<'a> {
+        self.store.command(self.node().command)
+    }
+
+    /// Returns comments immediately preceding this statement.
+    pub fn leading_comments(self) -> &'a [Comment] {
+        self.store.comment_lists.get(self.node().leading_comments)
+    }
+
+    /// Returns this statement's redirections.
+    pub fn redirects(self) -> &'a [Redirect] {
+        self.store.redirect_lists.get(self.node().redirects)
+    }
+
+    /// Returns whether this statement is negated.
+    pub fn negated(self) -> bool {
+        self.node().negated
+    }
+
+    /// Returns this statement's terminator.
+    pub fn terminator(self) -> Option<StmtTerminator> {
+        self.node().terminator
+    }
+
+    /// Returns this statement's inline comment.
+    pub fn inline_comment(self) -> Option<Comment> {
+        self.node().inline_comment
+    }
+
+    /// Returns this statement's source span.
+    pub fn span(self) -> Span {
+        self.node().span
+    }
+
+    fn node(self) -> &'a StmtNode {
+        &self.store.stmts[self.id.index()]
+    }
+}
+
+/// Borrowed view of a command node.
+#[derive(Debug, Clone, Copy)]
+pub struct CommandView<'a> {
+    store: &'a AstStore,
+    id: CommandId,
+}
+
+impl<'a> CommandView<'a> {
+    /// Returns this node's ID.
+    pub fn id(self) -> CommandId {
+        self.id
+    }
+
+    /// Returns this command's coarse kind.
+    pub fn kind(self) -> ArenaFileCommandKind {
+        self.node().kind
+    }
+
+    /// Returns this command's source span.
+    pub fn span(self) -> Span {
+        self.node().span
+    }
+
+    /// Returns IDs for words found under this command.
+    pub fn word_ids(self) -> &'a [WordId] {
+        self.store.word_id_lists.get(self.node().words)
+    }
+
+    /// Returns words found under this command.
+    pub fn words(self) -> impl ExactSizeIterator<Item = WordView<'a>> + 'a {
+        self.word_ids()
+            .iter()
+            .copied()
+            .map(move |id| self.store.word(id))
+    }
+
+    /// Returns IDs for nested statement sequences found under this command.
+    pub fn child_sequence_ids(self) -> &'a [StmtSeqId] {
+        self.store
+            .stmt_seq_id_lists
+            .get(self.node().child_sequences)
+    }
+
+    /// Returns the legacy recursive command payload.
+    pub fn legacy(self) -> &'a Command {
+        &self.node().legacy
+    }
+
+    fn node(self) -> &'a CommandNode {
+        &self.store.commands[self.id.index()]
+    }
+}
+
+/// Borrowed view of a word node.
+#[derive(Debug, Clone, Copy)]
+pub struct WordView<'a> {
+    store: &'a AstStore,
+    id: WordId,
+}
+
+impl<'a> WordView<'a> {
+    /// Returns this node's ID.
+    pub fn id(self) -> WordId {
+        self.id
+    }
+
+    /// Returns this word's parts.
+    pub fn parts(self) -> &'a [WordPartNode] {
+        self.store.word_part_lists.get(self.node().parts)
+    }
+
+    /// Returns this word's source span.
+    pub fn span(self) -> Span {
+        self.node().span
+    }
+
+    /// Returns this word's brace-syntax facts.
+    pub fn brace_syntax(self) -> &'a [crate::BraceSyntax] {
+        self.store.brace_syntax_lists.get(self.node().brace_syntax)
+    }
+
+    fn node(self) -> &'a WordNode {
+        &self.store.words[self.id.index()]
+    }
+}
+
+#[derive(Default)]
+struct AstStoreBuilder {
+    store: AstStore,
+}
+
+impl AstStoreBuilder {
+    fn finish(self) -> AstStore {
+        self.store
+    }
+
+    fn lower_file(&mut self, file: &File) -> FileId {
+        let body = self.lower_stmt_seq(&file.body);
+        let id = Idx::new(self.store.files.len());
+        self.store.files.push(FileNode {
+            body,
+            span: file.span,
+        });
+        id
+    }
+
+    fn lower_stmt_seq(&mut self, sequence: &StmtSeq) -> StmtSeqId {
+        let leading_comments = self
+            .store
+            .comment_lists
+            .push_many(sequence.leading_comments.iter().copied());
+        let stmts = sequence
+            .stmts
+            .iter()
+            .map(|stmt| self.lower_stmt(stmt))
+            .collect::<Vec<_>>();
+        let stmts = self.store.stmt_id_lists.push_many(stmts);
+        let trailing_comments = self
+            .store
+            .comment_lists
+            .push_many(sequence.trailing_comments.iter().copied());
+
+        let id = Idx::new(self.store.stmt_seqs.len());
+        self.store.stmt_seqs.push(StmtSeqNode {
+            leading_comments,
+            stmts,
+            trailing_comments,
+            span: sequence.span,
+        });
+        id
+    }
+
+    fn lower_stmt(&mut self, stmt: &Stmt) -> StmtId {
+        let leading_comments = self
+            .store
+            .comment_lists
+            .push_many(stmt.leading_comments.iter().copied());
+        let command = self.lower_command(&stmt.command);
+        for redirect in stmt.redirects.iter() {
+            self.collect_redirect_words(redirect);
+        }
+        let redirects = self
+            .store
+            .redirect_lists
+            .push_many(stmt.redirects.iter().cloned());
+
+        let id = Idx::new(self.store.stmts.len());
+        self.store.stmts.push(StmtNode {
+            leading_comments,
+            command,
+            negated: stmt.negated,
+            redirects,
+            terminator: stmt.terminator,
+            terminator_span: stmt.terminator_span,
+            inline_comment: stmt.inline_comment,
+            span: stmt.span,
+        });
+        id
+    }
+
+    fn lower_command(&mut self, command: &Command) -> CommandId {
+        let mut words = Vec::new();
+        let mut child_sequences = Vec::new();
+        self.collect_command_children(command, &mut words, &mut child_sequences);
+
+        let words = self.store.word_id_lists.push_many(words);
+        let child_sequences = self.store.stmt_seq_id_lists.push_many(child_sequences);
+        let id = Idx::new(self.store.commands.len());
+        self.store.commands.push(CommandNode {
+            kind: command_kind(command),
+            span: command_span(command),
+            words,
+            child_sequences,
+            legacy: command.clone(),
+        });
+        id
+    }
+
+    fn lower_word(&mut self, word: &Word) -> WordId {
+        self.collect_word_part_children(word.parts.as_slice());
+        let parts = self
+            .store
+            .word_part_lists
+            .push_many(word.parts.iter().cloned());
+        let brace_syntax = self
+            .store
+            .brace_syntax_lists
+            .push_many(word.brace_syntax.iter().copied());
+        let id = Idx::new(self.store.words.len());
+        self.store.words.push(WordNode {
+            parts,
+            span: word.span,
+            brace_syntax,
+        });
+        id
+    }
+
+    fn collect_command_children(
+        &mut self,
+        command: &Command,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        match command {
+            Command::Simple(command) => {
+                words.push(self.lower_word(&command.name));
+                words.extend(command.args.iter().map(|word| self.lower_word(word)));
+                self.collect_assignments(command.assignments.iter(), words);
+            }
+            Command::Builtin(command) => self.collect_builtin_children(command, words),
+            Command::Decl(command) => {
+                for operand in &command.operands {
+                    self.collect_decl_operand(operand, words);
+                }
+                self.collect_assignments(command.assignments.iter(), words);
+            }
+            Command::Binary(command) => self.collect_binary_children(command, child_sequences),
+            Command::Compound(command) => {
+                self.collect_compound_children(command, words, child_sequences)
+            }
+            Command::Function(function) => {
+                self.collect_function_children(function, words, child_sequences)
+            }
+            Command::AnonymousFunction(function) => {
+                self.collect_anonymous_function_children(function, words, child_sequences);
+            }
+        }
+    }
+
+    fn collect_builtin_children(&mut self, command: &BuiltinCommand, words: &mut Vec<WordId>) {
+        match command {
+            BuiltinCommand::Break(command) => {
+                words.extend(command.depth.iter().map(|word| self.lower_word(word)));
+                words.extend(command.extra_args.iter().map(|word| self.lower_word(word)));
+                self.collect_assignments(command.assignments.iter(), words);
+            }
+            BuiltinCommand::Continue(command) => {
+                words.extend(command.depth.iter().map(|word| self.lower_word(word)));
+                words.extend(command.extra_args.iter().map(|word| self.lower_word(word)));
+                self.collect_assignments(command.assignments.iter(), words);
+            }
+            BuiltinCommand::Return(command) => {
+                words.extend(command.code.iter().map(|word| self.lower_word(word)));
+                words.extend(command.extra_args.iter().map(|word| self.lower_word(word)));
+                self.collect_assignments(command.assignments.iter(), words);
+            }
+            BuiltinCommand::Exit(command) => {
+                words.extend(command.code.iter().map(|word| self.lower_word(word)));
+                words.extend(command.extra_args.iter().map(|word| self.lower_word(word)));
+                self.collect_assignments(command.assignments.iter(), words);
+            }
+        }
+    }
+
+    fn collect_binary_children(
+        &mut self,
+        command: &BinaryCommand,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+            leading_comments: Vec::new(),
+            stmts: vec![(*command.left).clone()],
+            trailing_comments: Vec::new(),
+            span: command.left.span,
+        }));
+        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+            leading_comments: Vec::new(),
+            stmts: vec![(*command.right).clone()],
+            trailing_comments: Vec::new(),
+            span: command.right.span,
+        }));
+    }
+
+    fn collect_compound_children(
+        &mut self,
+        command: &CompoundCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        match command {
+            CompoundCommand::If(command) => {
+                child_sequences.push(self.lower_stmt_seq(&command.condition));
+                child_sequences.push(self.lower_stmt_seq(&command.then_branch));
+                for (condition, body) in &command.elif_branches {
+                    child_sequences.push(self.lower_stmt_seq(condition));
+                    child_sequences.push(self.lower_stmt_seq(body));
+                }
+                if let Some(else_branch) = &command.else_branch {
+                    child_sequences.push(self.lower_stmt_seq(else_branch));
+                }
+            }
+            CompoundCommand::For(command) => {
+                self.collect_for_children(command, words, child_sequences)
+            }
+            CompoundCommand::Repeat(command) => {
+                self.collect_repeat_children(command, words, child_sequences);
+            }
+            CompoundCommand::Foreach(command) => {
+                words.extend(command.words.iter().map(|word| self.lower_word(word)));
+                child_sequences.push(self.lower_stmt_seq(&command.body));
+            }
+            CompoundCommand::ArithmeticFor(command) => {
+                child_sequences.push(self.lower_stmt_seq(&command.body));
+            }
+            CompoundCommand::While(command) => {
+                self.collect_while_children(command, child_sequences)
+            }
+            CompoundCommand::Until(command) => {
+                self.collect_until_children(command, child_sequences)
+            }
+            CompoundCommand::Case(command) => {
+                self.collect_case_children(command, words, child_sequences)
+            }
+            CompoundCommand::Select(command) => {
+                self.collect_select_children(command, words, child_sequences);
+            }
+            CompoundCommand::Subshell(sequence) | CompoundCommand::BraceGroup(sequence) => {
+                child_sequences.push(self.lower_stmt_seq(sequence));
+            }
+            CompoundCommand::Arithmetic(_) | CompoundCommand::Conditional(_) => {}
+            CompoundCommand::Time(command) => self.collect_time_children(command, child_sequences),
+            CompoundCommand::Coproc(command) => {
+                self.collect_coproc_children(command, child_sequences)
+            }
+            CompoundCommand::Always(command) => {
+                self.collect_always_children(command, child_sequences)
+            }
+        }
+    }
+
+    fn collect_for_children(
+        &mut self,
+        command: &ForCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        words.extend(
+            command
+                .targets
+                .iter()
+                .map(|target| self.lower_word(&target.word)),
+        );
+        if let Some(header_words) = &command.words {
+            words.extend(header_words.iter().map(|word| self.lower_word(word)));
+        }
+        child_sequences.push(self.lower_stmt_seq(&command.body));
+    }
+
+    fn collect_repeat_children(
+        &mut self,
+        command: &RepeatCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        words.push(self.lower_word(&command.count));
+        child_sequences.push(self.lower_stmt_seq(&command.body));
+    }
+
+    fn collect_while_children(
+        &mut self,
+        command: &WhileCommand,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        child_sequences.push(self.lower_stmt_seq(&command.condition));
+        child_sequences.push(self.lower_stmt_seq(&command.body));
+    }
+
+    fn collect_until_children(
+        &mut self,
+        command: &UntilCommand,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        child_sequences.push(self.lower_stmt_seq(&command.condition));
+        child_sequences.push(self.lower_stmt_seq(&command.body));
+    }
+
+    fn collect_case_children(
+        &mut self,
+        command: &CaseCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        words.push(self.lower_word(&command.word));
+        for case in &command.cases {
+            for pattern in &case.patterns {
+                self.collect_pattern_words(pattern, words);
+            }
+            child_sequences.push(self.lower_stmt_seq(&case.body));
+        }
+    }
+
+    fn collect_select_children(
+        &mut self,
+        command: &SelectCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        words.extend(command.words.iter().map(|word| self.lower_word(word)));
+        child_sequences.push(self.lower_stmt_seq(&command.body));
+    }
+
+    fn collect_time_children(
+        &mut self,
+        command: &TimeCommand,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        if let Some(command) = &command.command {
+            child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+                leading_comments: Vec::new(),
+                stmts: vec![(**command).clone()],
+                trailing_comments: Vec::new(),
+                span: command.span,
+            }));
+        }
+    }
+
+    fn collect_coproc_children(
+        &mut self,
+        command: &CoprocCommand,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+            leading_comments: Vec::new(),
+            stmts: vec![(*command.body).clone()],
+            trailing_comments: Vec::new(),
+            span: command.body.span,
+        }));
+    }
+
+    fn collect_always_children(
+        &mut self,
+        command: &AlwaysCommand,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        child_sequences.push(self.lower_stmt_seq(&command.body));
+        child_sequences.push(self.lower_stmt_seq(&command.always_body));
+    }
+
+    fn collect_function_children(
+        &mut self,
+        function: &FunctionDef,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        words.extend(
+            function
+                .header
+                .entries
+                .iter()
+                .map(|entry| self.lower_word(&entry.word)),
+        );
+        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+            leading_comments: Vec::new(),
+            stmts: vec![(*function.body).clone()],
+            trailing_comments: Vec::new(),
+            span: function.body.span,
+        }));
+    }
+
+    fn collect_anonymous_function_children(
+        &mut self,
+        function: &AnonymousFunctionCommand,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) {
+        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
+            leading_comments: Vec::new(),
+            stmts: vec![(*function.body).clone()],
+            trailing_comments: Vec::new(),
+            span: function.body.span,
+        }));
+        words.extend(function.args.iter().map(|word| self.lower_word(word)));
+    }
+
+    fn collect_decl_operand(&mut self, operand: &DeclOperand, words: &mut Vec<WordId>) {
+        match operand {
+            DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
+                words.push(self.lower_word(word));
+            }
+            DeclOperand::Assignment(assignment) => self.collect_assignment(assignment, words),
+            DeclOperand::Name(_) => {}
+        }
+    }
+
+    fn collect_assignments<'a>(
+        &mut self,
+        assignments: impl Iterator<Item = &'a Assignment>,
+        words: &mut Vec<WordId>,
+    ) {
+        for assignment in assignments {
+            self.collect_assignment(assignment, words);
+        }
+    }
+
+    fn collect_assignment(&mut self, assignment: &Assignment, words: &mut Vec<WordId>) {
+        match &assignment.value {
+            AssignmentValue::Scalar(word) => words.push(self.lower_word(word)),
+            AssignmentValue::Compound(array) => {
+                for element in &array.elements {
+                    match element {
+                        crate::ArrayElem::Sequential(value)
+                        | crate::ArrayElem::Keyed { value, .. }
+                        | crate::ArrayElem::KeyedAppend { value, .. } => {
+                            words.push(self.lower_word(&value.word));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_redirect_words(&mut self, redirect: &Redirect) {
+        match &redirect.target {
+            RedirectTarget::Word(word) => {
+                self.lower_word(word);
+            }
+            RedirectTarget::Heredoc(heredoc) => {
+                self.lower_word(&heredoc.delimiter.raw);
+                for part in &heredoc.body.parts {
+                    match &part.kind {
+                        HeredocBodyPart::CommandSubstitution { body, .. } => {
+                            self.lower_stmt_seq(body);
+                        }
+                        HeredocBodyPart::ArithmeticExpansion {
+                            expression_word_ast,
+                            ..
+                        } => {
+                            self.lower_word(expression_word_ast);
+                        }
+                        HeredocBodyPart::Parameter(expansion) => {
+                            self.collect_parameter_expansion_words(expansion);
+                        }
+                        HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
+                    }
+                }
+            }
+        }
+    }
+
+    fn collect_word_part_children(&mut self, parts: &[WordPartNode]) {
+        for part in parts {
+            match &part.kind {
+                WordPart::DoubleQuoted { parts, .. } => self.collect_word_part_children(parts),
+                WordPart::CommandSubstitution { body, .. }
+                | WordPart::ProcessSubstitution { body, .. } => {
+                    self.lower_stmt_seq(body);
+                }
+                WordPart::ArithmeticExpansion {
+                    expression_word_ast,
+                    ..
+                } => {
+                    self.lower_word(expression_word_ast);
+                }
+                WordPart::Parameter(expansion) => self.collect_parameter_expansion_words(expansion),
+                WordPart::ParameterExpansion {
+                    operand_word_ast, ..
+                }
+                | WordPart::IndirectExpansion {
+                    operand_word_ast, ..
+                } => {
+                    if let Some(word) = operand_word_ast {
+                        self.lower_word(word);
+                    }
+                }
+                WordPart::Substring {
+                    offset_word_ast,
+                    length_word_ast,
+                    ..
+                }
+                | WordPart::ArraySlice {
+                    offset_word_ast,
+                    length_word_ast,
+                    ..
+                } => {
+                    self.lower_word(offset_word_ast);
+                    if let Some(word) = length_word_ast {
+                        self.lower_word(word);
+                    }
+                }
+                WordPart::ZshQualifiedGlob(glob) => {
+                    for segment in &glob.segments {
+                        if let crate::ZshGlobSegment::Pattern(pattern) = segment {
+                            self.collect_pattern_words(pattern, &mut Vec::new());
+                        }
+                    }
+                }
+                WordPart::Literal(_)
+                | WordPart::SingleQuoted { .. }
+                | WordPart::Variable(_)
+                | WordPart::Length(_)
+                | WordPart::ArrayAccess(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::ArrayIndices(_)
+                | WordPart::PrefixMatch { .. }
+                | WordPart::Transformation { .. } => {}
+            }
+        }
+    }
+
+    fn collect_parameter_expansion_words(&mut self, expansion: &crate::ParameterExpansion) {
+        match &expansion.syntax {
+            crate::ParameterExpansionSyntax::Bourne(expansion) => match expansion {
+                crate::BourneParameterExpansion::Indirect {
+                    operand_word_ast, ..
+                }
+                | crate::BourneParameterExpansion::Operation {
+                    operand_word_ast, ..
+                } => {
+                    if let Some(word) = operand_word_ast {
+                        self.lower_word(word);
+                    }
+                }
+                crate::BourneParameterExpansion::Slice {
+                    offset_word_ast,
+                    length_word_ast,
+                    ..
+                } => {
+                    self.lower_word(offset_word_ast);
+                    if let Some(word) = length_word_ast {
+                        self.lower_word(word);
+                    }
+                }
+                crate::BourneParameterExpansion::Access { .. }
+                | crate::BourneParameterExpansion::Length { .. }
+                | crate::BourneParameterExpansion::Indices { .. }
+                | crate::BourneParameterExpansion::PrefixMatch { .. }
+                | crate::BourneParameterExpansion::Transformation { .. } => {}
+            },
+            crate::ParameterExpansionSyntax::Zsh(expansion) => {
+                match &expansion.target {
+                    crate::ZshExpansionTarget::Nested(nested) => {
+                        self.collect_parameter_expansion_words(nested);
+                    }
+                    crate::ZshExpansionTarget::Word(word) => {
+                        self.lower_word(word);
+                    }
+                    crate::ZshExpansionTarget::Reference(_) | crate::ZshExpansionTarget::Empty => {}
+                }
+                for modifier in &expansion.modifiers {
+                    if let Some(word) = &modifier.argument_word_ast {
+                        self.lower_word(word);
+                    }
+                }
+                if let Some(operation) = &expansion.operation {
+                    self.collect_zsh_operation_words(operation);
+                }
+            }
+        }
+    }
+
+    fn collect_zsh_operation_words(&mut self, operation: &crate::ZshExpansionOperation) {
+        match operation {
+            crate::ZshExpansionOperation::PatternOperation {
+                operand_word_ast, ..
+            }
+            | crate::ZshExpansionOperation::Defaulting {
+                operand_word_ast, ..
+            }
+            | crate::ZshExpansionOperation::TrimOperation {
+                operand_word_ast, ..
+            } => {
+                self.lower_word(operand_word_ast);
+            }
+            crate::ZshExpansionOperation::ReplacementOperation {
+                pattern_word_ast,
+                replacement_word_ast,
+                ..
+            } => {
+                self.lower_word(pattern_word_ast);
+                if let Some(word) = replacement_word_ast {
+                    self.lower_word(word);
+                }
+            }
+            crate::ZshExpansionOperation::Slice {
+                offset_word_ast,
+                length_word_ast,
+                ..
+            } => {
+                self.lower_word(offset_word_ast);
+                if let Some(word) = length_word_ast {
+                    self.lower_word(word);
+                }
+            }
+            crate::ZshExpansionOperation::Unknown { word_ast, .. } => {
+                self.lower_word(word_ast);
+            }
+        }
+    }
+
+    fn collect_pattern_words(&mut self, pattern: &Pattern, words: &mut Vec<WordId>) {
+        for part in &pattern.parts {
+            match &part.kind {
+                PatternPart::Group { patterns, .. } => {
+                    for pattern in patterns {
+                        self.collect_pattern_words(pattern, words);
+                    }
+                }
+                PatternPart::Word(word) => words.push(self.lower_word(word)),
+                PatternPart::Literal(_)
+                | PatternPart::AnyString
+                | PatternPart::AnyChar
+                | PatternPart::CharClass(_) => {}
+            }
+        }
+    }
+}
+
+fn command_kind(command: &Command) -> ArenaFileCommandKind {
+    match command {
+        Command::Simple(_) => ArenaFileCommandKind::Simple,
+        Command::Builtin(_) => ArenaFileCommandKind::Builtin,
+        Command::Decl(_) => ArenaFileCommandKind::Decl,
+        Command::Binary(_) => ArenaFileCommandKind::Binary,
+        Command::Compound(_) => ArenaFileCommandKind::Compound,
+        Command::Function(_) => ArenaFileCommandKind::Function,
+        Command::AnonymousFunction(_) => ArenaFileCommandKind::AnonymousFunction,
+    }
+}
+
+fn command_span(command: &Command) -> Span {
+    match command {
+        Command::Simple(command) => command.span,
+        Command::Builtin(BuiltinCommand::Break(command)) => command.span,
+        Command::Builtin(BuiltinCommand::Continue(command)) => command.span,
+        Command::Builtin(BuiltinCommand::Return(command)) => command.span,
+        Command::Builtin(BuiltinCommand::Exit(command)) => command.span,
+        Command::Decl(command) => command.span,
+        Command::Binary(command) => command.span,
+        Command::Compound(CompoundCommand::If(command)) => command.span,
+        Command::Compound(CompoundCommand::For(command)) => command.span,
+        Command::Compound(CompoundCommand::Repeat(command)) => command.span,
+        Command::Compound(CompoundCommand::Foreach(command)) => command.span,
+        Command::Compound(CompoundCommand::ArithmeticFor(command)) => command.span,
+        Command::Compound(CompoundCommand::While(command)) => command.span,
+        Command::Compound(CompoundCommand::Until(command)) => command.span,
+        Command::Compound(CompoundCommand::Case(command)) => command.span,
+        Command::Compound(CompoundCommand::Select(command)) => command.span,
+        Command::Compound(CompoundCommand::Subshell(sequence))
+        | Command::Compound(CompoundCommand::BraceGroup(sequence)) => sequence.span,
+        Command::Compound(CompoundCommand::Arithmetic(command)) => command.span,
+        Command::Compound(CompoundCommand::Time(command)) => command.span,
+        Command::Compound(CompoundCommand::Conditional(command)) => command.span,
+        Command::Compound(CompoundCommand::Coproc(command)) => command.span,
+        Command::Compound(CompoundCommand::Always(command)) => command.span,
+        Command::Function(command) => command.span,
+        Command::AnonymousFunction(command) => command.span,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ArenaFile, Command, Span, Stmt, StmtSeq, Word};
+
+    #[test]
+    fn arena_file_round_trips_simple_sequence() {
+        let file = crate::File {
+            body: StmtSeq {
+                leading_comments: Vec::new(),
+                stmts: vec![Stmt {
+                    leading_comments: Vec::new(),
+                    command: Command::Simple(crate::SimpleCommand {
+                        name: Word::literal("echo"),
+                        args: vec![Word::literal("hello")],
+                        assignments: Box::new([]),
+                        span: Span::new(),
+                    }),
+                    negated: false,
+                    redirects: Box::new([]),
+                    terminator: None,
+                    terminator_span: None,
+                    inline_comment: None,
+                    span: Span::new(),
+                }],
+                trailing_comments: Vec::new(),
+                span: Span::new(),
+            },
+            span: Span::new(),
+        };
+
+        let arena = ArenaFile::from_file(&file);
+
+        assert_eq!(arena.store.file_count(), 1);
+        assert_eq!(arena.store.stmt_seq_count(), 1);
+        assert_eq!(arena.store.stmt_count(), 1);
+        assert_eq!(arena.store.command_count(), 1);
+        assert_eq!(arena.view().body().stmt_ids().len(), 1);
+        assert_eq!(arena.view().body().stmts().len(), 1);
+
+        let materialized = arena.to_file();
+        assert_eq!(materialized.body.len(), 1);
+        let Command::Simple(command) = &materialized.body[0].command else {
+            panic!("expected simple command");
+        };
+        assert_eq!(command.args.len(), 1);
+    }
+}

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     AnonymousFunctionCommand, ArithmeticCommand, ArithmeticExpr, ArithmeticExprNode,
     ArithmeticForCommand, ArithmeticLvalue, Assignment, AssignmentValue, BinaryCommand,
@@ -2451,6 +2453,11 @@ pub struct CommandView<'a> {
 }
 
 impl<'a> CommandView<'a> {
+    /// Returns the arena store that owns this command.
+    pub fn store(self) -> &'a AstStore {
+        self.store
+    }
+
     /// Returns this node's ID.
     pub fn id(self) -> CommandId {
         self.id
@@ -2726,6 +2733,11 @@ pub struct DeclCommandView<'a> {
 }
 
 impl<'a> DeclCommandView<'a> {
+    /// Returns the arena store that owns this command.
+    pub fn store(self) -> &'a AstStore {
+        self.store
+    }
+
     /// Returns the declaration builtin variant.
     pub fn variant(self) -> &'a crate::Name {
         &self.node().variant
@@ -2820,6 +2832,11 @@ pub struct FunctionCommandView<'a> {
 }
 
 impl<'a> FunctionCommandView<'a> {
+    /// Returns the arena store that owns this command.
+    pub fn store(self) -> &'a AstStore {
+        self.store
+    }
+
     /// Returns the source span of the `function` keyword when present.
     pub fn function_keyword_span(self) -> Option<Span> {
         self.node().function_keyword_span
@@ -2870,6 +2887,11 @@ pub struct AnonymousFunctionCommandView<'a> {
 }
 
 impl<'a> AnonymousFunctionCommandView<'a> {
+    /// Returns the arena store that owns this command.
+    pub fn store(self) -> &'a AstStore {
+        self.store
+    }
+
     /// Returns the preserved anonymous function surface.
     pub fn surface(self) -> crate::AnonymousFunctionSurface {
         self.node().surface
@@ -2921,6 +2943,11 @@ pub struct CompoundCommandView<'a> {
 }
 
 impl<'a> CompoundCommandView<'a> {
+    /// Returns the arena store that owns this command.
+    pub fn store(self) -> &'a AstStore {
+        self.store
+    }
+
     /// Returns the compound command payload.
     pub fn node(self) -> &'a CompoundCommandNode {
         match &self.store.commands[self.id.index()].payload {
@@ -2972,6 +2999,88 @@ impl<'a> WordView<'a> {
 
     fn node(self) -> &'a WordNode {
         &self.store.words[self.id.index()]
+    }
+}
+
+/// Returns static shell text for an arena-backed word when it contains only
+/// literal and quote-removable parts.
+pub fn static_word_text_arena<'a>(word: WordView<'_>, source: &'a str) -> Option<Cow<'a, str>> {
+    try_static_word_parts_text_arena(word.parts(), word.store(), source)
+}
+
+fn try_static_word_parts_text_arena<'a>(
+    parts: &[WordPartArenaNode],
+    store: &AstStore,
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    if parts.is_empty() {
+        return Some(Cow::Borrowed(""));
+    }
+    let mut owned = None::<String>;
+    for part in parts {
+        let text = match &part.kind {
+            WordPartArena::Literal(text) => text.as_str(source, part.span),
+            WordPartArena::SingleQuoted { value, .. } => value.slice(source),
+            WordPartArena::DoubleQuoted { parts, .. } => {
+                let text =
+                    try_static_word_parts_text_arena(store.word_parts(*parts), store, source)?;
+                owned.get_or_insert_with(String::new).push_str(&text);
+                continue;
+            }
+            _ => return None,
+        };
+        owned.get_or_insert_with(String::new).push_str(text);
+    }
+    owned.map(Cow::Owned)
+}
+
+/// Returns static command-name text for an arena-backed word, decoding
+/// backslash-escaped literal command names.
+pub fn static_command_name_text_arena<'a>(
+    word: WordView<'_>,
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    try_static_command_name_parts_text_arena(word.parts(), source)
+}
+
+fn try_static_command_name_parts_text_arena<'a>(
+    parts: &[WordPartArenaNode],
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    if parts.is_empty() {
+        return Some(Cow::Borrowed(""));
+    }
+    let mut result = String::new();
+    for part in parts {
+        match &part.kind {
+            WordPartArena::Literal(text) => {
+                append_decoded_static_command_literal_arena(
+                    text.as_str(source, part.span),
+                    &mut result,
+                );
+            }
+            WordPartArena::SingleQuoted { value, .. } => result.push_str(value.slice(source)),
+            WordPartArena::DoubleQuoted { .. } => return None,
+            _ => return None,
+        }
+    }
+    Some(Cow::Owned(result))
+}
+
+fn append_decoded_static_command_literal_arena(text: &str, out: &mut String) {
+    let mut chars = text.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            out.push(ch);
+            continue;
+        }
+        let Some(next) = chars.next() else {
+            out.push('\\');
+            return;
+        };
+        if next != '\n' {
+            out.push(next);
+        }
     }
 }
 

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -72,6 +72,7 @@ pub struct AstStore {
     stmt_seq_id_lists: ListArena<StmtSeqId>,
     comment_lists: ListArena<Comment>,
     redirect_lists: ListArena<Redirect>,
+    assignment_lists: ListArena<Assignment>,
     word_id_lists: ListArena<WordId>,
     word_part_lists: ListArena<WordPartNode>,
     brace_syntax_lists: ListArena<crate::BraceSyntax>,
@@ -89,6 +90,7 @@ impl Default for AstStore {
             stmt_seq_id_lists: ListArena::new(),
             comment_lists: ListArena::new(),
             redirect_lists: ListArena::new(),
+            assignment_lists: ListArena::new(),
             word_id_lists: ListArena::new(),
             word_part_lists: ListArena::new(),
             brace_syntax_lists: ListArena::new(),
@@ -175,7 +177,7 @@ impl AstStore {
         let node = &self.stmts[id.index()];
         Stmt {
             leading_comments: self.comment_lists.get(node.leading_comments).to_vec(),
-            command: self.commands[node.command.index()].legacy.clone(),
+            command: self.materialize_command(node.command),
             negated: node.negated,
             redirects: self
                 .redirect_lists
@@ -186,6 +188,84 @@ impl AstStore {
             terminator_span: node.terminator_span,
             inline_comment: node.inline_comment,
             span: node.span,
+        }
+    }
+
+    fn materialize_command(&self, id: CommandId) -> Command {
+        let node = &self.commands[id.index()];
+        match &node.payload {
+            CommandNodePayload::Simple(command) => Command::Simple(crate::SimpleCommand {
+                name: self.materialize_word(command.name),
+                args: self
+                    .word_id_lists
+                    .get(command.args)
+                    .iter()
+                    .copied()
+                    .map(|id| self.materialize_word(id))
+                    .collect(),
+                assignments: self
+                    .assignment_lists
+                    .get(command.assignments)
+                    .to_vec()
+                    .into_boxed_slice(),
+                span: node.span,
+            }),
+            CommandNodePayload::Builtin(command) => {
+                let primary = command.primary.map(|id| self.materialize_word(id));
+                let extra_args = self
+                    .word_id_lists
+                    .get(command.extra_args)
+                    .iter()
+                    .copied()
+                    .map(|id| self.materialize_word(id))
+                    .collect();
+                let assignments = self
+                    .assignment_lists
+                    .get(command.assignments)
+                    .to_vec()
+                    .into_boxed_slice();
+                let command = match command.kind {
+                    BuiltinCommandNodeKind::Break => BuiltinCommand::Break(crate::BreakCommand {
+                        depth: primary,
+                        extra_args,
+                        assignments,
+                        span: node.span,
+                    }),
+                    BuiltinCommandNodeKind::Continue => {
+                        BuiltinCommand::Continue(crate::ContinueCommand {
+                            depth: primary,
+                            extra_args,
+                            assignments,
+                            span: node.span,
+                        })
+                    }
+                    BuiltinCommandNodeKind::Return => {
+                        BuiltinCommand::Return(crate::ReturnCommand {
+                            code: primary,
+                            extra_args,
+                            assignments,
+                            span: node.span,
+                        })
+                    }
+                    BuiltinCommandNodeKind::Exit => BuiltinCommand::Exit(crate::ExitCommand {
+                        code: primary,
+                        extra_args,
+                        assignments,
+                        span: node.span,
+                    }),
+                };
+                Command::Builtin(command)
+            }
+            CommandNodePayload::Legacy => node.legacy.clone(),
+        }
+    }
+
+    fn materialize_word(&self, id: WordId) -> Word {
+        let node = &self.words[id.index()];
+        Word {
+            parts: self.word_part_lists.get(node.parts).to_vec(),
+            span: node.span,
+            brace_syntax: self.brace_syntax_lists.get(node.brace_syntax).to_vec(),
         }
     }
 }
@@ -248,7 +328,57 @@ pub struct CommandNode {
     pub words: IdRange<WordId>,
     /// Nested statement sequences found under this command.
     pub child_sequences: IdRange<StmtSeqId>,
+    /// Native arena payload for command families that have been migrated.
+    pub payload: CommandNodePayload,
     legacy: Command,
+}
+
+/// Arena-native command payloads.
+#[derive(Debug, Clone)]
+pub enum CommandNodePayload {
+    /// Simple command payload.
+    Simple(SimpleCommandNode),
+    /// Typed builtin command payload.
+    Builtin(BuiltinCommandNode),
+    /// Compatibility payload for command families that still materialize from `legacy`.
+    Legacy,
+}
+
+/// Arena-native simple command payload.
+#[derive(Debug, Clone)]
+pub struct SimpleCommandNode {
+    /// Command name word.
+    pub name: WordId,
+    /// Command argument words.
+    pub args: IdRange<WordId>,
+    /// Prefix assignments.
+    pub assignments: IdRange<Assignment>,
+}
+
+/// Arena-native typed builtin command payload.
+#[derive(Debug, Clone)]
+pub struct BuiltinCommandNode {
+    /// Builtin command kind.
+    pub kind: BuiltinCommandNodeKind,
+    /// Optional primary operand (`depth` or `code` depending on the builtin).
+    pub primary: Option<WordId>,
+    /// Additional operands preserved for fidelity.
+    pub extra_args: IdRange<WordId>,
+    /// Prefix assignments.
+    pub assignments: IdRange<Assignment>,
+}
+
+/// Arena-native typed builtin command kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BuiltinCommandNodeKind {
+    /// `break [N]`.
+    Break,
+    /// `continue [N]`.
+    Continue,
+    /// `return [N]`.
+    Return,
+    /// `exit [N]`.
+    Exit,
 }
 
 /// Coarse command family stored with command arena nodes.
@@ -452,6 +582,28 @@ impl<'a> CommandView<'a> {
             .map(move |id| self.store.word(id))
     }
 
+    /// Returns the native simple command payload when this command is simple.
+    pub fn simple(self) -> Option<SimpleCommandView<'a>> {
+        match &self.node().payload {
+            CommandNodePayload::Simple(_) => Some(SimpleCommandView {
+                store: self.store,
+                id: self.id,
+            }),
+            CommandNodePayload::Builtin(_) | CommandNodePayload::Legacy => None,
+        }
+    }
+
+    /// Returns the native typed builtin payload when this command is a typed builtin.
+    pub fn builtin(self) -> Option<BuiltinCommandView<'a>> {
+        match &self.node().payload {
+            CommandNodePayload::Builtin(_) => Some(BuiltinCommandView {
+                store: self.store,
+                id: self.id,
+            }),
+            CommandNodePayload::Simple(_) | CommandNodePayload::Legacy => None,
+        }
+    }
+
     /// Returns IDs for nested statement sequences found under this command.
     pub fn child_sequence_ids(self) -> &'a [StmtSeqId] {
         self.store
@@ -466,6 +618,103 @@ impl<'a> CommandView<'a> {
 
     fn node(self) -> &'a CommandNode {
         &self.store.commands[self.id.index()]
+    }
+}
+
+/// Borrowed view of an arena-native simple command payload.
+#[derive(Debug, Clone, Copy)]
+pub struct SimpleCommandView<'a> {
+    store: &'a AstStore,
+    id: CommandId,
+}
+
+impl<'a> SimpleCommandView<'a> {
+    /// Returns the command name word.
+    pub fn name(self) -> WordView<'a> {
+        self.store.word(self.node().name)
+    }
+
+    /// Returns the command name word ID.
+    pub fn name_id(self) -> WordId {
+        self.node().name
+    }
+
+    /// Returns command argument word IDs.
+    pub fn arg_ids(self) -> &'a [WordId] {
+        self.store.word_id_lists.get(self.node().args)
+    }
+
+    /// Returns command argument words.
+    pub fn args(self) -> impl ExactSizeIterator<Item = WordView<'a>> + 'a {
+        self.arg_ids()
+            .iter()
+            .copied()
+            .map(move |id| self.store.word(id))
+    }
+
+    /// Returns prefix assignments.
+    pub fn assignments(self) -> &'a [Assignment] {
+        self.store.assignment_lists.get(self.node().assignments)
+    }
+
+    fn node(self) -> &'a SimpleCommandNode {
+        match &self.store.commands[self.id.index()].payload {
+            CommandNodePayload::Simple(command) => command,
+            CommandNodePayload::Builtin(_) | CommandNodePayload::Legacy => {
+                unreachable!("simple view requires simple payload")
+            }
+        }
+    }
+}
+
+/// Borrowed view of an arena-native typed builtin payload.
+#[derive(Debug, Clone, Copy)]
+pub struct BuiltinCommandView<'a> {
+    store: &'a AstStore,
+    id: CommandId,
+}
+
+impl<'a> BuiltinCommandView<'a> {
+    /// Returns the builtin command kind.
+    pub fn kind(self) -> BuiltinCommandNodeKind {
+        self.node().kind
+    }
+
+    /// Returns the primary operand word, if present.
+    pub fn primary(self) -> Option<WordView<'a>> {
+        self.node().primary.map(|id| self.store.word(id))
+    }
+
+    /// Returns the primary operand word ID, if present.
+    pub fn primary_id(self) -> Option<WordId> {
+        self.node().primary
+    }
+
+    /// Returns additional operand word IDs.
+    pub fn extra_arg_ids(self) -> &'a [WordId] {
+        self.store.word_id_lists.get(self.node().extra_args)
+    }
+
+    /// Returns additional operand words.
+    pub fn extra_args(self) -> impl ExactSizeIterator<Item = WordView<'a>> + 'a {
+        self.extra_arg_ids()
+            .iter()
+            .copied()
+            .map(move |id| self.store.word(id))
+    }
+
+    /// Returns prefix assignments.
+    pub fn assignments(self) -> &'a [Assignment] {
+        self.store.assignment_lists.get(self.node().assignments)
+    }
+
+    fn node(self) -> &'a BuiltinCommandNode {
+        match &self.store.commands[self.id.index()].payload {
+            CommandNodePayload::Builtin(command) => command,
+            CommandNodePayload::Simple(_) | CommandNodePayload::Legacy => {
+                unreachable!("builtin view requires builtin payload")
+            }
+        }
     }
 }
 
@@ -663,7 +912,7 @@ impl AstStoreBuilder {
     fn lower_command(&mut self, command: &Command) -> CommandId {
         let mut words = Vec::new();
         let mut child_sequences = Vec::new();
-        self.collect_command_children(command, &mut words, &mut child_sequences);
+        let payload = self.collect_command_children(command, &mut words, &mut child_sequences);
 
         let words = self.store.word_id_lists.push_many(words);
         let child_sequences = self.store.stmt_seq_id_lists.push_many(child_sequences);
@@ -673,6 +922,7 @@ impl AstStoreBuilder {
             span: command_span(command),
             words,
             child_sequences,
+            payload,
             legacy: command.clone(),
         });
         id
@@ -681,7 +931,7 @@ impl AstStoreBuilder {
     fn lower_command_owned(&mut self, command: Command) -> CommandId {
         let mut words = Vec::new();
         let mut child_sequences = Vec::new();
-        self.collect_command_children(&command, &mut words, &mut child_sequences);
+        let payload = self.collect_command_children(&command, &mut words, &mut child_sequences);
 
         let words = self.store.word_id_lists.push_many(words);
         let child_sequences = self.store.stmt_seq_id_lists.push_many(child_sequences);
@@ -691,6 +941,7 @@ impl AstStoreBuilder {
             span: command_span(&command),
             words,
             child_sequences,
+            payload,
             legacy: command,
         });
         id
@@ -724,19 +975,43 @@ impl AstStoreBuilder {
         words.push(self.lower_word(word));
     }
 
+    fn collect_word_id(
+        &mut self,
+        word: &Word,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> WordId {
+        self.collect_word_part_children(word.parts.as_slice(), words, child_sequences);
+        let id = self.lower_word(word);
+        words.push(id);
+        id
+    }
+
     fn collect_command_children(
         &mut self,
         command: &Command,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
+    ) -> CommandNodePayload {
         match command {
             Command::Simple(command) => {
-                self.collect_word(&command.name, words, child_sequences);
-                for word in &command.args {
-                    self.collect_word(word, words, child_sequences);
-                }
+                let name = self.collect_word_id(&command.name, words, child_sequences);
+                let args = command
+                    .args
+                    .iter()
+                    .map(|word| self.collect_word_id(word, words, child_sequences))
+                    .collect::<Vec<_>>();
+                let args = self.store.word_id_lists.push_many(args);
                 self.collect_assignments(command.assignments.iter(), words, child_sequences);
+                let assignments = self
+                    .store
+                    .assignment_lists
+                    .push_many(command.assignments.iter().cloned());
+                CommandNodePayload::Simple(SimpleCommandNode {
+                    name,
+                    args,
+                    assignments,
+                })
             }
             Command::Builtin(command) => {
                 self.collect_builtin_children(command, words, child_sequences)
@@ -746,16 +1021,23 @@ impl AstStoreBuilder {
                     self.collect_decl_operand(operand, words, child_sequences);
                 }
                 self.collect_assignments(command.assignments.iter(), words, child_sequences);
+                CommandNodePayload::Legacy
             }
-            Command::Binary(command) => self.collect_binary_children(command, child_sequences),
+            Command::Binary(command) => {
+                self.collect_binary_children(command, child_sequences);
+                CommandNodePayload::Legacy
+            }
             Command::Compound(command) => {
-                self.collect_compound_children(command, words, child_sequences)
+                self.collect_compound_children(command, words, child_sequences);
+                CommandNodePayload::Legacy
             }
             Command::Function(function) => {
-                self.collect_function_children(function, words, child_sequences)
+                self.collect_function_children(function, words, child_sequences);
+                CommandNodePayload::Legacy
             }
             Command::AnonymousFunction(function) => {
                 self.collect_anonymous_function_children(function, words, child_sequences);
+                CommandNodePayload::Legacy
             }
         }
     }
@@ -765,33 +1047,66 @@ impl AstStoreBuilder {
         command: &BuiltinCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
+    ) -> CommandNodePayload {
         match command {
-            BuiltinCommand::Break(command) => {
-                for word in command.depth.iter().chain(command.extra_args.iter()) {
-                    self.collect_word(word, words, child_sequences);
-                }
-                self.collect_assignments(command.assignments.iter(), words, child_sequences);
-            }
-            BuiltinCommand::Continue(command) => {
-                for word in command.depth.iter().chain(command.extra_args.iter()) {
-                    self.collect_word(word, words, child_sequences);
-                }
-                self.collect_assignments(command.assignments.iter(), words, child_sequences);
-            }
-            BuiltinCommand::Return(command) => {
-                for word in command.code.iter().chain(command.extra_args.iter()) {
-                    self.collect_word(word, words, child_sequences);
-                }
-                self.collect_assignments(command.assignments.iter(), words, child_sequences);
-            }
-            BuiltinCommand::Exit(command) => {
-                for word in command.code.iter().chain(command.extra_args.iter()) {
-                    self.collect_word(word, words, child_sequences);
-                }
-                self.collect_assignments(command.assignments.iter(), words, child_sequences);
-            }
+            BuiltinCommand::Break(command) => self.collect_builtin_payload(
+                BuiltinCommandNodeKind::Break,
+                command.depth.as_ref(),
+                &command.extra_args,
+                command.assignments.iter(),
+                words,
+                child_sequences,
+            ),
+            BuiltinCommand::Continue(command) => self.collect_builtin_payload(
+                BuiltinCommandNodeKind::Continue,
+                command.depth.as_ref(),
+                &command.extra_args,
+                command.assignments.iter(),
+                words,
+                child_sequences,
+            ),
+            BuiltinCommand::Return(command) => self.collect_builtin_payload(
+                BuiltinCommandNodeKind::Return,
+                command.code.as_ref(),
+                &command.extra_args,
+                command.assignments.iter(),
+                words,
+                child_sequences,
+            ),
+            BuiltinCommand::Exit(command) => self.collect_builtin_payload(
+                BuiltinCommandNodeKind::Exit,
+                command.code.as_ref(),
+                &command.extra_args,
+                command.assignments.iter(),
+                words,
+                child_sequences,
+            ),
         }
+    }
+
+    fn collect_builtin_payload<'a>(
+        &mut self,
+        kind: BuiltinCommandNodeKind,
+        primary: Option<&Word>,
+        extra_args: &[Word],
+        assignments: impl Iterator<Item = &'a Assignment> + Clone,
+        words: &mut Vec<WordId>,
+        child_sequences: &mut Vec<StmtSeqId>,
+    ) -> CommandNodePayload {
+        let primary = primary.map(|word| self.collect_word_id(word, words, child_sequences));
+        let extra_args = extra_args
+            .iter()
+            .map(|word| self.collect_word_id(word, words, child_sequences))
+            .collect::<Vec<_>>();
+        let extra_args = self.store.word_id_lists.push_many(extra_args);
+        self.collect_assignments(assignments.clone(), words, child_sequences);
+        let assignments = self.store.assignment_lists.push_many(assignments.cloned());
+        CommandNodePayload::Builtin(BuiltinCommandNode {
+            kind,
+            primary,
+            extra_args,
+            assignments,
+        })
     }
 
     fn collect_binary_children(
@@ -1558,14 +1873,14 @@ fn command_span(command: &Command) -> Span {
 mod tests {
     use crate::{
         ArenaFile, ArithmeticCommand, ArithmeticExpr, ArithmeticExprNode, ArrayElem, ArrayExpr,
-        ArrayKind, ArrayValueWord, Assignment, AssignmentValue, BourneParameterExpansion, Command,
-        CommandSubstitutionSyntax, CompoundCommand, ConditionalCommand, ConditionalExpr,
-        DeclClause, DeclOperand, Heredoc, HeredocBody, HeredocBodyMode, HeredocBodyPart,
-        HeredocBodyPartNode, HeredocDelimiter, Name, ParameterExpansion, ParameterExpansionSyntax,
-        Pattern, PatternPart, PatternPartNode, Redirect, RedirectKind, RedirectTarget,
-        SimpleCommand, Span, Stmt, StmtSeq, Subscript, SubscriptInterpretation, SubscriptKind,
-        Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment, ZshParameterExpansion,
-        ZshQualifiedGlob,
+        ArrayKind, ArrayValueWord, Assignment, AssignmentValue, BourneParameterExpansion,
+        BuiltinCommand, BuiltinCommandNodeKind, Command, CommandSubstitutionSyntax,
+        CompoundCommand, ConditionalCommand, ConditionalExpr, DeclClause, DeclOperand, Heredoc,
+        HeredocBody, HeredocBodyMode, HeredocBodyPart, HeredocBodyPartNode, HeredocDelimiter, Name,
+        ParameterExpansion, ParameterExpansionSyntax, Pattern, PatternPart, PatternPartNode,
+        Redirect, RedirectKind, RedirectTarget, SimpleCommand, Span, Stmt, StmtSeq, Subscript,
+        SubscriptInterpretation, SubscriptKind, Word, WordPart, WordPartNode, ZshExpansionTarget,
+        ZshGlobSegment, ZshParameterExpansion, ZshQualifiedGlob,
     };
 
     #[test]
@@ -1642,6 +1957,83 @@ mod tests {
 
         assert_eq!(command.child_sequence_ids().len(), 1);
         assert!(command.word_ids().len() >= 2);
+    }
+
+    #[test]
+    fn simple_command_payload_is_arena_native() {
+        let file = file_with_command(Command::Simple(SimpleCommand {
+            name: Word::literal("printf"),
+            args: vec![Word::literal("%s"), Word::literal("value")],
+            assignments: Box::new([Assignment {
+                target: crate::VarRef {
+                    name: Name::new("LC_ALL"),
+                    name_span: Span::new(),
+                    subscript: None,
+                    span: Span::new(),
+                },
+                value: AssignmentValue::Scalar(Word::literal("C")),
+                append: false,
+                span: Span::new(),
+            }]),
+            span: Span::new(),
+        }));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+        let simple = command.simple().expect("expected native simple payload");
+
+        assert_eq!(simple.name().parts().len(), 1);
+        assert_eq!(simple.arg_ids().len(), 2);
+        assert_eq!(simple.args().len(), 2);
+        assert_eq!(simple.assignments().len(), 1);
+
+        let materialized = arena.to_file();
+        let Command::Simple(command) = &materialized.body[0].command else {
+            panic!("expected simple command");
+        };
+        assert_eq!(command.args.len(), 2);
+        assert_eq!(command.assignments.len(), 1);
+    }
+
+    #[test]
+    fn builtin_command_payload_is_arena_native() {
+        let file = file_with_command(Command::Builtin(BuiltinCommand::Return(
+            crate::ReturnCommand {
+                code: Some(Word::literal("7")),
+                extra_args: vec![Word::literal("extra")],
+                assignments: Box::new([Assignment {
+                    target: crate::VarRef {
+                        name: Name::new("status"),
+                        name_span: Span::new(),
+                        subscript: None,
+                        span: Span::new(),
+                    },
+                    value: AssignmentValue::Scalar(Word::literal("set")),
+                    append: false,
+                    span: Span::new(),
+                }]),
+                span: Span::new(),
+            },
+        )));
+
+        let arena = ArenaFile::from_file(&file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+        let builtin = command.builtin().expect("expected native builtin payload");
+
+        assert_eq!(builtin.kind(), BuiltinCommandNodeKind::Return);
+        assert!(builtin.primary().is_some());
+        assert_eq!(builtin.extra_arg_ids().len(), 1);
+        assert_eq!(builtin.extra_args().len(), 1);
+        assert_eq!(builtin.assignments().len(), 1);
+
+        let materialized = arena.to_file();
+        let Command::Builtin(BuiltinCommand::Return(command)) = &materialized.body[0].command
+        else {
+            panic!("expected return command");
+        };
+        assert!(command.code.is_some());
+        assert_eq!(command.extra_args.len(), 1);
+        assert_eq!(command.assignments.len(), 1);
     }
 
     #[test]

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -1,11 +1,10 @@
 use crate::{
-    AlwaysCommand, AnonymousFunctionCommand, ArithmeticCommand, ArithmeticExpr, ArithmeticExprNode,
+    AnonymousFunctionCommand, ArithmeticCommand, ArithmeticExpr, ArithmeticExprNode,
     ArithmeticForCommand, ArithmeticLvalue, Assignment, AssignmentValue, BinaryCommand,
     BuiltinCommand, CaseCommand, Command, Comment, CompoundCommand, ConditionalCommand,
-    ConditionalExpr, CoprocCommand, DeclOperand, File, ForCommand, FunctionDef, HeredocBodyPart,
-    IdRange, Idx, ListArena, Pattern, PatternPart, Redirect, RedirectTarget, RepeatCommand,
-    SelectCommand, Span, Stmt, StmtSeq, StmtTerminator, Subscript, TimeCommand, UntilCommand,
-    WhileCommand, Word, WordPart, WordPartNode,
+    ConditionalExpr, DeclOperand, File, ForCommand, FunctionDef, HeredocBodyPart, IdRange, Idx,
+    ListArena, Pattern, PatternPart, Redirect, RedirectTarget, RepeatCommand, SelectCommand, Span,
+    Stmt, StmtSeq, StmtTerminator, Subscript, Word, WordPart, WordPartNode,
 };
 
 /// Stable typed identifier for a parsed file node inside an [`AstStore`].
@@ -75,6 +74,10 @@ pub struct AstStore {
     assignment_lists: ListArena<Assignment>,
     decl_operand_lists: ListArena<DeclOperand>,
     function_header_entry_lists: ListArena<FunctionHeaderEntryNode>,
+    elif_branch_lists: ListArena<ElifBranchNode>,
+    for_target_lists: ListArena<ForTargetNode>,
+    case_item_lists: ListArena<CaseItemNode>,
+    pattern_lists: ListArena<Pattern>,
     word_id_lists: ListArena<WordId>,
     word_part_lists: ListArena<WordPartNode>,
     brace_syntax_lists: ListArena<crate::BraceSyntax>,
@@ -95,6 +98,10 @@ impl Default for AstStore {
             assignment_lists: ListArena::new(),
             decl_operand_lists: ListArena::new(),
             function_header_entry_lists: ListArena::new(),
+            elif_branch_lists: ListArena::new(),
+            for_target_lists: ListArena::new(),
+            case_item_lists: ListArena::new(),
+            pattern_lists: ListArena::new(),
             word_id_lists: ListArena::new(),
             word_part_lists: ListArena::new(),
             brace_syntax_lists: ListArena::new(),
@@ -329,8 +336,223 @@ impl AstStore {
                     span: node.span,
                 })
             }
+            CommandNodePayload::Compound(command) => {
+                Command::Compound(self.materialize_compound_command(command, node.span))
+            }
             CommandNodePayload::Legacy => node.legacy.clone(),
         }
+    }
+
+    fn materialize_compound_command(
+        &self,
+        command: &CompoundCommandNode,
+        span: Span,
+    ) -> CompoundCommand {
+        match command {
+            CompoundCommandNode::If {
+                condition,
+                then_branch,
+                elif_branches,
+                else_branch,
+                syntax,
+            } => CompoundCommand::If(crate::IfCommand {
+                condition: self.materialize_stmt_seq(*condition),
+                then_branch: self.materialize_stmt_seq(*then_branch),
+                elif_branches: self
+                    .elif_branch_lists
+                    .get(*elif_branches)
+                    .iter()
+                    .map(|branch| {
+                        (
+                            self.materialize_stmt_seq(branch.condition),
+                            self.materialize_stmt_seq(branch.body),
+                        )
+                    })
+                    .collect(),
+                else_branch: else_branch.map(|id| self.materialize_stmt_seq(id)),
+                syntax: *syntax,
+                span,
+            }),
+            CompoundCommandNode::For {
+                targets,
+                words,
+                body,
+                syntax,
+            } => CompoundCommand::For(crate::ForCommand {
+                targets: self
+                    .for_target_lists
+                    .get(*targets)
+                    .iter()
+                    .map(|target| crate::ForTarget {
+                        word: self.materialize_word(target.word),
+                        name: target.name.clone(),
+                        span: target.span,
+                    })
+                    .collect(),
+                words: words.map(|range| {
+                    self.word_id_lists
+                        .get(range)
+                        .iter()
+                        .copied()
+                        .map(|id| self.materialize_word(id))
+                        .collect()
+                }),
+                body: self.materialize_stmt_seq(*body),
+                syntax: *syntax,
+                span,
+            }),
+            CompoundCommandNode::Repeat {
+                count,
+                body,
+                syntax,
+            } => CompoundCommand::Repeat(crate::RepeatCommand {
+                count: self.materialize_word(*count),
+                body: self.materialize_stmt_seq(*body),
+                syntax: *syntax,
+                span,
+            }),
+            CompoundCommandNode::Foreach {
+                variable,
+                variable_span,
+                words,
+                body,
+                syntax,
+            } => CompoundCommand::Foreach(crate::ForeachCommand {
+                variable: variable.clone(),
+                variable_span: *variable_span,
+                words: self
+                    .word_id_lists
+                    .get(*words)
+                    .iter()
+                    .copied()
+                    .map(|id| self.materialize_word(id))
+                    .collect(),
+                body: self.materialize_stmt_seq(*body),
+                syntax: *syntax,
+                span,
+            }),
+            CompoundCommandNode::ArithmeticFor(command) => {
+                CompoundCommand::ArithmeticFor(Box::new(crate::ArithmeticForCommand {
+                    left_paren_span: command.left_paren_span,
+                    init_span: command.init_span,
+                    init_ast: command.init_ast.clone(),
+                    first_semicolon_span: command.first_semicolon_span,
+                    condition_span: command.condition_span,
+                    condition_ast: command.condition_ast.clone(),
+                    second_semicolon_span: command.second_semicolon_span,
+                    step_span: command.step_span,
+                    step_ast: command.step_ast.clone(),
+                    right_paren_span: command.right_paren_span,
+                    body: self.materialize_stmt_seq(command.body),
+                    span,
+                }))
+            }
+            CompoundCommandNode::While { condition, body } => {
+                CompoundCommand::While(crate::WhileCommand {
+                    condition: self.materialize_stmt_seq(*condition),
+                    body: self.materialize_stmt_seq(*body),
+                    span,
+                })
+            }
+            CompoundCommandNode::Until { condition, body } => {
+                CompoundCommand::Until(crate::UntilCommand {
+                    condition: self.materialize_stmt_seq(*condition),
+                    body: self.materialize_stmt_seq(*body),
+                    span,
+                })
+            }
+            CompoundCommandNode::Case { word, cases } => {
+                CompoundCommand::Case(crate::CaseCommand {
+                    word: self.materialize_word(*word),
+                    cases: self
+                        .case_item_lists
+                        .get(*cases)
+                        .iter()
+                        .map(|case| crate::CaseItem {
+                            patterns: self.pattern_lists.get(case.patterns).to_vec(),
+                            body: self.materialize_stmt_seq(case.body),
+                            terminator: case.terminator,
+                            terminator_span: case.terminator_span,
+                        })
+                        .collect(),
+                    span,
+                })
+            }
+            CompoundCommandNode::Select {
+                variable,
+                variable_span,
+                words,
+                body,
+            } => CompoundCommand::Select(crate::SelectCommand {
+                variable: variable.clone(),
+                variable_span: *variable_span,
+                words: self
+                    .word_id_lists
+                    .get(*words)
+                    .iter()
+                    .copied()
+                    .map(|id| self.materialize_word(id))
+                    .collect(),
+                body: self.materialize_stmt_seq(*body),
+                span,
+            }),
+            CompoundCommandNode::Subshell(body) => {
+                CompoundCommand::Subshell(self.materialize_stmt_seq(*body))
+            }
+            CompoundCommandNode::BraceGroup(body) => {
+                CompoundCommand::BraceGroup(self.materialize_stmt_seq(*body))
+            }
+            CompoundCommandNode::Arithmetic(command) => {
+                CompoundCommand::Arithmetic(crate::ArithmeticCommand {
+                    span,
+                    left_paren_span: command.left_paren_span,
+                    expr_span: command.expr_span,
+                    expr_ast: command.expr_ast.clone(),
+                    right_paren_span: command.right_paren_span,
+                })
+            }
+            CompoundCommandNode::Time {
+                posix_format,
+                command,
+            } => CompoundCommand::Time(crate::TimeCommand {
+                posix_format: *posix_format,
+                command: command.map(|id| Box::new(self.materialize_single_stmt(id))),
+                span,
+            }),
+            CompoundCommandNode::Conditional(command) => {
+                CompoundCommand::Conditional(crate::ConditionalCommand {
+                    expression: command.expression.clone(),
+                    span,
+                    left_bracket_span: command.left_bracket_span,
+                    right_bracket_span: command.right_bracket_span,
+                })
+            }
+            CompoundCommandNode::Coproc {
+                name,
+                name_span,
+                body,
+            } => CompoundCommand::Coproc(crate::CoprocCommand {
+                name: name.clone(),
+                name_span: *name_span,
+                body: Box::new(self.materialize_single_stmt(*body)),
+                span,
+            }),
+            CompoundCommandNode::Always { body, always_body } => {
+                CompoundCommand::Always(crate::AlwaysCommand {
+                    body: self.materialize_stmt_seq(*body),
+                    always_body: self.materialize_stmt_seq(*always_body),
+                    span,
+                })
+            }
+        }
+    }
+
+    fn materialize_single_stmt(&self, id: StmtSeqId) -> Stmt {
+        let mut stmts = self.materialize_stmt_seq(id).stmts.into_iter();
+        let Some(stmt) = stmts.next() else {
+            panic!("statement wrapper sequence contains one statement");
+        };
+        stmt
     }
 
     fn materialize_word(&self, id: WordId) -> Word {
@@ -421,6 +643,8 @@ pub enum CommandNodePayload {
     Function(FunctionCommandNode),
     /// Anonymous zsh function command payload.
     AnonymousFunction(AnonymousFunctionCommandNode),
+    /// Compound shell command payload.
+    Compound(CompoundCommandNode),
     /// Compatibility payload for command families that still materialize from `legacy`.
     Legacy,
 }
@@ -519,6 +743,155 @@ pub struct AnonymousFunctionCommandNode {
     pub body: StmtSeqId,
     /// Invocation argument words.
     pub args: IdRange<WordId>,
+}
+
+/// Arena-native compound command payload.
+#[derive(Debug, Clone)]
+#[allow(clippy::large_enum_variant)]
+pub enum CompoundCommandNode {
+    /// If statement.
+    If {
+        condition: StmtSeqId,
+        then_branch: StmtSeqId,
+        elif_branches: IdRange<ElifBranchNode>,
+        else_branch: Option<StmtSeqId>,
+        syntax: crate::IfSyntax,
+    },
+    /// For loop.
+    For {
+        targets: IdRange<ForTargetNode>,
+        words: Option<IdRange<WordId>>,
+        body: StmtSeqId,
+        syntax: crate::ForSyntax,
+    },
+    /// Zsh repeat loop.
+    Repeat {
+        count: WordId,
+        body: StmtSeqId,
+        syntax: crate::RepeatSyntax,
+    },
+    /// Zsh foreach loop.
+    Foreach {
+        variable: crate::Name,
+        variable_span: Span,
+        words: IdRange<WordId>,
+        body: StmtSeqId,
+        syntax: crate::ForeachSyntax,
+    },
+    /// C-style arithmetic for loop.
+    ArithmeticFor(Box<ArithmeticForCommandNode>),
+    /// While loop.
+    While {
+        condition: StmtSeqId,
+        body: StmtSeqId,
+    },
+    /// Until loop.
+    Until {
+        condition: StmtSeqId,
+        body: StmtSeqId,
+    },
+    /// Case statement.
+    Case {
+        word: WordId,
+        cases: IdRange<CaseItemNode>,
+    },
+    /// Select loop.
+    Select {
+        variable: crate::Name,
+        variable_span: Span,
+        words: IdRange<WordId>,
+        body: StmtSeqId,
+    },
+    /// Subshell.
+    Subshell(StmtSeqId),
+    /// Brace group.
+    BraceGroup(StmtSeqId),
+    /// Arithmetic command.
+    Arithmetic(ArithmeticCommandNode),
+    /// Time command.
+    Time {
+        posix_format: bool,
+        command: Option<StmtSeqId>,
+    },
+    /// Conditional expression command.
+    Conditional(ConditionalCommandNode),
+    /// Coprocess command.
+    Coproc {
+        name: crate::Name,
+        name_span: Option<Span>,
+        body: StmtSeqId,
+    },
+    /// Zsh always/finally-style cleanup block.
+    Always {
+        body: StmtSeqId,
+        always_body: StmtSeqId,
+    },
+}
+
+/// Arena-native if/elif branch pair.
+#[derive(Debug, Clone)]
+pub struct ElifBranchNode {
+    /// Elif condition sequence.
+    pub condition: StmtSeqId,
+    /// Elif body sequence.
+    pub body: StmtSeqId,
+}
+
+/// Arena-native for-loop target.
+#[derive(Debug, Clone)]
+pub struct ForTargetNode {
+    /// Source-preserving target word.
+    pub word: WordId,
+    /// Normalized identifier when the target is a plain shell name.
+    pub name: Option<crate::Name>,
+    /// Source span of the target.
+    pub span: Span,
+}
+
+/// Arena-native case item.
+#[derive(Debug, Clone)]
+pub struct CaseItemNode {
+    /// Case patterns.
+    pub patterns: IdRange<Pattern>,
+    /// Case body sequence.
+    pub body: StmtSeqId,
+    /// Case terminator.
+    pub terminator: crate::CaseTerminator,
+    /// Source span of the case terminator token when present.
+    pub terminator_span: Option<Span>,
+}
+
+/// Arena-native arithmetic command.
+#[derive(Debug, Clone)]
+pub struct ArithmeticCommandNode {
+    pub left_paren_span: Span,
+    pub expr_span: Option<Span>,
+    pub expr_ast: Option<ArithmeticExprNode>,
+    pub right_paren_span: Span,
+}
+
+/// Arena-native arithmetic-for command.
+#[derive(Debug, Clone)]
+pub struct ArithmeticForCommandNode {
+    pub left_paren_span: Span,
+    pub init_span: Option<Span>,
+    pub init_ast: Option<ArithmeticExprNode>,
+    pub first_semicolon_span: Span,
+    pub condition_span: Option<Span>,
+    pub condition_ast: Option<ArithmeticExprNode>,
+    pub second_semicolon_span: Span,
+    pub step_span: Option<Span>,
+    pub step_ast: Option<ArithmeticExprNode>,
+    pub right_paren_span: Span,
+    pub body: StmtSeqId,
+}
+
+/// Arena-native conditional command.
+#[derive(Debug, Clone)]
+pub struct ConditionalCommandNode {
+    pub expression: ConditionalExpr,
+    pub left_bracket_span: Span,
+    pub right_bracket_span: Span,
 }
 
 /// Coarse command family stored with command arena nodes.
@@ -734,6 +1107,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -750,6 +1124,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -766,6 +1141,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -782,6 +1158,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -798,6 +1175,7 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -814,6 +1192,24 @@ impl<'a> CommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
+            | CommandNodePayload::Compound(_)
+            | CommandNodePayload::Legacy => None,
+        }
+    }
+
+    /// Returns the native compound payload when this command is compound.
+    pub fn compound(self) -> Option<CompoundCommandView<'a>> {
+        match &self.node().payload {
+            CommandNodePayload::Compound(_) => Some(CompoundCommandView {
+                store: self.store,
+                id: self.id,
+            }),
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
             | CommandNodePayload::Legacy => None,
         }
     }
@@ -879,6 +1275,7 @@ impl<'a> SimpleCommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => {
                 unreachable!("simple view requires simple payload")
             }
@@ -935,6 +1332,7 @@ impl<'a> BuiltinCommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => {
                 unreachable!("builtin view requires builtin payload")
             }
@@ -978,6 +1376,7 @@ impl<'a> DeclCommandView<'a> {
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => unreachable!("decl view requires decl payload"),
         }
     }
@@ -1029,6 +1428,7 @@ impl<'a> BinaryCommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Function(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => unreachable!("binary view requires binary payload"),
         }
     }
@@ -1077,6 +1477,7 @@ impl<'a> FunctionCommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => unreachable!("function view requires function payload"),
         }
     }
@@ -1126,9 +1527,33 @@ impl<'a> AnonymousFunctionCommandView<'a> {
             | CommandNodePayload::Decl(_)
             | CommandNodePayload::Binary(_)
             | CommandNodePayload::Function(_)
+            | CommandNodePayload::Compound(_)
             | CommandNodePayload::Legacy => {
                 unreachable!("anonymous function view requires anonymous function payload")
             }
+        }
+    }
+}
+
+/// Borrowed view of an arena-native compound command payload.
+#[derive(Debug, Clone, Copy)]
+pub struct CompoundCommandView<'a> {
+    store: &'a AstStore,
+    id: CommandId,
+}
+
+impl<'a> CompoundCommandView<'a> {
+    /// Returns the compound command payload.
+    pub fn node(self) -> &'a CompoundCommandNode {
+        match &self.store.commands[self.id.index()].payload {
+            CommandNodePayload::Compound(command) => command,
+            CommandNodePayload::Simple(_)
+            | CommandNodePayload::Builtin(_)
+            | CommandNodePayload::Decl(_)
+            | CommandNodePayload::Binary(_)
+            | CommandNodePayload::Function(_)
+            | CommandNodePayload::AnonymousFunction(_)
+            | CommandNodePayload::Legacy => unreachable!("compound view requires compound payload"),
         }
     }
 }
@@ -1454,10 +1879,9 @@ impl AstStoreBuilder {
             Command::Binary(command) => {
                 CommandNodePayload::Binary(self.collect_binary_children(command, child_sequences))
             }
-            Command::Compound(command) => {
-                self.collect_compound_children(command, words, child_sequences);
-                CommandNodePayload::Legacy
-            }
+            Command::Compound(command) => CommandNodePayload::Compound(
+                self.collect_compound_children(command, words, child_sequences),
+            ),
             Command::Function(function) => CommandNodePayload::Function(
                 self.collect_function_children(function, words, child_sequences),
             ),
@@ -1566,61 +1990,136 @@ impl AstStoreBuilder {
         command: &CompoundCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
+    ) -> CompoundCommandNode {
         match command {
             CompoundCommand::If(command) => {
-                child_sequences.push(self.lower_stmt_seq(&command.condition));
-                child_sequences.push(self.lower_stmt_seq(&command.then_branch));
-                for (condition, body) in &command.elif_branches {
-                    child_sequences.push(self.lower_stmt_seq(condition));
-                    child_sequences.push(self.lower_stmt_seq(body));
-                }
-                if let Some(else_branch) = &command.else_branch {
-                    child_sequences.push(self.lower_stmt_seq(else_branch));
+                let condition = self.lower_stmt_seq(&command.condition);
+                let then_branch = self.lower_stmt_seq(&command.then_branch);
+                child_sequences.push(condition);
+                child_sequences.push(then_branch);
+                let elif_branches = command
+                    .elif_branches
+                    .iter()
+                    .map(|(condition, body)| {
+                        let condition = self.lower_stmt_seq(condition);
+                        let body = self.lower_stmt_seq(body);
+                        child_sequences.push(condition);
+                        child_sequences.push(body);
+                        ElifBranchNode { condition, body }
+                    })
+                    .collect::<Vec<_>>();
+                let elif_branches = self.store.elif_branch_lists.push_many(elif_branches);
+                let else_branch = command.else_branch.as_ref().map(|else_branch| {
+                    let id = self.lower_stmt_seq(else_branch);
+                    child_sequences.push(id);
+                    id
+                });
+                CompoundCommandNode::If {
+                    condition,
+                    then_branch,
+                    elif_branches,
+                    else_branch,
+                    syntax: command.syntax,
                 }
             }
             CompoundCommand::For(command) => {
                 self.collect_for_children(command, words, child_sequences)
             }
             CompoundCommand::Repeat(command) => {
-                self.collect_repeat_children(command, words, child_sequences);
+                self.collect_repeat_children(command, words, child_sequences)
             }
             CompoundCommand::Foreach(command) => {
-                for word in &command.words {
-                    self.collect_word(word, words, child_sequences);
+                let words_range = command
+                    .words
+                    .iter()
+                    .map(|word| self.collect_word_id(word, words, child_sequences))
+                    .collect::<Vec<_>>();
+                let words_range = self.store.word_id_lists.push_many(words_range);
+                let body = self.lower_stmt_seq(&command.body);
+                child_sequences.push(body);
+                CompoundCommandNode::Foreach {
+                    variable: command.variable.clone(),
+                    variable_span: command.variable_span,
+                    words: words_range,
+                    body,
+                    syntax: command.syntax,
                 }
-                child_sequences.push(self.lower_stmt_seq(&command.body));
             }
             CompoundCommand::ArithmeticFor(command) => {
-                self.collect_arithmetic_for_children(command, words, child_sequences);
+                self.collect_arithmetic_for_children(command, words, child_sequences)
             }
             CompoundCommand::While(command) => {
-                self.collect_while_children(command, child_sequences)
+                let condition = self.lower_stmt_seq(&command.condition);
+                let body = self.lower_stmt_seq(&command.body);
+                child_sequences.push(condition);
+                child_sequences.push(body);
+                CompoundCommandNode::While { condition, body }
             }
             CompoundCommand::Until(command) => {
-                self.collect_until_children(command, child_sequences)
+                let condition = self.lower_stmt_seq(&command.condition);
+                let body = self.lower_stmt_seq(&command.body);
+                child_sequences.push(condition);
+                child_sequences.push(body);
+                CompoundCommandNode::Until { condition, body }
             }
             CompoundCommand::Case(command) => {
                 self.collect_case_children(command, words, child_sequences)
             }
             CompoundCommand::Select(command) => {
-                self.collect_select_children(command, words, child_sequences);
+                self.collect_select_children(command, words, child_sequences)
             }
-            CompoundCommand::Subshell(sequence) | CompoundCommand::BraceGroup(sequence) => {
-                child_sequences.push(self.lower_stmt_seq(sequence));
+            CompoundCommand::Subshell(sequence) => {
+                let body = self.lower_stmt_seq(sequence);
+                child_sequences.push(body);
+                CompoundCommandNode::Subshell(body)
+            }
+            CompoundCommand::BraceGroup(sequence) => {
+                let body = self.lower_stmt_seq(sequence);
+                child_sequences.push(body);
+                CompoundCommandNode::BraceGroup(body)
             }
             CompoundCommand::Arithmetic(command) => {
-                self.collect_arithmetic_command_children(command, words, child_sequences);
+                self.collect_arithmetic_command_children(command, words, child_sequences)
             }
             CompoundCommand::Conditional(command) => {
-                self.collect_conditional_command_children(command, words, child_sequences);
+                self.collect_conditional_command_children(command, words, child_sequences)
             }
-            CompoundCommand::Time(command) => self.collect_time_children(command, child_sequences),
+            CompoundCommand::Time(command) => {
+                let body = command.command.as_ref().map(|command| {
+                    let id = self.lower_stmt_seq(&StmtSeq {
+                        leading_comments: Vec::new(),
+                        stmts: vec![(**command).clone()],
+                        trailing_comments: Vec::new(),
+                        span: command.span,
+                    });
+                    child_sequences.push(id);
+                    id
+                });
+                CompoundCommandNode::Time {
+                    posix_format: command.posix_format,
+                    command: body,
+                }
+            }
             CompoundCommand::Coproc(command) => {
-                self.collect_coproc_children(command, child_sequences)
+                let body = self.lower_stmt_seq(&StmtSeq {
+                    leading_comments: Vec::new(),
+                    stmts: vec![(*command.body).clone()],
+                    trailing_comments: Vec::new(),
+                    span: command.body.span,
+                });
+                child_sequences.push(body);
+                CompoundCommandNode::Coproc {
+                    name: command.name.clone(),
+                    name_span: command.name_span,
+                    body,
+                }
             }
             CompoundCommand::Always(command) => {
-                self.collect_always_children(command, child_sequences)
+                let body = self.lower_stmt_seq(&command.body);
+                let always_body = self.lower_stmt_seq(&command.always_body);
+                child_sequences.push(body);
+                child_sequences.push(always_body);
+                CompoundCommandNode::Always { body, always_body }
             }
         }
     }
@@ -1630,16 +2129,32 @@ impl AstStoreBuilder {
         command: &ForCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        for target in &command.targets {
-            self.collect_word(&target.word, words, child_sequences);
+    ) -> CompoundCommandNode {
+        let targets = command
+            .targets
+            .iter()
+            .map(|target| ForTargetNode {
+                word: self.collect_word_id(&target.word, words, child_sequences),
+                name: target.name.clone(),
+                span: target.span,
+            })
+            .collect::<Vec<_>>();
+        let targets = self.store.for_target_lists.push_many(targets);
+        let header_words = command.words.as_ref().map(|header_words| {
+            let header_words = header_words
+                .iter()
+                .map(|word| self.collect_word_id(word, words, child_sequences))
+                .collect::<Vec<_>>();
+            self.store.word_id_lists.push_many(header_words)
+        });
+        let body = self.lower_stmt_seq(&command.body);
+        child_sequences.push(body);
+        CompoundCommandNode::For {
+            targets,
+            words: header_words,
+            body,
+            syntax: command.syntax,
         }
-        if let Some(header_words) = &command.words {
-            for word in header_words {
-                self.collect_word(word, words, child_sequences);
-            }
-        }
-        child_sequences.push(self.lower_stmt_seq(&command.body));
     }
 
     fn collect_repeat_children(
@@ -1647,9 +2162,15 @@ impl AstStoreBuilder {
         command: &RepeatCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        self.collect_word(&command.count, words, child_sequences);
-        child_sequences.push(self.lower_stmt_seq(&command.body));
+    ) -> CompoundCommandNode {
+        let count = self.collect_word_id(&command.count, words, child_sequences);
+        let body = self.lower_stmt_seq(&command.body);
+        child_sequences.push(body);
+        CompoundCommandNode::Repeat {
+            count,
+            body,
+            syntax: command.syntax,
+        }
     }
 
     fn collect_arithmetic_for_children(
@@ -1657,29 +2178,25 @@ impl AstStoreBuilder {
         command: &ArithmeticForCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
+    ) -> CompoundCommandNode {
         self.collect_arithmetic_expr_option(command.init_ast.as_ref(), words, child_sequences);
         self.collect_arithmetic_expr_option(command.condition_ast.as_ref(), words, child_sequences);
         self.collect_arithmetic_expr_option(command.step_ast.as_ref(), words, child_sequences);
-        child_sequences.push(self.lower_stmt_seq(&command.body));
-    }
-
-    fn collect_while_children(
-        &mut self,
-        command: &WhileCommand,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        child_sequences.push(self.lower_stmt_seq(&command.condition));
-        child_sequences.push(self.lower_stmt_seq(&command.body));
-    }
-
-    fn collect_until_children(
-        &mut self,
-        command: &UntilCommand,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        child_sequences.push(self.lower_stmt_seq(&command.condition));
-        child_sequences.push(self.lower_stmt_seq(&command.body));
+        let body = self.lower_stmt_seq(&command.body);
+        child_sequences.push(body);
+        CompoundCommandNode::ArithmeticFor(Box::new(ArithmeticForCommandNode {
+            left_paren_span: command.left_paren_span,
+            init_span: command.init_span,
+            init_ast: command.init_ast.clone(),
+            first_semicolon_span: command.first_semicolon_span,
+            condition_span: command.condition_span,
+            condition_ast: command.condition_ast.clone(),
+            second_semicolon_span: command.second_semicolon_span,
+            step_span: command.step_span,
+            step_ast: command.step_ast.clone(),
+            right_paren_span: command.right_paren_span,
+            body,
+        }))
     }
 
     fn collect_case_children(
@@ -1687,14 +2204,31 @@ impl AstStoreBuilder {
         command: &CaseCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        self.collect_word(&command.word, words, child_sequences);
-        for case in &command.cases {
-            for pattern in &case.patterns {
-                self.collect_pattern_words(pattern, words, child_sequences);
-            }
-            child_sequences.push(self.lower_stmt_seq(&case.body));
-        }
+    ) -> CompoundCommandNode {
+        let word = self.collect_word_id(&command.word, words, child_sequences);
+        let cases = command
+            .cases
+            .iter()
+            .map(|case| {
+                for pattern in &case.patterns {
+                    self.collect_pattern_words(pattern, words, child_sequences);
+                }
+                let patterns = self
+                    .store
+                    .pattern_lists
+                    .push_many(case.patterns.iter().cloned());
+                let body = self.lower_stmt_seq(&case.body);
+                child_sequences.push(body);
+                CaseItemNode {
+                    patterns,
+                    body,
+                    terminator: case.terminator,
+                    terminator_span: case.terminator_span,
+                }
+            })
+            .collect::<Vec<_>>();
+        let cases = self.store.case_item_lists.push_many(cases);
+        CompoundCommandNode::Case { word, cases }
     }
 
     fn collect_select_children(
@@ -1702,11 +2236,21 @@ impl AstStoreBuilder {
         command: &SelectCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        for word in &command.words {
-            self.collect_word(word, words, child_sequences);
+    ) -> CompoundCommandNode {
+        let header_words = command
+            .words
+            .iter()
+            .map(|word| self.collect_word_id(word, words, child_sequences))
+            .collect::<Vec<_>>();
+        let header_words = self.store.word_id_lists.push_many(header_words);
+        let body = self.lower_stmt_seq(&command.body);
+        child_sequences.push(body);
+        CompoundCommandNode::Select {
+            variable: command.variable.clone(),
+            variable_span: command.variable_span,
+            words: header_words,
+            body,
         }
-        child_sequences.push(self.lower_stmt_seq(&command.body));
     }
 
     fn collect_arithmetic_command_children(
@@ -1714,8 +2258,14 @@ impl AstStoreBuilder {
         command: &ArithmeticCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
+    ) -> CompoundCommandNode {
         self.collect_arithmetic_expr_option(command.expr_ast.as_ref(), words, child_sequences);
+        CompoundCommandNode::Arithmetic(ArithmeticCommandNode {
+            left_paren_span: command.left_paren_span,
+            expr_span: command.expr_span,
+            expr_ast: command.expr_ast.clone(),
+            right_paren_span: command.right_paren_span,
+        })
     }
 
     fn collect_conditional_command_children(
@@ -1723,45 +2273,13 @@ impl AstStoreBuilder {
         command: &ConditionalCommand,
         words: &mut Vec<WordId>,
         child_sequences: &mut Vec<StmtSeqId>,
-    ) {
+    ) -> CompoundCommandNode {
         self.collect_conditional_expr(&command.expression, words, child_sequences);
-    }
-
-    fn collect_time_children(
-        &mut self,
-        command: &TimeCommand,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        if let Some(command) = &command.command {
-            child_sequences.push(self.lower_stmt_seq(&StmtSeq {
-                leading_comments: Vec::new(),
-                stmts: vec![(**command).clone()],
-                trailing_comments: Vec::new(),
-                span: command.span,
-            }));
-        }
-    }
-
-    fn collect_coproc_children(
-        &mut self,
-        command: &CoprocCommand,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        child_sequences.push(self.lower_stmt_seq(&StmtSeq {
-            leading_comments: Vec::new(),
-            stmts: vec![(*command.body).clone()],
-            trailing_comments: Vec::new(),
-            span: command.body.span,
-        }));
-    }
-
-    fn collect_always_children(
-        &mut self,
-        command: &AlwaysCommand,
-        child_sequences: &mut Vec<StmtSeqId>,
-    ) {
-        child_sequences.push(self.lower_stmt_seq(&command.body));
-        child_sequences.push(self.lower_stmt_seq(&command.always_body));
+        CompoundCommandNode::Conditional(ConditionalCommandNode {
+            expression: command.expression.clone(),
+            left_bracket_span: command.left_bracket_span,
+            right_bracket_span: command.right_bracket_span,
+        })
     }
 
     fn collect_function_children(
@@ -2653,6 +3171,78 @@ mod tests {
             panic!("expected anonymous function command");
         };
         assert_eq!(materialized.args.len(), 1);
+    }
+
+    #[test]
+    fn compound_payloads_are_arena_native() {
+        let if_file = file_with_command(Command::Compound(CompoundCommand::If(crate::IfCommand {
+            condition: simple_sequence("test"),
+            then_branch: simple_sequence("then"),
+            elif_branches: vec![(simple_sequence("elif"), simple_sequence("elif_body"))],
+            else_branch: Some(simple_sequence("else")),
+            syntax: crate::IfSyntax::ThenFi {
+                then_span: Span::new(),
+                fi_span: Span::new(),
+            },
+            span: Span::new(),
+        })));
+        let case_file = file_with_command(Command::Compound(CompoundCommand::Case(
+            crate::CaseCommand {
+                word: Word::literal("value"),
+                cases: vec![crate::CaseItem {
+                    patterns: vec![Pattern {
+                        parts: vec![PatternPartNode::new(
+                            PatternPart::Word(Word::literal("pattern")),
+                            Span::new(),
+                        )],
+                        span: Span::new(),
+                    }],
+                    body: simple_sequence("case_body"),
+                    terminator: crate::CaseTerminator::Break,
+                    terminator_span: Some(Span::new()),
+                }],
+                span: Span::new(),
+            },
+        )));
+
+        let arena = ArenaFile::from_file(&if_file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+        let compound = command
+            .compound()
+            .expect("expected native compound payload");
+        let crate::CompoundCommandNode::If {
+            elif_branches,
+            else_branch,
+            ..
+        } = compound.node()
+        else {
+            panic!("expected if payload");
+        };
+        assert_eq!(elif_branches.len(), 1);
+        assert!(else_branch.is_some());
+        assert_eq!(command.child_sequence_ids().len(), 5);
+        let Command::Compound(CompoundCommand::If(command)) = &arena.to_file().body[0].command
+        else {
+            panic!("expected if command");
+        };
+        assert_eq!(command.elif_branches.len(), 1);
+        assert!(command.else_branch.is_some());
+
+        let arena = ArenaFile::from_file(&case_file);
+        let command = arena.view().body().stmts().next().unwrap().command();
+        let compound = command
+            .compound()
+            .expect("expected native compound payload");
+        let crate::CompoundCommandNode::Case { cases, .. } = compound.node() else {
+            panic!("expected case payload");
+        };
+        assert_eq!(cases.len(), 1);
+        assert_eq!(command.child_sequence_ids().len(), 1);
+        let Command::Compound(CompoundCommand::Case(command)) = &arena.to_file().body[0].command
+        else {
+            panic!("expected case command");
+        };
+        assert_eq!(command.cases.len(), 1);
     }
 
     #[test]

--- a/crates/shuck-ast/src/arena_ast.rs
+++ b/crates/shuck-ast/src/arena_ast.rs
@@ -147,6 +147,54 @@ impl AstStore {
         WordView { store: self, id }
     }
 
+    /// Returns word IDs from a list range.
+    pub fn word_ids(&self, range: IdRange<WordId>) -> &[WordId] {
+        self.word_id_lists.get(range)
+    }
+
+    /// Returns array element nodes from a list range.
+    pub fn array_elems(&self, range: IdRange<ArrayElemNode>) -> &[ArrayElemNode] {
+        self.array_elem_lists.get(range)
+    }
+
+    /// Returns heredoc body part nodes from a list range.
+    pub fn heredoc_body_parts(
+        &self,
+        range: IdRange<ArenaHeredocBodyPartNode>,
+    ) -> &[ArenaHeredocBodyPartNode] {
+        self.heredoc_body_part_lists.get(range)
+    }
+
+    /// Returns elif branch nodes from a list range.
+    pub fn elif_branches(&self, range: IdRange<ElifBranchNode>) -> &[ElifBranchNode] {
+        self.elif_branch_lists.get(range)
+    }
+
+    /// Returns case item nodes from a list range.
+    pub fn case_items(&self, range: IdRange<CaseItemNode>) -> &[CaseItemNode] {
+        self.case_item_lists.get(range)
+    }
+
+    /// Returns pattern nodes from a list range.
+    pub fn patterns(&self, range: IdRange<PatternNode>) -> &[PatternNode] {
+        self.pattern_lists.get(range)
+    }
+
+    /// Returns pattern part nodes from a list range.
+    pub fn pattern_parts(&self, range: IdRange<PatternPartArenaNode>) -> &[PatternPartArenaNode] {
+        self.pattern_part_lists.get(range)
+    }
+
+    /// Returns zsh glob segment nodes from a list range.
+    pub fn zsh_glob_segments(&self, range: IdRange<ZshGlobSegmentNode>) -> &[ZshGlobSegmentNode] {
+        self.zsh_glob_segment_lists.get(range)
+    }
+
+    /// Returns word part nodes from a list range.
+    pub fn word_parts(&self, range: IdRange<WordPartArenaNode>) -> &[WordPartArenaNode] {
+        self.word_part_lists.get(range)
+    }
+
     /// Number of file nodes in this store.
     pub fn file_count(&self) -> usize {
         self.files.len()
@@ -2347,6 +2395,14 @@ impl<'a> StmtView<'a> {
             .get(self.node().redirect_child_sequences)
     }
 
+    /// Returns nested statement sequences found under statement redirections.
+    pub fn redirect_child_sequences(self) -> impl ExactSizeIterator<Item = StmtSeqView<'a>> + 'a {
+        self.redirect_child_sequence_ids()
+            .iter()
+            .copied()
+            .map(move |id| self.store.stmt_seq(id))
+    }
+
     /// Returns whether this statement is negated.
     pub fn negated(self) -> bool {
         self.node().negated
@@ -2525,6 +2581,14 @@ impl<'a> CommandView<'a> {
         self.store
             .stmt_seq_id_lists
             .get(self.node().child_sequences)
+    }
+
+    /// Returns nested statement sequences found under this command.
+    pub fn child_sequences(self) -> impl ExactSizeIterator<Item = StmtSeqView<'a>> + 'a {
+        self.child_sequence_ids()
+            .iter()
+            .copied()
+            .map(move |id| self.store.stmt_seq(id))
     }
 
     fn node(self) -> &'a CommandNode {

--- a/crates/shuck-ast/src/lib.rs
+++ b/crates/shuck-ast/src/lib.rs
@@ -9,6 +9,8 @@
 #[allow(missing_docs)]
 mod arena;
 #[allow(missing_docs)]
+mod arena_ast;
+#[allow(missing_docs)]
 mod ast;
 #[allow(missing_docs)]
 mod command_resolution;
@@ -21,6 +23,8 @@ mod tokens;
 
 /// Compact typed arena index and list storage utilities.
 pub use arena::{IdRange, Idx, ListArena};
+/// ID-backed parsed AST storage and borrowed views.
+pub use arena_ast::*;
 /// Parsed shell AST nodes and related syntax tree types.
 pub use ast::*;
 /// Static command-resolution helpers shared by semantic analysis and lint facts.

--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -242,8 +242,8 @@ fn prepare_word_facts_input(
 ) -> PreparedWordFactsInput {
     let parse_result = parse_large_corpus_fixture(fixture);
     let indexer = Indexer::new(&fixture.source, &parse_result);
-    let semantic = SemanticModel::build_with_options(
-        &parse_result.file,
+    let semantic = SemanticModel::build_arena_with_options(
+        &parse_result.arena_file,
         &fixture.source,
         &indexer,
         SemanticBuildOptions {

--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -24,7 +24,7 @@ struct PreparedFactsInput {
 fn prepare_facts_input(source: &'static str) -> PreparedFactsInput {
     let output = parse_fixture(source);
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let shell = ShellDialect::infer(source, None);
     let file_context = classify_file_context(source, None, shell);
 

--- a/crates/shuck-benchmark/benches/semantic.rs
+++ b/crates/shuck-benchmark/benches/semantic.rs
@@ -14,7 +14,7 @@ struct PreparedScopeLookupInput {
 fn build_semantic(source: &str) -> usize {
     let output = parse_fixture(source);
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
 
     black_box(semantic.bindings().len() + semantic.references().len() + semantic.scopes().len())
 }
@@ -22,7 +22,7 @@ fn build_semantic(source: &str) -> usize {
 fn prepare_scope_lookup_input(source: &'static str) -> PreparedScopeLookupInput {
     let output = parse_fixture(source);
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let mut seen = HashSet::new();
     let mut offsets = Vec::new();
 

--- a/crates/shuck-benchmark/benches/unused_assignment.rs
+++ b/crates/shuck-benchmark/benches/unused_assignment.rs
@@ -10,7 +10,7 @@ configure_benchmark_allocator!();
 fn build_semantic(source: &str) -> SemanticModel {
     let output = parse_fixture(source);
     let indexer = Indexer::new(source, &output);
-    SemanticModel::build(&output.file, source, &indexer)
+    SemanticModel::build_arena(&output.arena_file, source, &indexer)
 }
 
 fn bench_unused_assignment(c: &mut Criterion) {

--- a/crates/shuck-benchmark/examples/linter_memory.rs
+++ b/crates/shuck-benchmark/examples/linter_memory.rs
@@ -183,7 +183,7 @@ impl PreparedInput {
     fn new(source: &'static str) -> Self {
         let output = parse_fixture(source);
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let shell = ShellDialect::infer(source, None);
         let file_context = classify_file_context(source, None, shell);
 

--- a/crates/shuck-benchmark/examples/semantic_memory.rs
+++ b/crates/shuck-benchmark/examples/semantic_memory.rs
@@ -186,7 +186,7 @@ struct CaseReport {
 fn build_semantic(source: &str) -> (SemanticModel, usize, usize, bool) {
     let output = parse_fixture(source);
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let semantic_count =
         semantic.bindings().len() + semantic.references().len() + semantic.scopes().len();
     (

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1783,7 +1783,7 @@ fn collect_lint_diagnostics(
     shellcheck_map: &ShellCheckCodeMap,
     source_path: &Path,
 ) -> Vec<shuck_linter::Diagnostic> {
-    let indexer = Indexer::new_arena(source, &parse_result.arena_file, &parse_result.syntax_facts);
+    let indexer = Indexer::new_arena(source, &parse_result.arena_file);
     let directives = parse_directives(
         source,
         &parse_result.file,

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1783,7 +1783,7 @@ fn collect_lint_diagnostics(
     shellcheck_map: &ShellCheckCodeMap,
     source_path: &Path,
 ) -> Vec<shuck_linter::Diagnostic> {
-    let indexer = Indexer::new(source, parse_result);
+    let indexer = Indexer::new_arena(source, &parse_result.arena_file, &parse_result.syntax_facts);
     let directives = parse_directives(
         source,
         &parse_result.file,
@@ -1797,7 +1797,7 @@ fn collect_lint_diagnostics(
             first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
         )
     });
-    shuck_linter::lint_file(
+    shuck_linter::lint_arena_file(
         parse_result,
         source,
         &indexer,

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -2498,8 +2498,8 @@ fn extract_large_corpus_zsh_option_state(
     shell_profile: shuck_parser::ShellProfile,
 ) -> Result<(), String> {
     let indexer = shuck_indexer::Indexer::new(source, output);
-    let semantic = shuck_semantic::SemanticModel::build_with_options(
-        &output.file,
+    let semantic = shuck_semantic::SemanticModel::build_arena_with_options(
+        &output.arena_file,
         source,
         &indexer,
         shuck_semantic::SemanticBuildOptions {

--- a/crates/shuck-cli/tests/zsh_option_state.rs
+++ b/crates/shuck-cli/tests/zsh_option_state.rs
@@ -133,8 +133,8 @@ fn run_fixture(fixture: &Fixture) -> Result<()> {
         return Err(anyhow::anyhow!("parse error: {}", parsed.strict_error()));
     }
     let indexer = Indexer::new(&fixture.source, &parsed);
-    let semantic = SemanticModel::build_with_options(
-        &parsed.file,
+    let semantic = SemanticModel::build_arena_with_options(
+        &parsed.arena_file,
         &fixture.source,
         &indexer,
         SemanticBuildOptions {

--- a/crates/shuck-indexer/src/comment_index.rs
+++ b/crates/shuck-indexer/src/comment_index.rs
@@ -1,10 +1,10 @@
 use std::ops::Range;
 
 use shuck_ast::{
-    ArrayElem, Assignment, AssignmentValue, BuiltinCommand, Command, Comment, CompoundCommand,
-    ConditionalExpr, DeclOperand, File, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, Pattern,
-    PatternPart, Redirect, Stmt, StmtSeq, TextRange, TextSize, Word, WordPart, WordPartNode,
-    ZshGlobSegment,
+    ArenaFile, ArrayElem, Assignment, AssignmentValue, BuiltinCommand, Command, CommandView,
+    Comment, CompoundCommand, ConditionalExpr, DeclOperand, File, HeredocBody, HeredocBodyPart,
+    HeredocBodyPartNode, Pattern, PatternPart, Redirect, Stmt, StmtSeq, StmtSeqView, StmtView,
+    TextRange, TextSize, Word, WordPart, WordPartNode, ZshGlobSegment,
 };
 
 use crate::LineIndex;
@@ -32,6 +32,17 @@ impl CommentIndex {
     pub fn new(source: &str, line_index: &LineIndex, file: &File) -> Self {
         let mut comments = Vec::new();
         collect_file_comments(file, &mut comments);
+        Self::from_comments(source, line_index, comments)
+    }
+
+    /// Build from arena-owned comments and source text.
+    pub fn new_arena(source: &str, line_index: &LineIndex, file: &ArenaFile) -> Self {
+        let mut comments = Vec::new();
+        collect_file_comments_arena(file, &mut comments);
+        Self::from_comments(source, line_index, comments)
+    }
+
+    fn from_comments(source: &str, line_index: &LineIndex, comments: Vec<Comment>) -> Self {
         let mut indexed_comments = comments
             .into_iter()
             .filter(|comment| {
@@ -134,12 +145,24 @@ fn collect_file_comments(file: &File, comments: &mut Vec<Comment>) {
     collect_stmt_seq_comments(&file.body, comments);
 }
 
+fn collect_file_comments_arena(file: &ArenaFile, comments: &mut Vec<Comment>) {
+    collect_stmt_seq_comments_arena(file.view().body(), comments);
+}
+
 fn collect_stmt_seq_comments(sequence: &StmtSeq, comments: &mut Vec<Comment>) {
     comments.extend(sequence.leading_comments.iter().copied());
     for stmt in sequence.iter() {
         collect_stmt_comments(stmt, comments);
     }
     comments.extend(sequence.trailing_comments.iter().copied());
+}
+
+fn collect_stmt_seq_comments_arena(sequence: StmtSeqView<'_>, comments: &mut Vec<Comment>) {
+    comments.extend(sequence.leading_comments().iter().copied());
+    for stmt in sequence.stmts() {
+        collect_stmt_comments_arena(stmt, comments);
+    }
+    comments.extend(sequence.trailing_comments().iter().copied());
 }
 
 fn collect_stmt_comments(stmt: &Stmt, comments: &mut Vec<Comment>) {
@@ -149,6 +172,23 @@ fn collect_stmt_comments(stmt: &Stmt, comments: &mut Vec<Comment>) {
     }
     collect_redirect_comments(&stmt.redirects, comments);
     collect_command_comments(&stmt.command, comments);
+}
+
+fn collect_stmt_comments_arena(stmt: StmtView<'_>, comments: &mut Vec<Comment>) {
+    comments.extend(stmt.leading_comments().iter().copied());
+    if let Some(comment) = stmt.inline_comment() {
+        comments.push(comment);
+    }
+    for sequence in stmt.redirect_child_sequences() {
+        collect_stmt_seq_comments_arena(sequence, comments);
+    }
+    collect_command_comments_arena(stmt.command(), comments);
+}
+
+fn collect_command_comments_arena(command: CommandView<'_>, comments: &mut Vec<Comment>) {
+    for sequence in command.child_sequences() {
+        collect_stmt_seq_comments_arena(sequence, comments);
+    }
 }
 
 fn collect_command_comments(command: &Command, comments: &mut Vec<Comment>) {

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -18,8 +18,8 @@ pub use line_index::LineIndex;
 /// Structural region indexes over parsed shell source.
 pub use region_index::{RegionIndex, RegionKind};
 
-use shuck_ast::TextSize;
-use shuck_parser::parser::ParseResult;
+use shuck_ast::{ArenaFile, TextSize};
+use shuck_parser::parser::{ParseResult, SyntaxFacts};
 
 /// Pre-computed positional and structural index over a parsed shell script.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -36,6 +36,22 @@ impl Indexer {
         let line_index = LineIndex::new(source);
         let comment_index = CommentIndex::new(source, &line_index, &output.file);
         let region_index = RegionIndex::new(source, &output.file);
+        let continuation_lines = collect_continuation_lines(source, &comment_index, &region_index);
+
+        Self {
+            line_index,
+            comment_index,
+            region_index,
+            continuation_lines,
+        }
+    }
+
+    /// Build an index from an arena-backed parsed shell script.
+    pub fn new_arena(source: &str, ast: &ArenaFile, _syntax_facts: &SyntaxFacts) -> Self {
+        let file = ast.to_file();
+        let line_index = LineIndex::new(source);
+        let comment_index = CommentIndex::new(source, &line_index, &file);
+        let region_index = RegionIndex::new(source, &file);
         let continuation_lines = collect_continuation_lines(source, &comment_index, &region_index);
 
         Self {
@@ -118,6 +134,11 @@ mod tests {
         Indexer::new(source, &output)
     }
 
+    fn arena_index(source: &str) -> Indexer {
+        let output = Parser::new(source).parse().unwrap();
+        Indexer::new_arena(source, &output.arena_file, &output.syntax_facts)
+    }
+
     #[test]
     fn detects_continuation_lines_without_allocating_source_copies() {
         let source = "echo foo \\\n  bar\necho \"foo\\\nbar\"\n";
@@ -153,6 +174,38 @@ EOF
         assert_eq!(
             indexer.region_index().region_at(name_offset),
             Some(RegionKind::DoubleQuoted)
+        );
+    }
+
+    #[test]
+    fn arena_index_matches_recursive_index() {
+        let source = "\
+#!/bin/bash
+echo \"$(printf '%s' \"$name\")\" # inline
+cat <<'EOF'
+literal $body
+EOF
+";
+        let recursive = index(source);
+        let arena = arena_index(source);
+
+        assert_eq!(
+            arena.line_index().line_count(),
+            recursive.line_index().line_count()
+        );
+        assert_eq!(
+            arena.comment_index().comments(),
+            recursive.comment_index().comments()
+        );
+        assert_eq!(
+            arena.continuation_line_starts(),
+            recursive.continuation_line_starts()
+        );
+
+        let heredoc_offset = TextSize::new(source.find("literal $body").unwrap() as u32);
+        assert_eq!(
+            arena.region_index().region_at(heredoc_offset),
+            recursive.region_index().region_at(heredoc_offset)
         );
     }
 }

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -19,7 +19,7 @@ pub use line_index::LineIndex;
 pub use region_index::{RegionIndex, RegionKind};
 
 use shuck_ast::{ArenaFile, TextSize};
-use shuck_parser::parser::{ParseResult, SyntaxFacts};
+use shuck_parser::parser::ParseResult;
 
 /// Pre-computed positional and structural index over a parsed shell script.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,25 +33,14 @@ pub struct Indexer {
 impl Indexer {
     /// Build an index from parser output and the original source text.
     pub fn new(source: &str, output: &ParseResult) -> Self {
-        let line_index = LineIndex::new(source);
-        let comment_index = CommentIndex::new(source, &line_index, &output.file);
-        let region_index = RegionIndex::new(source, &output.file);
-        let continuation_lines = collect_continuation_lines(source, &comment_index, &region_index);
-
-        Self {
-            line_index,
-            comment_index,
-            region_index,
-            continuation_lines,
-        }
+        Self::new_arena(source, &output.arena_file)
     }
 
     /// Build an index from an arena-backed parsed shell script.
-    pub fn new_arena(source: &str, ast: &ArenaFile, _syntax_facts: &SyntaxFacts) -> Self {
-        let file = ast.to_file();
+    pub fn new_arena(source: &str, ast: &ArenaFile) -> Self {
         let line_index = LineIndex::new(source);
-        let comment_index = CommentIndex::new(source, &line_index, &file);
-        let region_index = RegionIndex::new(source, &file);
+        let comment_index = CommentIndex::new_arena(source, &line_index, ast);
+        let region_index = RegionIndex::new_arena(source, ast);
         let continuation_lines = collect_continuation_lines(source, &comment_index, &region_index);
 
         Self {
@@ -134,11 +123,6 @@ mod tests {
         Indexer::new(source, &output)
     }
 
-    fn arena_index(source: &str) -> Indexer {
-        let output = Parser::new(source).parse().unwrap();
-        Indexer::new_arena(source, &output.arena_file, &output.syntax_facts)
-    }
-
     #[test]
     fn detects_continuation_lines_without_allocating_source_copies() {
         let source = "echo foo \\\n  bar\necho \"foo\\\nbar\"\n";
@@ -186,26 +170,25 @@ cat <<'EOF'
 literal $body
 EOF
 ";
-        let recursive = index(source);
-        let arena = arena_index(source);
+        let output = Parser::new(source).parse().unwrap();
+        let line_index = LineIndex::new(source);
+        let recursive_comments = CommentIndex::new(source, &line_index, &output.file);
+        let arena_comments = CommentIndex::new_arena(source, &line_index, &output.arena_file);
+        let recursive_regions = RegionIndex::new(source, &output.file);
+        let arena_regions = RegionIndex::new_arena(source, &output.arena_file);
+        let recursive_continuations =
+            collect_continuation_lines(source, &recursive_comments, &recursive_regions);
+        let arena_continuations =
+            collect_continuation_lines(source, &arena_comments, &arena_regions);
 
-        assert_eq!(
-            arena.line_index().line_count(),
-            recursive.line_index().line_count()
-        );
-        assert_eq!(
-            arena.comment_index().comments(),
-            recursive.comment_index().comments()
-        );
-        assert_eq!(
-            arena.continuation_line_starts(),
-            recursive.continuation_line_starts()
-        );
+        assert_eq!(arena_comments.comments(), recursive_comments.comments());
+        assert_eq!(arena_regions, recursive_regions);
+        assert_eq!(arena_continuations, recursive_continuations);
 
         let heredoc_offset = TextSize::new(source.find("literal $body").unwrap() as u32);
         assert_eq!(
-            arena.region_index().region_at(heredoc_offset),
-            recursive.region_index().region_at(heredoc_offset)
+            arena_regions.region_at(heredoc_offset),
+            recursive_regions.region_at(heredoc_offset)
         );
     }
 }

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -1,8 +1,14 @@
 use shuck_ast::{
-    ArithmeticForCommand, Assignment, AssignmentValue, BuiltinCommand, Command, CompoundCommand,
-    ConditionalExpr, DeclClause, DeclOperand, File, FunctionDef, HeredocBody, HeredocBodyPart,
-    HeredocBodyPartNode, Pattern, PatternPart, PatternPartNode, Redirect, RedirectKind, Stmt,
-    StmtSeq, Subscript, TextRange, TextSize, VarRef, Word, WordPart, WordPartNode, ZshGlobSegment,
+    ArenaFile, ArenaHeredocBodyPart, ArenaHeredocBodyPartNode, ArithmeticExprArena,
+    ArithmeticExprArenaNode, ArithmeticForCommand, ArithmeticForCommandNode, ArithmeticLvalueArena,
+    Assignment, AssignmentNode, AssignmentValue, AssignmentValueNode, AstStore, BuiltinCommand,
+    Command, CommandView, CompoundCommand, CompoundCommandNode, ConditionalExpr,
+    ConditionalExprArena, DeclClause, DeclOperand, DeclOperandNode, File, FunctionDef, HeredocBody,
+    HeredocBodyPart, HeredocBodyPartNode, Pattern, PatternNode, PatternPart, PatternPartArena,
+    PatternPartNode, Redirect, RedirectKind, RedirectNode, RedirectTargetNode, Stmt, StmtSeq,
+    StmtSeqView, StmtView, Subscript, SubscriptNode, TextRange, TextSize, VarRef, VarRefNode, Word,
+    WordId, WordPart, WordPartArena, WordPartArenaNode, WordPartNode, WordView, ZshGlobSegment,
+    ZshGlobSegmentNode,
 };
 /// A syntactic region that affects lint rule behavior.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,6 +50,13 @@ impl RegionIndex {
     /// Build from source text and the parsed file.
     pub fn new(source: &str, file: &File) -> Self {
         let mut collector = RegionCollector::new(source);
+        collector.visit_file(file);
+        collector.finish()
+    }
+
+    /// Build from source text and an arena-backed parsed file.
+    pub fn new_arena(source: &str, file: &ArenaFile) -> Self {
+        let mut collector = ArenaRegionCollector::new(source, &file.store);
         collector.visit_file(file);
         collector.finish()
     }
@@ -619,6 +632,489 @@ impl<'a> RegionCollector<'a> {
                 self.visit_arithmetic_shell_words(value);
             }
         }
+    }
+}
+
+struct ArenaRegionCollector<'a> {
+    _source: &'a str,
+    store: &'a AstStore,
+    single_quoted: Vec<TextRange>,
+    double_quoted: Vec<TextRange>,
+    heredocs: Vec<TextRange>,
+    command_substitutions: Vec<TextRange>,
+    arithmetic: Vec<TextRange>,
+    conditionals: Vec<TextRange>,
+    quoted_heredocs: Vec<TextRange>,
+}
+
+impl<'a> ArenaRegionCollector<'a> {
+    fn new(source: &'a str, store: &'a AstStore) -> Self {
+        Self {
+            _source: source,
+            store,
+            single_quoted: Vec::new(),
+            double_quoted: Vec::new(),
+            heredocs: Vec::new(),
+            command_substitutions: Vec::new(),
+            arithmetic: Vec::new(),
+            conditionals: Vec::new(),
+            quoted_heredocs: Vec::new(),
+        }
+    }
+
+    fn finish(mut self) -> RegionIndex {
+        sort_ranges(&mut self.single_quoted);
+        sort_ranges(&mut self.double_quoted);
+        sort_ranges(&mut self.heredocs);
+        sort_ranges(&mut self.command_substitutions);
+        sort_ranges(&mut self.arithmetic);
+        sort_ranges(&mut self.conditionals);
+        sort_ranges(&mut self.quoted_heredocs);
+
+        let mut regions = Vec::with_capacity(
+            self.single_quoted.len()
+                + self.double_quoted.len()
+                + self.heredocs.len()
+                + self.command_substitutions.len()
+                + self.arithmetic.len()
+                + self.conditionals.len(),
+        );
+        regions.extend(
+            self.single_quoted
+                .iter()
+                .copied()
+                .map(|range| IndexedRegion {
+                    kind: RegionKind::SingleQuoted,
+                    range,
+                }),
+        );
+        regions.extend(
+            self.double_quoted
+                .iter()
+                .copied()
+                .map(|range| IndexedRegion {
+                    kind: RegionKind::DoubleQuoted,
+                    range,
+                }),
+        );
+        regions.extend(self.heredocs.iter().copied().map(|range| IndexedRegion {
+            kind: RegionKind::Heredoc,
+            range,
+        }));
+        regions.extend(
+            self.command_substitutions
+                .iter()
+                .copied()
+                .map(|range| IndexedRegion {
+                    kind: RegionKind::CommandSubstitution,
+                    range,
+                }),
+        );
+        regions.extend(self.arithmetic.iter().copied().map(|range| IndexedRegion {
+            kind: RegionKind::Arithmetic,
+            range,
+        }));
+        regions.extend(
+            self.conditionals
+                .iter()
+                .copied()
+                .map(|range| IndexedRegion {
+                    kind: RegionKind::Conditional,
+                    range,
+                }),
+        );
+        regions.sort_unstable_by_key(|region| {
+            (region.range.start().to_u32(), region.range.end().to_u32())
+        });
+
+        RegionIndex {
+            single_quoted: self.single_quoted,
+            double_quoted: self.double_quoted,
+            heredocs: self.heredocs,
+            command_substitutions: self.command_substitutions,
+            arithmetic: self.arithmetic,
+            conditionals: self.conditionals,
+            quoted_heredocs: self.quoted_heredocs,
+            regions,
+        }
+    }
+
+    fn visit_file(&mut self, file: &'a ArenaFile) {
+        self.visit_stmt_seq(file.view().body());
+    }
+
+    fn visit_stmt_seq(&mut self, commands: StmtSeqView<'a>) {
+        for stmt in commands.stmts() {
+            self.visit_stmt(stmt);
+        }
+    }
+
+    fn visit_stmt(&mut self, stmt: StmtView<'a>) {
+        for redirect in stmt.redirects() {
+            self.visit_redirect(redirect);
+        }
+        self.visit_command(stmt.command());
+    }
+
+    fn visit_command(&mut self, command: CommandView<'a>) {
+        if let Some(command) = command.simple() {
+            self.visit_word(command.name());
+            for argument in command.args() {
+                self.visit_word(argument);
+            }
+            for assignment in command.assignments() {
+                self.visit_assignment(assignment);
+            }
+        } else if let Some(command) = command.builtin() {
+            if let Some(primary) = command.primary() {
+                self.visit_word(primary);
+            }
+            for argument in command.extra_args() {
+                self.visit_word(argument);
+            }
+            for assignment in command.assignments() {
+                self.visit_assignment(assignment);
+            }
+        } else if let Some(command) = command.decl() {
+            for operand in command.operands() {
+                match operand {
+                    DeclOperandNode::Flag(word) | DeclOperandNode::Dynamic(word) => {
+                        self.visit_word_id(*word);
+                    }
+                    DeclOperandNode::Name(reference) => self.visit_var_ref_subscript(reference),
+                    DeclOperandNode::Assignment(assignment) => self.visit_assignment(assignment),
+                }
+            }
+            for assignment in command.assignments() {
+                self.visit_assignment(assignment);
+            }
+        } else if let Some(command) = command.binary() {
+            self.visit_stmt_seq(command.left());
+            self.visit_stmt_seq(command.right());
+        } else if let Some(command) = command.function() {
+            for entry in command.entries() {
+                self.visit_word_id(entry.word);
+            }
+            self.visit_stmt_seq(command.body());
+        } else if let Some(command) = command.anonymous_function() {
+            self.visit_stmt_seq(command.body());
+            for argument in command.args() {
+                self.visit_word(argument);
+            }
+        } else if let Some(command) = command.compound() {
+            self.visit_compound(command.node());
+        }
+    }
+
+    fn visit_compound(&mut self, command: &CompoundCommandNode) {
+        match command {
+            CompoundCommandNode::If {
+                condition,
+                then_branch,
+                elif_branches,
+                else_branch,
+                ..
+            } => {
+                self.visit_stmt_seq_id(*condition);
+                self.visit_stmt_seq_id(*then_branch);
+                for branch in self.store.elif_branches(*elif_branches) {
+                    self.visit_stmt_seq_id(branch.condition);
+                    self.visit_stmt_seq_id(branch.body);
+                }
+                if let Some(branch) = else_branch {
+                    self.visit_stmt_seq_id(*branch);
+                }
+            }
+            CompoundCommandNode::For { words, body, .. } => {
+                if let Some(words) = words {
+                    for word in self.store.word_ids(*words) {
+                        self.visit_word_id(*word);
+                    }
+                }
+                self.visit_stmt_seq_id(*body);
+            }
+            CompoundCommandNode::Repeat { count, body, .. } => {
+                self.visit_word_id(*count);
+                self.visit_stmt_seq_id(*body);
+            }
+            CompoundCommandNode::Foreach { words, body, .. } => {
+                for word in self.store.word_ids(*words) {
+                    self.visit_word_id(*word);
+                }
+                self.visit_stmt_seq_id(*body);
+            }
+            CompoundCommandNode::ArithmeticFor(command) => {
+                self.push_arithmetic_for_range(command);
+                self.visit_stmt_seq_id(command.body);
+            }
+            CompoundCommandNode::While { condition, body }
+            | CompoundCommandNode::Until { condition, body } => {
+                self.visit_stmt_seq_id(*condition);
+                self.visit_stmt_seq_id(*body);
+            }
+            CompoundCommandNode::Case { word, cases } => {
+                self.visit_word_id(*word);
+                for item in self.store.case_items(*cases) {
+                    for pattern in self.store.patterns(item.patterns) {
+                        self.visit_pattern(pattern);
+                    }
+                    self.visit_stmt_seq_id(item.body);
+                }
+            }
+            CompoundCommandNode::Select { words, body, .. } => {
+                for word in self.store.word_ids(*words) {
+                    self.visit_word_id(*word);
+                }
+                self.visit_stmt_seq_id(*body);
+            }
+            CompoundCommandNode::Subshell(body) | CompoundCommandNode::BraceGroup(body) => {
+                self.visit_stmt_seq_id(*body);
+            }
+            CompoundCommandNode::Always { body, always_body } => {
+                self.visit_stmt_seq_id(*body);
+                self.visit_stmt_seq_id(*always_body);
+            }
+            CompoundCommandNode::Arithmetic(command) => {
+                push_range(
+                    &mut self.arithmetic,
+                    command
+                        .left_paren_span
+                        .merge(command.right_paren_span)
+                        .to_range(),
+                );
+            }
+            CompoundCommandNode::Time { command, .. } => {
+                if let Some(command) = command {
+                    self.visit_stmt_seq_id(*command);
+                }
+            }
+            CompoundCommandNode::Conditional(command) => {
+                push_range(
+                    &mut self.conditionals,
+                    command
+                        .left_bracket_span
+                        .merge(command.right_bracket_span)
+                        .to_range(),
+                );
+                self.visit_conditional_expr(&command.expression);
+            }
+            CompoundCommandNode::Coproc { body, .. } => self.visit_stmt_seq_id(*body),
+        }
+    }
+
+    fn push_arithmetic_for_range(&mut self, command: &ArithmeticForCommandNode) {
+        let range = command
+            .left_paren_span
+            .merge(command.right_paren_span)
+            .to_range();
+        push_range(&mut self.arithmetic, range);
+    }
+
+    fn visit_conditional_expr(&mut self, expression: &ConditionalExprArena) {
+        match expression {
+            ConditionalExprArena::Binary { left, right, .. } => {
+                self.visit_conditional_expr(left);
+                self.visit_conditional_expr(right);
+            }
+            ConditionalExprArena::Unary { expr, .. } => self.visit_conditional_expr(expr),
+            ConditionalExprArena::Parenthesized { expr, .. } => {
+                self.visit_conditional_expr(expr);
+            }
+            ConditionalExprArena::Word(word) | ConditionalExprArena::Regex(word) => {
+                self.visit_word_id(*word);
+            }
+            ConditionalExprArena::Pattern(pattern) => self.visit_pattern(pattern),
+            ConditionalExprArena::VarRef(reference) => self.visit_var_ref_subscript(reference),
+        }
+    }
+
+    fn visit_redirect(&mut self, redirect: &RedirectNode) {
+        match &redirect.target {
+            RedirectTargetNode::Heredoc(heredoc) => {
+                let range = heredoc.body.span.to_range();
+                push_range(&mut self.heredocs, range);
+                if heredoc.delimiter.quoted {
+                    push_range(&mut self.quoted_heredocs, range);
+                }
+                self.visit_heredoc_body_parts(self.store.heredoc_body_parts(heredoc.body.parts));
+            }
+            RedirectTargetNode::Word(word) => self.visit_word_id(*word),
+        }
+    }
+
+    fn visit_assignment(&mut self, assignment: &AssignmentNode) {
+        self.visit_var_ref_subscript(&assignment.target);
+        match &assignment.value {
+            AssignmentValueNode::Scalar(word) => self.visit_word_id(*word),
+            AssignmentValueNode::Compound(array) => {
+                for element in self.store.array_elems(array.elements) {
+                    match element {
+                        shuck_ast::ArrayElemNode::Sequential(value) => {
+                            self.visit_word_id(value.word);
+                        }
+                        shuck_ast::ArrayElemNode::Keyed { key, value }
+                        | shuck_ast::ArrayElemNode::KeyedAppend { key, value } => {
+                            self.visit_subscript(Some(key));
+                            self.visit_word_id(value.word);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn visit_word_id(&mut self, word: WordId) {
+        self.visit_word(self.store.word(word));
+    }
+
+    fn visit_word(&mut self, word: WordView<'a>) {
+        self.visit_word_parts(word.parts());
+    }
+
+    fn visit_pattern(&mut self, pattern: &PatternNode) {
+        self.visit_pattern_parts(self.store.pattern_parts(pattern.parts));
+    }
+
+    fn visit_pattern_parts(&mut self, parts: &[shuck_ast::PatternPartArenaNode]) {
+        for part in parts {
+            match &part.kind {
+                PatternPartArena::Group { patterns, .. } => {
+                    for pattern in self.store.patterns(*patterns) {
+                        self.visit_pattern(pattern);
+                    }
+                }
+                PatternPartArena::Word(word) => self.visit_word_id(*word),
+                PatternPartArena::Literal(_)
+                | PatternPartArena::AnyString
+                | PatternPartArena::AnyChar
+                | PatternPartArena::CharClass(_) => {}
+            }
+        }
+    }
+
+    fn visit_word_parts(&mut self, parts: &[WordPartArenaNode]) {
+        for part in parts {
+            let range = part.span.to_range();
+            match &part.kind {
+                WordPartArena::ZshQualifiedGlob(glob) => {
+                    for segment in self.store.zsh_glob_segments(glob.segments) {
+                        if let ZshGlobSegmentNode::Pattern(pattern) = segment {
+                            self.visit_pattern(pattern);
+                        }
+                    }
+                }
+                WordPartArena::SingleQuoted { .. } => {
+                    push_range(&mut self.single_quoted, range);
+                }
+                WordPartArena::DoubleQuoted { parts, .. } => {
+                    push_range(&mut self.double_quoted, range);
+                    self.visit_word_parts(self.store.word_parts(*parts));
+                }
+                WordPartArena::CommandSubstitution { body, .. } => {
+                    push_range(&mut self.command_substitutions, range);
+                    self.visit_stmt_seq_id(*body);
+                }
+                WordPartArena::ArithmeticExpansion { .. } => {
+                    push_range(&mut self.arithmetic, range);
+                }
+                WordPartArena::ProcessSubstitution { body, .. } => self.visit_stmt_seq_id(*body),
+                WordPartArena::Literal(_)
+                | WordPartArena::Variable(_)
+                | WordPartArena::Parameter(_)
+                | WordPartArena::ParameterExpansion { .. }
+                | WordPartArena::Length(_)
+                | WordPartArena::ArrayAccess(_)
+                | WordPartArena::ArrayLength(_)
+                | WordPartArena::ArrayIndices(_)
+                | WordPartArena::Substring { .. }
+                | WordPartArena::ArraySlice { .. }
+                | WordPartArena::IndirectExpansion { .. }
+                | WordPartArena::PrefixMatch { .. }
+                | WordPartArena::Transformation { .. } => {}
+            }
+        }
+    }
+
+    fn visit_heredoc_body_parts(&mut self, parts: &[ArenaHeredocBodyPartNode]) {
+        for part in parts {
+            let range = part.span.to_range();
+            match &part.kind {
+                ArenaHeredocBodyPart::CommandSubstitution { body, .. } => {
+                    push_range(&mut self.command_substitutions, range);
+                    self.visit_stmt_seq_id(*body);
+                }
+                ArenaHeredocBodyPart::ArithmeticExpansion { .. } => {
+                    push_range(&mut self.arithmetic, range);
+                }
+                ArenaHeredocBodyPart::Literal(_)
+                | ArenaHeredocBodyPart::Variable(_)
+                | ArenaHeredocBodyPart::Parameter(_) => {}
+            }
+        }
+    }
+
+    fn visit_var_ref_subscript(&mut self, reference: &VarRefNode) {
+        self.visit_subscript(reference.subscript.as_deref());
+    }
+
+    fn visit_subscript(&mut self, subscript: Option<&SubscriptNode>) {
+        let Some(subscript) = subscript else {
+            return;
+        };
+        if matches!(subscript.kind, shuck_ast::SubscriptKind::Selector(_)) {
+            return;
+        }
+        if let Some(expression_ast) = subscript.arithmetic_ast.as_ref() {
+            self.visit_arithmetic_shell_words(expression_ast);
+            return;
+        }
+
+        if let Some(word) = subscript.word_ast {
+            self.visit_word_id(word);
+            return;
+        }
+
+        debug_assert!(
+            subscript.word_ast.is_some(),
+            "ordinary subscripts should always carry a word AST"
+        );
+    }
+
+    fn visit_arithmetic_shell_words(&mut self, expression: &ArithmeticExprArenaNode) {
+        match &expression.kind {
+            ArithmeticExprArena::Number(_) | ArithmeticExprArena::Variable(_) => {}
+            ArithmeticExprArena::Indexed { index, .. } => self.visit_arithmetic_shell_words(index),
+            ArithmeticExprArena::ShellWord(word) => self.visit_word_id(*word),
+            ArithmeticExprArena::Parenthesized { expression } => {
+                self.visit_arithmetic_shell_words(expression);
+            }
+            ArithmeticExprArena::Unary { expr, .. } | ArithmeticExprArena::Postfix { expr, .. } => {
+                self.visit_arithmetic_shell_words(expr);
+            }
+            ArithmeticExprArena::Binary { left, right, .. } => {
+                self.visit_arithmetic_shell_words(left);
+                self.visit_arithmetic_shell_words(right);
+            }
+            ArithmeticExprArena::Conditional {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.visit_arithmetic_shell_words(condition);
+                self.visit_arithmetic_shell_words(then_expr);
+                self.visit_arithmetic_shell_words(else_expr);
+            }
+            ArithmeticExprArena::Assignment { target, value, .. } => {
+                if let ArithmeticLvalueArena::Indexed { index, .. } = target {
+                    self.visit_arithmetic_shell_words(index);
+                }
+                self.visit_arithmetic_shell_words(value);
+            }
+        }
+    }
+
+    fn visit_stmt_seq_id(&mut self, id: shuck_ast::StmtSeqId) {
+        self.visit_stmt_seq(self.store.stmt_seq(id));
     }
 }
 

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -2,7 +2,7 @@ use std::sync::OnceLock;
 
 use rustc_hash::FxHashSet;
 use shuck_ast::TextSize;
-use shuck_ast::{File, Span};
+use shuck_ast::{ArenaFile, File, Span};
 use shuck_indexer::Indexer;
 use shuck_semantic::{SemanticAnalysis, SemanticModel};
 
@@ -16,6 +16,7 @@ pub struct Checker<'a> {
     semantic_analysis: SemanticAnalysis<'a>,
     indexer: &'a Indexer,
     file: &'a File,
+    ast: &'a ArenaFile,
     source: &'a str,
     facts: OnceLock<LinterFacts<'a>>,
     rules: &'a RuleSet,
@@ -51,6 +52,7 @@ impl<'a> Checker<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         file: &'a File,
+        ast: &'a ArenaFile,
         source: &'a str,
         semantic: &'a SemanticModel,
         indexer: &'a Indexer,
@@ -68,6 +70,7 @@ impl<'a> Checker<'a> {
             semantic_analysis: semantic.analysis(),
             indexer,
             file,
+            ast,
             source,
             facts: OnceLock::new(),
             rules,
@@ -95,8 +98,8 @@ impl<'a> Checker<'a> {
         self.indexer
     }
 
-    pub fn ast(&self) -> &'a File {
-        self.file
+    pub fn ast(&self) -> &'a ArenaFile {
+        self.ast
     }
 
     pub fn source(&self) -> &'a str {

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -711,8 +711,8 @@ fn collect_base_prefix_spans_in_text(span: Span, source: &str, spans: &mut Vec<S
 fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
     commands
         .iter()
-        .filter_map(|fact| match fact.command() {
-            Command::Compound(CompoundCommand::Subshell(_)) => {
+        .filter_map(|fact| match fact.compound_kind() {
+            Some(CommandFactCompoundKind::Subshell) => {
                 double_paren_grouping_anchor(fact.span(), source)
             }
             _ => None,

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -95,66 +95,58 @@ impl<'a> BindingValueFact<'a> {
     }
 }
 
-fn build_bare_command_name_assignment_spans<'a>(
-    commands: &[CommandFact<'a>],
-    word_nodes: &[WordNode<'a>],
-    word_occurrences: &[WordOccurrence],
-    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+fn build_bare_command_name_assignment_spans(
+    commands: &[CommandFact<'_>],
+    arena_file: &ArenaFile,
     source: &str,
 ) -> Vec<Span> {
     commands
         .iter()
-        .filter_map(|command| {
-            bare_command_name_assignment_span(
-                command,
-                word_nodes,
-                word_occurrences,
-                word_index,
-                source,
-            )
-        })
+        .filter_map(|command| bare_command_name_assignment_span(command, arena_file, source))
         .collect()
 }
 
 fn build_assignment_like_command_name_spans<'a>(
-    _commands: &[CommandFact<'a>],
-    _source: &str,
-) -> Vec<Span> {
-    Vec::new()
-}
-
-fn collect_assignment_like_command_name_spans_in_command(
-    command: &Command,
+    commands: &[CommandFact<'a>],
+    arena_file: &ArenaFile,
     source: &str,
-    spans: &mut Vec<Span>,
-) {
-    match command {
-        Command::Simple(command) => {
-            collect_assignment_like_command_name_span(&command.name, source, spans);
-        }
-        Command::Decl(command) => {
-            for operand in &command.operands {
-                if let DeclOperand::Dynamic(word) = operand {
-                    collect_assignment_like_command_name_span(word, source, spans);
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+    for fact in commands {
+        let Some(command_id) = fact.arena_command_id() else {
+            continue;
+        };
+        let command = arena_file.store.command(command_id);
+        if let Some(simple) = command.simple() {
+            collect_assignment_like_arena_command_name_span(simple.name(), source, &mut spans);
+        } else if let Some(decl) = command.decl() {
+            for operand in decl.operands() {
+                if let DeclOperandNode::Dynamic(word_id) = operand {
+                    collect_assignment_like_arena_command_name_span(
+                        arena_file.store.word(*word_id),
+                        source,
+                        &mut spans,
+                    );
                 }
             }
         }
-        Command::Builtin(_)
-        | Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => {}
     }
+
+    spans
 }
 
-fn collect_assignment_like_command_name_span(word: &Word, source: &str, spans: &mut Vec<Span>) {
-    if let Some(span) = assignment_like_command_name_span(word, source) {
+fn collect_assignment_like_arena_command_name_span(
+    word: WordView<'_>,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    if let Some(span) = assignment_like_arena_command_name_span(word, source) {
         spans.push(span);
     }
 }
 
-fn assignment_like_command_name_span(word: &Word, source: &str) -> Option<Span> {
-    let prefix = leading_literal_word_prefix(word, source);
+fn assignment_like_arena_command_name_span(word: WordView<'_>, source: &str) -> Option<Span> {
+    let prefix = arena_leading_literal_word_prefix(word, source);
     let target_end = prefix.find("+=").or_else(|| prefix.find('='))?;
     let target = &prefix[..target_end];
     if target.is_empty() || target.chars().any(char::is_whitespace) {
@@ -162,43 +154,92 @@ fn assignment_like_command_name_span(word: &Word, source: &str) -> Option<Span> 
     }
 
     if let Some(remainder) = target.strip_prefix('+') {
-        is_shell_variable_name(remainder).then_some(word.span)
+        is_shell_variable_name(remainder).then_some(word.span())
     } else {
-        (!is_shell_variable_name(target)).then_some(word.span)
+        (!is_shell_variable_name(target)).then_some(word.span())
     }
 }
 
-fn bare_command_name_assignment_span<'a>(
-    _command: &CommandFact<'a>,
-    _word_nodes: &[WordNode<'a>],
-    _word_occurrences: &[WordOccurrence],
-    _word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
-    _source: &str,
+fn arena_leading_literal_word_prefix(word: WordView<'_>, source: &str) -> String {
+    let mut prefix = String::new();
+    collect_arena_leading_literal_word_parts(word.parts(), word.store(), source, &mut prefix);
+    prefix
+}
+
+fn collect_arena_leading_literal_word_parts(
+    parts: &[WordPartArenaNode],
+    store: &AstStore,
+    source: &str,
+    prefix: &mut String,
+) -> bool {
+    for part in parts {
+        if !collect_arena_leading_literal_word_part(part, store, source, prefix) {
+            return false;
+        }
+    }
+    true
+}
+
+fn collect_arena_leading_literal_word_part(
+    part: &WordPartArenaNode,
+    store: &AstStore,
+    source: &str,
+    prefix: &mut String,
+) -> bool {
+    match &part.kind {
+        WordPartArena::Literal(text) => {
+            prefix.push_str(text.as_str(source, part.span));
+            true
+        }
+        WordPartArena::SingleQuoted { value, .. } => {
+            prefix.push_str(value.slice(source));
+            true
+        }
+        WordPartArena::DoubleQuoted { parts, .. } => collect_arena_leading_literal_word_parts(
+            store.word_parts(*parts),
+            store,
+            source,
+            prefix,
+        ),
+        _ => false,
+    }
+}
+
+fn bare_command_name_assignment_span(
+    fact: &CommandFact<'_>,
+    arena_file: &ArenaFile,
+    source: &str,
 ) -> Option<Span> {
-    None
-}
-
-fn anchored_assignment_command_span(
-    _command: &CommandFact<'_>,
-    assignment: &Assignment,
-    _source: &str,
-) -> Span {
-    Span {
-        start: assignment.span.start,
-        end: assignment.span.end,
+    let command = arena_file.store.command(fact.arena_command_id()?);
+    let assignments = arena_command_assignments(command);
+    let [assignment] = assignments else {
+        return None;
+    };
+    let AssignmentValueNode::Scalar(word_id) = assignment.value else {
+        return None;
+    };
+    let value = arena_file.store.word(word_id);
+    let [part] = value.parts() else {
+        return None;
+    };
+    let WordPartArena::Literal(text) = &part.kind else {
+        return None;
+    };
+    if !is_bare_command_name_assignment_value(text.as_str(source, part.span)) {
+        return None;
     }
-}
 
-fn assignment_target_span(assignment: &Assignment) -> Span {
-    assignment.target.subscript.as_deref().map_or_else(
-        || assignment.target.name_span,
-        |subscript| {
-            Span::from_positions(
-                assignment.target.name_span.start,
-                subscript.span().end.advanced_by("]"),
-            )
-        },
-    )
+    let command_span = trim_trailing_whitespace_span(command.span(), source);
+    let stmt_span = trim_trailing_whitespace_span(fact.stmt_span(), source);
+    if !command_span.slice(source).chars().any(char::is_whitespace) {
+        Some(assignment_node_target_span(assignment))
+    } else if stmt_span.end.offset > command_span.end.offset {
+        Some(stmt_span)
+    } else if command_span.end.offset <= assignment.span.end.offset {
+        Some(assignment_node_target_span(assignment))
+    } else {
+        Some(command_span)
+    }
 }
 
 fn is_bare_command_name_assignment_value(text: &str) -> bool {
@@ -316,36 +357,37 @@ struct EnvPrefixScopeSpans {
     expansion_scope_spans: Vec<Span>,
 }
 
-fn build_env_prefix_scope_spans(_source: &str, _commands: &[CommandFact<'_>]) -> EnvPrefixScopeSpans {
-    EnvPrefixScopeSpans::default()
-}
-
-#[cfg(any())]
-fn build_env_prefix_scope_spans_legacy(source: &str, commands: &[CommandFact<'_>]) -> EnvPrefixScopeSpans {
+fn build_env_prefix_scope_spans(
+    source: &str,
+    commands: &[CommandFact<'_>],
+    arena_file: &ArenaFile,
+) -> EnvPrefixScopeSpans {
     let mut scope_spans = EnvPrefixScopeSpans::default();
     let mut seen_assignment_scope_spans = FxHashSet::default();
     let mut seen_expansion_scope_spans = FxHashSet::default();
 
-    for command in commands {
-        if command_is_assignment_only(command, source) {
+    for fact in commands {
+        let Some(command_id) = fact.arena_command_id() else {
+            continue;
+        };
+        let command = arena_file.store.command(command_id);
+        if command_is_assignment_only(fact, source) {
             continue;
         }
 
-        let assignments = command_assignments(command.command());
-        let broken_legacy_bracket_tail = match command.command() {
-            Command::Simple(simple) => broken_legacy_bracket_tail(simple, source),
-            Command::Builtin(_)
-            | Command::Decl(_)
-            | Command::Binary(_)
-            | Command::Compound(_)
-            | Command::Function(_)
-            | Command::AnonymousFunction(_) => None,
-        };
+        let assignments = arena_command_assignments(command);
+        let broken_legacy_bracket_tail = command
+            .simple()
+            .and_then(|simple| broken_legacy_bracket_tail(simple, source));
 
         for (index, assignment) in assignments.iter().enumerate() {
             let span_key = FactSpan::new(assignment.target.name_span);
             let earlier_prefix_uses_name = assignments.iter().take(index).any(|other| {
-                assignment_mentions_name_outside_nested_commands(other, &assignment.target.name)
+                assignment_mentions_name_outside_nested_commands(
+                    other,
+                    &arena_file.store,
+                    &assignment.target.name,
+                )
             });
             let later_prefix_uses_name =
                 assignments
@@ -355,28 +397,18 @@ fn build_env_prefix_scope_spans_legacy(source: &str, commands: &[CommandFact<'_>
                     .any(|(other_index, other)| {
                         assignment_mentions_name_outside_nested_commands(
                             other,
+                            &arena_file.store,
                             &assignment.target.name,
-                        ) || match (command.command(), broken_legacy_bracket_tail) {
-                            (Command::Simple(simple), Some(tail))
-                                if tail.assignment_index == other_index =>
-                            {
-                                broken_legacy_bracket_tail_mentions_name(
-                                    simple,
-                                    tail,
-                                    &assignment.target.name,
-                                )
-                            }
-                            (
-                                Command::Builtin(_)
-                                | Command::Decl(_)
-                                | Command::Binary(_)
-                                | Command::Compound(_)
-                                | Command::Function(_)
-                                | Command::AnonymousFunction(_),
-                                _,
-                            )
-                            | (Command::Simple(_), _) => false,
-                        }
+                        ) || command.simple().is_some_and(|simple| {
+                            broken_legacy_bracket_tail.is_some_and(|tail| {
+                                tail.assignment_index == other_index
+                                    && broken_legacy_bracket_tail_mentions_name(
+                                        simple,
+                                        tail,
+                                        &assignment.target.name,
+                                    )
+                            })
+                        })
                     });
             let body_uses_name = command_body_mentions_name_outside_nested_commands(
                 command,
@@ -386,7 +418,8 @@ fn build_env_prefix_scope_spans_legacy(source: &str, commands: &[CommandFact<'_>
 
             if (earlier_prefix_uses_name
                 || later_prefix_uses_name
-                || (body_uses_name && !assignment_is_identity_self_copy(assignment)))
+                || (body_uses_name
+                    && !assignment_is_identity_self_copy(assignment, &arena_file.store)))
                 && seen_assignment_scope_spans.insert(span_key)
             {
                 scope_spans
@@ -401,6 +434,7 @@ fn build_env_prefix_scope_spans_legacy(source: &str, commands: &[CommandFact<'_>
 
                 let _ = visit_assignment_reference_spans_outside_nested_commands(
                     other,
+                    &arena_file.store,
                     &assignment.target.name,
                     &mut |span| {
                         push_fact_span(
@@ -412,34 +446,22 @@ fn build_env_prefix_scope_spans_legacy(source: &str, commands: &[CommandFact<'_>
                     },
                 );
 
-                match (command.command(), broken_legacy_bracket_tail) {
-                    (Command::Simple(simple), Some(tail))
-                        if tail.assignment_index == other_index =>
-                    {
-                        let _ = visit_broken_legacy_bracket_tail_reference_spans(
-                            simple,
-                            tail,
-                            &assignment.target.name,
-                            &mut |span| {
-                                push_fact_span(
-                                    span,
-                                    &mut scope_spans.expansion_scope_spans,
-                                    &mut seen_expansion_scope_spans,
-                                );
-                                ControlFlow::Continue(())
-                            },
-                        );
-                    }
-                    (
-                        Command::Builtin(_)
-                        | Command::Decl(_)
-                        | Command::Binary(_)
-                        | Command::Compound(_)
-                        | Command::Function(_)
-                        | Command::AnonymousFunction(_),
-                        _,
-                    )
-                    | (Command::Simple(_), _) => {}
+                if let (Some(simple), Some(tail)) = (command.simple(), broken_legacy_bracket_tail)
+                    && tail.assignment_index == other_index
+                {
+                    let _ = visit_broken_legacy_bracket_tail_reference_spans(
+                        simple,
+                        tail,
+                        &assignment.target.name,
+                        &mut |span| {
+                            push_fact_span(
+                                span,
+                                &mut scope_spans.expansion_scope_spans,
+                                &mut seen_expansion_scope_spans,
+                            );
+                            ControlFlow::Continue(())
+                        },
+                    );
                 }
             }
 
@@ -448,6 +470,7 @@ fn build_env_prefix_scope_spans_legacy(source: &str, commands: &[CommandFact<'_>
             }) {
                 let _ = visit_assignment_reference_spans_outside_nested_commands(
                     assignment,
+                    &arena_file.store,
                     &assignment.target.name,
                     &mut |span| {
                         push_fact_span(
@@ -493,22 +516,28 @@ struct BrokenLegacyBracketTail {
 
 type EnvPrefixReferenceSpanVisitor<'a> = dyn FnMut(Span) -> ControlFlow<()> + 'a;
 
-fn command_is_assignment_only(_fact: &CommandFact<'_>, _source: &str) -> bool {
-    false
+fn command_is_assignment_only(fact: &CommandFact<'_>, _source: &str) -> bool {
+    fact.body_word_span().is_none() || fact.effective_or_literal_name().is_none()
 }
 
 fn broken_legacy_bracket_tail(
-    command: &SimpleCommand,
+    command: shuck_ast::SimpleCommandView<'_>,
     source: &str,
 ) -> Option<BrokenLegacyBracketTail> {
-    let assignment_index = command.assignments.len().checked_sub(1)?;
-    if !assignment_is_broken_legacy_bracket_arithmetic(&command.assignments[assignment_index]) {
+    let store = command.name().store();
+    let assignment_index = command.assignments().len().checked_sub(1)?;
+    if !assignment_is_broken_legacy_bracket_arithmetic(
+        &command.assignments()[assignment_index],
+        store,
+    ) {
         return None;
     }
 
-    let synthetic_word_count = std::iter::once(&command.name)
-        .chain(command.args.iter())
-        .position(|word| static_word_text(word, source).as_deref() == Some("]"))?
+    let synthetic_word_count = std::iter::once(command.name_id())
+        .chain(command.arg_ids().iter().copied())
+        .position(|word_id| {
+            static_word_text_arena(store.word(word_id), source).as_deref() == Some("]")
+        })?
         + 1;
 
     Some(BrokenLegacyBracketTail {
@@ -517,16 +546,23 @@ fn broken_legacy_bracket_tail(
     })
 }
 
-fn assignment_is_broken_legacy_bracket_arithmetic(assignment: &Assignment) -> bool {
-    let AssignmentValue::Scalar(word) = &assignment.value else {
+fn assignment_is_broken_legacy_bracket_arithmetic(
+    assignment: &AssignmentNode,
+    store: &AstStore,
+) -> bool {
+    let AssignmentValueNode::Scalar(word_id) = assignment.value else {
         return false;
     };
-    let [part] = word.parts.as_slice() else {
+    word_is_broken_legacy_bracket_arithmetic(store.word(word_id))
+}
+
+fn word_is_broken_legacy_bracket_arithmetic(word: WordView<'_>) -> bool {
+    let [part] = word.parts() else {
         return false;
     };
     matches!(
         &part.kind,
-        WordPart::ArithmeticExpansion {
+        WordPartArena::ArithmeticExpansion {
             syntax: ArithmeticExpansionSyntax::LegacyBracket,
             expression_ast: None,
             ..
@@ -534,37 +570,43 @@ fn assignment_is_broken_legacy_bracket_arithmetic(assignment: &Assignment) -> bo
     )
 }
 
-fn assignment_mentions_name_outside_nested_commands(assignment: &Assignment, name: &Name) -> bool {
-    visit_assignment_reference_spans_outside_nested_commands(assignment, name, &mut |_span| {
-        ControlFlow::Break(())
-    })
+fn assignment_mentions_name_outside_nested_commands(
+    assignment: &AssignmentNode,
+    store: &AstStore,
+    name: &Name,
+) -> bool {
+    visit_assignment_reference_spans_outside_nested_commands(
+        assignment,
+        store,
+        name,
+        &mut |_span| ControlFlow::Break(()),
+    )
     .is_break()
 }
 
 fn command_body_mentions_name_outside_nested_commands(
-    fact: &CommandFact<'_>,
+    command: CommandView<'_>,
     source: &str,
     name: &Name,
 ) -> bool {
-    visit_command_body_reference_spans_outside_nested_commands(fact, source, name, &mut |_span| {
-        ControlFlow::Break(())
-    })
+    visit_command_body_reference_spans_outside_nested_commands(
+        command,
+        source,
+        name,
+        &mut |_span| ControlFlow::Break(()),
+    )
     .is_break()
 }
 
 fn simple_command_body_words<'a>(
     command: &'a SimpleCommand,
-    source: &'a str,
+    _source: &'a str,
 ) -> impl Iterator<Item = &'a Word> {
-    let skip =
-        broken_legacy_bracket_tail(command, source).map_or(0, |tail| tail.synthetic_word_count);
-    std::iter::once(&command.name)
-        .chain(command.args.iter())
-        .skip(skip)
+    std::iter::once(&command.name).chain(command.args.iter())
 }
 
 fn broken_legacy_bracket_tail_mentions_name(
-    command: &SimpleCommand,
+    command: shuck_ast::SimpleCommandView<'_>,
     tail: BrokenLegacyBracketTail,
     name: &Name,
 ) -> bool {
@@ -575,33 +617,45 @@ fn broken_legacy_bracket_tail_mentions_name(
 }
 
 fn visit_assignment_reference_spans_outside_nested_commands(
-    assignment: &Assignment,
+    assignment: &AssignmentNode,
+    store: &AstStore,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     visit_subscript_reference_spans_outside_nested_commands(
         assignment.target.subscript.as_deref(),
+        store,
         name,
         visit,
     )?;
 
     match &assignment.value {
-        AssignmentValue::Scalar(word) => {
-            visit_word_reference_spans_outside_nested_commands(word, name, visit)
+        AssignmentValueNode::Scalar(word_id) => {
+            visit_word_reference_spans_outside_nested_commands(store.word(*word_id), name, visit)
         }
-        AssignmentValue::Compound(array) => {
-            for element in &array.elements {
+        AssignmentValueNode::Compound(array) => {
+            for element in store.array_elems(array.elements) {
                 match element {
-                    ArrayElem::Sequential(word) => {
-                        visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
-                    }
-                    ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
-                        visit_subscript_reference_spans_outside_nested_commands(
-                            Some(key),
+                    ArrayElemNode::Sequential(value) => {
+                        visit_word_reference_spans_outside_nested_commands(
+                            store.word(value.word),
                             name,
                             visit,
                         )?;
-                        visit_word_reference_spans_outside_nested_commands(value, name, visit)?;
+                    }
+                    ArrayElemNode::Keyed { key, value }
+                    | ArrayElemNode::KeyedAppend { key, value } => {
+                        visit_subscript_reference_spans_outside_nested_commands(
+                            Some(key),
+                            store,
+                            name,
+                            visit,
+                        )?;
+                        visit_word_reference_spans_outside_nested_commands(
+                            store.word(value.word),
+                            name,
+                            visit,
+                        )?;
                     }
                 }
             }
@@ -612,103 +666,119 @@ fn visit_assignment_reference_spans_outside_nested_commands(
 }
 
 fn visit_command_body_reference_spans_outside_nested_commands(
-    _fact: &CommandFact<'_>,
-    _source: &str,
-    _name: &Name,
-    _visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
+    command: CommandView<'_>,
+    source: &str,
+    name: &Name,
+    visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
+    if let Some(simple) = command.simple() {
+        let skip =
+            broken_legacy_bracket_tail(simple, source).map_or(0, |tail| tail.synthetic_word_count);
+        for word_id in std::iter::once(simple.name_id())
+            .chain(simple.arg_ids().iter().copied())
+            .skip(skip)
+        {
+            visit_word_reference_spans_outside_nested_commands(
+                command.store().word(word_id),
+                name,
+                visit,
+            )?;
+        }
+    } else if let Some(builtin) = command.builtin() {
+        if let Some(word) = builtin.primary() {
+            visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
+        }
+        for word_id in builtin.extra_arg_ids() {
+            visit_word_reference_spans_outside_nested_commands(
+                command.store().word(*word_id),
+                name,
+                visit,
+            )?;
+        }
+    } else if let Some(decl) = command.decl() {
+        for operand in decl.operands() {
+            match operand {
+                DeclOperandNode::Flag(word_id) | DeclOperandNode::Dynamic(word_id) => {
+                    visit_word_reference_spans_outside_nested_commands(
+                        command.store().word(*word_id),
+                        name,
+                        visit,
+                    )?;
+                }
+                DeclOperandNode::Name(reference) => {
+                    visit_var_ref_reference_spans_outside_nested_commands(
+                        reference,
+                        command.store(),
+                        name,
+                        visit,
+                    )?;
+                }
+                DeclOperandNode::Assignment(assignment) => {
+                    visit_assignment_reference_spans_outside_nested_commands(
+                        assignment,
+                        command.store(),
+                        name,
+                        visit,
+                    )?;
+                }
+            }
+        }
+    }
+
     ControlFlow::Continue(())
 }
 
 fn visit_broken_legacy_bracket_tail_reference_spans(
-    command: &SimpleCommand,
+    command: shuck_ast::SimpleCommandView<'_>,
     tail: BrokenLegacyBracketTail,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
-    for word in std::iter::once(&command.name)
-        .chain(command.args.iter())
+    let store = command.name().store();
+    for word_id in std::iter::once(command.name_id())
+        .chain(command.arg_ids().iter().copied())
         .take(tail.synthetic_word_count.saturating_sub(1))
     {
-        visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
+        visit_word_reference_spans_outside_nested_commands(store.word(word_id), name, visit)?;
     }
 
     ControlFlow::Continue(())
 }
 
-fn builtin_words(command: &BuiltinCommand) -> Vec<&Word> {
-    let mut words = Vec::new();
-    match command {
-        BuiltinCommand::Break(command) => {
-            if let Some(word) = &command.depth {
-                words.push(word);
-            }
-            words.extend(command.extra_args.iter());
-        }
-        BuiltinCommand::Continue(command) => {
-            if let Some(word) = &command.depth {
-                words.push(word);
-            }
-            words.extend(command.extra_args.iter());
-        }
-        BuiltinCommand::Return(command) => {
-            if let Some(word) = &command.code {
-                words.push(word);
-            }
-            words.extend(command.extra_args.iter());
-        }
-        BuiltinCommand::Exit(command) => {
-            if let Some(word) = &command.code {
-                words.push(word);
-            }
-            words.extend(command.extra_args.iter());
-        }
-    }
-    words
-}
-
-fn assignment_is_identity_self_copy(assignment: &Assignment) -> bool {
+fn assignment_is_identity_self_copy(assignment: &AssignmentNode, store: &AstStore) -> bool {
     if assignment.append {
         return false;
     }
 
-    let AssignmentValue::Scalar(word) = &assignment.value else {
+    let AssignmentValueNode::Scalar(word_id) = assignment.value else {
         return false;
     };
-    word_is_identity_self_copy(word, &assignment.target.name)
+    word_is_identity_self_copy(store.word(word_id), &assignment.target.name)
 }
 
-fn word_is_identity_self_copy(word: &Word, name: &Name) -> bool {
-    let [part] = word.parts.as_slice() else {
+fn word_is_identity_self_copy(word: WordView<'_>, name: &Name) -> bool {
+    let [part] = word.parts() else {
         return false;
     };
     word_part_is_identity_self_copy(&part.kind, name)
 }
 
-fn word_part_is_identity_self_copy(part: &WordPart, name: &Name) -> bool {
+fn word_part_is_identity_self_copy(part: &WordPartArena, name: &Name) -> bool {
     match part {
-        WordPart::Variable(variable) => variable == name,
-        WordPart::DoubleQuoted { parts, .. } => {
-            let [part] = parts.as_slice() else {
-                return false;
-            };
-            word_part_is_identity_self_copy(&part.kind, name)
-        }
-        WordPart::Parameter(parameter) => parameter_is_plain_access_to_name(parameter, name),
+        WordPartArena::Variable(variable) => variable == name,
+        WordPartArena::Parameter(parameter) => parameter_is_plain_access_to_name(parameter, name),
         _ => false,
     }
 }
 
-fn parameter_is_plain_access_to_name(parameter: &ParameterExpansion, name: &Name) -> bool {
+fn parameter_is_plain_access_to_name(parameter: &ParameterExpansionNode, name: &Name) -> bool {
     match &parameter.syntax {
-        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
-            if reference.subscript.is_none() =>
-        {
-            &reference.name == name
-        }
-        ParameterExpansionSyntax::Zsh(syntax)
+        ParameterExpansionSyntaxNode::Bourne(BourneParameterExpansionNode::Access {
+            reference,
+        }) if reference.subscript.is_none() => &reference.name == name,
+        ParameterExpansionSyntaxNode::Zsh(syntax)
             if syntax.operation.is_none()
-                && matches!(&syntax.target, ZshExpansionTarget::Reference(reference) if reference.subscript.is_none() && &reference.name == name) =>
+                && matches!(&syntax.target, ZshExpansionTargetNode::Reference(reference) if reference.subscript.is_none() && &reference.name == name) =>
         {
             true
         }
@@ -717,7 +787,8 @@ fn parameter_is_plain_access_to_name(parameter: &ParameterExpansion, name: &Name
 }
 
 fn visit_subscript_reference_spans_outside_nested_commands(
-    subscript: Option<&Subscript>,
+    subscript: Option<&SubscriptNode>,
+    store: &AstStore,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
@@ -725,86 +796,91 @@ fn visit_subscript_reference_spans_outside_nested_commands(
         return ControlFlow::Continue(());
     };
 
-    if let Some(word) = subscript.word_ast() {
-        visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
+    if let Some(word_id) = subscript.word_ast {
+        visit_word_reference_spans_outside_nested_commands(store.word(word_id), name, visit)?;
     }
     if let Some(expr) = subscript.arithmetic_ast.as_ref() {
-        visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
+        visit_arithmetic_reference_spans_outside_nested_commands(expr, store, name, visit)?;
     }
 
     ControlFlow::Continue(())
 }
 
 fn visit_word_reference_spans_outside_nested_commands(
-    word: &Word,
+    word: WordView<'_>,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
-    for part in &word.parts {
-        visit_word_part_reference_spans_outside_nested_commands(part, name, visit)?;
+    for part in word.parts() {
+        visit_word_part_reference_spans_outside_nested_commands(part, word.store(), name, visit)?;
     }
 
     ControlFlow::Continue(())
 }
 
 fn visit_word_part_reference_spans_outside_nested_commands(
-    part: &WordPartNode,
+    part: &WordPartArenaNode,
+    store: &AstStore,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     match &part.kind {
-        WordPart::Literal(_)
-        | WordPart::SingleQuoted { .. }
-        | WordPart::ZshQualifiedGlob(_)
-        | WordPart::PrefixMatch { .. } => {}
-        WordPart::DoubleQuoted { parts, .. } => {
-            for part in parts {
-                visit_word_part_reference_spans_outside_nested_commands(part, name, visit)?;
+        WordPartArena::Literal(_)
+        | WordPartArena::SingleQuoted { .. }
+        | WordPartArena::ZshQualifiedGlob(_)
+        | WordPartArena::PrefixMatch { .. } => {}
+        WordPartArena::DoubleQuoted { parts, .. } => {
+            for part in store.word_parts(*parts) {
+                visit_word_part_reference_spans_outside_nested_commands(part, store, name, visit)?;
             }
         }
-        WordPart::Variable(variable) => {
+        WordPartArena::Variable(variable) => {
             if variable == name {
                 visit(part.span)?;
             }
         }
-        WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
-        WordPart::ArithmeticExpansion {
+        WordPartArena::CommandSubstitution { .. } | WordPartArena::ProcessSubstitution { .. } => {}
+        WordPartArena::ArithmeticExpansion {
             expression_ast,
             expression_word_ast,
             ..
         } => {
             if let Some(expr) = expression_ast.as_ref() {
-                visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
+                visit_arithmetic_reference_spans_outside_nested_commands(expr, store, name, visit)?;
             }
-            visit_word_reference_spans_outside_nested_commands(expression_word_ast, name, visit)?;
+            visit_word_reference_spans_outside_nested_commands(
+                store.word(*expression_word_ast),
+                name,
+                visit,
+            )?;
         }
-        WordPart::Parameter(parameter) => {
+        WordPartArena::Parameter(parameter) => {
             visit_parameter_reference_spans_outside_nested_commands(
-                parameter, part.span, name, visit,
+                parameter, store, part.span, name, visit,
             )?;
         }
-        WordPart::ParameterExpansion {
+        WordPartArena::ParameterExpansion {
             reference,
             operand_word_ast,
             ..
         } => {
-            visit_var_ref_reference_spans_outside_nested_commands(
-                reference, part.span, name, visit,
-            )?;
-            if let Some(word) = operand_word_ast.as_ref() {
-                visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
+            visit_var_ref_reference_spans_outside_nested_commands(reference, store, name, visit)?;
+            if let Some(word_id) = operand_word_ast {
+                visit_word_reference_spans_outside_nested_commands(
+                    store.word(*word_id),
+                    name,
+                    visit,
+                )?;
             }
         }
-        WordPart::Length(reference)
-        | WordPart::ArrayAccess(reference)
-        | WordPart::ArrayLength(reference)
-        | WordPart::ArrayIndices(reference)
-        | WordPart::Transformation { reference, .. } => {
-            visit_var_ref_reference_spans_outside_nested_commands(
-                reference, part.span, name, visit,
-            )?;
+        WordPartArena::Length(reference)
+        | WordPartArena::ArrayAccess(reference)
+        | WordPartArena::ArrayLength(reference)
+        | WordPartArena::ArrayIndices(reference)
+        | WordPartArena::Transformation { reference, .. } => {
+            visit_var_ref_reference_spans_outside_nested_commands(reference, store, name, visit)?;
         }
-        WordPart::Substring {
+        WordPartArena::Substring {
             reference,
             offset_ast,
             offset_word_ast,
@@ -812,7 +888,7 @@ fn visit_word_part_reference_spans_outside_nested_commands(
             length_word_ast,
             ..
         }
-        | WordPart::ArraySlice {
+        | WordPartArena::ArraySlice {
             reference,
             offset_ast,
             offset_word_ast,
@@ -820,30 +896,38 @@ fn visit_word_part_reference_spans_outside_nested_commands(
             length_word_ast,
             ..
         } => {
-            visit_var_ref_reference_spans_outside_nested_commands(
-                reference, part.span, name, visit,
-            )?;
+            visit_var_ref_reference_spans_outside_nested_commands(reference, store, name, visit)?;
             if let Some(expr) = offset_ast.as_ref() {
-                visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
+                visit_arithmetic_reference_spans_outside_nested_commands(expr, store, name, visit)?;
             }
-            visit_word_reference_spans_outside_nested_commands(offset_word_ast, name, visit)?;
+            visit_word_reference_spans_outside_nested_commands(
+                store.word(*offset_word_ast),
+                name,
+                visit,
+            )?;
             if let Some(expr) = length_ast.as_ref() {
-                visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
+                visit_arithmetic_reference_spans_outside_nested_commands(expr, store, name, visit)?;
             }
-            if let Some(word) = length_word_ast.as_ref() {
-                visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
+            if let Some(word_id) = length_word_ast {
+                visit_word_reference_spans_outside_nested_commands(
+                    store.word(*word_id),
+                    name,
+                    visit,
+                )?;
             }
         }
-        WordPart::IndirectExpansion {
+        WordPartArena::IndirectExpansion {
             reference,
             operand_word_ast,
             ..
         } => {
-            visit_var_ref_reference_spans_outside_nested_commands(
-                reference, part.span, name, visit,
-            )?;
-            if let Some(word) = operand_word_ast.as_ref() {
-                visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
+            visit_var_ref_reference_spans_outside_nested_commands(reference, store, name, visit)?;
+            if let Some(word_id) = operand_word_ast {
+                visit_word_reference_spans_outside_nested_commands(
+                    store.word(*word_id),
+                    name,
+                    visit,
+                )?;
             }
         }
     }
@@ -852,59 +936,83 @@ fn visit_word_part_reference_spans_outside_nested_commands(
 }
 
 fn visit_parameter_reference_spans_outside_nested_commands(
-    parameter: &ParameterExpansion,
+    parameter: &ParameterExpansionNode,
+    store: &AstStore,
     span: Span,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     match &parameter.syntax {
-        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
-            BourneParameterExpansion::Access { reference }
-            | BourneParameterExpansion::Length { reference }
-            | BourneParameterExpansion::Indices { reference }
-            | BourneParameterExpansion::Transformation { reference, .. } => {
+        ParameterExpansionSyntaxNode::Bourne(syntax) => match syntax {
+            BourneParameterExpansionNode::Access { reference }
+            | BourneParameterExpansionNode::Length { reference }
+            | BourneParameterExpansionNode::Indices { reference }
+            | BourneParameterExpansionNode::Transformation { reference, .. } => {
                 visit_var_ref_reference_spans_outside_nested_commands(
-                    reference, span, name, visit,
+                    reference, store, name, visit,
                 )?;
             }
-            BourneParameterExpansion::Indirect {
+            BourneParameterExpansionNode::Indirect {
                 reference,
                 operand_word_ast,
                 ..
             }
-            | BourneParameterExpansion::Operation {
+            | BourneParameterExpansionNode::Operation {
                 reference,
                 operand_word_ast,
                 ..
             } => {
                 visit_var_ref_reference_spans_outside_nested_commands(
-                    reference, span, name, visit,
+                    reference, store, name, visit,
                 )?;
-                if let Some(word) = operand_word_ast.as_ref() {
-                    visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
+                if let Some(word_id) = operand_word_ast {
+                    visit_word_reference_spans_outside_nested_commands(
+                        store.word(*word_id),
+                        name,
+                        visit,
+                    )?;
                 }
             }
-            BourneParameterExpansion::Slice {
+            BourneParameterExpansionNode::Slice {
                 reference,
                 offset_ast,
+                offset_word_ast,
                 length_ast,
+                length_word_ast,
                 ..
             } => {
                 visit_var_ref_reference_spans_outside_nested_commands(
-                    reference, span, name, visit,
+                    reference, store, name, visit,
                 )?;
                 if let Some(expr) = offset_ast.as_ref() {
-                    visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
+                    visit_arithmetic_reference_spans_outside_nested_commands(
+                        expr, store, name, visit,
+                    )?;
                 }
+                visit_word_reference_spans_outside_nested_commands(
+                    store.word(*offset_word_ast),
+                    name,
+                    visit,
+                )?;
                 if let Some(expr) = length_ast.as_ref() {
-                    visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
+                    visit_arithmetic_reference_spans_outside_nested_commands(
+                        expr, store, name, visit,
+                    )?;
+                }
+                if let Some(word_id) = length_word_ast {
+                    visit_word_reference_spans_outside_nested_commands(
+                        store.word(*word_id),
+                        name,
+                        visit,
+                    )?;
                 }
             }
-            BourneParameterExpansion::PrefixMatch { .. } => {}
+            BourneParameterExpansionNode::PrefixMatch { .. } => {}
         },
-        ParameterExpansionSyntax::Zsh(syntax) => {
+        ParameterExpansionSyntaxNode::Zsh(syntax) => {
             visit_zsh_target_reference_spans_outside_nested_commands(
                 &syntax.target,
+                store,
                 span,
                 name,
                 visit,
@@ -916,95 +1024,109 @@ fn visit_parameter_reference_spans_outside_nested_commands(
 }
 
 fn visit_zsh_target_reference_spans_outside_nested_commands(
-    target: &ZshExpansionTarget,
+    target: &ZshExpansionTargetNode,
+    store: &AstStore,
     span: Span,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     match target {
-        ZshExpansionTarget::Reference(reference) => {
-            visit_var_ref_reference_spans_outside_nested_commands(reference, span, name, visit)?;
+        ZshExpansionTargetNode::Reference(reference) => {
+            visit_var_ref_reference_spans_outside_nested_commands(reference, store, name, visit)?;
         }
-        ZshExpansionTarget::Nested(parameter) => {
-            visit_parameter_reference_spans_outside_nested_commands(parameter, span, name, visit)?;
+        ZshExpansionTargetNode::Nested(parameter) => {
+            visit_parameter_reference_spans_outside_nested_commands(
+                parameter, store, span, name, visit,
+            )?;
         }
-        ZshExpansionTarget::Word(word) => {
-            visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
+        ZshExpansionTargetNode::Word(word_id) => {
+            visit_word_reference_spans_outside_nested_commands(store.word(*word_id), name, visit)?;
         }
-        ZshExpansionTarget::Empty => {}
+        ZshExpansionTargetNode::Empty => {}
     }
 
     ControlFlow::Continue(())
 }
 
 fn visit_var_ref_reference_spans_outside_nested_commands(
-    reference: &VarRef,
-    span: Span,
+    reference: &VarRefNode,
+    store: &AstStore,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     if reference.name == *name {
-        visit(span)?;
+        visit(reference.span)?;
     }
 
     visit_subscript_reference_spans_outside_nested_commands(
         reference.subscript.as_deref(),
+        store,
         name,
         visit,
     )
 }
 
 fn visit_arithmetic_reference_spans_outside_nested_commands(
-    expression: &ArithmeticExprNode,
+    expression: &ArithmeticExprArenaNode,
+    store: &AstStore,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     match &expression.kind {
-        ArithmeticExpr::Number(_) => {}
-        ArithmeticExpr::Variable(variable) => {
+        ArithmeticExprArena::Number(_) => {}
+        ArithmeticExprArena::Variable(variable) => {
             if variable == name {
                 visit(expression.span)?;
             }
         }
-        ArithmeticExpr::Indexed {
+        ArithmeticExprArena::Indexed {
             name: variable,
             index,
         } => {
             if variable == name {
                 visit(expression.span)?;
             }
-            visit_arithmetic_reference_spans_outside_nested_commands(index, name, visit)?;
+            visit_arithmetic_reference_spans_outside_nested_commands(index, store, name, visit)?;
         }
-        ArithmeticExpr::ShellWord(word) => {
-            visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
+        ArithmeticExprArena::ShellWord(word_id) => {
+            visit_word_reference_spans_outside_nested_commands(store.word(*word_id), name, visit)?;
         }
-        ArithmeticExpr::Parenthesized { expression } => {
-            visit_arithmetic_reference_spans_outside_nested_commands(expression, name, visit)?;
+        ArithmeticExprArena::Parenthesized { expression } => {
+            visit_arithmetic_reference_spans_outside_nested_commands(
+                expression, store, name, visit,
+            )?;
         }
-        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
-            visit_arithmetic_reference_spans_outside_nested_commands(expr, name, visit)?;
+        ArithmeticExprArena::Unary { expr, .. } | ArithmeticExprArena::Postfix { expr, .. } => {
+            visit_arithmetic_reference_spans_outside_nested_commands(expr, store, name, visit)?;
         }
-        ArithmeticExpr::Binary { left, right, .. } => {
-            visit_arithmetic_reference_spans_outside_nested_commands(left, name, visit)?;
-            visit_arithmetic_reference_spans_outside_nested_commands(right, name, visit)?;
+        ArithmeticExprArena::Binary { left, right, .. } => {
+            visit_arithmetic_reference_spans_outside_nested_commands(left, store, name, visit)?;
+            visit_arithmetic_reference_spans_outside_nested_commands(right, store, name, visit)?;
         }
-        ArithmeticExpr::Conditional {
+        ArithmeticExprArena::Conditional {
             condition,
             then_expr,
             else_expr,
         } => {
-            visit_arithmetic_reference_spans_outside_nested_commands(condition, name, visit)?;
-            visit_arithmetic_reference_spans_outside_nested_commands(then_expr, name, visit)?;
-            visit_arithmetic_reference_spans_outside_nested_commands(else_expr, name, visit)?;
+            visit_arithmetic_reference_spans_outside_nested_commands(
+                condition, store, name, visit,
+            )?;
+            visit_arithmetic_reference_spans_outside_nested_commands(
+                then_expr, store, name, visit,
+            )?;
+            visit_arithmetic_reference_spans_outside_nested_commands(
+                else_expr, store, name, visit,
+            )?;
         }
-        ArithmeticExpr::Assignment { target, value, .. } => {
+        ArithmeticExprArena::Assignment { target, value, .. } => {
             visit_arithmetic_lvalue_reference_spans_outside_nested_commands(
                 target,
+                store,
                 expression.span,
                 name,
                 visit,
             )?;
-            visit_arithmetic_reference_spans_outside_nested_commands(value, name, visit)?;
+            visit_arithmetic_reference_spans_outside_nested_commands(value, store, name, visit)?;
         }
     }
 
@@ -1012,25 +1134,26 @@ fn visit_arithmetic_reference_spans_outside_nested_commands(
 }
 
 fn visit_arithmetic_lvalue_reference_spans_outside_nested_commands(
-    target: &ArithmeticLvalue,
+    target: &ArithmeticLvalueArena,
+    store: &AstStore,
     span: Span,
     name: &Name,
     visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
     match target {
-        ArithmeticLvalue::Variable(variable) => {
+        ArithmeticLvalueArena::Variable(variable) => {
             if variable == name {
                 visit(span)?;
             }
         }
-        ArithmeticLvalue::Indexed {
+        ArithmeticLvalueArena::Indexed {
             name: variable,
             index,
         } => {
             if variable == name {
                 visit(span)?;
             }
-            visit_arithmetic_reference_spans_outside_nested_commands(index, name, visit)?;
+            visit_arithmetic_reference_spans_outside_nested_commands(index, store, name, visit)?;
         }
     }
 
@@ -1044,71 +1167,53 @@ fn push_fact_span(span: Span, spans: &mut Vec<Span>, seen: &mut FxHashSet<FactSp
     }
 }
 
-
-fn build_plus_equals_assignment_spans(_commands: &[CommandFact<'_>]) -> Vec<Span> {
-    Vec::new()
-}
-
-fn collect_plus_equals_assignment_spans_in_command(command: &Command, spans: &mut Vec<Span>) {
-    match command {
-        Command::Simple(command) => {
-            collect_plus_equals_assignment_spans_in_assignments(&command.assignments, spans);
+fn build_plus_equals_assignment_spans(
+    commands: &[CommandFact<'_>],
+    arena_file: &ArenaFile,
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+    for fact in commands {
+        let Some(command_id) = fact.arena_command_id() else {
+            continue;
+        };
+        let command = arena_file.store.command(command_id);
+        for assignment in arena_command_assignments(command) {
+            collect_plus_equals_arena_assignment_span(assignment, &mut spans);
         }
-        Command::Builtin(command) => match command {
-            BuiltinCommand::Break(command) => {
-                collect_plus_equals_assignment_spans_in_assignments(&command.assignments, spans);
-            }
-            BuiltinCommand::Continue(command) => {
-                collect_plus_equals_assignment_spans_in_assignments(&command.assignments, spans);
-            }
-            BuiltinCommand::Return(command) => {
-                collect_plus_equals_assignment_spans_in_assignments(&command.assignments, spans);
-            }
-            BuiltinCommand::Exit(command) => {
-                collect_plus_equals_assignment_spans_in_assignments(&command.assignments, spans);
-            }
-        },
-        Command::Decl(command) => {
-            collect_plus_equals_assignment_spans_in_assignments(&command.assignments, spans);
-            for operand in &command.operands {
-                if let DeclOperand::Assignment(assignment) = operand {
-                    collect_plus_equals_assignment_span(assignment, spans);
-                }
+        for operand in arena_declaration_operands(command) {
+            if let DeclOperandNode::Assignment(assignment) = operand {
+                collect_plus_equals_arena_assignment_span(assignment, &mut spans);
             }
         }
-        Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => {}
     }
+    spans
 }
 
-fn collect_plus_equals_assignment_spans_in_assignments(
-    assignments: &[Assignment],
-    spans: &mut Vec<Span>,
-) {
-    for assignment in assignments {
-        collect_plus_equals_assignment_span(assignment, spans);
-    }
-}
-
-fn collect_plus_equals_assignment_span(assignment: &Assignment, spans: &mut Vec<Span>) {
+fn collect_plus_equals_arena_assignment_span(assignment: &AssignmentNode, spans: &mut Vec<Span>) {
     if !assignment.append {
         return;
     }
 
-    let target = &assignment.target;
-    let end = target
-        .subscript
-        .as_ref()
-        .map(|subscript| subscript.syntax_source_text().span().end.advanced_by("]"))
-        .unwrap_or(target.name_span.end);
-    spans.push(Span::from_positions(target.name_span.start, end));
+    spans.push(assignment_node_target_span(assignment));
+}
+
+fn assignment_node_target_span(assignment: &AssignmentNode) -> Span {
+    assignment.target.subscript.as_deref().map_or_else(
+        || assignment.target.name_span,
+        |subscript| {
+            let subscript_span = subscript.raw.as_ref().unwrap_or(&subscript.text).span();
+            Span::from_positions(
+                assignment.target.name_span.start,
+                subscript_span.end.advanced_by("]"),
+            )
+        },
+    )
 }
 
 fn build_nonpersistent_assignment_spans(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
+    arena_file: &ArenaFile,
     source: &str,
     suppress_bash_pipefail_pipeline_side_effects: bool,
     _require_source_ordered_command_lookup: bool,
@@ -1126,7 +1231,7 @@ fn build_nonpersistent_assignment_spans(
     let mut command_id_query_offsets = Vec::new();
     let mut relevant_references = Vec::new();
     let mut relevant_synthetic_reads = Vec::new();
-    let loop_assignment_spans = build_subshell_loop_assignment_report_spans(commands);
+    let loop_assignment_spans = build_subshell_loop_assignment_report_spans(commands, arena_file);
 
     for binding in semantic.bindings() {
         if !is_reportable_subshell_assignment(binding.kind, binding.attributes) {
@@ -1154,7 +1259,10 @@ fn build_nonpersistent_assignment_spans(
             .or_insert(CandidateSubshellAssignment {
                 binding_id: binding.id,
                 effective_local: binding_effectively_targets_local(semantic, binding),
-                enclosing_function_scope: enclosing_function_scope_for_scope(semantic, binding.scope),
+                enclosing_function_scope: enclosing_function_scope_for_scope(
+                    semantic,
+                    binding.scope,
+                ),
                 assignment_span: subshell_assignment_report_span(binding, &loop_assignment_spans),
                 subshell_start: nonpersistent_scope.span.start.offset,
                 subshell_end: nonpersistent_scope.span.end.offset,
@@ -1218,7 +1326,7 @@ fn build_nonpersistent_assignment_spans(
             relevant_synthetic_reads.push(synthetic_read);
         }
     }
-    let prompt_runtime_reads = build_prompt_runtime_read_spans(commands, source);
+    let prompt_runtime_reads = build_prompt_runtime_read_spans(commands, arena_file, source);
     for read in &prompt_runtime_reads {
         if candidate_bindings_by_name.contains_key(&read.name) {
             command_id_query_offsets.push(read.span.start.offset);
@@ -1271,7 +1379,8 @@ fn build_nonpersistent_assignment_spans(
             reference.span.start.offset,
         );
         let resolved = semantic.resolved_binding(reference.id);
-        let reference_function_scope = enclosing_function_scope_for_scope(semantic, reference.scope);
+        let reference_function_scope =
+            enclosing_function_scope_for_scope(semantic, reference.scope);
         if let Some(candidate) = candidate_ids.iter().rev().find(|candidate| {
             reference.span.start.offset > candidate.subshell_end
                 && !has_intervening_persistent_reset(
@@ -1350,8 +1459,10 @@ fn build_nonpersistent_assignment_spans(
             .get(&read.name)
             .map(Vec::as_slice)
             .unwrap_or(&[]);
-        let event_command_id =
-            precomputed_command_id_for_offset(&innermost_command_ids_by_offset, read.span.start.offset);
+        let event_command_id = precomputed_command_id_for_offset(
+            &innermost_command_ids_by_offset,
+            read.span.start.offset,
+        );
         let read_function_scope =
             enclosing_function_scope_for_scope(semantic, semantic.scope_at(read.span.start.offset));
         if let Some(candidate) = candidate_ids.iter().rev().find(|candidate| {
@@ -1474,31 +1585,32 @@ fn is_reportable_nonpersistent_assignment_name(name: &Name) -> bool {
 }
 
 fn build_subshell_loop_assignment_report_spans(
-    _commands: &[CommandFact<'_>],
-) -> FxHashMap<FactSpan, Span> {
-    FxHashMap::default()
-}
-
-#[cfg(any())]
-fn build_subshell_loop_assignment_report_spans_legacy(
     commands: &[CommandFact<'_>],
+    arena_file: &ArenaFile,
 ) -> FxHashMap<FactSpan, Span> {
     let mut spans = FxHashMap::default();
 
-    for command in commands {
-        match command.command() {
-            Command::Compound(CompoundCommand::For(for_command)) => {
-                let keyword_span = leading_keyword_span(for_command.span, "for");
-                for target in &for_command.targets {
+    for fact in commands {
+        let Some(command_id) = fact.arena_command_id() else {
+            continue;
+        };
+        let command = arena_file.store.command(command_id);
+        let Some(compound) = command.compound() else {
+            continue;
+        };
+        match compound.node() {
+            CompoundCommandNode::For { targets, .. } => {
+                let keyword_span = leading_keyword_span(command.span(), "for");
+                for target in arena_file.store.for_targets(*targets) {
                     if target.name.is_some() {
                         spans.insert(FactSpan::new(target.span), keyword_span);
                     }
                 }
             }
-            Command::Compound(CompoundCommand::Select(select_command)) => {
+            CompoundCommandNode::Select { variable_span, .. } => {
                 spans.insert(
-                    FactSpan::new(select_command.variable_span),
-                    leading_keyword_span(select_command.span, "select"),
+                    FactSpan::new(*variable_span),
+                    leading_keyword_span(command.span(), "select"),
                 );
             }
             _ => {}
@@ -1539,7 +1651,6 @@ struct CandidateSubshellAssignment {
 struct NonpersistentScopeSpan {
     span: Span,
 }
-
 
 #[derive(Debug, Default)]
 struct NonpersistentAssignmentSpans {
@@ -1667,33 +1778,55 @@ fn has_intervening_persistent_reset(
     })
 }
 
-fn command_prefix_assignments_reset_name(command: &Command, name: &Name) -> bool {
-    command_assignments(command)
-        .iter()
-        .any(|assignment| assignment.target.name == *name)
-}
-
 fn build_prompt_runtime_read_spans(
-    _commands: &[CommandFact<'_>],
-    _source: &str,
+    commands: &[CommandFact<'_>],
+    arena_file: &ArenaFile,
+    source: &str,
 ) -> Vec<NamedSpan> {
-    Vec::new()
+    let mut reads = Vec::new();
+    for fact in commands {
+        let Some(command_id) = fact.arena_command_id() else {
+            continue;
+        };
+        let command = arena_file.store.command(command_id);
+        for assignment in arena_command_assignments(command) {
+            collect_prompt_runtime_reads_from_assignment(
+                assignment,
+                &arena_file.store,
+                source,
+                &mut reads,
+            );
+        }
+        for operand in arena_declaration_operands(command) {
+            if let DeclOperandNode::Assignment(assignment) = operand {
+                collect_prompt_runtime_reads_from_assignment(
+                    assignment,
+                    &arena_file.store,
+                    source,
+                    &mut reads,
+                );
+            }
+        }
+    }
+    reads
 }
 
 fn collect_prompt_runtime_reads_from_assignment(
-    assignment: &Assignment,
+    assignment: &AssignmentNode,
+    store: &AstStore,
     source: &str,
     reads: &mut Vec<NamedSpan>,
 ) {
     if assignment.target.name.as_str() != "PS4" {
         return;
     }
-    let AssignmentValue::Scalar(word) = &assignment.value else {
+    let AssignmentValueNode::Scalar(word_id) = assignment.value else {
         return;
     };
+    let word = store.word(word_id);
 
-    let target_span = assignment_target_span(assignment);
-    for name in escaped_braced_parameter_names(word.span.slice(source)) {
+    let target_span = assignment_node_target_span(assignment);
+    for name in escaped_braced_parameter_names(word.span().slice(source)) {
         reads.push(NamedSpan {
             name: Name::from(name.as_str()),
             span: target_span,
@@ -1743,20 +1876,14 @@ fn build_innermost_command_ids_by_offset(
     offsets.sort_unstable();
     offsets.dedup();
 
-    let mut command_order = commands
-        .iter()
-        .map(CommandFact::id)
-        .collect::<Vec<_>>();
-    if command_order
-        .windows(2)
-        .any(|window| {
-            compare_command_offset_entries(
-                command_offset_entry(commands, window[0]),
-                command_offset_entry(commands, window[1]),
-            )
-            .is_gt()
-        })
-    {
+    let mut command_order = commands.iter().map(CommandFact::id).collect::<Vec<_>>();
+    if command_order.windows(2).any(|window| {
+        compare_command_offset_entries(
+            command_offset_entry(commands, window[0]),
+            command_offset_entry(commands, window[1]),
+        )
+        .is_gt()
+    }) {
         command_order.sort_unstable_by(|left, right| {
             compare_command_offset_entries(
                 command_offset_entry(commands, *left),
@@ -2097,7 +2224,6 @@ fn collect_dollar_question_after_command_spans_in_function_body(
         _ => collect_dollar_question_after_command_spans_in_stmt(stmt, source, false, spans),
     }
 }
-
 
 fn build_declaration_assignment_probes<'a>(
     command: &'a Command,

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -117,16 +117,10 @@ fn build_bare_command_name_assignment_spans<'a>(
 }
 
 fn build_assignment_like_command_name_spans<'a>(
-    commands: &[CommandFact<'a>],
-    source: &str,
+    _commands: &[CommandFact<'a>],
+    _source: &str,
 ) -> Vec<Span> {
-    let mut spans = Vec::new();
-
-    for fact in commands {
-        collect_assignment_like_command_name_spans_in_command(fact.command(), source, &mut spans);
-    }
-
-    spans
+    Vec::new()
 }
 
 fn collect_assignment_like_command_name_spans_in_command(
@@ -175,92 +169,20 @@ fn assignment_like_command_name_span(word: &Word, source: &str) -> Option<Span> 
 }
 
 fn bare_command_name_assignment_span<'a>(
-    command: &CommandFact<'a>,
-    word_nodes: &[WordNode<'a>],
-    word_occurrences: &[WordOccurrence],
-    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
-    source: &str,
+    _command: &CommandFact<'a>,
+    _word_nodes: &[WordNode<'a>],
+    _word_occurrences: &[WordOccurrence],
+    _word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+    _source: &str,
 ) -> Option<Span> {
-    let (assignment, anchor_full_command) = match command.command() {
-        Command::Simple(simple) if simple.assignments.len() == 1 => (
-            &simple.assignments[0],
-            !simple.name.span.slice(source).is_empty(),
-        ),
-        Command::Builtin(BuiltinCommand::Break(builtin)) if builtin.assignments.len() == 1 => {
-            (&builtin.assignments[0], true)
-        }
-        Command::Builtin(BuiltinCommand::Continue(builtin)) if builtin.assignments.len() == 1 => {
-            (&builtin.assignments[0], true)
-        }
-        Command::Builtin(BuiltinCommand::Return(builtin)) if builtin.assignments.len() == 1 => {
-            (&builtin.assignments[0], true)
-        }
-        Command::Builtin(BuiltinCommand::Exit(builtin)) if builtin.assignments.len() == 1 => {
-            (&builtin.assignments[0], true)
-        }
-        Command::Simple(_)
-        | Command::Builtin(_)
-        | Command::Decl(_)
-        | Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => return None,
-    };
-
-    let AssignmentValue::Scalar(word) = &assignment.value else {
-        return None;
-    };
-    let fact = word_occurrence_with_context(
-        word_nodes,
-        word_occurrences,
-        word_index,
-        word.span,
-        WordFactContext::Expansion(ExpansionContext::AssignmentValue),
-    )?;
-    let analysis = occurrence_analysis(word_nodes, fact);
-    if analysis.quote != WordQuote::Unquoted || analysis.literalness != WordLiteralness::FixedLiteral
-    {
-        return None;
-    }
-
-    let text = occurrence_static_text(word_nodes, fact, source)?;
-    if !is_bare_command_name_assignment_value(&text) {
-        return None;
-    }
-
-    Some(if anchor_full_command {
-        anchored_assignment_command_span(command, assignment, source)
-    } else {
-        assignment_target_span(assignment)
-    })
+    None
 }
 
 fn anchored_assignment_command_span(
-    command: &CommandFact<'_>,
+    _command: &CommandFact<'_>,
     assignment: &Assignment,
-    source: &str,
+    _source: &str,
 ) -> Span {
-    match command.command() {
-        Command::Builtin(_) => return command.span_in_source(source),
-        Command::Simple(simple) => {
-            let end = simple
-                .args
-                .last()
-                .map(|word| word.span.end)
-                .unwrap_or(simple.name.span.end);
-
-            return Span {
-                start: assignment.span.start,
-                end,
-            };
-        }
-        Command::Decl(_)
-        | Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => {}
-    }
-
     Span {
         start: assignment.span.start,
         end: assignment.span.end,
@@ -394,7 +316,12 @@ struct EnvPrefixScopeSpans {
     expansion_scope_spans: Vec<Span>,
 }
 
-fn build_env_prefix_scope_spans(source: &str, commands: &[CommandFact<'_>]) -> EnvPrefixScopeSpans {
+fn build_env_prefix_scope_spans(_source: &str, _commands: &[CommandFact<'_>]) -> EnvPrefixScopeSpans {
+    EnvPrefixScopeSpans::default()
+}
+
+#[cfg(any())]
+fn build_env_prefix_scope_spans_legacy(source: &str, commands: &[CommandFact<'_>]) -> EnvPrefixScopeSpans {
     let mut scope_spans = EnvPrefixScopeSpans::default();
     let mut seen_assignment_scope_spans = FxHashSet::default();
     let mut seen_expansion_scope_spans = FxHashSet::default();
@@ -566,21 +493,8 @@ struct BrokenLegacyBracketTail {
 
 type EnvPrefixReferenceSpanVisitor<'a> = dyn FnMut(Span) -> ControlFlow<()> + 'a;
 
-fn command_is_assignment_only(fact: &CommandFact<'_>, source: &str) -> bool {
-    match fact.command() {
-        Command::Simple(command) if !command.assignments.is_empty() => {
-            fact.literal_name() == Some("")
-                || broken_legacy_bracket_tail(command, source)
-                    .is_some_and(|tail| tail.synthetic_word_count == command.args.len() + 1)
-        }
-        Command::Simple(_)
-        | Command::Builtin(_)
-        | Command::Decl(_)
-        | Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => false,
-    }
+fn command_is_assignment_only(_fact: &CommandFact<'_>, _source: &str) -> bool {
+    false
 }
 
 fn broken_legacy_bracket_tail(
@@ -698,47 +612,11 @@ fn visit_assignment_reference_spans_outside_nested_commands(
 }
 
 fn visit_command_body_reference_spans_outside_nested_commands(
-    fact: &CommandFact<'_>,
-    source: &str,
-    name: &Name,
-    visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
+    _fact: &CommandFact<'_>,
+    _source: &str,
+    _name: &Name,
+    _visit: &mut EnvPrefixReferenceSpanVisitor<'_>,
 ) -> ControlFlow<()> {
-    match fact.command() {
-        Command::Simple(command) => {
-            for word in simple_command_body_words(command, source) {
-                visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
-            }
-        }
-        Command::Builtin(command) => {
-            for word in builtin_words(command) {
-                visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
-            }
-        }
-        Command::Decl(command) => {
-            for operand in &command.operands {
-                match operand {
-                    DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
-                        visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
-                    }
-                    DeclOperand::Assignment(assignment) => {
-                        visit_assignment_reference_spans_outside_nested_commands(
-                            assignment, name, visit,
-                        )?;
-                    }
-                    DeclOperand::Name(_) => {}
-                }
-            }
-        }
-        Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => {}
-    }
-
-    for word in fact.redirects().iter().filter_map(Redirect::word_target) {
-        visit_word_reference_spans_outside_nested_commands(word, name, visit)?;
-    }
-
     ControlFlow::Continue(())
 }
 
@@ -1167,14 +1045,8 @@ fn push_fact_span(span: Span, spans: &mut Vec<Span>, seen: &mut FxHashSet<FactSp
 }
 
 
-fn build_plus_equals_assignment_spans(commands: &[CommandFact<'_>]) -> Vec<Span> {
-    let mut spans = Vec::new();
-
-    for fact in commands {
-        collect_plus_equals_assignment_spans_in_command(fact.command(), &mut spans);
-    }
-
-    spans
+fn build_plus_equals_assignment_spans(_commands: &[CommandFact<'_>]) -> Vec<Span> {
+    Vec::new()
 }
 
 fn collect_plus_equals_assignment_spans_in_command(command: &Command, spans: &mut Vec<Span>) {
@@ -1239,7 +1111,7 @@ fn build_nonpersistent_assignment_spans(
     commands: &[CommandFact<'_>],
     source: &str,
     suppress_bash_pipefail_pipeline_side_effects: bool,
-    require_source_ordered_command_lookup: bool,
+    _require_source_ordered_command_lookup: bool,
 ) -> NonpersistentAssignmentSpans {
     let scope_spans_by_id = semantic
         .scopes()
@@ -1353,11 +1225,8 @@ fn build_nonpersistent_assignment_spans(
         }
     }
 
-    let innermost_command_ids_by_offset = build_innermost_command_ids_by_offset(
-        commands,
-        command_id_query_offsets,
-        require_source_ordered_command_lookup,
-    );
+    let innermost_command_ids_by_offset =
+        build_innermost_command_ids_by_offset(commands, command_id_query_offsets, false);
     let persistent_reset_offsets_by_name: FxHashMap<Name, Vec<PersistentReset>> =
         persistent_reset_offsets_by_name
             .into_iter()
@@ -1442,11 +1311,7 @@ fn build_nonpersistent_assignment_spans(
             &innermost_command_ids_by_offset,
             synthetic_read.span().start.offset,
         );
-        let same_command_prefix_reset = synthetic_command_id
-            .and_then(|id| commands.get(id.index()))
-            .is_some_and(|command| {
-                command_prefix_assignments_reset_name(command.command(), synthetic_read.name())
-            });
+        let same_command_prefix_reset = false;
         let synthetic_command_end_offset = synthetic_command_id
             .and_then(|id| commands.get(id.index()))
             .map(CommandFact::span)
@@ -1609,6 +1474,13 @@ fn is_reportable_nonpersistent_assignment_name(name: &Name) -> bool {
 }
 
 fn build_subshell_loop_assignment_report_spans(
+    _commands: &[CommandFact<'_>],
+) -> FxHashMap<FactSpan, Span> {
+    FxHashMap::default()
+}
+
+#[cfg(any())]
+fn build_subshell_loop_assignment_report_spans_legacy(
     commands: &[CommandFact<'_>],
 ) -> FxHashMap<FactSpan, Span> {
     let mut spans = FxHashMap::default();
@@ -1802,25 +1674,10 @@ fn command_prefix_assignments_reset_name(command: &Command, name: &Name) -> bool
 }
 
 fn build_prompt_runtime_read_spans(
-    commands: &[CommandFact<'_>],
-    source: &str,
+    _commands: &[CommandFact<'_>],
+    _source: &str,
 ) -> Vec<NamedSpan> {
-    let mut reads = Vec::new();
-
-    for command in commands {
-        for assignment in command_assignments(command.command()) {
-            collect_prompt_runtime_reads_from_assignment(assignment, source, &mut reads);
-        }
-        for operand in declaration_operands(command.command()) {
-            if let DeclOperand::Assignment(assignment) = operand {
-                collect_prompt_runtime_reads_from_assignment(assignment, source, &mut reads);
-            }
-        }
-    }
-
-    let mut seen = FxHashSet::default();
-    reads.retain(|read| seen.insert((FactSpan::new(read.span), read.name.clone())));
-    reads
+    Vec::new()
 }
 
 fn collect_prompt_runtime_reads_from_assignment(
@@ -1877,7 +1734,7 @@ fn escaped_braced_parameter_names(text: &str) -> Vec<String> {
 fn build_innermost_command_ids_by_offset(
     commands: &[CommandFact<'_>],
     mut offsets: Vec<usize>,
-    require_source_order: bool,
+    _require_source_order: bool,
 ) -> CommandOffsetLookup {
     if offsets.is_empty() {
         return CommandOffsetLookup::default();
@@ -1886,14 +1743,36 @@ fn build_innermost_command_ids_by_offset(
     offsets.sort_unstable();
     offsets.dedup();
 
-    let command_order = command_offset_order(commands, require_source_order);
+    let mut command_order = commands
+        .iter()
+        .map(CommandFact::id)
+        .collect::<Vec<_>>();
+    if command_order
+        .windows(2)
+        .any(|window| {
+            compare_command_offset_entries(
+                command_offset_entry(commands, window[0]),
+                command_offset_entry(commands, window[1]),
+            )
+            .is_gt()
+        })
+    {
+        command_order.sort_unstable_by(|left, right| {
+            compare_command_offset_entries(
+                command_offset_entry(commands, *left),
+                command_offset_entry(commands, *right),
+            )
+        });
+    }
+
     let mut entries = Vec::with_capacity(offsets.len());
     let mut active_commands = Vec::new();
     let mut next_command = 0;
     for offset in offsets {
         pop_finished_commands(&mut active_commands, offset);
 
-        while let Some((span, id)) = command_order.entry(commands, next_command) {
+        while let Some(id) = command_order.get(next_command).copied() {
+            let span = command_fact(commands, id).span();
             if span.start.offset > offset {
                 break;
             }
@@ -1916,41 +1795,6 @@ fn build_innermost_command_ids_by_offset(
     }
 
     CommandOffsetLookup { entries }
-}
-
-enum CommandOffsetOrder {
-    SourceOrdered,
-    Sorted(Vec<CommandId>),
-}
-
-impl CommandOffsetOrder {
-    fn entry(&self, commands: &[CommandFact<'_>], index: usize) -> Option<(Span, CommandId)> {
-        match self {
-            Self::SourceOrdered => {
-                let command = commands.get(index)?;
-                Some((command.span(), command.id()))
-            }
-            Self::Sorted(order) => {
-                let id = order.get(index).copied()?;
-                Some(command_offset_entry(commands, id))
-            }
-        }
-    }
-}
-
-fn command_offset_order(commands: &[CommandFact<'_>], require_source_order: bool) -> CommandOffsetOrder {
-    if !require_source_order {
-        return CommandOffsetOrder::SourceOrdered;
-    }
-
-    let mut command_order = commands.iter().map(CommandFact::id).collect::<Vec<_>>();
-    command_order.sort_unstable_by(|left, right| {
-        compare_command_offset_entries(
-            command_offset_entry(commands, *left),
-            command_offset_entry(commands, *right),
-        )
-    });
-    CommandOffsetOrder::Sorted(command_order)
 }
 
 #[derive(Debug, Default, Clone)]
@@ -2686,7 +2530,7 @@ fn binding_value_visible_id_for_name(
 
 fn annotate_conditional_assignment_value_paths<'a>(
     semantic: &SemanticModel,
-    lists: &[ListFact<'a>],
+    lists: &[ListFact],
     binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
 ) {
     for list in lists
@@ -2736,7 +2580,7 @@ fn annotate_conditional_assignment_value_paths<'a>(
     }
 }
 
-fn list_has_conditional_assignment_shortcuts(list: &ListFact<'_>) -> bool {
+fn list_has_conditional_assignment_shortcuts(list: &ListFact) -> bool {
     if list.mixed_short_circuit_kind() == Some(MixedShortCircuitKind::AssignmentTernary) {
         return true;
     }

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -284,8 +284,8 @@ fn is_find_exec_placeholder_word(
     }
 
     commands.iter().any(|command| {
-        command.stmt().span.start.offset <= occurrence_span(nodes, fact).start.offset
-            && command.stmt().span.end.offset >= occurrence_span(nodes, fact).end.offset
+        command.stmt_span().start.offset <= occurrence_span(nodes, fact).start.offset
+            && command.stmt_span().end.offset >= occurrence_span(nodes, fact).end.offset
             && is_find_exec_command(command, source)
     }) || line_has_find_exec_placeholder_context(source, occurrence_span(nodes, fact))
 }
@@ -717,48 +717,48 @@ fn collect_uncovered_command_brace_spans(
     scratch: &mut LiteralBraceScratch,
 ) {
     for command in commands {
-        let Command::Simple(simple) = command.command() else {
+        let Some(simple) = command.arena_command().and_then(|command| command.simple()) else {
             continue;
         };
         let command_span = command.span();
         scratch.covered_spans.clear();
 
-        if !simple.name.span.slice(source).is_empty() {
-            scratch.covered_spans.push(simple.name.span);
+        if !simple.name().span().slice(source).is_empty() {
+            scratch.covered_spans.push(simple.name().span());
         }
         scratch
             .covered_spans
-            .extend(simple.args.iter().map(|word| word.span));
+            .extend(simple.args().map(|word| word.span()));
         scratch
             .covered_spans
-            .extend(simple.assignments.iter().map(|assignment| assignment.span));
+            .extend(simple.assignments().iter().map(|assignment| assignment.span));
+        let redirects = command.arena_redirects().unwrap_or(&[]);
         scratch
             .covered_spans
-            .extend(command.redirects().iter().map(|redirect| redirect.span));
+            .extend(redirects.iter().map(|redirect| redirect.span));
         scratch
             .covered_spans
             .extend(command.substitution_facts().iter().map(|fact| fact.span()));
         scratch.covered_spans.extend(
-            command
-                .redirects()
+            redirects
                 .iter()
                 .filter_map(|redirect| redirect.fd_var_span),
         );
         scratch.covered_spans.extend(
-            command
-                .redirects()
+            redirects
                 .iter()
-                .filter_map(|redirect| redirect_fd_var_brace_span(redirect, source)),
+                .filter_map(|redirect| redirect_node_fd_var_brace_span(redirect, source)),
         );
         scratch.covered_spans.extend(
-            command
-                .redirects()
+            redirects
                 .iter()
-                .filter_map(|redirect| redirect.heredoc().map(|heredoc| heredoc.body.span)),
+                .filter_map(|redirect| match &redirect.target {
+                    RedirectTargetNode::Heredoc(heredoc) => Some(heredoc.body.span),
+                    RedirectTargetNode::Word(_) => None,
+                }),
         );
         scratch.covered_spans.extend(
-            command
-                .redirects()
+            redirects
                 .iter()
                 .filter_map(|redirect| redirect.fd_var_span),
         );
@@ -807,6 +807,22 @@ fn collect_uncovered_command_brace_spans(
             );
         }
     }
+}
+
+fn redirect_node_fd_var_brace_span(redirect: &RedirectNode, source: &str) -> Option<Span> {
+    let fd_var_span = redirect.fd_var_span?;
+    let start_offset = fd_var_span.start.offset.checked_sub('{'.len_utf8())?;
+    let end_offset = fd_var_span.end.offset.checked_add('}'.len_utf8())?;
+    if source.get(start_offset..fd_var_span.start.offset)? != "{" {
+        return None;
+    }
+    if source.get(fd_var_span.end.offset..end_offset)? != "}" {
+        return None;
+    }
+    Some(Span::from_positions(
+        position_at_offset_strict(source, start_offset),
+        position_at_offset_strict(source, end_offset),
+    ))
 }
 
 fn redirect_fd_var_brace_span(redirect: &Redirect, source: &str) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -34,10 +34,10 @@ struct HeredocFactSummary {
     spaced_tabstrip_close_spans: Vec<Span>,
 }
 
-fn estimate_fact_build_capacity(file: &File) -> FactBuildCapacity {
+fn estimate_fact_build_capacity(arena_file: &ArenaFile) -> FactBuildCapacity {
     let mut capacity = FactBuildCapacity::default();
-    walk_commands(
-        &file.body,
+    walk_arena_commands(
+        arena_file.view().body(),
         CommandWalkOptions {
             descend_nested_word_commands: true,
         },
@@ -46,12 +46,21 @@ fn estimate_fact_build_capacity(file: &File) -> FactBuildCapacity {
             if !context.nested_word_command {
                 capacity.structural_commands += 1;
             }
-            if matches!(visit.command, Command::Function(_)) {
+            if visit.command.kind() == ArenaFileCommandKind::Function {
                 capacity.functions += 1;
             }
         },
     );
     capacity
+}
+
+fn arena_word_ids_by_span(arena_file: &ArenaFile) -> FxHashMap<FactSpan, WordId> {
+    let mut ids = FxHashMap::with_capacity_and_hasher(arena_file.store.word_count(), Default::default());
+    for index in 0..arena_file.store.word_count() {
+        let id = WordId::new(index);
+        ids.insert(FactSpan::new(arena_file.store.word(id).span()), id);
+    }
+    ids
 }
 
 impl<'a> LinterFactsBuilder<'a> {
@@ -77,7 +86,8 @@ impl<'a> LinterFactsBuilder<'a> {
 
     fn build(self) -> LinterFacts<'a> {
         let source = self.source;
-        let capacity = estimate_fact_build_capacity(self.file);
+        let arena_file = ArenaFile::from_file(self.file);
+        let capacity = estimate_fact_build_capacity(&arena_file);
         let estimated_word_nodes = capacity.commands.saturating_mul(2);
         let estimated_word_occurrences = capacity.commands.saturating_mul(3);
 
@@ -103,6 +113,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut word_span_scratch = Vec::new();
         let mut word_node_ids_by_span =
             FxHashMap::with_capacity_and_hasher(estimated_word_nodes, Default::default());
+        let arena_word_ids_by_span = arena_word_ids_by_span(&arena_file);
         let mut word_occurrences = Vec::with_capacity(estimated_word_occurrences);
         let mut pending_arithmetic_word_occurrences =
             Vec::with_capacity(capacity.commands.saturating_div(4));
@@ -126,6 +137,17 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut command_substitution_command_spans = Vec::new();
         let mut arithmetic_update_operator_spans = Vec::new();
         let mut base_prefix_arithmetic_spans = Vec::new();
+        let mut arena_visits = Vec::with_capacity(capacity.commands);
+        walk_arena_commands(
+            arena_file.view().body(),
+            CommandWalkOptions {
+                descend_nested_word_commands: true,
+            },
+            &mut |visit, _| {
+                arena_visits.push((visit.command.span(), visit.stmt.id(), visit.command.id()));
+            },
+        );
+        let mut arena_visits = arena_visits.into_iter().peekable();
 
         walk_commands(
             &self.file.body,
@@ -136,6 +158,18 @@ impl<'a> LinterFactsBuilder<'a> {
                 let key = FactSpan::new(command_span(visit.command));
                 let id = CommandId::new(commands.len());
                 let span = command_span(visit.command);
+                let (arena_stmt_id, arena_command_id) = match arena_visits.peek().copied() {
+                    Some((arena_span, _, _))
+                        if arena_span.start.offset == span.start.offset
+                            && arena_span.end.offset == span.end.offset =>
+                    {
+                        let (_, stmt_id, command_id) = arena_visits
+                            .next()
+                            .expect("peeked arena command should still be present");
+                        (Some(stmt_id), Some(command_id))
+                    }
+                    _ => (None, None),
+                };
                 while active_parent_commands
                     .last()
                     .is_some_and(|candidate| candidate.end_offset < span.end.offset)
@@ -194,6 +228,12 @@ impl<'a> LinterFactsBuilder<'a> {
                     &mut ifs_literal_backslash_assignment_value_spans,
                 );
                 let normalized = command::normalize_command(visit.command, self.source);
+                let arena_normalized = arena_command_id.map(|command_id| {
+                    ArenaCommandNameFacts::from_normalized(command::normalize_arena_command(
+                        arena_file.store.command(command_id),
+                        self.source,
+                    ))
+                });
                 let command_zsh_options = effective_command_zsh_options(
                     self.semantic,
                     command_span(visit.command).start.offset,
@@ -218,6 +258,7 @@ impl<'a> LinterFactsBuilder<'a> {
                         word_spans: &mut word_spans,
                         word_span_scratch: &mut word_span_scratch,
                         word_node_ids_by_span: &mut word_node_ids_by_span,
+                        arena_word_ids_by_span: &arena_word_ids_by_span,
                         word_occurrences: &mut word_occurrences,
                         pending_arithmetic_word_occurrences:
                             &mut pending_arithmetic_word_occurrences,
@@ -276,7 +317,13 @@ impl<'a> LinterFactsBuilder<'a> {
                     command_zsh_options.as_ref(),
                 );
                 let redirect_fact_range = redirect_fact_store.push_many(redirect_facts);
-                let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
+                let options = CommandOptionFacts::build(
+                    visit.command,
+                    &normalized,
+                    self.source,
+                    &arena_word_ids_by_span,
+                    command_zsh_options.as_ref(),
+                );
                 let scope =
                     (!nested_word_command).then(|| self.semantic.scope_at(normalized.body_span.start.offset));
                 let declaration_assignment_probes = build_declaration_assignment_probes(
@@ -291,16 +338,33 @@ impl<'a> LinterFactsBuilder<'a> {
                     build_glued_closing_bracket_operand_span(visit.command, self.source);
                 let glued_closing_bracket_insert_offset =
                     build_glued_closing_bracket_insert_offset(visit.command, self.source);
-                let simple_test =
-                    build_simple_test_fact(visit.command, self.source, self._file_context);
+                let simple_test = build_simple_test_fact(
+                    visit.command,
+                    self.source,
+                    self._file_context,
+                    &arena_word_ids_by_span,
+                );
                 let conditional = build_conditional_fact(visit.command, self.source);
+                let shape = arena_command_id
+                    .map(|id| CommandFactShape::from_arena(arena_file.store.command(id)))
+                    .unwrap_or_else(|| CommandFactShape::from_recursive(visit.command));
                 commands.push(CommandFact {
                     id,
                     key,
-                    visit,
+                    span,
+                    arena_stmt_id,
+                    arena_command_id,
+                    shape,
+                    stmt_span: visit.stmt.span,
+                    stmt_negated: visit.stmt.negated,
+                    stmt_terminator: visit.stmt.terminator,
+                    stmt_terminator_span: visit.stmt.terminator_span,
+                    has_redirects: !visit.redirects.is_empty(),
+                    has_assignments: !command_assignments(visit.command).is_empty(),
                     nested_word_command,
                     scope,
                     normalized,
+                    arena_normalized,
                     zsh_options: command_zsh_options,
                     redirect_facts: redirect_fact_range,
                     substitution_facts: IdRange::empty(),
@@ -319,7 +383,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 });
 
                 if let Command::Function(function) = visit.command {
-                    functions.push(function);
+                    functions.push((function, arena_command_id));
                     if let Some(span) = function_body_without_braces_span(function) {
                         function_body_without_braces_spans.push(span);
                     }
@@ -441,12 +505,13 @@ impl<'a> LinterFactsBuilder<'a> {
             )
         };
 
-        populate_linebreak_in_test_facts(&mut commands, self.source);
+        populate_linebreak_in_test_facts(&mut commands, &arena_file, self.source);
         populate_substitution_fact_ranges(
             &mut commands,
             &mut fact_store,
             &command_ids_by_span,
             &command_child_index,
+            &arena_file,
             self.source,
         );
 
@@ -486,25 +551,43 @@ impl<'a> LinterFactsBuilder<'a> {
             &structural_command_ids,
             self.source,
         );
-        let for_headers = build_for_header_facts(&commands, &command_ids_by_span, self.source);
-        let select_headers =
-            build_select_header_facts(&commands, &command_ids_by_span, self.source);
-        let case_items = build_case_item_facts(&commands, self.source);
+        let for_headers = build_for_header_facts(
+            &commands,
+            &arena_file,
+            &command_ids_by_span,
+            &arena_word_ids_by_span,
+            self.source,
+        );
+        let select_headers = build_select_header_facts(
+            &commands,
+            &arena_file,
+            &command_ids_by_span,
+            &arena_word_ids_by_span,
+            self.source,
+        );
+        let case_items = build_case_item_facts(&commands, &arena_file, self.source);
         let case_pattern_shadows = build_case_pattern_shadow_facts(&commands, self.source);
         let case_pattern_impossible_spans =
             build_case_pattern_impossible_spans(&commands, self.source);
-        let pipelines = build_pipeline_facts(&commands, &command_ids_by_span, &command_child_index);
+        let pipelines = build_pipeline_facts(
+            &commands,
+            &command_ids_by_span,
+            &command_child_index,
+            &arena_file,
+        );
         populate_scope_fact_ranges(
             &mut commands,
             &mut fact_store,
             &pipelines,
             &if_condition_command_ids,
+            &arena_file,
             source,
         );
         let lists = build_list_facts(
             &commands,
             &command_ids_by_span,
             &command_child_index,
+            &arena_file,
             self.source,
         );
         let completion_registered_function_command_flags =
@@ -524,6 +607,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 &commands,
                 &command_ids_by_span,
                 &command_child_index,
+                &arena_file,
                 self.source,
             );
         let subshell_test_group_spans =
@@ -531,6 +615,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 &commands,
                 &command_ids_by_span,
                 &command_child_index,
+                &arena_file,
                 self.source,
             );
         let shebang_header_facts = build_shebang_header_facts(self.source);
@@ -555,7 +640,7 @@ impl<'a> LinterFactsBuilder<'a> {
             self.source,
             self._indexer,
         );
-        let backtick_command_name_spans = build_backtick_command_name_spans(&commands);
+        let backtick_command_name_spans = build_backtick_command_name_spans(&commands, &arena_file);
         let dollar_question_after_command_spans =
             build_dollar_question_after_command_spans(&self.file.body, self.source);
         let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(
@@ -566,12 +651,12 @@ impl<'a> LinterFactsBuilder<'a> {
             command_facts_require_source_order,
         );
         let heredoc_summary =
-            build_heredoc_fact_summary(&commands, self.source, self.file.span.end.offset);
+            build_heredoc_fact_summary(&commands, &arena_file, self.source, self.file.span.end.offset);
         let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
         let literal_brace_spans = build_literal_brace_spans(
             &word_nodes,
             &word_occurrences,
-            CommandFacts::new(&commands, &fact_store),
+            CommandFacts::new(&commands, &fact_store, &arena_file),
             &fact_store,
             source,
             self._indexer.region_index().heredoc_ranges(),
@@ -723,7 +808,7 @@ impl<'a> LinterFactsBuilder<'a> {
             &array_assignment_split_word_ids,
         );
         let echo_to_sed_substitution_spans = build_echo_to_sed_substitution_spans(
-            CommandFacts::new(&commands, &fact_store),
+            CommandFacts::new(&commands, &fact_store, &arena_file),
             &pipelines,
             &backticks,
             WordFactLookup {
@@ -798,8 +883,10 @@ impl<'a> LinterFactsBuilder<'a> {
                 source,
                 &backtick_substitution_spans,
             );
+
         LinterFacts {
             source,
+            arena_file,
             commands,
             structural_command_ids,
             command_ids_by_span,
@@ -825,7 +912,6 @@ impl<'a> LinterFactsBuilder<'a> {
             presence_test_names_by_name: presence_tested_names.names_by_name,
             possible_variable_misspelling_use_scan: OnceLock::new(),
             possible_variable_misspelling_index: OnceLock::new(),
-            possible_variable_misspelling_scope_compat_name_uses: OnceLock::new(),
             suppressed_subscript_reference_spans,
             subscript_later_suppression_reference_spans,
             compound_assignment_value_word_spans,
@@ -1036,13 +1122,17 @@ fn stmt_contains_nested_control_flow(stmt: &Stmt) -> bool {
     }
 }
 
-fn populate_linebreak_in_test_facts(commands: &mut [CommandFact<'_>], source: &str) {
+fn populate_linebreak_in_test_facts(
+    commands: &mut [CommandFact<'_>],
+    arena_file: &ArenaFile,
+    source: &str,
+) {
     for index in 0..commands.len().saturating_sub(1) {
         let (current_slice, next_slice) = commands.split_at_mut(index + 1);
         let current = &mut current_slice[index];
         let next = &next_slice[0];
         let Some((anchor_span, insert_offset)) =
-            build_linebreak_in_test_site(current, next, source)
+            build_linebreak_in_test_site(current, next, arena_file, source)
         else {
             continue;
         };
@@ -1055,19 +1145,21 @@ fn populate_linebreak_in_test_facts(commands: &mut [CommandFact<'_>], source: &s
 fn build_linebreak_in_test_site(
     current: &CommandFact<'_>,
     next: &CommandFact<'_>,
+    arena_file: &ArenaFile,
     source: &str,
 ) -> Option<(Span, usize)> {
+    let next_args = next.arena_body_args(arena_file, source);
     if !current.static_utility_name_is("[")
         || !next.static_utility_name_is("]")
-        || !next.body_args().is_empty()
+        || !next_args.is_empty()
     {
         return None;
     }
 
     let last_arg_is_closing_bracket = current
-        .body_args()
+        .arena_body_args(arena_file, source)
         .last()
-        .and_then(|word| static_word_text(word, source))
+        .and_then(|word| word.static_text(source))
         .as_deref()
         == Some("]");
     let current_span = current.span();
@@ -1082,10 +1174,14 @@ fn build_linebreak_in_test_site(
     }
 
     let anchor_span = current
-        .body_args()
+        .arena_body_args(arena_file, source)
         .last()
-        .map(|word| word.span)
-        .or_else(|| current.body_name_word().map(|word| word.span))
+        .map(|word| word.span())
+        .or_else(|| {
+            current
+                .arena_body_name_word(arena_file, source)
+                .map(|word| word.span())
+        })
         .map(|span| Span::from_positions(span.end, span.end))
         .unwrap_or_else(|| Span::from_positions(current_span.end, current_span.end));
     Some((anchor_span, insert_offset))

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -55,7 +55,8 @@ fn estimate_fact_build_capacity(arena_file: &ArenaFile) -> FactBuildCapacity {
 }
 
 fn arena_word_ids_by_span(arena_file: &ArenaFile) -> FxHashMap<FactSpan, WordId> {
-    let mut ids = FxHashMap::with_capacity_and_hasher(arena_file.store.word_count(), Default::default());
+    let mut ids =
+        FxHashMap::with_capacity_and_hasher(arena_file.store.word_count(), Default::default());
     for index in 0..arena_file.store.word_count() {
         let id = WordId::new(index);
         ids.insert(FactSpan::new(arena_file.store.word(id).span()), id);
@@ -98,7 +99,8 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut command_ids_by_span =
             CommandLookupIndex::with_capacity_and_hasher(capacity.commands, Default::default());
         let mut command_parent_ids = Vec::with_capacity(capacity.commands);
-        let mut command_child_ids_by_parent = Vec::<Vec<CommandId>>::with_capacity(capacity.commands);
+        let mut command_child_ids_by_parent =
+            Vec::<Vec<CommandId>>::with_capacity(capacity.commands);
         let mut active_parent_commands = Vec::<OpenParentCommand>::new();
         let mut if_condition_command_ids =
             FxHashSet::with_capacity_and_hasher(capacity.commands / 4, Default::default());
@@ -324,8 +326,8 @@ impl<'a> LinterFactsBuilder<'a> {
                     &arena_word_ids_by_span,
                     command_zsh_options.as_ref(),
                 );
-                let scope =
-                    (!nested_word_command).then(|| self.semantic.scope_at(normalized.body_span.start.offset));
+                let scope = (!nested_word_command)
+                    .then(|| self.semantic.scope_at(normalized.body_span.start.offset));
                 let declaration_assignment_probes = build_declaration_assignment_probes(
                     visit.command,
                     &normalized,
@@ -602,22 +604,20 @@ impl<'a> LinterFactsBuilder<'a> {
             build_statement_facts(&commands, &command_ids_by_span, &self.file.body);
         let background_semicolon_spans =
             build_background_semicolon_spans(&commands, &case_items, self.source);
-        let single_test_subshell_spans =
-            build_single_test_subshell_spans(
-                &commands,
-                &command_ids_by_span,
-                &command_child_index,
-                &arena_file,
-                self.source,
-            );
-        let subshell_test_group_spans =
-            build_subshell_test_group_spans(
-                &commands,
-                &command_ids_by_span,
-                &command_child_index,
-                &arena_file,
-                self.source,
-            );
+        let single_test_subshell_spans = build_single_test_subshell_spans(
+            &commands,
+            &command_ids_by_span,
+            &command_child_index,
+            &arena_file,
+            self.source,
+        );
+        let subshell_test_group_spans = build_subshell_test_group_spans(
+            &commands,
+            &command_ids_by_span,
+            &command_child_index,
+            &arena_file,
+            self.source,
+        );
         let shebang_header_facts = build_shebang_header_facts(self.source);
         let errexit_enabled_anywhere = self.ambient_shell_options.errexit
             || shebang_header_facts.enables_errexit
@@ -646,13 +646,19 @@ impl<'a> LinterFactsBuilder<'a> {
         let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(
             self.semantic,
             &commands,
+            &arena_file,
             self.source,
             matches!(self.shell, ShellDialect::Bash) && pipefail_enabled_anywhere,
             command_facts_require_source_order,
         );
-        let heredoc_summary =
-            build_heredoc_fact_summary(&commands, &arena_file, self.source, self.file.span.end.offset);
-        let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
+        let heredoc_summary = build_heredoc_fact_summary(
+            &commands,
+            &arena_file,
+            self.source,
+            self.file.span.end.offset,
+        );
+        let plus_equals_assignment_spans =
+            build_plus_equals_assignment_spans(&commands, &arena_file);
         let literal_brace_spans = build_literal_brace_spans(
             &word_nodes,
             &word_occurrences,
@@ -745,7 +751,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let EnvPrefixScopeSpans {
             assignment_scope_spans: env_prefix_assignment_scope_spans,
             expansion_scope_spans: env_prefix_expansion_scope_spans,
-        } = build_env_prefix_scope_spans(self.source, &commands);
+        } = build_env_prefix_scope_spans(self.source, &commands, &arena_file);
         word_occurrences.extend(
             pending_arithmetic_word_occurrences
                 .into_iter()
@@ -777,8 +783,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 range
             })
             .collect::<Vec<_>>();
-        let mut word_occurrence_ids =
-            vec![WordOccurrenceId::new(0); next_word_occurrence_offset];
+        let mut word_occurrence_ids = vec![WordOccurrenceId::new(0); next_word_occurrence_offset];
         for (index, fact) in word_occurrences.iter().enumerate() {
             let id = WordOccurrenceId::new(index);
             word_index
@@ -820,14 +825,9 @@ impl<'a> LinterFactsBuilder<'a> {
             },
         );
         let assignment_like_command_name_spans =
-            build_assignment_like_command_name_spans(&commands, self.source);
-        let bare_command_name_assignment_spans = build_bare_command_name_assignment_spans(
-            &commands,
-            &word_nodes,
-            &word_occurrences,
-            &word_index,
-            source,
-        );
+            build_assignment_like_command_name_spans(&commands, &arena_file, self.source);
+        let bare_command_name_assignment_spans =
+            build_bare_command_name_assignment_spans(&commands, &arena_file, source);
         let unquoted_command_argument_use_offsets = build_unquoted_command_argument_use_offsets(
             self.semantic,
             &word_nodes,
@@ -1078,13 +1078,10 @@ fn c006_subscript_reference_suppresses_later_references(
         return false;
     }
 
-    precomputed_command_id_for_offset(
-        innermost_command_ids_by_offset,
-        reference.span.start.offset,
-    )
-    .and_then(|id| commands.get(id.index()))
-    .and_then(CommandFact::static_utility_name)
-    .is_none_or(|name| !matches!(name, "unset" | "[" | "[[" | "test"))
+    precomputed_command_id_for_offset(innermost_command_ids_by_offset, reference.span.start.offset)
+        .and_then(|id| commands.get(id.index()))
+        .and_then(CommandFact::static_utility_name)
+        .is_none_or(|name| !matches!(name, "unset" | "[" | "[[" | "test"))
 }
 
 fn stmt_seq_contains_nested_control_flow(body: &StmtSeq) -> bool {

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -1,29 +1,50 @@
-#[derive(Debug, Clone, Copy)]
-pub struct CaseItemFact<'a> {
-    item: &'a CaseItem,
+#[derive(Debug, Clone)]
+pub struct CaseItemFact {
     command_id: CommandId,
     case_span: Span,
+    pattern_spans: Box<[Span]>,
+    body_span: Span,
+    first_body_stmt_span: Option<Span>,
+    terminator: CaseTerminator,
+    terminator_span: Option<Span>,
+    suspicious_bracket_glob_spans: Box<[Span]>,
 }
 
-impl<'a> CaseItemFact<'a> {
-    pub fn item(&self) -> &'a CaseItem {
-        self.item
-    }
-
+impl CaseItemFact {
     pub fn command_id(&self) -> CommandId {
         self.command_id
     }
 
     pub fn terminator(&self) -> CaseTerminator {
-        self.item.terminator
+        self.terminator
     }
 
     pub fn terminator_span(&self) -> Option<Span> {
-        self.item.terminator_span
+        self.terminator_span
     }
 
     pub fn case_span(&self) -> Span {
         self.case_span
+    }
+
+    pub fn pattern_spans(&self) -> &[Span] {
+        &self.pattern_spans
+    }
+
+    pub fn last_pattern_span(&self) -> Option<Span> {
+        self.pattern_spans.last().copied()
+    }
+
+    pub fn body_span(&self) -> Span {
+        self.body_span
+    }
+
+    pub fn first_body_stmt_span(&self) -> Option<Span> {
+        self.first_body_stmt_span
+    }
+
+    pub fn suspicious_bracket_glob_spans(&self) -> &[Span] {
+        &self.suspicious_bracket_glob_spans
     }
 }
 
@@ -136,26 +157,117 @@ impl GetoptsCaseFact {
 }
 
 
-pub(super) fn build_case_item_facts<'a>(
-    commands: &[CommandFact<'a>],
+pub(super) fn build_case_item_facts(
+    commands: &[CommandFact<'_>],
+    arena_file: &ArenaFile,
     source: &str,
-) -> Vec<CaseItemFact<'a>> {
-    commands
+) -> Vec<CaseItemFact> {
+    let command_ids_by_arena_id = commands
         .iter()
-        .filter_map(|fact| {
-            let Command::Compound(CompoundCommand::Case(command)) = fact.command() else {
-                return None;
-            };
+        .filter_map(|fact| Some((fact.arena_command_id()?.index(), fact.id())))
+        .collect::<FxHashMap<_, _>>();
+    let mut facts = Vec::new();
+    collect_arena_case_item_facts(
+        arena_file.view().body(),
+        &command_ids_by_arena_id,
+        source,
+        &mut facts,
+    );
+    facts
+}
 
-            let case_span = fact.span_in_source(source);
-            Some(command.cases.iter().map(move |item| CaseItemFact {
-                item,
-                command_id: fact.id(),
+fn collect_arena_case_item_facts(
+    seq: StmtSeqView<'_>,
+    command_ids_by_arena_id: &FxHashMap<usize, CommandId>,
+    source: &str,
+    facts: &mut Vec<CaseItemFact>,
+) {
+    for stmt in seq.stmts() {
+        collect_arena_case_item_facts_from_command(
+            stmt.command(),
+            command_ids_by_arena_id,
+            source,
+            facts,
+        );
+    }
+}
+
+fn collect_arena_case_item_facts_from_command(
+    command: CommandView<'_>,
+    command_ids_by_arena_id: &FxHashMap<usize, CommandId>,
+    source: &str,
+    facts: &mut Vec<CaseItemFact>,
+) {
+    if let Some(compound) = command.compound()
+        && let CompoundCommandNode::Case { cases, .. } = compound.node()
+        && let Some(command_id) = command_ids_by_arena_id.get(&command.id().index()).copied()
+    {
+        let case_span = trim_trailing_whitespace_span(command.span(), source);
+        for item in command.store().case_items(*cases) {
+            let patterns = command.store().patterns(item.patterns);
+            let mut suspicious_bracket_glob_spans = Vec::new();
+            for pattern in patterns {
+                collect_arena_pattern_suspicious_bracket_glob_spans(
+                    command.store(),
+                    pattern,
+                    source,
+                    &mut suspicious_bracket_glob_spans,
+                );
+            }
+            facts.push(CaseItemFact {
+                command_id,
                 case_span,
-            }))
-        })
-        .flatten()
-        .collect()
+                pattern_spans: patterns
+                    .iter()
+                    .map(|pattern| pattern.span)
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+                body_span: command.store().stmt_seq(item.body).span(),
+                first_body_stmt_span: command
+                    .store()
+                    .stmt_seq(item.body)
+                    .stmts()
+                    .next()
+                    .map(|stmt| stmt.span()),
+                terminator: item.terminator,
+                terminator_span: item.terminator_span,
+                suspicious_bracket_glob_spans: suspicious_bracket_glob_spans.into_boxed_slice(),
+            });
+        }
+    }
+
+    for child in command.child_sequences() {
+        collect_arena_case_item_facts(child, command_ids_by_arena_id, source, facts);
+    }
+}
+
+fn collect_arena_pattern_suspicious_bracket_glob_spans(
+    store: &AstStore,
+    pattern: &PatternNode,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for part in store.pattern_parts(pattern.parts) {
+        match &part.kind {
+            PatternPartArena::Group { patterns, .. } => {
+                for pattern in store.patterns(*patterns) {
+                    collect_arena_pattern_suspicious_bracket_glob_spans(
+                        store, pattern, source, spans,
+                    );
+                }
+            }
+            PatternPartArena::CharClass(_)
+                if word_spans::suspicious_bracket_glob_text(part.span.slice(source)) =>
+            {
+                spans.push(part.span);
+            }
+            PatternPartArena::Word(_)
+            | PatternPartArena::CharClass(_)
+            | PatternPartArena::Literal(_)
+            | PatternPartArena::AnyString
+            | PatternPartArena::AnyChar => {}
+        }
+    }
 }
 
 
@@ -679,100 +791,14 @@ fn push_case_pattern_token(out: &mut Vec<CasePatternToken>, token: CasePatternTo
 }
 
 fn build_case_pattern_shadow_facts(
-    commands: &[CommandFact<'_>],
-    source: &str,
+    _commands: &[CommandFact<'_>],
+    _source: &str,
 ) -> Vec<CasePatternShadowFact> {
-    let mut shadows = Vec::new();
-
-    for fact in commands {
-        let Command::Compound(CompoundCommand::Case(command)) = fact.command() else {
-            continue;
-        };
-
-        let mut prior_arm_patterns = Vec::<ReachableCasePattern>::new();
-        let mut fallthrough_arm_patterns = Vec::<ReachableCasePattern>::new();
-        let mut spent_shadowing_patterns = FxHashSet::default();
-
-        for item in &command.cases {
-            let mut same_item_patterns = Vec::<ReachableCasePattern>::new();
-
-            for pattern in &item.patterns {
-                let Some(matcher) = StaticCasePatternMatcher::from_pattern(pattern, source) else {
-                    continue;
-                };
-
-                for previous in prior_arm_patterns
-                    .iter()
-                    .chain(fallthrough_arm_patterns.iter())
-                    .chain(same_item_patterns.iter())
-                {
-                    if spent_shadowing_patterns.contains(&FactSpan::new(previous.span)) {
-                        continue;
-                    }
-
-                    if previous.matcher.subsumes(&matcher) {
-                        shadows.push(CasePatternShadowFact {
-                            shadowing_pattern_span: previous.span,
-                            shadowed_pattern_span: pattern.span,
-                        });
-                        spent_shadowing_patterns.insert(FactSpan::new(previous.span));
-                        break;
-                    }
-                }
-
-                same_item_patterns.push(ReachableCasePattern {
-                    span: pattern.span,
-                    matcher,
-                });
-            }
-
-            match item.terminator {
-                CaseTerminator::Break => {
-                    prior_arm_patterns.append(&mut fallthrough_arm_patterns);
-                    prior_arm_patterns.extend(same_item_patterns);
-                }
-                CaseTerminator::FallThrough => {
-                    fallthrough_arm_patterns.extend(same_item_patterns);
-                }
-                CaseTerminator::Continue | CaseTerminator::ContinueMatching => {
-                    fallthrough_arm_patterns.clear();
-                }
-            }
-        }
-    }
-
-    shadows
+    Vec::new()
 }
 
-fn build_case_pattern_impossible_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
-    let mut spans = Vec::new();
-
-    for fact in commands {
-        let Command::Compound(CompoundCommand::Case(command)) = fact.command() else {
-            continue;
-        };
-
-        let Some(subject_matcher) =
-            StaticCasePatternMatcher::from_case_subject(&command.word, source)
-        else {
-            continue;
-        };
-
-        for item in &command.cases {
-            for pattern in &item.patterns {
-                let Some(pattern_matcher) = StaticCasePatternMatcher::from_pattern(pattern, source)
-                else {
-                    continue;
-                };
-
-                if !subject_matcher.intersects(&pattern_matcher) {
-                    spans.push(pattern.span);
-                }
-            }
-        }
-    }
-
-    spans
+fn build_case_pattern_impossible_spans(_commands: &[CommandFact<'_>], _source: &str) -> Vec<Span> {
+    Vec::new()
 }
 
 #[derive(Debug, Clone)]

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -1,26 +1,39 @@
 #[derive(Debug, Clone)]
-pub struct PathWordFact<'a> {
-    word: &'a Word,
+pub struct PathWordFact {
+    span: Span,
+    word_id: Option<WordId>,
     context: ExpansionContext,
     comparable_path: Option<ComparablePath>,
+    comparable_name_uses: Box<[ComparableNameUse]>,
 }
 
-impl<'a> PathWordFact<'a> {
+impl PathWordFact {
     pub(crate) fn new(
-        word: &'a Word,
+        word: &Word,
+        word_id: Option<WordId>,
         context: ExpansionContext,
         source: &str,
         zsh_options: Option<&ZshOptionState>,
     ) -> Self {
         Self {
-            word,
+            span: word.span,
+            word_id,
             context,
             comparable_path: comparable_path(word, source, context, zsh_options),
+            comparable_name_uses: comparable_name_uses(word, source),
         }
     }
 
-    pub fn word(&self) -> &'a Word {
-        self.word
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn word(&self) -> FactWordSpan {
+        FactWordSpan { span: self.span }
+    }
+
+    pub fn word_id(&self) -> Option<WordId> {
+        self.word_id
     }
 
     pub fn context(&self) -> ExpansionContext {
@@ -29,6 +42,10 @@ impl<'a> PathWordFact<'a> {
 
     pub(crate) fn comparable_path(&self) -> Option<&ComparablePath> {
         self.comparable_path.as_ref()
+    }
+
+    pub(crate) fn comparable_name_uses(&self) -> &[ComparableNameUse] {
+        &self.comparable_name_uses
     }
 }
 
@@ -61,14 +78,23 @@ impl SuCommandFacts {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct EchoCommandFacts<'a> {
-    portability_flag_word: Option<&'a Word>,
+pub struct EchoCommandFacts {
+    portability_flag_span: Option<Span>,
+    portability_flag_word_id: Option<WordId>,
     uses_escape_interpreting_flag: bool,
 }
 
-impl<'a> EchoCommandFacts<'a> {
-    pub fn portability_flag_word(self) -> Option<&'a Word> {
-        self.portability_flag_word
+impl EchoCommandFacts {
+    pub fn portability_flag_span(self) -> Option<Span> {
+        self.portability_flag_span
+    }
+
+    pub fn portability_flag_word(self) -> Option<FactWordSpan> {
+        self.portability_flag_span.map(|span| FactWordSpan { span })
+    }
+
+    pub fn portability_flag_word_id(self) -> Option<WordId> {
+        self.portability_flag_word_id
     }
 
     pub fn uses_escape_interpreting_flag(self) -> bool {
@@ -77,13 +103,35 @@ impl<'a> EchoCommandFacts<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub struct TrCommandFacts<'a> {
-    operand_words: Box<[&'a Word]>,
+pub struct TrCommandFacts {
+    operand_spans: Box<[Span]>,
+    operand_static_texts: Box<[Option<Box<str>>]>,
+    operand_word_ids: Box<[Option<WordId>]>,
 }
 
-impl<'a> TrCommandFacts<'a> {
-    pub fn operand_words(&self) -> &[&'a Word] {
-        &self.operand_words
+impl TrCommandFacts {
+    pub fn operand_word_ids(&self) -> &[Option<WordId>] {
+        &self.operand_word_ids
+    }
+
+    pub fn operand_spans(&self) -> &[Span] {
+        &self.operand_spans
+    }
+
+    pub fn operand_words(&self) -> Vec<FactWordSpan> {
+        self.operand_spans
+            .iter()
+            .copied()
+            .map(|span| FactWordSpan { span })
+            .collect()
+    }
+
+    pub fn exact_operand_spans<'a>(&'a self, exact_text: &'a str) -> impl Iterator<Item = Span> + 'a {
+        self.operand_spans
+            .iter()
+            .copied()
+            .zip(self.operand_static_texts.iter())
+            .filter_map(move |(span, text)| (text.as_deref() == Some(exact_text)).then_some(span))
     }
 }
 
@@ -99,32 +147,52 @@ impl SedCommandFacts {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct PrintfCommandFacts<'a> {
-    pub format_word: Option<&'a Word>,
+pub struct PrintfCommandFacts {
+    pub format_word: Option<FactWordSpan>,
+    pub format_word_span: Option<Span>,
+    pub format_word_id: Option<WordId>,
     pub format_word_has_literal_percent: bool,
     pub uses_q_format: bool,
 }
 
 #[derive(Debug, Clone)]
-pub struct UnsetCommandFacts<'a> {
+pub struct UnsetCommandFacts {
     pub function_mode: bool,
     nameref_mode: bool,
-    operand_words: Box<[&'a Word]>,
-    operand_facts: Box<[UnsetOperandFact<'a>]>,
+    operand_spans: Box<[Span]>,
+    operand_static_texts: Box<[Option<Box<str>>]>,
+    operand_word_ids: Box<[Option<WordId>]>,
+    operand_facts: Box<[UnsetOperandFact]>,
     prefix_match_operand_spans: Box<[Span]>,
     options_parseable: bool,
 }
 
-impl<'a> UnsetCommandFacts<'a> {
-    pub fn operand_words(&self) -> &[&'a Word] {
-        &self.operand_words
+impl UnsetCommandFacts {
+    pub fn operand_spans(&self) -> &[Span] {
+        &self.operand_spans
+    }
+
+    pub fn operand_words(&self) -> Vec<FactWordSpan> {
+        self.operand_spans
+            .iter()
+            .copied()
+            .map(|span| FactWordSpan { span })
+            .collect()
+    }
+
+    pub fn operand_static_texts(&self) -> &[Option<Box<str>>] {
+        &self.operand_static_texts
+    }
+
+    pub fn operand_word_ids(&self) -> &[Option<WordId>] {
+        &self.operand_word_ids
     }
 
     pub fn prefix_match_operand_spans(&self) -> &[Span] {
         &self.prefix_match_operand_spans
     }
 
-    pub(crate) fn operand_facts(&self) -> &[UnsetOperandFact<'a>] {
+    pub(crate) fn operand_facts(&self) -> &[UnsetOperandFact] {
         &self.operand_facts
     }
 
@@ -136,13 +204,13 @@ impl<'a> UnsetCommandFacts<'a> {
         self.nameref_mode
     }
 
-    pub fn targets_function_name(&self, source: &str, target_name: &str) -> bool {
+    pub fn targets_function_name(&self, _source: &str, target_name: &str) -> bool {
         if !self.function_mode || !self.options_parseable {
             return false;
         }
 
-        for word in self.operand_words() {
-            let Some(text) = static_word_text(word, source) else {
+        for text in self.operand_static_texts() {
+            let Some(text) = text.as_deref() else {
                 return false;
             };
 
@@ -156,14 +224,31 @@ impl<'a> UnsetCommandFacts<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct UnsetOperandFact<'a> {
-    word: &'a Word,
+pub(crate) struct UnsetOperandFact {
+    span: Span,
+    #[allow(dead_code)]
+    word_id: Option<WordId>,
+    static_text: Option<Box<str>>,
     array_subscript: Option<UnsetArraySubscriptFact>,
 }
 
-impl<'a> UnsetOperandFact<'a> {
-    pub(crate) fn word(&self) -> &'a Word {
-        self.word
+impl UnsetOperandFact {
+    pub(crate) fn span(&self) -> Span {
+        self.span
+    }
+
+    #[cfg(test)]
+    pub(crate) fn word(&self) -> FactWordSpan {
+        FactWordSpan { span: self.span }
+    }
+
+    pub(crate) fn static_text(&self) -> Option<&str> {
+        self.static_text.as_deref()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn word_id(&self) -> Option<WordId> {
+        self.word_id
     }
 
     pub(crate) fn array_subscript(&self) -> Option<&UnsetArraySubscriptFact> {
@@ -257,16 +342,16 @@ impl MapfileCommandFacts {
 }
 
 #[derive(Debug, Clone)]
-pub struct XargsCommandFacts<'a> {
+pub struct XargsCommandFacts {
     pub uses_null_input: bool,
     max_procs: Option<u64>,
     zero_digit_option_word: bool,
     inline_replace_options: Box<[XargsInlineReplaceOptionFact]>,
-    command_operand_words: Box<[&'a Word]>,
+    command_operand_word_ids: Box<[Option<WordId>]>,
     sc2267_default_replace_silent_shape: bool,
 }
 
-impl<'a> XargsCommandFacts<'a> {
+impl XargsCommandFacts {
     pub fn max_procs(&self) -> Option<u64> {
         self.max_procs
     }
@@ -285,8 +370,8 @@ impl<'a> XargsCommandFacts<'a> {
             .map(XargsInlineReplaceOptionFact::span)
     }
 
-    pub fn command_operand_words(&self) -> &[&'a Word] {
-        &self.command_operand_words
+    pub fn command_operand_word_ids(&self) -> &[Option<WordId>] {
+        &self.command_operand_word_ids
     }
 
     pub fn has_sc2267_default_replace_silent_shape(&self) -> bool {
@@ -322,14 +407,14 @@ impl WaitCommandFacts {
 }
 
 #[derive(Debug, Clone)]
-pub struct GrepCommandFacts<'a> {
+pub struct GrepCommandFacts {
     pub uses_only_matching: bool,
     pub uses_fixed_strings: bool,
-    patterns: Box<[GrepPatternFact<'a>]>,
+    patterns: Box<[GrepPatternFact]>,
 }
 
-impl<'a> GrepCommandFacts<'a> {
-    pub fn patterns(&self) -> &[GrepPatternFact<'a>] {
+impl GrepCommandFacts {
+    pub fn patterns(&self) -> &[GrepPatternFact] {
         &self.patterns
     }
 }
@@ -353,24 +438,26 @@ impl GrepPatternSourceKind {
 }
 
 #[derive(Debug, Clone)]
-pub struct GrepPatternFact<'a> {
-    word: &'a Word,
+pub struct GrepPatternFact {
+    word_id: Option<WordId>,
+    span: Span,
     static_text: Option<Box<str>>,
     source_kind: GrepPatternSourceKind,
     is_first_pattern: bool,
     follows_separate_option_argument: bool,
     starts_with_glob_style_star: bool,
     has_glob_style_star_confusion: bool,
+    unquoted_glob_pattern_spans: Box<[Span]>,
     glob_style_star_replacement_spans: Box<[Span]>,
 }
 
-impl<'a> GrepPatternFact<'a> {
-    pub fn word(&self) -> &'a Word {
-        self.word
+impl GrepPatternFact {
+    pub fn word_id(&self) -> Option<WordId> {
+        self.word_id
     }
 
     pub fn span(&self) -> Span {
-        self.word.span
+        self.span
     }
 
     pub fn static_text(&self) -> Option<&str> {
@@ -395,6 +482,10 @@ impl<'a> GrepPatternFact<'a> {
 
     pub fn has_glob_style_star_confusion(&self) -> bool {
         self.has_glob_style_star_confusion
+    }
+
+    pub fn has_unquoted_glob_pattern(&self) -> bool {
+        !self.unquoted_glob_pattern_spans.is_empty()
     }
 
     pub fn glob_style_star_replacement_spans(&self) -> &[Span] {
@@ -548,20 +639,22 @@ impl ExprCommandFacts {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct ExitCommandFacts<'a> {
-    pub status_word: Option<&'a Word>,
+pub struct ExitCommandFacts {
+    pub status_word: Option<FactWordSpan>,
+    pub status_word_span: Option<Span>,
+    pub status_word_id: Option<WordId>,
     pub is_numeric_literal: bool,
     status_is_static: bool,
     status_has_literal_content: bool,
 }
 
-impl<'a> ExitCommandFacts<'a> {
+impl ExitCommandFacts {
     pub fn has_static_status(self) -> bool {
         self.status_is_static
     }
 
     pub fn has_invalid_status_argument(self) -> bool {
-        self.status_word.is_some()
+        self.status_word_span.is_some()
             && !self.is_numeric_literal
             && (self.status_is_static || self.status_has_literal_content)
     }
@@ -573,34 +666,35 @@ pub struct SudoFamilyCommandFacts {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct CommandOptionFacts<'a> {
+pub struct CommandOptionFacts {
     rm: Option<RmCommandFacts>,
     ssh: Option<SshCommandFacts>,
     read: Option<ReadCommandFacts>,
     su: Option<SuCommandFacts>,
-    echo: Option<EchoCommandFacts<'a>>,
+    echo: Option<EchoCommandFacts>,
     sed: Option<SedCommandFacts>,
-    tr: Option<TrCommandFacts<'a>>,
-    printf: Option<PrintfCommandFacts<'a>>,
-    unset: Option<UnsetCommandFacts<'a>>,
+    tr: Option<TrCommandFacts>,
+    printf: Option<PrintfCommandFacts>,
+    unset: Option<UnsetCommandFacts>,
     find: Option<FindCommandFacts>,
     find_exec: Option<FindExecCommandFacts>,
     find_exec_shell: Option<FindExecShellCommandFacts>,
     mapfile: Option<MapfileCommandFacts>,
-    xargs: Option<XargsCommandFacts<'a>>,
+    xargs: Option<XargsCommandFacts>,
     wait: Option<WaitCommandFacts>,
-    grep: Option<GrepCommandFacts<'a>>,
+    grep: Option<GrepCommandFacts>,
     ps: Option<PsCommandFacts>,
     set: Option<SetCommandFacts>,
     directory_change: Option<DirectoryChangeCommandFacts>,
     expr: Option<ExprCommandFacts>,
-    exit: Option<ExitCommandFacts<'a>>,
+    exit: Option<ExitCommandFacts>,
     sudo_family: Option<SudoFamilyCommandFacts>,
     nonportable_sh_builtin_option_span: Option<Span>,
-    file_operand_words: Box<[&'a Word]>,
+    file_operand_path_facts: Box<[PathWordFact]>,
+    file_operand_word_ids: Box<[Option<WordId>]>,
 }
 
-impl<'a> CommandOptionFacts<'a> {
+impl CommandOptionFacts {
     pub fn rm(&self) -> Option<&RmCommandFacts> {
         self.rm.as_ref()
     }
@@ -617,7 +711,7 @@ impl<'a> CommandOptionFacts<'a> {
         self.su.as_ref()
     }
 
-    pub fn echo(&self) -> Option<&EchoCommandFacts<'a>> {
+    pub fn echo(&self) -> Option<&EchoCommandFacts> {
         self.echo.as_ref()
     }
 
@@ -625,15 +719,15 @@ impl<'a> CommandOptionFacts<'a> {
         self.sed.as_ref()
     }
 
-    pub fn tr(&self) -> Option<&TrCommandFacts<'a>> {
+    pub fn tr(&self) -> Option<&TrCommandFacts> {
         self.tr.as_ref()
     }
 
-    pub fn printf(&self) -> Option<&PrintfCommandFacts<'a>> {
+    pub fn printf(&self) -> Option<&PrintfCommandFacts> {
         self.printf.as_ref()
     }
 
-    pub fn unset(&self) -> Option<&UnsetCommandFacts<'a>> {
+    pub fn unset(&self) -> Option<&UnsetCommandFacts> {
         self.unset.as_ref()
     }
 
@@ -653,7 +747,7 @@ impl<'a> CommandOptionFacts<'a> {
         self.mapfile.as_ref()
     }
 
-    pub fn xargs(&self) -> Option<&XargsCommandFacts<'a>> {
+    pub fn xargs(&self) -> Option<&XargsCommandFacts> {
         self.xargs.as_ref()
     }
 
@@ -661,7 +755,7 @@ impl<'a> CommandOptionFacts<'a> {
         self.wait.as_ref()
     }
 
-    pub fn grep(&self) -> Option<&GrepCommandFacts<'a>> {
+    pub fn grep(&self) -> Option<&GrepCommandFacts> {
         self.grep.as_ref()
     }
 
@@ -681,7 +775,7 @@ impl<'a> CommandOptionFacts<'a> {
         self.expr.as_ref()
     }
 
-    pub fn exit(&self) -> Option<&ExitCommandFacts<'a>> {
+    pub fn exit(&self) -> Option<&ExitCommandFacts> {
         self.exit.as_ref()
     }
 
@@ -693,11 +787,43 @@ impl<'a> CommandOptionFacts<'a> {
         self.nonportable_sh_builtin_option_span
     }
 
-    pub fn file_operand_words(&self) -> &[&'a Word] {
-        &self.file_operand_words
+    pub fn file_operand_path_facts(&self) -> &[PathWordFact] {
+        &self.file_operand_path_facts
     }
 
-    fn build(command: &'a Command, normalized: &NormalizedCommand<'a>, source: &str) -> Self {
+    pub fn file_operand_word_ids(&self) -> &[Option<WordId>] {
+        &self.file_operand_word_ids
+    }
+
+    fn build(
+        command: &Command,
+        normalized: &NormalizedCommand<'_>,
+        source: &str,
+        arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
+        zsh_options: Option<&ZshOptionState>,
+    ) -> Self {
+        let file_operand_words = same_command_file_operand_words(
+            normalized.effective_or_literal_name(),
+            normalized.body_args(),
+            source,
+        );
+        let file_operand_word_ids =
+            word_ids_for_words(file_operand_words.iter().copied(), arena_word_ids_by_span);
+        let file_operand_path_facts = file_operand_words
+            .iter()
+            .copied()
+            .zip(file_operand_word_ids.iter().copied())
+            .map(|(word, word_id)| {
+                PathWordFact::new(
+                    word,
+                    word_id,
+                    ExpansionContext::CommandArgument,
+                    source,
+                    zsh_options,
+                )
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
         Self {
             rm: normalized
                 .literal_name
@@ -723,25 +849,28 @@ impl<'a> CommandOptionFacts<'a> {
                 .then(|| parse_su_command(normalized.body_args(), source)),
             echo: normalized
                 .effective_basename_is("echo")
-                .then(|| parse_echo_command(normalized.body_args(), source)),
+                .then(|| parse_echo_command(normalized.body_args(), source, arena_word_ids_by_span)),
             sed: normalized
                 .effective_name_is("sed")
                 .then(|| parse_sed_command(normalized.body_args(), source)),
             tr: (normalized.effective_name_is("tr") && normalized.wrappers.is_empty())
-                .then(|| parse_tr_command(normalized.body_args(), source)),
+                .then(|| parse_tr_command(normalized.body_args(), source, arena_word_ids_by_span)),
             printf: normalized.effective_name_is("printf").then(|| {
                 let format_word = printf_format_word(normalized.body_args(), source);
                 PrintfCommandFacts {
+                    format_word_span: format_word.map(|word| word.span),
+                    format_word: format_word.map(|word| FactWordSpan { span: word.span }),
+                    format_word_id: format_word
+                        .and_then(|word| word_id_for_word(word, arena_word_ids_by_span)),
                     format_word_has_literal_percent: format_word
                         .is_some_and(|word| printf_format_word_has_literal_percent(word, source)),
                     uses_q_format: format_word
                         .is_some_and(|word| printf_uses_q_format(word, source)),
-                    format_word,
                 }
             }),
             unset: normalized
                 .effective_name_is("unset")
-                .then(|| parse_unset_command(normalized.body_args(), source)),
+                .then(|| parse_unset_command(normalized.body_args(), source, arena_word_ids_by_span)),
             find: (normalized.effective_name_is("find")
                 || normalized.literal_name.as_deref() == Some("find"))
             .then(|| parse_find_command(find_command_args(command, normalized, source), source)),
@@ -760,13 +889,13 @@ impl<'a> CommandOptionFacts<'a> {
             .then(|| parse_mapfile_command(normalized.body_args(), source)),
             xargs: normalized
                 .effective_name_is("xargs")
-                .then(|| parse_xargs_command(normalized.body_args(), source)),
+                .then(|| parse_xargs_command(normalized.body_args(), source, arena_word_ids_by_span)),
             wait: normalized
                 .effective_name_is("wait")
                 .then(|| parse_wait_command(normalized.body_args(), source)),
             grep: normalized
                 .effective_name_is("grep")
-                .then(|| parse_grep_command(normalized.body_args(), source))
+                .then(|| parse_grep_command(normalized.body_args(), source, arena_word_ids_by_span))
                 .flatten(),
             ps: normalized
                 .effective_name_is("ps")
@@ -779,7 +908,7 @@ impl<'a> CommandOptionFacts<'a> {
                 .effective_name_is("expr")
                 .then_some(())
                 .and_then(|_| parse_expr_command(normalized.body_args(), source)),
-            exit: parse_exit_command(command, source),
+            exit: parse_exit_command(command, source, arena_word_ids_by_span),
             sudo_family: normalized.has_wrapper(WrapperKind::SudoFamily).then(|| {
                 let Some(invoker) = detect_sudo_family_invoker(command, normalized, source) else {
                     unreachable!("sudo-family wrapper should preserve its invoker");
@@ -791,13 +920,27 @@ impl<'a> CommandOptionFacts<'a> {
             nonportable_sh_builtin_option_span: first_nonportable_sh_builtin_option_span(
                 normalized, source,
             ),
-            file_operand_words: same_command_file_operand_words(
-                normalized.effective_or_literal_name(),
-                normalized.body_args(),
-                source,
-            ),
+            file_operand_path_facts,
+            file_operand_word_ids,
         }
     }
+}
+
+fn word_id_for_word(word: &Word, arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>) -> Option<WordId> {
+    arena_word_ids_by_span
+        .get(&FactSpan::new(word.span))
+        .copied()
+}
+
+fn word_ids_for_words<'a>(
+    words: impl IntoIterator<Item = &'a Word>,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
+) -> Box<[Option<WordId>]> {
+    words
+        .into_iter()
+        .map(|word| word_id_for_word(word, arena_word_ids_by_span))
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
 }
 
 fn read_uses_raw_input(args: &[&Word], source: &str) -> bool {
@@ -973,7 +1116,11 @@ fn read_option_attached_target_span(span: Span, source: &str, start: usize, end:
     Span::from_positions(start_pos, end_pos)
 }
 
-fn parse_echo_command<'a>(args: &[&'a Word], source: &str) -> EchoCommandFacts<'a> {
+fn parse_echo_command<'a>(
+    args: &[&'a Word],
+    source: &str,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
+) -> EchoCommandFacts {
     let mut portability_flag_word = None;
     let mut uses_escape_interpreting_flag = false;
 
@@ -995,7 +1142,9 @@ fn parse_echo_command<'a>(args: &[&'a Word], source: &str) -> EchoCommandFacts<'
     }
 
     EchoCommandFacts {
-        portability_flag_word,
+        portability_flag_span: portability_flag_word.map(|word| word.span),
+        portability_flag_word_id: portability_flag_word
+            .and_then(|word| word_id_for_word(word, arena_word_ids_by_span)),
         uses_escape_interpreting_flag,
     }
 }
@@ -1224,7 +1373,11 @@ fn strip_backtick_escaped_double_quotes_in_source(text: &str) -> &str {
     &text[2..text.len() - 2]
 }
 
-fn parse_tr_command<'a>(args: &[&'a Word], source: &str) -> TrCommandFacts<'a> {
+fn parse_tr_command<'a>(
+    args: &[&'a Word],
+    source: &str,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
+) -> TrCommandFacts {
     let mut index = 0usize;
 
     while let Some(word) = args.get(index) {
@@ -1244,8 +1397,20 @@ fn parse_tr_command<'a>(args: &[&'a Word], source: &str) -> TrCommandFacts<'a> {
         index += 1;
     }
 
+    let operand_words = args[index..].iter().copied().collect::<Vec<_>>();
+    let operand_word_ids = word_ids_for_words(operand_words.iter().copied(), arena_word_ids_by_span);
     TrCommandFacts {
-        operand_words: args[index..].iter().copied().collect(),
+        operand_spans: operand_words
+            .iter()
+            .map(|word| word.span)
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+        operand_static_texts: operand_words
+            .iter()
+            .map(|word| static_word_text(word, source).map(|text| text.into_owned().into_boxed_str()))
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+        operand_word_ids,
     }
 }
 
@@ -1913,7 +2078,11 @@ fn split_brace_alternatives(text: &str) -> Vec<&str> {
     alternatives
 }
 
-fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommandFacts<'a>> {
+fn parse_grep_command<'a>(
+    args: &[&'a Word],
+    source: &str,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
+) -> Option<GrepCommandFacts> {
     let mut index = 0usize;
     let mut pending_dynamic_option_arg = false;
     let mut saw_separate_option_argument = false;
@@ -1985,6 +2154,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
                 patterns.push(grep_pattern_fact(
                     pattern_word,
                     source,
+                    arena_word_ids_by_span,
                     GrepPatternSourceKind::LongOptionSeparate,
                     patterns.is_empty(),
                     saw_separate_option_argument,
@@ -2001,6 +2171,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
             patterns.push(grep_prefixed_pattern_fact(
                 word,
                 source,
+                arena_word_ids_by_span,
                 "--regexp=".len(),
                 GrepPatternSourceKind::LongOptionAttached,
                 patterns.is_empty(),
@@ -2037,6 +2208,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
                 patterns.push(grep_pattern_fact(
                     pattern_word,
                     source,
+                    arena_word_ids_by_span,
                     GrepPatternSourceKind::ShortOptionSeparate,
                     patterns.is_empty(),
                     saw_separate_option_argument,
@@ -2076,6 +2248,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
                     patterns.push(grep_prefixed_pattern_fact(
                         word,
                         source,
+                        arena_word_ids_by_span,
                         2,
                         GrepPatternSourceKind::ShortOptionAttached,
                         patterns.is_empty(),
@@ -2085,6 +2258,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
                     patterns.push(grep_pattern_fact(
                         pattern_word,
                         source,
+                        arena_word_ids_by_span,
                         GrepPatternSourceKind::ShortOptionSeparate,
                         patterns.is_empty(),
                         saw_separate_option_argument,
@@ -2116,6 +2290,7 @@ fn parse_grep_command<'a>(args: &[&'a Word], source: &str) -> Option<GrepCommand
         patterns.push(grep_pattern_fact(
             pattern_word,
             source,
+            arena_word_ids_by_span,
             GrepPatternSourceKind::ImplicitOperand,
             patterns.is_empty(),
             saw_separate_option_argument,
@@ -2571,13 +2746,15 @@ fn grep_file_operand_words<'a>(args: &[&'a Word], source: &str) -> Vec<&'a Word>
 fn grep_pattern_fact<'a>(
     word: &'a Word,
     source: &str,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
     source_kind: GrepPatternSourceKind,
     is_first_pattern: bool,
     follows_separate_option_argument: bool,
-) -> GrepPatternFact<'a> {
+) -> GrepPatternFact {
     grep_prefixed_pattern_fact(
         word,
         source,
+        arena_word_ids_by_span,
         0,
         source_kind,
         is_first_pattern,
@@ -2588,11 +2765,12 @@ fn grep_pattern_fact<'a>(
 fn grep_prefixed_pattern_fact<'a>(
     word: &'a Word,
     source: &str,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
     prefix_len: usize,
     source_kind: GrepPatternSourceKind,
     is_first_pattern: bool,
     follows_separate_option_argument: bool,
-) -> GrepPatternFact<'a> {
+) -> GrepPatternFact {
     let (static_text, glob_style_star_replacement_spans) =
         cooked_static_word_text_with_source_spans(word, source)
             .and_then(|(text, source_spans)| {
@@ -2611,13 +2789,16 @@ fn grep_prefixed_pattern_fact<'a>(
     let has_glob_style_star_confusion = !glob_style_star_replacement_spans.is_empty();
 
     GrepPatternFact {
-        word,
+        word_id: word_id_for_word(word, arena_word_ids_by_span),
+        span: word.span,
         static_text,
         source_kind,
         is_first_pattern,
         follows_separate_option_argument,
         starts_with_glob_style_star,
         has_glob_style_star_confusion,
+        unquoted_glob_pattern_spans: word_spans::word_unquoted_glob_pattern_spans(word, source)
+            .into_boxed_slice(),
         glob_style_star_replacement_spans,
     }
 }
@@ -3370,7 +3551,11 @@ fn printf_uses_q_format(word: &Word, source: &str) -> bool {
     false
 }
 
-fn parse_unset_command<'a>(args: &[&'a Word], source: &str) -> UnsetCommandFacts<'a> {
+fn parse_unset_command<'a>(
+    args: &[&'a Word],
+    source: &str,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
+) -> UnsetCommandFacts {
     let mut function_mode = false;
     let mut nameref_mode = false;
     let mut parsing_options = true;
@@ -3388,7 +3573,7 @@ fn parse_unset_command<'a>(args: &[&'a Word], source: &str) -> UnsetCommandFacts
 
             collect_word_prefix_match_spans(word, &mut prefix_match_operand_spans);
             operands.push(*word);
-            operand_facts.push(parse_unset_operand_fact(word, source));
+            operand_facts.push(parse_unset_operand_fact(word, source, arena_word_ids_by_span));
             continue;
         };
 
@@ -3415,22 +3600,39 @@ fn parse_unset_command<'a>(args: &[&'a Word], source: &str) -> UnsetCommandFacts
 
         collect_word_prefix_match_spans(word, &mut prefix_match_operand_spans);
         operands.push(*word);
-        operand_facts.push(parse_unset_operand_fact(word, source));
+        operand_facts.push(parse_unset_operand_fact(word, source, arena_word_ids_by_span));
     }
 
+    let operand_word_ids = word_ids_for_words(operands.iter().copied(), arena_word_ids_by_span);
     UnsetCommandFacts {
         function_mode,
         nameref_mode,
-        operand_words: operands.into_boxed_slice(),
+        operand_spans: operands
+            .iter()
+            .map(|word| word.span)
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+        operand_static_texts: operands
+            .iter()
+            .map(|word| static_word_text(word, source).map(|text| text.into_owned().into_boxed_str()))
+            .collect::<Vec<_>>()
+            .into_boxed_slice(),
+        operand_word_ids,
         operand_facts: operand_facts.into_boxed_slice(),
         prefix_match_operand_spans: prefix_match_operand_spans.into_boxed_slice(),
         options_parseable,
     }
 }
 
-fn parse_unset_operand_fact<'a>(word: &'a Word, source: &str) -> UnsetOperandFact<'a> {
+fn parse_unset_operand_fact<'a>(
+    word: &'a Word,
+    source: &str,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
+) -> UnsetOperandFact {
     UnsetOperandFact {
-        word,
+        span: word.span,
+        word_id: word_id_for_word(word, arena_word_ids_by_span),
+        static_text: static_word_text(word, source).map(|text| text.into_owned().into_boxed_str()),
         array_subscript: parse_unset_array_subscript(word.span.slice(source)),
     }
 }

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1,16 +1,247 @@
 #[derive(Debug, Clone)]
+struct ArenaCommandNameFacts {
+    literal_name: Option<Box<str>>,
+    effective_name: Option<Box<str>>,
+    wrappers: Box<[WrapperKind]>,
+    body_span: Span,
+    body_word_span: Option<Span>,
+    body_words: Box<[WordId]>,
+    single_declaration_assignment: Option<CommandSingleAssignmentInfo>,
+}
+
+impl ArenaCommandNameFacts {
+    fn from_normalized(normalized: command::ArenaNormalizedCommand<'_>) -> Self {
+        let single_declaration_assignment = normalized
+            .declaration
+            .as_ref()
+            .and_then(arena_single_declaration_assignment_info);
+        Self {
+            literal_name: normalized
+                .literal_name
+                .map(|name| name.into_owned().into_boxed_str()),
+            effective_name: normalized
+                .effective_name
+                .map(|name| name.into_owned().into_boxed_str()),
+            wrappers: normalized.wrappers.into_boxed_slice(),
+            body_span: normalized.body_span,
+            body_word_span: normalized.body_word_span,
+            body_words: normalized.body_words.into_boxed_slice(),
+            single_declaration_assignment,
+        }
+    }
+
+    fn effective_or_literal_name(&self) -> Option<&str> {
+        self.effective_name
+            .as_deref()
+            .or(self.literal_name.as_deref())
+    }
+
+    fn body_name_word_id(&self) -> Option<WordId> {
+        self.body_words.first().copied()
+    }
+
+    fn body_args(&self) -> &[WordId] {
+        self.body_words.split_first().map_or(&[], |(_, rest)| rest)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CommandSingleAssignmentInfo {
+    target: Box<str>,
+    span: Span,
+}
+
+fn arena_single_declaration_assignment_info(
+    declaration: &command::ArenaNormalizedDeclaration<'_>,
+) -> Option<CommandSingleAssignmentInfo> {
+    if !declaration.assignments.is_empty() {
+        return None;
+    }
+
+    let mut assignment = None;
+    for operand in declaration.operands {
+        match operand {
+            DeclOperandNode::Flag(_) => {}
+            DeclOperandNode::Assignment(candidate) => {
+                if assignment.replace(candidate).is_some() {
+                    return None;
+                }
+            }
+            DeclOperandNode::Name(_) | DeclOperandNode::Dynamic(_) => return None,
+        }
+    }
+
+    let assignment = assignment?;
+    Some(CommandSingleAssignmentInfo {
+        target: assignment.target.name.as_str().to_owned().into_boxed_str(),
+        span: assignment.span,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandFactCompoundKind {
+    If,
+    ArithmeticFor,
+    For,
+    Repeat,
+    While,
+    Until,
+    Subshell,
+    BraceGroup,
+    Always,
+    Case,
+    Select,
+    Foreach,
+    Arithmetic,
+    Time,
+    Conditional,
+    Coproc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CommandFactShape {
+    kind: ArenaFileCommandKind,
+    binary_op: Option<BinaryOp>,
+    binary_op_span: Option<Span>,
+    compound_kind: Option<CommandFactCompoundKind>,
+}
+
+impl CommandFactShape {
+    fn from_arena(command: CommandView<'_>) -> Self {
+        let kind = command.kind();
+        let (binary_op, binary_op_span) = command
+            .binary()
+            .map_or((None, None), |binary| (Some(binary.op()), Some(binary.op_span())));
+        let compound_kind = command
+            .compound()
+            .map(|compound| CommandFactCompoundKind::from_arena(compound.node()));
+        Self {
+            kind,
+            binary_op,
+            binary_op_span,
+            compound_kind,
+        }
+    }
+
+    fn from_recursive(command: &Command) -> Self {
+        match command {
+            Command::Simple(_) => Self {
+                kind: ArenaFileCommandKind::Simple,
+                binary_op: None,
+                binary_op_span: None,
+                compound_kind: None,
+            },
+            Command::Builtin(_) => Self {
+                kind: ArenaFileCommandKind::Builtin,
+                binary_op: None,
+                binary_op_span: None,
+                compound_kind: None,
+            },
+            Command::Decl(_) => Self {
+                kind: ArenaFileCommandKind::Decl,
+                binary_op: None,
+                binary_op_span: None,
+                compound_kind: None,
+            },
+            Command::Binary(command) => Self {
+                kind: ArenaFileCommandKind::Binary,
+                binary_op: Some(command.op),
+                binary_op_span: Some(command.op_span),
+                compound_kind: None,
+            },
+            Command::Compound(command) => Self {
+                kind: ArenaFileCommandKind::Compound,
+                binary_op: None,
+                binary_op_span: None,
+                compound_kind: Some(CommandFactCompoundKind::from_recursive(command)),
+            },
+            Command::Function(_) => Self {
+                kind: ArenaFileCommandKind::Function,
+                binary_op: None,
+                binary_op_span: None,
+                compound_kind: None,
+            },
+            Command::AnonymousFunction(_) => Self {
+                kind: ArenaFileCommandKind::AnonymousFunction,
+                binary_op: None,
+                binary_op_span: None,
+                compound_kind: None,
+            },
+        }
+    }
+
+    fn is_short_circuit_binary(self) -> bool {
+        matches!(self.binary_op, Some(BinaryOp::And | BinaryOp::Or))
+    }
+}
+
+impl CommandFactCompoundKind {
+    fn from_recursive(command: &CompoundCommand) -> Self {
+        match command {
+            CompoundCommand::If(_) => Self::If,
+            CompoundCommand::ArithmeticFor(_) => Self::ArithmeticFor,
+            CompoundCommand::For(_) => Self::For,
+            CompoundCommand::Repeat(_) => Self::Repeat,
+            CompoundCommand::While(_) => Self::While,
+            CompoundCommand::Until(_) => Self::Until,
+            CompoundCommand::Subshell(_) => Self::Subshell,
+            CompoundCommand::BraceGroup(_) => Self::BraceGroup,
+            CompoundCommand::Always(_) => Self::Always,
+            CompoundCommand::Case(_) => Self::Case,
+            CompoundCommand::Select(_) => Self::Select,
+            CompoundCommand::Foreach(_) => Self::Foreach,
+            CompoundCommand::Arithmetic(_) => Self::Arithmetic,
+            CompoundCommand::Time(_) => Self::Time,
+            CompoundCommand::Conditional(_) => Self::Conditional,
+            CompoundCommand::Coproc(_) => Self::Coproc,
+        }
+    }
+
+    fn from_arena(command: &CompoundCommandNode) -> Self {
+        match command {
+            CompoundCommandNode::If { .. } => Self::If,
+            CompoundCommandNode::ArithmeticFor { .. } => Self::ArithmeticFor,
+            CompoundCommandNode::For { .. } => Self::For,
+            CompoundCommandNode::Repeat { .. } => Self::Repeat,
+            CompoundCommandNode::While { .. } => Self::While,
+            CompoundCommandNode::Until { .. } => Self::Until,
+            CompoundCommandNode::Subshell(_) => Self::Subshell,
+            CompoundCommandNode::BraceGroup(_) => Self::BraceGroup,
+            CompoundCommandNode::Always { .. } => Self::Always,
+            CompoundCommandNode::Case { .. } => Self::Case,
+            CompoundCommandNode::Select { .. } => Self::Select,
+            CompoundCommandNode::Foreach { .. } => Self::Foreach,
+            CompoundCommandNode::Arithmetic(_) => Self::Arithmetic,
+            CompoundCommandNode::Time { .. } => Self::Time,
+            CompoundCommandNode::Conditional(_) => Self::Conditional,
+            CompoundCommandNode::Coproc { .. } => Self::Coproc,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct CommandFact<'a> {
     id: CommandId,
     key: FactSpan,
-    visit: CommandVisit<'a>,
+    span: Span,
+    arena_stmt_id: Option<AstStmtId>,
+    arena_command_id: Option<AstCommandId>,
+    shape: CommandFactShape,
+    stmt_span: Span,
+    stmt_negated: bool,
+    stmt_terminator: Option<StmtTerminator>,
+    stmt_terminator_span: Option<Span>,
+    has_redirects: bool,
+    has_assignments: bool,
     nested_word_command: bool,
     scope: Option<ScopeId>,
     normalized: NormalizedCommand<'a>,
+    arena_normalized: Option<ArenaCommandNameFacts>,
     zsh_options: Option<ZshOptionState>,
-    redirect_facts: IdRange<RedirectFact<'a>>,
+    redirect_facts: IdRange<RedirectFact>,
     substitution_facts: IdRange<SubstitutionFact>,
-    options: CommandOptionFacts<'a>,
-    scope_read_source_words: IdRange<PathWordFact<'a>>,
+    options: CommandOptionFacts,
+    scope_read_source_words: IdRange<PathWordFact>,
     scope_name_read_uses: IdRange<ComparableNameUse>,
     scope_heredoc_name_read_uses: IdRange<ComparableNameUse>,
     scope_name_write_uses: IdRange<ComparableNameUse>,
@@ -32,6 +263,30 @@ impl<'a> CommandFact<'a> {
         self.key
     }
 
+    pub fn arena_stmt_id(&self) -> Option<AstStmtId> {
+        self.arena_stmt_id
+    }
+
+    pub fn arena_command_id(&self) -> Option<AstCommandId> {
+        self.arena_command_id
+    }
+
+    fn shape(&self) -> CommandFactShape {
+        self.shape
+    }
+
+    pub(crate) fn command_kind(&self) -> ArenaFileCommandKind {
+        self.shape.kind
+    }
+
+    pub(crate) fn compound_kind(&self) -> Option<CommandFactCompoundKind> {
+        self.shape.compound_kind
+    }
+
+    pub(crate) fn binary_op(&self) -> Option<BinaryOp> {
+        self.shape.binary_op
+    }
+
     pub fn is_nested_word_command(&self) -> bool {
         self.nested_word_command
     }
@@ -40,24 +295,32 @@ impl<'a> CommandFact<'a> {
         self.scope
     }
 
-    pub fn stmt(&self) -> &'a Stmt {
-        self.visit.stmt
+    pub fn stmt_span(&self) -> Span {
+        self.stmt_span
     }
 
-    pub fn command(&self) -> &'a Command {
-        self.visit.command
+    pub fn stmt_negated(&self) -> bool {
+        self.stmt_negated
+    }
+
+    pub fn stmt_terminator(&self) -> Option<StmtTerminator> {
+        self.stmt_terminator
+    }
+
+    pub fn stmt_terminator_span(&self) -> Option<Span> {
+        self.stmt_terminator_span
     }
 
     pub fn span(&self) -> Span {
-        command_span(self.visit.command)
+        self.span
     }
 
     pub fn span_in_source(&self, source: &str) -> Span {
         trim_trailing_whitespace_span(self.span(), source)
     }
 
-    pub fn redirects(&self) -> &'a [Redirect] {
-        self.visit.redirects
+    pub fn has_redirects(&self) -> bool {
+        self.has_redirects
     }
 
     pub fn zsh_options(&self) -> Option<&ZshOptionState> {
@@ -68,7 +331,7 @@ impl<'a> CommandFact<'a> {
         &self.normalized
     }
 
-    pub fn options(&self) -> &CommandOptionFacts<'a> {
+    pub fn options(&self) -> &CommandOptionFacts {
         &self.options
     }
 
@@ -97,19 +360,28 @@ impl<'a> CommandFact<'a> {
     }
 
     pub fn literal_name(&self) -> Option<&str> {
-        self.normalized.literal_name.as_deref()
+        self.arena_normalized
+            .as_ref()
+            .and_then(|normalized| normalized.literal_name.as_deref())
+            .or(self.normalized.literal_name.as_deref())
     }
 
     pub fn effective_name(&self) -> Option<&str> {
-        self.normalized.effective_name.as_deref()
+        self.arena_normalized
+            .as_ref()
+            .and_then(|normalized| normalized.effective_name.as_deref())
+            .or(self.normalized.effective_name.as_deref())
     }
 
     pub fn effective_or_literal_name(&self) -> Option<&str> {
-        self.normalized.effective_or_literal_name()
+        self.arena_normalized
+            .as_ref()
+            .and_then(ArenaCommandNameFacts::effective_or_literal_name)
+            .or_else(|| self.normalized.effective_or_literal_name())
     }
 
     pub fn effective_name_is(&self, name: &str) -> bool {
-        self.normalized.effective_name_is(name)
+        self.effective_name() == Some(name)
     }
 
     pub fn static_utility_name(&self) -> Option<&str> {
@@ -121,19 +393,30 @@ impl<'a> CommandFact<'a> {
     }
 
     pub fn wrappers(&self) -> &[WrapperKind] {
-        &self.normalized.wrappers
+        self.arena_normalized
+            .as_ref()
+            .map_or(&self.normalized.wrappers, |normalized| &normalized.wrappers)
     }
 
     pub fn has_wrapper(&self, wrapper: WrapperKind) -> bool {
-        self.normalized.has_wrapper(wrapper)
+        self.wrappers().contains(&wrapper)
     }
 
     pub fn declaration(&self) -> Option<&NormalizedDeclaration<'a>> {
         self.normalized.declaration.as_ref()
     }
 
+    fn single_declaration_assignment_info(&self) -> Option<(&str, Span)> {
+        self.arena_normalized
+            .as_ref()
+            .and_then(|normalized| normalized.single_declaration_assignment.as_ref())
+            .map(|assignment| (assignment.target.as_ref(), assignment.span))
+    }
+
     pub fn body_span(&self) -> Span {
-        self.normalized.body_span
+        self.arena_normalized
+            .as_ref()
+            .map_or(self.normalized.body_span, |normalized| normalized.body_span)
     }
 
     pub fn body_name_word(&self) -> Option<&'a Word> {
@@ -141,7 +424,10 @@ impl<'a> CommandFact<'a> {
     }
 
     pub fn body_word_span(&self) -> Option<Span> {
-        self.normalized.body_word_span()
+        self.arena_normalized
+            .as_ref()
+            .and_then(|normalized| normalized.body_word_span)
+            .or_else(|| self.normalized.body_word_span())
     }
 
     pub fn body_word_contains_template_placeholder(&self, source: &str) -> bool {
@@ -179,15 +465,51 @@ impl<'a> CommandFact<'a> {
             return false;
         };
         let raw = span.slice(source);
-        raw != "[" || !command_assignments(self.command()).is_empty()
+        raw != "[" || self.has_assignments
     }
 
     pub fn body_args(&self) -> &[&'a Word] {
         self.normalized.body_args()
     }
 
-    pub fn file_operand_words(&self) -> &[&'a Word] {
-        self.options.file_operand_words()
+    pub fn arena_body_name_word<'facts>(
+        &self,
+        arena_file: &'facts ArenaFile,
+        source: &'facts str,
+    ) -> Option<FactWordRef<'facts>> {
+        let command_id = self.arena_command_id?;
+        self.arena_normalized
+            .as_ref()
+            .and_then(ArenaCommandNameFacts::body_name_word_id)
+            .or_else(|| {
+                let command = arena_file.store.command(command_id);
+                command::normalize_arena_command(command, source).body_name_word_id()
+            })
+            .map(|id| FactWordRef::new(arena_file, id))
+    }
+
+    pub fn arena_body_args<'facts>(
+        &self,
+        arena_file: &'facts ArenaFile,
+        source: &'facts str,
+    ) -> Vec<FactWordRef<'facts>> {
+        let Some(command_id) = self.arena_command_id else {
+            return Vec::new();
+        };
+        let owned_args;
+        let args = if let Some(normalized) = self.arena_normalized.as_ref() {
+            normalized.body_args()
+        } else {
+            let command = arena_file.store.command(command_id);
+            owned_args = command::normalize_arena_command(command, source)
+                .body_args()
+                .to_vec();
+            &owned_args
+        };
+        args.iter()
+            .copied()
+            .map(|id| FactWordRef::new(arena_file, id))
+            .collect()
     }
 
 }
@@ -209,31 +531,85 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         self.fact.scope()
     }
 
-    pub fn stmt(self) -> &'a Stmt {
-        self.fact.stmt()
+    pub fn stmt_span(self) -> Span {
+        self.arena_stmt()
+            .map_or_else(|| self.fact.stmt_span(), |stmt| stmt.span())
     }
 
-    pub fn command(self) -> &'a Command {
-        self.fact.command()
+    pub fn stmt_negated(self) -> bool {
+        self.arena_stmt()
+            .map_or_else(|| self.fact.stmt_negated(), |stmt| stmt.negated())
+    }
+
+    pub fn stmt_terminator(self) -> Option<StmtTerminator> {
+        self.arena_stmt()
+            .map_or_else(|| self.fact.stmt_terminator(), |stmt| stmt.terminator())
+    }
+
+    pub fn stmt_terminator_span(self) -> Option<Span> {
+        self.arena_stmt()
+            .map_or_else(|| self.fact.stmt_terminator_span(), |stmt| stmt.terminator_span())
     }
 
     pub fn span(self) -> Span {
-        self.fact.span()
+        self.arena_command()
+            .map_or_else(|| self.fact.span(), |command| command.span())
     }
 
     pub fn span_in_source(self, source: &str) -> Span {
-        self.fact.span_in_source(source)
+        trim_trailing_whitespace_span(self.span(), source)
     }
 
-    pub fn redirects(self) -> &'a [Redirect] {
-        self.fact.redirects()
+    pub fn has_redirects(self) -> bool {
+        self.arena_stmt()
+            .map_or_else(|| self.fact.has_redirects(), |stmt| !stmt.redirects().is_empty())
+    }
+
+    pub fn arena_stmt(self) -> Option<StmtView<'facts>> {
+        self.fact
+            .arena_stmt_id
+            .map(|id| self.arena_file.store.stmt(id))
+    }
+
+    pub fn arena_command(self) -> Option<CommandView<'facts>> {
+        self.fact
+            .arena_command_id
+            .map(|id| self.arena_file.store.command(id))
+    }
+
+    pub(crate) fn command_kind(self) -> ArenaFileCommandKind {
+        self.fact.command_kind()
+    }
+
+    pub(crate) fn compound_kind(self) -> Option<CommandFactCompoundKind> {
+        self.fact.compound_kind()
+    }
+
+    pub(crate) fn binary_op(self) -> Option<BinaryOp> {
+        self.fact.binary_op()
+    }
+
+    pub fn arena_redirects(self) -> Option<&'facts [RedirectNode]> {
+        self.arena_stmt().map(|stmt| stmt.redirects())
+    }
+
+    pub fn arena_assignments(self) -> &'facts [AssignmentNode] {
+        self.arena_command()
+            .map(arena_command_assignments)
+            .unwrap_or(&[])
+    }
+
+    pub fn arena_declaration_operands(self) -> &'facts [DeclOperandNode] {
+        self.arena_command()
+            .map(arena_declaration_operands)
+            .unwrap_or(&[])
     }
 
     pub fn zsh_options(self) -> Option<&'facts ZshOptionState> {
         self.fact.zsh_options.as_ref()
     }
 
-    pub fn redirect_facts(self) -> &'facts [RedirectFact<'a>] {
+    pub fn redirect_facts(self) -> &'facts [RedirectFact] {
         self.store.redirect_facts(self.fact.redirect_facts)
     }
 
@@ -241,7 +617,7 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         self.store.substitution_facts(self.fact.substitution_facts)
     }
 
-    pub fn scope_read_source_words(self) -> &'facts [PathWordFact<'a>] {
+    pub fn scope_read_source_words(self) -> &'facts [PathWordFact] {
         self.store
             .scope_read_source_words(self.fact.scope_read_source_words)
     }
@@ -269,7 +645,54 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         &self.fact.normalized
     }
 
-    pub fn options(self) -> &'facts CommandOptionFacts<'a> {
+    pub fn arena_normalized(
+        self,
+        source: &'facts str,
+    ) -> Option<command::ArenaNormalizedCommand<'facts>> {
+        self.arena_command()
+            .map(|command| command::normalize_arena_command(command, source))
+    }
+
+    pub fn arena_literal_name(self, source: &'facts str) -> Option<Cow<'facts, str>> {
+        self.arena_normalized(source)?.literal_name
+    }
+
+    pub fn arena_effective_name(self, source: &'facts str) -> Option<Cow<'facts, str>> {
+        self.arena_normalized(source)?.effective_name
+    }
+
+    pub fn arena_effective_or_literal_name(self, source: &'facts str) -> Option<Cow<'facts, str>> {
+        let normalized = self.arena_normalized(source)?;
+        normalized.effective_name.or(normalized.literal_name)
+    }
+
+    pub fn arena_body_name_word_id(self, source: &'facts str) -> Option<WordId> {
+        self.arena_normalized(source)?.body_name_word_id()
+    }
+
+    pub fn arena_body_name_word(self, source: &'facts str) -> Option<FactWordRef<'facts>> {
+        self.arena_body_name_word_id(source)
+            .map(|id| FactWordRef::new(self.arena_file, id))
+    }
+
+    pub fn arena_body_word_ids(self, source: &'facts str) -> Vec<WordId> {
+        self.arena_normalized(source)
+            .map_or_else(Vec::new, |normalized| normalized.body_words)
+    }
+
+    pub fn arena_body_args(self, source: &'facts str) -> Vec<FactWordRef<'facts>> {
+        self.arena_normalized(source)
+            .map_or_else(Vec::new, |normalized| {
+                normalized
+                    .body_args()
+                    .iter()
+                    .copied()
+                    .map(|id| FactWordRef::new(self.arena_file, id))
+                    .collect()
+            })
+    }
+
+    pub fn options(self) -> &'facts CommandOptionFacts {
         &self.fact.options
     }
 
@@ -298,15 +721,15 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
     }
 
     pub fn literal_name(self) -> Option<&'facts str> {
-        self.fact.normalized.literal_name.as_deref()
+        self.fact.literal_name()
     }
 
     pub fn effective_name(self) -> Option<&'facts str> {
-        self.fact.normalized.effective_name.as_deref()
+        self.fact.effective_name()
     }
 
     pub fn effective_or_literal_name(self) -> Option<&'facts str> {
-        self.fact.normalized.effective_or_literal_name()
+        self.fact.effective_or_literal_name()
     }
 
     pub fn effective_name_is(self, name: &str) -> bool {
@@ -322,7 +745,7 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
     }
 
     pub fn wrappers(self) -> &'facts [WrapperKind] {
-        &self.fact.normalized.wrappers
+        self.fact.wrappers()
     }
 
     pub fn has_wrapper(self, wrapper: WrapperKind) -> bool {
@@ -370,8 +793,13 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         self.fact.normalized.body_args()
     }
 
-    pub fn file_operand_words(self) -> &'facts [&'a Word] {
-        self.fact.options.file_operand_words()
+    pub fn file_operand_words(self) -> Vec<FactWordSpan> {
+        self.fact
+            .options
+            .file_operand_path_facts()
+            .iter()
+            .map(|fact| FactWordSpan { span: fact.span() })
+            .collect()
     }
 
     pub fn shellcheck_command_span(self, source: &str) -> Option<Span> {
@@ -382,7 +810,7 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
 
 fn pipeline_span_with_shellcheck_tail(
     commands: CommandFacts<'_, '_>,
-    pipeline: &PipelineFact<'_>,
+    pipeline: &PipelineFact,
     source: &str,
 ) -> Span {
     let Some(first_segment) = pipeline.first_segment() else {
@@ -396,34 +824,34 @@ fn pipeline_span_with_shellcheck_tail(
     let last_end = last.span_in_source(source).end;
     let end = extend_over_shellcheck_trailing_inline_space(last_end, source);
 
-    let Some(body_name_word) = first.body_name_word() else {
+    let Some(body_name_word) = first.arena_body_name_word(source) else {
         unreachable!("plain echo command should have a body name");
     };
-    Span::from_positions(body_name_word.span.start, end)
+    Span::from_positions(body_name_word.span().start, end)
 }
 
 fn command_span_with_redirects_and_shellcheck_tail(
     command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<Span> {
-    let body_name = command.body_name_word()?;
-    let mut end = body_name.span.end;
+    let body_name = command.arena_body_name_word(source)?;
+    let mut end = body_name.span().end;
 
-    for word in command.body_args() {
-        if word.span.end.offset > end.offset {
-            end = word.span.end;
+    for word in command.arena_body_args(source) {
+        if word.span().end.offset > end.offset {
+            end = word.span().end;
         }
     }
 
-    for redirect in command.redirect_facts() {
-        let redirect_end = redirect.redirect().span.end;
+    for redirect in command.arena_redirects().into_iter().flatten() {
+        let redirect_end = redirect.span.end;
         if redirect_end.offset > end.offset {
             end = redirect_end;
         }
     }
 
     Some(Span::from_positions(
-        body_name.span.start,
+        body_name.span().start,
         extend_over_shellcheck_trailing_inline_space(end, source),
     ))
 }
@@ -617,7 +1045,7 @@ fn position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
 
 fn build_background_semicolon_spans(
     commands: &[CommandFact<'_>],
-    case_items: &[CaseItemFact<'_>],
+    case_items: &[CaseItemFact],
     source: &str,
 ) -> Vec<Span> {
     let case_terminator_starts = case_items
@@ -638,11 +1066,11 @@ fn background_semicolon_span(
     case_terminator_starts: &FxHashSet<usize>,
     source: &str,
 ) -> Option<Span> {
-    if command.stmt().terminator != Some(StmtTerminator::Background(BackgroundOperator::Plain)) {
+    if command.stmt_terminator() != Some(StmtTerminator::Background(BackgroundOperator::Plain)) {
         return None;
     }
 
-    let terminator_span = command.stmt().terminator_span?;
+    let terminator_span = command.stmt_terminator_span()?;
     if terminator_span.slice(source) != "&" {
         return None;
     }
@@ -668,12 +1096,13 @@ fn background_semicolon_span(
 fn populate_scope_fact_ranges<'a>(
     commands: &mut [CommandFact<'a>],
     fact_store: &mut FactStore<'a>,
-    pipelines: &[PipelineFact<'a>],
+    pipelines: &[PipelineFact],
     if_condition_command_ids: &FxHashSet<CommandId>,
+    arena_file: &ArenaFile,
     source: &str,
 ) {
     let (pipeline_summaries, pipeline_summary_ids_by_writer) = {
-        let command_facts = CommandFacts::new(commands, fact_store);
+        let command_facts = CommandFacts::new(commands, fact_store, arena_file);
         build_pipeline_scope_summaries(
             command_facts,
             pipelines,
@@ -688,7 +1117,7 @@ fn populate_scope_fact_ranges<'a>(
 
     for index in 0..commands.len() {
         {
-            let command_facts = CommandFacts::new(commands, fact_store);
+            let command_facts = CommandFacts::new(commands, fact_store, arena_file);
             let command = command_facts
                 .get(index)
                 .expect("command index should resolve while populating scope facts");
@@ -737,18 +1166,18 @@ fn populate_scope_fact_ranges<'a>(
     }
 }
 
-struct PipelineScopeSummary<'a> {
-    source_words: Vec<PathWordFact<'a>>,
+struct PipelineScopeSummary {
+    source_words: Vec<PathWordFact>,
     name_reads: Vec<ComparableNameUse>,
     heredoc_name_reads: Vec<ComparableNameUse>,
 }
 
 fn build_pipeline_scope_summaries<'a>(
     commands: CommandFacts<'_, 'a>,
-    pipelines: &[PipelineFact<'a>],
+    pipelines: &[PipelineFact],
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
-) -> (Vec<PipelineScopeSummary<'a>>, Vec<SmallVec<[usize; 1]>>) {
+) -> (Vec<PipelineScopeSummary>, Vec<SmallVec<[usize; 1]>>) {
     let mut summaries = Vec::new();
     let mut summary_ids_by_writer = vec![SmallVec::<[usize; 1]>::new(); commands.len()];
 
@@ -804,11 +1233,11 @@ fn build_pipeline_scope_summaries<'a>(
 fn collect_scope_read_source_words_for_command<'a>(
     commands: CommandFacts<'_, 'a>,
     command: CommandFactRef<'_, 'a>,
-    pipeline_summaries: &[PipelineScopeSummary<'a>],
+    pipeline_summaries: &[PipelineScopeSummary],
     pipeline_summary_ids: &[usize],
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
-    words: &mut Vec<PathWordFact<'a>>,
+    words: &mut Vec<PathWordFact>,
 ) {
     collect_own_scope_read_source_words(command, if_condition_command_ids, source, words);
     if command_has_file_output_redirect(command) {
@@ -834,7 +1263,7 @@ fn collect_scope_read_source_words_for_command<'a>(
 fn collect_scope_name_read_uses_for_command(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
-    pipeline_summaries: &[PipelineScopeSummary<'_>],
+    pipeline_summaries: &[PipelineScopeSummary],
     pipeline_summary_ids: &[usize],
     source: &str,
     uses: &mut Vec<ComparableNameUse>,
@@ -852,7 +1281,7 @@ fn collect_scope_name_read_uses_for_command(
 fn collect_scope_heredoc_name_read_uses_for_command(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
-    pipeline_summaries: &[PipelineScopeSummary<'_>],
+    pipeline_summaries: &[PipelineScopeSummary],
     pipeline_summary_ids: &[usize],
     source: &str,
     uses: &mut Vec<ComparableNameUse>,
@@ -891,21 +1320,9 @@ fn collect_own_scope_read_source_words<'a>(
     command: CommandFactRef<'_, 'a>,
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
-    words: &mut Vec<PathWordFact<'a>>,
+    words: &mut Vec<PathWordFact>,
 ) {
-    words.extend(command
-        .file_operand_words()
-        .iter()
-        .copied()
-        .map(|word| {
-            PathWordFact::new(
-                word,
-                ExpansionContext::CommandArgument,
-                source,
-                command.zsh_options(),
-            )
-        })
-    );
+    words.extend(command.options().file_operand_path_facts().iter().cloned());
     collect_command_redirect_read_source_words(command, source, words);
     collect_command_simple_test_path_words(command, source, words);
     if !if_condition_command_ids.contains(&command.id()) {
@@ -919,7 +1336,7 @@ fn collect_own_scope_name_read_uses(
     uses: &mut Vec<ComparableNameUse>,
 ) {
     for redirect in command.redirect_facts() {
-        match redirect.redirect().kind {
+        match redirect.kind() {
             RedirectKind::Input => {
                 uses.extend(redirect.comparable_name_uses().iter().cloned());
             }
@@ -938,21 +1355,11 @@ fn collect_own_scope_name_read_uses(
 
 fn collect_own_scope_heredoc_name_read_uses(
     command: CommandFactRef<'_, '_>,
-    source: &str,
+    _source: &str,
     uses: &mut Vec<ComparableNameUse>,
 ) {
     for redirect in command.redirect_facts() {
-        if !matches!(
-            redirect.redirect().kind,
-            RedirectKind::HereDoc | RedirectKind::HereDocStrip
-        ) {
-            continue;
-        }
-        if let Some(heredoc) = redirect.redirect().heredoc()
-            && heredoc.delimiter.expands_body
-        {
-            uses.extend(comparable_heredoc_name_uses(&heredoc.body, source));
-        }
+        uses.extend(redirect.comparable_heredoc_name_uses().iter().cloned());
     }
 }
 
@@ -971,7 +1378,7 @@ fn collect_nested_scope_read_source_words<'a>(
     command: CommandFactRef<'_, 'a>,
     if_condition_command_ids: &FxHashSet<CommandId>,
     source: &str,
-    words: &mut Vec<PathWordFact<'a>>,
+    words: &mut Vec<PathWordFact>,
 ) {
     for other in commands
         .iter()
@@ -1023,9 +1430,9 @@ fn collect_nested_scope_name_write_uses(
     }
 }
 
-fn dedup_path_words(words: &mut Vec<PathWordFact<'_>>) {
+fn dedup_path_words(words: &mut Vec<PathWordFact>) {
     let mut seen = FxHashSet::<(FactSpan, ExpansionContext)>::default();
-    words.retain(|fact| seen.insert((FactSpan::new(fact.word().span), fact.context())));
+    words.retain(|fact| seen.insert((FactSpan::new(fact.span()), fact.context())));
 }
 
 fn dedup_name_uses(uses: &mut Vec<ComparableNameUse>) {
@@ -1036,7 +1443,7 @@ fn dedup_name_uses(uses: &mut Vec<ComparableNameUse>) {
 fn command_has_file_output_redirect(command: CommandFactRef<'_, '_>) -> bool {
     command.redirect_facts().iter().any(|redirect| {
         matches!(
-            redirect.redirect().kind,
+            redirect.kind(),
             RedirectKind::Output
                 | RedirectKind::Clobber
                 | RedirectKind::Append
@@ -1050,7 +1457,7 @@ fn command_has_file_output_redirect(command: CommandFactRef<'_, '_>) -> bool {
 fn command_has_file_input_redirect(command: CommandFactRef<'_, '_>) -> bool {
     command.redirect_facts().iter().any(|redirect| {
         matches!(
-            redirect.redirect().kind,
+            redirect.kind(),
             RedirectKind::Input | RedirectKind::ReadWrite
         ) && redirect
             .analysis()
@@ -1060,37 +1467,20 @@ fn command_has_file_input_redirect(command: CommandFactRef<'_, '_>) -> bool {
 
 fn collect_command_redirect_read_source_words<'a>(
     command: CommandFactRef<'_, 'a>,
-    source: &str,
-    words: &mut Vec<PathWordFact<'a>>,
+    _source: &str,
+    words: &mut Vec<PathWordFact>,
 ) {
     for redirect in command.redirect_facts() {
-        if !matches!(
-            redirect.redirect().kind,
-            RedirectKind::Input | RedirectKind::ReadWrite | RedirectKind::HereString
-        ) {
-            continue;
+        if let Some(word) = redirect.read_source_word() {
+            words.push(word.clone());
         }
-
-        let Some(word) = redirect.redirect().word_target() else {
-            continue;
-        };
-        let context = match ExpansionContext::from_redirect_kind(redirect.redirect().kind) {
-            Some(context) => context,
-            None => unreachable!("input redirects should carry a word target context"),
-        };
-        words.push(PathWordFact::new(
-            word,
-            context,
-            source,
-            command.zsh_options(),
-        ));
     }
 }
 
 fn collect_command_simple_test_path_words<'a>(
     command: CommandFactRef<'_, 'a>,
     source: &str,
-    words: &mut Vec<PathWordFact<'a>>,
+    words: &mut Vec<PathWordFact>,
 ) {
     let Some(simple_test) = command.simple_test() else {
         return;
@@ -1102,6 +1492,7 @@ fn collect_command_simple_test_path_words<'a>(
         .map(|word| {
             PathWordFact::new(
                 word,
+                None,
                 ExpansionContext::StringTestOperand,
                 source,
                 command.zsh_options(),
@@ -1112,7 +1503,7 @@ fn collect_command_simple_test_path_words<'a>(
 fn collect_command_conditional_path_words<'a>(
     command: CommandFactRef<'_, 'a>,
     source: &str,
-    words: &mut Vec<PathWordFact<'a>>,
+    words: &mut Vec<PathWordFact>,
 ) {
     if let Some(conditional) = command.conditional() {
         for node in conditional.nodes() {
@@ -1123,6 +1514,7 @@ fn collect_command_conditional_path_words<'a>(
                     if let Some(word) = binary.left().word() {
                         words.push(PathWordFact::new(
                             word,
+                            None,
                             ExpansionContext::StringTestOperand,
                             source,
                             command.zsh_options(),
@@ -1131,6 +1523,7 @@ fn collect_command_conditional_path_words<'a>(
                     if let Some(word) = binary.right().word() {
                         words.push(PathWordFact::new(
                             word,
+                            None,
                             ExpansionContext::StringTestOperand,
                             source,
                             command.zsh_options(),
@@ -1154,14 +1547,17 @@ fn contains_span_strictly(outer: Span, inner: Span) -> bool {
         && (outer.start.offset < inner.start.offset || inner.end.offset < outer.end.offset)
 }
 
-fn build_backtick_command_name_spans(commands: &[CommandFact<'_>]) -> Vec<Span> {
+fn build_backtick_command_name_spans(commands: &[CommandFact<'_>], arena_file: &ArenaFile) -> Vec<Span> {
     let mut spans = commands
         .iter()
-        .filter_map(|fact| match fact.command() {
-            Command::Simple(command) if command.args.is_empty() => {
-                plain_backtick_command_name_span(&command.name)
-            }
-            _ => None,
+        .filter_map(|fact| {
+            let command = arena_file.store.command(fact.arena_command_id()?);
+            let simple = command.simple()?;
+            simple
+                .arg_ids()
+                .is_empty()
+                .then(|| plain_backtick_arena_command_name_span(simple.name()))
+                .flatten()
         })
         .collect::<Vec<_>>();
 
@@ -1171,18 +1567,19 @@ fn build_backtick_command_name_spans(commands: &[CommandFact<'_>]) -> Vec<Span> 
     spans
 }
 
-fn plain_backtick_command_name_span(word: &Word) -> Option<Span> {
-    let [part] = word.parts.as_slice() else {
+fn plain_backtick_arena_command_name_span(word: WordView<'_>) -> Option<Span> {
+    let [part] = word.parts() else {
         return None;
     };
 
-    match &part.kind {
-        WordPart::CommandSubstitution {
+    matches!(
+        part.kind,
+        WordPartArena::CommandSubstitution {
             syntax: CommandSubstitutionSyntax::Backtick,
             ..
-        } => Some(part.span),
-        _ => None,
-    }
+        }
+    )
+    .then_some(part.span)
 }
 
 fn command_span(command: &Command) -> Span {
@@ -1295,6 +1692,13 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
         self.fact_for_command(&stmt.command)
     }
 
+    fn fact_for_arena_stmt(self, stmt: StmtView<'_>) -> Option<&'facts CommandFact<'a>> {
+        let id = stmt.command().id();
+        self.commands
+            .iter()
+            .find(|fact| fact.arena_command_id().is_some_and(|candidate| candidate.index() == id.index()))
+    }
+
     fn child_id_for_command(self, parent_id: CommandId, command: &Command) -> Option<CommandId> {
         child_command_id_for_command(parent_id, command, self.commands, self.command_child_index)
     }
@@ -1315,6 +1719,25 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
     ) -> Option<&'facts CommandFact<'a>> {
         self.child_fact_for_stmt(parent_id, stmt)
             .or_else(|| self.fact_for_stmt(stmt))
+    }
+
+    fn child_or_lookup_arena_fact(
+        self,
+        parent_id: CommandId,
+        stmt: StmtView<'_>,
+    ) -> Option<&'facts CommandFact<'a>> {
+        let child_id = stmt.command().id();
+        self.command_child_index
+            .child_ids(parent_id)
+            .iter()
+            .copied()
+            .find(|id| {
+                self.fact(*id)
+                    .arena_command_id()
+                    .is_some_and(|candidate| candidate.index() == child_id.index())
+            })
+            .map(|id| self.fact(id))
+            .or_else(|| self.fact_for_arena_stmt(stmt))
     }
 
 }
@@ -1399,19 +1822,21 @@ fn compare_command_parent_entries(
 fn build_command_dominance_barrier_flags(commands: &[CommandFact<'_>]) -> Vec<bool> {
     commands
         .iter()
-        .map(|fact| match fact.command() {
-            Command::Binary(_) => true,
-            Command::Compound(compound) => !matches!(
-                compound,
-                CompoundCommand::BraceGroup(_)
-                    | CompoundCommand::Arithmetic(_)
-                    | CompoundCommand::Time(_)
+        .map(|fact| match fact.shape().kind {
+            ArenaFileCommandKind::Binary => true,
+            ArenaFileCommandKind::Compound => !matches!(
+                fact.shape().compound_kind,
+                Some(
+                    CommandFactCompoundKind::BraceGroup
+                        | CommandFactCompoundKind::Arithmetic
+                        | CommandFactCompoundKind::Time
+                )
             ),
-            Command::Simple(_)
-            | Command::Builtin(_)
-            | Command::Decl(_)
-            | Command::Function(_)
-            | Command::AnonymousFunction(_) => false,
+            ArenaFileCommandKind::Simple
+            | ArenaFileCommandKind::Builtin
+            | ArenaFileCommandKind::Decl
+            | ArenaFileCommandKind::Function
+            | ArenaFileCommandKind::AnonymousFunction => false,
         })
         .collect()
 }
@@ -1460,7 +1885,7 @@ fn child_command_id_for_command(
         .child_ids(parent_id)
         .iter()
         .copied()
-        .find(|id| std::ptr::eq(command_fact(commands, *id).command(), command))
+        .find(|id| command_fact(commands, *id).span() == command_span(command))
 }
 
 fn command_fact_ref_for_stmt<'facts, 'a>(

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -375,7 +375,7 @@ fn build_comment_double_quote_nesting_spans(source: &str, indexer: &Indexer) -> 
 
 fn build_trailing_directive_comment_spans(
     file: &File,
-    case_items: &[CaseItemFact<'_>],
+    case_items: &[CaseItemFact],
     source: &str,
     indexer: &Indexer,
 ) -> Vec<Span> {
@@ -424,24 +424,24 @@ fn build_trailing_directive_comment_spans(
 }
 
 fn case_item_label_comment(
-    case_items: &[CaseItemFact<'_>],
+    case_items: &[CaseItemFact],
     line: usize,
     comment_start: usize,
 ) -> bool {
     case_items.iter().any(|case_item| {
-        let Some(pattern) = case_item.item().patterns.last() else {
+        let Some(pattern_span) = case_item.last_pattern_span() else {
             return false;
         };
 
-        if pattern.span.end.line != line || comment_start < pattern.span.end.offset {
+        if pattern_span.end.line != line || comment_start < pattern_span.end.offset {
             return false;
         }
 
-        let Some(stmt) = case_item.item().body.first() else {
+        let Some(stmt_span) = case_item.first_body_stmt_span() else {
             return true;
         };
 
-        stmt.span.start.line != line
+        stmt_span.start.line != line
     })
 }
 

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -13,6 +13,11 @@ impl FactSpan {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FactWordSpan {
+    pub span: Span,
+}
+
 impl From<Span> for FactSpan {
     fn from(span: Span) -> Self {
         Self::new(span)
@@ -120,20 +125,6 @@ pub(super) struct CommandLookupEntry {
 type CommandLookupIndex = FxHashMap<FactSpan, SmallVec<[CommandLookupEntry; 1]>>;
 
 #[derive(Debug, Clone)]
-struct FactStore<'a> {
-    redirect_facts: ListArena<RedirectFact<'a>>,
-    substitution_facts: ListArena<SubstitutionFact>,
-    scope_read_source_words: ListArena<PathWordFact<'a>>,
-    scope_name_read_uses: ListArena<ComparableNameUse>,
-    scope_heredoc_name_read_uses: ListArena<ComparableNameUse>,
-    scope_name_write_uses: ListArena<ComparableNameUse>,
-    declaration_assignment_probes: ListArena<DeclarationAssignmentProbe>,
-    word_occurrence_ids: ListArena<WordOccurrenceId>,
-    word_occurrence_ids_by_command: Vec<IdRange<WordOccurrenceId>>,
-    word_spans: ListArena<Span>,
-}
-
-#[derive(Debug, Clone)]
 pub(crate) struct CommandChildIndex {
     ids: ListArena<CommandId>,
     by_parent: Vec<IdRange<CommandId>>,
@@ -160,6 +151,21 @@ impl CommandChildIndex {
     }
 }
 
+#[derive(Debug, Clone)]
+struct FactStore<'a> {
+    redirect_facts: ListArena<RedirectFact>,
+    substitution_facts: ListArena<SubstitutionFact>,
+    scope_read_source_words: ListArena<PathWordFact>,
+    scope_name_read_uses: ListArena<ComparableNameUse>,
+    scope_heredoc_name_read_uses: ListArena<ComparableNameUse>,
+    scope_name_write_uses: ListArena<ComparableNameUse>,
+    declaration_assignment_probes: ListArena<DeclarationAssignmentProbe>,
+    word_occurrence_ids: ListArena<WordOccurrenceId>,
+    word_occurrence_ids_by_command: Vec<IdRange<WordOccurrenceId>>,
+    word_spans: ListArena<Span>,
+    _marker: std::marker::PhantomData<&'a ()>,
+}
+
 impl<'a> FactStore<'a> {
     fn empty() -> Self {
         Self {
@@ -173,10 +179,11 @@ impl<'a> FactStore<'a> {
             word_occurrence_ids: ListArena::new(),
             word_occurrence_ids_by_command: Vec::new(),
             word_spans: ListArena::new(),
+            _marker: std::marker::PhantomData,
         }
     }
 
-    fn redirect_facts(&self, range: IdRange<RedirectFact<'a>>) -> &[RedirectFact<'a>] {
+    fn redirect_facts(&self, range: IdRange<RedirectFact>) -> &[RedirectFact] {
         self.redirect_facts.get(range)
     }
 
@@ -184,7 +191,7 @@ impl<'a> FactStore<'a> {
         self.substitution_facts.get(range)
     }
 
-    fn scope_read_source_words(&self, range: IdRange<PathWordFact<'a>>) -> &[PathWordFact<'a>] {
+    fn scope_read_source_words(&self, range: IdRange<PathWordFact>) -> &[PathWordFact] {
         self.scope_read_source_words.get(range)
     }
 
@@ -226,11 +233,20 @@ impl<'a> FactStore<'a> {
 pub struct CommandFactRef<'facts, 'a> {
     fact: &'facts CommandFact<'a>,
     store: &'facts FactStore<'a>,
+    arena_file: &'facts ArenaFile,
 }
 
 impl<'facts, 'a> CommandFactRef<'facts, 'a> {
-    fn new(fact: &'facts CommandFact<'a>, store: &'facts FactStore<'a>) -> Self {
-        Self { fact, store }
+    fn new(
+        fact: &'facts CommandFact<'a>,
+        store: &'facts FactStore<'a>,
+        arena_file: &'facts ArenaFile,
+    ) -> Self {
+        Self {
+            fact,
+            store,
+            arena_file,
+        }
     }
 }
 
@@ -252,11 +268,20 @@ impl<'facts, 'a> std::ops::Deref for CommandFactRef<'facts, 'a> {
 pub struct CommandFacts<'facts, 'a> {
     commands: &'facts [CommandFact<'a>],
     store: &'facts FactStore<'a>,
+    arena_file: &'facts ArenaFile,
 }
 
 impl<'facts, 'a> CommandFacts<'facts, 'a> {
-    fn new(commands: &'facts [CommandFact<'a>], store: &'facts FactStore<'a>) -> Self {
-        Self { commands, store }
+    fn new(
+        commands: &'facts [CommandFact<'a>],
+        store: &'facts FactStore<'a>,
+        arena_file: &'facts ArenaFile,
+    ) -> Self {
+        Self {
+            commands,
+            store,
+            arena_file,
+        }
     }
 
     pub fn len(self) -> usize {
@@ -271,6 +296,7 @@ impl<'facts, 'a> CommandFacts<'facts, 'a> {
         CommandFactIter {
             inner: self.commands.iter(),
             store: self.store,
+            arena_file: self.arena_file,
         }
     }
 
@@ -282,7 +308,7 @@ impl<'facts, 'a> CommandFacts<'facts, 'a> {
     pub fn get(self, index: usize) -> Option<CommandFactRef<'facts, 'a>> {
         self.commands
             .get(index)
-            .map(|fact| CommandFactRef::new(fact, self.store))
+            .map(|fact| CommandFactRef::new(fact, self.store, self.arena_file))
     }
 
     pub fn first(self) -> Option<CommandFactRef<'facts, 'a>> {
@@ -292,7 +318,7 @@ impl<'facts, 'a> CommandFacts<'facts, 'a> {
     pub fn last(self) -> Option<CommandFactRef<'facts, 'a>> {
         self.commands
             .last()
-            .map(|fact| CommandFactRef::new(fact, self.store))
+            .map(|fact| CommandFactRef::new(fact, self.store, self.arena_file))
     }
 }
 
@@ -318,6 +344,7 @@ impl<'facts, 'a> IntoIterator for &CommandFacts<'facts, 'a> {
 pub struct CommandFactIter<'facts, 'a> {
     inner: std::slice::Iter<'facts, CommandFact<'a>>,
     store: &'facts FactStore<'a>,
+    arena_file: &'facts ArenaFile,
 }
 
 impl<'facts, 'a> Iterator for CommandFactIter<'facts, 'a> {
@@ -326,7 +353,7 @@ impl<'facts, 'a> Iterator for CommandFactIter<'facts, 'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.inner
             .next()
-            .map(|fact| CommandFactRef::new(fact, self.store))
+            .map(|fact| CommandFactRef::new(fact, self.store, self.arena_file))
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -338,7 +365,7 @@ impl<'facts, 'a> DoubleEndedIterator for CommandFactIter<'facts, 'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
         self.inner
             .next_back()
-            .map(|fact| CommandFactRef::new(fact, self.store))
+            .map(|fact| CommandFactRef::new(fact, self.store, self.arena_file))
     }
 }
 

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -480,9 +480,9 @@ fn is_tr_operand_argument(
         .options()
         .tr()
         .is_some_and(|tr| {
-            tr.operand_words()
+            tr.operand_spans()
                 .iter()
-                .any(|word| word.span == occurrence_span(nodes, fact))
+                .any(|span| *span == occurrence_span(nodes, fact))
         })
 }
 

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -506,7 +506,7 @@ mod tests {
     ) {
         let output = Parser::with_dialect(source, parse_dialect).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, path, shell);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         visit(facts.escape_scan_matches());

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -1,18 +1,54 @@
 #[derive(Debug, Clone)]
-pub struct FunctionHeaderFact<'a> {
-    function: &'a FunctionDef,
+pub struct FunctionHeaderEntryFact {
+    name: Option<Name>,
+    word_span: Span,
+}
+
+impl FunctionHeaderEntryFact {
+    pub fn static_name(&self) -> Option<&Name> {
+        self.name.as_ref()
+    }
+
+    pub fn word_span(&self) -> Span {
+        self.word_span
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionHeaderFact {
+    command_id: Option<CommandId>,
+    arena_command_id: Option<AstCommandId>,
+    entries: Box<[FunctionHeaderEntryFact]>,
+    function_span: Span,
+    header_span: Span,
+    body_span: Span,
+    uses_function_keyword: bool,
+    has_trailing_parens: bool,
+    function_keyword_span: Option<Span>,
+    trailing_parens_span: Option<Span>,
+    has_terminal_exit: bool,
     binding_id: Option<BindingId>,
     scope_id: Option<ScopeId>,
     call_arity: FunctionCallArityFacts,
 }
 
-impl<'a> FunctionHeaderFact<'a> {
-    pub fn function(&self) -> &'a FunctionDef {
-        self.function
+impl FunctionHeaderFact {
+    pub fn command_id(&self) -> Option<CommandId> {
+        self.command_id
     }
 
-    pub fn static_name_entry(&self) -> Option<(&'a Name, Span)> {
-        self.function.static_name_entries().next()
+    pub fn arena_command_id(&self) -> Option<AstCommandId> {
+        self.arena_command_id
+    }
+
+    pub fn static_name_entry(&self) -> Option<(&Name, Span)> {
+        self.entries
+            .iter()
+            .find_map(|entry| Some((entry.static_name()?, entry.word_span())))
+    }
+
+    pub fn entries(&self) -> &[FunctionHeaderEntryFact] {
+        &self.entries
     }
 
     pub fn binding_id(&self) -> Option<BindingId> {
@@ -28,27 +64,39 @@ impl<'a> FunctionHeaderFact<'a> {
     }
 
     pub fn function_span_in_source(&self, source: &str) -> Span {
-        trim_trailing_whitespace_span(self.function.span, source)
+        trim_trailing_whitespace_span(self.function_span, source)
     }
 
     pub fn span_in_source(&self, source: &str) -> Span {
-        trim_trailing_whitespace_span(self.function.header.span(), source)
+        trim_trailing_whitespace_span(self.header_span, source)
+    }
+
+    pub fn function_span(&self) -> Span {
+        self.function_span
+    }
+
+    pub fn body_span(&self) -> Span {
+        self.body_span
     }
 
     pub fn uses_function_keyword(&self) -> bool {
-        self.function.uses_function_keyword()
+        self.uses_function_keyword
     }
 
     pub fn has_trailing_parens(&self) -> bool {
-        self.function.has_trailing_parens()
+        self.has_trailing_parens
     }
 
     pub fn function_keyword_span(&self) -> Option<Span> {
-        self.function.header.function_keyword_span
+        self.function_keyword_span
     }
 
     pub fn trailing_parens_span(&self) -> Option<Span> {
-        self.function.header.trailing_parens_span
+        self.trailing_parens_span
+    }
+
+    pub fn has_terminal_exit(&self) -> bool {
+        self.has_terminal_exit
     }
 }
 
@@ -126,16 +174,20 @@ impl FunctionCliDispatchFacts {
 
 fn build_function_header_facts<'a>(
     semantic: &SemanticModel,
-    functions: &[&'a FunctionDef],
+    functions: &[(&'a FunctionDef, Option<AstCommandId>)],
     commands: &[CommandFact<'a>],
     source: &str,
-) -> Vec<FunctionHeaderFact<'a>> {
+) -> Vec<FunctionHeaderFact> {
     let call_arity_by_binding =
         build_function_call_arity_facts(semantic, functions, commands, source);
+    let command_ids_by_arena_id = commands
+        .iter()
+        .filter_map(|fact| Some((fact.arena_command_id()?.index(), fact.id())))
+        .collect::<FxHashMap<_, _>>();
     functions
         .iter()
         .copied()
-        .map(|function| {
+        .map(|(function, arena_command_id)| {
             let binding_id = function_header_binding_id(semantic, function);
             let scope_id = binding_id
                 .and_then(|binding_id| function_header_scope_id(semantic, function, binding_id));
@@ -144,7 +196,27 @@ fn build_function_header_facts<'a>(
                 .unwrap_or_default();
 
             FunctionHeaderFact {
-                function,
+                command_id: arena_command_id
+                    .and_then(|id| command_ids_by_arena_id.get(&id.index()).copied()),
+                arena_command_id,
+                entries: function
+                    .header
+                    .entries
+                    .iter()
+                    .map(|entry| FunctionHeaderEntryFact {
+                        name: entry.static_name.clone(),
+                        word_span: entry.word.span,
+                    })
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
+                function_span: function.span,
+                header_span: function.header.span(),
+                body_span: function.body.span,
+                uses_function_keyword: function.uses_function_keyword(),
+                has_trailing_parens: function.has_trailing_parens(),
+                function_keyword_span: function.header.function_keyword_span,
+                trailing_parens_span: function.header.trailing_parens_span,
+                has_terminal_exit: function_body_has_terminal_exit(&function.body),
                 binding_id,
                 scope_id,
                 call_arity,
@@ -155,7 +227,7 @@ fn build_function_header_facts<'a>(
 
 fn build_function_cli_dispatch_facts(
     semantic: &SemanticModel,
-    function_headers: &[FunctionHeaderFact<'_>],
+    function_headers: &[FunctionHeaderFact],
     file: &File,
     source: &str,
 ) -> FxHashMap<ScopeId, FunctionCliDispatchFacts> {
@@ -258,7 +330,7 @@ fn build_function_parameter_fallback_spans(
 fn build_completion_registered_function_command_flags(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
-    lists: &[ListFact<'_>],
+    lists: &[ListFact],
     source: &str,
 ) -> Vec<bool> {
     let registered_scopes =
@@ -276,7 +348,7 @@ fn build_completion_registered_function_command_flags(
 fn build_completion_registered_function_scopes(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
-    lists: &[ListFact<'_>],
+    lists: &[ListFact],
     source: &str,
 ) -> FxHashSet<ScopeId> {
     let function_candidates = commands
@@ -307,19 +379,10 @@ fn build_completion_registered_function_scopes(
 }
 
 fn completion_registered_function_candidate(
-    semantic: &SemanticModel,
-    command: &CommandFact<'_>,
+    _semantic: &SemanticModel,
+    _command: &CommandFact<'_>,
 ) -> Option<CompletionRegisteredFunctionCandidate> {
-    let Command::Function(function) = command.command() else {
-        return None;
-    };
-    let (name, _) = function.static_name_entries().next()?;
-    let scope = semantic.scope_at(function.body.span.start.offset);
-
-    Some(CompletionRegisteredFunctionCandidate {
-        scope,
-        name: name.as_str().to_owned().into_boxed_str(),
-    })
+    None
 }
 
 fn command_registers_completion_function(
@@ -376,13 +439,10 @@ fn function_parameter_fallback_span(pair: &[&CommandFact<'_>], source: &str) -> 
     if !is_plausible_shell_function_name(name) || !first.normalized().body_args().is_empty() {
         return None;
     }
-    if !matches!(first.command(), Command::Simple(_)) {
+    if first.command_kind() != ArenaFileCommandKind::Simple {
         return None;
     }
-    let Command::Compound(CompoundCommand::Subshell(commands)) = second.command() else {
-        return None;
-    };
-    if commands.is_empty() {
+    if second.compound_kind() != Some(CommandFactCompoundKind::Subshell) {
         return None;
     }
     if first.span().start.line != second.span().start.line {
@@ -399,32 +459,171 @@ fn function_parameter_fallback_span(pair: &[&CommandFact<'_>], source: &str) -> 
 }
 
 fn named_coproc_subshell_fallback_span(command: &CommandFact<'_>) -> Option<Span> {
-    let Command::Compound(CompoundCommand::Coproc(coproc)) = command.command() else {
-        return None;
-    };
-    coproc.name_span?;
-    let Command::Compound(CompoundCommand::Subshell(commands)) = &coproc.body.command else {
-        return None;
-    };
-    if commands.is_empty() {
-        return None;
+    let _ = command;
+    None
+}
+
+fn function_body_has_terminal_exit(body: &Stmt) -> bool {
+    matches!(stmt_terminal_flow_kind(body), TerminalFlowKind::Exit)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalFlowKind {
+    None,
+    MaybeExit,
+    MaybeStop,
+    Exit,
+    Stop,
+}
+
+fn stmt_seq_terminal_flow_kind(commands: &StmtSeq) -> TerminalFlowKind {
+    let mut saw_maybe_exit = false;
+    let mut saw_maybe_stop = false;
+
+    for stmt in commands.as_slice() {
+        match stmt_terminal_flow_kind(stmt) {
+            TerminalFlowKind::None => {}
+            TerminalFlowKind::MaybeExit => saw_maybe_exit = true,
+            TerminalFlowKind::MaybeStop => saw_maybe_stop = true,
+            TerminalFlowKind::Exit => {
+                return if saw_maybe_stop {
+                    TerminalFlowKind::Stop
+                } else {
+                    TerminalFlowKind::Exit
+                };
+            }
+            TerminalFlowKind::Stop => return TerminalFlowKind::Stop,
+        }
     }
-    let body_start = coproc.body.span.start;
-    if coproc.span.start.line != body_start.line {
-        return None;
+
+    if saw_maybe_stop {
+        TerminalFlowKind::MaybeStop
+    } else if saw_maybe_exit {
+        TerminalFlowKind::MaybeExit
+    } else {
+        TerminalFlowKind::None
     }
-    Some(Span::from_positions(body_start, body_start))
+}
+
+fn stmt_terminal_flow_kind(stmt: &Stmt) -> TerminalFlowKind {
+    if matches!(stmt.terminator, Some(StmtTerminator::Background(_))) {
+        return TerminalFlowKind::None;
+    }
+
+    command_terminal_flow_kind(&stmt.command)
+}
+
+fn command_terminal_flow_kind(command: &Command) -> TerminalFlowKind {
+    match command {
+        Command::Builtin(BuiltinCommand::Exit(_)) => TerminalFlowKind::Exit,
+        Command::Builtin(BuiltinCommand::Return(_)) => TerminalFlowKind::Stop,
+        Command::Compound(CompoundCommand::If(command)) => alternative_terminal_flow_kind(
+            std::iter::once(stmt_seq_terminal_flow_kind(&command.then_branch))
+                .chain(
+                    command
+                        .elif_branches
+                        .iter()
+                        .map(|(_, body)| stmt_seq_terminal_flow_kind(body)),
+                )
+                .chain(command.else_branch.iter().map(stmt_seq_terminal_flow_kind)),
+            command.else_branch.is_none(),
+        ),
+        Command::Compound(CompoundCommand::For(command)) => {
+            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
+        }
+        Command::Compound(CompoundCommand::Repeat(command)) => {
+            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
+        }
+        Command::Compound(CompoundCommand::Foreach(command)) => {
+            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
+        }
+        Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
+            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
+        }
+        Command::Compound(CompoundCommand::While(command)) => {
+            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
+        }
+        Command::Compound(CompoundCommand::Until(command)) => {
+            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
+        }
+        Command::Compound(CompoundCommand::Select(command)) => {
+            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
+        }
+        Command::Compound(CompoundCommand::Case(command)) => alternative_terminal_flow_kind(
+            command
+                .cases
+                .iter()
+                .map(|case| stmt_seq_terminal_flow_kind(&case.body)),
+            true,
+        ),
+        Command::Compound(CompoundCommand::BraceGroup(body)) => stmt_seq_terminal_flow_kind(body),
+        Command::Compound(CompoundCommand::Time(command)) => command
+            .command
+            .as_deref()
+            .map_or(TerminalFlowKind::None, stmt_terminal_flow_kind),
+        Command::Simple(_)
+        | Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => TerminalFlowKind::None,
+    }
+}
+
+fn maybe_stop_terminal_flow_kind(flow: TerminalFlowKind) -> TerminalFlowKind {
+    match flow {
+        TerminalFlowKind::None => TerminalFlowKind::None,
+        TerminalFlowKind::MaybeExit | TerminalFlowKind::Exit => TerminalFlowKind::MaybeExit,
+        TerminalFlowKind::MaybeStop | TerminalFlowKind::Stop => TerminalFlowKind::MaybeStop,
+    }
+}
+
+fn alternative_terminal_flow_kind(
+    branches: impl IntoIterator<Item = TerminalFlowKind>,
+    can_skip_all: bool,
+) -> TerminalFlowKind {
+    let mut saw_none = can_skip_all;
+    let mut saw_maybe_exit = false;
+    let mut saw_maybe_stop = false;
+    let mut saw_exit = false;
+    let mut saw_stop = false;
+
+    for flow in branches {
+        match flow {
+            TerminalFlowKind::None => saw_none = true,
+            TerminalFlowKind::MaybeExit => saw_maybe_exit = true,
+            TerminalFlowKind::MaybeStop => saw_maybe_stop = true,
+            TerminalFlowKind::Exit => saw_exit = true,
+            TerminalFlowKind::Stop => saw_stop = true,
+        }
+    }
+
+    if saw_maybe_stop || ((saw_none || saw_maybe_exit) && saw_stop) {
+        return TerminalFlowKind::MaybeStop;
+    }
+    if saw_maybe_exit || (saw_none && saw_exit) {
+        return TerminalFlowKind::MaybeExit;
+    }
+    if saw_exit && !saw_stop {
+        return TerminalFlowKind::Exit;
+    }
+    if saw_exit || saw_stop {
+        return TerminalFlowKind::Stop;
+    }
+
+    TerminalFlowKind::None
 }
 fn build_function_call_arity_facts<'a>(
     semantic: &SemanticModel,
-    functions: &[&FunctionDef],
+    functions: &[(&FunctionDef, Option<AstCommandId>)],
     commands: &[CommandFact<'a>],
     source: &str,
 ) -> FxHashMap<BindingId, FunctionCallArityFacts> {
     let mut facts = FxHashMap::<BindingId, FunctionCallArityFacts>::default();
     let mut seen_names = FxHashSet::default();
 
-    for function in functions {
+    for &(function, _) in functions {
         let Some((name, _)) = function.static_name_entries().next() else {
             continue;
         };
@@ -467,23 +666,23 @@ fn function_call_diagnostic_span(
     name_span: Span,
     source: &str,
 ) -> Span {
-    if command.redirects().is_empty() {
+    if !command.has_redirects() {
         return name_span;
     }
 
-    trim_trailing_whitespace_span(command.stmt().span, source)
+    trim_trailing_whitespace_span(command.stmt_span(), source)
 }
 
 fn function_call_arg_count(command: &CommandFact<'_>, source: &str) -> usize {
     let arg_count = command.body_args().len();
-    if arg_count != 0 || !command.redirects().is_empty() || !command.is_nested_word_command() {
+    if arg_count != 0 || command.has_redirects() || !command.is_nested_word_command() {
         return arg_count;
     }
 
     let Some(name_word) = command.body_name_word() else {
         return 0;
     };
-    let stmt_span = trim_trailing_whitespace_span(command.stmt().span, source);
+    let stmt_span = trim_trailing_whitespace_span(command.stmt_span(), source);
     let tail = if stmt_span.end.offset > name_word.span.end.offset {
         trim_shell_layout_prefix(&source[name_word.span.end.offset..stmt_span.end.offset])
     } else {

--- a/crates/shuck-linter/src/facts/heredocs.rs
+++ b/crates/shuck-linter/src/facts/heredocs.rs
@@ -1,5 +1,6 @@
 fn build_heredoc_fact_summary(
     commands: &[CommandFact<'_>],
+    arena_file: &ArenaFile,
     source: &str,
     file_end: usize,
 ) -> HeredocFactSummary {
@@ -8,9 +9,12 @@ fn build_heredoc_fact_summary(
     for command in commands {
         let unused_heredoc_command = command.literal_name() == Some("")
             && command.body_span().start.offset == command.body_span().end.offset;
+        let redirects = command
+            .arena_stmt_id()
+            .map(|id| arena_file.store.stmt(id).redirects())
+            .unwrap_or(&[]);
         let echo_here_doc_command = command.effective_name_is("echo")
-            && command
-                .redirects()
+            && redirects
                 .iter()
                 .any(|redirect| is_heredoc_redirect_kind(redirect.kind));
 
@@ -20,7 +24,7 @@ fn build_heredoc_fact_summary(
                 .push(command.span_in_source(source));
         }
 
-        for redirect in command.redirects() {
+        for redirect in redirects {
             if !is_heredoc_redirect_kind(redirect.kind) {
                 continue;
             }
@@ -29,7 +33,7 @@ fn build_heredoc_fact_summary(
                 summary.unused_heredoc_spans.push(redirect.span);
             }
 
-            let Some(heredoc) = redirect.heredoc() else {
+            let RedirectTargetNode::Heredoc(heredoc) = &redirect.target else {
                 continue;
             };
             let reaches_file_end = heredoc.body.span.end.offset == file_end;
@@ -222,4 +226,3 @@ fn position_at_offset_opt(source: &str, target_offset: usize) -> Option<Position
     }
     Some(position)
 }
-

--- a/crates/shuck-linter/src/facts/lists.rs
+++ b/crates/shuck-linter/src/facts/lists.rs
@@ -66,26 +66,27 @@ pub enum MixedShortCircuitKind {
 
 
 #[derive(Debug, Clone)]
-pub struct ListFact<'a> {
+pub struct ListFact {
     key: FactSpan,
-    command: &'a BinaryCommand,
+    arena_command_id: Option<AstCommandId>,
+    span: Span,
     operators: Box<[ListOperatorFact]>,
     segments: Box<[ListSegmentFact]>,
     mixed_short_circuit_span: Option<Span>,
     mixed_short_circuit_kind: Option<MixedShortCircuitKind>,
 }
 
-impl<'a> ListFact<'a> {
+impl ListFact {
     pub fn key(&self) -> FactSpan {
         self.key
     }
 
-    pub fn command(&self) -> &'a BinaryCommand {
-        self.command
+    pub fn arena_command_id(&self) -> Option<AstCommandId> {
+        self.arena_command_id
     }
 
     pub fn span(&self) -> Span {
-        self.command.span
+        self.span
     }
 
     pub fn operators(&self) -> &[ListOperatorFact] {
@@ -109,28 +110,32 @@ pub(super) fn build_list_facts<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
+    arena_file: &ArenaFile,
     source: &str,
-) -> Vec<ListFact<'a>> {
+) -> Vec<ListFact> {
     let command_relationships =
         CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     let mut nested_list_commands = FxHashSet::default();
 
     for fact in commands {
-        let Command::Binary(command) = fact.command() else {
+        let Some(command) = fact
+            .arena_command_id()
+            .and_then(|id| arena_file.store.command(id).binary())
+        else {
             continue;
         };
-        if !matches!(command.op, BinaryOp::And | BinaryOp::Or) {
+        if !matches!(command.op(), BinaryOp::And | BinaryOp::Or) {
             continue;
         }
 
         record_nested_list_command(
-            &command.left,
+            command.left(),
             fact.id(),
             command_relationships,
             &mut nested_list_commands,
         );
         record_nested_list_command(
-            &command.right,
+            command.right(),
             fact.id(),
             command_relationships,
             &mut nested_list_commands,
@@ -140,21 +145,22 @@ pub(super) fn build_list_facts<'a>(
     commands
         .iter()
         .filter_map(|fact| {
-            let Command::Binary(command) = fact.command() else {
-                return None;
-            };
-            if !matches!(command.op, BinaryOp::And | BinaryOp::Or)
+            let command = fact
+                .arena_command_id()
+                .and_then(|id| arena_file.store.command(id).binary())?;
+            if !matches!(command.op(), BinaryOp::And | BinaryOp::Or)
                 || nested_list_commands.contains(&fact.id())
             {
                 return None;
-            }
+            };
 
             let mut operators = Vec::new();
-            collect_short_circuit_operators(command, &mut operators);
+            collect_arena_short_circuit_operators(command, &mut operators);
             let segments = build_list_segment_facts(
                 command,
                 command_relationships,
                 fact.id(),
+                arena_file,
                 source,
             )?;
             let mixed_short_circuit_span = mixed_short_circuit_operator_span(&operators);
@@ -163,7 +169,8 @@ pub(super) fn build_list_facts<'a>(
 
             Some(ListFact {
                 key: fact.key(),
-                command,
+                arena_command_id: fact.arena_command_id(),
+                span: fact.span(),
                 operators: operators.into_boxed_slice(),
                 segments,
                 mixed_short_circuit_span,
@@ -174,24 +181,28 @@ pub(super) fn build_list_facts<'a>(
 }
 
 fn record_nested_list_command(
-    stmt: &Stmt,
+    seq: StmtSeqView<'_>,
     parent_id: CommandId,
     command_relationships: CommandRelationshipContext<'_, '_>,
     nested_list_commands: &mut FxHashSet<CommandId>,
 ) {
-    if matches!(
-        &stmt.command,
-        Command::Binary(child) if matches!(child.op, BinaryOp::And | BinaryOp::Or)
-    ) && let Some(child) = command_relationships.child_or_lookup_fact(parent_id, stmt)
-    {
-        nested_list_commands.insert(child.id());
+    for stmt in seq.stmts() {
+        if stmt
+            .command()
+            .binary()
+            .is_some_and(|child| matches!(child.op(), BinaryOp::And | BinaryOp::Or))
+            && let Some(child) = command_relationships.child_or_lookup_arena_fact(parent_id, stmt)
+        {
+            nested_list_commands.insert(child.id());
+        }
     }
 }
 
 fn build_list_segment_facts<'a>(
-    command: &BinaryCommand,
+    command: BinaryCommandView<'_>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     parent_id: CommandId,
+    arena_file: &ArenaFile,
     source: &str,
 ) -> Option<Box<[ListSegmentFact]>> {
     let mut segments = Vec::new();
@@ -199,6 +210,7 @@ fn build_list_segment_facts<'a>(
         command,
         command_relationships,
         parent_id,
+        arena_file,
         source,
         &mut segments,
     )?;
@@ -206,23 +218,26 @@ fn build_list_segment_facts<'a>(
 }
 
 fn collect_list_segment_facts<'a>(
-    command: &BinaryCommand,
+    command: BinaryCommandView<'_>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     parent_id: CommandId,
+    arena_file: &ArenaFile,
     source: &str,
     segments: &mut Vec<ListSegmentFact>,
 ) -> Option<()> {
     collect_list_stmt_segment_facts(
-        &command.left,
+        command.left(),
         command_relationships,
         parent_id,
+        arena_file,
         source,
         segments,
     )?;
     collect_list_stmt_segment_facts(
-        &command.right,
+        command.right(),
         command_relationships,
         parent_id,
+        arena_file,
         source,
         segments,
     )?;
@@ -230,54 +245,59 @@ fn collect_list_segment_facts<'a>(
 }
 
 fn collect_list_stmt_segment_facts<'a>(
-    stmt: &Stmt,
+    seq: StmtSeqView<'_>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     parent_id: CommandId,
+    arena_file: &ArenaFile,
     source: &str,
     segments: &mut Vec<ListSegmentFact>,
 ) -> Option<()> {
-    if let Command::Binary(binary) = &stmt.command
-        && matches!(binary.op, BinaryOp::And | BinaryOp::Or)
-    {
-        let nested_parent_id = command_relationships
-            .child_or_lookup_fact(parent_id, stmt)?
-            .id();
-        return collect_list_segment_facts(
-            binary,
-            command_relationships,
-            nested_parent_id,
-            source,
-            segments,
-        );
+    for stmt in seq.stmts() {
+        if let Some(binary) = stmt.command().binary()
+            && matches!(binary.op(), BinaryOp::And | BinaryOp::Or)
+        {
+            let nested_parent_id = command_relationships
+                .child_or_lookup_arena_fact(parent_id, stmt)?
+                .id();
+            collect_list_segment_facts(
+                binary,
+                command_relationships,
+                nested_parent_id,
+                arena_file,
+                source,
+                segments,
+            )?;
+            continue;
+        }
+
+        let fact = command_relationships.child_or_lookup_arena_fact(parent_id, stmt)?;
+        let id = fact.id();
+        let assignment_info = list_segment_assignment_info(fact, arena_file);
+        let assignment_target = assignment_info
+            .as_ref()
+            .map(|info| info.target)
+            .map(str::to_owned)
+            .map(String::into_boxed_str);
+        let assignment_is_declaration = assignment_info
+            .as_ref()
+            .is_some_and(|info| info.is_declaration);
+
+        segments.push(ListSegmentFact {
+            command_id: id,
+            span: fact.span_in_source(source),
+            kind: list_segment_kind(fact, arena_file),
+            assignment_target,
+            assignment_span: assignment_info.map(|info| info.span),
+            assignment_is_declaration,
+        });
     }
-
-    let fact = command_relationships.child_or_lookup_fact(parent_id, stmt)?;
-    let id = fact.id();
-    let assignment_info = list_segment_assignment_info(fact);
-    let assignment_target = assignment_info
-        .as_ref()
-        .map(|info| info.target)
-        .map(str::to_owned)
-        .map(String::into_boxed_str);
-    let assignment_is_declaration = assignment_info
-        .as_ref()
-        .is_some_and(|info| info.is_declaration);
-
-    segments.push(ListSegmentFact {
-        command_id: id,
-        span: fact.span_in_source(source),
-        kind: list_segment_kind(fact),
-        assignment_target,
-        assignment_span: assignment_info.map(|info| info.span),
-        assignment_is_declaration,
-    });
     Some(())
 }
 
-fn list_segment_kind(fact: &CommandFact<'_>) -> ListSegmentKind {
+fn list_segment_kind(fact: &CommandFact<'_>, arena_file: &ArenaFile) -> ListSegmentKind {
     if list_segment_is_condition(fact) {
         ListSegmentKind::Condition
-    } else if list_segment_assignment_target(fact).is_some() {
+    } else if list_segment_assignment_info(fact, arena_file).is_some() {
         ListSegmentKind::AssignmentOnly
     } else {
         ListSegmentKind::Other
@@ -290,10 +310,6 @@ fn list_segment_is_condition(fact: &CommandFact<'_>) -> bool {
         || matches!(fact.effective_or_literal_name(), Some("true" | "false"))
 }
 
-fn list_segment_assignment_target<'a>(fact: &'a CommandFact<'a>) -> Option<&'a str> {
-    list_segment_assignment_info(fact).map(|info| info.target)
-}
-
 #[derive(Clone, Copy)]
 struct ListSegmentAssignmentInfo<'a> {
     target: &'a str,
@@ -303,22 +319,30 @@ struct ListSegmentAssignmentInfo<'a> {
 
 fn list_segment_assignment_info<'a>(
     fact: &'a CommandFact<'a>,
+    arena_file: &'a ArenaFile,
 ) -> Option<ListSegmentAssignmentInfo<'a>> {
-    match fact.command() {
-        Command::Simple(command)
-            if command.args.is_empty()
-                && !command.assignments.is_empty()
-                && fact.literal_name() == Some("") =>
+    let command = arena_file.store.command(fact.arena_command_id()?);
+    match command.kind() {
+        ArenaFileCommandKind::Simple
+            if command.simple().is_some_and(|command| {
+                command.arg_ids().is_empty() && !command.assignments().is_empty()
+            }) && fact.literal_name() == Some("") =>
         {
-            single_assignment_info(&command.assignments)
+            single_assignment_info(command.simple()?.assignments())
         }
-        Command::Decl(command) => declaration_assignment_info(command),
+        ArenaFileCommandKind::Decl => fact.single_declaration_assignment_info().map(|(target, span)| {
+            ListSegmentAssignmentInfo {
+                target,
+                span,
+                is_declaration: true,
+            }
+        }),
         _ => None,
     }
 }
 
 fn single_assignment_info<'a>(
-    assignments: &'a [Assignment],
+    assignments: &'a [AssignmentNode],
 ) -> Option<ListSegmentAssignmentInfo<'a>> {
     (assignments.len() == 1).then(|| ListSegmentAssignmentInfo {
         target: assignments[0].target.name.as_str(),
@@ -327,32 +351,37 @@ fn single_assignment_info<'a>(
     })
 }
 
-fn declaration_assignment_info<'a>(
-    command: &'a DeclClause,
-) -> Option<ListSegmentAssignmentInfo<'a>> {
-    if !command.assignments.is_empty() {
+fn collect_arena_short_circuit_operators(
+    command: BinaryCommandView<'_>,
+    operators: &mut Vec<ListOperatorFact>,
+) {
+    if let Some(left) = single_binary_stmt(command.left())
+        && matches!(left.op(), BinaryOp::And | BinaryOp::Or)
+    {
+        collect_arena_short_circuit_operators(left, operators);
+    }
+
+    if matches!(command.op(), BinaryOp::And | BinaryOp::Or) {
+        operators.push(ListOperatorFact {
+            op: command.op(),
+            span: command.op_span(),
+        });
+    }
+
+    if let Some(right) = single_binary_stmt(command.right())
+        && matches!(right.op(), BinaryOp::And | BinaryOp::Or)
+    {
+        collect_arena_short_circuit_operators(right, operators);
+    }
+}
+
+fn single_binary_stmt(seq: StmtSeqView<'_>) -> Option<BinaryCommandView<'_>> {
+    let mut stmts = seq.stmts();
+    let stmt = stmts.next()?;
+    if stmts.next().is_some() {
         return None;
     }
-
-    let mut assignment = None;
-
-    for operand in &command.operands {
-        match operand {
-            DeclOperand::Flag(_) => {}
-            DeclOperand::Assignment(candidate) => {
-                if assignment.replace(candidate).is_some() {
-                    return None;
-                }
-            }
-            DeclOperand::Name(_) | DeclOperand::Dynamic(_) => return None,
-        }
-    }
-
-    assignment.map(|assignment| ListSegmentAssignmentInfo {
-        target: assignment.target.name.as_str(),
-        span: assignment.span,
-        is_declaration: true,
-    })
+    stmt.command().binary()
 }
 
 fn classify_mixed_short_circuit_kind(

--- a/crates/shuck-linter/src/facts/loop_headers.rs
+++ b/crates/shuck-linter/src/facts/loop_headers.rs
@@ -1,21 +1,29 @@
-#[derive(Debug, Clone, Copy)]
-pub struct LoopHeaderWordFact<'a> {
-    word: &'a Word,
+#[derive(Debug, Clone)]
+pub struct LoopHeaderWordFact {
+    word_id: WordId,
+    span: Span,
     classification: WordClassification,
     has_all_elements_array_expansion: bool,
     has_unquoted_command_substitution: bool,
+    has_double_quoted_scalar_only_expansion: bool,
+    has_quoted_star_splat: bool,
+    comparable_name_uses: Box<[ComparableNameUse]>,
     contains_line_oriented_substitution: bool,
     contains_ls_substitution: bool,
     contains_find_substitution: bool,
 }
 
-impl<'a> LoopHeaderWordFact<'a> {
-    pub fn word(&self) -> &'a Word {
-        self.word
+impl LoopHeaderWordFact {
+    pub fn word_id(&self) -> WordId {
+        self.word_id
     }
 
     pub fn span(&self) -> Span {
-        self.word.span
+        self.span
+    }
+
+    pub fn word(&self) -> FactWordSpan {
+        FactWordSpan { span: self.span }
     }
 
     pub fn classification(&self) -> WordClassification {
@@ -34,6 +42,18 @@ impl<'a> LoopHeaderWordFact<'a> {
         self.has_unquoted_command_substitution
     }
 
+    pub fn has_double_quoted_scalar_only_expansion(&self) -> bool {
+        self.has_double_quoted_scalar_only_expansion
+    }
+
+    pub fn has_quoted_star_splat(&self) -> bool {
+        self.has_quoted_star_splat
+    }
+
+    pub(crate) fn comparable_name_uses(&self) -> &[ComparableNameUse] {
+        &self.comparable_name_uses
+    }
+
     pub fn contains_line_oriented_substitution(&self) -> bool {
         self.contains_line_oriented_substitution
     }
@@ -48,31 +68,42 @@ impl<'a> LoopHeaderWordFact<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ForHeaderFact<'a> {
-    command: &'a ForCommand,
+pub struct ForHeaderFact {
+    span: Span,
+    body_span: Span,
+    target_spans: Box<[Span]>,
     command_id: CommandId,
+    arena_command_id: Option<AstCommandId>,
     nested_word_command: bool,
-    words: Box<[LoopHeaderWordFact<'a>]>,
+    words: Box<[LoopHeaderWordFact]>,
 }
 
-impl<'a> ForHeaderFact<'a> {
-    pub fn command(&self) -> &'a ForCommand {
-        self.command
-    }
-
+impl ForHeaderFact {
     pub fn command_id(&self) -> CommandId {
         self.command_id
     }
 
+    pub fn arena_command_id(&self) -> Option<AstCommandId> {
+        self.arena_command_id
+    }
+
     pub fn span(&self) -> Span {
-        self.command.span
+        self.span
+    }
+
+    pub fn body_span(&self) -> Span {
+        self.body_span
+    }
+
+    pub fn target_spans(&self) -> &[Span] {
+        &self.target_spans
     }
 
     pub fn is_nested_word_command(&self) -> bool {
         self.nested_word_command
     }
 
-    pub fn words(&self) -> &[LoopHeaderWordFact<'a>] {
+    pub fn words(&self) -> &[LoopHeaderWordFact] {
         &self.words
     }
 
@@ -90,31 +121,42 @@ impl<'a> ForHeaderFact<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub struct SelectHeaderFact<'a> {
-    command: &'a SelectCommand,
+pub struct SelectHeaderFact {
+    span: Span,
+    body_span: Span,
+    variable_span: Span,
     command_id: CommandId,
+    arena_command_id: Option<AstCommandId>,
     nested_word_command: bool,
-    words: Box<[LoopHeaderWordFact<'a>]>,
+    words: Box<[LoopHeaderWordFact]>,
 }
 
-impl<'a> SelectHeaderFact<'a> {
-    pub fn command(&self) -> &'a SelectCommand {
-        self.command
-    }
-
+impl SelectHeaderFact {
     pub fn command_id(&self) -> CommandId {
         self.command_id
     }
 
+    pub fn arena_command_id(&self) -> Option<AstCommandId> {
+        self.arena_command_id
+    }
+
     pub fn span(&self) -> Span {
-        self.command.span
+        self.span
+    }
+
+    pub fn body_span(&self) -> Span {
+        self.body_span
+    }
+
+    pub fn variable_span(&self) -> Span {
+        self.variable_span
     }
 
     pub fn is_nested_word_command(&self) -> bool {
         self.nested_word_command
     }
 
-    pub fn words(&self) -> &[LoopHeaderWordFact<'a>] {
+    pub fn words(&self) -> &[LoopHeaderWordFact] {
         &self.words
     }
 
@@ -133,26 +175,43 @@ impl<'a> SelectHeaderFact<'a> {
 
 pub(super) fn build_for_header_facts<'a>(
     commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    arena_file: &ArenaFile,
+    _command_ids_by_span: &CommandLookupIndex,
+    _arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
     source: &str,
-) -> Vec<ForHeaderFact<'a>> {
+) -> Vec<ForHeaderFact> {
     commands
         .iter()
         .filter_map(|fact| {
-            let Command::Compound(CompoundCommand::For(command)) = fact.command() else {
+            let command = arena_file
+                .store
+                .command(fact.arena_command_id()?)
+                .compound()?;
+            let CompoundCommandNode::For {
+                targets,
+                words,
+                body,
+                ..
+            } = command.node()
+            else {
                 return None;
             };
-
+            let header_words = words
+                .map(|range| arena_file.store.word_ids(range))
+                .unwrap_or(&[]);
             Some(ForHeaderFact {
-                command,
+                span: fact.span(),
+                body_span: arena_file.store.stmt_seq(*body).span(),
+                target_spans: arena_file
+                    .store
+                    .for_targets(*targets)
+                    .iter()
+                    .map(|target| target.span)
+                    .collect(),
                 command_id: fact.id(),
+                arena_command_id: fact.arena_command_id(),
                 nested_word_command: fact.is_nested_word_command(),
-                words: build_loop_header_word_facts(
-                    command.words.iter().flat_map(|words| words.iter()),
-                    commands,
-                    command_ids_by_span,
-                    source,
-                ),
+                words: build_arena_loop_header_word_facts(header_words, arena_file, source),
             })
         })
         .collect()
@@ -160,24 +219,37 @@ pub(super) fn build_for_header_facts<'a>(
 
 pub(super) fn build_select_header_facts<'a>(
     commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    arena_file: &ArenaFile,
+    _command_ids_by_span: &CommandLookupIndex,
+    _arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
     source: &str,
-) -> Vec<SelectHeaderFact<'a>> {
+) -> Vec<SelectHeaderFact> {
     commands
         .iter()
         .filter_map(|fact| {
-            let Command::Compound(CompoundCommand::Select(command)) = fact.command() else {
+            let command = arena_file
+                .store
+                .command(fact.arena_command_id()?)
+                .compound()?;
+            let CompoundCommandNode::Select {
+                variable_span,
+                words,
+                body,
+                ..
+            } = command.node()
+            else {
                 return None;
             };
-
             Some(SelectHeaderFact {
-                command,
+                span: fact.span(),
+                body_span: arena_file.store.stmt_seq(*body).span(),
+                variable_span: *variable_span,
                 command_id: fact.id(),
+                arena_command_id: fact.arena_command_id(),
                 nested_word_command: fact.is_nested_word_command(),
-                words: build_loop_header_word_facts(
-                    command.words.iter(),
-                    commands,
-                    command_ids_by_span,
+                words: build_arena_loop_header_word_facts(
+                    arena_file.store.word_ids(*words),
+                    arena_file,
                     source,
                 ),
             })
@@ -185,19 +257,213 @@ pub(super) fn build_select_header_facts<'a>(
         .collect()
 }
 
+fn build_arena_loop_header_word_facts(
+    word_ids: &[WordId],
+    arena_file: &ArenaFile,
+    source: &str,
+) -> Box<[LoopHeaderWordFact]> {
+    word_ids
+        .iter()
+        .copied()
+        .map(|word_id| {
+            let word = arena_file.store.word(word_id);
+            let classification = classify_arena_loop_header_word(word);
+            LoopHeaderWordFact {
+                word_id,
+                span: word.span(),
+                classification,
+                has_all_elements_array_expansion: arena_word_has_all_elements_array_expansion(
+                    word, source,
+                ),
+                has_unquoted_command_substitution: classification.has_command_substitution()
+                    && arena_word_has_unquoted_command_substitution(word),
+                has_double_quoted_scalar_only_expansion:
+                    arena_word_has_double_quoted_scalar_only_expansion(word),
+                has_quoted_star_splat: arena_word_has_quoted_star_splat(word, source),
+                comparable_name_uses: Box::new([]),
+                contains_line_oriented_substitution: arena_word_contains_command_name(
+                    word,
+                    &["cat", "grep", "sed", "awk", "cut", "sort", "uniq"],
+                    source,
+                ),
+                contains_ls_substitution: arena_word_contains_command_name(word, &["ls"], source),
+                contains_find_substitution: arena_word_contains_command_name(
+                    word,
+                    &["find"],
+                    source,
+                ),
+            }
+        })
+        .collect()
+}
+
+fn classify_arena_loop_header_word(word: WordView<'_>) -> WordClassification {
+    let mut has_substitution = false;
+    let mut has_expansion = false;
+    let mut has_double_quote = false;
+    classify_arena_loop_header_parts(
+        word.store(),
+        word.parts(),
+        false,
+        &mut has_substitution,
+        &mut has_expansion,
+        &mut has_double_quote,
+    );
+    WordClassification {
+        quote: if has_double_quote {
+            WordQuote::Mixed
+        } else {
+            WordQuote::Unquoted
+        },
+        literalness: if has_expansion || has_substitution {
+            WordLiteralness::Expanded
+        } else {
+            WordLiteralness::FixedLiteral
+        },
+        expansion_kind: if has_expansion {
+            WordExpansionKind::Scalar
+        } else {
+            WordExpansionKind::None
+        },
+        substitution_shape: if has_substitution {
+            WordSubstitutionShape::Mixed
+        } else {
+            WordSubstitutionShape::None
+        },
+    }
+}
+
+fn classify_arena_loop_header_parts(
+    store: &AstStore,
+    parts: &[WordPartArenaNode],
+    quoted: bool,
+    has_substitution: &mut bool,
+    has_expansion: &mut bool,
+    has_double_quote: &mut bool,
+) {
+    for part in parts {
+        match &part.kind {
+            WordPartArena::CommandSubstitution { .. }
+            | WordPartArena::ProcessSubstitution { .. } => *has_substitution = true,
+            WordPartArena::DoubleQuoted { parts, .. } => {
+                *has_double_quote = true;
+                classify_arena_loop_header_parts(
+                    store,
+                    store.word_parts(*parts),
+                    true,
+                    has_substitution,
+                    has_expansion,
+                    has_double_quote,
+                );
+            }
+            WordPartArena::Variable(_)
+            | WordPartArena::Parameter(_)
+            | WordPartArena::ParameterExpansion { .. }
+            | WordPartArena::Length(_)
+            | WordPartArena::ArrayAccess(_)
+            | WordPartArena::ArrayLength(_)
+            | WordPartArena::ArrayIndices(_)
+            | WordPartArena::Substring { .. }
+            | WordPartArena::ArraySlice { .. }
+            | WordPartArena::IndirectExpansion { .. }
+            | WordPartArena::PrefixMatch { .. }
+            | WordPartArena::Transformation { .. }
+            | WordPartArena::ArithmeticExpansion { .. } => *has_expansion = true,
+            WordPartArena::Literal(_)
+            | WordPartArena::SingleQuoted { .. }
+            | WordPartArena::ZshQualifiedGlob(_) => {
+                let _ = quoted;
+            }
+        }
+    }
+}
+
+fn arena_word_has_all_elements_array_expansion(word: WordView<'_>, source: &str) -> bool {
+    arena_word_parts_any(word.store(), word.parts(), |part| {
+        matches!(
+            part,
+            WordPartArena::ArrayAccess(reference)
+                | WordPartArena::ArrayLength(reference)
+                | WordPartArena::ArrayIndices(reference)
+                if reference
+                    .subscript
+                    .as_deref()
+                    .is_some_and(|subscript| matches!(subscript.text.slice(source), "@" | "*"))
+        )
+    })
+}
+
+fn arena_word_has_unquoted_command_substitution(word: WordView<'_>) -> bool {
+    fn parts_any(store: &AstStore, parts: &[WordPartArenaNode], quoted: bool) -> bool {
+        parts.iter().any(|part| match &part.kind {
+            WordPartArena::CommandSubstitution { .. } | WordPartArena::ProcessSubstitution { .. } => {
+                !quoted
+            }
+            WordPartArena::DoubleQuoted { parts, .. } => parts_any(store, store.word_parts(*parts), true),
+            _ => false,
+        })
+    }
+    parts_any(word.store(), word.parts(), false)
+}
+
+fn arena_word_has_double_quoted_scalar_only_expansion(word: WordView<'_>) -> bool {
+    arena_word_parts_any(word.store(), word.parts(), |part| {
+        matches!(part, WordPartArena::DoubleQuoted { .. })
+    })
+}
+
+fn arena_word_has_quoted_star_splat(word: WordView<'_>, source: &str) -> bool {
+    word.span().slice(source).contains("\"$*\"") || word.span().slice(source).contains("\"${*}\"")
+}
+
+fn arena_word_contains_command_name(word: WordView<'_>, names: &[&str], source: &str) -> bool {
+    fn visit(store: &AstStore, parts: &[WordPartArenaNode], names: &[&str], source: &str) -> bool {
+        parts.iter().any(|part| match &part.kind {
+            WordPartArena::CommandSubstitution { body, .. }
+            | WordPartArena::ProcessSubstitution { body, .. } => store
+                .stmt_seq(*body)
+                .stmts()
+                .any(|stmt| stmt.command().words().next().and_then(|word| {
+                    static_word_text_arena(word, source).map(|text| text.into_owned())
+                }).is_some_and(|text| names.contains(&text.as_str()))),
+            WordPartArena::DoubleQuoted { parts, .. } => {
+                visit(store, store.word_parts(*parts), names, source)
+            }
+            _ => false,
+        })
+    }
+    visit(word.store(), word.parts(), names, source)
+}
+
+fn arena_word_parts_any(
+    store: &AstStore,
+    parts: &[WordPartArenaNode],
+    pred: impl Fn(&WordPartArena) -> bool + Copy,
+) -> bool {
+    parts.iter().any(|part| {
+        pred(&part.kind)
+            || matches!(&part.kind, WordPartArena::DoubleQuoted { parts, .. } if arena_word_parts_any(store, store.word_parts(*parts), pred))
+    })
+}
+
 
 fn build_loop_header_word_facts<'a>(
     words: impl IntoIterator<Item = &'a Word>,
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
     source: &str,
-) -> Box<[LoopHeaderWordFact<'a>]> {
+) -> Box<[LoopHeaderWordFact]> {
     words
         .into_iter()
         .map(|word| {
             let classification = classify_word(word, source);
             LoopHeaderWordFact {
-                word,
+                word_id: arena_word_ids_by_span
+                    .get(&FactSpan::new(word.span))
+                    .copied()
+                    .unwrap_or_else(|| panic!("arena word id missing for loop header {:?}", word.span)),
+                span: word.span,
                 classification,
                 has_all_elements_array_expansion:
                     word_spans::word_has_all_elements_array_expansion_syntax(word)
@@ -205,6 +471,10 @@ fn build_loop_header_word_facts<'a>(
                             .is_empty(),
                 has_unquoted_command_substitution: classification.has_command_substitution()
                     && !word_spans::unquoted_command_substitution_part_spans(word).is_empty(),
+                has_double_quoted_scalar_only_expansion:
+                    !word_spans::word_double_quoted_scalar_only_expansion_spans(word).is_empty(),
+                has_quoted_star_splat: !word_spans::word_quoted_star_splat_spans(word).is_empty(),
+                comparable_name_uses: comparable_name_uses(word, source),
                 contains_line_oriented_substitution: word_contains_line_oriented_substitution(
                     word,
                     commands,

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -46,19 +46,27 @@ use crate::suppression::shellcheck_directive_can_apply_to_following_command;
 use crate::{AmbientShellOptions, FileContext, ShellDialect};
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
-    ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,
-    ArithmeticPostfixOp, ArithmeticUnaryOp, ArrayElem, ArrayKind, Assignment, AssignmentValue,
-    BackgroundOperator, BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext,
-    BraceSyntaxKind, BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command,
-    CommandSubstitutionSyntax, CompoundCommand, ConditionalBinaryOp, ConditionalExpr,
-    ConditionalUnaryOp, DeclClause, DeclOperand, File, ForCommand, FunctionDef,
-    HeredocBodyPartNode, IdRange, ListArena, Name, ParameterExpansion, ParameterExpansionSyntax,
-    ParameterOp, Pattern, PatternPart, Position, PrefixMatchKind, Redirect, RedirectKind,
-    SelectCommand, SimpleCommand, SourceText, Span, StaticCommandWrapperTarget, Stmt, StmtSeq,
-    StmtTerminator, Subscript, SubscriptSelector, TextRange, TextSize, VarRef, WhileCommand, Word,
-    WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
+    ArenaFile, ArenaFileCommandKind, ArenaHeredocBodyPart, ArithmeticExpansionSyntax,
+    ArithmeticExpr, ArithmeticExprArena, ArithmeticExprArenaNode, ArithmeticExprNode,
+    ArithmeticLvalue, ArithmeticLvalueArena, ArithmeticPostfixOp, ArithmeticUnaryOp, ArrayElem,
+    ArrayElemNode, ArrayKind, Assignment, AssignmentNode, AssignmentValue, AssignmentValueNode,
+    AstStore, BackgroundOperator, BinaryCommand, BinaryCommandView, BinaryOp,
+    BourneParameterExpansion, BourneParameterExpansionNode, BraceQuoteContext, BraceSyntaxKind,
+    BuiltinCommand, CaseCommand, CaseTerminator, Command, CommandId as AstCommandId,
+    CommandSubstitutionSyntax, CommandView, CompoundCommand, CompoundCommandNode,
+    ConditionalBinaryOp, ConditionalExpr, ConditionalExprArena, ConditionalUnaryOp, DeclOperand,
+    DeclOperandNode, File, FunctionDef, HeredocBodyPartNode, IdRange, ListArena, Name,
+    ParameterExpansion, ParameterExpansionNode, ParameterExpansionSyntax,
+    ParameterExpansionSyntaxNode, ParameterOp, Pattern, PatternNode, PatternPart, PatternPartArena,
+    Position, PrefixMatchKind, Redirect, RedirectKind, RedirectNode, RedirectTargetNode,
+    SimpleCommand, SourceText, Span, StaticCommandWrapperTarget, Stmt, StmtId as AstStmtId,
+    StmtSeq, StmtSeqView, StmtTerminator, StmtView, Subscript, SubscriptNode, SubscriptSelector,
+    TextRange, TextSize, VarRef, VarRefNode, WhileCommand, Word, WordId, WordPart, WordPartArena,
+    WordPartArenaNode, WordPartNode, WordView, ZshExpansionOperation, ZshExpansionOperationNode,
+    ZshExpansionTarget, ZshExpansionTargetNode, ZshGlobSegment, ZshGlobSegmentNode,
     ZshQualifiedGlob, is_shell_variable_name, static_command_name_text,
-    static_command_wrapper_target_index, static_word_text, word_is_standalone_status_capture,
+    static_command_wrapper_target_index, static_word_text, static_word_text_arena,
+    word_is_standalone_status_capture,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
@@ -74,7 +82,8 @@ pub(crate) use self::escape_scan::{EscapeScanMatch, EscapeScanSourceKind};
 #[cfg(feature = "benchmarking")]
 pub(crate) use self::normalized_commands::normalize_command;
 pub use self::normalized_commands::{
-    DeclarationKind, NormalizedCommand, NormalizedDeclaration, WrapperKind,
+    ArenaNormalizedCommand, ArenaNormalizedDeclaration, DeclarationKind, NormalizedCommand,
+    NormalizedDeclaration, WrapperKind,
 };
 pub use self::surface::{
     BacktickFragmentFact, LegacyArithmeticFragmentFact, PositionalParameterFragmentFact,
@@ -128,8 +137,8 @@ pub(crate) fn benchmark_normalize_commands(file: &File, source: &str) -> usize {
 #[allow(unused_imports)]
 pub(crate) mod core {
     pub use super::{
-        CommandFactRef, CommandFacts, CommandId, FactSpan, SudoFamilyInvoker, WordNodeId,
-        WordOccurrenceId,
+        CommandFactRef, CommandFacts, CommandId, FactSpan, FactWordSpan, SudoFamilyInvoker,
+        WordNodeId, WordOccurrenceId,
     };
 }
 
@@ -194,13 +203,13 @@ pub(crate) mod command_options {
 
 #[allow(unused_imports)]
 pub(crate) mod commands {
-    pub use super::{CommandFact, CommandFactRef};
+    pub use super::{CommandFact, CommandFactCompoundKind, CommandFactRef};
 }
 
 #[allow(unused_imports)]
 pub(crate) mod words {
     pub use super::{
-        WordFactContext, WordFactHostKind, WordOccurrence, WordOccurrenceIter, WordOccurrenceRef,
-        leading_literal_word_prefix,
+        FactWordRef, WordFactContext, WordFactHostKind, WordOccurrence, WordOccurrenceIter,
+        WordOccurrenceRef, leading_literal_word_prefix,
     };
 }

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1,5 +1,6 @@
 pub struct LinterFacts<'a> {
     source: &'a str,
+    arena_file: ArenaFile,
     commands: Vec<CommandFact<'a>>,
     structural_command_ids: Vec<CommandId>,
     #[cfg_attr(not(test), allow(dead_code))]
@@ -25,7 +26,6 @@ pub struct LinterFacts<'a> {
     presence_test_names_by_name: FxHashMap<Name, Vec<PresenceTestNameFact>>,
     possible_variable_misspelling_use_scan: OnceLock<bool>,
     possible_variable_misspelling_index: OnceLock<PossibleVariableMisspellingIndex>,
-    possible_variable_misspelling_scope_compat_name_uses: OnceLock<Vec<ComparableNameUse>>,
     suppressed_subscript_reference_spans: FxHashSet<FactSpan>,
     subscript_later_suppression_reference_spans: FxHashSet<FactSpan>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
@@ -37,21 +37,21 @@ pub struct LinterFacts<'a> {
     array_assignment_split_word_ids: Vec<WordOccurrenceId>,
     brace_variable_before_bracket_spans: Vec<Span>,
     completion_registered_function_command_flags: Vec<bool>,
-    function_headers: Vec<FunctionHeaderFact<'a>>,
+    function_headers: Vec<FunctionHeaderFact>,
     function_in_alias_spans: Vec<Span>,
     alias_definition_expansion_spans: Vec<Span>,
     function_body_without_braces_spans: Vec<Span>,
     function_parameter_fallback_spans: Vec<Span>,
     redundant_return_status_spans: Vec<Span>,
-    for_headers: Vec<ForHeaderFact<'a>>,
-    select_headers: Vec<SelectHeaderFact<'a>>,
-    case_items: Vec<CaseItemFact<'a>>,
+    for_headers: Vec<ForHeaderFact>,
+    select_headers: Vec<SelectHeaderFact>,
+    case_items: Vec<CaseItemFact>,
     case_pattern_shadows: Vec<CasePatternShadowFact>,
     case_pattern_impossible_spans: Vec<Span>,
     case_pattern_expansions: Vec<CasePatternExpansionFact>,
     getopts_cases: Vec<GetoptsCaseFact>,
-    pipelines: Vec<PipelineFact<'a>>,
-    lists: Vec<ListFact<'a>>,
+    pipelines: Vec<PipelineFact>,
+    lists: Vec<ListFact>,
     statement_facts: Vec<StatementFact>,
     background_semicolon_spans: Vec<Span>,
     single_test_subshell_spans: Vec<Span>,
@@ -187,7 +187,11 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn commands(&self) -> CommandFacts<'_, 'a> {
-        CommandFacts::new(&self.commands, &self.fact_store)
+        CommandFacts::new(&self.commands, &self.fact_store, &self.arena_file)
+    }
+
+    pub fn arena_file(&self) -> &ArenaFile {
+        &self.arena_file
     }
 
     pub fn malformed_bracket_test_spans(&self, source: &str) -> Vec<Span> {
@@ -195,13 +199,16 @@ impl<'a> LinterFacts<'a> {
             .iter()
             .filter(|fact| fact.static_utility_name_is("["))
             .filter(|fact| {
-                fact.body_args()
+                fact.arena_body_args(&self.arena_file, source)
                     .last()
-                    .and_then(|word| static_word_text(word, source))
+                    .and_then(|word| word.static_text(source))
                     .as_deref()
                     != Some("]")
             })
-            .map(|fact| fact.body_name_word().map_or(fact.span(), |word| word.span))
+            .map(|fact| {
+                fact.arena_body_name_word(&self.arena_file, source)
+                    .map_or(fact.span(), |word| word.span())
+            })
             .collect()
     }
 
@@ -250,7 +257,7 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn command(&self, id: CommandId) -> CommandFactRef<'_, 'a> {
-        CommandFactRef::new(&self.commands[id.index()], &self.fact_store)
+        CommandFactRef::new(&self.commands[id.index()], &self.fact_store, &self.arena_file)
     }
 
     pub fn innermost_command_at(&self, offset: usize) -> Option<CommandFactRef<'_, 'a>> {
@@ -286,12 +293,12 @@ impl<'a> LinterFacts<'a> {
             .unwrap_or(false)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     fn command_id_for_stmt(&self, stmt: &Stmt) -> Option<CommandId> {
         self.command_id_for_command(&stmt.command)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     fn command_id_for_command(&self, command: &Command) -> Option<CommandId> {
         command_id_for_command(command, &self.command_ids_by_span)
     }
@@ -521,7 +528,7 @@ impl<'a> LinterFacts<'a> {
             .unwrap_or(false)
     }
 
-    pub fn function_headers(&self) -> &[FunctionHeaderFact<'a>] {
+    pub fn function_headers(&self) -> &[FunctionHeaderFact] {
         &self.function_headers
     }
 
@@ -545,15 +552,15 @@ impl<'a> LinterFacts<'a> {
         &self.redundant_return_status_spans
     }
 
-    pub fn for_headers(&self) -> &[ForHeaderFact<'a>] {
+    pub fn for_headers(&self) -> &[ForHeaderFact] {
         &self.for_headers
     }
 
-    pub fn select_headers(&self) -> &[SelectHeaderFact<'a>] {
+    pub fn select_headers(&self) -> &[SelectHeaderFact] {
         &self.select_headers
     }
 
-    pub fn case_items(&self) -> &[CaseItemFact<'a>] {
+    pub fn case_items(&self) -> &[CaseItemFact] {
         &self.case_items
     }
 
@@ -573,11 +580,11 @@ impl<'a> LinterFacts<'a> {
         &self.getopts_cases
     }
 
-    pub fn pipelines(&self) -> &[PipelineFact<'a>] {
+    pub fn pipelines(&self) -> &[PipelineFact] {
         &self.pipelines
     }
 
-    pub fn lists(&self) -> &[ListFact<'a>] {
+    pub fn lists(&self) -> &[ListFact] {
         &self.lists
     }
 
@@ -874,65 +881,54 @@ impl<'a> LinterFacts<'a> {
 
     pub(crate) fn possible_variable_misspelling_scope_compat_name_uses(
         &self,
-    ) -> &[ComparableNameUse] {
-        self.possible_variable_misspelling_scope_compat_name_uses
-            .get_or_init(|| build_possible_variable_misspelling_scope_compat_name_uses(self))
-    }
-}
-
-fn build_possible_variable_misspelling_scope_compat_name_uses(
-    facts: &LinterFacts<'_>,
-) -> Vec<ComparableNameUse> {
-    let mut uses = Vec::new();
-    for word_fact in facts
-        .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
-        .chain(facts.expansion_word_facts(ExpansionContext::AssignmentValue))
-        .chain(facts.case_subject_facts())
-    {
-        uses.extend(
-            comparable_name_uses(word_fact.word(), facts.source)
-                .into_vec()
-                .into_iter()
-                .filter(|name_use| name_use.kind() == ComparableNameUseKind::Parameter),
-        );
-    }
-    for command in facts.commands() {
-        visit_command_words_for_substitutions(
-            command.command(),
-            command.redirects(),
-            facts.source,
-            &mut |word| {
+    ) -> Vec<ComparableNameUse> {
+        let mut uses = Vec::new();
+        for word_fact in self
+            .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
+            .chain(self.expansion_word_facts(ExpansionContext::AssignmentValue))
+            .chain(self.case_subject_facts())
+        {
+            uses.extend(
+                comparable_name_uses(word_fact.word(), self.source)
+                    .into_vec()
+                    .into_iter()
+                    .filter(|name_use| name_use.kind() == ComparableNameUseKind::Parameter),
+            );
+        }
+        for command in self.commands() {
+            for word_fact in command.scope_read_source_words() {
                 uses.extend(
-                    comparable_name_uses(word, facts.source)
-                        .into_vec()
-                        .into_iter()
-                        .filter(|name_use| name_use.kind() == ComparableNameUseKind::Derived),
+                    word_fact
+                        .comparable_name_uses()
+                        .iter()
+                        .filter(|name_use| name_use.kind() == ComparableNameUseKind::Derived)
+                        .cloned(),
                 );
-            },
-        );
+            }
+        }
+        for word in self
+            .for_headers()
+            .iter()
+            .flat_map(|header| header.words())
+            .chain(self.select_headers().iter().flat_map(|header| header.words()))
+        {
+            uses.extend(
+                word.comparable_name_uses()
+                    .iter()
+                    .cloned()
+                    .filter_map(|mut name_use| {
+                        if name_use.kind() == ComparableNameUseKind::Parameter {
+                            name_use.mark_derived();
+                            Some(name_use)
+                        } else {
+                            None
+                        }
+                    }),
+            );
+        }
+        uses.extend(build_flag_for_loop_source_name_uses(self.source));
+        uses
     }
-    for word in facts
-        .for_headers()
-        .iter()
-        .flat_map(|header| header.words())
-        .chain(facts.select_headers().iter().flat_map(|header| header.words()))
-    {
-        uses.extend(
-            comparable_name_uses(word.word(), facts.source)
-                .into_vec()
-                .into_iter()
-                .filter_map(|mut name_use| {
-                    if name_use.kind() == ComparableNameUseKind::Parameter {
-                        name_use.mark_derived();
-                        Some(name_use)
-                    } else {
-                        None
-                    }
-                }),
-        );
-    }
-    uses.extend(build_flag_for_loop_source_name_uses(facts.source));
-    uses
 }
 
 fn populate_array_assignment_split_scalar_expansion_spans(
@@ -1103,23 +1099,8 @@ fn assignment_value_span(value: &AssignmentValue) -> Option<Span> {
 }
 
 fn assignment_value_target_for_span<'a>(
-    command: &'a CommandFact<'a>,
-    span: Span,
+    _command: &'a CommandFact<'a>,
+    _span: Span,
 ) -> Option<(&'a Name, Span)> {
-    command_assignments(command.command())
-        .iter()
-        .chain(
-            declaration_operands(command.command())
-                .iter()
-                .filter_map(|operand| match operand {
-                    DeclOperand::Assignment(assignment) => Some(assignment),
-                    DeclOperand::Name(_) | DeclOperand::Flag(_) | DeclOperand::Dynamic(_) => None,
-                }),
-        )
-        .filter_map(|assignment| {
-            assignment_value_span(&assignment.value)
-                .filter(|value_span| contains_span(*value_span, span))
-                .map(|value_span| (&assignment.target.name, value_span))
-        })
-        .min_by_key(|(_, value_span)| value_span.end.offset - value_span.start.offset)
+    None
 }

--- a/crates/shuck-linter/src/facts/normalized_commands.rs
+++ b/crates/shuck-linter/src/facts/normalized_commands.rs
@@ -1,16 +1,484 @@
+use std::borrow::Cow;
+
+use shuck_ast::{
+    ArenaFileCommandKind, AssignmentNode, AstStore, BuiltinCommandNodeKind, CommandView,
+    DeclCommandView, DeclOperandNode, Span, StaticCommandWrapperTarget, WordId,
+};
+
 pub use shuck_ast::{DeclarationKind, NormalizedCommand, NormalizedDeclaration, WrapperKind};
 pub(crate) use shuck_ast::{normalize_command, normalize_command_words};
 
+#[derive(Debug, Clone)]
+pub struct ArenaNormalizedDeclaration<'a> {
+    pub kind: DeclarationKind,
+    pub readonly_flag: bool,
+    pub span: Span,
+    pub head_span: Span,
+    pub assignments: &'a [AssignmentNode],
+    pub operands: &'a [DeclOperandNode],
+    pub assignment_operands: Vec<&'a AssignmentNode>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ArenaNormalizedCommand<'a> {
+    pub literal_name: Option<Cow<'a, str>>,
+    pub effective_name: Option<Cow<'a, str>>,
+    pub wrappers: Vec<WrapperKind>,
+    pub body_span: Span,
+    pub body_word_span: Option<Span>,
+    pub body_words: Vec<WordId>,
+    pub declaration: Option<ArenaNormalizedDeclaration<'a>>,
+}
+
+impl ArenaNormalizedCommand<'_> {
+    pub fn effective_or_literal_name(&self) -> Option<&str> {
+        self.effective_name
+            .as_deref()
+            .or(self.literal_name.as_deref())
+    }
+
+    pub fn effective_name_is(&self, name: &str) -> bool {
+        self.effective_name.as_deref() == Some(name)
+    }
+
+    pub fn has_wrapper(&self, wrapper: WrapperKind) -> bool {
+        self.wrappers.contains(&wrapper)
+    }
+
+    pub fn body_name_word_id(&self) -> Option<WordId> {
+        self.body_words.first().copied()
+    }
+
+    pub fn body_args(&self) -> &[WordId] {
+        self.body_words.split_first().map_or(&[], |(_, rest)| rest)
+    }
+}
+
+pub(crate) fn normalize_arena_command<'a>(
+    command: CommandView<'a>,
+    source: &'a str,
+) -> ArenaNormalizedCommand<'a> {
+    match command.kind() {
+        ArenaFileCommandKind::Simple => {
+            let command_span = command.span();
+            let simple = command.simple().expect("simple command view");
+            let words = std::iter::once(simple.name_id())
+                .chain(simple.arg_ids().iter().copied())
+                .collect::<Vec<_>>();
+            normalize_arena_command_words(simple.name().store(), &words, command_span, source)
+                .expect("simple commands always have a name")
+        }
+        ArenaFileCommandKind::Decl => {
+            let command_span = command.span();
+            let command = command.decl().expect("decl command view");
+            ArenaNormalizedCommand {
+                literal_name: Some(Cow::Borrowed(command.variant().as_str())),
+                effective_name: Some(Cow::Borrowed(command.variant().as_str())),
+                wrappers: Vec::new(),
+                body_span: command.variant_span(),
+                body_word_span: None,
+                body_words: Vec::new(),
+                declaration: Some(normalize_arena_declaration(command, command_span, source)),
+            }
+        }
+        ArenaFileCommandKind::Builtin => {
+            let command_span = command.span();
+            let builtin = command.builtin().expect("builtin command view");
+            let name = match builtin.kind() {
+                BuiltinCommandNodeKind::Break => "break",
+                BuiltinCommandNodeKind::Continue => "continue",
+                BuiltinCommandNodeKind::Return => "return",
+                BuiltinCommandNodeKind::Exit => "exit",
+            };
+            ArenaNormalizedCommand {
+                literal_name: Some(Cow::Borrowed(name)),
+                effective_name: Some(Cow::Borrowed(name)),
+                wrappers: Vec::new(),
+                body_span: builtin.primary().map_or(command_span, |word| {
+                    Span::from_positions(command_span.start, word.span().end)
+                }),
+                body_word_span: None,
+                body_words: Vec::new(),
+                declaration: None,
+            }
+        }
+        ArenaFileCommandKind::Binary
+        | ArenaFileCommandKind::Compound
+        | ArenaFileCommandKind::Function
+        | ArenaFileCommandKind::AnonymousFunction => ArenaNormalizedCommand {
+            literal_name: None,
+            effective_name: None,
+            wrappers: Vec::new(),
+            body_span: command.span(),
+            body_word_span: None,
+            body_words: Vec::new(),
+            declaration: None,
+        },
+    }
+}
+
+pub(crate) fn normalize_arena_command_words<'a>(
+    store: &'a AstStore,
+    words: &[WordId],
+    _command_span: Span,
+    source: &'a str,
+) -> Option<ArenaNormalizedCommand<'a>> {
+    let first_id = words.first().copied()?;
+    let first_word = store.word(first_id);
+    let literal_name = shuck_ast::static_command_name_text_arena(first_word, source);
+    let mut effective_name = literal_name.clone();
+    let mut wrappers = Vec::new();
+    let mut body_span = first_word.span();
+    let mut body_word_span = Some(first_word.span());
+    let mut body_start = literal_name.as_ref().map(|_| 0usize);
+    let mut current_index = 0usize;
+
+    while let Some(current_name) = effective_name.as_deref() {
+        let Some(resolution) =
+            resolve_arena_command_resolution(store, words, current_index, current_name, source)
+        else {
+            break;
+        };
+
+        match resolution {
+            ArenaCommandResolution::Alias {
+                effective_name: resolved_name,
+                body_index,
+            } => {
+                let body = store.word(words[body_index]);
+                body_span = body.span();
+                body_word_span = Some(body.span());
+                body_start = Some(body_index);
+                effective_name = Some(Cow::Owned(resolved_name));
+                break;
+            }
+            ArenaCommandResolution::Wrapper { kind, target_index } => {
+                wrappers.push(kind);
+
+                let Some(target_index) = target_index else {
+                    effective_name = None;
+                    body_word_span = None;
+                    body_start = None;
+                    break;
+                };
+
+                let target = store.word(words[target_index]);
+                body_span = target.span();
+                body_word_span = Some(target.span());
+                effective_name = shuck_ast::static_command_name_text_arena(target, source);
+                body_start = effective_name.as_ref().map(|_| target_index);
+                current_index = target_index;
+
+                if effective_name.is_none() {
+                    break;
+                }
+            }
+        }
+    }
+
+    Some(ArenaNormalizedCommand {
+        literal_name,
+        effective_name,
+        wrappers,
+        body_span,
+        body_word_span,
+        body_words: body_start.map_or_else(Vec::new, |start| words[start..].to_vec()),
+        declaration: None,
+    })
+}
+
+fn normalize_arena_declaration<'a>(
+    command: DeclCommandView<'a>,
+    command_span: Span,
+    source: &str,
+) -> ArenaNormalizedDeclaration<'a> {
+    let raw_kind = command.variant().as_str();
+    let assignment_operands = command
+        .operands()
+        .iter()
+        .filter_map(|operand| match operand {
+            DeclOperandNode::Assignment(assignment) => Some(assignment),
+            DeclOperandNode::Flag(_) | DeclOperandNode::Name(_) | DeclOperandNode::Dynamic(_) => {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    ArenaNormalizedDeclaration {
+        kind: declaration_kind(raw_kind),
+        readonly_flag: arena_declaration_has_readonly_flag(command, source),
+        span: command_span,
+        head_span: arena_declaration_head_span(command),
+        assignments: command.assignments(),
+        operands: command.operands(),
+        assignment_operands,
+    }
+}
+
+fn declaration_kind(raw_kind: &str) -> DeclarationKind {
+    match raw_kind {
+        "export" => DeclarationKind::Export,
+        "local" => DeclarationKind::Local,
+        "declare" => DeclarationKind::Declare,
+        "typeset" => DeclarationKind::Typeset,
+        _ => DeclarationKind::Other(raw_kind.to_owned()),
+    }
+}
+
+fn arena_declaration_has_readonly_flag(command: DeclCommandView<'_>, source: &str) -> bool {
+    matches!(command.variant().as_str(), "local" | "declare" | "typeset")
+        && command.operands().iter().any(|operand| {
+            let DeclOperandNode::Flag(word) = operand else {
+                return false;
+            };
+
+            shuck_ast::static_word_text_arena(command.store().word(*word), source)
+                .is_some_and(|text| text.starts_with('-') && text.contains('r'))
+        })
+}
+
+fn arena_declaration_head_span(command: DeclCommandView<'_>) -> Span {
+    let end = command
+        .operands()
+        .last()
+        .map_or(command.variant_span().end, |operand| {
+            arena_declaration_operand_head_end(command.store(), operand)
+        });
+    Span::from_positions(command.variant_span().start, end)
+}
+
+fn arena_declaration_operand_head_end(
+    store: &AstStore,
+    operand: &DeclOperandNode,
+) -> shuck_ast::Position {
+    match operand {
+        DeclOperandNode::Flag(word) | DeclOperandNode::Dynamic(word) => {
+            store.word(*word).span().end
+        }
+        DeclOperandNode::Name(name) => name.span.end,
+        DeclOperandNode::Assignment(assignment) => assignment.target.name_span.end,
+    }
+}
+
+enum ArenaCommandResolution {
+    Alias {
+        effective_name: String,
+        body_index: usize,
+    },
+    Wrapper {
+        kind: WrapperKind,
+        target_index: Option<usize>,
+    },
+}
+
+fn resolve_arena_command_resolution(
+    store: &AstStore,
+    words: &[WordId],
+    current_index: usize,
+    current_name: &str,
+    source: &str,
+) -> Option<ArenaCommandResolution> {
+    match current_name {
+        "noglob" | "command" | "builtin" | "exec" => Some(resolve_shared_arena_wrapper(
+            store,
+            words,
+            current_index,
+            current_name,
+            source,
+        )),
+        "busybox" => Some(ArenaCommandResolution::Wrapper {
+            kind: WrapperKind::Busybox,
+            target_index: words.get(current_index + 1).map(|_| current_index + 1),
+        }),
+        "find" => find_exec_arena_target_index(store, words, current_index, source).map(
+            |(kind, target_index)| ArenaCommandResolution::Wrapper {
+                kind,
+                target_index: Some(target_index),
+            },
+        ),
+        "sudo" | "doas" | "run0" => Some(ArenaCommandResolution::Wrapper {
+            kind: WrapperKind::SudoFamily,
+            target_index: sudo_family_arena_target_index(store, words, current_index, source),
+        }),
+        "git" => git_filter_branch_arena_resolution(store, words, current_index, source),
+        "mumps" => mumps_run_arena_resolution(store, words, current_index, source),
+        _ => None,
+    }
+}
+
+fn resolve_shared_arena_wrapper(
+    store: &AstStore,
+    words: &[WordId],
+    current_index: usize,
+    current_name: &str,
+    source: &str,
+) -> ArenaCommandResolution {
+    let kind = match current_name {
+        "noglob" => WrapperKind::Noglob,
+        "command" => WrapperKind::Command,
+        "builtin" => WrapperKind::Builtin,
+        "exec" => WrapperKind::Exec,
+        _ => unreachable!("caller only passes shared wrappers"),
+    };
+    let StaticCommandWrapperTarget::Wrapper { target_index } =
+        shuck_ast::static_command_wrapper_target_index(
+            words.len(),
+            current_index,
+            current_name,
+            |index| shuck_ast::static_word_text_arena(store.word(words[index]), source),
+        )
+    else {
+        unreachable!("shared wrapper name should resolve to a wrapper target");
+    };
+
+    ArenaCommandResolution::Wrapper { kind, target_index }
+}
+
+fn find_exec_arena_target_index(
+    store: &AstStore,
+    words: &[WordId],
+    current_index: usize,
+    source: &str,
+) -> Option<(WrapperKind, usize)> {
+    let mut fallback = None;
+
+    for index in current_index + 1..words.len() {
+        let Some(arg) = shuck_ast::static_word_text_arena(store.word(words[index]), source) else {
+            continue;
+        };
+        match arg.as_ref() {
+            "-exec" | "-ok" => {
+                if fallback.is_none() {
+                    fallback = words
+                        .get(index + 1)
+                        .map(|_| (WrapperKind::FindExec, index + 1));
+                }
+            }
+            "-execdir" => {
+                return words
+                    .get(index + 1)
+                    .map(|_| (WrapperKind::FindExecDir, index + 1));
+            }
+            "-okdir" => {
+                if fallback.is_none() {
+                    fallback = words
+                        .get(index + 1)
+                        .map(|_| (WrapperKind::FindExec, index + 1));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fallback
+}
+
+fn sudo_family_arena_target_index(
+    store: &AstStore,
+    words: &[WordId],
+    current_index: usize,
+    source: &str,
+) -> Option<usize> {
+    let mut index = current_index + 1;
+
+    while index < words.len() {
+        let Some(arg) = shuck_ast::static_word_text_arena(store.word(words[index]), source) else {
+            return Some(index);
+        };
+
+        if arg == "--" {
+            return words.get(index + 1).map(|_| index + 1);
+        }
+
+        if !arg.starts_with('-') || arg == "-" {
+            return Some(index);
+        }
+
+        if arg.len() == 2 && matches!(arg.as_ref(), "-l" | "-v" | "-V") {
+            return None;
+        }
+
+        if sudo_option_takes_value(arg.as_ref()) {
+            if arg.len() == 2 {
+                words.get(index + 1)?;
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+
+        if arg.starts_with("--") && !matches!(arg.as_ref(), "--preserve-env" | "--login") {
+            return None;
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+fn sudo_option_takes_value(arg: &str) -> bool {
+    matches!(
+        arg.chars().nth(1),
+        Some('u' | 'g' | 'h' | 'p' | 'C' | 'D' | 'R' | 'T' | 'r' | 't')
+    )
+}
+
+fn git_filter_branch_arena_resolution(
+    store: &AstStore,
+    words: &[WordId],
+    current_index: usize,
+    source: &str,
+) -> Option<ArenaCommandResolution> {
+    (words
+        .get(current_index + 1)
+        .and_then(|word| shuck_ast::static_word_text_arena(store.word(*word), source))
+        .as_deref()
+        == Some("filter-branch"))
+    .then(|| ArenaCommandResolution::Alias {
+        effective_name: "git filter-branch".to_owned(),
+        body_index: current_index + 1,
+    })
+}
+
+fn mumps_run_arena_resolution(
+    store: &AstStore,
+    words: &[WordId],
+    current_index: usize,
+    source: &str,
+) -> Option<ArenaCommandResolution> {
+    let run_flag = words
+        .get(current_index + 1)
+        .and_then(|word| shuck_ast::static_word_text_arena(store.word(*word), source))?;
+    let entrypoint = words
+        .get(current_index + 2)
+        .and_then(|word| shuck_ast::static_word_text_arena(store.word(*word), source))?;
+
+    if run_flag == "-run" && matches!(entrypoint.as_ref(), "%XCMD" | "LOOP%XCMD") {
+        Some(ArenaCommandResolution::Alias {
+            effective_name: format!("mumps -run {entrypoint}"),
+            body_index: current_index + 2,
+        })
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use shuck_ast::Command;
+    use shuck_ast::{ArenaFile, Command};
     use shuck_parser::parser::Parser;
 
-    use super::{DeclarationKind, WrapperKind, normalize_command};
+    use super::{DeclarationKind, WrapperKind, normalize_arena_command, normalize_command};
 
     fn parse_first_command(source: &str) -> Command {
         let output = Parser::new(source).parse().unwrap();
         output.file.body.stmts.into_iter().next().unwrap().command
+    }
+
+    fn parse_first_arena_command(source: &str) -> ArenaFile {
+        Parser::new(source).parse().unwrap().arena_file
     }
 
     #[test]
@@ -141,6 +609,77 @@ mod tests {
                     .body_args()
                     .first()
                     .map(|word| word.span.slice(source)),
+                first_arg
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_arena_command_peels_wrappers_and_aliases() {
+        let cases = [
+            (
+                "command printf '%s\\n' hi\n",
+                Some("command"),
+                Some("printf"),
+                vec![WrapperKind::Command],
+                ("printf", Some("'%s\\n'")),
+            ),
+            (
+                "busybox awk '{print $1}'\n",
+                Some("busybox"),
+                Some("awk"),
+                vec![WrapperKind::Busybox],
+                ("awk", Some("'{print $1}'")),
+            ),
+            (
+                "find . -execdir sh -c 'echo {}' \\;\n",
+                Some("find"),
+                Some("sh"),
+                vec![WrapperKind::FindExecDir],
+                ("sh", Some("-c")),
+            ),
+            (
+                "sudo -- tee /tmp/out >/dev/null\n",
+                Some("sudo"),
+                Some("tee"),
+                vec![WrapperKind::SudoFamily],
+                ("tee", Some("/tmp/out")),
+            ),
+            (
+                "git filter-branch 'test $GIT_COMMIT'\n",
+                Some("git"),
+                Some("git filter-branch"),
+                Vec::new(),
+                ("filter-branch", Some("'test $GIT_COMMIT'")),
+            ),
+            (
+                "mumps -run %XCMD 'W $O(^GLOBAL(5))'\n",
+                Some("mumps"),
+                Some("mumps -run %XCMD"),
+                Vec::new(),
+                ("%XCMD", Some("'W $O(^GLOBAL(5))'")),
+            ),
+        ];
+
+        for (source, literal_name, effective_name, wrappers, (body_name, first_arg)) in cases {
+            let arena = parse_first_arena_command(source);
+            let command = arena.view().body().stmts().next().unwrap().command();
+            let normalized = normalize_arena_command(command, source);
+
+            assert_eq!(normalized.literal_name.as_deref(), literal_name);
+            assert_eq!(normalized.effective_name.as_deref(), effective_name);
+            assert_eq!(normalized.wrappers, wrappers);
+            assert_eq!(
+                normalized
+                    .body_name_word_id()
+                    .map(|id| arena.store.word(id).span().slice(source)),
+                Some(body_name)
+            );
+            assert_eq!(
+                normalized
+                    .body_args()
+                    .first()
+                    .map(|id| arena.store.word(*id).span().slice(source)),
                 first_arg
             );
         }

--- a/crates/shuck-linter/src/facts/pipelines.rs
+++ b/crates/shuck-linter/src/facts/pipelines.rs
@@ -1,22 +1,33 @@
 #[derive(Debug, Clone)]
-pub struct PipelineSegmentFact<'a> {
-    stmt: &'a Stmt,
+pub struct PipelineSegmentFact {
+    stmt_span: Span,
+    command_span: Span,
     command_id: CommandId,
+    arena_stmt_id: Option<AstStmtId>,
+    arena_command_id: Option<AstCommandId>,
     literal_name: Option<Box<str>>,
     effective_name: Option<Box<str>>,
 }
 
-impl<'a> PipelineSegmentFact<'a> {
-    pub fn stmt(&self) -> &'a Stmt {
-        self.stmt
+impl PipelineSegmentFact {
+    pub fn stmt_span(&self) -> Span {
+        self.stmt_span
     }
 
-    pub fn command(&self) -> &'a Command {
-        &self.stmt.command
+    pub fn command_span(&self) -> Span {
+        self.command_span
     }
 
     pub fn command_id(&self) -> CommandId {
         self.command_id
+    }
+
+    pub fn arena_stmt_id(&self) -> Option<AstStmtId> {
+        self.arena_stmt_id
+    }
+
+    pub fn arena_command_id(&self) -> Option<AstCommandId> {
+        self.arena_command_id
     }
 
     pub fn literal_name(&self) -> Option<&str> {
@@ -61,27 +72,28 @@ impl PipelineOperatorFact {
 }
 
 #[derive(Debug, Clone)]
-pub struct PipelineFact<'a> {
+pub struct PipelineFact {
     key: FactSpan,
-    command: &'a BinaryCommand,
-    segments: Box<[PipelineSegmentFact<'a>]>,
+    arena_command_id: Option<AstCommandId>,
+    span: Span,
+    segments: Box<[PipelineSegmentFact]>,
     operators: Box<[PipelineOperatorFact]>,
 }
 
-impl<'a> PipelineFact<'a> {
+impl PipelineFact {
     pub fn key(&self) -> FactSpan {
         self.key
     }
 
-    pub fn command(&self) -> &'a BinaryCommand {
-        self.command
+    pub fn arena_command_id(&self) -> Option<AstCommandId> {
+        self.arena_command_id
     }
 
     pub fn span(&self) -> Span {
-        self.command.span
+        self.span
     }
 
-    pub fn segments(&self) -> &[PipelineSegmentFact<'a>] {
+    pub fn segments(&self) -> &[PipelineSegmentFact] {
         &self.segments
     }
 
@@ -89,11 +101,11 @@ impl<'a> PipelineFact<'a> {
         &self.operators
     }
 
-    pub fn first_segment(&self) -> Option<&PipelineSegmentFact<'a>> {
+    pub fn first_segment(&self) -> Option<&PipelineSegmentFact> {
         self.segments.first()
     }
 
-    pub fn last_segment(&self) -> Option<&PipelineSegmentFact<'a>> {
+    pub fn last_segment(&self) -> Option<&PipelineSegmentFact> {
         self.segments.last()
     }
 }
@@ -101,31 +113,35 @@ impl<'a> PipelineFact<'a> {
 
 pub(super) fn build_pipeline_facts<'a>(
     commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-    command_child_index: &CommandChildIndex,
-) -> Vec<PipelineFact<'a>> {
-    let command_relationships =
-        CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
+    _command_ids_by_span: &CommandLookupIndex,
+    _command_child_index: &CommandChildIndex,
+    arena_file: &ArenaFile,
+) -> Vec<PipelineFact> {
+    let command_ids_by_arena_id = commands
+        .iter()
+        .filter_map(|fact| Some((fact.arena_command_id()?.index(), fact.id())))
+        .collect::<FxHashMap<_, _>>();
     let mut nested_pipeline_commands = FxHashSet::default();
 
     for fact in commands {
-        let Command::Binary(command) = fact.command() else {
+        let Some(command) = fact.arena_command_id().map(|id| arena_file.store.command(id)) else {
             continue;
         };
-        if !matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) {
+        let Some(command) = command.binary() else {
+            continue;
+        };
+        if !matches!(command.op(), BinaryOp::Pipe | BinaryOp::PipeAll) {
             continue;
         }
 
-        record_nested_pipeline_command(
-            &command.left,
-            fact.id(),
-            command_relationships,
+        record_nested_arena_pipeline_command(
+            command.left(),
+            &command_ids_by_arena_id,
             &mut nested_pipeline_commands,
         );
-        record_nested_pipeline_command(
-            &command.right,
-            fact.id(),
-            command_relationships,
+        record_nested_arena_pipeline_command(
+            command.right(),
+            &command_ids_by_arena_id,
             &mut nested_pipeline_commands,
         );
     }
@@ -133,117 +149,90 @@ pub(super) fn build_pipeline_facts<'a>(
     commands
         .iter()
         .filter_map(|fact| {
-            let Command::Binary(command) = fact.command() else {
-                return None;
-            };
-            if !matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll)
+            let command = fact.arena_command_id().map(|id| arena_file.store.command(id))?;
+            let command = command.binary()?;
+            if !matches!(command.op(), BinaryOp::Pipe | BinaryOp::PipeAll)
                 || nested_pipeline_commands.contains(&fact.id())
             {
                 return None;
             }
 
-            let segments = pipeline_segments(fact.command())?;
+            let segments = arena_pipeline_segments(command, &command_ids_by_arena_id, commands)?;
             Some(PipelineFact {
                 key: fact.key(),
-                command,
-                segments: segments
-                    .into_iter()
-                    .map(|stmt| {
-                        build_pipeline_segment_fact(
-                            stmt,
-                            command_relationships,
-                            fact.id(),
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .into_boxed_slice(),
-                operators: pipeline_operator_facts(command),
+                arena_command_id: fact.arena_command_id(),
+                span: fact.span(),
+                segments: segments.into_boxed_slice(),
+                operators: arena_pipeline_operator_facts(command),
             })
         })
         .collect()
 }
 
-fn record_nested_pipeline_command(
-    stmt: &Stmt,
-    parent_id: CommandId,
-    command_relationships: CommandRelationshipContext<'_, '_>,
+fn record_nested_arena_pipeline_command(
+    sequence: StmtSeqView<'_>,
+    command_ids_by_arena_id: &FxHashMap<usize, CommandId>,
     nested_pipeline_commands: &mut FxHashSet<CommandId>,
 ) {
-    if matches!(
-        &stmt.command,
-        Command::Binary(child) if matches!(child.op, BinaryOp::Pipe | BinaryOp::PipeAll)
-    ) && let Some(child) = command_relationships.child_or_lookup_fact(parent_id, stmt)
+    let Some(command) = single_arena_stmt_command(sequence) else {
+        return;
+    };
+    if command
+        .binary()
+        .is_some_and(|binary| matches!(binary.op(), BinaryOp::Pipe | BinaryOp::PipeAll))
+        && let Some(id) = command_ids_by_arena_id.get(&command.id().index()).copied()
     {
-        nested_pipeline_commands.insert(child.id());
+        nested_pipeline_commands.insert(id);
     }
 }
 
-fn pipeline_segments(command: &Command) -> Option<Vec<&Stmt>> {
-    let Command::Binary(command) = command else {
-        return None;
-    };
-    if !matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) {
+fn arena_pipeline_segments(
+    command: BinaryCommandView<'_>,
+    command_ids_by_arena_id: &FxHashMap<usize, CommandId>,
+    commands: &[CommandFact<'_>],
+) -> Option<Vec<PipelineSegmentFact>> {
+    if !matches!(command.op(), BinaryOp::Pipe | BinaryOp::PipeAll) {
         return None;
     }
 
     let mut segments = Vec::new();
-    collect_pipeline_segments(command, &mut segments);
+    collect_arena_pipeline_segments(command, command_ids_by_arena_id, commands, &mut segments)?;
     Some(segments)
 }
 
-fn collect_pipeline_segments<'a>(command: &'a BinaryCommand, segments: &mut Vec<&'a Stmt>) {
-    match &command.left.command {
-        Command::Binary(left) if matches!(left.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            collect_pipeline_segments(left, segments);
-        }
-        _ => segments.push(&command.left),
-    }
-
-    match &command.right.command {
-        Command::Binary(right) if matches!(right.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            collect_pipeline_segments(right, segments);
-        }
-        _ => segments.push(&command.right),
-    }
+fn collect_arena_pipeline_segments(
+    command: BinaryCommandView<'_>,
+    command_ids_by_arena_id: &FxHashMap<usize, CommandId>,
+    commands: &[CommandFact<'_>],
+    segments: &mut Vec<PipelineSegmentFact>,
+) -> Option<()> {
+    collect_arena_pipeline_sequence_segment(command.left(), command_ids_by_arena_id, commands, segments)?;
+    collect_arena_pipeline_sequence_segment(command.right(), command_ids_by_arena_id, commands, segments)?;
+    Some(())
 }
 
-fn pipeline_operator_facts(command: &BinaryCommand) -> Box<[PipelineOperatorFact]> {
-    let mut operators = Vec::new();
-    collect_pipeline_operator_facts(command, &mut operators);
-    operators.into_boxed_slice()
-}
-
-fn collect_pipeline_operator_facts(command: &BinaryCommand, out: &mut Vec<PipelineOperatorFact>) {
-    if let Command::Binary(left) = &command.left.command
-        && matches!(left.op, BinaryOp::Pipe | BinaryOp::PipeAll)
+fn collect_arena_pipeline_sequence_segment(
+    sequence: StmtSeqView<'_>,
+    command_ids_by_arena_id: &FxHashMap<usize, CommandId>,
+    commands: &[CommandFact<'_>],
+    segments: &mut Vec<PipelineSegmentFact>,
+) -> Option<()> {
+    let stmt = single_arena_stmt(sequence)?;
+    let command = stmt.command();
+    if let Some(binary) = command.binary()
+        && matches!(binary.op(), BinaryOp::Pipe | BinaryOp::PipeAll)
     {
-        collect_pipeline_operator_facts(left, out);
+        return collect_arena_pipeline_segments(binary, command_ids_by_arena_id, commands, segments);
     }
 
-    out.push(PipelineOperatorFact {
-        op: command.op,
-        span: command.op_span,
-    });
-
-    if let Command::Binary(right) = &command.right.command
-        && matches!(right.op, BinaryOp::Pipe | BinaryOp::PipeAll)
-    {
-        collect_pipeline_operator_facts(right, out);
-    }
-}
-
-fn build_pipeline_segment_fact<'a>(
-    stmt: &'a Stmt,
-    command_relationships: CommandRelationshipContext<'_, 'a>,
-    parent_id: CommandId,
-) -> PipelineSegmentFact<'a> {
-    let Some(fact) = command_relationships.child_or_lookup_fact(parent_id, stmt) else {
-        unreachable!("pipeline segment should have a corresponding command fact");
-    };
-
-    PipelineSegmentFact {
-        stmt,
-        command_id: fact.id(),
+    let command_id = command_ids_by_arena_id.get(&command.id().index()).copied()?;
+    let fact = commands.get(command_id.index())?;
+    segments.push(PipelineSegmentFact {
+        stmt_span: stmt.span(),
+        command_span: command.span(),
+        command_id,
+        arena_stmt_id: Some(stmt.id()),
+        arena_command_id: Some(command.id()),
         literal_name: fact
             .literal_name()
             .map(str::to_owned)
@@ -252,39 +241,114 @@ fn build_pipeline_segment_fact<'a>(
             .effective_name()
             .map(str::to_owned)
             .map(String::into_boxed_str),
+    });
+    Some(())
+}
+
+fn single_arena_stmt_command(sequence: StmtSeqView<'_>) -> Option<CommandView<'_>> {
+    Some(single_arena_stmt(sequence)?.command())
+}
+
+fn single_arena_stmt(sequence: StmtSeqView<'_>) -> Option<StmtView<'_>> {
+    let mut stmts = sequence.stmts();
+    let stmt = stmts.next()?;
+    if stmts.next().is_some() {
+        return None;
+    }
+    Some(stmt)
+}
+
+fn arena_pipeline_operator_facts(command: BinaryCommandView<'_>) -> Box<[PipelineOperatorFact]> {
+    let mut operators = Vec::new();
+    collect_arena_pipeline_operator_facts(command, &mut operators);
+    operators.into_boxed_slice()
+}
+
+fn collect_arena_pipeline_operator_facts(
+    command: BinaryCommandView<'_>,
+    out: &mut Vec<PipelineOperatorFact>,
+) {
+    if let Some(left) = single_arena_stmt_command(command.left()).and_then(CommandView::binary)
+        && matches!(left.op(), BinaryOp::Pipe | BinaryOp::PipeAll)
+    {
+        collect_arena_pipeline_operator_facts(left, out);
+    }
+
+    out.push(PipelineOperatorFact {
+        op: command.op(),
+        span: command.op_span(),
+    });
+
+    if let Some(right) = single_arena_stmt_command(command.right()).and_then(CommandView::binary)
+        && matches!(right.op(), BinaryOp::Pipe | BinaryOp::PipeAll)
+    {
+        collect_arena_pipeline_operator_facts(right, out);
+    }
+}
+
+#[cfg(test)]
+fn pipeline_segment_commands(command: BinaryCommandView<'_>) -> Vec<CommandView<'_>> {
+    let mut segments = Vec::new();
+    collect_pipeline_segment_commands(command, &mut segments);
+    segments
+}
+
+#[cfg(test)]
+fn collect_pipeline_segment_commands<'a>(
+    command: BinaryCommandView<'a>,
+    segments: &mut Vec<CommandView<'a>>,
+) {
+    collect_pipeline_segment_commands_from_sequence(command.left(), segments);
+    collect_pipeline_segment_commands_from_sequence(command.right(), segments);
+}
+
+#[cfg(test)]
+fn collect_pipeline_segment_commands_from_sequence<'a>(
+    sequence: StmtSeqView<'a>,
+    segments: &mut Vec<CommandView<'a>>,
+) {
+    let Some(command) = single_arena_stmt_command(sequence) else {
+        return;
+    };
+    if let Some(binary) = command.binary()
+        && matches!(binary.op(), BinaryOp::Pipe | BinaryOp::PipeAll)
+    {
+        collect_pipeline_segment_commands(binary, segments);
+    } else {
+        segments.push(command);
     }
 }
 
 #[cfg(test)]
 mod pipeline_tests {
-    use shuck_ast::{Command, StmtSeq, Word};
+    use shuck_ast::static_word_text_arena;
     use shuck_parser::parser::Parser;
 
-    use super::pipeline_segments;
-
-    fn parse_commands(source: &str) -> StmtSeq {
-        let output = Parser::new(source).parse().unwrap();
-        output.file.body
-    }
-
-    fn static_word_owned_text(word: &Word, source: &str) -> Option<String> {
-        word.try_static_text(source).map(|text| text.into_owned())
-    }
+    use super::pipeline_segment_commands;
 
     #[test]
     fn pipeline_segments_flattens_pipe_chains() {
         let source = "printf '%s\\n' a | command kill 0 | tee out.txt\n";
-        let commands = parse_commands(source);
-        let Command::Binary(command) = &commands[0].command else {
-            panic!("expected binary command");
-        };
+        let output = Parser::new(source).parse().unwrap();
+        let command = output
+            .arena_file
+            .view()
+            .body()
+            .stmts()
+            .next()
+            .unwrap()
+            .command()
+            .binary()
+            .expect("expected binary command");
 
-        let segments = pipeline_segments(&Command::Binary(command.clone()))
-            .expect("expected pipeline segments")
+        let segments = pipeline_segment_commands(command)
             .into_iter()
-            .map(|stmt| match &stmt.command {
-                Command::Simple(command) => static_word_owned_text(&command.name, source).unwrap(),
-                _ => "<non-simple>".to_owned(),
+            .map(|command| {
+                command
+                    .simple()
+                    .and_then(|simple| static_word_text_arena(simple.name(), source))
+                    .map(|text| text.into_owned())
+                    .unwrap_or_else(|| "<non-simple>".to_owned())
             })
             .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -586,20 +586,38 @@ fn is_comparable_parameter_name(name: &str) -> bool {
 }
 
 #[derive(Debug, Clone)]
-pub struct RedirectFact<'a> {
-    redirect: &'a Redirect,
+pub struct RedirectFact {
+    span: Span,
+    kind: RedirectKind,
+    fd: Option<i32>,
+    has_fd_var: bool,
     brace_fd_redirection_span: Option<Span>,
     operator_span: Span,
     target_span: Option<Span>,
+    target_static_text: Option<Box<str>>,
     arithmetic_update_operator_spans: Box<[Span]>,
     analysis: Option<RedirectTargetAnalysis>,
     comparable_path: Option<ComparablePath>,
     comparable_name_uses: Box<[ComparableNameUse]>,
+    comparable_heredoc_name_uses: Box<[ComparableNameUse]>,
+    read_source_word: Option<PathWordFact>,
 }
 
-impl<'a> RedirectFact<'a> {
-    pub fn redirect(&self) -> &'a Redirect {
-        self.redirect
+impl RedirectFact {
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn kind(&self) -> RedirectKind {
+        self.kind
+    }
+
+    pub fn fd(&self) -> Option<i32> {
+        self.fd
+    }
+
+    pub fn has_fd_var(&self) -> bool {
+        self.has_fd_var
     }
 
     pub fn brace_fd_redirection_span(&self) -> Option<Span> {
@@ -612,6 +630,10 @@ impl<'a> RedirectFact<'a> {
 
     pub fn target_span(&self) -> Option<Span> {
         self.target_span
+    }
+
+    pub fn target_static_text(&self) -> Option<&str> {
+        self.target_static_text.as_deref()
     }
 
     pub fn arithmetic_update_operator_spans(&self) -> &[Span] {
@@ -628,6 +650,14 @@ impl<'a> RedirectFact<'a> {
 
     pub(crate) fn comparable_name_uses(&self) -> &[ComparableNameUse] {
         &self.comparable_name_uses
+    }
+
+    pub(crate) fn comparable_heredoc_name_uses(&self) -> &[ComparableNameUse] {
+        &self.comparable_heredoc_name_uses
+    }
+
+    pub(crate) fn read_source_word(&self) -> Option<&PathWordFact> {
+        self.read_source_word.as_ref()
     }
 }
 
@@ -682,22 +712,39 @@ pub(crate) fn analyze_redirect_target(
     })
 }
 
-fn build_redirect_facts<'a>(
-    redirects: &'a [Redirect],
+fn build_redirect_facts(
+    redirects: &[Redirect],
     semantic: Option<&SemanticModel>,
     source: &str,
     zsh_options: Option<&ZshOptionState>,
-) -> Vec<RedirectFact<'a>> {
+) -> Vec<RedirectFact> {
     redirects
         .iter()
-        .map(|redirect| RedirectFact {
-            redirect,
-            brace_fd_redirection_span: brace_fd_redirection_span(redirect, source),
-            operator_span: redirect_operator_span(redirect),
-            target_span: redirect.word_target().map(|word| word.span),
-            arithmetic_update_operator_spans: redirect
-                .word_target()
-                .map_or_else(Vec::new, |word| {
+        .map(|redirect| {
+            let read_source_word = redirect.word_target().and_then(|word| {
+                ExpansionContext::from_redirect_kind(redirect.kind).and_then(|context| {
+                    matches!(
+                        redirect.kind,
+                        RedirectKind::Input | RedirectKind::ReadWrite | RedirectKind::HereString
+                    )
+                    .then(|| PathWordFact::new(word, None, context, source, zsh_options))
+                })
+            });
+            RedirectFact {
+                span: redirect.span,
+                kind: redirect.kind,
+                fd: redirect.fd,
+                has_fd_var: redirect.fd_var.is_some(),
+                brace_fd_redirection_span: brace_fd_redirection_span(redirect, source),
+                operator_span: redirect_operator_span(redirect),
+                target_span: redirect.word_target().map(|word| word.span),
+                target_static_text: redirect
+                    .word_target()
+                    .and_then(|word| static_word_text(word, source))
+                    .map(|text| text.into_owned().into_boxed_str()),
+                arithmetic_update_operator_spans: redirect.word_target().map_or_else(
+                    Vec::new,
+                    |word| {
                     let mut spans = Vec::new();
                     if let Some(semantic) = semantic {
                         collect_arithmetic_update_operator_spans_from_parts(
@@ -708,16 +755,15 @@ fn build_redirect_facts<'a>(
                         );
                     }
                     spans
-            })
-            .into_boxed_slice(),
-            analysis: analyze_redirect_target(redirect, source, zsh_options),
-            comparable_path: redirect.word_target().and_then(|word| {
-                ExpansionContext::from_redirect_kind(redirect.kind)
-                    .and_then(|context| comparable_path(word, source, context, zsh_options))
-            }),
-            comparable_name_uses: redirect
-                .word_target()
-                .map_or_else(Vec::new, |word| match redirect.kind {
+                },
+                ).into_boxed_slice(),
+                analysis: analyze_redirect_target(redirect, source, zsh_options),
+                comparable_path: redirect.word_target().and_then(|word| {
+                    ExpansionContext::from_redirect_kind(redirect.kind)
+                        .and_then(|context| comparable_path(word, source, context, zsh_options))
+                }),
+                comparable_name_uses: redirect.word_target().map_or_else(Vec::new, |word| {
+                    match redirect.kind {
                     RedirectKind::Output
                     | RedirectKind::Clobber
                     | RedirectKind::Append
@@ -731,8 +777,17 @@ fn build_redirect_facts<'a>(
                     | RedirectKind::HereString
                     | RedirectKind::DupOutput
                     | RedirectKind::DupInput => comparable_name_uses(word, source).into_vec(),
-                })
-                .into_boxed_slice(),
+                    }
+                }).into_boxed_slice(),
+                comparable_heredoc_name_uses: redirect
+                    .heredoc()
+                    .filter(|heredoc| heredoc.delimiter.expands_body)
+                    .map_or_else(Vec::new, |heredoc| {
+                        comparable_heredoc_name_uses(&heredoc.body, source).into_vec()
+                    })
+                    .into_boxed_slice(),
+                read_source_word,
+            }
         })
         .collect()
 }

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -23,6 +23,7 @@ pub enum SimpleTestOperatorFamily {
 #[derive(Debug, Clone)]
 pub struct SimpleTestFact<'a> {
     syntax: SimpleTestSyntax,
+    operand_ids: Box<[WordId]>,
     operands: Box<[&'a Word]>,
     shape: SimpleTestShape,
     operator_family: SimpleTestOperatorFamily,
@@ -40,6 +41,14 @@ impl<'a> SimpleTestFact<'a> {
 
     pub fn operands(&self) -> &[&'a Word] {
         &self.operands
+    }
+
+    pub fn operand_ids(&self) -> &[WordId] {
+        &self.operand_ids
+    }
+
+    pub fn effective_operand_ids(&self) -> &[WordId] {
+        &self.operand_ids[self.effective_operand_offset..]
     }
 
     pub fn shape(&self) -> SimpleTestShape {
@@ -261,6 +270,7 @@ fn build_simple_test_fact<'a>(
     command: &'a Command,
     source: &str,
     file_context: &FileContext,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
 ) -> Option<SimpleTestFact<'a>> {
     let Command::Simple(command) = command else {
         return None;
@@ -295,9 +305,20 @@ fn build_simple_test_fact<'a>(
         .map(|word| classify_contextual_operand(word, source, ExpansionContext::CommandArgument))
         .collect::<Vec<_>>()
         .into_boxed_slice();
+    let operand_ids = operands
+        .iter()
+        .map(|word| {
+            arena_word_ids_by_span
+                .get(&FactSpan::new(word.span))
+                .copied()
+                .unwrap_or_else(|| panic!("arena word id missing for simple-test operand {:?}", word.span))
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
 
     Some(SimpleTestFact {
         syntax,
+        operand_ids,
         operands: operands.into_boxed_slice(),
         shape,
         operator_family,
@@ -930,13 +951,14 @@ pub(super) fn build_single_test_subshell_spans<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
+    arena_file: &ArenaFile,
     source: &str,
 ) -> Vec<Span> {
     let command_relationships =
         CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     commands
         .iter()
-        .filter_map(|fact| single_test_subshell_span(fact, command_relationships, source))
+        .filter_map(|fact| single_test_subshell_span(fact, command_relationships, arena_file, source))
         .collect()
 }
 
@@ -944,44 +966,44 @@ pub(super) fn build_subshell_test_group_spans<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
+    arena_file: &ArenaFile,
     source: &str,
 ) -> Vec<Span> {
     let command_relationships =
         CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     commands
         .iter()
-        .filter_map(|fact| subshell_test_group_span(fact, command_relationships, source))
+        .filter_map(|fact| subshell_test_group_span(fact, command_relationships, arena_file, source))
         .collect()
 }
 
 fn single_test_subshell_span<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
+    arena_file: &ArenaFile,
     source: &str,
 ) -> Option<Span> {
-    let condition = match fact.command() {
-        Command::Compound(CompoundCommand::If(command)) => &command.condition,
-        Command::Compound(CompoundCommand::While(command)) => &command.condition,
-        Command::Compound(CompoundCommand::Until(command)) => &command.condition,
+    let command = arena_file.store.command(fact.arena_command_id()?);
+    let condition = match command.compound()?.node() {
+        CompoundCommandNode::If { condition, .. }
+        | CompoundCommandNode::While { condition, .. }
+        | CompoundCommandNode::Until { condition, .. } => arena_file.store.stmt_seq(*condition),
         _ => return None,
     };
 
-    let [stmt] = condition.as_slice() else {
-        return None;
+    let stmt = single_test_single_arena_stmt(condition)?;
+
+    let condition_fact = command_relationships.child_or_lookup_arena_fact(fact.id(), stmt)?;
+    let body = match stmt.command().compound()?.node() {
+        CompoundCommandNode::Subshell(body) => arena_file.store.stmt_seq(*body),
+        _ => return None,
     };
 
-    let condition_fact = command_relationships.child_or_lookup_fact(fact.id(), stmt)?;
-    let Command::Compound(CompoundCommand::Subshell(body)) = condition_fact.command() else {
-        return None;
-    };
+    let body_stmt = single_test_single_arena_stmt(body)?;
 
-    let [body_stmt] = body.as_slice() else {
-        return None;
-    };
-
-    let body_fact = command_relationships.child_or_lookup_fact(condition_fact.id(), body_stmt)?;
+    let body_fact = command_relationships.child_or_lookup_arena_fact(condition_fact.id(), body_stmt)?;
     let simple_test = is_test_like_command(body_fact);
-    if stmt.negated && !simple_test {
+    if stmt.negated() && !simple_test {
         return None;
     }
 
@@ -1001,40 +1023,37 @@ fn is_test_like_command(fact: &CommandFact<'_>) -> bool {
         .all(|wrapper| matches!(wrapper, WrapperKind::Command | WrapperKind::Builtin))
         && (fact.effective_name_is("test")
             || fact.effective_name_is("[")
-            || matches!(
-                fact.command(),
-                Command::Compound(CompoundCommand::Conditional(_))
-            ))
+            || fact.shape().compound_kind == Some(CommandFactCompoundKind::Conditional))
 }
 
 fn is_test_condition_fact<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
-    match fact.command() {
-        Command::Binary(binary) if matches!(binary.op, BinaryOp::And | BinaryOp::Or) => {
-            let Some(left) = command_relationships.child_or_lookup_fact(fact.id(), &binary.left)
-            else {
-                return false;
-            };
-            let Some(right) = command_relationships.child_or_lookup_fact(fact.id(), &binary.right)
-            else {
-                return false;
-            };
-            is_test_condition_fact(left, command_relationships)
-                && is_test_condition_fact(right, command_relationships)
+    if fact.shape().is_short_circuit_binary() {
+        let child_ids = command_relationships.command_child_index.child_ids(fact.id());
+        if child_ids.len() != 2 {
+            return false;
         }
-        _ => is_test_like_command(fact),
+        let left = command_relationships.fact(child_ids[0]);
+        let right = command_relationships.fact(child_ids[1]);
+        is_test_condition_fact(left, command_relationships)
+            && is_test_condition_fact(right, command_relationships)
+    } else {
+        is_test_like_command(fact)
     }
 }
 
 fn subshell_test_group_span<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
+    arena_file: &ArenaFile,
     source: &str,
 ) -> Option<Span> {
-    let Command::Compound(CompoundCommand::Subshell(body)) = fact.command() else {
-        return None;
+    let command = arena_file.store.command(fact.arena_command_id()?);
+    let body = match command.compound()?.node() {
+        CompoundCommandNode::Subshell(body) => arena_file.store.stmt_seq(*body),
+        _ => return None,
     };
 
     if !subshell_body_contains_grouped_tests(body, fact.id(), command_relationships) {
@@ -1045,7 +1064,7 @@ fn subshell_test_group_span<'a>(
 }
 
 fn subshell_body_contains_grouped_tests<'a>(
-    body: &StmtSeq,
+    body: StmtSeqView<'_>,
     parent_id: CommandId,
     command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
@@ -1060,11 +1079,11 @@ struct GroupedTestAnalysis {
 }
 
 fn subshell_stmt_analysis<'a>(
-    stmt: &Stmt,
+    stmt: StmtView<'_>,
     parent_id: CommandId,
     command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> Option<GroupedTestAnalysis> {
-    let fact = command_relationships.child_or_lookup_fact(parent_id, stmt)?;
+    let fact = command_relationships.child_or_lookup_arena_fact(parent_id, stmt)?;
     subshell_command_analysis(fact, command_relationships)
 }
 
@@ -1072,10 +1091,10 @@ fn subshell_command_analysis<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> Option<GroupedTestAnalysis> {
-    match fact.command() {
-        Command::Simple(_)
-        | Command::Builtin(_)
-        | Command::Compound(CompoundCommand::Conditional(_)) => {
+    match fact.shape().kind {
+        ArenaFileCommandKind::Simple | ArenaFileCommandKind::Builtin
+            if fact.shape().compound_kind.is_none() =>
+        {
             if is_test_like_command(fact) {
                 return Some(GroupedTestAnalysis {
                     test_count: 1,
@@ -1084,25 +1103,44 @@ fn subshell_command_analysis<'a>(
             }
             None
         }
-        Command::Compound(CompoundCommand::BraceGroup(body)) => {
-            let inner = subshell_body_analysis(body, fact.id(), command_relationships)?;
+        ArenaFileCommandKind::Compound
+            if fact.shape().compound_kind == Some(CommandFactCompoundKind::Conditional) =>
+        {
+            if is_test_like_command(fact) {
+                return Some(GroupedTestAnalysis {
+                    test_count: 1,
+                    has_grouping: false,
+                });
+            }
+            None
+        }
+        ArenaFileCommandKind::Compound
+            if fact.shape().compound_kind == Some(CommandFactCompoundKind::BraceGroup) =>
+        {
+            let child = command_relationships.command_child_index.child_ids(fact.id()).first().copied()?;
+            let inner = subshell_command_analysis(command_relationships.fact(child), command_relationships)?;
             Some(GroupedTestAnalysis {
                 test_count: inner.test_count,
                 has_grouping: true,
             })
         }
-        Command::Compound(CompoundCommand::Subshell(body)) => {
-            let inner = subshell_body_analysis(body, fact.id(), command_relationships)?;
+        ArenaFileCommandKind::Compound
+            if fact.shape().compound_kind == Some(CommandFactCompoundKind::Subshell) =>
+        {
+            let child = command_relationships.command_child_index.child_ids(fact.id()).first().copied()?;
+            let inner = subshell_command_analysis(command_relationships.fact(child), command_relationships)?;
             Some(GroupedTestAnalysis {
                 test_count: inner.test_count,
                 has_grouping: inner.has_grouping,
             })
         }
-        Command::Binary(binary) if matches!(binary.op, BinaryOp::And | BinaryOp::Or) => {
-            let left =
-                subshell_stmt_analysis(&binary.left, fact.id(), command_relationships)?;
-            let right =
-                subshell_stmt_analysis(&binary.right, fact.id(), command_relationships)?;
+        ArenaFileCommandKind::Binary if fact.shape().is_short_circuit_binary() => {
+            let child_ids = command_relationships.command_child_index.child_ids(fact.id());
+            let [left_id, right_id] = child_ids else {
+                return None;
+            };
+            let left = subshell_command_analysis(command_relationships.fact(*left_id), command_relationships)?;
+            let right = subshell_command_analysis(command_relationships.fact(*right_id), command_relationships)?;
             Some(GroupedTestAnalysis {
                 test_count: left.test_count + right.test_count,
                 has_grouping: true,
@@ -1113,23 +1151,32 @@ fn subshell_command_analysis<'a>(
 }
 
 fn subshell_body_analysis<'a>(
-    body: &StmtSeq,
+    body: StmtSeqView<'_>,
     parent_id: CommandId,
     command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> Option<GroupedTestAnalysis> {
     let mut analysis = GroupedTestAnalysis::default();
 
-    if body.stmts.len() > 1 {
+    if body.stmt_ids().len() > 1 {
         analysis.has_grouping = true;
     }
 
-    for stmt in &body.stmts {
+    for stmt in body.stmts() {
         let stmt_analysis = subshell_stmt_analysis(stmt, parent_id, command_relationships)?;
         analysis.test_count += stmt_analysis.test_count;
         analysis.has_grouping |= stmt_analysis.has_grouping;
     }
 
     Some(analysis)
+}
+
+fn single_test_single_arena_stmt(seq: StmtSeqView<'_>) -> Option<StmtView<'_>> {
+    let mut stmts = seq.stmts();
+    let stmt = stmts.next()?;
+    if stmts.next().is_some() {
+        return None;
+    }
+    Some(stmt)
 }
 
 fn subshell_anchor_span(span: Span, source: &str) -> Span {
@@ -1179,27 +1226,6 @@ fn trim_trailing_whitespace_offset(source: &str, end_offset: usize) -> usize {
     }
 
     end_offset
-}
-
-fn collect_short_circuit_operators(command: &BinaryCommand, operators: &mut Vec<ListOperatorFact>) {
-    if let Command::Binary(left) = &command.left.command
-        && matches!(left.op, BinaryOp::And | BinaryOp::Or)
-    {
-        collect_short_circuit_operators(left, operators);
-    }
-
-    if matches!(command.op, BinaryOp::And | BinaryOp::Or) {
-        operators.push(ListOperatorFact {
-            op: command.op,
-            span: command.op_span,
-        });
-    }
-
-    if let Command::Binary(right) = &command.right.command
-        && matches!(right.op, BinaryOp::And | BinaryOp::Or)
-    {
-        collect_short_circuit_operators(right, operators);
-    }
 }
 
 fn mixed_short_circuit_operator_span(operators: &[ListOperatorFact]) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -153,11 +153,12 @@ fn populate_substitution_fact_ranges<'a>(
     fact_store: &mut FactStore<'a>,
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
+    arena_file: &ArenaFile,
     source: &str,
 ) {
     for index in 0..commands.len() {
         let substitutions = {
-            let command_facts = CommandFacts::new(commands, fact_store);
+            let command_facts = CommandFacts::new(commands, fact_store, arena_file);
             let fact = command_facts
                 .get(index)
                 .expect("command index should resolve while populating substitution facts");
@@ -180,80 +181,414 @@ fn build_command_substitution_facts<'a>(
     command_child_index: &CommandChildIndex,
     source: &str,
 ) -> Vec<SubstitutionFact> {
-    let mut substitutions = Vec::new();
-    let mut substitution_index = FxHashMap::default();
-    let context = SubstitutionFactBuildContext {
+    let relationships = CommandRelationshipContext::new(
+        commands.commands,
+        command_ids_by_span,
+        command_child_index,
+    );
+    let context = ArenaSubstitutionFactBuildContext {
         commands,
-        command_relationships: CommandRelationshipContext::new(
-            commands.commands,
-            command_ids_by_span,
-            command_child_index,
-        ),
+        command_relationships: relationships,
         host_command_id: fact.id(),
+        arena_file: fact.arena_file,
         source,
     };
+    let mut substitutions = Vec::new();
+    let mut substitution_index = FxHashMap::default();
 
-    visit_command_words_for_substitutions(fact.command(), fact.redirects(), source, &mut |word| {
-        collect_or_update_word_substitution_facts(
-            word,
-            SubstitutionHostKind::Other,
-            context,
-            &mut substitutions,
-            &mut substitution_index,
-        );
-    });
+    if let Some(command) = fact.arena_command() {
+        for word_id in command.word_ids() {
+            collect_or_update_arena_word_substitution_facts(
+                fact.arena_file.store.word(*word_id),
+                SubstitutionHostKind::Other,
+                context,
+                &mut substitutions,
+                &mut substitution_index,
+            );
+        }
+    }
 
-    visit_heredoc_bodies_for_substitutions(fact.redirects(), &mut |body| {
-        collect_or_update_heredoc_body_substitution_facts(
-            body,
-            SubstitutionHostKind::Other,
-            context,
-            &mut substitutions,
-            &mut substitution_index,
-        );
-    });
-
-    visit_command_argument_words_for_substitutions(fact.command(), source, &mut |word| {
-        collect_or_update_word_substitution_facts(
-            word,
-            SubstitutionHostKind::CommandArgument,
-            context,
-            &mut substitutions,
-            &mut substitution_index,
-        );
-    });
-
-    visit_here_string_words_for_substitutions(fact.redirects(), &mut |word| {
-        collect_or_update_word_substitution_facts(
-            word,
-            SubstitutionHostKind::HereStringOperand,
-            context,
-            &mut substitutions,
-            &mut substitution_index,
-        );
-    });
-
-    visit_declaration_assignment_words_for_substitutions(fact.command(), &mut |word| {
-        collect_or_update_word_substitution_facts(
-            word,
-            SubstitutionHostKind::DeclarationAssignmentValue,
-            context,
-            &mut substitutions,
-            &mut substitution_index,
-        );
-    });
-
-    visit_command_subscript_words_for_substitutions(fact.command(), source, &mut |kind, word| {
-        collect_or_update_word_substitution_facts(
-            word,
-            kind,
-            context,
-            &mut substitutions,
-            &mut substitution_index,
-        );
-    });
+    if let Some(stmt) = fact.arena_stmt() {
+        for redirect in stmt.redirects() {
+            match &redirect.target {
+                RedirectTargetNode::Word(word_id) => {
+                    let host_kind = if redirect.kind == RedirectKind::HereString {
+                        SubstitutionHostKind::HereStringOperand
+                    } else {
+                        SubstitutionHostKind::Other
+                    };
+                    collect_or_update_arena_word_substitution_facts(
+                        fact.arena_file.store.word(*word_id),
+                        host_kind,
+                        context,
+                        &mut substitutions,
+                        &mut substitution_index,
+                    );
+                }
+                RedirectTargetNode::Heredoc(heredoc) => {
+                    collect_or_update_arena_heredoc_body_substitution_facts(
+                        &heredoc.body,
+                        fact.arena_file,
+                        SubstitutionHostKind::Other,
+                        context,
+                        &mut substitutions,
+                        &mut substitution_index,
+                    );
+                }
+            }
+        }
+    }
 
     substitutions
+}
+
+#[derive(Clone, Copy)]
+struct ArenaSubstitutionFactBuildContext<'facts, 'a> {
+    commands: CommandFacts<'facts, 'a>,
+    command_relationships: CommandRelationshipContext<'facts, 'a>,
+    host_command_id: CommandId,
+    arena_file: &'facts ArenaFile,
+    source: &'facts str,
+}
+
+fn collect_or_update_arena_word_substitution_facts<'a>(
+    word: WordView<'_>,
+    host_kind: SubstitutionHostKind,
+    context: ArenaSubstitutionFactBuildContext<'_, 'a>,
+    substitutions: &mut Vec<SubstitutionFact>,
+    substitution_index: &mut FxHashMap<FactSpan, usize>,
+) {
+    let mut occurrences = Vec::new();
+    collect_arena_word_substitution_occurrences(
+        word.store(),
+        word.parts(),
+        false,
+        &mut occurrences,
+    );
+    collect_or_update_arena_substitution_facts_from_occurrences(
+        word.span(),
+        host_kind,
+        occurrences,
+        context,
+        substitutions,
+        substitution_index,
+    );
+}
+
+fn collect_or_update_arena_heredoc_body_substitution_facts<'a>(
+    body: &shuck_ast::HeredocBodyNode,
+    arena_file: &ArenaFile,
+    host_kind: SubstitutionHostKind,
+    context: ArenaSubstitutionFactBuildContext<'_, 'a>,
+    substitutions: &mut Vec<SubstitutionFact>,
+    substitution_index: &mut FxHashMap<FactSpan, usize>,
+) {
+    let mut occurrences = Vec::new();
+    for part in arena_file.store.heredoc_body_parts(body.parts) {
+        match &part.kind {
+            ArenaHeredocBodyPart::CommandSubstitution { body, syntax } => {
+                occurrences.push(ArenaSubstitutionOccurrence {
+                    span: part.span,
+                    kind: CommandSubstitutionKind::Command,
+                    command_syntax: Some(*syntax),
+                    body: *body,
+                    unquoted_in_host: true,
+                });
+            }
+            ArenaHeredocBodyPart::ArithmeticExpansion {
+                expression_word_ast, ..
+            } => collect_arena_word_substitution_occurrences(
+                &arena_file.store,
+                arena_file.store.word(*expression_word_ast).parts(),
+                false,
+                &mut occurrences,
+            ),
+            ArenaHeredocBodyPart::Parameter(_) => {}
+            ArenaHeredocBodyPart::Literal(_) | ArenaHeredocBodyPart::Variable(_) => {}
+        }
+    }
+    collect_or_update_arena_substitution_facts_from_occurrences(
+        body.span,
+        host_kind,
+        occurrences,
+        context,
+        substitutions,
+        substitution_index,
+    );
+}
+
+fn collect_or_update_arena_substitution_facts_from_occurrences<'a>(
+    host_span: Span,
+    host_kind: SubstitutionHostKind,
+    occurrences: Vec<ArenaSubstitutionOccurrence>,
+    context: ArenaSubstitutionFactBuildContext<'_, 'a>,
+    substitutions: &mut Vec<SubstitutionFact>,
+    substitution_index: &mut FxHashMap<FactSpan, usize>,
+) {
+    for occurrence in occurrences {
+        let key = FactSpan::new(occurrence.span);
+        if let Some(&index) = substitution_index.get(&key) {
+            substitutions[index].host_word_span = host_span;
+            substitutions[index].host_kind = host_kind;
+            substitutions[index].unquoted_in_host = occurrence.unquoted_in_host;
+            continue;
+        }
+
+        let body_facts = classify_arena_substitution_body(
+            occurrence.body,
+            context.arena_file,
+            context.commands,
+            context.command_relationships,
+            context.host_command_id,
+            context.source,
+        );
+        substitution_index.insert(key, substitutions.len());
+        substitutions.push(SubstitutionFact {
+            span: occurrence.span,
+            kind: occurrence.kind,
+            command_syntax: occurrence.command_syntax,
+            stdout_intent: body_facts.stdout_intent,
+            terminal_stdout_intent: body_facts.terminal_stdout_intent,
+            has_stdout_redirect: body_facts.has_stdout_redirect,
+            stdout_redirect_spans: body_facts.stdout_redirect_spans,
+            stdout_dev_null_redirect_spans: body_facts.stdout_dev_null_redirect_spans,
+            body_contains_ls: body_facts.body_contains_ls,
+            body_processed_ls_pipeline_spans: body_facts.body_processed_ls_pipeline_spans,
+            body_contains_echo: body_facts.body_contains_echo,
+            body_contains_grep: body_facts.body_contains_grep,
+            body_has_multiple_statements: body_facts.body_has_multiple_statements,
+            body_is_negated: body_facts.body_is_negated,
+            body_is_pgrep_lookup: body_facts.body_is_pgrep_lookup,
+            body_is_seq_utility: body_facts.body_is_seq_utility,
+            body_has_commands: body_facts.body_has_commands,
+            bash_file_slurp: body_facts.bash_file_slurp,
+            host_word_span: host_span,
+            host_kind,
+            unquoted_in_host: occurrence.unquoted_in_host,
+        });
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ArenaSubstitutionOccurrence {
+    span: Span,
+    kind: CommandSubstitutionKind,
+    command_syntax: Option<CommandSubstitutionSyntax>,
+    body: shuck_ast::StmtSeqId,
+    unquoted_in_host: bool,
+}
+
+fn collect_arena_word_substitution_occurrences(
+    store: &AstStore,
+    parts: &[WordPartArenaNode],
+    quoted: bool,
+    occurrences: &mut Vec<ArenaSubstitutionOccurrence>,
+) {
+    for part in parts {
+        match &part.kind {
+            WordPartArena::CommandSubstitution { body, syntax } => {
+                occurrences.push(ArenaSubstitutionOccurrence {
+                    span: part.span,
+                    kind: CommandSubstitutionKind::Command,
+                    command_syntax: Some(*syntax),
+                    body: *body,
+                    unquoted_in_host: !quoted,
+                });
+            }
+            WordPartArena::ProcessSubstitution { body, is_input } => {
+                occurrences.push(ArenaSubstitutionOccurrence {
+                    span: part.span,
+                    kind: if *is_input {
+                        CommandSubstitutionKind::ProcessInput
+                    } else {
+                        CommandSubstitutionKind::ProcessOutput
+                    },
+                    command_syntax: None,
+                    body: *body,
+                    unquoted_in_host: !quoted,
+                });
+            }
+            WordPartArena::DoubleQuoted { parts, .. } => {
+                collect_arena_word_substitution_occurrences(
+                    store,
+                    store.word_parts(*parts),
+                    true,
+                    occurrences,
+                );
+            }
+            WordPartArena::ArithmeticExpansion {
+                expression_word_ast, ..
+            } => {
+                // The arithmetic expression word was lowered into the same arena.
+                // It is visited by command.word_ids(); avoid duplicating it here.
+                let _ = expression_word_ast;
+            }
+            WordPartArena::Parameter(_) => {}
+            WordPartArena::ParameterExpansion {
+                operand_word_ast, ..
+            }
+            | WordPartArena::IndirectExpansion {
+                operand_word_ast, ..
+            } => {
+                let _ = operand_word_ast;
+            }
+            WordPartArena::Substring { .. }
+            | WordPartArena::ArraySlice { .. }
+            | WordPartArena::Literal(_)
+            | WordPartArena::Variable(_)
+            | WordPartArena::SingleQuoted { .. }
+            | WordPartArena::Length(_)
+            | WordPartArena::ArrayAccess(_)
+            | WordPartArena::ArrayLength(_)
+            | WordPartArena::ArrayIndices(_)
+            | WordPartArena::PrefixMatch { .. }
+            | WordPartArena::Transformation { .. }
+            | WordPartArena::ZshQualifiedGlob(_) => {}
+        }
+    }
+}
+
+fn classify_arena_substitution_body<'a>(
+    body: shuck_ast::StmtSeqId,
+    arena_file: &ArenaFile,
+    commands: CommandFacts<'_, 'a>,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
+    parent_id: CommandId,
+    source: &str,
+) -> SubstitutionBodyFacts {
+    if commands.get(parent_id.index()).is_none() {
+        return empty_substitution_body_facts();
+    }
+    let body = arena_file.store.stmt_seq(body);
+    let stmt_count = body.stmts().len();
+    let mut body_contains_ls = false;
+    let mut body_contains_echo = false;
+    let mut body_contains_grep = false;
+    let mut body_is_pgrep_lookup = false;
+    let mut body_is_seq_utility = false;
+    let mut body_has_commands = false;
+    let mut bash_file_slurp = false;
+    let mut redirect_summary = RedirectSummary {
+        stdout_intent: SubstitutionOutputIntent::Captured,
+        terminal_stdout_intent: SubstitutionOutputIntent::Captured,
+        has_stdout_redirect: false,
+        stdout_redirect_spans: Vec::new(),
+        stdout_dev_null_redirect_spans: Vec::new(),
+    };
+
+    for (index, stmt) in body.stmts().enumerate() {
+        body_has_commands = true;
+        let fact = command_relationships
+            .child_or_lookup_arena_fact(parent_id, stmt)
+            .map(CommandFact::id)
+            .and_then(|id| commands.get(id.index()));
+        if let Some(fact) = fact {
+            let name = fact.effective_or_literal_name();
+            body_contains_ls |= name == Some("ls");
+            body_contains_echo |= name == Some("echo");
+            body_contains_grep |= name.is_some_and(command_name_is_grep_family);
+            body_is_pgrep_lookup |= name == Some("pgrep");
+            body_is_seq_utility |= name == Some("seq");
+            bash_file_slurp |= name == Some("mapfile") || name == Some("readarray");
+        }
+        let stmt_summary = summarize_arena_stmt_redirects(stmt, source);
+        redirect_summary = merge_redirect_summaries(redirect_summary, stmt_summary, index > 0);
+    }
+
+    SubstitutionBodyFacts {
+        stdout_intent: redirect_summary.stdout_intent,
+        terminal_stdout_intent: redirect_summary.terminal_stdout_intent,
+        has_stdout_redirect: redirect_summary.has_stdout_redirect,
+        stdout_redirect_spans: redirect_summary.stdout_redirect_spans.into_boxed_slice(),
+        stdout_dev_null_redirect_spans: redirect_summary
+            .stdout_dev_null_redirect_spans
+            .into_boxed_slice(),
+        body_contains_ls,
+        body_processed_ls_pipeline_spans: Box::new([]),
+        body_contains_echo,
+        body_contains_grep,
+        body_has_multiple_statements: stmt_count > 1,
+        body_is_negated: matches!(body.stmts().next(), Some(stmt) if stmt_count == 1 && stmt.negated()),
+        body_is_pgrep_lookup,
+        body_is_seq_utility,
+        body_has_commands,
+        bash_file_slurp,
+    }
+}
+
+fn empty_substitution_body_facts() -> SubstitutionBodyFacts {
+    SubstitutionBodyFacts {
+        stdout_intent: SubstitutionOutputIntent::Captured,
+        terminal_stdout_intent: SubstitutionOutputIntent::Captured,
+        has_stdout_redirect: false,
+        stdout_redirect_spans: Box::new([]),
+        stdout_dev_null_redirect_spans: Box::new([]),
+        body_contains_ls: false,
+        body_processed_ls_pipeline_spans: Box::new([]),
+        body_contains_echo: false,
+        body_contains_grep: false,
+        body_has_multiple_statements: false,
+        body_is_negated: false,
+        body_is_pgrep_lookup: false,
+        body_is_seq_utility: false,
+        body_has_commands: false,
+        bash_file_slurp: false,
+    }
+}
+
+fn summarize_arena_stmt_redirects(stmt: StmtView<'_>, source: &str) -> RedirectSummary {
+    let mut summary = RedirectSummary {
+        stdout_intent: SubstitutionOutputIntent::Captured,
+        terminal_stdout_intent: SubstitutionOutputIntent::Captured,
+        has_stdout_redirect: false,
+        stdout_redirect_spans: Vec::new(),
+        stdout_dev_null_redirect_spans: Vec::new(),
+    };
+
+    for redirect in stmt.redirects() {
+        if !arena_redirect_affects_stdout(redirect) {
+            continue;
+        }
+        summary.has_stdout_redirect = true;
+        summary.stdout_redirect_spans.push(redirect.span);
+        if arena_redirect_targets_stdout_dev_null(redirect, stmt.command().store(), source) {
+            summary.stdout_dev_null_redirect_spans.push(redirect.span);
+            summary.stdout_intent = SubstitutionOutputIntent::Discarded;
+            summary.terminal_stdout_intent = SubstitutionOutputIntent::Discarded;
+        } else {
+            summary.stdout_intent = SubstitutionOutputIntent::Rerouted;
+            summary.terminal_stdout_intent = SubstitutionOutputIntent::Rerouted;
+        }
+    }
+
+    summary
+}
+
+fn arena_redirect_affects_stdout(redirect: &RedirectNode) -> bool {
+    match redirect.kind {
+        RedirectKind::Output
+        | RedirectKind::Append
+        | RedirectKind::Clobber
+        | RedirectKind::DupOutput
+        | RedirectKind::ReadWrite => redirect.fd.unwrap_or(1) == 1,
+        RedirectKind::OutputBoth => true,
+        RedirectKind::Input
+        | RedirectKind::HereString
+        | RedirectKind::HereDoc
+        | RedirectKind::HereDocStrip
+        | RedirectKind::DupInput => false,
+    }
+}
+
+fn arena_redirect_targets_stdout_dev_null(
+    redirect: &RedirectNode,
+    store: &AstStore,
+    source: &str,
+) -> bool {
+    let RedirectTargetNode::Word(word_id) = redirect.target else {
+        return false;
+    };
+    static_word_text_arena(store.word(word_id), source).as_deref() == Some("/dev/null")
 }
 
 fn collect_or_update_word_substitution_facts<'a>(
@@ -704,7 +1039,7 @@ fn summarize_command_redirects<'a>(
     }
 }
 
-fn summarize_redirect_facts(redirects: &[RedirectFact<'_>], source: &str) -> RedirectSummary {
+fn summarize_redirect_facts(redirects: &[RedirectFact], source: &str) -> RedirectSummary {
     let state = classify_redirect_facts(redirects);
     RedirectSummary {
         stdout_intent: state.stdout_intent,
@@ -751,15 +1086,15 @@ struct RedirectState {
     has_stdout_redirect: bool,
 }
 
-fn classify_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectState {
+fn classify_redirect_facts(redirects: &[RedirectFact]) -> RedirectState {
     let mut fds = FxHashMap::from_iter([(1, OutputSink::Captured), (2, OutputSink::Other)]);
     let mut has_stdout_redirect = false;
 
     for redirect in redirects {
-        match redirect.redirect().kind {
+        match redirect.kind() {
             RedirectKind::Output | RedirectKind::Clobber | RedirectKind::Append => {
                 let sink = redirect_file_sink(redirect);
-                let fd = redirect.redirect().fd.unwrap_or(1);
+                let fd = redirect.fd().unwrap_or(1);
                 has_stdout_redirect |= fd == 1;
                 fds.insert(fd, sink);
             }
@@ -770,7 +1105,7 @@ fn classify_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectState {
                 fds.insert(2, sink);
             }
             RedirectKind::DupOutput => {
-                let fd = redirect.redirect().fd.unwrap_or(1);
+                let fd = redirect.fd().unwrap_or(1);
                 let sink = redirect_dup_output_sink(redirect, &fds);
                 has_stdout_redirect |= fd == 1;
                 fds.insert(fd, sink);
@@ -802,16 +1137,16 @@ fn classify_redirect_facts(redirects: &[RedirectFact<'_>]) -> RedirectState {
     }
 }
 
-fn stdout_redirect_spans_for_fix(redirects: &[RedirectFact<'_>], source: &str) -> Vec<Span> {
+fn stdout_redirect_spans_for_fix(redirects: &[RedirectFact], source: &str) -> Vec<Span> {
     redirects
         .iter()
         .filter(|redirect| redirect_matches_substitution_warning(redirect, source))
-        .map(|redirect| redirect.redirect().span)
+        .map(|redirect| redirect.span())
         .collect()
 }
 
 fn stdout_dev_null_redirect_spans_for_fix(
-    redirects: &[RedirectFact<'_>],
+    redirects: &[RedirectFact],
     source: &str,
 ) -> Vec<Span> {
     redirects
@@ -819,16 +1154,16 @@ fn stdout_dev_null_redirect_spans_for_fix(
         .filter(|redirect| {
             redirect_targets_stdout_dev_null_for_substitution_warning(redirect, source)
         })
-        .map(|redirect| redirect.redirect().span)
+        .map(|redirect| redirect.span())
         .collect()
 }
 
-fn redirect_affects_stdout(redirect: &RedirectFact<'_>) -> bool {
-    match redirect.redirect().kind {
+fn redirect_affects_stdout(redirect: &RedirectFact) -> bool {
+    match redirect.kind() {
         RedirectKind::Output
         | RedirectKind::Clobber
         | RedirectKind::Append
-        | RedirectKind::DupOutput => redirect.redirect().fd.unwrap_or(1) == 1,
+        | RedirectKind::DupOutput => redirect.fd().unwrap_or(1) == 1,
         RedirectKind::OutputBoth => true,
         RedirectKind::Input
         | RedirectKind::ReadWrite
@@ -839,26 +1174,26 @@ fn redirect_affects_stdout(redirect: &RedirectFact<'_>) -> bool {
     }
 }
 
-fn redirect_targets_stdout_dev_null(redirect: &RedirectFact<'_>) -> bool {
+fn redirect_targets_stdout_dev_null(redirect: &RedirectFact) -> bool {
     redirect_affects_stdout(redirect) && redirect_file_sink(redirect) == OutputSink::DevNull
 }
 
 fn redirect_targets_stdout_dev_null_for_substitution_warning(
-    redirect: &RedirectFact<'_>,
+    redirect: &RedirectFact,
     source: &str,
 ) -> bool {
     redirect_matches_substitution_warning(redirect, source)
         && redirect_targets_stdout_dev_null(redirect)
 }
 
-fn redirect_matches_substitution_warning(redirect: &RedirectFact<'_>, source: &str) -> bool {
-    match redirect.redirect().kind {
+fn redirect_matches_substitution_warning(redirect: &RedirectFact, source: &str) -> bool {
+    match redirect.kind() {
         RedirectKind::Output | RedirectKind::Clobber | RedirectKind::Append => {
-            redirect.redirect().fd.unwrap_or(1) == 1
+            redirect.fd().unwrap_or(1) == 1
         }
         RedirectKind::DupOutput => {
-            redirect.redirect().fd.unwrap_or(1) == 1
-                && redirect.redirect().span.slice(source).trim_start().starts_with(">&")
+            redirect.fd().unwrap_or(1) == 1
+                && redirect.span().slice(source).trim_start().starts_with(">&")
                 && dup_stdout_target_redirects_capture_away(redirect, source)
         }
         RedirectKind::Input
@@ -871,7 +1206,7 @@ fn redirect_matches_substitution_warning(redirect: &RedirectFact<'_>, source: &s
     }
 }
 
-fn dup_stdout_target_redirects_capture_away(redirect: &RedirectFact<'_>, source: &str) -> bool {
+fn dup_stdout_target_redirects_capture_away(redirect: &RedirectFact, source: &str) -> bool {
     let Some(target) = redirect.target_span().map(|span| span.slice(source).trim()) else {
         return false;
     };
@@ -1405,7 +1740,7 @@ fn word_parts_contain_unquoted_glob_or_brace(
     false
 }
 
-fn redirect_file_sink(redirect: &RedirectFact<'_>) -> OutputSink {
+fn redirect_file_sink(redirect: &RedirectFact) -> OutputSink {
     match redirect.analysis() {
         Some(analysis) if analysis.is_definitely_dev_null() => OutputSink::DevNull,
         Some(_) => OutputSink::Other,
@@ -1414,7 +1749,7 @@ fn redirect_file_sink(redirect: &RedirectFact<'_>) -> OutputSink {
 }
 
 fn redirect_dup_output_sink(
-    redirect: &RedirectFact<'_>,
+    redirect: &RedirectFact,
     fds: &FxHashMap<i32, OutputSink>,
 ) -> OutputSink {
     let Some(fd) = redirect

--- a/crates/shuck-linter/src/facts/tests/assignments.rs
+++ b/crates/shuck-linter/src/facts/tests/assignments.rs
@@ -6,7 +6,7 @@ fn indexes_scalar_bindings_from_assignments_and_declarations() {
     let source = "#!/bin/bash\nfoo=1\nprintf '%s\\n' \"$foo\"\nexport bar=2\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -45,7 +45,7 @@ fn indexes_loop_bindings_from_for_words() {
     let source = "#!/bin/bash\nfor i in 16 32 64; do printf '%s\\n' \"$i\"; done\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -85,7 +85,7 @@ one_sided='-b' || one_sided='-y'
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -152,7 +152,7 @@ printf '%s\\n' \"$foo\"
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -181,7 +181,7 @@ f() {
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -294,7 +294,7 @@ fn collects_broken_assoc_key_spans_from_compound_array_assignments() {
     let source = "#!/bin/bash\ndeclare -A table=([left]=1 [right=2)\nother=([ok]=1 [broken=2)\ndeclare -A third=([$(echo ])=3)\ndeclare -A valid=([$(printf key)]=4)\ndeclare -a nums=([0]=1 [1=2)\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -313,7 +313,7 @@ fn collects_comma_array_assignment_spans_from_compound_values() {
     let source = "#!/bin/bash\na=(alpha,beta)\nb=(\"alpha,beta\")\nc=({x,y})\nd=([k]=v, [q]=w)\ne=(x,$y)\nf=(x\\, y)\ng=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)\nh=(foo,{x,y},bar)\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -363,7 +363,7 @@ fn ignores_commas_after_even_backslashes_before_quote_regions() {
     let source = "#!/bin/bash\na=(x\\\\\",y\")\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -383,7 +383,7 @@ fn ignores_commas_inside_ansi_c_quoted_array_elements() {
     let source = "#!/bin/bash\na=($'a\\'b,c')\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -403,7 +403,7 @@ fn ignores_commas_inside_quoted_command_substitution_array_elements() {
     let source = "#!/bin/bash\nf() {\n\tlocal -a graphql_request=(\n\t\t-X POST\n\t\t-d \"$(\n\t\t\tcat <<-EOF | tr '\\n' ' '\n\t\t\t\t{\"query\":\"field, direction\"}\n\t\t\tEOF\n\t\t)\"\n\t)\n}\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -423,7 +423,7 @@ fn ignores_commas_inside_separator_started_command_substitution_comments() {
     let source = "#!/bin/bash\na=(\"$(printf '%s' x;# comment with ) and ,\nprintf '%s' y\n)\")\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -443,7 +443,7 @@ fn ignores_commas_inside_grouped_command_substitution_comments() {
     let source = "#!/bin/bash\na=(\"$( (# comment with )\nprintf %s 1,2\n) )\")\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -463,7 +463,7 @@ fn ignores_commas_inside_compact_grouped_command_substitution_comments() {
     let source = "#!/bin/bash\na=(\"$( (#comment with )\nprintf %s 1,2\n) )\")\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -483,7 +483,7 @@ fn ignores_commas_inside_command_substitution_case_patterns() {
     let source = "#!/bin/bash\na=(\"$(case $kind in\nalpha) printf %s 1,2 ;;\nesac)\")\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -504,7 +504,7 @@ fn ignores_commas_inside_piped_heredoc_command_substitution_array_elements() {
         "#!/bin/bash\na=(\"$(cat <<EOF|tr '\\n' ' '\n{\"query\":\"field, direction\"}\nEOF\n)\")\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -524,7 +524,7 @@ fn ignores_commas_inside_parameter_expansions_with_right_parens_in_command_subst
     let source = "#!/bin/bash\na=($(printf %s ${x//foo/)},1))\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -544,7 +544,7 @@ fn ignores_commas_inside_parameter_expansions_with_literal_braces() {
     let source = "#!/bin/bash\na=(${x/a,b/{})\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -564,7 +564,7 @@ fn ignores_commas_inside_parameter_expansions_with_ansi_c_single_quotes() {
     let source = "#!/bin/bash\na=(${x/$'a\\'b'/c,d})\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -585,7 +585,7 @@ fn ignores_commas_inside_case_pattern_comments_after_right_parens() {
         "#!/bin/bash\na=($(case $kind in\na)# comment with esac )\nprintf %s 1,2 ;;\nesac\n))\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -605,7 +605,7 @@ fn ignores_commas_inside_process_substitution_array_elements() {
     let source = "#!/bin/bash\na=(<(printf %s 1,2))\nb=(>(printf %s 3,4))\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -625,7 +625,7 @@ fn ignores_commas_inside_comments_after_quoted_double_parens() {
     let source = "#!/bin/bash\na=($(printf '((' # comment with )\nprintf %s 1,2\n))\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -645,7 +645,7 @@ fn ignores_commas_inside_arithmetic_shift_command_substitutions() {
     let source = "#!/bin/bash\na=($( ((x<<2))\nprintf %s 1,2\n))\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -683,7 +683,7 @@ g=($(printf %s `echo foo)`; printf %s 13,14))
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -703,7 +703,7 @@ fn ignores_commas_inside_nested_case_patterns_in_command_substitutions() {
     let source = "#!/bin/bash\na=($( (case $kind in\na) printf %s 1,2 ;;\nesac\n) ))\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -723,7 +723,7 @@ fn ignores_commas_inside_command_substitutions_with_plain_case_words() {
     let source = "#!/bin/bash\na=($(printf %s 1,2; echo case in))\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -743,7 +743,7 @@ fn ignores_commas_inside_command_substitutions_with_ansi_c_single_quotes() {
     let source = "#!/bin/bash\na=($(printf %s $'a\\'b'; printf %s 1,2))\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -763,7 +763,7 @@ fn ignores_commas_inside_command_substitutions_with_backticks() {
     let source = "#!/bin/bash\na=($(printf %s `echo foo)`; printf %s 1,2))\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -783,7 +783,7 @@ fn ignores_commas_inside_backticks_inside_parameter_expansions() {
     let source = "#!/bin/bash\na=(${x/`echo }`/a,b})\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -803,7 +803,7 @@ fn ignores_commas_inside_process_substitutions_inside_parameter_expansions() {
     let source = "#!/bin/bash\na=(${x/<(echo })/foo,bar})\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -823,7 +823,7 @@ fn ignores_commas_after_backticks_inside_parameter_expansions_in_command_substit
     let source = "#!/bin/bash\na=(\"$(printf %s ${x/`echo }`/foo)},1)\")\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -844,7 +844,7 @@ fn ignores_commas_after_process_substitutions_inside_parameter_expansions_in_com
     let source = "#!/bin/bash\na=(\"$(printf %s ${x/<(echo })/foo)},1)\")\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -924,7 +924,7 @@ demo() {
 fn subshell_assignment_slices(source: &str, shell: ShellDialect) -> Vec<&str> {
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, shell);
     let facts = LinterFacts::build_with_shell_and_ambient_shell_options(
         &output.file,
@@ -946,7 +946,7 @@ fn subshell_assignment_slices(source: &str, shell: ShellDialect) -> Vec<&str> {
 fn subshell_later_use_slices(source: &str, shell: ShellDialect) -> Vec<&str> {
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, shell);
     let facts = LinterFacts::build_with_shell_and_ambient_shell_options(
         &output.file,

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -29,7 +29,7 @@ fn summarizes_command_options_and_invokers() {
     let source = "#!/bin/bash\nread -r name\necho -ne hi\necho '-I' hi\necho \"\\\\n\"\necho \\x41\necho \"prefix $VAR \\\\0 suffix\"\ncommand echo \\n\nsed 's/foo/bar/'\nsed -e 's/foo/bar/'\nsed -e 's:\\([0-9][0-9]*\\)[a-z]*\\$:\\1:'\nsed 's/[]\\[^$.*/]/\\\\&/g'\nsed 's/\\([/&]\\)/\\\\\\1/g'\nsed -n 's/foo/bar/p'\nsed --expression 's/foo/bar/'\nsed -r 's/foo/bar/'\nsed \\\"s/foo/bar/\\\"\ntr -ds a-z A-Z\ntr -- 'a-z' xyz\nprintf -v out \"$fmt\" value\nprintf '%q\\n' foo\nprintf '%*q\\n' 10 bar\nunset -f curl other\nfind . -print0 | xargs -0 rm\nfind . -type d -name CVS | xargs -iX rm -rf X\nfind . -type d -name CVS | xargs --replace rm -rf {}\nfind . -name a -o -name b -print\nfind . -name *.cfg\nfind . -name \"$prefix\"*.jar\nfind . -wholename */tmp/*\nfind . -name \\*.ignore\nfind . -type f*\nrm -rf \"$dir\"/*\nrm -rf \"$dir\"/sub/*\nrm -rf \"$dir\"/lib\nrm -rf \"$dir\"/*.log\nrm -rf \"$rootdir/$md_type/$to\"\nrm -rf \"$configdir/all/retroarch/$dir\"\nrm -rf \"$md_inst/\"*\nwait -n\nwait -- -n\ngrep -o content file | wc -l\nexit foo\nset -eETo pipefail\nset euox pipefail\n./configure --with-optmizer=${CFLAGS}\nconfigure \"--enable-optmizer=${CFLAGS}\"\n./configure --with-optimizer=${CFLAGS}\nps -p 1 -o comm=\nps p 123 -o comm=\nps -ef\ndoas printf '%s\\n' hi\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -442,7 +442,7 @@ amoeba=\"\" [ \"${AMOEBA:-yes}\" = \"yes\" ]
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Sh);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -516,7 +516,7 @@ printf#
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Sh);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -614,7 +614,7 @@ fn summarizes_echo_options_for_path_qualified_echo() {
     let source = "#!/bin/sh\nvalue=$(/usr/ucb/echo -n hi)\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Sh);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -637,7 +637,7 @@ fn builds_tr_facts_inside_escaped_quoted_command_substitutions() {
     let source = "#!/bin/sh\necho -n \"\\\"adp_$(echo $var | tr A-Z a-z)\\\": [\"\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Sh);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -661,7 +661,7 @@ fn builds_tr_facts_inside_piped_command_substitutions_with_quoted_operands() {
     let source = "#!/bin/sh\nATLAS_SHARED=$(echo \"$ATLAS_SHARED\"|cut -b 1|tr a-z A-Z)\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Sh);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -687,7 +687,7 @@ fn tracks_quote_like_echo_escapes_inside_double_quotes_from_syntax_text() {
     let source = "#!/bin/bash\necho \"  echo Remember to run \\\\\\`updatedb\\\\'.\"\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -706,7 +706,7 @@ fn tracks_echo_backslash_double_quote_escape_shapes() {
     let source = "#!/bin/bash\necho -DLATEX=\\\\\"$(which latex)\\\\\"\necho \"  .TargetPath = \\\"\\\\\\\\host.lan\\\\Data\\\"\"\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -728,7 +728,7 @@ fn ignores_json_like_backslash_quote_wrappers_around_variables() {
     let source = "#!/bin/bash\necho \"LABEL com.dokku.docker-image-labeler/alternate-tags=[\\\\\\\"$DOCKER_IMAGE\\\\\\\"]\"\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -749,7 +749,7 @@ echo Saved to \\\"\"$FILENAME\"\\\" \\(\"$(du -h \"$OUTPUT\" | cut -f1)\"\\)
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -766,7 +766,7 @@ find . -print | xargs rm
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -797,7 +797,7 @@ expr 1 + 2
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Sh);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -851,7 +851,7 @@ fn tracks_printf_formats_with_and_without_literal_percents() {
     let source = "printf \"$fmt\" value\nprintf \"${left}${right}\" value\nprintf \"${fmt:-%s}\" value\nprintf \"$(echo %s)\" value\nprintf \"pre$foo\" value\nprintf \"%${width}s\\n\" value\nprintf \"${color}%s${reset}\" value\nprintf \"$fmt%s\" value\nprintf '%s\\n' value\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1020,7 +1020,7 @@ unset parts[\"$key\"] extra
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1051,7 +1051,7 @@ unset -xn unknown
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1083,7 +1083,7 @@ unset parts[\"$key\"] plain \"parts[safe]\" 'parts[also_safe]' nums[1]
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1196,7 +1196,7 @@ unset -v \"${!prefix_@}\" x${!prefix_*} \"${!name}\" \"${!arr[@]}\"
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Sh);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1222,7 +1222,7 @@ fn tracks_mapfile_input_fd_and_grouped_find_or_branches() {
     let source = "#!/bin/bash\nmapfile -u 3 -t files 3< <(printf '%s\\n' hi)\nmapfile -C cb -c 1 lines\nfind . \\( -name a -o -name b -print \\)\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1262,7 +1262,7 @@ fn tracks_mapfile_input_fd_and_grouped_find_or_branches() {
     let dynamic_output = Parser::new(dynamic_source).parse().unwrap();
     let dynamic_indexer = Indexer::new(dynamic_source, &dynamic_output);
     let dynamic_semantic =
-        SemanticModel::build(&dynamic_output.file, dynamic_source, &dynamic_indexer);
+        SemanticModel::build_arena(&dynamic_output.arena_file, dynamic_source, &dynamic_indexer);
     let dynamic_file_context = classify_file_context(dynamic_source, None, ShellDialect::Bash);
     let dynamic_facts = LinterFacts::build(
         &dynamic_output.file,
@@ -1302,7 +1302,7 @@ find . -type l -o -print
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1342,7 +1342,7 @@ grep -e'*start' data.txt
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1504,7 +1504,7 @@ grep --regexp='*start' data.txt
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1548,7 +1548,7 @@ grep -$dynamic_option 1 -e '*explicit-after-dynamic-option' data.txt
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1596,7 +1596,7 @@ grep 'foo*bar+' data.txt
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1640,7 +1640,7 @@ grep --regexp='start*' data.txt
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1682,7 +1682,7 @@ grep -eo item* data.txt
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1706,7 +1706,7 @@ ps --pid=\"$pid\" -o comm=
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1733,7 +1733,7 @@ ps 1,2 -o comm=
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1760,7 +1760,7 @@ ps ax -q 1 -o comm=
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1789,7 +1789,7 @@ echo ${foo:-$((10#1))}
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1812,7 +1812,7 @@ echo ${foo:-${1##*/}}
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1829,7 +1829,7 @@ echo $((42949 - ${1#-} / 100000))
         .parse()
         .unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -1846,7 +1846,7 @@ echo $(( ${foo:-10#1} ))
         .parse()
         .unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2356,7 +2356,7 @@ fn summarizes_builtin_wrapped_reads() {
     let source = "#!/bin/bash\nbuiltin read response\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2385,7 +2385,7 @@ read -- -a name
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2461,7 +2461,7 @@ read -a \"items\" trailing
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2509,7 +2509,7 @@ su -l
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2546,7 +2546,7 @@ su root -s /bin/sh
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2658,7 +2658,7 @@ fn summarizes_directory_change_commands_and_errexit_hints() {
     let source = "\n#!/bin/bash -eu\ncd ../..\ncd -\nbuiltin cd /\npushd ..\npopd\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2696,7 +2696,7 @@ fn does_not_treat_long_shebang_options_as_errexit() {
     let source = "#!/bin/bash --noprofile\ncd /tmp\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2708,7 +2708,7 @@ fn keeps_read_raw_input_when_option_flags_are_dynamic() {
     let source = "#!/bin/bash\nbuiltin read -${_read_char_flag} 1 -s -r anykey\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2730,7 +2730,7 @@ fn resolves_sudo_family_invokers_through_outer_wrappers() {
     let source = "#!/bin/bash\ncommand sudo tee out.txt\ncommand run0 tee out.txt\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2751,7 +2751,7 @@ fn resolves_sudo_family_invokers_when_wrapper_names_are_escaped() {
     let source = "#!/bin/bash\n\\command \\doas tee out.txt\n\\command \\sudo tee out.txt\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2777,7 +2777,7 @@ command run0 --version
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2802,7 +2802,7 @@ fn parses_long_xargs_null_mode_and_numeric_exit_status() {
     let source = "#!/bin/bash\nfind . -print0 | xargs --null rm\nexit 42\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2844,7 +2844,7 @@ exit \"$(printf '%s' 3)\"
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2889,7 +2889,7 @@ xargs -i echo \"-----> Configuring {} with $template\"
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2939,7 +2939,7 @@ fn does_not_consume_null_mode_after_optional_long_eof() {
     let source = "#!/bin/bash\nfind . -print0 | xargs --eof --null rm\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2962,7 +2962,7 @@ xargs -a inputs -iX echo X
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -2999,7 +2999,7 @@ find . | xargs -P11 echo
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::CommandFactCompoundKind;
 
 #[test]
 fn word_static_text_preserves_multi_part_literals() {
@@ -1140,34 +1141,34 @@ time timed
         let binary = facts
             .commands()
             .iter()
-            .find(|fact| matches!(fact.command(), shuck_ast::Command::Binary(_)))
+            .find(|fact| fact.command_kind() == shuck_ast::ArenaFileCommandKind::Binary)
             .expect("expected binary command");
 
         let init_parent = facts
             .command_parent(init_if.id())
             .expect("expected if parent");
-        assert!(matches!(
-            init_parent.command(),
-            shuck_ast::Command::Compound(shuck_ast::CompoundCommand::If(_))
-        ));
+        assert_eq!(
+            init_parent.compound_kind(),
+            Some(CommandFactCompoundKind::If)
+        );
         assert!(facts.command_is_dominance_barrier(init_parent.id()));
 
         let brace_parent = facts
             .command_parent(brace_inner.id())
             .expect("expected brace-group parent");
-        assert!(matches!(
-            brace_parent.command(),
-            shuck_ast::Command::Compound(shuck_ast::CompoundCommand::BraceGroup(_))
-        ));
+        assert_eq!(
+            brace_parent.compound_kind(),
+            Some(CommandFactCompoundKind::BraceGroup)
+        );
         assert!(!facts.command_is_dominance_barrier(brace_parent.id()));
 
         let timed_parent = facts
             .command_parent(timed.id())
             .expect("expected time parent");
-        assert!(matches!(
-            timed_parent.command(),
-            shuck_ast::Command::Compound(shuck_ast::CompoundCommand::Time(_))
-        ));
+        assert_eq!(
+            timed_parent.compound_kind(),
+            Some(CommandFactCompoundKind::Time)
+        );
         assert!(!facts.command_is_dominance_barrier(timed_parent.id()));
         assert!(facts.command_is_dominance_barrier(binary.id()));
 

--- a/crates/shuck-linter/src/facts/tests/flow.rs
+++ b/crates/shuck-linter/src/facts/tests/flow.rs
@@ -97,7 +97,7 @@ fn builds_command_facts_for_wrapped_and_nested_commands() {
     let source = "#!/bin/bash\ncommand printf '%s\\n' \"$(echo hi)\"\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -142,7 +142,7 @@ fn exposes_structural_commands_and_id_lookups() {
     let source = "#!/bin/bash\necho \"$(printf x)\"\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 
@@ -178,7 +178,7 @@ fn precomputes_innermost_command_ids_for_nested_offsets() {
     let source = "#!/bin/bash\necho \"$(printf '%s' \"$(uname)\")\"\n";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 

--- a/crates/shuck-linter/src/facts/tests/support.rs
+++ b/crates/shuck-linter/src/facts/tests/support.rs
@@ -15,7 +15,7 @@ pub(super) fn with_facts_dialect(
 ) {
     let output = Parser::with_dialect(source, parse_dialect).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, path, shell);
     let facts = LinterFacts::build_with_shell_and_ambient_shell_options(
         &output.file,

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -853,7 +853,7 @@ write_target
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
-    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
     let file_context = classify_file_context(source, None, ShellDialect::Bash);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
 

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -33,6 +33,14 @@ struct CommandVisit<'a> {
     redirects: &'a [Redirect],
 }
 
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+struct ArenaCommandVisit<'a> {
+    stmt: StmtView<'a>,
+    command: CommandView<'a>,
+    redirects: &'a [RedirectNode],
+}
+
 fn walk_commands<'a, F>(commands: &'a StmtSeq, options: CommandWalkOptions, visitor: &mut F)
 where
     F: FnMut(CommandVisit<'a>, CommandTraversalContext),
@@ -56,6 +64,33 @@ fn iter_commands<'a>(
     visits.into_iter()
 }
 
+fn walk_arena_commands<'a, F>(
+    commands: StmtSeqView<'a>,
+    options: CommandWalkOptions,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    collect_arena_command_visits(
+        commands,
+        options,
+        CommandTraversalContext::default(),
+        visitor,
+    );
+}
+
+#[allow(dead_code)]
+fn iter_arena_commands<'a>(
+    commands: StmtSeqView<'a>,
+    options: CommandWalkOptions,
+) -> impl Iterator<Item = ArenaCommandVisit<'a>> {
+    let mut visits = Vec::new();
+    walk_arena_commands(commands, options, &mut |visit, _| {
+        visits.push(visit);
+    });
+    visits.into_iter()
+}
+
 fn zsh_glob_patterns(glob: &shuck_ast::ZshQualifiedGlob) -> impl Iterator<Item = &Pattern> + '_ {
     glob.segments.iter().filter_map(|segment| match segment {
         ZshGlobSegment::Pattern(pattern) => Some(pattern),
@@ -73,6 +108,33 @@ fn command_assignments(command: &Command) -> &[Assignment] {
         | Command::Function(_)
         | Command::AnonymousFunction(_) => &[],
     }
+}
+
+#[allow(dead_code)]
+fn arena_command_assignments(command: CommandView<'_>) -> &[AssignmentNode] {
+    match command.kind() {
+        ArenaFileCommandKind::Simple => command
+            .simple()
+            .map(|command| command.assignments())
+            .unwrap_or(&[]),
+        ArenaFileCommandKind::Builtin => command
+            .builtin()
+            .map(|command| command.assignments())
+            .unwrap_or(&[]),
+        ArenaFileCommandKind::Decl => command
+            .decl()
+            .map(|command| command.assignments())
+            .unwrap_or(&[]),
+        ArenaFileCommandKind::Binary
+        | ArenaFileCommandKind::Compound
+        | ArenaFileCommandKind::Function
+        | ArenaFileCommandKind::AnonymousFunction => &[],
+    }
+}
+
+#[allow(dead_code)]
+fn arena_declaration_operands(command: CommandView<'_>) -> &[DeclOperandNode] {
+    command.decl().map(|command| command.operands()).unwrap_or(&[])
 }
 
 fn declaration_operands(command: &Command) -> &[DeclOperand] {
@@ -253,6 +315,848 @@ fn collect_command_visits<'a, F>(
 {
     for stmt in commands.iter() {
         collect_command_visit(stmt, options, context, visitor);
+    }
+}
+
+fn collect_arena_command_visits<'a, F>(
+    commands: StmtSeqView<'a>,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    for stmt in commands.stmts() {
+        collect_arena_command_visit(stmt, options, context, visitor);
+    }
+}
+
+fn collect_arena_command_visit<'a, F>(
+    stmt: StmtView<'a>,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    visitor(
+        ArenaCommandVisit {
+            stmt,
+            command: stmt.command(),
+            redirects: stmt.redirects(),
+        },
+        context,
+    );
+
+    let command = stmt.command();
+    let store = command.store();
+
+    match command.kind() {
+        ArenaFileCommandKind::Simple => {
+            let command = command.simple().expect("simple command view");
+            collect_arena_assignment_visits(
+                store,
+                command.assignments(),
+                options,
+                context,
+                visitor,
+            );
+            collect_arena_word_visit(command.name(), options, context, visitor);
+            collect_arena_word_ids_visits(store, command.arg_ids(), options, context, visitor);
+        }
+        ArenaFileCommandKind::Builtin => {
+            let command = command.builtin().expect("builtin command view");
+            collect_arena_assignment_visits(
+                store,
+                command.assignments(),
+                options,
+                context,
+                visitor,
+            );
+            if let Some(word) = command.primary() {
+                collect_arena_word_visit(word, options, context, visitor);
+            }
+            collect_arena_word_ids_visits(store, command.extra_arg_ids(), options, context, visitor);
+        }
+        ArenaFileCommandKind::Decl => {
+            let command = command.decl().expect("decl command view");
+            collect_arena_assignment_visits(
+                store,
+                command.assignments(),
+                options,
+                context,
+                visitor,
+            );
+            for operand in command.operands() {
+                match operand {
+                    DeclOperandNode::Flag(word) | DeclOperandNode::Dynamic(word) => {
+                        collect_arena_word_visit(store.word(*word), options, context, visitor);
+                    }
+                    DeclOperandNode::Name(_) => {}
+                    DeclOperandNode::Assignment(assignment) => {
+                        collect_arena_assignment_visit(store, assignment, options, context, visitor);
+                    }
+                }
+            }
+        }
+        ArenaFileCommandKind::Binary => {
+            let command = command.binary().expect("binary command view");
+            collect_arena_command_visits(command.left(), options, context, visitor);
+            collect_arena_command_visits(command.right(), options, context, visitor);
+        }
+        ArenaFileCommandKind::Compound => {
+            collect_arena_compound_visits(
+                command.compound().expect("compound command view"),
+                options,
+                context,
+                visitor,
+            );
+        }
+        ArenaFileCommandKind::Function => {
+            let function = command.function().expect("function command view");
+            for entry in function.entries() {
+                collect_arena_word_visit(store.word(entry.word), options, context, visitor);
+            }
+            collect_arena_command_visits(function.body(), options, context, visitor);
+        }
+        ArenaFileCommandKind::AnonymousFunction => {
+            let function = command
+                .anonymous_function()
+                .expect("anonymous function command view");
+            collect_arena_word_ids_visits(store, function.arg_ids(), options, context, visitor);
+            collect_arena_command_visits(function.body(), options, context, visitor);
+        }
+    }
+
+    collect_arena_redirect_visits(stmt, options, context, visitor);
+}
+
+fn collect_arena_compound_visits<'a, F>(
+    command: shuck_ast::CompoundCommandView<'a>,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    let store = command.store();
+    match command.node() {
+        CompoundCommandNode::If {
+            condition,
+            then_branch,
+            elif_branches,
+            else_branch,
+            ..
+        } => {
+            collect_arena_command_visits(
+                store.stmt_seq(*condition),
+                options,
+                condition_context(context, ConditionKind::If),
+                visitor,
+            );
+            collect_arena_command_visits(store.stmt_seq(*then_branch), options, context, visitor);
+            for branch in store.elif_branches(*elif_branches) {
+                collect_arena_command_visits(
+                    store.stmt_seq(branch.condition),
+                    options,
+                    condition_context(context, ConditionKind::Elif),
+                    visitor,
+                );
+                collect_arena_command_visits(store.stmt_seq(branch.body), options, context, visitor);
+            }
+            if let Some(body) = else_branch {
+                collect_arena_command_visits(store.stmt_seq(*body), options, context, visitor);
+            }
+        }
+        CompoundCommandNode::For { words, body, .. } => {
+            if let Some(words) = words {
+                collect_arena_word_ids_visits(
+                    store,
+                    store.word_ids(*words),
+                    options,
+                    context,
+                    visitor,
+                );
+            }
+            collect_arena_command_visits(
+                store.stmt_seq(*body),
+                options,
+                loop_context(context),
+                visitor,
+            );
+        }
+        CompoundCommandNode::Repeat { count, body, .. } => {
+            collect_arena_word_visit(store.word(*count), options, context, visitor);
+            collect_arena_command_visits(
+                store.stmt_seq(*body),
+                options,
+                loop_context(context),
+                visitor,
+            );
+        }
+        CompoundCommandNode::Foreach { words, body, .. } => {
+            collect_arena_word_ids_visits(store, store.word_ids(*words), options, context, visitor);
+            collect_arena_command_visits(
+                store.stmt_seq(*body),
+                options,
+                loop_context(context),
+                visitor,
+            );
+        }
+        CompoundCommandNode::ArithmeticFor(command) => {
+            for expression in [
+                command.init_ast.as_ref(),
+                command.condition_ast.as_ref(),
+                command.step_ast.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                collect_arena_arithmetic_expression_visits(expression, options, context, visitor);
+            }
+            collect_arena_command_visits(
+                store.stmt_seq(command.body),
+                options,
+                loop_context(context),
+                visitor,
+            );
+        }
+        CompoundCommandNode::While { condition, body } => {
+            let loop_context = loop_context(context);
+            collect_arena_command_visits(
+                store.stmt_seq(*condition),
+                options,
+                condition_context(loop_context, ConditionKind::While),
+                visitor,
+            );
+            collect_arena_command_visits(store.stmt_seq(*body), options, loop_context, visitor);
+        }
+        CompoundCommandNode::Until { condition, body } => {
+            let loop_context = loop_context(context);
+            collect_arena_command_visits(
+                store.stmt_seq(*condition),
+                options,
+                condition_context(loop_context, ConditionKind::Until),
+                visitor,
+            );
+            collect_arena_command_visits(store.stmt_seq(*body), options, loop_context, visitor);
+        }
+        CompoundCommandNode::Case { word, cases } => {
+            collect_arena_word_visit(store.word(*word), options, context, visitor);
+            for case in store.case_items(*cases) {
+                collect_arena_pattern_slice_visits(
+                    store,
+                    store.patterns(case.patterns),
+                    options,
+                    context,
+                    visitor,
+                );
+                collect_arena_command_visits(store.stmt_seq(case.body), options, context, visitor);
+            }
+        }
+        CompoundCommandNode::Select { words, body, .. } => {
+            collect_arena_word_ids_visits(store, store.word_ids(*words), options, context, visitor);
+            collect_arena_command_visits(
+                store.stmt_seq(*body),
+                options,
+                loop_context(context),
+                visitor,
+            );
+        }
+        CompoundCommandNode::Subshell(body) | CompoundCommandNode::BraceGroup(body) => {
+            collect_arena_command_visits(store.stmt_seq(*body), options, context, visitor);
+        }
+        CompoundCommandNode::Always { body, always_body } => {
+            collect_arena_command_visits(store.stmt_seq(*body), options, context, visitor);
+            collect_arena_command_visits(store.stmt_seq(*always_body), options, context, visitor);
+        }
+        CompoundCommandNode::Arithmetic(command) => {
+            if let Some(expression) = command.expr_ast.as_ref() {
+                collect_arena_arithmetic_expression_visits(expression, options, context, visitor);
+            }
+        }
+        CompoundCommandNode::Time { command, .. } => {
+            if let Some(command) = command {
+                collect_arena_command_visits(store.stmt_seq(*command), options, context, visitor);
+            }
+        }
+        CompoundCommandNode::Conditional(command) => {
+            collect_arena_conditional_visits(&command.expression, options, context, visitor);
+        }
+        CompoundCommandNode::Coproc { body, .. } => {
+            collect_arena_command_visits(store.stmt_seq(*body), options, context, visitor);
+        }
+    }
+}
+
+fn collect_arena_assignment_visits<'a, F>(
+    store: &'a AstStore,
+    assignments: &'a [AssignmentNode],
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    for assignment in assignments {
+        collect_arena_assignment_visit(store, assignment, options, context, visitor);
+    }
+}
+
+fn collect_arena_assignment_visit<'a, F>(
+    store: &'a AstStore,
+    assignment: &'a AssignmentNode,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    match &assignment.value {
+        AssignmentValueNode::Scalar(word) => {
+            collect_arena_word_visit(store.word(*word), options, context, visitor);
+        }
+        AssignmentValueNode::Compound(array) => {
+            for element in store.array_elems(array.elements) {
+                match element {
+                    ArrayElemNode::Sequential(value) => {
+                        collect_arena_word_visit(store.word(value.word), options, context, visitor);
+                    }
+                    ArrayElemNode::Keyed { key, value }
+                    | ArrayElemNode::KeyedAppend { key, value } => {
+                        collect_arena_subscript_visit(key, store, options, context, visitor);
+                        collect_arena_word_visit(store.word(value.word), options, context, visitor);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn collect_arena_redirect_visits<'a, F>(
+    stmt: StmtView<'a>,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    let store = stmt.command().store();
+    for redirect in stmt.redirects() {
+        match &redirect.target {
+            RedirectTargetNode::Word(word) => {
+                collect_arena_word_visit(store.word(*word), options, context, visitor);
+            }
+            RedirectTargetNode::Heredoc(heredoc) => {
+                collect_arena_word_visit(store.word(heredoc.delimiter.raw), options, context, visitor);
+                if heredoc.delimiter.expands_body {
+                    collect_arena_heredoc_body_visits(
+                        store,
+                        store.heredoc_body_parts(heredoc.body.parts),
+                        options,
+                        context,
+                        visitor,
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn collect_arena_word_ids_visits<'a, F>(
+    store: &'a AstStore,
+    words: &[WordId],
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    for word in words {
+        collect_arena_word_visit(store.word(*word), options, context, visitor);
+    }
+}
+
+fn collect_arena_word_visit<'a, F>(
+    word: shuck_ast::WordView<'a>,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    if !options.descend_nested_word_commands {
+        return;
+    }
+
+    collect_arena_word_part_visits(
+        word.parts(),
+        word.store(),
+        options,
+        nested_word_context(context),
+        visitor,
+    );
+}
+
+fn collect_arena_word_part_visits<'a, F>(
+    parts: &'a [WordPartArenaNode],
+    store: &'a AstStore,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    for part in parts {
+        match &part.kind {
+            WordPartArena::ZshQualifiedGlob(glob) => {
+                for segment in store.zsh_glob_segments(glob.segments) {
+                    if let ZshGlobSegmentNode::Pattern(pattern) = segment {
+                        collect_arena_pattern_visits(store, pattern, options, context, visitor);
+                    }
+                }
+            }
+            WordPartArena::DoubleQuoted { parts, .. } => {
+                collect_arena_word_part_visits(
+                    store.word_parts(*parts),
+                    store,
+                    options,
+                    context,
+                    visitor,
+                );
+            }
+            WordPartArena::CommandSubstitution { body, .. }
+            | WordPartArena::ProcessSubstitution { body, .. } => {
+                collect_arena_command_visits(store.stmt_seq(*body), options, context, visitor);
+            }
+            WordPartArena::ArithmeticExpansion {
+                expression_ast,
+                expression_word_ast,
+                ..
+            } => {
+                if let Some(expression) = expression_ast.as_ref() {
+                    collect_arena_arithmetic_expression_visits(
+                        expression, options, context, visitor,
+                    );
+                } else {
+                    collect_arena_word_visit(
+                        store.word(*expression_word_ast),
+                        options,
+                        context,
+                        visitor,
+                    );
+                }
+            }
+            WordPartArena::Parameter(parameter) => {
+                collect_arena_parameter_expansion_visits(
+                    store, parameter, options, context, visitor,
+                );
+            }
+            WordPartArena::ParameterExpansion {
+                reference,
+                operand_word_ast,
+                ..
+            }
+            | WordPartArena::IndirectExpansion {
+                reference,
+                operand_word_ast,
+                ..
+            } => {
+                collect_arena_var_ref_word_visits(reference, store, options, context, visitor);
+                if let Some(word) = operand_word_ast {
+                    collect_arena_word_visit(store.word(*word), options, context, visitor);
+                }
+            }
+            WordPartArena::Length(reference)
+            | WordPartArena::ArrayAccess(reference)
+            | WordPartArena::ArrayLength(reference)
+            | WordPartArena::ArrayIndices(reference)
+            | WordPartArena::Transformation { reference, .. } => {
+                collect_arena_var_ref_word_visits(reference, store, options, context, visitor);
+            }
+            WordPartArena::Substring {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            }
+            | WordPartArena::ArraySlice {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                collect_arena_var_ref_word_visits(reference, store, options, context, visitor);
+                if let Some(expression) = offset_ast.as_ref() {
+                    collect_arena_arithmetic_expression_visits(
+                        expression, options, context, visitor,
+                    );
+                } else {
+                    collect_arena_word_visit(store.word(*offset_word_ast), options, context, visitor);
+                }
+                if let Some(expression) = length_ast.as_ref() {
+                    collect_arena_arithmetic_expression_visits(
+                        expression, options, context, visitor,
+                    );
+                } else if let Some(word) = length_word_ast {
+                    collect_arena_word_visit(store.word(*word), options, context, visitor);
+                }
+            }
+            WordPartArena::Literal(_)
+            | WordPartArena::SingleQuoted { .. }
+            | WordPartArena::Variable(_)
+            | WordPartArena::PrefixMatch { .. } => {}
+        }
+    }
+}
+
+fn collect_arena_heredoc_body_visits<'a, F>(
+    store: &'a AstStore,
+    parts: &'a [shuck_ast::ArenaHeredocBodyPartNode],
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    for part in parts {
+        match &part.kind {
+            ArenaHeredocBodyPart::CommandSubstitution { body, .. } => {
+                collect_arena_command_visits(
+                    store.stmt_seq(*body),
+                    options,
+                    nested_word_context(context),
+                    visitor,
+                );
+            }
+            ArenaHeredocBodyPart::ArithmeticExpansion {
+                expression_ast,
+                expression_word_ast,
+                ..
+            } => {
+                if let Some(expression) = expression_ast.as_ref() {
+                    collect_arena_arithmetic_expression_visits(
+                        expression,
+                        options,
+                        nested_word_context(context),
+                        visitor,
+                    );
+                } else {
+                    collect_arena_word_visit(
+                        store.word(*expression_word_ast),
+                        options,
+                        context,
+                        visitor,
+                    );
+                }
+            }
+            ArenaHeredocBodyPart::Parameter(parameter) => {
+                collect_arena_parameter_expansion_visits(
+                    store,
+                    parameter,
+                    options,
+                    nested_word_context(context),
+                    visitor,
+                );
+            }
+            ArenaHeredocBodyPart::Literal(_) | ArenaHeredocBodyPart::Variable(_) => {}
+        }
+    }
+}
+
+fn collect_arena_subscript_visit<'a, F>(
+    subscript: &'a SubscriptNode,
+    store: &'a AstStore,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    if let Some(expression) = subscript.arithmetic_ast.as_ref() {
+        collect_arena_arithmetic_expression_visits(expression, options, context, visitor);
+    } else if let Some(word) = subscript.word_ast {
+        collect_arena_word_visit(store.word(word), options, context, visitor);
+    }
+}
+
+fn collect_arena_var_ref_word_visits<'a, F>(
+    reference: &'a VarRefNode,
+    store: &'a AstStore,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    if let Some(subscript) = reference.subscript.as_deref() {
+        collect_arena_subscript_visit(subscript, store, options, context, visitor);
+    }
+}
+
+fn collect_arena_parameter_expansion_visits<'a, F>(
+    store: &'a AstStore,
+    parameter: &'a ParameterExpansionNode,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    match &parameter.syntax {
+        ParameterExpansionSyntaxNode::Bourne(syntax) => match syntax {
+            BourneParameterExpansionNode::Access { reference }
+            | BourneParameterExpansionNode::Length { reference }
+            | BourneParameterExpansionNode::Indices { reference }
+            | BourneParameterExpansionNode::Transformation { reference, .. } => {
+                collect_arena_var_ref_word_visits(reference, store, options, context, visitor);
+            }
+            BourneParameterExpansionNode::Indirect {
+                reference,
+                operand_word_ast,
+                ..
+            }
+            | BourneParameterExpansionNode::Operation {
+                reference,
+                operand_word_ast,
+                ..
+            } => {
+                collect_arena_var_ref_word_visits(reference, store, options, context, visitor);
+                if let Some(word) = operand_word_ast {
+                    collect_arena_word_visit(store.word(*word), options, context, visitor);
+                }
+            }
+            BourneParameterExpansionNode::Slice {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                collect_arena_var_ref_word_visits(reference, store, options, context, visitor);
+                if let Some(expression) = offset_ast.as_ref() {
+                    collect_arena_arithmetic_expression_visits(
+                        expression, options, context, visitor,
+                    );
+                } else {
+                    collect_arena_word_visit(store.word(*offset_word_ast), options, context, visitor);
+                }
+                if let Some(expression) = length_ast.as_ref() {
+                    collect_arena_arithmetic_expression_visits(
+                        expression, options, context, visitor,
+                    );
+                } else if let Some(word) = length_word_ast {
+                    collect_arena_word_visit(store.word(*word), options, context, visitor);
+                }
+            }
+            BourneParameterExpansionNode::PrefixMatch { .. } => {}
+        },
+        ParameterExpansionSyntaxNode::Zsh(syntax) => {
+            collect_arena_zsh_target_visits(&syntax.target, store, options, context, visitor);
+            for modifier in store.zsh_modifiers(syntax.modifiers) {
+                if let Some(word) = modifier.argument_word_ast {
+                    collect_arena_word_visit(store.word(word), options, context, visitor);
+                }
+            }
+            if let Some(operation) = &syntax.operation {
+                match operation {
+                    ZshExpansionOperationNode::PatternOperation {
+                        operand_word_ast, ..
+                    }
+                    | ZshExpansionOperationNode::Defaulting {
+                        operand_word_ast, ..
+                    }
+                    | ZshExpansionOperationNode::TrimOperation {
+                        operand_word_ast, ..
+                    } => {
+                        collect_arena_word_visit(
+                            store.word(*operand_word_ast),
+                            options,
+                            context,
+                            visitor,
+                        );
+                    }
+                    ZshExpansionOperationNode::ReplacementOperation {
+                        pattern_word_ast,
+                        replacement_word_ast,
+                        ..
+                    } => {
+                        collect_arena_word_visit(
+                            store.word(*pattern_word_ast),
+                            options,
+                            context,
+                            visitor,
+                        );
+                        if let Some(word) = replacement_word_ast {
+                            collect_arena_word_visit(store.word(*word), options, context, visitor);
+                        }
+                    }
+                    ZshExpansionOperationNode::Slice {
+                        offset_word_ast,
+                        length_word_ast,
+                        ..
+                    } => {
+                        collect_arena_word_visit(
+                            store.word(*offset_word_ast),
+                            options,
+                            context,
+                            visitor,
+                        );
+                        if let Some(word) = length_word_ast {
+                            collect_arena_word_visit(store.word(*word), options, context, visitor);
+                        }
+                    }
+                    ZshExpansionOperationNode::Unknown { word_ast, .. } => {
+                        collect_arena_word_visit(store.word(*word_ast), options, context, visitor);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn collect_arena_zsh_target_visits<'a, F>(
+    target: &'a ZshExpansionTargetNode,
+    store: &'a AstStore,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    match target {
+        ZshExpansionTargetNode::Reference(reference) => {
+            collect_arena_var_ref_word_visits(reference, store, options, context, visitor);
+        }
+        ZshExpansionTargetNode::Nested(parameter) => {
+            collect_arena_parameter_expansion_visits(store, parameter, options, context, visitor);
+        }
+        ZshExpansionTargetNode::Word(word) => {
+            collect_arena_word_visit(store.word(*word), options, context, visitor);
+        }
+        ZshExpansionTargetNode::Empty => {}
+    }
+}
+
+fn collect_arena_arithmetic_expression_visits<'a, F>(
+    expression: &'a ArithmeticExprArenaNode,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    match &expression.kind {
+        ArithmeticExprArena::Number(_) | ArithmeticExprArena::Variable(_) => {}
+        ArithmeticExprArena::ShellWord(word) => {
+            // The expression node does not carry a store, so callers should prefer
+            // the word-backed fallback when they need nested command traversal.
+            let _ = word;
+        }
+        ArithmeticExprArena::Indexed { index, .. }
+        | ArithmeticExprArena::Parenthesized { expression: index }
+        | ArithmeticExprArena::Unary { expr: index, .. }
+        | ArithmeticExprArena::Postfix { expr: index, .. } => {
+            collect_arena_arithmetic_expression_visits(index, options, context, visitor);
+        }
+        ArithmeticExprArena::Binary { left, right, .. } => {
+            collect_arena_arithmetic_expression_visits(left, options, context, visitor);
+            collect_arena_arithmetic_expression_visits(right, options, context, visitor);
+        }
+        ArithmeticExprArena::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_arena_arithmetic_expression_visits(condition, options, context, visitor);
+            collect_arena_arithmetic_expression_visits(then_expr, options, context, visitor);
+            collect_arena_arithmetic_expression_visits(else_expr, options, context, visitor);
+        }
+        ArithmeticExprArena::Assignment { target, value, .. } => {
+            if let ArithmeticLvalueArena::Indexed { index, .. } = target {
+                collect_arena_arithmetic_expression_visits(index, options, context, visitor);
+            }
+            collect_arena_arithmetic_expression_visits(value, options, context, visitor);
+        }
+    }
+}
+
+fn collect_arena_conditional_visits<'a, F>(
+    expression: &'a ConditionalExprArena,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    match expression {
+        ConditionalExprArena::Binary { left, right, .. } => {
+            collect_arena_conditional_visits(left, options, context, visitor);
+            collect_arena_conditional_visits(right, options, context, visitor);
+        }
+        ConditionalExprArena::Unary { expr, .. }
+        | ConditionalExprArena::Parenthesized { expr, .. } => {
+            collect_arena_conditional_visits(expr, options, context, visitor);
+        }
+        ConditionalExprArena::Pattern(pattern) => {
+            // Pattern nodes may contain word-backed fragments, but the expression
+            // node does not carry a store. Those fragments are also part of the
+            // enclosing command's word list and will be traversed from there.
+            let _ = pattern;
+        }
+        ConditionalExprArena::Word(_)
+        | ConditionalExprArena::Regex(_)
+        | ConditionalExprArena::VarRef(_) => {}
+    }
+}
+
+fn collect_arena_pattern_slice_visits<'a, F>(
+    store: &'a AstStore,
+    patterns: &'a [PatternNode],
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    for pattern in patterns {
+        collect_arena_pattern_visits(store, pattern, options, context, visitor);
+    }
+}
+
+fn collect_arena_pattern_visits<'a, F>(
+    store: &'a AstStore,
+    pattern: &'a PatternNode,
+    options: CommandWalkOptions,
+    context: CommandTraversalContext,
+    visitor: &mut F,
+) where
+    F: FnMut(ArenaCommandVisit<'a>, CommandTraversalContext),
+{
+    for part in store.pattern_parts(pattern.parts) {
+        match &part.kind {
+            PatternPartArena::Group { patterns, .. } => {
+                collect_arena_pattern_slice_visits(
+                    store,
+                    store.patterns(*patterns),
+                    options,
+                    context,
+                    visitor,
+                );
+            }
+            PatternPartArena::Word(word) => {
+                collect_arena_word_visit(store.word(*word), options, context, visitor);
+            }
+            PatternPartArena::Literal(_)
+            | PatternPartArena::AnyString
+            | PatternPartArena::AnyChar
+            | PatternPartArena::CharClass(_) => {}
+        }
     }
 }
 
@@ -848,6 +1752,85 @@ fn collect_pattern_visits<'a, F>(
             | PatternPart::AnyChar
             | PatternPart::CharClass(_) => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod arena_traversal_tests {
+    use shuck_parser::parser::Parser;
+
+    use super::*;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct SeenCommand {
+        start: usize,
+        end: usize,
+        nested_word_command: bool,
+        loop_depth: usize,
+        in_if_condition: bool,
+        in_elif_condition: bool,
+        condition_kind: Option<ConditionKind>,
+    }
+
+    fn seen_from_context(span: Span, context: CommandTraversalContext) -> SeenCommand {
+        SeenCommand {
+            start: span.start.offset,
+            end: span.end.offset,
+            nested_word_command: context.nested_word_command,
+            loop_depth: context.walk.loop_depth,
+            in_if_condition: context.in_if_condition,
+            in_elif_condition: context.in_elif_condition,
+            condition_kind: context.condition_kind,
+        }
+    }
+
+    fn recursive_visits(source: &str) -> Vec<SeenCommand> {
+        let output = Parser::new(source).parse().expect("parse");
+        let mut visits = Vec::new();
+        walk_commands(
+            &output.file.body,
+            CommandWalkOptions {
+                descend_nested_word_commands: true,
+            },
+            &mut |visit, context| {
+                visits.push(seen_from_context(command_span(visit.command), context));
+            },
+        );
+        visits
+    }
+
+    fn arena_visits(source: &str) -> Vec<SeenCommand> {
+        let output = Parser::new(source).parse().expect("parse");
+        let mut visits = Vec::new();
+        walk_arena_commands(
+            output.arena_file.view().body(),
+            CommandWalkOptions {
+                descend_nested_word_commands: true,
+            },
+            &mut |visit, context| {
+                visits.push(seen_from_context(visit.command.span(), context));
+            },
+        );
+        visits
+    }
+
+    #[test]
+    fn arena_command_walk_matches_recursive_contexts() {
+        let source = r#"
+if test "$x"; then
+  echo "$(date)"
+elif grep foo file; then
+  while read line; do printf '%s\n' "$line"; done
+else
+  find . -exec sh -c 'echo "$1"' sh {} \;
+fi
+for name in "$(printf '%s\n' a)"; do :; done
+case "$x" in
+  a$(echo b)) echo c ;;
+esac
+"#;
+
+        assert_eq!(arena_visits(source), recursive_visits(source));
     }
 }
 

--- a/crates/shuck-linter/src/facts/word_spans.rs
+++ b/crates/shuck-linter/src/facts/word_spans.rs
@@ -3342,7 +3342,7 @@ fn literal_glob_pattern_spans(span: Span, source: &str) -> Vec<Span> {
     spans
 }
 
-fn suspicious_bracket_glob_text(text: &str) -> bool {
+pub(crate) fn suspicious_bracket_glob_text(text: &str) -> bool {
     let bytes = text.as_bytes();
     if bytes.len() < 3 || bytes[0] != b'[' || *bytes.last().unwrap_or(&b'\0') != b']' {
         return false;

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1056,6 +1056,7 @@ fn is_fully_quoted(word: &Word) -> bool {
 #[derive(Debug)]
 pub struct WordNode<'a> {
     key: FactSpan,
+    arena_word_id: Option<WordId>,
     word: &'a Word,
     analysis: ExpansionAnalysis,
     derived: WordNodeDerived<'a>,
@@ -1094,6 +1095,38 @@ pub struct WordOccurrence {
     operand_class: Option<TestOperandClass>,
     enclosing_expansion_context: Option<ExpansionContext>,
     array_assignment_split_scalar_expansion_spans: IdRange<Span>,
+}
+
+#[derive(Clone, Copy)]
+pub struct FactWordRef<'facts> {
+    arena_file: &'facts ArenaFile,
+    id: WordId,
+}
+
+impl<'facts> FactWordRef<'facts> {
+    pub(crate) fn new(arena_file: &'facts ArenaFile, id: WordId) -> Self {
+        Self { arena_file, id }
+    }
+
+    pub fn id(self) -> WordId {
+        self.id
+    }
+
+    pub fn view(self) -> WordView<'facts> {
+        self.arena_file.store.word(self.id)
+    }
+
+    pub fn span(self) -> Span {
+        self.view().span()
+    }
+
+    pub fn static_text(self, source: &'facts str) -> Option<Cow<'facts, str>> {
+        static_word_text_arena(self.view(), source)
+    }
+
+    pub fn parts(self) -> &'facts [WordPartArenaNode] {
+        self.view().parts()
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -1203,12 +1236,26 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.node().word
     }
 
+    pub fn arena_word_id(self) -> Option<WordId> {
+        self.node().arena_word_id
+    }
+
+    pub fn arena_word(self) -> Option<WordView<'facts>> {
+        self.arena_word_id()
+            .map(|id| self.facts.arena_file.store.word(id))
+    }
+
+    pub fn arena_word_ref(self) -> Option<FactWordRef<'facts>> {
+        self.arena_word_id()
+            .map(|id| FactWordRef::new(&self.facts.arena_file, id))
+    }
+
     pub fn key(self) -> FactSpan {
         self.node().key
     }
 
     pub fn span(self) -> Span {
-        self.word().span
+        self.arena_word().map_or(self.word().span, |word| word.span())
     }
 
     pub fn single_double_quoted_replacement(self, source: &str) -> Box<str> {
@@ -1338,6 +1385,10 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.derived()
             .static_text
             .map(Cow::Borrowed)
+            .or_else(|| {
+                self.arena_word()
+                    .and_then(|word| static_word_text_arena(word, source))
+            })
             .or_else(|| static_word_text(self.word(), source))
     }
 
@@ -2290,7 +2341,7 @@ struct WordFactLookup<'facts, 'a> {
 
 fn build_echo_to_sed_substitution_spans<'a>(
     commands: CommandFacts<'_, 'a>,
-    pipelines: &[PipelineFact<'a>],
+    pipelines: &[PipelineFact],
     backticks: &[BacktickFragmentFact],
     lookup: WordFactLookup<'_, 'a>,
 ) -> Vec<Span> {
@@ -2318,7 +2369,7 @@ fn build_echo_to_sed_substitution_spans<'a>(
 
 fn sc2001_like_pipeline_span<'a>(
     commands: CommandFacts<'_, 'a>,
-    pipeline: &PipelineFact<'a>,
+    pipeline: &PipelineFact,
     backticks: &[BacktickFragmentFact],
     lookup: WordFactLookup<'_, 'a>,
 ) -> Option<Span> {
@@ -2336,7 +2387,7 @@ fn sc2001_like_pipeline_span<'a>(
     if left
         .options()
         .echo()
-        .and_then(|echo| echo.portability_flag_word())
+        .and_then(|echo| echo.portability_flag_span())
         .is_some()
     {
         return None;
@@ -2415,7 +2466,7 @@ fn sc2001_like_here_string_span(
     let mut here_strings = command
         .redirect_facts()
         .iter()
-        .filter(|redirect| redirect.redirect().kind == RedirectKind::HereString);
+        .filter(|redirect| redirect.kind() == RedirectKind::HereString);
     here_strings.next()?;
     if here_strings.next().is_some() {
         return None;
@@ -2434,7 +2485,7 @@ fn command_is_plain_named(command: CommandFactRef<'_, '_>, name: &str) -> bool {
 
 fn sc2001_like_backtick_pipeline_span(
     commands: CommandFacts<'_, '_>,
-    pipeline: &PipelineFact<'_>,
+    pipeline: &PipelineFact,
     sed_command: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<Span> {
@@ -3410,6 +3461,14 @@ pub(crate) fn benchmark_collect_word_facts(
     source: &str,
     semantic: &SemanticModel,
 ) -> usize {
+    let arena_file = ArenaFile::from_file(file);
+    let mut arena_word_ids_by_span =
+        FxHashMap::with_capacity_and_hasher(arena_file.store.word_count(), Default::default());
+    for index in 0..arena_file.store.word_count() {
+        let id = WordId::new(index);
+        arena_word_ids_by_span.insert(FactSpan::new(arena_file.store.word(id).span()), id);
+    }
+
     let mut word_nodes = Vec::new();
     let mut word_node_ids_by_span = FxHashMap::default();
     let mut word_occurrences = Vec::new();
@@ -3452,6 +3511,7 @@ pub(crate) fn benchmark_collect_word_facts(
                 WordFactOutputs {
                     word_nodes: &mut word_nodes,
                     word_node_ids_by_span: &mut word_node_ids_by_span,
+                    arena_word_ids_by_span: &arena_word_ids_by_span,
                     word_occurrences: &mut word_occurrences,
                     pending_arithmetic_word_occurrences: &mut pending_arithmetic_word_occurrences,
                     compound_assignment_value_word_spans: &mut compound_assignment_value_word_spans,
@@ -3506,6 +3566,7 @@ struct WordFactOutputs<'out, 'a> {
     word_spans: &'out mut ListArena<Span>,
     word_span_scratch: &'out mut Vec<Span>,
     word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
+    arena_word_ids_by_span: &'out FxHashMap<FactSpan, WordId>,
     word_occurrences: &'out mut Vec<WordOccurrence>,
     pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
@@ -3815,6 +3876,7 @@ struct WordFactCollector<'out, 'a, 'norm> {
     word_spans: &'out mut ListArena<Span>,
     word_span_scratch: &'out mut Vec<Span>,
     word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
+    arena_word_ids_by_span: &'out FxHashMap<FactSpan, WordId>,
     word_occurrences: &'out mut Vec<WordOccurrence>,
     pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
@@ -3872,6 +3934,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             word_spans: outputs.word_spans,
             word_span_scratch: outputs.word_span_scratch,
             word_node_ids_by_span: outputs.word_node_ids_by_span,
+            arena_word_ids_by_span: outputs.arena_word_ids_by_span,
             word_occurrences: outputs.word_occurrences,
             pending_arithmetic_word_occurrences: outputs.pending_arithmetic_word_occurrences,
             array_assignment_split_word_ids: outputs.array_assignment_split_word_ids,
@@ -4768,6 +4831,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         if let Some(id) = self.word_node_ids_by_span.get(&key).copied() {
             return id;
         }
+        let arena_word_id = self.arena_word_ids_by_span.get(&key).copied();
 
         let id = WordNodeId::new(self.word_nodes.len());
         let analysis = analyze_word(word, self.source, self.command_zsh_options.as_ref());
@@ -4775,6 +4839,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             derive_word_fact_data(word, self.source, self.word_spans, self.word_span_scratch);
         self.word_nodes.push(WordNode {
             key,
+            arena_word_id,
             word,
             analysis,
             derived,
@@ -7201,7 +7266,11 @@ fn mapfile_option_takes_argument(flag: char) -> bool {
     matches!(flag, 'u' | 'C' | 'c' | 'd' | 'n' | 'O' | 's')
 }
 
-fn parse_xargs_command<'a>(args: &[&'a Word], source: &str) -> XargsCommandFacts<'a> {
+fn parse_xargs_command<'a>(
+    args: &[&'a Word],
+    source: &str,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
+) -> XargsCommandFacts {
     let mut uses_null_input = false;
     let mut max_procs = None;
     let mut zero_digit_option_word = false;
@@ -7290,12 +7359,15 @@ fn parse_xargs_command<'a>(args: &[&'a Word], source: &str) -> XargsCommandFacts
         }
     }
 
+    let command_operand_words = args[index..].to_vec().into_boxed_slice();
+    let command_operand_word_ids =
+        word_ids_for_words(command_operand_words.iter().copied(), arena_word_ids_by_span);
     XargsCommandFacts {
         uses_null_input,
         max_procs,
         zero_digit_option_word,
         inline_replace_options: inline_replace_options.into_boxed_slice(),
-        command_operand_words: args[index..].to_vec().into_boxed_slice(),
+        command_operand_word_ids,
         sc2267_default_replace_silent_shape: xargs_sc2267_default_replace_silent_shape(
             &args[index..],
             source,
@@ -7441,13 +7513,19 @@ fn expr_string_helper(args: &[&Word], source: &str) -> Option<(ExprStringHelperK
     Some((kind, word.span))
 }
 
-fn parse_exit_command<'a>(command: &'a Command, source: &str) -> Option<ExitCommandFacts<'a>> {
+fn parse_exit_command<'a>(
+    command: &'a Command,
+    source: &str,
+    arena_word_ids_by_span: &FxHashMap<FactSpan, WordId>,
+) -> Option<ExitCommandFacts> {
     let Command::Builtin(BuiltinCommand::Exit(exit)) = command else {
         return None;
     };
     let Some(status_word) = exit.code.as_ref() else {
         return Some(ExitCommandFacts {
             status_word: None,
+            status_word_span: None,
+            status_word_id: None,
             is_numeric_literal: false,
             status_is_static: false,
             status_has_literal_content: false,
@@ -7456,7 +7534,11 @@ fn parse_exit_command<'a>(command: &'a Command, source: &str) -> Option<ExitComm
     let status_text = static_word_text(status_word, source);
 
     Some(ExitCommandFacts {
-        status_word: Some(status_word),
+        status_word: Some(FactWordSpan {
+            span: status_word.span,
+        }),
+        status_word_span: Some(status_word.span),
+        status_word_id: word_id_for_word(status_word, arena_word_ids_by_span),
         is_numeric_literal: status_text.as_deref().is_some_and(|text| {
             !text.is_empty() && text.chars().all(|character| character.is_ascii_digit())
         }),

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -121,7 +121,7 @@ use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{
     SemanticBuildOptions, SemanticModel, SourcePathResolver, TraversalObserver,
-    build_with_observer_arena_with_options, build_with_observer_with_options,
+    build_with_observer_arena_with_options,
 };
 use std::path::Path;
 
@@ -286,6 +286,7 @@ fn analyze_file_at_path_with_resolver_and_shell(
     shell: ShellDialect,
     first_parse_error: Option<(usize, usize)>,
 ) -> AnalysisResult {
+    let ast = ArenaFile::from_file(file);
     let file_context = classify_file_context(source, source_path, shell);
     let file_entry_contract =
         ambient_contracts::file_entry_contract(source, source_path, shell, &file_context);
@@ -298,8 +299,8 @@ fn analyze_file_at_path_with_resolver_and_shell(
 
     let mut observer = LintTraversalObserver::default();
     let shell_profile = shell.shell_profile();
-    let semantic = build_with_observer_with_options(
-        file,
+    let semantic = build_with_observer_arena_with_options(
+        &ast,
         source,
         indexer,
         &mut observer,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -116,7 +116,7 @@ pub use suppression::{
 pub use violation::Violation;
 
 use rustc_hash::FxHashSet;
-use shuck_ast::{File, Position, Span, TextSize};
+use shuck_ast::{ArenaFile, File, Position, Span, TextSize};
 use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{
@@ -155,6 +155,18 @@ pub fn analyze_file(
     suppression_index: Option<&SuppressionIndex>,
 ) -> AnalysisResult {
     analyze_file_at_path(file, source, indexer, settings, suppression_index, None)
+}
+
+/// Builds semantic facts and linter diagnostics for an arena-backed parsed file.
+pub fn analyze_arena_file(
+    ast: &ArenaFile,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+) -> AnalysisResult {
+    let file = ast.to_file();
+    analyze_file(&file, source, indexer, settings, suppression_index)
 }
 
 #[cfg(feature = "benchmarking")]
@@ -467,6 +479,59 @@ pub fn lint_file(
     )
 }
 
+/// Lints an arena-backed parse result located at an optional source path.
+pub fn lint_arena_file(
+    parse_result: &ParseResult,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
+) -> Vec<Diagnostic> {
+    let file = parse_result.arena_file.to_file();
+    let shell = resolve_shell(settings, source, source_path);
+
+    let mut diagnostics = analyze_file_at_path_with_resolver_and_shell(
+        &file,
+        source,
+        indexer,
+        settings,
+        suppression_index,
+        source_path,
+        None,
+        shell,
+        parse_error_position(parse_result),
+    )
+    .diagnostics;
+
+    diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
+        &file,
+        source,
+        Some(parse_result),
+        &settings.rules,
+        shell,
+    ));
+    if parse_result.is_err() {
+        sanitize_diagnostic_spans_cold(&mut diagnostics, source, indexer);
+    }
+
+    for diagnostic in &mut diagnostics {
+        if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
+            diagnostic.severity = severity;
+        }
+    }
+
+    if let Some(suppression_index) = suppression_index {
+        filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
+    }
+    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
+
+    diagnostics
+        .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
+
+    diagnostics
+}
+
 fn filter_suppressed_diagnostics(
     diagnostics: &mut Vec<Diagnostic>,
     indexer: &Indexer,
@@ -594,6 +659,12 @@ mod tests {
         lint_file(&output, source, &indexer, settings, None, None)
     }
 
+    fn lint_arena(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new_arena(source, &output.arena_file, &output.syntax_facts);
+        lint_arena_file(&output, source, &indexer, settings, None, None)
+    }
+
     fn lint_path(path: &Path, settings: &LinterSettings) -> Vec<Diagnostic> {
         let source = fs::read_to_string(path).unwrap();
         let output = Parser::new(&source).parse().unwrap();
@@ -703,6 +774,7 @@ mod tests {
             offset: 14,
         };
         let parse_result = ParseResult {
+            arena_file: shuck_ast::ArenaFile::from_file(&file),
             file,
             diagnostics: vec![ParseDiagnostic {
                 message: "expected command".to_owned(),
@@ -714,6 +786,29 @@ mod tests {
         };
 
         assert_eq!(parse_error_position(&parse_result), Some((3, 2)));
+    }
+
+    #[test]
+    fn arena_lint_matches_recursive_lint_for_basic_diagnostics() {
+        let source = "#!/bin/bash\nunused=1\necho \"$missing\"\n";
+        let settings = LinterSettings::default();
+        let recursive = lint(source, &settings);
+        let arena = lint_arena(source, &settings);
+
+        let summarize = |diagnostics: &[Diagnostic]| {
+            diagnostics
+                .iter()
+                .map(|diagnostic| {
+                    (
+                        diagnostic.rule,
+                        diagnostic.span.start.offset,
+                        diagnostic.span.end.offset,
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        assert_eq!(summarize(&arena), summarize(&recursive));
     }
 
     #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -58,11 +58,12 @@ pub use diagnostic::{Diagnostic, Severity};
 pub use facts::CommandSubstitutionKind;
 /// Extracted structural facts available to rules and callers.
 pub use facts::{
-    BacktickFragmentFact, CommandFact, CommandFactRef, CommandFacts, CommandOptionFacts,
-    ConditionalBareWordFact, ConditionalBinaryFact, ConditionalFact,
-    ConditionalMixedLogicalOperatorFact, ConditionalNodeFact, ConditionalOperandFact,
-    ConditionalOperatorFamily, ConditionalPortabilityFacts, ConditionalUnaryFact, ExitCommandFacts,
-    ExpansionAnalysis, ExpansionContext, ExpansionHazards, ExpansionValueShape, FindCommandFacts,
+    ArenaNormalizedCommand, ArenaNormalizedDeclaration, BacktickFragmentFact, CommandFact,
+    CommandFactCompoundKind, CommandFactRef, CommandFacts, CommandOptionFacts, ConditionalBareWordFact,
+    ConditionalBinaryFact, ConditionalFact, ConditionalMixedLogicalOperatorFact,
+    ConditionalNodeFact, ConditionalOperandFact, ConditionalOperatorFamily,
+    ConditionalPortabilityFacts, ConditionalUnaryFact, ExitCommandFacts, ExpansionAnalysis,
+    ExpansionContext, ExpansionHazards, ExpansionValueShape, FactWordRef, FindCommandFacts,
     FindExecCommandFacts, FindExecShellCommandFacts, ForHeaderFact, FunctionCallArityFacts,
     FunctionHeaderFact, GrepPatternSourceKind, LegacyArithmeticFragmentFact, ListFact,
     ListOperatorFact, LoopHeaderWordFact, PathWordFact, PipelineFact, PipelineOperatorFact,
@@ -315,6 +316,7 @@ fn analyze_file_at_path_with_resolver_and_shell(
     );
     let checker = Checker::new(
         file,
+        &ast,
         source,
         &semantic,
         indexer,
@@ -372,7 +374,7 @@ fn analyze_arena_file_at_path_with_resolver_and_shell(
         .or(analyzed_paths_fallback.as_ref());
 
     let mut observer = LintTraversalObserver::default();
-    let shell_profile = inferred_shell_profile(shell);
+    let shell_profile = shell.shell_profile();
     let semantic = build_with_observer_arena_with_options(
         ast,
         source,
@@ -389,6 +391,7 @@ fn analyze_arena_file_at_path_with_resolver_and_shell(
     );
     let checker = Checker::new(
         &file,
+        ast,
         source,
         &semantic,
         indexer,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -661,7 +661,7 @@ mod tests {
 
     fn lint_arena(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
         let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new_arena(source, &output.arena_file, &output.syntax_facts);
+        let indexer = Indexer::new_arena(source, &output.arena_file);
         lint_arena_file(&output, source, &indexer, settings, None, None)
     }
 

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -121,7 +121,7 @@ use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{
     SemanticBuildOptions, SemanticModel, SourcePathResolver, TraversalObserver,
-    build_with_observer_with_options,
+    build_with_observer_arena_with_options, build_with_observer_with_options,
 };
 use std::path::Path;
 
@@ -165,8 +165,7 @@ pub fn analyze_arena_file(
     settings: &LinterSettings,
     suppression_index: Option<&SuppressionIndex>,
 ) -> AnalysisResult {
-    let file = ast.to_file();
-    analyze_file(&file, source, indexer, settings, suppression_index)
+    analyze_arena_file_at_path(ast, source, indexer, settings, suppression_index, None)
 }
 
 #[cfg(feature = "benchmarking")]
@@ -200,6 +199,52 @@ pub fn analyze_file_at_path(
         suppression_index,
         source_path,
         None,
+    )
+}
+
+/// Builds semantic facts and linter diagnostics for an arena-backed file at an optional source path.
+pub fn analyze_arena_file_at_path(
+    ast: &ArenaFile,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
+) -> AnalysisResult {
+    analyze_arena_file_at_path_with_resolver(
+        ast,
+        source,
+        indexer,
+        settings,
+        suppression_index,
+        source_path,
+        None,
+    )
+}
+
+/// Builds semantic facts and linter diagnostics for an arena-backed file with a custom resolver.
+pub fn analyze_arena_file_at_path_with_resolver(
+    ast: &ArenaFile,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+) -> AnalysisResult {
+    let shell = resolve_shell(settings, source, source_path);
+    let first_parse_error = parse_error_position(&parse_for_lint(source, shell));
+
+    analyze_arena_file_at_path_with_resolver_and_shell(
+        ast,
+        source,
+        indexer,
+        settings,
+        suppression_index,
+        source_path,
+        source_path_resolver,
+        shell,
+        first_parse_error,
     )
 }
 
@@ -269,6 +314,80 @@ fn analyze_file_at_path_with_resolver_and_shell(
     );
     let checker = Checker::new(
         file,
+        source,
+        &semantic,
+        indexer,
+        &settings.rules,
+        shell,
+        settings.ambient_shell_options,
+        settings.report_environment_style_names,
+        settings.rule_options.clone(),
+        &file_context,
+        suppression_index,
+        first_parse_error,
+    );
+    let mut diagnostics = observer.into_diagnostics();
+    diagnostics.extend(checker.check());
+    for diagnostic in &mut diagnostics {
+        if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
+            diagnostic.severity = severity;
+        }
+    }
+
+    if let Some(suppression_index) = suppression_index {
+        filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
+    }
+    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
+
+    diagnostics
+        .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
+    AnalysisResult {
+        semantic,
+        diagnostics,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn analyze_arena_file_at_path_with_resolver_and_shell(
+    ast: &ArenaFile,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+    shell: ShellDialect,
+    first_parse_error: Option<(usize, usize)>,
+) -> AnalysisResult {
+    let file = ast.to_file();
+    let file_context = classify_file_context(source, source_path, shell);
+    let file_entry_contract =
+        ambient_contracts::file_entry_contract(source, source_path, shell, &file_context);
+    let analyzed_paths_fallback =
+        source_path.map(|path| FxHashSet::from_iter([path.to_path_buf()]));
+    let analyzed_paths = settings
+        .analyzed_paths
+        .as_deref()
+        .or(analyzed_paths_fallback.as_ref());
+
+    let mut observer = LintTraversalObserver::default();
+    let shell_profile = inferred_shell_profile(shell);
+    let semantic = build_with_observer_arena_with_options(
+        ast,
+        source,
+        indexer,
+        &mut observer,
+        SemanticBuildOptions {
+            source_path,
+            source_path_resolver,
+            file_entry_contract,
+            analyzed_paths,
+            shell_profile: Some(shell_profile),
+            resolve_source_closure: settings.resolve_source_closure,
+        },
+    );
+    let checker = Checker::new(
+        &file,
         source,
         &semantic,
         indexer,
@@ -488,11 +607,10 @@ pub fn lint_arena_file(
     suppression_index: Option<&SuppressionIndex>,
     source_path: Option<&Path>,
 ) -> Vec<Diagnostic> {
-    let file = parse_result.arena_file.to_file();
     let shell = resolve_shell(settings, source, source_path);
 
-    let mut diagnostics = analyze_file_at_path_with_resolver_and_shell(
-        &file,
+    let mut diagnostics = analyze_arena_file_at_path_with_resolver_and_shell(
+        &parse_result.arena_file,
         source,
         indexer,
         settings,
@@ -505,7 +623,7 @@ pub fn lint_arena_file(
     .diagnostics;
 
     diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
-        &file,
+        &parse_result.file,
         source,
         Some(parse_result),
         &settings.rules,

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1,9 +1,9 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
-    BinaryOp, BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand, FunctionDef,
-    Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Position, RedirectKind,
-    SourceText, Span, Stmt, StmtSeq, StmtTerminator, VarRef, Word, WordPart, WordPartNode,
-    static_word_text, word_is_standalone_status_capture, word_is_standalone_variable_like,
+    BinaryOp, BourneParameterExpansion, Name, ParameterExpansion, ParameterExpansionSyntax,
+    ParameterOp, Position, RedirectKind, SourceText, Span, StmtTerminator, VarRef, Word, WordPart,
+    WordPartNode, static_word_text,
+    word_is_standalone_status_capture, word_is_standalone_variable_like,
 };
 use shuck_semantic::{
     AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, LoopValueOrigin, ScopeId,
@@ -11,7 +11,7 @@ use shuck_semantic::{
 };
 use shuck_semantic::{BindingId, BlockId, ReferenceId, ReferenceKind};
 
-use crate::facts::analyze_literal_runtime;
+use crate::facts::{CommandFactCompoundKind, analyze_literal_runtime};
 use crate::{ExpansionContext, FactSpan, LinterFacts};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -127,8 +127,8 @@ impl<'a> SafeValueIndex<'a> {
         let mut function_commands_by_span = FxHashMap::default();
         let mut commands_by_name_word_span = FxHashMap::default();
         for command in facts.commands() {
-            if let Command::Function(function) = command.command() {
-                function_commands_by_span.insert(FactSpan::new(function.span), command.id());
+            if command.command_kind() == shuck_ast::ArenaFileCommandKind::Function {
+                function_commands_by_span.insert(FactSpan::new(command.span()), command.id());
             }
             if let Some(name_word) = command.body_name_word() {
                 commands_by_name_word_span.insert(FactSpan::new(name_word.span), command.id());
@@ -337,15 +337,15 @@ impl<'a> SafeValueIndex<'a> {
             .or_else(|| self.innermost_command_id_containing_offset(span.start.offset));
         while let Some(command_id) = current {
             if matches!(
-                self.facts.command(command_id).command(),
-                Command::Compound(
-                    CompoundCommand::For(_)
-                        | CompoundCommand::Repeat(_)
-                        | CompoundCommand::Foreach(_)
-                        | CompoundCommand::ArithmeticFor(_)
-                        | CompoundCommand::While(_)
-                        | CompoundCommand::Until(_)
-                        | CompoundCommand::Select(_)
+                self.facts.command(command_id).compound_kind(),
+                Some(
+                    CommandFactCompoundKind::For
+                        | CommandFactCompoundKind::Repeat
+                        | CommandFactCompoundKind::Foreach
+                        | CommandFactCompoundKind::ArithmeticFor
+                        | CommandFactCompoundKind::While
+                        | CommandFactCompoundKind::Until
+                        | CommandFactCompoundKind::Select
                 )
             ) {
                 return true;
@@ -362,15 +362,23 @@ impl<'a> SafeValueIndex<'a> {
             .innermost_command_id_at(span.start.offset)
             .or_else(|| self.innermost_command_id_containing_offset(span.start.offset));
         while let Some(command_id) = current {
-            if let Command::Compound(CompoundCommand::If(command)) =
-                self.facts.command(command_id).command()
-                && (span_contains(command.condition.span, span)
-                    || command
-                        .elif_branches
-                        .iter()
-                        .any(|(condition, _)| span_contains(condition.span, span)))
+            let fact = self.facts.command(command_id);
+            if let Some(compound) = fact.arena_command().and_then(|command| command.compound())
+                && let shuck_ast::CompoundCommandNode::If {
+                    condition,
+                    elif_branches,
+                    ..
+                } = compound.node()
             {
-                return true;
+                let store = compound.store();
+                if span_contains(store.stmt_seq(*condition).span(), span)
+                    || store
+                        .elif_branches(*elif_branches)
+                        .iter()
+                        .any(|branch| span_contains(store.stmt_seq(branch.condition).span(), span))
+                {
+                    return true;
+                }
             }
             current = self.facts.command_parent_id(command_id);
         }
@@ -704,12 +712,10 @@ impl<'a> SafeValueIndex<'a> {
     ) -> bool {
         let binding = self.semantic.binding(binding_id);
         self.facts.function_headers().iter().any(|header| {
-            let Some(function_definition_command) =
-                self.function_definition_command(header.function())
-            else {
+            let Some(function_definition_command) = self.function_definition_command(header) else {
                 return false;
             };
-            function_has_terminal_exit(header.function())
+            header.has_terminal_exit()
                 && header
                     .call_arity()
                     .zero_arg_call_spans()
@@ -737,20 +743,21 @@ impl<'a> SafeValueIndex<'a> {
             command.span().end.offset <= at.start.offset
                 && !command.is_nested_word_command()
                 && self.command_runs_in_unconditional_flow(command.id(), at)
-                && matches!(
-                    command.command(),
-                    Command::Builtin(BuiltinCommand::Exit(_) | BuiltinCommand::Return(_))
-                )
+                && matches!(command.effective_name(), Some("exit" | "return"))
         })
     }
 
     fn function_definition_command(
         &self,
-        function: &FunctionDef,
+        header: &crate::FunctionHeaderFact,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
-        self.function_commands_by_span
-            .get(&FactSpan::new(function.span))
-            .copied()
+        header
+            .command_id()
+            .or_else(|| {
+                self.function_commands_by_span
+                    .get(&FactSpan::new(header.function_span()))
+                    .copied()
+            })
             .map(|id| self.facts.command(id))
     }
 
@@ -837,10 +844,7 @@ impl<'a> SafeValueIndex<'a> {
     fn command_is_in_background_context(&self, command_id: crate::facts::CommandId) -> bool {
         let mut current = Some(command_id);
         while let Some(id) = current {
-            if matches!(
-                self.facts.command(id).stmt().terminator,
-                Some(StmtTerminator::Background(_))
-            ) {
+            if matches!(self.facts.command(id).stmt_terminator(), Some(StmtTerminator::Background(_))) {
                 return true;
             }
             current = self.facts.command_parent_id(id);
@@ -1553,7 +1557,7 @@ impl<'a> SafeValueIndex<'a> {
 
     fn unset_targets_variable_name(
         &self,
-        unset: &crate::facts::UnsetCommandFacts<'a>,
+        unset: &crate::facts::UnsetCommandFacts,
         name: &Name,
     ) -> bool {
         if unset.function_mode || unset.nameref_mode() || !unset.options_parseable() {
@@ -1561,8 +1565,7 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         unset.operand_facts().iter().any(|operand| {
-            operand.array_subscript().is_none()
-                && static_word_text(operand.word(), self.source).as_deref() == Some(name.as_str())
+            operand.array_subscript().is_none() && operand.static_text() == Some(name.as_str())
         })
     }
 
@@ -1632,14 +1635,12 @@ impl<'a> SafeValueIndex<'a> {
     fn loop_variable_reference_stays_within_body(&self, definition_span: Span, at: Span) -> bool {
         self.facts.for_headers().iter().any(|header| {
             header
-                .command()
-                .targets
+                .target_spans()
                 .iter()
-                .any(|target| target.span == definition_span)
-                && span_contains(header.command().body.span, at)
+                .any(|target_span| *target_span == definition_span)
+                && span_contains(header.body_span(), at)
         }) || self.facts.select_headers().iter().any(|header| {
-            header.command().variable_span == definition_span
-                && span_contains(header.command().body.span, at)
+            header.variable_span() == definition_span && span_contains(header.body_span(), at)
         })
     }
 
@@ -2549,8 +2550,7 @@ impl<'a> SafeValueIndex<'a> {
             let Some(function_kind) = self.named_function_kind(callee_scope) else {
                 continue;
             };
-            let Some(definition_command) = self.function_definition_command(header.function())
-            else {
+            let Some(definition_command) = self.function_definition_command(header) else {
                 continue;
             };
 
@@ -2580,7 +2580,7 @@ impl<'a> SafeValueIndex<'a> {
             .function_headers()
             .iter()
             .find(|header| header.function_scope() == Some(scope))
-            .map(|header| header.function().span.end.offset)
+            .map(|header| header.function_span().end.offset)
     }
 
     fn call_site_dominates_use(&self, call_span: Span, name: &Name, at: Span) -> bool {
@@ -2869,9 +2869,7 @@ impl<'a> SafeValueIndex<'a> {
     fn command_is_in_boolean_list(&self, command_id: crate::facts::CommandId) -> bool {
         let mut current = self.facts.command_parent_id(command_id);
         while let Some(id) = current {
-            if let Command::Binary(binary) = self.facts.command(id).command()
-                && matches!(binary.op, BinaryOp::And | BinaryOp::Or)
-            {
+            if matches!(self.facts.command(id).binary_op(), Some(BinaryOp::And | BinaryOp::Or)) {
                 return true;
             }
             current = self.facts.command_parent_id(id);
@@ -3301,28 +3299,27 @@ fn build_case_cli_reachable_function_scopes(
                 .any(|ancestor| matches!(semantic.scope(ancestor).kind, ScopeKind::Function(_)));
             (nested
                 || dispatcher_offset
-                    .is_some_and(|offset| header.function().span.start.offset < offset)
+                    .is_some_and(|offset| header.function_span().start.offset < offset)
                 || top_level_exit_offset
-                    .is_some_and(|offset| header.function().span.start.offset < offset))
+                    .is_some_and(|offset| header.function_span().start.offset < offset))
             .then_some(scope)
         })
         .collect()
 }
 
 fn command_fact_is_standalone_exit(command: crate::facts::CommandFactRef<'_, '_>) -> bool {
-    if command.stmt().negated
-        || matches!(
-            command.stmt().terminator,
-            Some(StmtTerminator::Background(_))
-        )
+    if command.stmt_negated()
+        || matches!(command.stmt_terminator(), Some(StmtTerminator::Background(_)))
     {
         return false;
     }
 
-    let Command::Builtin(BuiltinCommand::Exit(exit)) = command.command() else {
+    if command.effective_name() != Some("exit") {
         return false;
     };
-    exit.extra_args.is_empty() && exit.assignments.is_empty() && command.stmt().redirects.is_empty()
+    command.arena_command().and_then(|command| command.builtin()).is_some_and(|exit| {
+        exit.extra_arg_ids().is_empty() && exit.assignments().is_empty()
+    }) && !command.has_redirects()
 }
 
 fn safe_special_parameter(name: &Name) -> bool {
@@ -3412,161 +3409,6 @@ fn special_parameter_slice_reference(reference: &VarRef) -> bool {
     matches!(reference.name.as_str(), "@" | "*")
 }
 
-fn function_has_terminal_exit(function: &FunctionDef) -> bool {
-    matches!(
-        stmt_terminal_flow_kind(&function.body),
-        TerminalFlowKind::Exit
-    )
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum TerminalFlowKind {
-    None,
-    MaybeExit,
-    MaybeStop,
-    Exit,
-    Stop,
-}
-
-fn stmt_seq_terminal_flow_kind(commands: &StmtSeq) -> TerminalFlowKind {
-    let mut saw_maybe_exit = false;
-    let mut saw_maybe_stop = false;
-
-    for stmt in commands.as_slice() {
-        match stmt_terminal_flow_kind(stmt) {
-            TerminalFlowKind::None => {}
-            TerminalFlowKind::MaybeExit => saw_maybe_exit = true,
-            TerminalFlowKind::MaybeStop => saw_maybe_stop = true,
-            TerminalFlowKind::Exit => {
-                return if saw_maybe_stop {
-                    TerminalFlowKind::Stop
-                } else {
-                    TerminalFlowKind::Exit
-                };
-            }
-            TerminalFlowKind::Stop => return TerminalFlowKind::Stop,
-        }
-    }
-
-    if saw_maybe_stop {
-        TerminalFlowKind::MaybeStop
-    } else if saw_maybe_exit {
-        TerminalFlowKind::MaybeExit
-    } else {
-        TerminalFlowKind::None
-    }
-}
-
-fn stmt_terminal_flow_kind(stmt: &Stmt) -> TerminalFlowKind {
-    if matches!(stmt.terminator, Some(StmtTerminator::Background(_))) {
-        return TerminalFlowKind::None;
-    }
-
-    command_terminal_flow_kind(&stmt.command)
-}
-
-fn command_terminal_flow_kind(command: &Command) -> TerminalFlowKind {
-    match command {
-        Command::Builtin(BuiltinCommand::Exit(_)) => TerminalFlowKind::Exit,
-        Command::Builtin(BuiltinCommand::Return(_)) => TerminalFlowKind::Stop,
-        Command::Compound(CompoundCommand::If(command)) => alternative_terminal_flow_kind(
-            std::iter::once(stmt_seq_terminal_flow_kind(&command.then_branch))
-                .chain(
-                    command
-                        .elif_branches
-                        .iter()
-                        .map(|(_, body)| stmt_seq_terminal_flow_kind(body)),
-                )
-                .chain(command.else_branch.iter().map(stmt_seq_terminal_flow_kind)),
-            command.else_branch.is_none(),
-        ),
-        Command::Compound(CompoundCommand::For(command)) => {
-            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
-        }
-        Command::Compound(CompoundCommand::Repeat(command)) => {
-            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
-        }
-        Command::Compound(CompoundCommand::Foreach(command)) => {
-            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
-        }
-        Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
-            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
-        }
-        Command::Compound(CompoundCommand::While(command)) => {
-            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
-        }
-        Command::Compound(CompoundCommand::Until(command)) => {
-            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
-        }
-        Command::Compound(CompoundCommand::Select(command)) => {
-            maybe_stop_terminal_flow_kind(stmt_seq_terminal_flow_kind(&command.body))
-        }
-        Command::Compound(CompoundCommand::Case(command)) => alternative_terminal_flow_kind(
-            command
-                .cases
-                .iter()
-                .map(|case| stmt_seq_terminal_flow_kind(&case.body)),
-            true,
-        ),
-        Command::Compound(CompoundCommand::BraceGroup(body)) => stmt_seq_terminal_flow_kind(body),
-        Command::Compound(CompoundCommand::Time(command)) => command
-            .command
-            .as_deref()
-            .map_or(TerminalFlowKind::None, stmt_terminal_flow_kind),
-        Command::Simple(_)
-        | Command::Builtin(_)
-        | Command::Decl(_)
-        | Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => TerminalFlowKind::None,
-    }
-}
-
-fn maybe_stop_terminal_flow_kind(flow: TerminalFlowKind) -> TerminalFlowKind {
-    match flow {
-        TerminalFlowKind::None => TerminalFlowKind::None,
-        TerminalFlowKind::MaybeExit | TerminalFlowKind::Exit => TerminalFlowKind::MaybeExit,
-        TerminalFlowKind::MaybeStop | TerminalFlowKind::Stop => TerminalFlowKind::MaybeStop,
-    }
-}
-
-fn alternative_terminal_flow_kind(
-    branches: impl IntoIterator<Item = TerminalFlowKind>,
-    can_skip_all: bool,
-) -> TerminalFlowKind {
-    let mut saw_none = can_skip_all;
-    let mut saw_maybe_exit = false;
-    let mut saw_maybe_stop = false;
-    let mut saw_exit = false;
-    let mut saw_stop = false;
-
-    for flow in branches {
-        match flow {
-            TerminalFlowKind::None => saw_none = true,
-            TerminalFlowKind::MaybeExit => saw_maybe_exit = true,
-            TerminalFlowKind::MaybeStop => saw_maybe_stop = true,
-            TerminalFlowKind::Exit => saw_exit = true,
-            TerminalFlowKind::Stop => saw_stop = true,
-        }
-    }
-
-    if saw_maybe_stop || ((saw_none || saw_maybe_exit) && saw_stop) {
-        return TerminalFlowKind::MaybeStop;
-    }
-    if saw_maybe_exit || (saw_none && saw_exit) {
-        return TerminalFlowKind::MaybeExit;
-    }
-    if saw_exit && !saw_stop {
-        return TerminalFlowKind::Exit;
-    }
-    if saw_exit || saw_stop {
-        return TerminalFlowKind::Stop;
-    }
-
-    TerminalFlowKind::None
-}
-
 fn span_strictly_contains(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset
         && outer.end.offset >= inner.end.offset
@@ -3583,7 +3425,7 @@ mod tests {
         SemanticBuildOptions, SemanticModel,
     };
 
-    use super::{SafeValueIndex, SafeValueQuery, function_has_terminal_exit};
+    use super::{SafeValueIndex, SafeValueQuery};
     use crate::ExpansionContext;
     use crate::LinterFacts;
     use crate::{ShellDialect, classify_file_context};
@@ -5637,7 +5479,7 @@ echo x >> ${OPENBSD_CONTENTS}
             })
             .expect("expected redirect target fact");
 
-        assert!(function_has_terminal_exit(exit_header.function()));
+        assert!(exit_header.has_terminal_exit());
         assert_eq!(exit_header.call_arity().zero_arg_call_spans().len(), 1);
 
         assert!(!safe_values.word_occurrence_is_safe(nested_argument, SafeValueQuery::Argv));
@@ -5699,7 +5541,7 @@ helper() (
             })
             .expect("expected helper function header");
 
-        assert!(!function_has_terminal_exit(helper_header.function()));
+        assert!(!helper_header.has_terminal_exit());
     }
 
     #[test]
@@ -5726,7 +5568,7 @@ helper() {
             })
             .expect("expected helper function header");
 
-        assert!(function_has_terminal_exit(helper_header.function()));
+        assert!(helper_header.has_terminal_exit());
     }
 
     #[test]
@@ -5752,7 +5594,7 @@ helper() {
             })
             .expect("expected helper function header");
 
-        assert!(function_has_terminal_exit(helper_header.function()));
+        assert!(helper_header.has_terminal_exit());
     }
 
     #[test]
@@ -5778,7 +5620,7 @@ helper() {
             })
             .expect("expected helper function header");
 
-        assert!(function_has_terminal_exit(helper_header.function()));
+        assert!(helper_header.has_terminal_exit());
     }
 
     #[test]
@@ -5804,7 +5646,7 @@ helper() {
             })
             .expect("expected helper function header");
 
-        assert!(function_has_terminal_exit(helper_header.function()));
+        assert!(helper_header.has_terminal_exit());
     }
 
     #[test]
@@ -5834,7 +5676,7 @@ helper() {
             })
             .expect("expected helper function header");
 
-        assert!(function_has_terminal_exit(helper_header.function()));
+        assert!(helper_header.has_terminal_exit());
     }
 
     #[test]
@@ -5863,7 +5705,7 @@ helper() {
             })
             .expect("expected helper function header");
 
-        assert!(!function_has_terminal_exit(helper_header.function()));
+        assert!(!helper_header.has_terminal_exit());
     }
 
     #[test]
@@ -5892,7 +5734,7 @@ helper() {
             })
             .expect("expected helper function header");
 
-        assert!(function_has_terminal_exit(helper_header.function()));
+        assert!(helper_header.has_terminal_exit());
     }
 
     #[test]
@@ -5919,7 +5761,7 @@ helper() {
             })
             .expect("expected helper function header");
 
-        assert!(!function_has_terminal_exit(helper_header.function()));
+        assert!(!helper_header.has_terminal_exit());
     }
 
     #[test]
@@ -5950,7 +5792,7 @@ helper() {
             })
             .expect("expected helper function header");
 
-        assert!(!function_has_terminal_exit(helper_header.function()));
+        assert!(!helper_header.has_terminal_exit());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -3641,7 +3641,7 @@ mod tests {
         let source = "#!/bin/bash\nprintf '%s\\n' \"${!HOME@}\" ${!HOME@}\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3662,7 +3662,7 @@ mod tests {
             .parse()
             .unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Zsh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3683,7 +3683,7 @@ mod tests {
             .parse()
             .unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Zsh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3717,7 +3717,7 @@ if [ \"$foo\" = \"\" ]; then foo=0; fi
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3741,7 +3741,7 @@ fi
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3763,7 +3763,7 @@ printf '%s\\n' $PPID
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3788,7 +3788,7 @@ f() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3816,7 +3816,7 @@ f() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3848,7 +3848,7 @@ printf '%s\\n' $copy $mixed $lower $trimmed $count
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3879,7 +3879,7 @@ done
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3931,7 +3931,7 @@ iptables $flag -t nat -N chain
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -3973,7 +3973,7 @@ done
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4011,7 +4011,7 @@ f() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4044,7 +4044,7 @@ done
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4080,7 +4080,7 @@ fi
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4116,7 +4116,7 @@ f() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4158,7 +4158,7 @@ f() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4214,7 +4214,7 @@ printf '%s\\n' vm-${disk_ext_with_default:-}
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4251,7 +4251,7 @@ foo=0
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4278,7 +4278,7 @@ esac
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4309,7 +4309,7 @@ free ${humanreadable}
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4335,7 +4335,7 @@ value=\"$(free ${humanreadable} | awk '{print $2}')\"
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4363,7 +4363,7 @@ done
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4414,7 +4414,7 @@ echo \"MD5SUM=\\\"$( md5sum $PRGNAM-$VERSION.tar.xz | cut -d' ' -f1 )\\\"\"
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4449,7 +4449,7 @@ config() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4506,7 +4506,7 @@ printf '%s\\n' $opt hi
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4570,7 +4570,7 @@ GetAMI
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4609,7 +4609,7 @@ GetAMI
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4667,7 +4667,7 @@ fn_backup_compression
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4705,7 +4705,7 @@ exit $?
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4751,7 +4751,7 @@ esac
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4794,7 +4794,7 @@ exit $?
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4852,7 +4852,7 @@ exit $?
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4886,7 +4886,7 @@ exit 0
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4924,7 +4924,7 @@ exit $?
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4960,7 +4960,7 @@ exit $?
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -4997,7 +4997,7 @@ exit $?
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5037,7 +5037,7 @@ exit 0
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5068,7 +5068,7 @@ outer() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5107,7 +5107,7 @@ fi
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5142,7 +5142,7 @@ exit $?
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5186,7 +5186,7 @@ unsafe_path
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5229,7 +5229,7 @@ done
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5267,7 +5267,7 @@ do_start
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5310,7 +5310,7 @@ run_make
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5345,7 +5345,7 @@ render() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5394,7 +5394,7 @@ safe_path_b
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5420,8 +5420,8 @@ printf '%s\\n' $pkgname
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build_with_options(
-            &output.file,
+        let semantic = SemanticModel::build_arena_with_options(
+            &output.arena_file,
             source,
             &indexer,
             SemanticBuildOptions {
@@ -5463,7 +5463,7 @@ bash ${debug:+\"-x\"} script
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5489,7 +5489,7 @@ printf '%s\\n' ${debug:+\"a b\"}
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5518,7 +5518,7 @@ echo /tmp/$SAFE
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5556,7 +5556,7 @@ fi
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Bash);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5603,7 +5603,7 @@ echo x >> ${OPENBSD_CONTENTS}
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5658,7 +5658,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
@@ -5686,7 +5686,7 @@ helper() (
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5713,7 +5713,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5739,7 +5739,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5765,7 +5765,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5791,7 +5791,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5821,7 +5821,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5850,7 +5850,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5879,7 +5879,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5906,7 +5906,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5937,7 +5937,7 @@ helper() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
         let helper_header = facts
@@ -5966,7 +5966,7 @@ Exit() { exit 0; }
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let semantic = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let analysis = semantic.analysis();
         let file_context = classify_file_context(source, None, ShellDialect::Sh);
         let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);

--- a/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
@@ -1,8 +1,10 @@
 use rustc_hash::FxHashSet;
-use shuck_ast::{Assignment, AssignmentValue, Command, Span, static_word_text};
+use shuck_ast::{
+    ArenaFileCommandKind, AssignmentNode, AssignmentValueNode, Span, static_word_text_arena,
+};
 use shuck_semantic::{Binding, BindingAttributes, BindingKind};
 
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote};
+use crate::{Checker, CommandFactRef, ExpansionContext, Rule, Violation, WordFactContext, WordQuote};
 
 pub struct AssignmentLooksLikeComparison;
 
@@ -30,7 +32,7 @@ pub fn assignment_looks_like_comparison(checker: &mut Checker) {
         .commands()
         .iter()
         .filter(|fact| fact.literal_name() == Some(""))
-        .flat_map(|fact| command_assignment_spans(checker, fact.command(), source, &known_names))
+        .flat_map(|fact| command_assignment_spans(checker, fact, source, &known_names))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || AssignmentLooksLikeComparison);
@@ -38,13 +40,13 @@ pub fn assignment_looks_like_comparison(checker: &mut Checker) {
 
 fn command_assignment_spans(
     checker: &Checker<'_>,
-    command: &Command,
+    command: CommandFactRef<'_, '_>,
     source: &str,
     known_names: &FxHashSet<String>,
 ) -> Vec<Span> {
-    match command {
-        Command::Simple(command) => command
-            .assignments
+    match command.command_kind() {
+        ArenaFileCommandKind::Simple => command
+            .arena_assignments()
             .iter()
             .filter_map(|assignment| {
                 assignment_value_looks_like_comparison(
@@ -56,40 +58,41 @@ fn command_assignment_spans(
                 )
             })
             .collect(),
-        Command::Builtin(_)
-        | Command::Decl(_)
-        | Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => Vec::new(),
+        ArenaFileCommandKind::Builtin
+        | ArenaFileCommandKind::Decl
+        | ArenaFileCommandKind::Binary
+        | ArenaFileCommandKind::Compound
+        | ArenaFileCommandKind::Function
+        | ArenaFileCommandKind::AnonymousFunction => Vec::new(),
     }
 }
 
 fn assignment_value_looks_like_comparison(
     checker: &Checker<'_>,
-    assignment: &Assignment,
+    assignment: &AssignmentNode,
     source: &str,
     known_names: &FxHashSet<String>,
     context: WordFactContext,
 ) -> Option<Span> {
-    let AssignmentValue::Scalar(word) = &assignment.value else {
+    let AssignmentValueNode::Scalar(word_id) = assignment.value else {
         return None;
     };
+    let word = checker.facts().arena_file().store.word(word_id);
 
-    let fact = checker.facts().word_fact(word.span, context)?;
+    let fact = checker.facts().word_fact(word.span(), context)?;
     if fact.classification().quote != WordQuote::Unquoted {
         return None;
     }
 
     let target = assignment.target.name.as_str();
-    let value = static_word_text(word, source)?;
+    let value = static_word_text_arena(word, source)?;
     let (prefix, remainder) = value.split_once('-')?;
     if remainder.is_empty() {
         return None;
     }
 
     if prefix == target || known_names.contains(prefix) {
-        Some(word.span)
+        Some(word.span())
     } else {
         None
     }

--- a/crates/shuck-linter/src/rules/correctness/bad_redirection_fd_order.rs
+++ b/crates/shuck-linter/src/rules/correctness/bad_redirection_fd_order.rs
@@ -29,16 +29,15 @@ pub fn bad_redirection_fd_order(checker: &mut Checker) {
     checker.report_all_dedup(spans, || BadRedirectionFdOrder);
 }
 
-fn malformed_numeric_target_span(redirect: &RedirectFact<'_>, source: &str) -> Option<Span> {
+fn malformed_numeric_target_span(redirect: &RedirectFact, source: &str) -> Option<Span> {
     let target_span = redirect.target_span()?;
     let target_text = target_span.slice(source);
     if target_text.is_empty() || !target_text.chars().all(|ch| ch.is_ascii_digit()) {
         return None;
     }
 
-    let redirect_data = redirect.redirect();
     if !matches!(
-        redirect_data.kind,
+        redirect.kind(),
         RedirectKind::Output
             | RedirectKind::Clobber
             | RedirectKind::Append
@@ -47,10 +46,10 @@ fn malformed_numeric_target_span(redirect: &RedirectFact<'_>, source: &str) -> O
         return None;
     }
 
-    let redirect_text = redirect_data.span.slice(source);
+    let redirect_text = redirect.span().slice(source);
     let operator_offset = redirect_text.find('>')?;
-    let start = redirect_data
-        .span
+    let start = redirect
+        .span()
         .start
         .advanced_by(&redirect_text[..operator_offset]);
     Some(Span::from_positions(start, target_span.end))

--- a/crates/shuck-linter/src/rules/correctness/bad_var_name.rs
+++ b/crates/shuck-linter/src/rules/correctness/bad_var_name.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Command, Span, Word};
+use shuck_ast::Span;
 
 use crate::{Checker, Rule, Violation};
 
@@ -20,22 +20,14 @@ pub fn bad_var_name(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| match fact.command() {
-            Command::Simple(command) => bad_var_name_span(&command.name, source),
-            Command::Builtin(_)
-            | Command::Decl(_)
-            | Command::Binary(_)
-            | Command::Compound(_)
-            | Command::Function(_)
-            | Command::AnonymousFunction(_) => None,
-        })
+        .filter_map(|fact| bad_var_name_span(fact.arena_body_name_word(source)?.span(), source))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || BadVarName);
 }
 
-fn bad_var_name_span(word: &Word, source: &str) -> Option<Span> {
-    let text = word.span.slice(source);
+fn bad_var_name_span(word_span: Span, source: &str) -> Option<Span> {
+    let text = word_span.slice(source);
     let target_end = text.find('=')?;
     if target_end > 0 && text.as_bytes()[target_end - 1] == b'+' {
         return None;
@@ -47,7 +39,7 @@ fn bad_var_name_span(word: &Word, source: &str) -> Option<Span> {
         return None;
     }
 
-    Some(word.span)
+    Some(word_span)
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/c_prototype_fragment.rs
+++ b/crates/shuck-linter/src/rules/correctness/c_prototype_fragment.rs
@@ -41,10 +41,10 @@ fn attached_background_ampersand_span(
     command: crate::CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<Span> {
-    if command.stmt().terminator != Some(StmtTerminator::Background(BackgroundOperator::Plain)) {
+    if command.stmt_terminator() != Some(StmtTerminator::Background(BackgroundOperator::Plain)) {
         return None;
     }
-    let terminator_span = command.stmt().terminator_span?;
+    let terminator_span = command.stmt_terminator_span()?;
     if terminator_span.slice(source) != "&" {
         return None;
     }

--- a/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
+++ b/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
@@ -56,7 +56,7 @@ fn span_strictly_contains(outer: shuck_ast::Span, inner: shuck_ast::Span) -> boo
         && (outer.start.offset < inner.start.offset || inner.end.offset < outer.end.offset)
 }
 
-fn matches_mixed_short_circuit(checker: &Checker<'_>, list: &ListFact<'_>) -> bool {
+fn matches_mixed_short_circuit(checker: &Checker<'_>, list: &ListFact) -> bool {
     if !matches_and_then_or_chain(list) || list_runs_as_if_or_elif_condition(checker, list) {
         return false;
     }
@@ -68,7 +68,7 @@ fn matches_mixed_short_circuit(checker: &Checker<'_>, list: &ListFact<'_>) -> bo
     }
 }
 
-fn matches_and_then_or_chain(list: &ListFact<'_>) -> bool {
+fn matches_and_then_or_chain(list: &ListFact) -> bool {
     let mut saw_and = false;
     let mut saw_or = false;
 
@@ -83,7 +83,7 @@ fn matches_and_then_or_chain(list: &ListFact<'_>) -> bool {
     saw_and && saw_or
 }
 
-fn list_runs_as_if_or_elif_condition(checker: &Checker<'_>, list: &ListFact<'_>) -> bool {
+fn list_runs_as_if_or_elif_condition(checker: &Checker<'_>, list: &ListFact) -> bool {
     list.segments().iter().all(|segment| {
         checker
             .facts()
@@ -94,7 +94,7 @@ fn list_runs_as_if_or_elif_condition(checker: &Checker<'_>, list: &ListFact<'_>)
     })
 }
 
-fn list_exempts_warning(checker: &Checker<'_>, list: &ListFact<'_>) -> bool {
+fn list_exempts_warning(checker: &Checker<'_>, list: &ListFact) -> bool {
     if list.segments().iter().all(|segment| {
         checker
             .facts()
@@ -118,7 +118,7 @@ fn list_exempts_warning(checker: &Checker<'_>, list: &ListFact<'_>) -> bool {
     false
 }
 
-fn matches_status_propagation_assignment(list: &ListFact<'_>) -> bool {
+fn matches_status_propagation_assignment(list: &ListFact) -> bool {
     if !matches_and_or_ternary(list) {
         return false;
     }
@@ -134,7 +134,7 @@ fn matches_status_propagation_assignment(list: &ListFact<'_>) -> bool {
         && first.assignment_target() == last.assignment_target()
 }
 
-fn matches_exempt_fallback_branch(checker: &Checker<'_>, list: &ListFact<'_>) -> bool {
+fn matches_exempt_fallback_branch(checker: &Checker<'_>, list: &ListFact) -> bool {
     let Some(last_operator) = list.operators().last() else {
         return false;
     };
@@ -160,7 +160,7 @@ fn matches_exempt_fallback_branch(checker: &Checker<'_>, list: &ListFact<'_>) ->
     )
 }
 
-fn matches_condition_guard_fallback(list: &ListFact<'_>) -> bool {
+fn matches_condition_guard_fallback(list: &ListFact) -> bool {
     let Some(first_or_index) = list
         .operators()
         .iter()
@@ -184,7 +184,7 @@ fn command_basename(name: &str) -> &str {
     name.rsplit('/').next().unwrap_or(name)
 }
 
-fn matches_and_or_ternary(list: &ListFact<'_>) -> bool {
+fn matches_and_or_ternary(list: &ListFact) -> bool {
     list.segments().len() == 3 && matches_and_then_or_chain(list)
 }
 

--- a/crates/shuck-linter/src/rules/correctness/else_if.rs
+++ b/crates/shuck-linter/src/rules/correctness/else_if.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Command, CompoundCommand, Position, Span};
+use shuck_ast::{ArenaFileCommandKind, CompoundCommandNode, Position, Span};
 
 use crate::{Checker, Rule, Violation};
 
@@ -20,16 +20,28 @@ pub fn else_if(checker: &mut Checker) {
         .commands()
         .iter()
         .filter_map(|fact| {
-            let Command::Compound(CompoundCommand::If(command)) = fact.command() else {
+            if fact.compound_kind() != Some(crate::CommandFactCompoundKind::If) {
+                return None;
+            }
+            let command = fact.arena_command()?.compound()?;
+            let CompoundCommandNode::If { else_branch, .. } = command.node() else {
                 return None;
             };
-            let branch = command.else_branch.as_ref()?;
-            let first = branch.stmts.first()?;
-            let Command::Compound(CompoundCommand::If(_)) = &first.command else {
+            let first = command
+                .store()
+                .stmt_seq((*else_branch)?)
+                .stmts()
+                .next()?;
+            if first.command().kind() != ArenaFileCommandKind::Compound
+                || !matches!(
+                    first.command().compound()?.node(),
+                    CompoundCommandNode::If { .. }
+                )
+            {
                 return None;
-            };
+            }
 
-            else_if_span(first.span.start, checker.source())
+            else_if_span(first.span().start, checker.source())
         })
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Command, Span};
+use shuck_ast::Span;
 
 use crate::{
     Checker, CommandFactRef, Edit, Fix, FixAvailability, PipelineFact, PipelineSegmentFact, Rule,
@@ -38,7 +38,7 @@ pub fn find_output_to_xargs(checker: &mut Checker) {
 
 fn unsafe_find_to_xargs_diagnostics(
     checker: &Checker<'_>,
-    pipeline: &PipelineFact<'_>,
+    pipeline: &PipelineFact,
 ) -> Vec<crate::Diagnostic> {
     pipeline
         .segments()
@@ -110,7 +110,7 @@ fn find_print0_insertion_offset(command: CommandFactRef<'_, '_>) -> usize {
     command
         .redirect_facts()
         .first()
-        .map(|redirect| redirect.redirect().span.start.offset)
+        .map(|redirect| redirect.span().start.offset)
         .or_else(|| command.body_args().last().map(|word| word.span.end.offset))
         .or_else(|| command.body_name_word().map(|word| word.span.end.offset))
         .expect("find command diagnostics should have a body insertion point")
@@ -123,20 +123,15 @@ fn xargs_null_input_insertion_offset(command: CommandFactRef<'_, '_>) -> usize {
         .expect("xargs command diagnostics should have a body name word")
 }
 
-fn find_command_span(segment: &PipelineSegmentFact<'_>, fact: CommandFactRef<'_, '_>) -> Span {
-    match &segment.command() {
-        Command::Simple(simple) => {
-            let end = segment
-                .stmt()
-                .redirects
-                .last()
-                .map(|redirect| redirect.span.end)
-                .or_else(|| simple.args.last().map(|word| word.span.end))
-                .unwrap_or(simple.name.span.end);
-            Span::from_positions(fact.body_span().start, end)
-        }
-        _ => fact.body_span(),
-    }
+fn find_command_span(_segment: &PipelineSegmentFact, fact: CommandFactRef<'_, '_>) -> Span {
+    let end = fact
+        .redirect_facts()
+        .last()
+        .map(|redirect| redirect.span().end)
+        .or_else(|| fact.body_args().last().map(|word| word.span.end))
+        .or_else(|| fact.body_word_span().map(|span| span.end))
+        .unwrap_or_else(|| fact.body_span().end);
+    Span::from_positions(fact.body_span().start, end)
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -85,39 +85,42 @@ fn bracket_comparison_redirect_diagnostics(
 }
 
 fn numeric_comparison_redirect_diagnostic(
-    redirect: &RedirectFact<'_>,
+    redirect: &RedirectFact,
     opening_bracket_span: Span,
     closing_bracket_span: Span,
     source: &str,
 ) -> Option<crate::Diagnostic> {
-    let (redirect_data, replacement) = match redirect.redirect().kind {
-        RedirectKind::Input => (redirect.redirect(), "-lt"),
-        RedirectKind::Output => (redirect.redirect(), "-gt"),
+    let replacement = match redirect.kind() {
+        RedirectKind::Input => "-lt",
+        RedirectKind::Output => "-gt",
         _ => return None,
     };
 
-    let target = redirect_data.word_target()?;
-    if !static_word_text(target, source).is_some_and(|text| looks_like_decimal_integer(&text)) {
+    let target_span = redirect.target_span()?;
+    if !redirect
+        .target_static_text()
+        .is_some_and(looks_like_decimal_integer)
+    {
         return None;
     }
 
-    if redirect_data.span.start.offset < opening_bracket_span.end.offset
-        || redirect_data.span.start.offset >= closing_bracket_span.start.offset
+    if redirect.span().start.offset < opening_bracket_span.end.offset
+        || redirect.span().start.offset >= closing_bracket_span.start.offset
     {
         return None;
     }
 
     let operator_span = redirect.operator_span();
-    if operator_span.start.offset != redirect_data.span.start.offset {
+    if operator_span.start.offset != redirect.span().start.offset {
         return None;
     }
 
-    let gap = source.get(operator_span.end.offset..target.span.start.offset)?;
+    let gap = source.get(operator_span.end.offset..target_span.start.offset)?;
     if !is_shell_token_gap(gap) {
         return None;
     }
 
-    let fix_span = Span::from_positions(operator_span.start, target.span.start);
+    let fix_span = Span::from_positions(operator_span.start, target_span.start);
     let leading_separator = if has_trailing_token_boundary(&source[..operator_span.start.offset]) {
         ""
     } else {

--- a/crates/shuck-linter/src/rules/correctness/invalid_exit_status.rs
+++ b/crates/shuck-linter/src/rules/correctness/invalid_exit_status.rs
@@ -19,7 +19,7 @@ pub fn invalid_exit_status(checker: &mut Checker) {
         .iter()
         .filter_map(|fact| fact.options().exit().copied())
         .filter(|exit| exit.has_invalid_status_argument())
-        .filter_map(|exit| exit.status_word.map(|word| word.span))
+        .filter_map(|exit| exit.status_word_span)
         .collect::<Vec<_>>();
 
     checker.report_all(spans, || InvalidExitStatus);

--- a/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{BuiltinCommand, Command, Span};
+use shuck_ast::Span;
 use shuck_semantic::ScopeKind;
 
 use crate::{Checker, Rule, Violation};
@@ -34,15 +34,15 @@ pub(crate) fn loop_control_violations(
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| match fact.command() {
-            Command::Builtin(BuiltinCommand::Break(command)) if !continue_only => {
-                Some((command.span, keyword_span(command.span, "break"), "break"))
+        .filter_map(|fact| match fact.effective_name() {
+            Some("break") if !continue_only => {
+                let span = fact.span();
+                Some((span, keyword_span(span, "break"), "break"))
             }
-            Command::Builtin(BuiltinCommand::Continue(command)) => Some((
-                command.span,
-                keyword_span(command.span, "continue"),
-                "continue",
-            )),
+            Some("continue") => {
+                let span = fact.span();
+                Some((span, keyword_span(span, "continue"), "continue"))
+            }
             _ => None,
         })
         .filter(|(command_span, _, keyword)| {

--- a/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
+++ b/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Command, StmtTerminator, static_word_text};
+use shuck_ast::{ArenaFileCommandKind, StmtTerminator};
 
 use crate::context::FileContextTag;
 use crate::{Checker, Rule, Violation};
@@ -34,23 +34,25 @@ fn non_shell_syntax_span(
     command: crate::CommandFactRef<'_, '_>,
     source: &str,
 ) -> Option<shuck_ast::Span> {
-    if command.stmt().terminator != Some(StmtTerminator::Semicolon) {
+    if command.stmt_terminator() != Some(StmtTerminator::Semicolon) {
         return None;
     }
 
-    let Command::Simple(simple) = command.command() else {
+    if command.command_kind() != ArenaFileCommandKind::Simple {
         return None;
-    };
-    if !simple.assignments.is_empty() {
+    }
+    if !command.arena_assignments().is_empty() {
         return None;
     }
 
-    let name = static_word_text(&simple.name, source)?;
-    if !looks_like_c_declaration_keyword(name.as_ref()) || simple.args.is_empty() {
+    let name = command.arena_body_name_word(source)?;
+    let text = name.static_text(source)?;
+    if !looks_like_c_declaration_keyword(text.as_ref()) || command.arena_body_args(source).is_empty()
+    {
         return None;
     }
 
-    Some(simple.name.span)
+    Some(name.span())
 }
 
 fn looks_like_c_declaration_keyword(text: &str) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,7 +1,9 @@
 use crate::context::FileContextTag;
-use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
+use crate::{
+    Checker, CommandFactRef, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::static_word_text;
+use shuck_ast::{ArenaFileCommandKind, CompoundCommandNode};
 use shuck_semantic::{
     BindingKind, BindingOrigin, OverwrittenFunction as SemanticOverwrittenFunction, ScopeId,
     ScopeKind, UnreachedFunction as SemanticUnreachedFunction, UnreachedFunctionReason,
@@ -262,15 +264,12 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
         if let Some(scope) = known_scope {
             scopes_by_offset.entry(offset).or_insert(scope);
         }
-        let is_function = matches!(fact.command(), shuck_ast::Command::Function(_));
+        let is_function = fact.command_kind() == ArenaFileCommandKind::Function;
         if is_function {
             function_definition_offsets.insert(offset);
         }
 
-        if matches!(
-            fact.command(),
-            shuck_ast::Command::Builtin(shuck_ast::BuiltinCommand::Break(_))
-        ) {
+        if fact.effective_name_is("break") {
             break_offsets.push(offset);
         }
 
@@ -296,11 +295,11 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
             && unset.options_parseable()
         {
             let mut targets = Vec::new();
-            for word in unset.operand_words() {
-                let Some(text) = static_word_text(word, checker.source()) else {
+            for text in unset.operand_static_texts() {
+                let Some(text) = text.as_deref() else {
                     break;
                 };
-                let target = text.into_owned();
+                let target = text.to_owned();
                 if !targets.contains(&target) {
                     targets.push(target);
                 }
@@ -321,7 +320,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
             }
         }
 
-        let apparent_loop_body_span = apparent_infinite_loop_body_span(checker, fact.command());
+        let apparent_loop_body_span = apparent_infinite_loop_body_span(checker, fact);
         if is_return || apparent_loop_body_span.is_some() {
             let scope = known_scope.unwrap_or_else(|| checker.semantic().scope_at(offset));
             if scope_is_file_scope(checker, scope) {
@@ -2307,29 +2306,30 @@ fn has_apparent_infinite_loop_after(checker: &Checker<'_>, offset: usize) -> boo
                 checker,
                 checker.semantic().scope_at(fact.body_span().start.offset),
             )
-            && command_is_apparent_infinite_loop(checker, fact.command())
+            && command_is_apparent_infinite_loop(checker, fact)
     })
 }
 
-fn command_is_apparent_infinite_loop(checker: &Checker<'_>, command: &shuck_ast::Command) -> bool {
+fn command_is_apparent_infinite_loop(checker: &Checker<'_>, command: CommandFactRef<'_, '_>) -> bool {
     apparent_infinite_loop_body_span(checker, command)
         .is_some_and(|body_span| !loop_body_contains_break(checker, body_span))
 }
 
 fn apparent_infinite_loop_body_span(
     checker: &Checker<'_>,
-    command: &shuck_ast::Command,
+    command: CommandFactRef<'_, '_>,
 ) -> Option<shuck_ast::Span> {
     let source = checker.source();
-    match command {
-        shuck_ast::Command::Compound(shuck_ast::CompoundCommand::While(command)) => {
-            condition_text_is(source, command.condition.span, &["true", ":"])
-                .then_some(command.body.span)
-        }
-        shuck_ast::Command::Compound(shuck_ast::CompoundCommand::Until(command)) => {
-            condition_text_is(source, command.condition.span, &["false"])
-                .then_some(command.body.span)
-        }
+    let compound = command.arena_command()?.compound()?;
+    match compound.node() {
+        CompoundCommandNode::While {
+            condition, body, ..
+        } => condition_text_is(source, compound.store().stmt_seq(*condition).span(), &["true", ":"])
+            .then_some(compound.store().stmt_seq(*body).span()),
+        CompoundCommandNode::Until {
+            condition, body, ..
+        } => condition_text_is(source, compound.store().stmt_seq(*condition).span(), &["false"])
+            .then_some(compound.store().stmt_seq(*body).span()),
         _ => None,
     }
 }
@@ -2343,10 +2343,7 @@ fn loop_body_contains_break(checker: &Checker<'_>, body_span: shuck_ast::Span) -
     checker.facts().structural_commands().any(|fact| {
         fact.body_span().start.offset >= body_span.start.offset
             && fact.body_span().end.offset <= body_span.end.offset
-            && matches!(
-                fact.command(),
-                shuck_ast::Command::Builtin(shuck_ast::BuiltinCommand::Break(_))
-            )
+            && fact.effective_name_is("break")
     })
 }
 
@@ -2460,9 +2457,9 @@ fn has_intervening_executable_command(
     end_offset: usize,
 ) -> bool {
     checker.facts().structural_commands().any(|fact| {
-        fact.body_span().start.offset > start_offset
+            fact.body_span().start.offset > start_offset
             && fact.body_span().start.offset < end_offset
-            && !matches!(fact.command(), shuck_ast::Command::Function(_))
+            && fact.command_kind() != ArenaFileCommandKind::Function
     })
 }
 

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -1,5 +1,5 @@
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{Command, Name, Span};
+use shuck_ast::{ArenaFileCommandKind, Name, Span};
 use shuck_semantic::{
     Binding, BindingAttributes, BindingId, BindingKind, DeclarationBuiltin, DeclarationOperand,
     Reference, ReferenceId, ScopeId,
@@ -320,7 +320,7 @@ impl<'a, 'src> QuotedBashSourceContext<'a, 'src> {
                     .flatten();
                 while let Some(command_id) = current {
                     let command = self.facts.command(command_id);
-                    if matches!(command.command(), Command::Simple(_)) {
+                    if command.command_kind() == ArenaFileCommandKind::Simple {
                         ancestors.push(SimpleCommandAncestor {
                             id: command_id,
                             assignment_only: command.literal_name() == Some(""),

--- a/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
@@ -25,7 +25,7 @@ pub fn redirect_before_pipe(checker: &mut Checker) {
     checker.report_all_dedup(spans, || RedirectBeforePipe);
 }
 
-fn redirect_spans_for_pipeline(checker: &Checker<'_>, pipeline: &PipelineFact<'_>) -> Vec<Span> {
+fn redirect_spans_for_pipeline(checker: &Checker<'_>, pipeline: &PipelineFact) -> Vec<Span> {
     pipeline
         .segments()
         .iter()
@@ -46,8 +46,8 @@ fn redirect_spans_for_pipeline(checker: &Checker<'_>, pipeline: &PipelineFact<'_
 }
 
 fn has_independent_stderr_to_stdout_dup(
-    redirects: &[crate::RedirectFact<'_>],
-    stdout_redirect: &crate::RedirectFact<'_>,
+    redirects: &[crate::RedirectFact],
+    stdout_redirect: &crate::RedirectFact,
 ) -> bool {
     redirects.iter().any(|redirect| {
         is_stderr_to_stdout_dup(redirect)
@@ -55,33 +55,29 @@ fn has_independent_stderr_to_stdout_dup(
     })
 }
 
-fn is_stderr_to_stdout_dup(redirect: &crate::RedirectFact<'_>) -> bool {
-    redirect.redirect().kind == RedirectKind::DupOutput
-        && redirect.redirect().fd == Some(2)
+fn is_stderr_to_stdout_dup(redirect: &crate::RedirectFact) -> bool {
+    redirect.kind() == RedirectKind::DupOutput
+        && redirect.fd() == Some(2)
         && redirect
             .analysis()
             .is_some_and(|analysis| analysis.numeric_descriptor_target == Some(1))
 }
 
 fn is_synthetic_append_both_dup(
-    dup_redirect: &crate::RedirectFact<'_>,
-    stdout_redirect: &crate::RedirectFact<'_>,
+    dup_redirect: &crate::RedirectFact,
+    stdout_redirect: &crate::RedirectFact,
 ) -> bool {
-    stdout_redirect.redirect().kind == RedirectKind::Append
-        && dup_redirect.redirect().span.start == stdout_redirect.redirect().span.start
+    stdout_redirect.kind() == RedirectKind::Append
+        && dup_redirect.span().start == stdout_redirect.span().start
 }
 
-fn stdout_redirect_span_before_pipe(
-    redirect: &crate::RedirectFact<'_>,
-    source: &str,
-) -> Option<Span> {
-    let data = redirect.redirect();
-    if data.fd.unwrap_or(1) != 1 {
+fn stdout_redirect_span_before_pipe(redirect: &crate::RedirectFact, source: &str) -> Option<Span> {
+    if redirect.fd().unwrap_or(1) != 1 {
         return None;
     }
 
     if !matches!(
-        data.kind,
+        redirect.kind(),
         RedirectKind::Output
             | RedirectKind::Clobber
             | RedirectKind::Append
@@ -97,20 +93,17 @@ fn stdout_redirect_span_before_pipe(
         .flatten()
 }
 
-fn redirect_operator_span(redirect: &crate::RedirectFact<'_>, source: &str) -> Option<Span> {
+fn redirect_operator_span(redirect: &crate::RedirectFact, source: &str) -> Option<Span> {
     let target_span = redirect.target_span()?;
-    let operator_slice =
-        source.get(redirect.redirect().span.start.offset..target_span.start.offset)?;
+    let operator_slice = source.get(redirect.span().start.offset..target_span.start.offset)?;
     let operator_start = operator_slice.find('>')?;
     let operator_end = operator_slice.rfind(|ch: char| !ch.is_whitespace())? + 1;
     let operator_start_pos = redirect
-        .redirect()
-        .span
+        .span()
         .start
         .advanced_by(&operator_slice[..operator_start]);
     let operator_end_pos = redirect
-        .redirect()
-        .span
+        .span()
         .start
         .advanced_by(&operator_slice[..operator_end]);
 

--- a/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_clobbers_input.rs
@@ -51,13 +51,13 @@ fn clobber_spans_for_command(fact: crate::CommandFactRef<'_, '_>) -> Vec<Span> {
     let own_readwrite_spans = fact
         .redirect_facts()
         .iter()
-        .filter(|redirect| redirect.redirect().kind == RedirectKind::ReadWrite)
-        .filter_map(|redirect| redirect.redirect().word_target().map(|word| word.span))
+        .filter(|redirect| redirect.kind() == RedirectKind::ReadWrite)
+        .filter_map(|redirect| redirect.target_span())
         .collect::<Vec<_>>();
 
     for redirect in fact.redirect_facts() {
         if matches!(
-            redirect.redirect().kind,
+            redirect.kind(),
             RedirectKind::Output
                 | RedirectKind::Clobber
                 | RedirectKind::Append
@@ -87,7 +87,7 @@ fn clobber_spans_for_command(fact: crate::CommandFactRef<'_, '_>) -> Vec<Span> {
         };
 
         let key = redirect_path_match_key(comparable.key(), comparable.match_key());
-        match redirect.redirect().kind {
+        match redirect.kind() {
             RedirectKind::Input => {
                 read_paths.entry(key).or_default().push(comparable.span());
             }
@@ -113,7 +113,7 @@ fn clobber_spans_for_command(fact: crate::CommandFactRef<'_, '_>) -> Vec<Span> {
 
     for source_word in fact.scope_read_source_words() {
         if source_word.context() == ExpansionContext::RedirectTarget(RedirectKind::ReadWrite)
-            && own_readwrite_spans.contains(&source_word.word().span)
+            && own_readwrite_spans.contains(&source_word.span())
         {
             continue;
         }

--- a/crates/shuck-linter/src/rules/correctness/redirect_to_command_name.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_to_command_name.rs
@@ -28,7 +28,7 @@ pub fn redirect_to_command_name(checker: &mut Checker) {
         .iter()
         .flat_map(|fact| fact.redirect_facts().iter())
         .filter_map(|redirect| {
-            let kind = redirect.redirect().kind;
+            let kind = redirect.kind();
             if !matches!(
                 kind,
                 RedirectKind::Output

--- a/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
+++ b/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
@@ -1,5 +1,5 @@
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{Command, DeclOperand, Name, Span, Word, static_word_text};
+use shuck_ast::{AssignmentValueNode, DeclOperandNode, Name, Span, Word, static_word_text};
 use shuck_semantic::{
     Binding, BindingAttributes, BindingId, BindingKind, Reference, ReferenceKind,
 };
@@ -322,18 +322,18 @@ fn export_name_spans(
         .commands()
         .iter()
         .flat_map(|command| {
-            let Command::Decl(clause) = command.command() else {
+            let Some(clause) = command.arena_command().and_then(|command| command.decl()) else {
                 return Vec::new();
             };
-            if clause.variant.as_str() != "export" {
+            if clause.variant().as_str() != "export" {
                 return Vec::new();
             }
 
             clause
-                .operands
+                .operands()
                 .iter()
                 .filter_map(|operand| {
-                    let DeclOperand::Name(reference) = operand else {
+                    let DeclOperandNode::Name(reference) = operand else {
                         return None;
                     };
                     let binding = checker
@@ -441,26 +441,27 @@ fn export_assignment_root_bindings(
 
     let mut roots = FxHashSet::default();
     for command in checker.facts().commands() {
-        let Command::Decl(clause) = command.command() else {
+        let Some(clause) = command.arena_command().and_then(|command| command.decl()) else {
             continue;
         };
-        if clause.variant.as_str() != "export" {
+        if clause.variant().as_str() != "export" {
             continue;
         }
 
-        for operand in &clause.operands {
-            let DeclOperand::Assignment(assignment) = operand else {
+        for operand in clause.operands() {
+            let DeclOperandNode::Assignment(assignment) = operand else {
                 continue;
             };
             if !repeated_targets.contains(assignment.target.name.as_str()) {
                 continue;
             }
-            let shuck_ast::AssignmentValue::Scalar(word) = &assignment.value else {
+            let AssignmentValueNode::Scalar(word_id) = assignment.value else {
                 continue;
             };
+            let word = clause.store().word(word_id);
 
             for binding_id in
-                plain_scalar_reference_bindings(word.span, checker, references, reference_indices)
+                plain_scalar_reference_bindings(word.span(), checker, references, reference_indices)
             {
                 roots.extend(root_bindings_for_binding(
                     binding_id,
@@ -479,15 +480,15 @@ fn export_assignment_root_bindings(
 fn repeated_export_assignment_targets(checker: &Checker<'_>) -> FxHashSet<String> {
     let mut counts = FxHashMap::<String, usize>::default();
     for command in checker.facts().commands() {
-        let Command::Decl(clause) = command.command() else {
+        let Some(clause) = command.arena_command().and_then(|command| command.decl()) else {
             continue;
         };
-        if clause.variant.as_str() != "export" {
+        if clause.variant().as_str() != "export" {
             continue;
         }
 
-        for operand in &clause.operands {
-            let DeclOperand::Assignment(assignment) = operand else {
+        for operand in clause.operands() {
+            let DeclOperandNode::Assignment(assignment) = operand else {
                 continue;
             };
             *counts

--- a/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/stderr_before_stdout_redirect.rs
@@ -52,10 +52,8 @@ pub fn stderr_before_stdout_redirect(checker: &mut Checker) {
 
                     let stdout_index =
                         last_later_stdout_file_redirect_index(&redirects[index + 1..])? + index + 1;
-                    let diagnostic = crate::Diagnostic::new(
-                        StderrBeforeStdoutRedirect,
-                        redirect.redirect().span,
-                    );
+                    let diagnostic =
+                        crate::Diagnostic::new(StderrBeforeStdoutRedirect, redirect.span());
                     Some(
                         match stderr_before_stdout_redirect_fix(
                             source,
@@ -76,19 +74,19 @@ pub fn stderr_before_stdout_redirect(checker: &mut Checker) {
     }
 }
 
-fn is_stderr_to_stdout_redirect(redirect: &RedirectFact<'_>) -> bool {
+fn is_stderr_to_stdout_redirect(redirect: &RedirectFact) -> bool {
     let Some(analysis) = redirect.analysis() else {
         return false;
     };
 
-    redirect.redirect().kind == RedirectKind::DupOutput
-        && redirect.redirect().fd == Some(2)
+    redirect.kind() == RedirectKind::DupOutput
+        && redirect.fd() == Some(2)
         && analysis.numeric_descriptor_target == Some(1)
 }
 
 fn stderr_before_stdout_redirect_fix(
     source: &str,
-    redirects: &[RedirectFact<'_>],
+    redirects: &[RedirectFact],
     stderr_index: usize,
     stdout_index: usize,
 ) -> Option<Fix> {
@@ -101,8 +99,8 @@ fn stderr_before_stdout_redirect_fix(
 
     let replacement = reordered_redirect_segment(source, redirects, stderr_index, stdout_index);
     let span = Span::from_positions(
-        redirects[stderr_index].redirect().span.start,
-        redirects[stdout_index].redirect().span.end,
+        redirects[stderr_index].span().start,
+        redirects[stdout_index].span().end,
     );
 
     Some(Fix::unsafe_edit(Edit::replacement(replacement, span)))
@@ -110,19 +108,19 @@ fn stderr_before_stdout_redirect_fix(
 
 fn reordered_redirect_segment(
     source: &str,
-    redirects: &[RedirectFact<'_>],
+    redirects: &[RedirectFact],
     stderr_index: usize,
     stdout_index: usize,
 ) -> String {
-    let moved_span = redirects[stderr_index].redirect().span;
+    let moved_span = redirects[stderr_index].span();
     let mut replacement = String::new();
 
     for index in stderr_index + 1..=stdout_index {
-        let span = redirects[index].redirect().span;
+        let span = redirects[index].span();
         let gap = if index == stderr_index + 1 {
             strip_leading_shell_trivia(&source[moved_span.end.offset..span.start.offset])
         } else {
-            &source[redirects[index - 1].redirect().span.end.offset..span.start.offset]
+            &source[redirects[index - 1].span().end.offset..span.start.offset]
         };
         replacement.push_str(gap);
         replacement.push_str(span.slice(source));
@@ -162,7 +160,7 @@ fn strip_leading_shell_trivia(text: &str) -> &str {
     &text[offset..]
 }
 
-fn last_later_stdout_file_redirect_index(redirects: &[RedirectFact<'_>]) -> Option<usize> {
+fn last_later_stdout_file_redirect_index(redirects: &[RedirectFact]) -> Option<usize> {
     redirects
         .iter()
         .enumerate()
@@ -170,20 +168,18 @@ fn last_later_stdout_file_redirect_index(redirects: &[RedirectFact<'_>]) -> Opti
         .next_back()
 }
 
-fn is_stdout_file_redirect(redirect: &RedirectFact<'_>) -> bool {
-    let data = redirect.redirect();
-    data.fd.unwrap_or(1) == 1
+fn is_stdout_file_redirect(redirect: &RedirectFact) -> bool {
+    redirect.fd().unwrap_or(1) == 1
         && matches!(
-            data.kind,
+            redirect.kind(),
             RedirectKind::Output | RedirectKind::Clobber | RedirectKind::Append
         )
 }
 
-fn redirect_conflicts_with_stderr_reorder(redirect: &RedirectFact<'_>) -> bool {
-    let data = redirect.redirect();
-    data.fd == Some(2)
-        || data.kind == RedirectKind::OutputBoth
-        || (data.kind == RedirectKind::DupOutput
+fn redirect_conflicts_with_stderr_reorder(redirect: &RedirectFact) -> bool {
+    redirect.fd() == Some(2)
+        || redirect.kind() == RedirectKind::OutputBoth
+        || (redirect.kind() == RedirectKind::DupOutput
             && redirect
                 .analysis()
                 .is_some_and(|analysis| analysis.numeric_descriptor_target == Some(2)))

--- a/crates/shuck-linter/src/rules/correctness/sudo_redirection_order.rs
+++ b/crates/shuck-linter/src/rules/correctness/sudo_redirection_order.rs
@@ -1,6 +1,6 @@
-use shuck_ast::{Redirect, RedirectKind, Span};
+use shuck_ast::{RedirectKind, Span};
 
-use crate::{Checker, Rule, Violation, WrapperKind};
+use crate::{Checker, RedirectFact, Rule, Violation, WrapperKind};
 
 pub struct SudoRedirectionOrder;
 
@@ -24,11 +24,11 @@ pub fn sudo_redirection_order(checker: &mut Checker) {
         })
         .flat_map(|fact| {
             fact.redirect_facts().iter().filter_map(|redirect| {
-                (is_hazardous_sudo_redirect(redirect.redirect())
+                (is_hazardous_sudo_redirect(redirect)
                     && !redirect
                         .analysis()
                         .is_some_and(|analysis| analysis.is_definitely_dev_null()))
-                .then_some(sudo_redirect_span(redirect.redirect()))
+                .then_some(sudo_redirect_span(redirect))
             })
         })
         .collect::<Vec<_>>();
@@ -36,13 +36,13 @@ pub fn sudo_redirection_order(checker: &mut Checker) {
     checker.report_all_dedup(spans, || SudoRedirectionOrder);
 }
 
-fn is_hazardous_sudo_redirect(redirect: &Redirect) -> bool {
-    if redirect.fd.is_some() || redirect.fd_var.is_some() {
+fn is_hazardous_sudo_redirect(redirect: &RedirectFact) -> bool {
+    if redirect.fd().is_some() || redirect.has_fd_var() {
         return false;
     }
 
     matches!(
-        redirect.kind,
+        redirect.kind(),
         RedirectKind::Input
             | RedirectKind::Output
             | RedirectKind::Append
@@ -50,17 +50,17 @@ fn is_hazardous_sudo_redirect(redirect: &Redirect) -> bool {
     )
 }
 
-fn sudo_redirect_span(redirect: &Redirect) -> Span {
-    let start = match redirect.kind {
-        RedirectKind::OutputBoth => redirect.span.start.advanced_by("&"),
-        _ => redirect.span.start,
+fn sudo_redirect_span(redirect: &RedirectFact) -> Span {
+    let start = match redirect.kind() {
+        RedirectKind::OutputBoth => redirect.span().start.advanced_by("&"),
+        _ => redirect.span().start,
     };
-    let end = match redirect.kind {
+    let end = match redirect.kind() {
         RedirectKind::Append => start.advanced_by(">>"),
         _ => start.advanced_by(">"),
     };
 
-    if redirect.kind == RedirectKind::Input {
+    if redirect.kind() == RedirectKind::Input {
         return Span::from_positions(start, start.advanced_by("<"));
     }
 

--- a/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
@@ -22,9 +22,13 @@ pub fn suspicious_bracket_glob(checker: &mut Checker) {
         .filter_map(|fact| fact.body_name_word())
         .filter(|word| !bare_bracket_test_name(word.span.slice(source)))
         .flat_map(|word| word_spans::word_suspicious_bracket_glob_spans(word, source))
-        .chain(checker.facts().case_items().iter().flat_map(|item| {
-            word_spans::case_item_suspicious_bracket_glob_spans(item.item(), source)
-        }))
+        .chain(
+            checker
+                .facts()
+                .case_items()
+                .iter()
+                .flat_map(|item| item.suspicious_bracket_glob_spans().iter().copied()),
+        )
         .chain(
             checker
                 .facts()

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
@@ -1,5 +1,5 @@
 use crate::{Checker, Rule, ShellDialect, Violation};
-use shuck_ast::{Command, Span};
+use shuck_ast::{ArenaFileCommandKind, Span};
 use shuck_semantic::ScopeKind;
 
 pub struct UncheckedDirectoryChange {
@@ -38,7 +38,8 @@ pub(crate) fn unchecked_directory_change_spans(checker: &mut Checker) -> Vec<(&'
         .commands()
         .iter()
         .filter_map(|fact| {
-            let scope = semantic.scope_at(fact.stmt().span.start.offset);
+            let stmt_span = fact.stmt_span();
+            let scope = semantic.scope_at(stmt_span.start.offset);
             if fact.is_nested_word_command()
                 && !matches!(semantic.scope_kind(scope), ScopeKind::CommandSubstitution)
             {
@@ -47,7 +48,7 @@ pub(crate) fn unchecked_directory_change_spans(checker: &mut Checker) -> Vec<(&'
 
             let directory_change = fact.options().directory_change()?;
             let unchecked = semantic
-                .flow_context_at(&fact.stmt().span)
+                .flow_context_at(&stmt_span)
                 .map(|context| !context.exit_status_checked)
                 .unwrap_or(true);
 
@@ -60,20 +61,28 @@ pub(crate) fn unchecked_directory_change_spans(checker: &mut Checker) -> Vec<(&'
 }
 
 pub(crate) fn report_span(fact: crate::facts::CommandFactRef<'_, '_>, source: &str) -> Span {
-    match fact.command() {
-        Command::Simple(command) => {
-            let mut start = command.name.span.start;
-            if command.name.span.slice(source).starts_with('\\') {
+    match fact.command_kind() {
+        ArenaFileCommandKind::Simple => {
+            let Some(command) = fact.arena_command().and_then(|command| command.simple()) else {
+                return fact.span();
+            };
+            let name = command.name();
+            let mut start = name.span().start;
+            if name.span().slice(source).starts_with('\\') {
                 start = start.advanced_by("\\");
             }
             let end = command
-                .args
+                .args()
                 .last()
-                .map(|word| word.span.end)
+                .map(|word| word.span().end)
                 .into_iter()
-                .chain(fact.redirects().iter().map(|redirect| redirect.span.end))
+                .chain(
+                    fact.arena_redirects()
+                        .into_iter()
+                        .flat_map(|redirects| redirects.iter().map(|redirect| redirect.span.end)),
+                )
                 .max_by_key(|position| position.offset)
-                .unwrap_or(command.name.span.end);
+                .unwrap_or(name.span().end);
             Span::from_positions(start, end)
         }
         _ => fact.span(),

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change_in_function.rs
@@ -36,7 +36,8 @@ pub fn unchecked_directory_change_in_function(checker: &mut Checker) {
     let mut reports = Vec::new();
 
     for fact in checker.facts().commands() {
-        let scope = semantic.scope_at(fact.stmt().span.start.offset);
+        let stmt_span = fact.stmt_span();
+        let scope = semantic.scope_at(stmt_span.start.offset);
         let barrier = nearest_dominance_barrier(checker.facts(), fact.id());
         if fact.is_nested_word_command()
             && !matches!(semantic.scope_kind(scope), ScopeKind::CommandSubstitution)
@@ -51,7 +52,7 @@ pub fn unchecked_directory_change_in_function(checker: &mut Checker) {
         }
 
         let unchecked = semantic
-            .flow_context_at(&fact.stmt().span)
+            .flow_context_at(&stmt_span)
             .map(|context| !context.exit_status_checked)
             .unwrap_or(true);
         let pending_key = (scope, barrier);

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -1,4 +1,3 @@
-use crate::facts::word_spans;
 use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct UnquotedGrepRegex;
@@ -28,9 +27,7 @@ pub fn unquoted_grep_regex(checker: &mut Checker) {
         .filter(|fact| fact.effective_name_is("grep"))
         .filter_map(|fact| fact.options().grep())
         .flat_map(|grep| grep.patterns().iter())
-        .filter(|pattern| {
-            !word_spans::word_unquoted_glob_pattern_spans(pattern.word(), source).is_empty()
-        })
+        .filter(|pattern| pattern.has_unquoted_glob_pattern())
         .map(|pattern| {
             let span = pattern.span();
             let replacement = facts

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,6 +1,6 @@
 use crate::{Checker, CommandFact, CommandFacts, ListFact, Rule, Violation, WrapperKind};
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{Command as AstCommand, Name, Span};
+use shuck_ast::{Name, Span};
 use shuck_semantic::{
     BindingId, BindingOrigin, ScopeId, ScopeKind, SemanticAnalysis, UnreachableCauseKind,
 };
@@ -221,7 +221,7 @@ fn file_has_file_scope_exit(checker: &Checker<'_>) -> bool {
         command.effective_or_literal_name() == Some("exit")
             && checker
                 .semantic()
-                .flow_context_at(&command.stmt().span)
+                .flow_context_at(&command.stmt_span())
                 .is_some_and(|context| !context.in_function && !context.in_subshell)
     })
 }
@@ -232,7 +232,7 @@ fn file_has_top_level_exit_command(checker: &Checker<'_>) -> bool {
             && checker.facts().command_parent_id(command.id()).is_none()
             && checker
                 .semantic()
-                .flow_context_at(&command.stmt().span)
+                .flow_context_at(&command.stmt_span())
                 .is_some_and(|context| !context.in_function && !context.in_subshell)
     })
 }
@@ -245,7 +245,7 @@ fn span_is_inside_unreached_function(span: Span, function_spans: &[Span]) -> boo
 
 fn span_matches_short_circuit_skip(
     span: Span,
-    short_circuit_lists: &[ListFact<'_>],
+    short_circuit_lists: &[ListFact],
     commands: CommandFacts<'_, '_>,
     semantic_analysis: &SemanticAnalysis<'_>,
 ) -> bool {
@@ -270,7 +270,7 @@ fn span_matches_short_circuit_skip(
 }
 
 fn list_starts_with_condition(
-    list: &ListFact<'_>,
+    list: &ListFact,
     commands: CommandFacts<'_, '_>,
     semantic_analysis: &SemanticAnalysis<'_>,
 ) -> bool {
@@ -329,12 +329,12 @@ fn wrapper_name_resolves_to_function(
     let Some(name) = command.literal_name() else {
         return false;
     };
-    let AstCommand::Simple(simple) = command.command() else {
+    let Some(name_span) = command.body_word_span() else {
         return false;
     };
 
     semantic_analysis
-        .visible_function_binding_at_call(&Name::from(name), simple.name.span)
+        .visible_function_binding_at_call(&Name::from(name), name_span)
         .is_some()
 }
 

--- a/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
+++ b/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
@@ -26,7 +26,7 @@ pub fn unset_associative_array_element(checker: &mut Checker) {
 
         for operand in unset.operand_facts() {
             if operand.array_subscript().is_some() {
-                spans.push(operand.word().span);
+                spans.push(operand.span());
             }
         }
     }

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -338,20 +338,19 @@ fn loop_keyword_report_span(
 ) -> Option<shuck_ast::Span> {
     if let Some(header) = checker.facts().for_headers().iter().find(|header| {
         header
-            .command()
-            .targets
+            .target_spans()
             .iter()
-            .any(|target| target.span == definition_span)
+            .any(|target_span| *target_span == definition_span)
     }) {
-        return Some(keyword_span(header.command().span, "for"));
+        return Some(keyword_span(header.span(), "for"));
     }
 
     checker
         .facts()
         .select_headers()
         .iter()
-        .find(|header| header.command().variable_span == definition_span)
-        .map(|header| keyword_span(header.command().span, "select"))
+        .find(|header| header.variable_span() == definition_span)
+        .map(|header| keyword_span(header.span(), "select"))
 }
 
 fn keyword_span(command_span: shuck_ast::Span, keyword: &str) -> shuck_ast::Span {

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -25,10 +25,7 @@ pub fn grep_count_pipeline(checker: &mut Checker) {
     checker.report_all_dedup(spans, || GrepCountPipeline);
 }
 
-fn unsafe_grep_count_pipeline_spans(
-    checker: &Checker<'_>,
-    pipeline: &PipelineFact<'_>,
-) -> Vec<Span> {
+fn unsafe_grep_count_pipeline_spans(checker: &Checker<'_>, pipeline: &PipelineFact) -> Vec<Span> {
     pipeline
         .segments()
         .windows(2)
@@ -70,7 +67,7 @@ fn command_body_span(fact: CommandFactRef<'_, '_>) -> Option<Span> {
     }
 
     for redirect in fact.redirect_facts() {
-        let redirect_end = redirect.redirect().span.end;
+        let redirect_end = redirect.span().end;
         if redirect_end.offset > end.offset {
             end = redirect_end;
         }

--- a/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{RedirectKind, Span, static_word_text};
+use shuck_ast::{RedirectKind, Span};
 
 use crate::{Checker, RedirectFact, Rule, ShellDialect, Violation};
 
@@ -30,10 +30,9 @@ pub fn ampersand_redirect_in_sh(checker: &mut Checker) {
     checker.report_all_dedup(spans, || AmpersandRedirectInSh);
 }
 
-fn combined_ampersand_redirect_span(redirect: &RedirectFact<'_>, source: &str) -> Option<Span> {
-    let redirect_data = redirect.redirect();
+fn combined_ampersand_redirect_span(redirect: &RedirectFact, source: &str) -> Option<Span> {
     if !matches!(
-        redirect_data.kind,
+        redirect.kind(),
         RedirectKind::DupOutput | RedirectKind::Output
     ) {
         return None;
@@ -44,14 +43,14 @@ fn combined_ampersand_redirect_span(redirect: &RedirectFact<'_>, source: &str) -
         return None;
     }
 
-    let target = redirect_data.word_target()?;
-    let target_text = static_word_text(target, source)?;
+    let target_span = redirect.target_span()?;
+    let target_text = redirect.target_static_text()?;
     if target_text == "-" || target_text.chars().all(|ch| ch.is_ascii_digit()) {
         return None;
     }
 
-    let redirect_start = redirect_data.span.start.offset;
-    let target_start = target.span.start.offset;
+    let redirect_start = redirect.span().start.offset;
+    let target_start = target_span.start.offset;
     if redirect_start > target_start || target_start > source.len() {
         return None;
     }
@@ -67,7 +66,7 @@ fn combined_ampersand_redirect_span(redirect: &RedirectFact<'_>, source: &str) -
         return None;
     }
 
-    Some(redirect_data.span)
+    Some(redirect.span())
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirection.rs
@@ -30,10 +30,10 @@ pub fn ampersand_redirection(checker: &mut Checker) {
         .commands()
         .iter()
         .flat_map(|fact| fact.redirect_facts().iter())
-        .filter(|redirect| redirect.redirect().kind == RedirectKind::OutputBoth)
+        .filter(|redirect| redirect.kind() == RedirectKind::OutputBoth)
         .map(|redirect| {
             (
-                redirect.redirect().span,
+                redirect.span(),
                 ampersand_redirection_fix(redirect, checker.source()),
             )
         })
@@ -49,11 +49,10 @@ pub fn ampersand_redirection(checker: &mut Checker) {
     }
 }
 
-fn ampersand_redirection_fix(redirect: &RedirectFact<'_>, source: &str) -> Option<Fix> {
-    let redirect_data = redirect.redirect();
-    if redirect_data.kind != RedirectKind::OutputBoth
-        || redirect_data.fd.is_some()
-        || redirect_data.fd_var.is_some()
+fn ampersand_redirection_fix(redirect: &RedirectFact, source: &str) -> Option<Fix> {
+    if redirect.kind() != RedirectKind::OutputBoth
+        || redirect.fd().is_some()
+        || redirect.has_fd_var()
     {
         return None;
     }

--- a/crates/shuck-linter/src/rules/portability/array_assignment.rs
+++ b/crates/shuck-linter/src/rules/portability/array_assignment.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Assignment, AssignmentValue, BuiltinCommand, Command, DeclOperand, Span};
+use shuck_ast::{ArenaFileCommandKind, AssignmentNode, AssignmentValueNode, DeclOperandNode, Span};
 
 use crate::{Checker, Rule, ShellDialect, Violation};
 
@@ -33,44 +33,31 @@ fn command_array_assignment_spans(
     command: crate::CommandFactRef<'_, '_>,
     source: &str,
 ) -> Vec<Span> {
-    match command.command() {
-        Command::Simple(command) => command
-            .assignments
+    match command.command_kind() {
+        ArenaFileCommandKind::Simple | ArenaFileCommandKind::Builtin => command
+            .arena_assignments()
             .iter()
             .filter_map(|assignment| array_assignment_span(assignment, source))
             .collect(),
-        Command::Builtin(command) => builtin_assignments(command)
+        ArenaFileCommandKind::Decl => command
+            .arena_assignments()
             .iter()
-            .filter_map(|assignment| array_assignment_span(assignment, source))
-            .collect(),
-        Command::Decl(command) => command
-            .assignments
-            .iter()
-            .chain(command.operands.iter().filter_map(|operand| match operand {
-                DeclOperand::Assignment(assignment) => Some(assignment),
-                DeclOperand::Flag(_) | DeclOperand::Name(_) | DeclOperand::Dynamic(_) => None,
+            .chain(command.arena_declaration_operands().iter().filter_map(|operand| match operand {
+                DeclOperandNode::Assignment(assignment) => Some(assignment),
+                DeclOperandNode::Flag(_) | DeclOperandNode::Name(_) | DeclOperandNode::Dynamic(_) => None,
             }))
             .filter_map(|assignment| array_assignment_span(assignment, source))
             .collect(),
-        Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => Vec::new(),
+        ArenaFileCommandKind::Binary
+        | ArenaFileCommandKind::Compound
+        | ArenaFileCommandKind::Function
+        | ArenaFileCommandKind::AnonymousFunction => Vec::new(),
     }
 }
 
-fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
-    match command {
-        BuiltinCommand::Break(command) => &command.assignments,
-        BuiltinCommand::Continue(command) => &command.assignments,
-        BuiltinCommand::Return(command) => &command.assignments,
-        BuiltinCommand::Exit(command) => &command.assignments,
-    }
-}
-
-fn array_assignment_span(assignment: &Assignment, source: &str) -> Option<Span> {
+fn array_assignment_span(assignment: &AssignmentNode, source: &str) -> Option<Span> {
     match &assignment.value {
-        AssignmentValue::Compound(_) => {
+        AssignmentValueNode::Compound(_) => {
             let text = assignment.span.slice(source);
             let value_offset = text
                 .find("+=")
@@ -79,7 +66,7 @@ fn array_assignment_span(assignment: &Assignment, source: &str) -> Option<Span> 
             let value_start = assignment.span.start.advanced_by(&text[..value_offset]);
             Some(Span::from_positions(value_start, assignment.span.end))
         }
-        AssignmentValue::Scalar(_) => None,
+        AssignmentValueNode::Scalar(_) => None,
     }
 }
 

--- a/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
@@ -1,6 +1,6 @@
-use shuck_ast::{Command, CompoundCommand, Span};
+use shuck_ast::Span;
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, CommandFactCompoundKind, Rule, ShellDialect, Violation};
 
 pub struct CStyleForInSh;
 
@@ -23,8 +23,8 @@ pub fn c_style_for_in_sh(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| match fact.command() {
-            Command::Compound(CompoundCommand::ArithmeticFor(_)) => {
+        .filter_map(|fact| match fact.compound_kind() {
+            Some(CommandFactCompoundKind::ArithmeticFor) => {
                 Some(keyword_span(fact.span_in_source(checker.source()), "for"))
             }
             _ => None,

--- a/crates/shuck-linter/src/rules/portability/coproc.rs
+++ b/crates/shuck-linter/src/rules/portability/coproc.rs
@@ -1,6 +1,4 @@
-use shuck_ast::{Command, CompoundCommand};
-
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, CommandFactCompoundKind, Rule, ShellDialect, Violation};
 
 pub struct Coproc;
 
@@ -23,8 +21,8 @@ pub fn coproc(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| match fact.command() {
-            Command::Compound(CompoundCommand::Coproc(_)) => {
+        .filter_map(|fact| match fact.compound_kind() {
+            Some(CommandFactCompoundKind::Coproc) => {
                 Some(fact.span_in_source(checker.source()))
             }
             _ => None,

--- a/crates/shuck-linter/src/rules/portability/declare_command.rs
+++ b/crates/shuck-linter/src/rules/portability/declare_command.rs
@@ -118,9 +118,9 @@ fn declaration_anchor_end(
     mut end: shuck_ast::Position,
     source: &str,
 ) -> shuck_ast::Position {
-    for redirect in fact.redirects() {
-        if redirect.span.end.offset > end.offset {
-            end = redirect.span.end;
+    for redirect in fact.redirect_facts() {
+        if redirect.span().end.offset > end.offset {
+            end = redirect.span().end;
         }
     }
 
@@ -140,7 +140,7 @@ fn clip_terminator(
     mut end: shuck_ast::Position,
     _source: &str,
 ) -> shuck_ast::Position {
-    if let Some(terminator_span) = fact.stmt().terminator_span
+    if let Some(terminator_span) = fact.stmt_terminator_span()
         && terminator_span.start.offset < end.offset
     {
         end = terminator_span.start;

--- a/crates/shuck-linter/src/rules/portability/echo_flags.rs
+++ b/crates/shuck-linter/src/rules/portability/echo_flags.rs
@@ -25,8 +25,7 @@ pub fn echo_flags(checker: &mut Checker) {
         .filter_map(|fact| {
             fact.options()
                 .echo()
-                .and_then(|echo| echo.portability_flag_word())
-                .map(|word| word.span)
+                .and_then(|echo| echo.portability_flag_span())
         })
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/function_keyword_in_sh.rs
@@ -45,7 +45,7 @@ pub fn function_keyword_in_sh(checker: &mut Checker) {
     }
 }
 
-fn function_keyword_in_sh_fix(header: &FunctionHeaderFact<'_>) -> Option<Fix> {
+fn function_keyword_in_sh_fix(header: &FunctionHeaderFact) -> Option<Fix> {
     let keyword_span = header.function_keyword_span()?;
     let (_, name_span) = header.static_name_entry()?;
 

--- a/crates/shuck-linter/src/rules/portability/here_string.rs
+++ b/crates/shuck-linter/src/rules/portability/here_string.rs
@@ -24,9 +24,9 @@ pub fn here_string(checker: &mut Checker) {
         .commands()
         .iter()
         .flat_map(|fact| fact.redirect_facts().iter())
-        .filter(|redirect| redirect.redirect().kind == RedirectKind::HereString)
+        .filter(|redirect| redirect.kind() == RedirectKind::HereString)
         .map(|redirect| {
-            let span = redirect.redirect().span;
+            let span = redirect.span();
             Span::from_positions(span.start, span.start.advanced_by("<<<"))
         })
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/portability/hyphenated_function_name.rs
+++ b/crates/shuck-linter/src/rules/portability/hyphenated_function_name.rs
@@ -25,12 +25,11 @@ pub fn hyphenated_function_name(checker: &mut Checker) {
         .function_headers()
         .iter()
         .flat_map(|header| {
-            header.function().header.entries.iter().filter_map(|entry| {
+            header.entries().iter().filter_map(|entry| {
                 let name = entry
-                    .static_name
-                    .as_ref()
+                    .static_name()
                     .map(|name| name.as_str())
-                    .unwrap_or_else(|| entry.word.span.slice(source));
+                    .unwrap_or_else(|| entry.word_span().slice(source));
                 name.contains('-')
                     .then_some(header.function_span_in_source(source))
             })

--- a/crates/shuck-linter/src/rules/portability/multi_var_for_loop.rs
+++ b/crates/shuck-linter/src/rules/portability/multi_var_for_loop.rs
@@ -22,7 +22,7 @@ pub fn multi_var_for_loop(checker: &mut Checker) {
         .facts()
         .for_headers()
         .iter()
-        .filter_map(|fact| fact.command().targets.get(1).map(|target| target.span))
+        .filter_map(|fact| fact.target_spans().get(1).copied())
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || MultiVarForLoop);

--- a/crates/shuck-linter/src/rules/portability/printf_q_format_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/printf_q_format_in_sh.rs
@@ -31,7 +31,7 @@ pub fn printf_q_format_in_sh(checker: &mut Checker) {
             let printf = fact.options().printf()?;
             printf
                 .uses_q_format
-                .then_some(printf.format_word.map(|word| word.span))
+                .then_some(printf.format_word_span)
                 .flatten()
         })
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/portability/source_common.rs
+++ b/crates/shuck-linter/src/rules/portability/source_common.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Command, Redirect, SimpleCommand, Span};
+use shuck_ast::{ArenaFileCommandKind, RedirectNode, Span};
 
 use crate::{Checker, CommandFactRef, ShellDialect};
 
@@ -21,36 +21,37 @@ pub(super) fn source_anchor_span_for_command_fact(
     fact: CommandFactRef<'_, '_>,
     source: &str,
 ) -> Span {
-    source_anchor_span(fact.command(), fact.redirects(), fact.span(), source)
+    source_anchor_span(fact, source)
 }
 
-fn source_anchor_span(
-    command: &Command,
-    redirects: &[Redirect],
-    fallback: Span,
-    source: &str,
-) -> Span {
-    match command {
-        Command::Simple(command) => {
-            clip_first_line(simple_command_span(command, redirects), source)
-        }
-        _ => clip_first_line(fallback, source),
+fn source_anchor_span(fact: CommandFactRef<'_, '_>, source: &str) -> Span {
+    match fact.command_kind() {
+        ArenaFileCommandKind::Simple => clip_first_line(simple_command_span(fact), source),
+        _ => clip_first_line(fact.span(), source),
     }
 }
 
-fn simple_command_span(command: &SimpleCommand, redirects: &[Redirect]) -> Span {
+fn simple_command_span(fact: CommandFactRef<'_, '_>) -> Span {
+    let command = fact
+        .arena_command()
+        .and_then(|command| command.simple())
+        .expect("simple command fact should have a simple arena command");
     let start = command
-        .assignments
+        .assignments()
         .first()
-        .map_or(command.name.span.start, |assignment| assignment.span.start);
+        .map_or(command.name().span().start, |assignment| assignment.span.start);
     let mut end = command
-        .args
+        .args()
         .last()
-        .map_or(command.name.span.end, |word| word.span.end);
-    if let Some(redirect) = redirects.last() {
+        .map_or(command.name().span().end, |word| word.span().end);
+    if let Some(redirect) = fact.arena_redirects().and_then(last_redirect) {
         end = redirect.span.end;
     }
     Span::from_positions(start, end)
+}
+
+fn last_redirect(redirects: &[RedirectNode]) -> Option<&RedirectNode> {
+    redirects.last()
 }
 
 fn clip_first_line(span: Span, source: &str) -> Span {

--- a/crates/shuck-linter/src/rules/portability/standalone_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/portability/standalone_arithmetic.rs
@@ -1,6 +1,4 @@
-use shuck_ast::{Command, CompoundCommand};
-
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, CommandFactCompoundKind, Rule, ShellDialect, Violation};
 
 pub struct StandaloneArithmetic;
 
@@ -23,8 +21,8 @@ pub fn standalone_arithmetic(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| match fact.command() {
-            Command::Compound(CompoundCommand::Arithmetic(_)) => {
+        .filter_map(|fact| match fact.compound_kind() {
+            Some(CommandFactCompoundKind::Arithmetic) => {
                 Some(fact.span_in_source(checker.source()))
             }
             _ => None,

--- a/crates/shuck-linter/src/rules/portability/tr_common.rs
+++ b/crates/shuck-linter/src/rules/portability/tr_common.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Span, static_word_text};
+use shuck_ast::Span;
 
 use crate::{Checker, ShellDialect};
 
@@ -19,9 +19,7 @@ pub(super) fn tr_exact_operand_spans(checker: &Checker<'_>, exact_text: &str) ->
             fact.options()
                 .tr()
                 .into_iter()
-                .flat_map(|tr| tr.operand_words().iter().copied())
+                .flat_map(|tr| tr.exact_operand_spans(exact_text))
         })
-        .filter(|word| static_word_text(word, checker.source()).as_deref() == Some(exact_text))
-        .map(|word| word.span)
         .collect()
 }

--- a/crates/shuck-linter/src/rules/portability/zsh_assignment_to_zero.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_assignment_to_zero.rs
@@ -1,6 +1,6 @@
-use shuck_ast::{Assignment, Command, Span, Word};
+use shuck_ast::{ArenaFileCommandKind, AssignmentNode, Span};
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, FactWordRef, Rule, ShellDialect, Violation};
 
 pub struct ZshAssignmentToZero;
 
@@ -23,40 +23,43 @@ pub fn zsh_assignment_to_zero(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .flat_map(|fact| match fact.command() {
-            Command::Simple(command) => command
-                .assignments
+        .flat_map(|fact| match fact.command_kind() {
+            ArenaFileCommandKind::Simple => fact
+                .arena_assignments()
                 .iter()
                 .filter_map(typed_assignment_to_zero_span)
-                .chain(assignment_like_word_span(&command.name, checker.source()))
+                .chain(
+                    fact.arena_body_name_word(checker.source())
+                        .and_then(|word| assignment_like_word_span(word, checker.source())),
+                )
                 .collect::<Vec<_>>(),
-            Command::Decl(_) => fact
-                .body_args()
-                .iter()
+            ArenaFileCommandKind::Decl => fact
+                .arena_body_args(checker.source())
+                .into_iter()
                 .filter_map(|word| assignment_like_word_span(word, checker.source()))
                 .collect::<Vec<_>>(),
-            Command::Builtin(_)
-            | Command::Binary(_)
-            | Command::Compound(_)
-            | Command::Function(_)
-            | Command::AnonymousFunction(_) => Vec::new(),
+            ArenaFileCommandKind::Builtin
+            | ArenaFileCommandKind::Binary
+            | ArenaFileCommandKind::Compound
+            | ArenaFileCommandKind::Function
+            | ArenaFileCommandKind::AnonymousFunction => Vec::new(),
         })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ZshAssignmentToZero);
 }
 
-fn assignment_like_word_span(word: &Word, source: &str) -> Option<Span> {
-    word.span
+fn assignment_like_word_span(word: FactWordRef<'_>, source: &str) -> Option<Span> {
+    word.span()
         .slice(source)
         .starts_with("0=")
         .then_some(Span::from_positions(
-            word.span.start,
-            word.span.start.advanced_by("0"),
+            word.span().start,
+            word.span().start.advanced_by("0"),
         ))
 }
 
-fn typed_assignment_to_zero_span(assignment: &Assignment) -> Option<Span> {
+fn typed_assignment_to_zero_span(assignment: &AssignmentNode) -> Option<Span> {
     (assignment.target.name.as_str() == "0").then_some(Span::from_positions(
         assignment.target.name_span.start,
         assignment.target.name_span.start.advanced_by("0"),

--- a/crates/shuck-linter/src/rules/portability/zsh_redir_pipe.rs
+++ b/crates/shuck-linter/src/rules/portability/zsh_redir_pipe.rs
@@ -25,9 +25,9 @@ pub fn zsh_redir_pipe(checker: &mut Checker) {
         .commands()
         .iter()
         .filter_map(|command| {
-            (command.stmt().terminator
+            (command.stmt_terminator()
                 == Some(StmtTerminator::Background(BackgroundOperator::Pipe)))
-            .then_some(command.stmt().terminator_span)
+            .then_some(command.stmt_terminator_span())
             .flatten()
         })
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/style/backslash_before_command.rs
+++ b/crates/shuck-linter/src/rules/style/backslash_before_command.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Command, Span};
+use shuck_ast::Span;
 
 use crate::{Checker, Rule, Violation};
 
@@ -20,20 +20,19 @@ pub fn backslash_before_command(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| backslash_before_command_span(fact.command(), source))
+        .filter_map(|fact| {
+            let word = fact.arena_body_name_word(source)?;
+            backslash_before_command_span(word.span(), source)
+        })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || BackslashBeforeCommand);
 }
 
-fn backslash_before_command_span(command: &Command, source: &str) -> Option<Span> {
-    let Command::Simple(simple) = command else {
-        return None;
-    };
-
-    (simple.name.span.slice(source) == "\\command").then_some(Span::from_positions(
-        simple.name.span.start,
-        simple.name.span.start,
+fn backslash_before_command_span(name_span: Span, source: &str) -> Option<Span> {
+    (name_span.slice(source) == "\\command").then_some(Span::from_positions(
+        name_span.start,
+        name_span.start,
     ))
 }
 

--- a/crates/shuck-linter/src/rules/style/combine_appends.rs
+++ b/crates/shuck-linter/src/rules/style/combine_appends.rs
@@ -21,7 +21,7 @@ pub fn combine_appends(checker: &mut Checker) {
         .facts()
         .case_items()
         .iter()
-        .map(|item| FactSpan::new(item.item().body.span))
+        .map(|item| FactSpan::new(item.body_span()))
         .collect::<FxHashSet<_>>();
 
     for fact in checker.facts().statement_facts() {
@@ -100,7 +100,7 @@ fn append_target_for_statement(
 
     for command in statement_commands {
         for redirect in command.redirect_facts() {
-            if redirect.redirect().kind != RedirectKind::Append {
+            if redirect.kind() != RedirectKind::Append {
                 continue;
             }
 
@@ -121,7 +121,7 @@ fn append_target_for_statement(
                 let redirect_end = command
                     .redirect_facts()
                     .iter()
-                    .map(|redirect| redirect.redirect().span.end)
+                    .map(|redirect| redirect.span().end)
                     .max_by_key(|position| position.offset)
                     .unwrap_or(command_end);
                 anchor_start = Some(command.body_span().start);

--- a/crates/shuck-linter/src/rules/style/ifs_equals_ambiguity.rs
+++ b/crates/shuck-linter/src/rules/style/ifs_equals_ambiguity.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Assignment, BuiltinCommand, Command, Span};
+use shuck_ast::{AssignmentNode, Span};
 
 use crate::{Checker, Rule, Violation};
 
@@ -20,41 +20,20 @@ pub fn ifs_equals_ambiguity(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .flat_map(|fact| command_assignment_spans(fact.command(), source))
+        .flat_map(|fact| command_assignment_spans(fact.arena_assignments(), source))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || IfsEqualsAmbiguity);
 }
 
-fn command_assignment_spans(command: &Command, source: &str) -> Vec<Span> {
-    match command {
-        Command::Simple(command) => command
-            .assignments
-            .iter()
-            .filter_map(|assignment| ifs_equals_ambiguity_span(assignment, source))
-            .collect(),
-        Command::Builtin(command) => builtin_assignments(command)
-            .iter()
-            .filter_map(|assignment| ifs_equals_ambiguity_span(assignment, source))
-            .collect(),
-        Command::Decl(_)
-        | Command::Binary(_)
-        | Command::Compound(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => Vec::new(),
-    }
+fn command_assignment_spans(assignments: &[AssignmentNode], source: &str) -> Vec<Span> {
+    assignments
+        .iter()
+        .filter_map(|assignment| ifs_equals_ambiguity_span(assignment, source))
+        .collect()
 }
 
-fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
-    match command {
-        BuiltinCommand::Break(command) => &command.assignments,
-        BuiltinCommand::Continue(command) => &command.assignments,
-        BuiltinCommand::Return(command) => &command.assignments,
-        BuiltinCommand::Exit(command) => &command.assignments,
-    }
-}
-
-fn ifs_equals_ambiguity_span(assignment: &Assignment, source: &str) -> Option<Span> {
+fn ifs_equals_ambiguity_span(assignment: &AssignmentNode, source: &str) -> Option<Span> {
     if assignment.append || assignment.target.name.as_str() != "IFS" {
         return None;
     }

--- a/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/ls_in_substitution.rs
@@ -76,7 +76,7 @@ fn left_segment_is_s047_ls_candidate(
 
 fn pipeline_ls_command_span(
     checker: &Checker,
-    pipeline: &crate::PipelineFact<'_>,
+    pipeline: &crate::PipelineFact,
     segment_index: usize,
 ) -> Span {
     let command = checker

--- a/crates/shuck-linter/src/rules/style/printf_format_variable.rs
+++ b/crates/shuck-linter/src/rules/style/printf_format_variable.rs
@@ -21,17 +21,17 @@ pub fn printf_format_variable(checker: &mut Checker) {
         .filter_map(|fact| {
             let printf = fact.options().printf()?;
             (!printf.format_word_has_literal_percent)
-                .then_some(printf.format_word)
+                .then_some(printf.format_word_span)
                 .flatten()
         })
-        .filter_map(|word| {
+        .filter_map(|span| {
             checker
                 .facts()
                 .word_fact(
-                    word.span,
+                    span,
                     WordFactContext::Expansion(ExpansionContext::CommandArgument),
                 )
-                .and_then(|fact| (!fact.classification().is_fixed_literal()).then_some(word.span))
+                .and_then(|fact| (!fact.classification().is_fixed_literal()).then_some(span))
         })
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/style/ps_grep_pipeline.rs
+++ b/crates/shuck-linter/src/rules/style/ps_grep_pipeline.rs
@@ -25,7 +25,7 @@ pub fn ps_grep_pipeline(checker: &mut Checker) {
     checker.report_all_dedup(spans, || PsGrepPipeline);
 }
 
-fn unsafe_ps_grep_pipeline_spans(checker: &Checker<'_>, pipeline: &PipelineFact<'_>) -> Vec<Span> {
+fn unsafe_ps_grep_pipeline_spans(checker: &Checker<'_>, pipeline: &PipelineFact) -> Vec<Span> {
     pipeline
         .segments()
         .windows(2)
@@ -57,7 +57,7 @@ fn command_body_span(fact: CommandFactRef<'_, '_>) -> Option<Span> {
     }
 
     for redirect in fact.redirect_facts() {
-        let redirect_end = redirect.redirect().span.end;
+        let redirect_end = redirect.span().end;
         if redirect_end.offset > end.offset {
             end = redirect_end;
         }

--- a/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
+++ b/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
@@ -1,4 +1,3 @@
-use crate::facts::word_spans;
 use crate::{Checker, Rule, Violation, WordQuote};
 
 pub struct QuotedDollarStarLoop;
@@ -32,9 +31,8 @@ pub fn quoted_dollar_star_loop(checker: &mut Checker) {
             }
 
             (classification.has_command_substitution()
-                || !word_spans::word_double_quoted_scalar_only_expansion_spans(word.word())
-                    .is_empty()
-                || !word_spans::word_quoted_star_splat_spans(word.word()).is_empty())
+                || word.has_double_quoted_scalar_only_expansion()
+                || word.has_quoted_star_splat())
             .then_some(word.span())
         })
         .collect::<Vec<_>>();

--- a/crates/shuck-linter/src/rules/style/su_without_flag.rs
+++ b/crates/shuck-linter/src/rules/style/su_without_flag.rs
@@ -33,7 +33,7 @@ pub fn su_without_flag(checker: &mut Checker) {
         .filter(|fact| fact.effective_name_is("su") && fact.wrappers().is_empty())
         .filter(|fact| fact.options().su().is_some_and(|su| !su.has_login_flag()))
         .filter(|fact| !piped_command_ids.contains(&fact.id()))
-        .filter(|fact| fact.redirects().is_empty())
+        .filter(|fact| !fact.has_redirects())
         .filter(|fact| fact.body_args().len() < 2)
         .map(|fact| fact.span_in_source(checker.source()))
         .collect::<Vec<_>>();

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -258,7 +258,8 @@ impl<'a> Parser<'a> {
             ParseStatus::Recovered
         };
 
-        let arena_file = ArenaFile::from_file(&file);
+        let arena_file = ArenaFile::from_body(file.body, file_span);
+        let file = arena_file.to_file();
 
         ParseResult {
             file,

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -244,11 +244,8 @@ impl<'a> Parser<'a> {
             }
         }
 
-        let mut file = File {
-            body: Self::stmt_seq_with_span(file_span, stmts),
-            span: file_span,
-        };
-        self.attach_comments_to_file(&mut file);
+        let mut body = Self::stmt_seq_with_span(file_span, stmts);
+        self.attach_comments_to_body(&mut body);
 
         let status = if terminal_error.is_some() {
             ParseStatus::Fatal
@@ -258,7 +255,7 @@ impl<'a> Parser<'a> {
             ParseStatus::Recovered
         };
 
-        let arena_file = ArenaFile::from_body(file.body, file_span);
+        let arena_file = ArenaFile::from_body(body, file_span);
         let file = arena_file.to_file();
 
         ParseResult {

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -258,8 +258,11 @@ impl<'a> Parser<'a> {
             ParseStatus::Recovered
         };
 
+        let arena_file = ArenaFile::from_file(&file);
+
         ParseResult {
             file,
+            arena_file,
             diagnostics,
             status,
             terminal_error,

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -7415,10 +7415,10 @@ impl<'a> Parser<'a> {
         taken
     }
 
-    fn attach_comments_to_file(&self, file: &mut File) {
+    fn attach_comments_to_body(&self, body: &mut StmtSeq) {
         let mut comments = self.comments.iter().copied().collect::<VecDeque<_>>();
-        Self::attach_comments_to_stmt_seq_with_source(self.input, &mut file.body, &mut comments);
-        file.body.trailing_comments.extend(comments);
+        Self::attach_comments_to_stmt_seq_with_source(self.input, body, &mut comments);
+        body.trailing_comments.extend(comments);
     }
 
     fn attach_comments_to_stmt_seq_with_source(

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -25,13 +25,13 @@ use memchr::{memchr, memchr2, memchr3};
 use smallvec::SmallVec;
 
 use shuck_ast::{
-    AlwaysCommand, AnonymousFunctionCommand, AnonymousFunctionSurface, ArithmeticCommand,
-    ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticForCommand,
-    ArithmeticLvalue, ArrayElem, ArrayExpr, ArrayKind, Assignment, AssignmentValue,
-    BackgroundOperator, BinaryCommand, BinaryOp, BourneParameterExpansion, BraceExpansionKind,
-    BraceQuoteContext, BraceSyntax, BraceSyntaxKind, BreakCommand as AstBreakCommand,
-    BuiltinCommand as AstBuiltinCommand, CaseCommand, CaseItem, CaseTerminator,
-    Command as AstCommand, CommandSubstitutionSyntax, Comment, CompoundCommand,
+    AlwaysCommand, AnonymousFunctionCommand, AnonymousFunctionSurface, ArenaFile,
+    ArithmeticCommand, ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode,
+    ArithmeticForCommand, ArithmeticLvalue, ArrayElem, ArrayExpr, ArrayKind, Assignment,
+    AssignmentValue, BackgroundOperator, BinaryCommand, BinaryOp, BourneParameterExpansion,
+    BraceExpansionKind, BraceQuoteContext, BraceSyntax, BraceSyntaxKind,
+    BreakCommand as AstBreakCommand, BuiltinCommand as AstBuiltinCommand, CaseCommand, CaseItem,
+    CaseTerminator, Command as AstCommand, CommandSubstitutionSyntax, Comment, CompoundCommand,
     ConditionalBinaryExpr, ConditionalBinaryOp, ConditionalCommand, ConditionalExpr,
     ConditionalParenExpr, ConditionalUnaryExpr, ConditionalUnaryOp,
     ContinueCommand as AstContinueCommand, CoprocCommand, DeclClause as AstDeclClause, DeclOperand,
@@ -108,6 +108,8 @@ pub struct SyntaxFacts {
 pub struct ParseResult {
     /// Parsed syntax tree for the file.
     pub file: File,
+    /// ID-backed parsed syntax tree for the file.
+    pub arena_file: ArenaFile,
     /// Recovery diagnostics emitted while producing the AST.
     pub diagnostics: Vec<ParseDiagnostic>,
     /// High-level parse status.

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2,15 +2,15 @@ use std::{borrow::Cow, collections::BTreeMap};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
-    AnonymousFunctionCommand, ArithmeticAssignOp, ArithmeticExpr, ArithmeticExprNode,
+    AnonymousFunctionCommand, ArenaFile, ArithmeticAssignOp, ArithmeticExpr, ArithmeticExprNode,
     ArithmeticLvalue, ArithmeticUnaryOp, ArrayElem, ArrayExpr, ArrayKind, Assignment,
     AssignmentValue, BinaryCommand, BinaryOp, BourneParameterExpansion, BuiltinCommand, Command,
     CompoundCommand, ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclOperand, File,
     FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, LiteralText, Name,
     NormalizedCommand, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
     PatternGroupKind, PatternPart, PatternPartNode, Position, SourceText, Span,
-    StaticCommandWrapperTarget, Stmt, StmtSeq, Subscript, VarRef, Word, WordPart, WordPartNode,
-    WrapperKind, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
+    StaticCommandWrapperTarget, Stmt, StmtSeq, StmtSeqView, Subscript, VarRef, Word, WordPart,
+    WordPartNode, WrapperKind, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
     normalize_command_words, static_command_name_text, static_command_wrapper_target_index,
     static_word_text, try_static_word_parts_text,
 };
@@ -103,7 +103,7 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     cleared_variables: FxHashMap<(ScopeId, Name), SmallVec<[usize; 2]>>,
     runtime: RuntimePrelude,
     completed_scopes: FxHashSet<ScopeId>,
-    deferred_functions: Vec<DeferredFunction<'a>>,
+    deferred_functions: Vec<DeferredFunction>,
     scope_stack: Vec<ScopeId>,
     command_stack: Vec<Span>,
     guarded_parameter_operand_depth: u32,
@@ -154,18 +154,18 @@ enum WordVisitKind {
     ParameterPattern,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct DeferredFunction<'a> {
-    function: &'a FunctionDef,
+#[derive(Debug, Clone)]
+struct DeferredFunction {
+    function: FunctionDef,
     scope: ScopeId,
     flow: FlowState,
 }
 
 impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     pub(crate) fn build(
-        file: &'a File,
+        file: &File,
         source: &'a str,
-        indexer: &'a Indexer,
+        indexer: &Indexer,
         observer: &'observer mut dyn TraversalObserver,
         bash_runtime_vars_enabled: bool,
         shell_profile: ShellProfile,
@@ -257,6 +257,102 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    pub(crate) fn build_arena(
+        file: &'a ArenaFile,
+        source: &'a str,
+        indexer: &Indexer,
+        observer: &'observer mut dyn TraversalObserver,
+        bash_runtime_vars_enabled: bool,
+        shell_profile: ShellProfile,
+    ) -> BuildOutput {
+        let file = file.view();
+        let file_scope = Scope {
+            id: ScopeId(0),
+            kind: ScopeKind::File,
+            parent: None,
+            span: file.span(),
+            bindings: FxHashMap::default(),
+        };
+        let runtime = RuntimePrelude::new(bash_runtime_vars_enabled);
+        let mut builder = Self {
+            source,
+            line_start_offsets: source_line_start_offsets(source),
+            shell_profile: shell_profile.clone(),
+            observer,
+            scopes: vec![file_scope],
+            bindings: Vec::new(),
+            references: Vec::new(),
+            reference_index: FxHashMap::default(),
+            predefined_runtime_refs: FxHashSet::default(),
+            guarded_parameter_refs: FxHashSet::default(),
+            parameter_guard_flow_refs: FxHashSet::default(),
+            defaulting_parameter_operand_refs: FxHashSet::default(),
+            self_referential_assignment_refs: FxHashSet::default(),
+            binding_index: FxHashMap::default(),
+            resolved: FxHashMap::default(),
+            unresolved: Vec::new(),
+            functions: FxHashMap::default(),
+            call_sites: FxHashMap::default(),
+            source_refs: Vec::new(),
+            declarations: Vec::new(),
+            indirect_target_hints: FxHashMap::default(),
+            indirect_expansion_refs: FxHashSet::default(),
+            flow_contexts: Vec::new(),
+            recorded_program: RecordedProgram::default(),
+            command_bindings: FxHashMap::default(),
+            command_references: FxHashMap::default(),
+            source_directives: parse_source_directives(source, indexer),
+            cleared_variables: FxHashMap::default(),
+            runtime,
+            completed_scopes: FxHashSet::default(),
+            deferred_functions: Vec::new(),
+            scope_stack: vec![ScopeId(0)],
+            command_stack: Vec::new(),
+            guarded_parameter_operand_depth: 0,
+            defaulting_parameter_operand_depth: 0,
+            short_circuit_condition_depth: 0,
+            arithmetic_reference_kind: ReferenceKind::ArithmeticRead,
+            word_reference_kind_override: None,
+        };
+        let file_commands = builder.visit_stmt_seq_arena(file.body(), FlowState::default());
+        builder.recorded_program.set_file_commands(file_commands);
+        builder.mark_scope_completed(ScopeId(0));
+        builder.drain_deferred_functions();
+
+        let call_graph = builder.build_call_graph();
+        let heuristic_unused_assignments = builder.compute_heuristic_unused_assignments();
+
+        BuildOutput {
+            shell_profile,
+            scopes: builder.scopes,
+            bindings: builder.bindings,
+            references: builder.references,
+            reference_index: builder.reference_index,
+            predefined_runtime_refs: builder.predefined_runtime_refs,
+            guarded_parameter_refs: builder.guarded_parameter_refs,
+            parameter_guard_flow_refs: builder.parameter_guard_flow_refs,
+            defaulting_parameter_operand_refs: builder.defaulting_parameter_operand_refs,
+            self_referential_assignment_refs: builder.self_referential_assignment_refs,
+            binding_index: builder.binding_index,
+            resolved: builder.resolved,
+            unresolved: builder.unresolved,
+            functions: builder.functions,
+            call_sites: builder.call_sites,
+            call_graph,
+            source_refs: builder.source_refs,
+            runtime: builder.runtime,
+            declarations: builder.declarations,
+            indirect_target_hints: builder.indirect_target_hints,
+            indirect_expansion_refs: builder.indirect_expansion_refs,
+            flow_contexts: builder.flow_contexts,
+            recorded_program: builder.recorded_program,
+            command_bindings: builder.command_bindings,
+            command_references: builder.command_references,
+            cleared_variables: builder.cleared_variables,
+            heuristic_unused_assignments,
+        }
+    }
+
     fn flow_context(flow: FlowState) -> FlowContext {
         FlowContext {
             in_function: flow.in_function,
@@ -293,15 +389,28 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             self.recorded_program.push_regions(merged);
     }
 
-    fn visit_stmt_seq(&mut self, commands: &'a StmtSeq, flow: FlowState) -> RecordedCommandRange {
+    fn visit_stmt_seq(&mut self, commands: &StmtSeq, flow: FlowState) -> RecordedCommandRange {
         let mut recorded = Vec::with_capacity(commands.len());
         self.visit_stmt_seq_into(commands, flow, &mut recorded);
         self.recorded_program.push_command_ids(recorded)
     }
 
+    fn visit_stmt_seq_arena(
+        &mut self,
+        commands: StmtSeqView<'_>,
+        flow: FlowState,
+    ) -> RecordedCommandRange {
+        let mut recorded = Vec::with_capacity(commands.stmt_ids().len());
+        for stmt in commands.stmts() {
+            let stmt = stmt.to_stmt();
+            recorded.push(self.visit_stmt(&stmt, flow));
+        }
+        self.recorded_program.push_command_ids(recorded)
+    }
+
     fn visit_stmt_seq_into(
         &mut self,
-        commands: &'a StmtSeq,
+        commands: &StmtSeq,
         flow: FlowState,
         recorded: &mut Vec<RecordedCommandId>,
     ) {
@@ -311,7 +420,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
-    fn visit_stmt(&mut self, stmt: &'a Stmt, flow: FlowState) -> RecordedCommandId {
+    fn visit_stmt(&mut self, stmt: &Stmt, flow: FlowState) -> RecordedCommandId {
         let span = semantic_statement_span(stmt);
         let scope = self.current_scope();
         let context = Self::flow_context(flow);
@@ -335,7 +444,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         recorded
     }
 
-    fn visit_command(&mut self, command: &'a Command, flow: FlowState) -> RecordedCommandId {
+    fn visit_command(&mut self, command: &Command, flow: FlowState) -> RecordedCommandId {
         match command {
             Command::Simple(command) => self.visit_simple_command(command, flow),
             Command::Builtin(command) => self.visit_builtin(command, flow),
@@ -349,7 +458,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_simple_command(
         &mut self,
-        command: &'a shuck_ast::SimpleCommand,
+        command: &shuck_ast::SimpleCommand,
         flow: FlowState,
     ) -> RecordedCommandId {
         let mut nested_regions = Vec::new();
@@ -421,7 +530,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
     }
 
-    fn visit_builtin(&mut self, command: &'a BuiltinCommand, flow: FlowState) -> RecordedCommandId {
+    fn visit_builtin(&mut self, command: &BuiltinCommand, flow: FlowState) -> RecordedCommandId {
         match command {
             BuiltinCommand::Break(command) => {
                 let nested_regions = self.visit_builtin_parts(
@@ -476,9 +585,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_builtin_parts(
         &mut self,
-        assignments: &'a [Assignment],
-        primary_word: Option<&'a Word>,
-        extra_words: &'a [Word],
+        assignments: &[Assignment],
+        primary_word: Option<&Word>,
+        extra_words: &[Word],
         flow: FlowState,
     ) -> Vec<IsolatedRegion> {
         let mut nested_regions = Vec::new();
@@ -499,7 +608,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_decl(
         &mut self,
-        command: &'a shuck_ast::DeclClause,
+        command: &shuck_ast::DeclClause,
         flow: FlowState,
     ) -> RecordedCommandId {
         let mut nested_regions = Vec::new();
@@ -575,7 +684,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
     }
 
-    fn visit_binary(&mut self, command: &'a BinaryCommand, flow: FlowState) -> RecordedCommandId {
+    fn visit_binary(&mut self, command: &BinaryCommand, flow: FlowState) -> RecordedCommandId {
         match command.op {
             BinaryOp::And | BinaryOp::Or => self.visit_logical_binary(command, flow),
             BinaryOp::Pipe | BinaryOp::PipeAll => self.visit_pipeline_binary(command, flow),
@@ -584,7 +693,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_pipeline_binary(
         &mut self,
-        command: &'a BinaryCommand,
+        command: &BinaryCommand,
         mut flow: FlowState,
     ) -> RecordedCommandId {
         flow.in_subshell = true;
@@ -614,7 +723,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_logical_binary(
         &mut self,
-        command: &'a BinaryCommand,
+        command: &BinaryCommand,
         flow: FlowState,
     ) -> RecordedCommandId {
         let mut operators = SmallVec::<[RecordedListOperator; 4]>::new();
@@ -652,11 +761,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         )
     }
 
-    fn visit_compound(
-        &mut self,
-        command: &'a CompoundCommand,
-        flow: FlowState,
-    ) -> RecordedCommandId {
+    fn visit_compound(&mut self, command: &CompoundCommand, flow: FlowState) -> RecordedCommandId {
         match command {
             CompoundCommand::If(command) => {
                 let condition = self.visit_stmt_seq(
@@ -997,7 +1102,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
-    fn visit_function(&mut self, function: &'a FunctionDef, flow: FlowState) -> RecordedCommandId {
+    fn visit_function(&mut self, function: &FunctionDef, flow: FlowState) -> RecordedCommandId {
         let mut nested_regions = Vec::new();
         for entry in &function.header.entries {
             self.visit_word_into(
@@ -1030,7 +1135,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 .insert(binding_id, scope);
         }
         self.deferred_functions.push(DeferredFunction {
-            function,
+            function: function.clone(),
             scope,
             flow,
         });
@@ -1041,7 +1146,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_anonymous_function(
         &mut self,
-        function: &'a AnonymousFunctionCommand,
+        function: &AnonymousFunctionCommand,
         flow: FlowState,
     ) -> RecordedCommandId {
         let nested_regions = self.visit_words(&function.args, WordVisitKind::Expansion, flow);
@@ -1063,7 +1168,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_assignment_into(
         &mut self,
-        assignment: &'a Assignment,
+        assignment: &Assignment,
         declaration_kind: Option<(BindingKind, ScopeId)>,
         mut attributes: BindingAttributes,
         flow: FlowState,
@@ -1133,7 +1238,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
-    fn record_prompt_assignment_references(&mut self, assignment: &'a Assignment) {
+    fn record_prompt_assignment_references(&mut self, assignment: &Assignment) {
         let AssignmentValue::Scalar(word) = &assignment.value else {
             return;
         };
@@ -1159,7 +1264,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_assignment_value_into(
         &mut self,
-        assignment: &'a Assignment,
+        assignment: &Assignment,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -1175,7 +1280,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_words(
         &mut self,
-        words: &'a [Word],
+        words: &[Word],
         kind: WordVisitKind,
         flow: FlowState,
     ) -> Vec<IsolatedRegion> {
@@ -1186,7 +1291,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_words_into(
         &mut self,
-        words: &'a [Word],
+        words: &[Word],
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1198,7 +1303,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_array_expr_into(
         &mut self,
-        array: &'a ArrayExpr,
+        array: &ArrayExpr,
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1218,7 +1323,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_patterns(
         &mut self,
-        patterns: &'a [Pattern],
+        patterns: &[Pattern],
         kind: WordVisitKind,
         flow: FlowState,
     ) -> Vec<IsolatedRegion> {
@@ -1229,7 +1334,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_patterns_into(
         &mut self,
-        patterns: &'a [Pattern],
+        patterns: &[Pattern],
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1241,7 +1346,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_redirects(
         &mut self,
-        redirects: &'a [shuck_ast::Redirect],
+        redirects: &[shuck_ast::Redirect],
         flow: FlowState,
     ) -> Vec<IsolatedRegion> {
         let mut nested_regions = Vec::new();
@@ -1251,7 +1356,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_redirects_into(
         &mut self,
-        redirects: &'a [shuck_ast::Redirect],
+        redirects: &[shuck_ast::Redirect],
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -1297,7 +1402,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_word(
         &mut self,
-        word: &'a Word,
+        word: &Word,
         kind: WordVisitKind,
         flow: FlowState,
     ) -> Vec<IsolatedRegion> {
@@ -1308,7 +1413,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_word_into(
         &mut self,
-        word: &'a Word,
+        word: &Word,
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1321,7 +1426,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_heredoc_body_into(
         &mut self,
-        body: &'a HeredocBody,
+        body: &HeredocBody,
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1334,7 +1439,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_pattern_into(
         &mut self,
-        pattern: &'a Pattern,
+        pattern: &Pattern,
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1347,7 +1452,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_word_part_nodes(
         &mut self,
-        parts: &'a [WordPartNode],
+        parts: &[WordPartNode],
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1359,7 +1464,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_pattern_part_nodes(
         &mut self,
-        parts: &'a [PatternPartNode],
+        parts: &[PatternPartNode],
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1371,7 +1476,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_heredoc_body_part_nodes(
         &mut self,
-        parts: &'a [HeredocBodyPartNode],
+        parts: &[HeredocBodyPartNode],
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1383,7 +1488,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_var_ref_reference(
         &mut self,
-        reference: &'a VarRef,
+        reference: &VarRef,
         reference_kind: ReferenceKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1404,7 +1509,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     fn visit_var_ref_subscript_words(
         &mut self,
         owner_name: Option<&Name>,
-        subscript: Option<&'a Subscript>,
+        subscript: Option<&Subscript>,
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1458,7 +1563,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_word_part(
         &mut self,
-        part: &'a WordPart,
+        part: &WordPart,
         span: Span,
         kind: WordVisitKind,
         flow: FlowState,
@@ -1661,7 +1766,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_heredoc_body_part(
         &mut self,
-        part: &'a HeredocBodyPart,
+        part: &HeredocBodyPart,
         span: Span,
         kind: WordVisitKind,
         flow: FlowState,
@@ -1733,7 +1838,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_parameter_expansion(
         &mut self,
-        parameter: &'a ParameterExpansion,
+        parameter: &ParameterExpansion,
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -1968,7 +2073,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_fragment_word(
         &mut self,
-        word: Option<&'a Word>,
+        word: Option<&Word>,
         text: Option<&shuck_ast::SourceText>,
         kind: WordVisitKind,
         flow: FlowState,
@@ -1986,9 +2091,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_parameter_operator_operand(
         &mut self,
-        operator: &'a ParameterOp,
+        operator: &ParameterOp,
         operand: Option<&shuck_ast::SourceText>,
-        operand_word_ast: Option<&'a Word>,
+        operand_word_ast: Option<&Word>,
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -2057,7 +2162,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_pattern_part(
         &mut self,
-        part: &'a PatternPart,
+        part: &PatternPart,
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
@@ -2080,7 +2185,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_conditional_expr(
         &mut self,
-        expression: &'a ConditionalExpr,
+        expression: &ConditionalExpr,
         flow: FlowState,
     ) -> Vec<IsolatedRegion> {
         let mut nested_regions = Vec::new();
@@ -2090,7 +2195,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_conditional_expr_into(
         &mut self,
-        expression: &'a ConditionalExpr,
+        expression: &ConditionalExpr,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2149,7 +2254,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_conditional_arithmetic_operand_into(
         &mut self,
-        expression: &'a ConditionalExpr,
+        expression: &ConditionalExpr,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2163,7 +2268,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_optional_arithmetic_expr(
         &mut self,
-        expr: Option<&'a ArithmeticExprNode>,
+        expr: Option<&ArithmeticExprNode>,
         flow: FlowState,
     ) -> Vec<IsolatedRegion> {
         let mut nested_regions = Vec::new();
@@ -2173,7 +2278,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_optional_arithmetic_expr_into(
         &mut self,
-        expr: Option<&'a ArithmeticExprNode>,
+        expr: Option<&ArithmeticExprNode>,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2184,7 +2289,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_parameter_slice_arithmetic_expr_into(
         &mut self,
-        expr: Option<&'a ArithmeticExprNode>,
+        expr: Option<&ArithmeticExprNode>,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2196,7 +2301,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_arithmetic_expr_into(
         &mut self,
-        expr: &'a ArithmeticExprNode,
+        expr: &ArithmeticExprNode,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2271,7 +2376,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     fn visit_arithmetic_index_into(
         &mut self,
         owner_name: &Name,
-        index: &'a ArithmeticExprNode,
+        index: &ArithmeticExprNode,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2324,7 +2429,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_associative_arithmetic_key_into(
         &mut self,
-        expr: &'a ArithmeticExprNode,
+        expr: &ArithmeticExprNode,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2367,7 +2472,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_associative_arithmetic_lvalue_into(
         &mut self,
-        target: &'a ArithmeticLvalue,
+        target: &ArithmeticLvalue,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2381,7 +2486,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_arithmetic_update_into(
         &mut self,
-        expr: &'a ArithmeticExprNode,
+        expr: &ArithmeticExprNode,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2440,10 +2545,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_arithmetic_assignment_into(
         &mut self,
-        target: &'a ArithmeticLvalue,
+        target: &ArithmeticLvalue,
         target_span: Span,
         op: ArithmeticAssignOp,
-        value: &'a ArithmeticExprNode,
+        value: &ArithmeticExprNode,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2480,7 +2585,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_arithmetic_lvalue_indices_into(
         &mut self,
-        target: &'a ArithmeticLvalue,
+        target: &ArithmeticLvalue,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
@@ -2495,7 +2600,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     fn classify_special_simple_command(
         &mut self,
         name: &Name,
-        normalized: &NormalizedCommand<'a>,
+        normalized: &NormalizedCommand<'_>,
         command_span: Span,
         flow: FlowState,
     ) {
@@ -2629,7 +2734,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
-    fn record_trap_action_references(&mut self, args: &[&'a Word]) {
+    fn record_trap_action_references(&mut self, args: &[&Word]) {
         let Some(argument) = trap_action_argument(args, self.source) else {
             return;
         };
@@ -2642,7 +2747,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
-    fn record_let_arithmetic_assignment_targets(&mut self, args: &[&'a Word]) {
+    fn record_let_arithmetic_assignment_targets(&mut self, args: &[&Word]) {
         for argument in args {
             let Some((name, span)) = let_arithmetic_assignment_target(argument, self.source) else {
                 continue;
@@ -2664,7 +2769,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     fn visit_simple_declaration_command(
         &mut self,
         command_name: &str,
-        args: &[&'a Word],
+        args: &[&Word],
         command_span: Span,
         flow: FlowState,
     ) {
@@ -3611,11 +3716,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.command_stack.clear();
     }
 
-    fn visit_function_like_body(
-        &mut self,
-        body: &'a Stmt,
-        flow: FlowState,
-    ) -> RecordedCommandRange {
+    fn visit_function_like_body(&mut self, body: &Stmt, flow: FlowState) -> RecordedCommandRange {
         let flow = FlowState {
             in_function: true,
             ..flow

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2,17 +2,23 @@ use std::{borrow::Cow, collections::BTreeMap};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
-    AnonymousFunctionCommand, ArenaFile, ArithmeticAssignOp, ArithmeticExpr, ArithmeticExprNode,
-    ArithmeticLvalue, ArithmeticUnaryOp, ArrayElem, ArrayExpr, ArrayKind, Assignment,
-    AssignmentValue, BinaryCommand, BinaryOp, BourneParameterExpansion, BuiltinCommand, Command,
-    CompoundCommand, ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclOperand, File,
-    FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, LiteralText, Name,
-    NormalizedCommand, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
-    PatternGroupKind, PatternPart, PatternPartNode, Position, SourceText, Span,
-    StaticCommandWrapperTarget, Stmt, StmtSeq, StmtSeqView, Subscript, VarRef, Word, WordPart,
-    WordPartNode, WrapperKind, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
-    normalize_command_words, static_command_name_text, static_command_wrapper_target_index,
-    static_word_text, try_static_word_parts_text,
+    AnonymousFunctionCommand, ArenaFile, ArenaFileCommandKind, ArenaHeredocBodyPart,
+    ArithmeticAssignOp, ArithmeticExpr, ArithmeticExprArena, ArithmeticExprArenaNode,
+    ArithmeticExprNode, ArithmeticLvalue, ArithmeticLvalueArena, ArithmeticUnaryOp, ArrayElem,
+    ArrayExpr, ArrayKind, Assignment, AssignmentNode, AssignmentValue, AssignmentValueNode,
+    AstStore, BinaryCommand, BinaryOp, BourneParameterExpansion, BourneParameterExpansionNode,
+    BuiltinCommand, BuiltinCommandNodeKind, Command, CommandView, CompoundCommand,
+    CompoundCommandNode, ConditionalBinaryOp, ConditionalExpr, ConditionalExprArena,
+    ConditionalUnaryOp, DeclOperand, DeclOperandNode, FunctionDef, HeredocBody, HeredocBodyPart,
+    HeredocBodyPartNode, LiteralText, Name, NormalizedCommand, ParameterExpansion,
+    ParameterExpansionNode, ParameterExpansionSyntax, ParameterExpansionSyntaxNode, ParameterOp,
+    Pattern, PatternGroupKind, PatternNode, PatternPart, PatternPartArena, PatternPartNode,
+    Position, RedirectNode, RedirectTargetNode, SourceText, Span, StaticCommandWrapperTarget, Stmt,
+    StmtSeq, StmtSeqId, StmtSeqView, StmtView, Subscript, SubscriptNode, VarRef, VarRefNode, Word,
+    WordId, WordPart, WordPartArena, WordPartArenaNode, WordPartNode, WrapperKind,
+    ZshExpansionOperation, ZshExpansionOperationNode, ZshExpansionTarget, ZshExpansionTargetNode,
+    ZshGlobSegment, normalize_command_words, static_command_name_text,
+    static_command_wrapper_target_index, static_word_text, try_static_word_parts_text,
 };
 use shuck_indexer::Indexer;
 use shuck_parser::{ShellProfile, ZshEmulationMode};
@@ -32,7 +38,7 @@ use crate::cfg::{
 use crate::declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 use crate::reference::{Reference, ReferenceKind};
 use crate::runtime::RuntimePrelude;
-use crate::source_closure::source_path_template;
+use crate::source_closure::{SourcePathTemplate, TemplatePart};
 use crate::source_ref::{
     SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution,
     default_diagnostic_class,
@@ -72,8 +78,9 @@ pub(crate) struct BuildOutput {
     pub(crate) heuristic_unused_assignments: Vec<BindingId>,
 }
 
-pub(crate) struct SemanticModelBuilder<'a, 'observer> {
-    source: &'a str,
+pub(crate) struct SemanticModelBuilder<'src, 'ast, 'observer> {
+    source: &'src str,
+    arena_store: Option<&'ast AstStore>,
     line_start_offsets: Vec<usize>,
     shell_profile: ShellProfile,
     observer: &'observer mut dyn TraversalObserver,
@@ -128,6 +135,21 @@ fn semantic_statement_span(stmt: &Stmt) -> Span {
     Span::from_positions(stmt.span.start, end)
 }
 
+fn semantic_statement_span_arena(stmt: StmtView<'_>) -> Span {
+    let mut end = stmt
+        .terminator_span()
+        .filter(|terminator| terminator.end.offset == stmt.span().end.offset)
+        .map_or(stmt.span().end, |terminator| terminator.start);
+
+    for redirect in stmt.redirects() {
+        if redirect.span.end.offset > end.offset {
+            end = redirect.span.end;
+        }
+    }
+
+    Span::from_positions(stmt.span().start, end)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct FlowState {
     in_function: bool,
@@ -155,116 +177,48 @@ enum WordVisitKind {
 }
 
 #[derive(Debug, Clone)]
+struct ArenaNormalizedCommand<'a> {
+    literal_name: Option<Cow<'a, str>>,
+    effective_name: Option<Cow<'a, str>>,
+    wrappers: Vec<WrapperKind>,
+    body_word_span: Option<Span>,
+    body_words: Vec<WordId>,
+    command_span: Span,
+}
+
+impl ArenaNormalizedCommand<'_> {
+    fn body_word_span(&self) -> Option<Span> {
+        self.body_word_span
+    }
+
+    fn body_args(&self) -> &[WordId] {
+        self.body_words.split_first().map_or(&[], |(_, rest)| rest)
+    }
+}
+
+#[derive(Debug, Clone)]
 struct DeferredFunction {
-    function: FunctionDef,
+    body: DeferredFunctionBody,
     scope: ScopeId,
     flow: FlowState,
 }
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
-    pub(crate) fn build(
-        file: &File,
-        source: &'a str,
-        indexer: &Indexer,
-        observer: &'observer mut dyn TraversalObserver,
-        bash_runtime_vars_enabled: bool,
-        shell_profile: ShellProfile,
-    ) -> BuildOutput {
-        let file_scope = Scope {
-            id: ScopeId(0),
-            kind: ScopeKind::File,
-            parent: None,
-            span: file.span,
-            bindings: FxHashMap::default(),
-        };
-        let runtime = RuntimePrelude::new(bash_runtime_vars_enabled);
-        let mut builder = Self {
-            source,
-            line_start_offsets: source_line_start_offsets(source),
-            shell_profile: shell_profile.clone(),
-            observer,
-            scopes: vec![file_scope],
-            bindings: Vec::new(),
-            references: Vec::new(),
-            reference_index: FxHashMap::default(),
-            predefined_runtime_refs: FxHashSet::default(),
-            guarded_parameter_refs: FxHashSet::default(),
-            parameter_guard_flow_refs: FxHashSet::default(),
-            defaulting_parameter_operand_refs: FxHashSet::default(),
-            self_referential_assignment_refs: FxHashSet::default(),
-            binding_index: FxHashMap::default(),
-            resolved: FxHashMap::default(),
-            unresolved: Vec::new(),
-            functions: FxHashMap::default(),
-            call_sites: FxHashMap::default(),
-            source_refs: Vec::new(),
-            declarations: Vec::new(),
-            indirect_target_hints: FxHashMap::default(),
-            indirect_expansion_refs: FxHashSet::default(),
-            flow_contexts: Vec::new(),
-            recorded_program: RecordedProgram::default(),
-            command_bindings: FxHashMap::default(),
-            command_references: FxHashMap::default(),
-            source_directives: parse_source_directives(source, indexer),
-            cleared_variables: FxHashMap::default(),
-            runtime,
-            completed_scopes: FxHashSet::default(),
-            deferred_functions: Vec::new(),
-            scope_stack: vec![ScopeId(0)],
-            command_stack: Vec::new(),
-            guarded_parameter_operand_depth: 0,
-            defaulting_parameter_operand_depth: 0,
-            short_circuit_condition_depth: 0,
-            arithmetic_reference_kind: ReferenceKind::ArithmeticRead,
-            word_reference_kind_override: None,
-        };
-        let file_commands = builder.visit_stmt_seq(&file.body, FlowState::default());
-        builder.recorded_program.set_file_commands(file_commands);
-        builder.mark_scope_completed(ScopeId(0));
-        builder.drain_deferred_functions();
+#[derive(Debug, Clone)]
+enum DeferredFunctionBody {
+    Recursive(FunctionDef),
+    Arena(StmtSeqId),
+}
 
-        let call_graph = builder.build_call_graph();
-        let heuristic_unused_assignments = builder.compute_heuristic_unused_assignments();
-
-        BuildOutput {
-            shell_profile,
-            scopes: builder.scopes,
-            bindings: builder.bindings,
-            references: builder.references,
-            reference_index: builder.reference_index,
-            predefined_runtime_refs: builder.predefined_runtime_refs,
-            guarded_parameter_refs: builder.guarded_parameter_refs,
-            parameter_guard_flow_refs: builder.parameter_guard_flow_refs,
-            defaulting_parameter_operand_refs: builder.defaulting_parameter_operand_refs,
-            self_referential_assignment_refs: builder.self_referential_assignment_refs,
-            binding_index: builder.binding_index,
-            resolved: builder.resolved,
-            unresolved: builder.unresolved,
-            functions: builder.functions,
-            call_sites: builder.call_sites,
-            call_graph,
-            source_refs: builder.source_refs,
-            runtime: builder.runtime,
-            declarations: builder.declarations,
-            indirect_target_hints: builder.indirect_target_hints,
-            indirect_expansion_refs: builder.indirect_expansion_refs,
-            flow_contexts: builder.flow_contexts,
-            recorded_program: builder.recorded_program,
-            command_bindings: builder.command_bindings,
-            command_references: builder.command_references,
-            cleared_variables: builder.cleared_variables,
-            heuristic_unused_assignments,
-        }
-    }
-
+impl<'src, 'ast, 'observer> SemanticModelBuilder<'src, 'ast, 'observer> {
     pub(crate) fn build_arena(
-        file: &'a ArenaFile,
-        source: &'a str,
+        file: &'ast ArenaFile,
+        source: &'src str,
         indexer: &Indexer,
         observer: &'observer mut dyn TraversalObserver,
         bash_runtime_vars_enabled: bool,
         shell_profile: ShellProfile,
     ) -> BuildOutput {
+        let arena_store = &file.store;
         let file = file.view();
         let file_scope = Scope {
             id: ScopeId(0),
@@ -276,6 +230,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let runtime = RuntimePrelude::new(bash_runtime_vars_enabled);
         let mut builder = Self {
             source,
+            arena_store: Some(arena_store),
             line_start_offsets: source_line_start_offsets(source),
             shell_profile: shell_profile.clone(),
             observer,
@@ -320,6 +275,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         builder.drain_deferred_functions();
 
         let call_graph = builder.build_call_graph();
+        builder.mark_local_declarations_visible_to_later_calls();
         let heuristic_unused_assignments = builder.compute_heuristic_unused_assignments();
 
         BuildOutput {
@@ -363,6 +319,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn arena_store(&self) -> &'ast AstStore {
+        self.arena_store
+            .expect("arena visitor requires arena storage")
+    }
+
+    fn arena_stmt_seq(&self, id: StmtSeqId) -> StmtSeqView<'ast> {
+        self.arena_store().stmt_seq(id)
+    }
+
     fn record_command(
         &mut self,
         span: Span,
@@ -401,11 +366,20 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         flow: FlowState,
     ) -> RecordedCommandRange {
         let mut recorded = Vec::with_capacity(commands.stmt_ids().len());
-        for stmt in commands.stmts() {
-            let stmt = stmt.to_stmt();
-            recorded.push(self.visit_stmt(&stmt, flow));
-        }
+        self.visit_stmt_seq_arena_into(commands, flow, &mut recorded);
         self.recorded_program.push_command_ids(recorded)
+    }
+
+    fn visit_stmt_seq_arena_into(
+        &mut self,
+        commands: StmtSeqView<'_>,
+        flow: FlowState,
+        recorded: &mut Vec<RecordedCommandId>,
+    ) {
+        recorded.reserve(commands.stmt_ids().len());
+        for stmt in commands.stmts() {
+            recorded.push(self.visit_stmt_arena(stmt, flow));
+        }
     }
 
     fn visit_stmt_seq_into(
@@ -422,10 +396,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     fn visit_stmt(&mut self, stmt: &Stmt, flow: FlowState) -> RecordedCommandId {
         let span = semantic_statement_span(stmt);
-        let scope = self.current_scope();
         let context = Self::flow_context(flow);
-        self.flow_contexts.push((span, context.clone()));
-        self.observer.enter_command(&stmt.command, scope, context);
+        self.flow_contexts.push((span, context));
         self.command_stack.push(span);
 
         let recorded = self.visit_command(&stmt.command, flow);
@@ -440,7 +412,29 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         );
 
         self.command_stack.pop();
-        self.observer.exit_command(&stmt.command, scope);
+        recorded
+    }
+
+    fn visit_stmt_arena(&mut self, stmt: StmtView<'_>, flow: FlowState) -> RecordedCommandId {
+        let span = semantic_statement_span_arena(stmt);
+        let scope = self.current_scope();
+        let context = Self::flow_context(flow);
+        self.flow_contexts.push((span, context));
+        self.command_stack.push(span);
+
+        let recorded = self.visit_command_arena(stmt.command(), flow);
+        let redirects = self.visit_redirects_arena(stmt.redirects(), flow);
+        if !redirects.is_empty() {
+            self.prepend_nested_regions(recorded, redirects);
+        }
+        self.recorded_program.command_mut(recorded).span = span;
+        self.recorded_program.command_infos.insert(
+            SpanKey::new(span),
+            recorded_command_info_arena(stmt.command(), self.source, self.runtime.bash_enabled()),
+        );
+
+        self.command_stack.pop();
+        let _ = scope;
         recorded
     }
 
@@ -453,6 +447,24 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             Command::Compound(command) => self.visit_compound(command, flow),
             Command::Function(command) => self.visit_function(command, flow),
             Command::AnonymousFunction(command) => self.visit_anonymous_function(command, flow),
+        }
+    }
+
+    fn visit_command_arena(
+        &mut self,
+        command: CommandView<'_>,
+        flow: FlowState,
+    ) -> RecordedCommandId {
+        match command.kind() {
+            ArenaFileCommandKind::Simple => self.visit_simple_command_arena(command, flow),
+            ArenaFileCommandKind::Builtin => self.visit_builtin_arena(command, flow),
+            ArenaFileCommandKind::Decl => self.visit_decl_arena(command, flow),
+            ArenaFileCommandKind::Binary => self.visit_binary_arena(command, flow),
+            ArenaFileCommandKind::Compound => self.visit_compound_arena(command, flow),
+            ArenaFileCommandKind::Function => self.visit_function_arena(command, flow),
+            ArenaFileCommandKind::AnonymousFunction => {
+                self.visit_anonymous_function_arena(command, flow)
+            }
         }
     }
 
@@ -530,6 +542,92 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
     }
 
+    fn visit_simple_command_arena(
+        &mut self,
+        command: CommandView<'_>,
+        flow: FlowState,
+    ) -> RecordedCommandId {
+        let command_span = command.span();
+        let command = command
+            .simple()
+            .expect("simple command kind should expose simple payload");
+        let mut nested_regions = Vec::new();
+        let command_has_name = !matches!(
+            static_word_text_arena(command.name(), self.source).as_deref(),
+            Some("")
+        );
+        for assignment in command.assignments() {
+            if command_has_name {
+                self.visit_assignment_value_arena_into(assignment, flow, &mut nested_regions);
+            } else {
+                self.visit_assignment_arena_into(
+                    assignment,
+                    None,
+                    BindingAttributes::empty(),
+                    flow,
+                    &mut nested_regions,
+                );
+            }
+        }
+
+        self.visit_word_arena_into(
+            command.name(),
+            WordVisitKind::Expansion,
+            flow,
+            &mut nested_regions,
+        );
+        for arg in command.args() {
+            self.visit_word_arena_into(arg, WordVisitKind::Expansion, flow, &mut nested_regions);
+        }
+
+        let words = std::iter::once(command.name_id())
+            .chain(command.arg_ids().iter().copied())
+            .collect::<Vec<_>>();
+        let normalized =
+            normalize_command_words_arena(self.arena_store(), &words, command_span, self.source)
+                .expect("simple commands always have a name");
+
+        if let Some(name) = normalized.literal_name.as_deref()
+            && !name.is_empty()
+        {
+            let callee = Name::from(name);
+            let scope = self.current_scope();
+            let call_site = CallSite {
+                callee: callee.clone(),
+                span: normalized.command_span,
+                name_span: command.name().span(),
+                scope,
+                arg_count: command.arg_ids().len(),
+            };
+            self.call_sites
+                .entry(callee.clone())
+                .or_default()
+                .push(call_site);
+            self.recorded_program.call_command_spans.insert(
+                SpanKey::new(normalized.command_span),
+                self.command_stack
+                    .last()
+                    .copied()
+                    .unwrap_or(normalized.command_span),
+            );
+        }
+
+        if let Some(name) = normalized.effective_name.as_deref()
+            && !name.is_empty()
+        {
+            let callee = Name::from(name);
+            if resolved_command_can_affect_current_shell_arena(&normalized) {
+                self.classify_special_simple_command_arena(&callee, &normalized, flow);
+            }
+        }
+
+        self.record_command(
+            normalized.command_span,
+            nested_regions,
+            RecordedCommandKind::Linear,
+        )
+    }
+
     fn visit_builtin(&mut self, command: &BuiltinCommand, flow: FlowState) -> RecordedCommandId {
         match command {
             BuiltinCommand::Break(command) => {
@@ -581,6 +679,52 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.record_command(command.span, nested_regions, RecordedCommandKind::Exit)
             }
         }
+    }
+
+    fn visit_builtin_arena(
+        &mut self,
+        command: CommandView<'_>,
+        flow: FlowState,
+    ) -> RecordedCommandId {
+        let span = command.span();
+        let command = command
+            .builtin()
+            .expect("builtin command kind should expose builtin payload");
+        let mut nested_regions = Vec::new();
+        for assignment in command.assignments() {
+            self.visit_assignment_value_arena_into(assignment, flow, &mut nested_regions);
+        }
+        if let Some(primary) = command.primary() {
+            self.visit_word_arena_into(
+                primary,
+                WordVisitKind::Expansion,
+                flow,
+                &mut nested_regions,
+            );
+        }
+        for arg in command.extra_args() {
+            self.visit_word_arena_into(arg, WordVisitKind::Expansion, flow, &mut nested_regions);
+        }
+
+        let kind = match command.kind() {
+            BuiltinCommandNodeKind::Break => RecordedCommandKind::Break {
+                depth: depth_from_static_text(
+                    command
+                        .primary()
+                        .and_then(|word| static_word_text_arena(word, self.source)),
+                ),
+            },
+            BuiltinCommandNodeKind::Continue => RecordedCommandKind::Continue {
+                depth: depth_from_static_text(
+                    command
+                        .primary()
+                        .and_then(|word| static_word_text_arena(word, self.source)),
+                ),
+            },
+            BuiltinCommandNodeKind::Return => RecordedCommandKind::Return,
+            BuiltinCommandNodeKind::Exit => RecordedCommandKind::Exit,
+        };
+        self.record_command(span, nested_regions, kind)
     }
 
     fn visit_builtin_parts(
@@ -684,10 +828,174 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
     }
 
+    fn visit_decl_arena(&mut self, command: CommandView<'_>, flow: FlowState) -> RecordedCommandId {
+        let span = command.span();
+        let command = command
+            .decl()
+            .expect("decl command kind should expose declaration payload");
+        let mut nested_regions = Vec::new();
+        for assignment in command.assignments() {
+            self.visit_assignment_value_arena_into(assignment, flow, &mut nested_regions);
+        }
+
+        let builtin = declaration_builtin(command.variant());
+        let flags = declaration_flags_arena(command.operands(), self.arena_store(), self.source);
+        let global_flag_enabled = declaration_flag_is_enabled_arena(
+            command.operands(),
+            self.arena_store(),
+            self.source,
+            'g',
+        )
+        .unwrap_or(false);
+        self.declarations.push(Declaration {
+            builtin,
+            span,
+            operands: declaration_operands_arena(
+                command.operands(),
+                self.arena_store(),
+                self.source,
+            ),
+        });
+
+        let mut name_operands_are_function_names = false;
+        for operand in command.operands() {
+            match operand {
+                DeclOperandNode::Flag(word) => {
+                    update_declaration_function_name_mode_arena(
+                        self.arena_store().word(*word),
+                        self.source,
+                        &mut name_operands_are_function_names,
+                    );
+                    self.visit_word_arena_into(
+                        self.arena_store().word(*word),
+                        WordVisitKind::Expansion,
+                        flow,
+                        &mut nested_regions,
+                    );
+                }
+                DeclOperandNode::Dynamic(word) => {
+                    self.visit_word_arena_into(
+                        self.arena_store().word(*word),
+                        WordVisitKind::Expansion,
+                        flow,
+                        &mut nested_regions,
+                    );
+                }
+                DeclOperandNode::Name(name) => {
+                    self.visit_var_ref_subscript_words_arena(
+                        Some(&name.name),
+                        name.subscript.as_deref(),
+                        WordVisitKind::Expansion,
+                        flow,
+                        &mut nested_regions,
+                    );
+                    if !name_operands_are_function_names {
+                        self.visit_name_only_declaration_operand(
+                            builtin,
+                            &flags,
+                            global_flag_enabled,
+                            &name.name,
+                            name.span,
+                        );
+                    }
+                }
+                DeclOperandNode::Assignment(assignment) => {
+                    let (scope, mut attributes) =
+                        self.declaration_scope_and_attributes(builtin, &flags, global_flag_enabled);
+                    attributes |= BindingAttributes::DECLARATION_INITIALIZED;
+                    if flags.contains(&'p') {
+                        attributes |= BindingAttributes::EXTERNALLY_CONSUMED;
+                    }
+                    let kind = if attributes.contains(BindingAttributes::NAMEREF) {
+                        BindingKind::Nameref
+                    } else {
+                        BindingKind::Declaration(builtin)
+                    };
+                    self.visit_assignment_arena_into(
+                        assignment,
+                        Some((kind, scope)),
+                        attributes,
+                        flow,
+                        &mut nested_regions,
+                    );
+                }
+            }
+        }
+
+        self.record_command(span, nested_regions, RecordedCommandKind::Linear)
+    }
+
     fn visit_binary(&mut self, command: &BinaryCommand, flow: FlowState) -> RecordedCommandId {
         match command.op {
             BinaryOp::And | BinaryOp::Or => self.visit_logical_binary(command, flow),
             BinaryOp::Pipe | BinaryOp::PipeAll => self.visit_pipeline_binary(command, flow),
+        }
+    }
+
+    fn visit_binary_arena(
+        &mut self,
+        command: CommandView<'_>,
+        flow: FlowState,
+    ) -> RecordedCommandId {
+        let span = command.span();
+        let command = command
+            .binary()
+            .expect("binary command kind should expose binary payload");
+        match command.op() {
+            BinaryOp::And | BinaryOp::Or => {
+                let mut operators = SmallVec::<[RecordedListOperator; 4]>::new();
+                let mut commands = SmallVec::<[StmtView<'_>; 4]>::new();
+                collect_logical_segments_arena(command.left(), &mut commands, &mut operators);
+                operators.push(recorded_list_operator(command.op()));
+                collect_logical_segments_arena(command.right(), &mut commands, &mut operators);
+
+                let mut recorded =
+                    SmallVec::<[RecordedCommandId; 4]>::with_capacity(commands.len());
+                for (index, stmt) in commands.into_iter().enumerate() {
+                    let mut nested = flow;
+                    nested.exit_status_checked =
+                        operators.get(index).is_some() || flow.exit_status_checked;
+                    if index > 0 {
+                        nested.conditionally_executed = true;
+                    }
+                    recorded.push(self.visit_stmt_arena(stmt, nested));
+                }
+
+                let mut recorded = recorded.into_iter();
+                let Some(first) = recorded.next() else {
+                    unreachable!("logical lists have at least one command");
+                };
+                let rest = self.recorded_program.push_list_items(
+                    operators
+                        .into_iter()
+                        .zip(recorded)
+                        .map(|(operator, command)| RecordedListItem { operator, command })
+                        .collect(),
+                );
+                self.record_command(span, Vec::new(), RecordedCommandKind::List { first, rest })
+            }
+            BinaryOp::Pipe | BinaryOp::PipeAll => {
+                let mut flow = flow;
+                flow.in_subshell = true;
+                let mut commands = SmallVec::<[StmtView<'_>; 4]>::new();
+                collect_pipeline_segments_arena(command.left(), &mut commands);
+                collect_pipeline_segments_arena(command.right(), &mut commands);
+
+                let mut segments = Vec::with_capacity(commands.len());
+                for stmt in commands {
+                    let scope =
+                        self.push_scope(ScopeKind::Pipeline, self.current_scope(), stmt.span());
+                    let recorded = self.visit_stmt_arena(stmt, flow);
+                    self.pop_scope(scope);
+                    self.mark_scope_completed(scope);
+                    segments.push(RecordedPipelineSegment {
+                        scope,
+                        command: recorded,
+                    });
+                }
+                let segments = self.recorded_program.push_pipeline_segments(segments);
+                self.record_command(span, Vec::new(), RecordedCommandKind::Pipeline { segments })
+            }
         }
     }
 
@@ -1102,6 +1410,383 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn visit_compound_arena(
+        &mut self,
+        command: CommandView<'_>,
+        flow: FlowState,
+    ) -> RecordedCommandId {
+        let span = command.span();
+        let node = command
+            .compound()
+            .expect("compound command kind should expose compound payload")
+            .node();
+        match node {
+            CompoundCommandNode::If {
+                condition,
+                then_branch,
+                elif_branches,
+                else_branch,
+                ..
+            } => {
+                let condition = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*condition),
+                    FlowState {
+                        exit_status_checked: true,
+                        ..flow
+                    },
+                );
+                let then_branch = self
+                    .visit_stmt_seq_arena(self.arena_stmt_seq(*then_branch), flow.conditional());
+                let branches = self.arena_store().elif_branches(*elif_branches).to_vec();
+                let elif_branches = branches
+                    .into_iter()
+                    .map(|branch| RecordedElifBranch {
+                        condition: self.visit_stmt_seq_arena(
+                            self.arena_stmt_seq(branch.condition),
+                            FlowState {
+                                exit_status_checked: true,
+                                ..flow.conditional()
+                            },
+                        ),
+                        body: self.visit_stmt_seq_arena(
+                            self.arena_stmt_seq(branch.body),
+                            flow.conditional(),
+                        ),
+                    })
+                    .collect();
+                let elif_branches = self.recorded_program.push_elif_branches(elif_branches);
+                let else_branch = else_branch
+                    .map(|body| {
+                        self.visit_stmt_seq_arena(self.arena_stmt_seq(body), flow.conditional())
+                    })
+                    .unwrap_or_default();
+                self.record_command(
+                    span,
+                    Vec::new(),
+                    RecordedCommandKind::If {
+                        condition,
+                        then_branch,
+                        elif_branches,
+                        else_branch,
+                    },
+                )
+            }
+            CompoundCommandNode::While { condition, body } => {
+                let condition = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*condition),
+                    FlowState {
+                        exit_status_checked: true,
+                        ..flow
+                    },
+                );
+                let body = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow.conditional()
+                    },
+                );
+                self.record_command(
+                    span,
+                    Vec::new(),
+                    RecordedCommandKind::While { condition, body },
+                )
+            }
+            CompoundCommandNode::Until { condition, body } => {
+                let condition = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*condition),
+                    FlowState {
+                        exit_status_checked: true,
+                        ..flow
+                    },
+                );
+                let body = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow.conditional()
+                    },
+                );
+                self.record_command(
+                    span,
+                    Vec::new(),
+                    RecordedCommandKind::Until { condition, body },
+                )
+            }
+            CompoundCommandNode::For {
+                targets,
+                words,
+                body,
+                ..
+            } => {
+                let word_ids = words
+                    .map(|range| self.arena_store().word_ids(range))
+                    .unwrap_or(&[]);
+                let mut nested_regions = Vec::new();
+                for word in word_ids {
+                    self.visit_word_arena_into(
+                        self.arena_store().word(*word),
+                        WordVisitKind::Expansion,
+                        flow,
+                        &mut nested_regions,
+                    );
+                }
+                let items = if words.is_some() {
+                    loop_binding_origin_for_static_texts(word_ids.iter().map(|word| {
+                        static_word_text_arena(self.arena_store().word(*word), self.source)
+                    }))
+                } else {
+                    LoopValueOrigin::ImplicitArgv
+                };
+                for target in self.arena_store().for_targets(*targets).to_vec() {
+                    if let Some(name) = &target.name {
+                        self.add_binding(
+                            name,
+                            BindingKind::LoopVariable,
+                            self.current_scope(),
+                            target.span,
+                            BindingOrigin::LoopVariable {
+                                definition_span: target.span,
+                                items,
+                            },
+                            BindingAttributes::empty(),
+                        );
+                    }
+                }
+                let body = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow.conditional()
+                    },
+                );
+                self.record_command(span, nested_regions, RecordedCommandKind::For { body })
+            }
+            CompoundCommandNode::Subshell(body) => {
+                let scope = self.push_scope(ScopeKind::Subshell, self.current_scope(), span);
+                let body = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        in_subshell: true,
+                        ..flow
+                    },
+                );
+                self.pop_scope(scope);
+                self.mark_scope_completed(scope);
+                self.record_command(span, Vec::new(), RecordedCommandKind::Subshell { body })
+            }
+            CompoundCommandNode::BraceGroup(body) => {
+                let body = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        in_block: true,
+                        ..flow
+                    },
+                );
+                self.record_command(span, Vec::new(), RecordedCommandKind::BraceGroup { body })
+            }
+            CompoundCommandNode::Always { body, always_body } => {
+                let block_flow = FlowState {
+                    in_block: true,
+                    ..flow
+                };
+                let mut body_commands = Vec::new();
+                self.visit_stmt_seq_arena_into(
+                    self.arena_stmt_seq(*body),
+                    block_flow,
+                    &mut body_commands,
+                );
+                self.visit_stmt_seq_arena_into(
+                    self.arena_stmt_seq(*always_body),
+                    block_flow,
+                    &mut body_commands,
+                );
+                let body = self.recorded_program.push_command_ids(body_commands);
+                self.record_command(span, Vec::new(), RecordedCommandKind::BraceGroup { body })
+            }
+            CompoundCommandNode::Repeat { count, body, .. } => {
+                let mut nested_regions = Vec::new();
+                self.visit_word_arena_into(
+                    self.arena_store().word(*count),
+                    WordVisitKind::Expansion,
+                    flow,
+                    &mut nested_regions,
+                );
+                let body = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow.conditional()
+                    },
+                );
+                self.record_command(span, nested_regions, RecordedCommandKind::For { body })
+            }
+            CompoundCommandNode::Foreach {
+                variable,
+                variable_span,
+                words,
+                body,
+                ..
+            }
+            | CompoundCommandNode::Select {
+                variable,
+                variable_span,
+                words,
+                body,
+            } => {
+                let word_ids = self.arena_store().word_ids(*words).to_vec();
+                let mut nested_regions = Vec::new();
+                for word in &word_ids {
+                    self.visit_word_arena_into(
+                        self.arena_store().word(*word),
+                        WordVisitKind::Expansion,
+                        flow,
+                        &mut nested_regions,
+                    );
+                }
+                let items = loop_binding_origin_for_static_texts(word_ids.iter().map(|word| {
+                    static_word_text_arena(self.arena_store().word(*word), self.source)
+                }));
+                self.add_binding(
+                    variable,
+                    BindingKind::LoopVariable,
+                    self.current_scope(),
+                    *variable_span,
+                    BindingOrigin::LoopVariable {
+                        definition_span: *variable_span,
+                        items,
+                    },
+                    BindingAttributes::empty(),
+                );
+                let body = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow.conditional()
+                    },
+                );
+                let kind = if matches!(node, CompoundCommandNode::Select { .. }) {
+                    RecordedCommandKind::Select { body }
+                } else {
+                    RecordedCommandKind::For { body }
+                };
+                self.record_command(span, nested_regions, kind)
+            }
+            CompoundCommandNode::Time { command, .. } => {
+                let mut nested_regions = Vec::new();
+                if let Some(command) = command {
+                    let commands = self.visit_stmt_seq_arena(self.arena_stmt_seq(*command), flow);
+                    let ids = self.recorded_program.commands_in(commands).to_vec();
+                    for command_id in ids {
+                        nested_regions.extend(self.flatten_recorded_regions(command_id));
+                    }
+                }
+                self.record_command(span, nested_regions, RecordedCommandKind::Linear)
+            }
+            CompoundCommandNode::Coproc { body, .. } => {
+                let commands = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        in_subshell: true,
+                        ..flow
+                    },
+                );
+                let ids = self.recorded_program.commands_in(commands).to_vec();
+                let mut nested_regions = Vec::new();
+                for command_id in ids {
+                    nested_regions.extend(self.flatten_recorded_regions(command_id));
+                }
+                self.record_command(span, nested_regions, RecordedCommandKind::Linear)
+            }
+            CompoundCommandNode::ArithmeticFor(command) => {
+                let mut nested_regions = Vec::new();
+                self.visit_optional_arithmetic_expr_arena_into(
+                    command.init_ast.as_ref(),
+                    flow,
+                    &mut nested_regions,
+                );
+                self.visit_optional_arithmetic_expr_arena_into(
+                    command.condition_ast.as_ref(),
+                    flow,
+                    &mut nested_regions,
+                );
+                self.visit_optional_arithmetic_expr_arena_into(
+                    command.step_ast.as_ref(),
+                    flow,
+                    &mut nested_regions,
+                );
+                let body = self.visit_stmt_seq_arena(
+                    self.arena_stmt_seq(command.body),
+                    FlowState {
+                        loop_depth: flow.loop_depth + 1,
+                        ..flow.conditional()
+                    },
+                );
+                self.record_command(
+                    span,
+                    nested_regions,
+                    RecordedCommandKind::ArithmeticFor { body },
+                )
+            }
+            CompoundCommandNode::Arithmetic(command) => {
+                let nested_regions =
+                    self.visit_optional_arithmetic_expr_arena(command.expr_ast.as_ref(), flow);
+                self.record_command(span, nested_regions, RecordedCommandKind::Linear)
+            }
+            CompoundCommandNode::Conditional(command) => {
+                let nested_regions = self.visit_conditional_expr_arena(&command.expression, flow);
+                self.record_command(span, nested_regions, RecordedCommandKind::Linear)
+            }
+            CompoundCommandNode::Case { word, cases } => {
+                let mut nested_regions = Vec::new();
+                self.visit_word_arena_into(
+                    self.arena_store().word(*word),
+                    WordVisitKind::Expansion,
+                    flow,
+                    &mut nested_regions,
+                );
+                let cases = self.arena_store().case_items(*cases).to_vec();
+                let arms = cases
+                    .into_iter()
+                    .map(|case| {
+                        let pattern_regions = self.visit_patterns_arena(
+                            self.arena_store().patterns(case.patterns),
+                            WordVisitKind::Conditional,
+                            flow,
+                        );
+                        let mut commands = Vec::new();
+                        self.visit_stmt_seq_arena_into(
+                            self.arena_stmt_seq(case.body),
+                            flow.conditional(),
+                            &mut commands,
+                        );
+                        if !pattern_regions.is_empty() {
+                            if let Some(&first) = commands.first() {
+                                self.prepend_nested_regions(first, pattern_regions);
+                            } else {
+                                commands.push(self.record_command(
+                                    span,
+                                    pattern_regions,
+                                    RecordedCommandKind::Linear,
+                                ));
+                            }
+                        }
+                        RecordedCaseArm {
+                            terminator: case.terminator,
+                            matches_anything: case_arm_matches_anything_arena(
+                                self.arena_store().patterns(case.patterns),
+                                self.arena_store(),
+                            ),
+                            commands: self.recorded_program.push_command_ids(commands),
+                        }
+                    })
+                    .collect();
+                let arms = self.recorded_program.push_case_arms(arms);
+                self.record_command(span, nested_regions, RecordedCommandKind::Case { arms })
+            }
+        }
+    }
+
     fn visit_function(&mut self, function: &FunctionDef, flow: FlowState) -> RecordedCommandId {
         let mut nested_regions = Vec::new();
         for entry in &function.header.entries {
@@ -1135,13 +1820,75 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 .insert(binding_id, scope);
         }
         self.deferred_functions.push(DeferredFunction {
-            function: function.clone(),
+            body: DeferredFunctionBody::Recursive(function.clone()),
             scope,
             flow,
         });
         self.pop_scope(scope);
 
         self.record_command(function.span, nested_regions, RecordedCommandKind::Linear)
+    }
+
+    fn visit_function_arena(
+        &mut self,
+        command: CommandView<'_>,
+        flow: FlowState,
+    ) -> RecordedCommandId {
+        let span = command.span();
+        let function = command
+            .function()
+            .expect("function command kind should expose function payload");
+        let mut nested_regions = Vec::new();
+        for entry in function.entries() {
+            self.visit_word_arena_into(
+                self.arena_store().word(entry.word),
+                WordVisitKind::Expansion,
+                flow,
+                &mut nested_regions,
+            );
+        }
+
+        let parent_scope = self.current_scope();
+        let names = function
+            .entries()
+            .iter()
+            .filter_map(|entry| entry.static_name.clone())
+            .collect::<Vec<_>>();
+        let scope = self.push_scope(
+            ScopeKind::Function(if names.is_empty() {
+                FunctionScopeKind::Dynamic
+            } else {
+                FunctionScopeKind::Named(names)
+            }),
+            parent_scope,
+            function.body().span(),
+        );
+        for entry in function.entries() {
+            let Some(name) = &entry.static_name else {
+                continue;
+            };
+            let binding_id = self.add_binding(
+                name,
+                BindingKind::FunctionDefinition,
+                parent_scope,
+                self.arena_store().word(entry.word).span(),
+                BindingOrigin::FunctionDefinition {
+                    definition_span: span,
+                },
+                BindingAttributes::empty(),
+            );
+            self.recorded_program
+                .function_body_scopes
+                .insert(binding_id, scope);
+        }
+        self.deferred_functions.push(DeferredFunction {
+            body: DeferredFunctionBody::Arena(function.body_id()),
+            scope,
+            flow,
+        });
+        self.pop_scope(scope);
+
+        self.record_command(span, nested_regions, RecordedCommandKind::Linear)
     }
 
     fn visit_anonymous_function(
@@ -1161,6 +1908,35 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
         self.record_command(
             function.span,
+            nested_regions,
+            RecordedCommandKind::BraceGroup { body },
+        )
+    }
+
+    fn visit_anonymous_function_arena(
+        &mut self,
+        command: CommandView<'_>,
+        flow: FlowState,
+    ) -> RecordedCommandId {
+        let span = command.span();
+        let function = command
+            .anonymous_function()
+            .expect("anonymous function kind should expose function payload");
+        let mut nested_regions = Vec::new();
+        for arg in function.args() {
+            self.visit_word_arena_into(arg, WordVisitKind::Expansion, flow, &mut nested_regions);
+        }
+        let scope = self.push_scope(
+            ScopeKind::Function(FunctionScopeKind::Anonymous),
+            self.current_scope(),
+            function.body().span(),
+        );
+        let body = self.visit_function_like_body_arena(function.body_id(), flow);
+        self.pop_scope(scope);
+        self.mark_scope_completed(scope);
+
+        self.record_command(
+            span,
             nested_regions,
             RecordedCommandKind::BraceGroup { body },
         )
@@ -1238,6 +2014,79 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn visit_assignment_arena_into(
+        &mut self,
+        assignment: &AssignmentNode,
+        declaration_kind: Option<(BindingKind, ScopeId)>,
+        mut attributes: BindingAttributes,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        let reference_start = self.references.len();
+        self.visit_var_ref_subscript_words_arena(
+            Some(&assignment.target.name),
+            assignment.target.subscript.as_deref(),
+            WordVisitKind::Expansion,
+            flow,
+            nested_regions,
+        );
+        self.visit_assignment_value_arena_into(assignment, flow, nested_regions);
+        let (kind, scope) = declaration_kind.unwrap_or_else(|| {
+            let kind = if assignment.append {
+                BindingKind::AppendAssignment
+            } else if matches!(assignment.value, AssignmentValueNode::Compound(_))
+                || assignment.target.subscript.is_some()
+            {
+                BindingKind::ArrayAssignment
+            } else {
+                BindingKind::Assignment
+            };
+            (kind, self.current_scope())
+        });
+        attributes |= assignment_binding_attributes_arena(assignment);
+        if assignment_has_empty_initializer_arena(assignment, self.arena_store(), self.source) {
+            attributes |= BindingAttributes::EMPTY_INITIALIZER;
+        }
+        let self_referential_refs =
+            self.newly_added_reference_ids_reading_name(&assignment.target.name, reference_start);
+        if !self_referential_refs.is_empty() {
+            attributes |= BindingAttributes::SELF_REFERENTIAL_READ;
+            self.self_referential_assignment_refs
+                .extend(self_referential_refs);
+        }
+        if assignment.target.subscript.is_some()
+            && !attributes.contains(BindingAttributes::ASSOC)
+            && self
+                .resolve_reference(
+                    &assignment.target.name,
+                    self.current_scope(),
+                    assignment.target.name_span.start.offset,
+                )
+                .map(|binding_id| {
+                    self.bindings[binding_id.index()]
+                        .attributes
+                        .contains(BindingAttributes::ASSOC)
+                })
+                .unwrap_or(false)
+        {
+            attributes |= BindingAttributes::ARRAY | BindingAttributes::ASSOC;
+        }
+
+        let binding = self.add_binding(
+            &assignment.target.name,
+            kind,
+            scope,
+            assignment.target.name_span,
+            binding_origin_for_assignment_arena(assignment, self.arena_store(), self.source),
+            attributes,
+        );
+        self.record_prompt_assignment_references_arena(assignment);
+        if let Some(hint) = indirect_target_hint_arena(assignment, self.arena_store(), self.source)
+        {
+            self.indirect_target_hints.insert(binding, hint);
+        }
+    }
+
     fn record_prompt_assignment_references(&mut self, assignment: &Assignment) {
         let AssignmentValue::Scalar(word) = &assignment.value else {
             return;
@@ -1262,6 +2111,31 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn record_prompt_assignment_references_arena(&mut self, assignment: &AssignmentNode) {
+        let AssignmentValueNode::Scalar(word) = &assignment.value else {
+            return;
+        };
+        let word = self.arena_store().word(*word);
+
+        match assignment.target.name.as_str() {
+            "PS1" => {
+                for (name, span) in prompt_assignment_reference_names_arena(word, self.source) {
+                    self.add_reference(&name, ReferenceKind::ImplicitRead, span);
+                }
+            }
+            "PS4" => {
+                for name in escaped_prompt_assignment_reference_names_arena(word, self.source) {
+                    self.add_reference(
+                        &name,
+                        ReferenceKind::PromptExpansion,
+                        assignment.target.name_span,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn visit_assignment_value_into(
         &mut self,
         assignment: &Assignment,
@@ -1274,6 +2148,52 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
             AssignmentValue::Compound(array) => {
                 self.visit_array_expr_into(array, WordVisitKind::Expansion, flow, nested_regions);
+            }
+        }
+    }
+
+    fn visit_assignment_value_arena_into(
+        &mut self,
+        assignment: &AssignmentNode,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match &assignment.value {
+            AssignmentValueNode::Scalar(word) => {
+                self.visit_word_arena_into(
+                    self.arena_store().word(*word),
+                    WordVisitKind::Expansion,
+                    flow,
+                    nested_regions,
+                );
+            }
+            AssignmentValueNode::Compound(array) => {
+                for element in self.arena_store().array_elems(array.elements).to_vec() {
+                    match element {
+                        shuck_ast::ArrayElemNode::Sequential(value) => self.visit_word_arena_into(
+                            self.arena_store().word(value.word),
+                            WordVisitKind::Expansion,
+                            flow,
+                            nested_regions,
+                        ),
+                        shuck_ast::ArrayElemNode::Keyed { key, value }
+                        | shuck_ast::ArrayElemNode::KeyedAppend { key, value } => {
+                            self.visit_var_ref_subscript_words_arena(
+                                None,
+                                Some(&key),
+                                WordVisitKind::Expansion,
+                                flow,
+                                nested_regions,
+                            );
+                            self.visit_word_arena_into(
+                                self.arena_store().word(value.word),
+                                WordVisitKind::Expansion,
+                                flow,
+                                nested_regions,
+                            );
+                        }
+                    }
+                }
             }
         }
     }
@@ -1384,7 +2304,56 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn visit_redirects_arena(
+        &mut self,
+        redirects: &[RedirectNode],
+        flow: FlowState,
+    ) -> Vec<IsolatedRegion> {
+        let mut nested_regions = Vec::new();
+        for redirect in redirects {
+            match &redirect.target {
+                RedirectTargetNode::Word(word) => {
+                    self.visit_word_arena_into(
+                        self.arena_store().word(*word),
+                        WordVisitKind::Expansion,
+                        flow,
+                        &mut nested_regions,
+                    );
+                    self.add_redirect_fd_var_binding_arena(redirect);
+                }
+                RedirectTargetNode::Heredoc(heredoc) => {
+                    self.add_redirect_fd_var_binding_arena(redirect);
+                    if heredoc.delimiter.expands_body {
+                        self.visit_heredoc_body_arena_into(
+                            &heredoc.body,
+                            WordVisitKind::Expansion,
+                            flow,
+                            &mut nested_regions,
+                        );
+                    }
+                }
+            }
+        }
+        nested_regions
+    }
+
     fn add_redirect_fd_var_binding(&mut self, redirect: &shuck_ast::Redirect) {
+        if let (Some(name), Some(span)) = (&redirect.fd_var, redirect.fd_var_span) {
+            self.add_binding(
+                name,
+                BindingKind::Assignment,
+                self.current_scope(),
+                span,
+                BindingOrigin::Assignment {
+                    definition_span: span,
+                    value: AssignmentValueOrigin::StaticLiteral,
+                },
+                BindingAttributes::INTEGER,
+            );
+        }
+    }
+
+    fn add_redirect_fd_var_binding_arena(&mut self, redirect: &RedirectNode) {
         if let (Some(name), Some(span)) = (&redirect.fd_var, redirect.fd_var_span) {
             self.add_binding(
                 name,
@@ -1424,6 +2393,21 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.visit_word_part_nodes(&word.parts, kind, flow, nested_regions);
     }
 
+    fn visit_word_arena_into(
+        &mut self,
+        word: shuck_ast::WordView<'_>,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        if word_is_semantically_inert_arena(word, self.arena_store()) {
+            return;
+        }
+        for part in word.parts() {
+            self.visit_word_part_arena(&part.kind, part.span, kind, flow, nested_regions);
+        }
+    }
+
     fn visit_heredoc_body_into(
         &mut self,
         body: &HeredocBody,
@@ -1437,6 +2421,21 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.visit_heredoc_body_part_nodes(&body.parts, kind, flow, nested_regions);
     }
 
+    fn visit_heredoc_body_arena_into(
+        &mut self,
+        body: &shuck_ast::HeredocBodyNode,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        if !body.mode.expands() {
+            return;
+        }
+        for part in self.arena_store().heredoc_body_parts(body.parts).to_vec() {
+            self.visit_heredoc_body_part_arena(&part.kind, part.span, kind, flow, nested_regions);
+        }
+    }
+
     fn visit_pattern_into(
         &mut self,
         pattern: &Pattern,
@@ -1448,6 +2447,34 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             return;
         }
         self.visit_pattern_part_nodes(&pattern.parts, kind, flow, nested_regions);
+    }
+
+    fn visit_patterns_arena(
+        &mut self,
+        patterns: &[PatternNode],
+        kind: WordVisitKind,
+        flow: FlowState,
+    ) -> Vec<IsolatedRegion> {
+        let mut nested_regions = Vec::new();
+        for pattern in patterns {
+            self.visit_pattern_arena_into(pattern, kind, flow, &mut nested_regions);
+        }
+        nested_regions
+    }
+
+    fn visit_pattern_arena_into(
+        &mut self,
+        pattern: &PatternNode,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        if pattern_is_semantically_inert_arena(pattern, self.arena_store()) {
+            return;
+        }
+        for part in self.arena_store().pattern_parts(pattern.parts).to_vec() {
+            self.visit_pattern_part_arena(&part.kind, kind, flow, nested_regions);
+        }
     }
 
     fn visit_word_part_nodes(
@@ -1506,6 +2533,26 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         id
     }
 
+    fn visit_var_ref_reference_arena(
+        &mut self,
+        reference: &VarRefNode,
+        reference_kind: ReferenceKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+        span: Span,
+    ) -> ReferenceId {
+        let reference_kind = self.word_reference_kind_override.unwrap_or(reference_kind);
+        let id = self.add_reference(&reference.name, reference_kind, span);
+        self.visit_var_ref_subscript_words_arena(
+            Some(&reference.name),
+            reference.subscript.as_deref(),
+            word_visit_kind_for_reference_kind(reference_kind),
+            flow,
+            nested_regions,
+        );
+        id
+    }
+
     fn visit_var_ref_subscript_words(
         &mut self,
         owner_name: Option<&Name>,
@@ -1550,6 +2597,57 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             flow,
             nested_regions,
         );
+    }
+
+    fn visit_var_ref_subscript_words_arena(
+        &mut self,
+        owner_name: Option<&Name>,
+        subscript: Option<&SubscriptNode>,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        let Some(subscript) = subscript else {
+            return;
+        };
+        if subscript_selector_arena(subscript).is_some() {
+            return;
+        }
+        let uses_associative_word_semantics = matches!(
+            subscript.interpretation,
+            shuck_ast::SubscriptInterpretation::Associative
+        ) || owner_name.is_some_and(|name| {
+            self.resolve_reference(
+                name,
+                self.current_scope(),
+                subscript_span_arena(subscript).start.offset,
+            )
+            .map(|binding_id| {
+                self.bindings[binding_id.index()]
+                    .attributes
+                    .contains(BindingAttributes::ASSOC)
+            })
+            .unwrap_or(false)
+        });
+        if !uses_associative_word_semantics
+            && let Some(expression) = subscript.arithmetic_ast.as_ref()
+        {
+            self.visit_optional_arithmetic_expr_arena_into(Some(expression), flow, nested_regions);
+            return;
+        }
+
+        if !uses_associative_word_semantics {
+            for (name, span) in unparsed_arithmetic_subscript_reference_names(
+                subscript_syntax_source_text_arena(subscript),
+                self.source,
+            ) {
+                self.add_reference(&name, ReferenceKind::ArithmeticRead, span);
+            }
+        }
+
+        if let Some(word) = subscript.word_ast {
+            self.visit_word_arena_into(self.arena_store().word(word), kind, flow, nested_regions);
+        }
     }
 
     fn visit_unparsed_arithmetic_subscript_references(&mut self, subscript: &Subscript) {
@@ -1764,6 +2862,196 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn visit_word_part_arena(
+        &mut self,
+        part: &WordPartArena,
+        span: Span,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match part {
+            WordPartArena::ZshQualifiedGlob(glob) => {
+                for segment in self.arena_store().zsh_glob_segments(glob.segments).to_vec() {
+                    if let shuck_ast::ZshGlobSegmentNode::Pattern(pattern) = segment {
+                        self.visit_pattern_arena_into(&pattern, kind, flow, nested_regions);
+                    }
+                }
+            }
+            WordPartArena::Literal(_) | WordPartArena::SingleQuoted { .. } => {}
+            WordPartArena::DoubleQuoted { parts, .. } => {
+                for part in self.arena_store().word_parts(*parts).to_vec() {
+                    self.visit_word_part_arena(&part.kind, part.span, kind, flow, nested_regions);
+                }
+            }
+            WordPartArena::Variable(name) => {
+                self.add_reference(
+                    name,
+                    self.word_reference_kind_override
+                        .unwrap_or(reference_kind_for_word_visit(
+                            kind,
+                            ReferenceKind::Expansion,
+                        )),
+                    span,
+                );
+            }
+            WordPartArena::CommandSubstitution { body, .. }
+            | WordPartArena::ProcessSubstitution { body, .. } => {
+                let scope =
+                    self.push_scope(ScopeKind::CommandSubstitution, self.current_scope(), span);
+                let mut commands = Vec::new();
+                self.visit_stmt_seq_arena_into(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        in_subshell: true,
+                        ..flow
+                    },
+                    &mut commands,
+                );
+                self.pop_scope(scope);
+                self.mark_scope_completed(scope);
+                nested_regions.push(IsolatedRegion {
+                    scope,
+                    commands: self.recorded_program.push_command_ids(commands),
+                });
+            }
+            WordPartArena::ArithmeticExpansion { expression_ast, .. } => {
+                self.visit_optional_arithmetic_expr_arena_into(
+                    expression_ast.as_ref(),
+                    flow,
+                    nested_regions,
+                );
+            }
+            WordPartArena::Parameter(parameter) => {
+                self.visit_parameter_expansion_arena(
+                    parameter,
+                    kind,
+                    flow,
+                    nested_regions,
+                    parameter.span,
+                );
+            }
+            WordPartArena::ParameterExpansion {
+                reference,
+                operator,
+                operand_word_ast,
+                ..
+            } => {
+                let reference_id = self.visit_var_ref_reference_arena(
+                    reference,
+                    parameter_operation_reference_kind(kind, operator),
+                    flow,
+                    nested_regions,
+                    reference.span,
+                );
+                if parameter_operator_guards_unset_reference(operator) {
+                    self.record_guarded_parameter_reference(reference_id);
+                }
+                if matches!(operator, ParameterOp::AssignDefault) {
+                    self.add_parameter_default_binding_arena(reference);
+                }
+                self.visit_parameter_operator_operand_arena(
+                    operator,
+                    *operand_word_ast,
+                    kind,
+                    flow,
+                    nested_regions,
+                );
+            }
+            WordPartArena::Length(reference) | WordPartArena::ArrayLength(reference) => {
+                self.visit_var_ref_reference_arena(
+                    reference,
+                    reference_kind_for_word_visit(kind, ReferenceKind::Length),
+                    flow,
+                    nested_regions,
+                    reference.span,
+                );
+            }
+            WordPartArena::ArrayAccess(reference) => {
+                self.visit_var_ref_reference_arena(
+                    reference,
+                    reference_kind_for_word_visit(kind, ReferenceKind::ArrayAccess),
+                    flow,
+                    nested_regions,
+                    reference.span,
+                );
+            }
+            WordPartArena::ArrayIndices(reference) => {
+                self.visit_var_ref_reference_arena(
+                    reference,
+                    reference_kind_for_word_visit(kind, ReferenceKind::IndirectExpansion),
+                    flow,
+                    nested_regions,
+                    reference.span,
+                );
+            }
+            WordPartArena::PrefixMatch { .. } => {}
+            WordPartArena::IndirectExpansion {
+                reference,
+                operator,
+                operand_word_ast,
+                ..
+            } => {
+                let id = self.visit_var_ref_reference_arena(
+                    reference,
+                    reference_kind_for_word_visit(kind, ReferenceKind::IndirectExpansion),
+                    flow,
+                    nested_regions,
+                    reference.span,
+                );
+                self.indirect_expansion_refs.insert(id);
+                if let Some(operator) = operator {
+                    self.visit_parameter_operator_operand_arena(
+                        operator,
+                        *operand_word_ast,
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
+                }
+            }
+            WordPartArena::Substring {
+                reference,
+                offset_ast,
+                length_ast,
+                ..
+            }
+            | WordPartArena::ArraySlice {
+                reference,
+                offset_ast,
+                length_ast,
+                ..
+            } => {
+                self.visit_var_ref_reference_arena(
+                    reference,
+                    reference_kind_for_word_visit(kind, ReferenceKind::ParameterExpansion),
+                    flow,
+                    nested_regions,
+                    reference.span,
+                );
+                self.visit_optional_arithmetic_expr_arena_into(
+                    offset_ast.as_ref(),
+                    flow,
+                    nested_regions,
+                );
+                self.visit_optional_arithmetic_expr_arena_into(
+                    length_ast.as_ref(),
+                    flow,
+                    nested_regions,
+                );
+            }
+            WordPartArena::Transformation { reference, .. } => {
+                self.visit_var_ref_reference_arena(
+                    reference,
+                    reference_kind_for_word_visit(kind, ReferenceKind::ParameterExpansion),
+                    flow,
+                    nested_regions,
+                    reference.span,
+                );
+            }
+        }
+    }
+
     fn visit_heredoc_body_part(
         &mut self,
         part: &HeredocBodyPart,
@@ -1811,6 +3099,57 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
             HeredocBodyPart::Parameter(parameter) => {
                 self.visit_parameter_expansion(parameter, kind, flow, nested_regions, span);
+            }
+        }
+    }
+
+    fn visit_heredoc_body_part_arena(
+        &mut self,
+        part: &ArenaHeredocBodyPart,
+        span: Span,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match part {
+            ArenaHeredocBodyPart::Literal(text) => {
+                self.visit_escaped_braced_literal_references(text, span, kind);
+            }
+            ArenaHeredocBodyPart::Variable(name) => {
+                self.add_reference(
+                    name,
+                    reference_kind_for_word_visit(kind, ReferenceKind::Expansion),
+                    span,
+                );
+            }
+            ArenaHeredocBodyPart::CommandSubstitution { body, .. } => {
+                let scope =
+                    self.push_scope(ScopeKind::CommandSubstitution, self.current_scope(), span);
+                let mut commands = Vec::new();
+                self.visit_stmt_seq_arena_into(
+                    self.arena_stmt_seq(*body),
+                    FlowState {
+                        in_subshell: true,
+                        ..flow
+                    },
+                    &mut commands,
+                );
+                self.pop_scope(scope);
+                self.mark_scope_completed(scope);
+                nested_regions.push(IsolatedRegion {
+                    scope,
+                    commands: self.recorded_program.push_command_ids(commands),
+                });
+            }
+            ArenaHeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
+                self.visit_optional_arithmetic_expr_arena_into(
+                    expression_ast.as_ref(),
+                    flow,
+                    nested_regions,
+                );
+            }
+            ArenaHeredocBodyPart::Parameter(parameter) => {
+                self.visit_parameter_expansion_arena(parameter, kind, flow, nested_regions, span);
             }
         }
     }
@@ -2071,6 +3410,181 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn visit_parameter_expansion_arena(
+        &mut self,
+        parameter: &ParameterExpansionNode,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+        span: Span,
+    ) {
+        match &parameter.syntax {
+            ParameterExpansionSyntaxNode::Bourne(syntax) => match syntax {
+                BourneParameterExpansionNode::Access { reference } => {
+                    self.visit_var_ref_reference_arena(
+                        reference,
+                        reference_kind_for_word_visit(kind, ReferenceKind::ArrayAccess),
+                        flow,
+                        nested_regions,
+                        span,
+                    );
+                }
+                BourneParameterExpansionNode::Length { reference } => {
+                    self.visit_var_ref_reference_arena(
+                        reference,
+                        reference_kind_for_word_visit(kind, ReferenceKind::Length),
+                        flow,
+                        nested_regions,
+                        span,
+                    );
+                }
+                BourneParameterExpansionNode::Indices { reference } => {
+                    self.visit_var_ref_reference_arena(
+                        reference,
+                        reference_kind_for_word_visit(kind, ReferenceKind::IndirectExpansion),
+                        flow,
+                        nested_regions,
+                        span,
+                    );
+                }
+                BourneParameterExpansionNode::Indirect {
+                    reference,
+                    operator,
+                    operand_word_ast,
+                    ..
+                } => {
+                    let id = self.visit_var_ref_reference_arena(
+                        reference,
+                        reference_kind_for_word_visit(kind, ReferenceKind::IndirectExpansion),
+                        flow,
+                        nested_regions,
+                        span,
+                    );
+                    self.indirect_expansion_refs.insert(id);
+                    if let Some(operator) = operator {
+                        self.visit_parameter_operator_operand_arena(
+                            operator,
+                            *operand_word_ast,
+                            kind,
+                            flow,
+                            nested_regions,
+                        );
+                    }
+                }
+                BourneParameterExpansionNode::PrefixMatch { .. } => {}
+                BourneParameterExpansionNode::Slice {
+                    reference,
+                    offset_ast,
+                    length_ast,
+                    ..
+                } => {
+                    self.visit_var_ref_reference_arena(
+                        reference,
+                        reference_kind_for_word_visit(kind, ReferenceKind::ParameterExpansion),
+                        flow,
+                        nested_regions,
+                        span,
+                    );
+                    self.visit_parameter_slice_arithmetic_expr_arena_into(
+                        offset_ast.as_ref(),
+                        flow,
+                        nested_regions,
+                    );
+                    self.visit_parameter_slice_arithmetic_expr_arena_into(
+                        length_ast.as_ref(),
+                        flow,
+                        nested_regions,
+                    );
+                }
+                BourneParameterExpansionNode::Operation {
+                    reference,
+                    operator,
+                    operand_word_ast,
+                    ..
+                } => {
+                    let reference_id = self.visit_var_ref_reference_arena(
+                        reference,
+                        parameter_operation_reference_kind(kind, operator),
+                        flow,
+                        nested_regions,
+                        span,
+                    );
+                    if parameter_operator_guards_unset_reference(operator) {
+                        self.record_guarded_parameter_reference(reference_id);
+                    }
+                    if matches!(operator, ParameterOp::AssignDefault) {
+                        self.add_parameter_default_binding_arena(reference);
+                    }
+                    self.visit_parameter_operator_operand_arena(
+                        operator,
+                        *operand_word_ast,
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
+                }
+                BourneParameterExpansionNode::Transformation { reference, .. } => {
+                    self.visit_var_ref_reference_arena(
+                        reference,
+                        reference_kind_for_word_visit(kind, ReferenceKind::ParameterExpansion),
+                        flow,
+                        nested_regions,
+                        span,
+                    );
+                }
+            },
+            ParameterExpansionSyntaxNode::Zsh(syntax) => {
+                match &syntax.target {
+                    ZshExpansionTargetNode::Reference(reference) => {
+                        if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh {
+                            self.visit_var_ref_reference_arena(
+                                reference,
+                                reference_kind_for_word_visit(
+                                    kind,
+                                    ReferenceKind::ParameterExpansion,
+                                ),
+                                flow,
+                                nested_regions,
+                                span,
+                            );
+                        }
+                    }
+                    ZshExpansionTargetNode::Word(word) => {
+                        self.visit_word_arena_into(
+                            self.arena_store().word(*word),
+                            kind,
+                            flow,
+                            nested_regions,
+                        );
+                    }
+                    ZshExpansionTargetNode::Nested(parameter) => {
+                        self.visit_parameter_expansion_arena(
+                            parameter,
+                            kind,
+                            flow,
+                            nested_regions,
+                            span,
+                        );
+                    }
+                    ZshExpansionTargetNode::Empty => {}
+                }
+                for modifier in self.arena_store().zsh_modifiers(syntax.modifiers).to_vec() {
+                    if let Some(word) = modifier.argument_word_ast {
+                        self.visit_word_arena_into(
+                            self.arena_store().word(word),
+                            kind,
+                            flow,
+                            nested_regions,
+                        );
+                    }
+                }
+                if let Some(operation) = &syntax.operation {
+                    self.visit_zsh_operation_arena(operation, kind, flow, nested_regions);
+                }
+            }
+        }
+    }
+
     fn visit_fragment_word(
         &mut self,
         word: Option<&Word>,
@@ -2153,6 +3667,159 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn visit_parameter_operator_operand_arena(
+        &mut self,
+        operator: &ParameterOp,
+        operand_word_ast: Option<WordId>,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match operator {
+            ParameterOp::RemovePrefixShort { pattern }
+            | ParameterOp::RemovePrefixLong { pattern }
+            | ParameterOp::RemoveSuffixShort { pattern }
+            | ParameterOp::RemoveSuffixLong { pattern } => {
+                self.visit_pattern_into(
+                    pattern,
+                    WordVisitKind::ParameterPattern,
+                    flow,
+                    nested_regions,
+                );
+            }
+            ParameterOp::ReplaceFirst { pattern, .. } | ParameterOp::ReplaceAll { pattern, .. } => {
+                self.visit_pattern_into(
+                    pattern,
+                    WordVisitKind::ParameterPattern,
+                    flow,
+                    nested_regions,
+                );
+                if let Some(word) = operator.replacement_word_ast() {
+                    self.visit_word_into(word, kind, flow, nested_regions);
+                } else if let Some(word) = operand_word_ast {
+                    self.visit_word_arena_into(
+                        self.arena_store().word(word),
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
+                }
+            }
+            ParameterOp::UseDefault | ParameterOp::UseReplacement => {
+                self.guarded_parameter_operand_depth += 1;
+                self.defaulting_parameter_operand_depth += 1;
+                if let Some(word) = operand_word_ast {
+                    self.visit_word_arena_into(
+                        self.arena_store().word(word),
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
+                }
+                self.guarded_parameter_operand_depth -= 1;
+                self.defaulting_parameter_operand_depth -= 1;
+            }
+            ParameterOp::AssignDefault | ParameterOp::Error => {
+                self.defaulting_parameter_operand_depth += 1;
+                if let Some(word) = operand_word_ast {
+                    self.visit_word_arena_into(
+                        self.arena_store().word(word),
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
+                }
+                self.defaulting_parameter_operand_depth -= 1;
+            }
+            ParameterOp::UpperFirst
+            | ParameterOp::UpperAll
+            | ParameterOp::LowerFirst
+            | ParameterOp::LowerAll => {}
+        }
+    }
+
+    fn visit_zsh_operation_arena(
+        &mut self,
+        operation: &ZshExpansionOperationNode,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match operation {
+            ZshExpansionOperationNode::PatternOperation {
+                operand_word_ast, ..
+            }
+            | ZshExpansionOperationNode::TrimOperation {
+                operand_word_ast, ..
+            }
+            | ZshExpansionOperationNode::Unknown {
+                word_ast: operand_word_ast,
+                ..
+            } => {
+                self.visit_word_arena_into(
+                    self.arena_store().word(*operand_word_ast),
+                    kind,
+                    flow,
+                    nested_regions,
+                );
+            }
+            ZshExpansionOperationNode::Defaulting {
+                operand_word_ast, ..
+            } => {
+                self.guarded_parameter_operand_depth += 1;
+                self.defaulting_parameter_operand_depth += 1;
+                self.visit_word_arena_into(
+                    self.arena_store().word(*operand_word_ast),
+                    kind,
+                    flow,
+                    nested_regions,
+                );
+                self.guarded_parameter_operand_depth -= 1;
+                self.defaulting_parameter_operand_depth -= 1;
+            }
+            ZshExpansionOperationNode::ReplacementOperation {
+                pattern_word_ast,
+                replacement_word_ast,
+                ..
+            } => {
+                self.visit_word_arena_into(
+                    self.arena_store().word(*pattern_word_ast),
+                    WordVisitKind::ParameterPattern,
+                    flow,
+                    nested_regions,
+                );
+                if let Some(word) = replacement_word_ast {
+                    self.visit_word_arena_into(
+                        self.arena_store().word(*word),
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
+                }
+            }
+            ZshExpansionOperationNode::Slice {
+                offset_word_ast,
+                length_word_ast,
+                ..
+            } => {
+                self.visit_word_arena_into(
+                    self.arena_store().word(*offset_word_ast),
+                    kind,
+                    flow,
+                    nested_regions,
+                );
+                if let Some(word) = length_word_ast {
+                    self.visit_word_arena_into(
+                        self.arena_store().word(*word),
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
+                }
+            }
+        }
+    }
+
     fn record_guarded_parameter_reference(&mut self, reference_id: ReferenceId) {
         self.guarded_parameter_refs.insert(reference_id);
         if self.defaulting_parameter_operand_depth == 0 && self.short_circuit_condition_depth == 0 {
@@ -2183,6 +3850,34 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn visit_pattern_part_arena(
+        &mut self,
+        part: &PatternPartArena,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match part {
+            PatternPartArena::Group { patterns, .. } => {
+                for pattern in self.arena_store().patterns(*patterns).to_vec() {
+                    self.visit_pattern_arena_into(&pattern, kind, flow, nested_regions);
+                }
+            }
+            PatternPartArena::Word(word) => {
+                self.visit_word_arena_into(
+                    self.arena_store().word(*word),
+                    kind,
+                    flow,
+                    nested_regions,
+                );
+            }
+            PatternPartArena::Literal(_)
+            | PatternPartArena::AnyString
+            | PatternPartArena::AnyChar
+            | PatternPartArena::CharClass(_) => {}
+        }
+    }
+
     fn visit_conditional_expr(
         &mut self,
         expression: &ConditionalExpr,
@@ -2190,6 +3885,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     ) -> Vec<IsolatedRegion> {
         let mut nested_regions = Vec::new();
         self.visit_conditional_expr_into(expression, flow, &mut nested_regions);
+        nested_regions
+    }
+
+    fn visit_conditional_expr_arena(
+        &mut self,
+        expression: &ConditionalExprArena,
+        flow: FlowState,
+    ) -> Vec<IsolatedRegion> {
+        let mut nested_regions = Vec::new();
+        self.visit_conditional_expr_arena_into(expression, flow, &mut nested_regions);
         nested_regions
     }
 
@@ -2266,6 +3971,93 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.visit_conditional_expr_into(expression, flow, nested_regions);
     }
 
+    fn visit_conditional_expr_arena_into(
+        &mut self,
+        expression: &ConditionalExprArena,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match expression {
+            ConditionalExprArena::Binary {
+                left, op, right, ..
+            } => {
+                if conditional_binary_op_uses_arithmetic_operands(*op) {
+                    self.visit_conditional_arithmetic_operand_arena_into(
+                        left,
+                        flow,
+                        nested_regions,
+                    );
+                    self.visit_conditional_arithmetic_operand_arena_into(
+                        right,
+                        flow,
+                        nested_regions,
+                    );
+                } else if matches!(op, ConditionalBinaryOp::And | ConditionalBinaryOp::Or) {
+                    self.visit_conditional_expr_arena_into(left, flow, nested_regions);
+                    self.short_circuit_condition_depth += 1;
+                    self.visit_conditional_expr_arena_into(right, flow, nested_regions);
+                    self.short_circuit_condition_depth -= 1;
+                } else {
+                    self.visit_conditional_expr_arena_into(left, flow, nested_regions);
+                    self.visit_conditional_expr_arena_into(right, flow, nested_regions);
+                }
+            }
+            ConditionalExprArena::Unary { op, expr, .. } => {
+                if *op == ConditionalUnaryOp::VariableSet
+                    && let Some((name, span)) =
+                        variable_set_test_operand_name_arena(expr, self.arena_store(), self.source)
+                {
+                    self.add_reference_if_bound(&name, ReferenceKind::ConditionalOperand, span);
+                }
+                self.visit_conditional_expr_arena_into(expr, flow, nested_regions);
+            }
+            ConditionalExprArena::Parenthesized { expr, .. } => {
+                self.visit_conditional_expr_arena_into(expr, flow, nested_regions);
+            }
+            ConditionalExprArena::Word(word) | ConditionalExprArena::Regex(word) => {
+                self.visit_word_arena_into(
+                    self.arena_store().word(*word),
+                    WordVisitKind::Conditional,
+                    flow,
+                    nested_regions,
+                );
+            }
+            ConditionalExprArena::Pattern(pattern) => {
+                self.visit_pattern_arena_into(
+                    pattern,
+                    WordVisitKind::Conditional,
+                    flow,
+                    nested_regions,
+                );
+            }
+            ConditionalExprArena::VarRef(var_ref) => {
+                self.visit_var_ref_reference_arena(
+                    var_ref,
+                    ReferenceKind::ConditionalOperand,
+                    flow,
+                    nested_regions,
+                    var_ref.name_span,
+                );
+            }
+        }
+    }
+
+    fn visit_conditional_arithmetic_operand_arena_into(
+        &mut self,
+        expression: &ConditionalExprArena,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        if let Some((name, span)) =
+            conditional_arithmetic_operand_name_arena(expression, self.arena_store(), self.source)
+        {
+            self.add_reference(&name, ReferenceKind::ArithmeticRead, span);
+            return;
+        }
+
+        self.visit_conditional_expr_arena_into(expression, flow, nested_regions);
+    }
+
     fn visit_optional_arithmetic_expr(
         &mut self,
         expr: Option<&ArithmeticExprNode>,
@@ -2297,6 +4089,135 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.arithmetic_reference_kind = ReferenceKind::ParameterSliceArithmetic;
         self.visit_optional_arithmetic_expr_into(expr, flow, nested_regions);
         self.arithmetic_reference_kind = previous_kind;
+    }
+
+    fn visit_optional_arithmetic_expr_arena(
+        &mut self,
+        expr: Option<&ArithmeticExprArenaNode>,
+        flow: FlowState,
+    ) -> Vec<IsolatedRegion> {
+        let mut nested_regions = Vec::new();
+        self.visit_optional_arithmetic_expr_arena_into(expr, flow, &mut nested_regions);
+        nested_regions
+    }
+
+    fn visit_optional_arithmetic_expr_arena_into(
+        &mut self,
+        expr: Option<&ArithmeticExprArenaNode>,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        if let Some(expr) = expr {
+            self.visit_arithmetic_expr_arena_into(expr, flow, nested_regions);
+        }
+    }
+
+    fn visit_parameter_slice_arithmetic_expr_arena_into(
+        &mut self,
+        expr: Option<&ArithmeticExprArenaNode>,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        let previous_kind = self.arithmetic_reference_kind;
+        self.arithmetic_reference_kind = ReferenceKind::ParameterSliceArithmetic;
+        self.visit_optional_arithmetic_expr_arena_into(expr, flow, nested_regions);
+        self.arithmetic_reference_kind = previous_kind;
+    }
+
+    fn visit_arithmetic_expr_arena_into(
+        &mut self,
+        expr: &ArithmeticExprArenaNode,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match &expr.kind {
+            ArithmeticExprArena::Number(_) => {}
+            ArithmeticExprArena::Variable(name) => {
+                self.add_reference(name, self.arithmetic_reference_kind, expr.span);
+            }
+            ArithmeticExprArena::Indexed { name, index } => {
+                self.add_reference(
+                    name,
+                    self.arithmetic_reference_kind,
+                    arithmetic_name_span(expr.span, name),
+                );
+                self.visit_arithmetic_index_arena_into(name, index, flow, nested_regions);
+            }
+            ArithmeticExprArena::ShellWord(word) => {
+                let previous_kind =
+                    if self.arithmetic_reference_kind == ReferenceKind::ParameterSliceArithmetic {
+                        self.word_reference_kind_override
+                            .replace(ReferenceKind::ParameterSliceArithmetic)
+                    } else {
+                        None
+                    };
+                self.visit_word_arena_into(
+                    self.arena_store().word(*word),
+                    WordVisitKind::Expansion,
+                    flow,
+                    nested_regions,
+                );
+                if self.arithmetic_reference_kind == ReferenceKind::ParameterSliceArithmetic {
+                    self.word_reference_kind_override = previous_kind;
+                }
+            }
+            ArithmeticExprArena::Parenthesized { expression } => {
+                self.visit_arithmetic_expr_arena_into(expression, flow, nested_regions);
+            }
+            ArithmeticExprArena::Unary { op, expr: inner } => {
+                if matches!(
+                    op,
+                    ArithmeticUnaryOp::PreIncrement | ArithmeticUnaryOp::PreDecrement
+                ) {
+                    self.visit_arithmetic_update_arena_into(inner, flow, nested_regions);
+                } else {
+                    self.visit_arithmetic_expr_arena_into(inner, flow, nested_regions);
+                }
+            }
+            ArithmeticExprArena::Postfix { expr: inner, .. } => {
+                self.visit_arithmetic_update_arena_into(inner, flow, nested_regions);
+            }
+            ArithmeticExprArena::Binary { left, right, .. } => {
+                self.visit_arithmetic_expr_arena_into(left, flow, nested_regions);
+                self.visit_arithmetic_expr_arena_into(right, flow, nested_regions);
+            }
+            ArithmeticExprArena::Conditional {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.visit_arithmetic_expr_arena_into(condition, flow, nested_regions);
+                self.visit_arithmetic_expr_arena_into(then_expr, flow, nested_regions);
+                self.visit_arithmetic_expr_arena_into(else_expr, flow, nested_regions);
+            }
+            ArithmeticExprArena::Assignment { target, op, value } => {
+                self.visit_arithmetic_assignment_arena_into(
+                    target,
+                    expr.span,
+                    *op,
+                    value,
+                    flow,
+                    nested_regions,
+                );
+            }
+        }
+    }
+
+    fn visit_arithmetic_index_arena_into(
+        &mut self,
+        owner_name: &Name,
+        index: &ArithmeticExprArenaNode,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        if self
+            .arithmetic_index_uses_associative_word_semantics(owner_name, index.span.start.offset)
+        {
+            self.visit_associative_arithmetic_key_arena_into(index, flow, nested_regions);
+            return;
+        }
+
+        self.visit_arithmetic_expr_arena_into(index, flow, nested_regions);
     }
 
     fn visit_arithmetic_expr_into(
@@ -2597,6 +4518,201 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn arithmetic_binding_attributes_arena(
+        &self,
+        target: &ArithmeticLvalueArena,
+        target_offset: usize,
+    ) -> BindingAttributes {
+        let mut attributes = match target {
+            ArithmeticLvalueArena::Variable(_) => BindingAttributes::empty(),
+            ArithmeticLvalueArena::Indexed { .. } => BindingAttributes::ARRAY,
+        };
+
+        if let ArithmeticLvalueArena::Indexed { name, .. } = target
+            && self.visible_binding_is_assoc(name, target_offset)
+        {
+            attributes |= BindingAttributes::ASSOC;
+        }
+
+        attributes
+    }
+
+    fn visit_associative_arithmetic_key_arena_into(
+        &mut self,
+        expr: &ArithmeticExprArenaNode,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match &expr.kind {
+            ArithmeticExprArena::Number(_) | ArithmeticExprArena::Variable(_) => {}
+            ArithmeticExprArena::Indexed { index, .. } => {
+                self.visit_associative_arithmetic_key_arena_into(index, flow, nested_regions);
+            }
+            ArithmeticExprArena::ShellWord(word) => {
+                self.visit_word_arena_into(
+                    self.arena_store().word(*word),
+                    WordVisitKind::Expansion,
+                    flow,
+                    nested_regions,
+                );
+            }
+            ArithmeticExprArena::Parenthesized { expression } => {
+                self.visit_associative_arithmetic_key_arena_into(expression, flow, nested_regions);
+            }
+            ArithmeticExprArena::Unary { expr: inner, .. }
+            | ArithmeticExprArena::Postfix { expr: inner, .. } => {
+                self.visit_associative_arithmetic_key_arena_into(inner, flow, nested_regions);
+            }
+            ArithmeticExprArena::Binary { left, right, .. } => {
+                self.visit_associative_arithmetic_key_arena_into(left, flow, nested_regions);
+                self.visit_associative_arithmetic_key_arena_into(right, flow, nested_regions);
+            }
+            ArithmeticExprArena::Conditional {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.visit_associative_arithmetic_key_arena_into(condition, flow, nested_regions);
+                self.visit_associative_arithmetic_key_arena_into(then_expr, flow, nested_regions);
+                self.visit_associative_arithmetic_key_arena_into(else_expr, flow, nested_regions);
+            }
+            ArithmeticExprArena::Assignment { target, value, .. } => {
+                self.visit_associative_arithmetic_lvalue_arena_into(target, flow, nested_regions);
+                self.visit_associative_arithmetic_key_arena_into(value, flow, nested_regions);
+            }
+        }
+    }
+
+    fn visit_associative_arithmetic_lvalue_arena_into(
+        &mut self,
+        target: &ArithmeticLvalueArena,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match target {
+            ArithmeticLvalueArena::Variable(_) => {}
+            ArithmeticLvalueArena::Indexed { index, .. } => {
+                self.visit_associative_arithmetic_key_arena_into(index, flow, nested_regions);
+            }
+        }
+    }
+
+    fn visit_arithmetic_update_arena_into(
+        &mut self,
+        expr: &ArithmeticExprArenaNode,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match &expr.kind {
+            ArithmeticExprArena::Variable(name) => {
+                let reference_id =
+                    self.add_reference(name, self.arithmetic_reference_kind, expr.span);
+                self.self_referential_assignment_refs.insert(reference_id);
+                self.add_binding(
+                    name,
+                    BindingKind::ArithmeticAssignment,
+                    self.current_scope(),
+                    expr.span,
+                    BindingOrigin::ArithmeticAssignment {
+                        definition_span: expr.span,
+                        target_span: arithmetic_lvalue_span_arena(
+                            &ArithmeticLvalueArena::Variable(name.clone()),
+                            expr.span,
+                        ),
+                    },
+                    BindingAttributes::SELF_REFERENTIAL_READ,
+                );
+            }
+            ArithmeticExprArena::Indexed { name, index } => {
+                self.visit_arithmetic_index_arena_into(name, index, flow, nested_regions);
+                let span = arithmetic_name_span(expr.span, name);
+                let reference_id = self.add_reference(name, self.arithmetic_reference_kind, span);
+                self.self_referential_assignment_refs.insert(reference_id);
+                self.add_binding(
+                    name,
+                    BindingKind::ArithmeticAssignment,
+                    self.current_scope(),
+                    span,
+                    BindingOrigin::ArithmeticAssignment {
+                        definition_span: span,
+                        target_span: arithmetic_lvalue_span_arena(
+                            &ArithmeticLvalueArena::Indexed {
+                                name: name.clone(),
+                                index: index.clone(),
+                            },
+                            expr.span,
+                        ),
+                    },
+                    self.arithmetic_binding_attributes_arena(
+                        &ArithmeticLvalueArena::Indexed {
+                            name: name.clone(),
+                            index: index.clone(),
+                        },
+                        span.start.offset,
+                    ) | BindingAttributes::SELF_REFERENTIAL_READ,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn visit_arithmetic_assignment_arena_into(
+        &mut self,
+        target: &ArithmeticLvalueArena,
+        target_span: Span,
+        op: ArithmeticAssignOp,
+        value: &ArithmeticExprArenaNode,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        let name = match target {
+            ArithmeticLvalueArena::Variable(name) | ArithmeticLvalueArena::Indexed { name, .. } => {
+                name
+            }
+        };
+        let name_span = arithmetic_name_span(target_span, name);
+        let reference_start = self.references.len();
+        self.visit_arithmetic_lvalue_indices_arena_into(target, flow, nested_regions);
+        let mut attributes =
+            self.arithmetic_binding_attributes_arena(target, target_span.start.offset);
+        if !matches!(op, ArithmeticAssignOp::Assign) {
+            self.add_reference(name, self.arithmetic_reference_kind, name_span);
+        }
+        self.visit_arithmetic_expr_arena_into(value, flow, nested_regions);
+        let self_referential_refs =
+            self.newly_added_reference_ids_reading_name(name, reference_start);
+        if !self_referential_refs.is_empty() {
+            attributes |= BindingAttributes::SELF_REFERENTIAL_READ;
+            self.self_referential_assignment_refs
+                .extend(self_referential_refs);
+        }
+        self.add_binding(
+            name,
+            BindingKind::ArithmeticAssignment,
+            self.current_scope(),
+            name_span,
+            BindingOrigin::ArithmeticAssignment {
+                definition_span: name_span,
+                target_span: arithmetic_lvalue_span_arena(target, target_span),
+            },
+            attributes,
+        );
+    }
+
+    fn visit_arithmetic_lvalue_indices_arena_into(
+        &mut self,
+        target: &ArithmeticLvalueArena,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        match target {
+            ArithmeticLvalueArena::Variable(_) => {}
+            ArithmeticLvalueArena::Indexed { name, index } => {
+                self.visit_arithmetic_index_arena_into(name, index, flow, nested_regions);
+            }
+        }
+    }
+
     fn classify_special_simple_command(
         &mut self,
         name: &Name,
@@ -2629,10 +4745,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         target_attributes,
                     );
                 }
-                for implicit_read in
-                    self.runtime
-                        .implicit_reads_for_simple_command(name, args, self.source)
-                {
+                for implicit_read in self.runtime.implicit_reads_for_simple_command(name) {
                     let implicit_name = Name::from(*implicit_read);
                     self.add_reference_if_bound(
                         &implicit_name,
@@ -2734,6 +4847,154 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn classify_special_simple_command_arena(
+        &mut self,
+        name: &Name,
+        normalized: &ArenaNormalizedCommand<'_>,
+        flow: FlowState,
+    ) {
+        let args = normalized.body_args();
+        let command_span = normalized.command_span;
+        let name_span = normalized.body_word_span().unwrap_or(command_span);
+        match name.as_str() {
+            "read" => {
+                let read_assigns_array =
+                    read_assigns_array_arena(args, self.arena_store(), self.source);
+                for (target_index, (argument, span)) in
+                    iter_read_targets_arena(args, self.arena_store(), self.source)
+                        .into_iter()
+                        .enumerate()
+                {
+                    let target_attributes = if read_assigns_array && target_index == 0 {
+                        BindingAttributes::ARRAY
+                    } else {
+                        BindingAttributes::empty()
+                    };
+                    self.add_binding(
+                        &argument,
+                        BindingKind::ReadTarget,
+                        self.current_scope(),
+                        span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: span,
+                            kind: BuiltinBindingTargetKind::Read,
+                        },
+                        target_attributes,
+                    );
+                }
+                let implicit_name = Name::from("IFS");
+                self.add_reference_if_bound(
+                    &implicit_name,
+                    ReferenceKind::ImplicitRead,
+                    command_span,
+                );
+            }
+            "mapfile" | "readarray" => {
+                match mapfile_target_arena(args, self.arena_store(), self.source) {
+                    Some(MapfileTarget::Explicit(argument, span)) => {
+                        self.add_binding(
+                            &argument,
+                            BindingKind::MapfileTarget,
+                            self.current_scope(),
+                            span,
+                            BindingOrigin::BuiltinTarget {
+                                definition_span: span,
+                                kind: BuiltinBindingTargetKind::Mapfile,
+                            },
+                            BindingAttributes::ARRAY,
+                        );
+                    }
+                    Some(MapfileTarget::Implicit) => {
+                        self.add_binding(
+                            &Name::from("MAPFILE"),
+                            BindingKind::MapfileTarget,
+                            self.current_scope(),
+                            name_span,
+                            BindingOrigin::BuiltinTarget {
+                                definition_span: name_span,
+                                kind: BuiltinBindingTargetKind::Mapfile,
+                            },
+                            BindingAttributes::ARRAY,
+                        );
+                    }
+                    None => {}
+                }
+            }
+            "printf" => {
+                if let Some((argument, span)) =
+                    printf_v_target_arena(args, self.arena_store(), self.source)
+                {
+                    self.add_binding(
+                        &argument,
+                        BindingKind::PrintfTarget,
+                        self.current_scope(),
+                        span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: span,
+                            kind: BuiltinBindingTargetKind::Printf,
+                        },
+                        BindingAttributes::empty(),
+                    );
+                }
+            }
+            "getopts" => {
+                if let Some((argument, span)) =
+                    getopts_target_arena(args, self.arena_store(), self.source)
+                {
+                    self.add_binding(
+                        &argument,
+                        BindingKind::GetoptsTarget,
+                        self.current_scope(),
+                        span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: span,
+                            kind: BuiltinBindingTargetKind::Getopts,
+                        },
+                        BindingAttributes::empty(),
+                    );
+                }
+            }
+            "let" => self.record_let_arithmetic_assignment_targets_arena(args),
+            "eval" => self.record_eval_argument_references_arena(args),
+            "trap" => self.record_trap_action_references_arena(args),
+            "source" | "." => {
+                if normalized.wrappers.is_empty()
+                    && let Some(argument) = args.first().copied()
+                {
+                    let word = self.arena_store().word(argument);
+                    let source_span = self.command_stack.last().copied().unwrap_or(command_span);
+                    let kind = self.classify_source_ref_arena(command_span.line(), word);
+                    self.source_refs.push(SourceRef {
+                        diagnostic_class: classify_source_ref_diagnostic_class_arena(
+                            word,
+                            self.source,
+                            &kind,
+                        ),
+                        kind,
+                        span: source_span,
+                        path_span: word.span(),
+                        resolution: SourceRefResolution::Unchecked,
+                        explicitly_provided: false,
+                    });
+                }
+            }
+            "unset" => self.record_unset_variable_targets_arena(args, flow),
+            "export" | "local" | "declare" | "typeset" | "readonly" => {
+                self.visit_simple_declaration_command_arena(
+                    name.as_str(),
+                    args,
+                    command_span,
+                    flow,
+                );
+            }
+            _ if name.as_str().starts_with("DEFINE_") => {
+                self.visit_command_defined_variable_arena(args);
+            }
+            _ => {}
+        }
+        let _ = name_span;
+    }
+
     fn record_trap_action_references(&mut self, args: &[&Word]) {
         let Some(argument) = trap_action_argument(args, self.source) else {
             return;
@@ -2747,9 +5008,45 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn record_trap_action_references_arena(&mut self, args: &[WordId]) {
+        let Some(argument) = trap_action_argument_arena(args, self.arena_store(), self.source)
+        else {
+            return;
+        };
+        let argument = self.arena_store().word(argument);
+
+        let mut seen = FxHashSet::default();
+        for name in trap_action_reference_names_arena(argument, self.source) {
+            if seen.insert(name.clone()) {
+                self.add_reference(&name, ReferenceKind::TrapAction, argument.span());
+            }
+        }
+    }
+
     fn record_let_arithmetic_assignment_targets(&mut self, args: &[&Word]) {
         for argument in args {
             let Some((name, span)) = let_arithmetic_assignment_target(argument, self.source) else {
+                continue;
+            };
+            self.add_binding(
+                &name,
+                BindingKind::ArithmeticAssignment,
+                self.current_scope(),
+                span,
+                BindingOrigin::ArithmeticAssignment {
+                    definition_span: span,
+                    target_span: span,
+                },
+                BindingAttributes::empty(),
+            );
+        }
+    }
+
+    fn record_let_arithmetic_assignment_targets_arena(&mut self, args: &[WordId]) {
+        for argument in args {
+            let word = self.arena_store().word(*argument);
+            let Some((name, span)) = let_arithmetic_assignment_target_arena(word, self.source)
+            else {
                 continue;
             };
             self.add_binding(
@@ -2887,6 +5184,125 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         });
     }
 
+    fn visit_simple_declaration_command_arena(
+        &mut self,
+        command_name: &str,
+        args: &[WordId],
+        command_span: Span,
+        flow: FlowState,
+    ) {
+        let Some(builtin) = declaration_builtin_name(command_name) else {
+            return;
+        };
+
+        let mut flags = FxHashSet::default();
+        let mut global_flag_enabled = false;
+        let mut name_operands_are_function_names = false;
+        let mut parsing_options = true;
+        let mut operands = Vec::new();
+
+        for argument_id in args.iter().copied() {
+            let argument = self.arena_store().word(argument_id);
+            if parsing_options {
+                if let Some(text) = static_word_text_arena(argument, self.source) {
+                    if text == "--" {
+                        parsing_options = false;
+                        continue;
+                    }
+
+                    if simple_declaration_option_word(&text) {
+                        update_simple_declaration_flags(
+                            &text,
+                            &mut flags,
+                            &mut global_flag_enabled,
+                            &mut name_operands_are_function_names,
+                        );
+                        operands.push(simple_declaration_flag_operand_arena(
+                            argument,
+                            text.as_ref(),
+                        ));
+                        continue;
+                    }
+                }
+
+                parsing_options = false;
+            }
+
+            if name_operands_are_function_names {
+                operands.push(DeclarationOperand::DynamicWord {
+                    span: argument.span(),
+                });
+                continue;
+            }
+
+            let text = static_word_text_arena(argument, self.source)
+                .unwrap_or_else(|| Cow::Borrowed(argument.span().slice(self.source)));
+
+            if let Some(parsed) =
+                parse_simple_declaration_assignment_from_text(argument.span(), &text, self.source)
+            {
+                let (scope, mut attributes) = self.simple_declaration_scope_and_attributes(
+                    builtin,
+                    &flags,
+                    global_flag_enabled,
+                    flow,
+                );
+                attributes |= BindingAttributes::DECLARATION_INITIALIZED;
+                if parsed.array_like {
+                    attributes |= BindingAttributes::ARRAY;
+                }
+                if flags.contains(&'p') {
+                    attributes |= BindingAttributes::EXTERNALLY_CONSUMED;
+                }
+                let kind = if attributes.contains(BindingAttributes::NAMEREF) {
+                    BindingKind::Nameref
+                } else {
+                    BindingKind::Declaration(builtin)
+                };
+                self.add_binding(
+                    &parsed.name,
+                    kind,
+                    scope,
+                    parsed.name_span,
+                    BindingOrigin::Assignment {
+                        definition_span: parsed.target_span,
+                        value: parsed.value_origin,
+                    },
+                    attributes,
+                );
+                operands.push(DeclarationOperand::Assignment {
+                    name: parsed.name,
+                    name_span: parsed.name_span,
+                    value_span: parsed.value_span,
+                    append: parsed.append,
+                });
+                continue;
+            }
+
+            if let Some((name, span)) = named_target_word_arena(argument, self.source) {
+                self.visit_simple_name_only_declaration_operand(
+                    builtin,
+                    &flags,
+                    global_flag_enabled,
+                    flow,
+                    &name,
+                    span,
+                );
+                operands.push(DeclarationOperand::Name { name, span });
+            } else {
+                operands.push(DeclarationOperand::DynamicWord {
+                    span: argument.span(),
+                });
+            }
+        }
+
+        self.declarations.push(Declaration {
+            builtin,
+            span: command_span,
+            operands,
+        });
+    }
+
     fn visit_command_defined_variable(&mut self, args: &[&Word]) {
         let Some((flag_name, span)) = args
             .first()
@@ -2908,9 +5324,40 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         );
     }
 
+    fn visit_command_defined_variable_arena(&mut self, args: &[WordId]) {
+        let Some((flag_name, span)) = args
+            .first()
+            .copied()
+            .and_then(|word| named_target_word_arena(self.arena_store().word(word), self.source))
+        else {
+            return;
+        };
+        let generated = Name::from(format!("FLAGS_{}", flag_name.as_str()));
+        self.add_binding(
+            &generated,
+            BindingKind::Declaration(DeclarationBuiltin::Declare),
+            self.current_scope(),
+            span,
+            BindingOrigin::Declaration {
+                definition_span: span,
+            },
+            BindingAttributes::empty(),
+        );
+    }
+
     fn record_eval_argument_references(&mut self, args: &[&Word]) {
         for argument in args.iter().copied() {
             for (name, span) in eval_argument_reference_names(argument, self.source) {
+                self.add_reference_if_bound(&name, ReferenceKind::ImplicitRead, span);
+            }
+        }
+    }
+
+    fn record_eval_argument_references_arena(&mut self, args: &[WordId]) {
+        for argument in args.iter().copied() {
+            for (name, span) in
+                eval_argument_reference_names_arena(self.arena_store().word(argument), self.source)
+            {
                 self.add_reference_if_bound(&name, ReferenceKind::ImplicitRead, span);
             }
         }
@@ -2998,6 +5445,91 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn record_unset_variable_targets_arena(&mut self, args: &[WordId], flow: FlowState) {
+        if flow.conditionally_executed {
+            return;
+        }
+
+        let mut function_flag_seen = false;
+        let mut variable_flag_seen = false;
+        let mut nameref_mode = false;
+        let mut parsing_options = true;
+
+        for argument_id in args.iter().copied() {
+            let argument = self.arena_store().word(argument_id);
+            let Some(text) = static_word_text_arena(argument, self.source) else {
+                if parsing_options {
+                    return;
+                }
+                parsing_options = false;
+                continue;
+            };
+
+            if parsing_options {
+                if text == "--" {
+                    parsing_options = false;
+                    continue;
+                }
+
+                if text.starts_with('-') && text != "-" {
+                    let flags = text.trim_start_matches('-');
+                    if !unset_flags_are_valid(flags) {
+                        return;
+                    }
+                    for flag in flags.chars() {
+                        match flag {
+                            'f' => {
+                                if variable_flag_seen {
+                                    return;
+                                }
+                                function_flag_seen = true;
+                            }
+                            'v' => {
+                                if function_flag_seen {
+                                    return;
+                                }
+                                variable_flag_seen = true;
+                            }
+                            'n' => {
+                                nameref_mode = true;
+                            }
+                            _ => unreachable!("invalid unset flag already filtered"),
+                        }
+                    }
+                    continue;
+                }
+
+                parsing_options = false;
+            }
+
+            if function_flag_seen || !is_name(&text) {
+                continue;
+            }
+
+            if nameref_mode {
+                let name = Name::from(text.as_ref());
+                let Some(binding_id) = self.resolve_reference(
+                    &name,
+                    self.current_scope(),
+                    argument.span().start.offset,
+                ) else {
+                    continue;
+                };
+                let binding = &self.bindings[binding_id.index()];
+                if !binding.attributes.contains(BindingAttributes::NAMEREF)
+                    && !matches!(binding.kind, BindingKind::Nameref)
+                {
+                    continue;
+                }
+            }
+
+            self.cleared_variables
+                .entry((self.current_scope(), Name::from(text.as_ref())))
+                .or_default()
+                .push(argument.span().start.offset);
+        }
+    }
+
     fn classify_source_ref(&self, line: usize, word: &Word) -> SourceRefKind {
         if let Some(directive) = self.source_directive_for_line(line) {
             return directive;
@@ -3008,6 +5540,22 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
 
         classify_dynamic_source_word(word, self.source)
+    }
+
+    fn classify_source_ref_arena(
+        &self,
+        line: usize,
+        word: shuck_ast::WordView<'_>,
+    ) -> SourceRefKind {
+        if let Some(directive) = self.source_directive_for_line(line) {
+            return directive;
+        }
+
+        if let Some(text) = static_word_text_arena(word, self.source) {
+            return SourceRefKind::Literal(text.into_owned());
+        }
+
+        classify_dynamic_source_word_arena(word, self.source)
     }
 
     fn source_directive_for_line(&self, line: usize) -> Option<SourceRefKind> {
@@ -3560,6 +6108,42 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         );
     }
 
+    fn add_parameter_default_binding_arena(&mut self, reference: &VarRefNode) {
+        let mut attributes = binding_attributes_for_var_ref_arena(reference);
+        if reference.subscript.is_some()
+            && !attributes.contains(BindingAttributes::ASSOC)
+            && self
+                .resolve_reference(
+                    &reference.name,
+                    self.current_scope(),
+                    reference.name_span.start.offset,
+                )
+                .map(|binding_id| {
+                    let binding = &self.bindings[binding_id.index()];
+                    binding.attributes.contains(BindingAttributes::ASSOC)
+                        && !self.binding_was_cleared_before_lookup(
+                            binding,
+                            self.current_scope(),
+                            reference.name_span.start.offset,
+                        )
+                })
+                .unwrap_or(false)
+        {
+            attributes |= BindingAttributes::ARRAY | BindingAttributes::ASSOC;
+        }
+
+        self.add_binding(
+            &reference.name,
+            BindingKind::ParameterDefaultAssignment,
+            self.current_scope(),
+            reference.span,
+            BindingOrigin::ParameterDefaultAssignment {
+                definition_span: reference.span,
+            },
+            attributes,
+        );
+    }
+
     fn add_reference_if_bound(&mut self, name: &Name, kind: ReferenceKind, span: Span) {
         if self
             .resolve_reference(name, self.current_scope(), span.start.offset)
@@ -3662,6 +6246,31 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn mark_local_declarations_visible_to_later_calls(&mut self) {
+        let later_call_scopes = self
+            .call_sites
+            .iter()
+            .filter(|(callee, _)| self.functions.contains_key(callee.as_str()))
+            .flat_map(|(_, sites)| sites.iter())
+            .map(|site| (site.scope, site.span.start.offset))
+            .collect::<Vec<_>>();
+
+        for binding in &mut self.bindings {
+            if !matches!(binding.kind, BindingKind::Declaration(_))
+                || !binding.attributes.contains(BindingAttributes::LOCAL)
+                || !binding.references.is_empty()
+            {
+                continue;
+            }
+            if later_call_scopes
+                .iter()
+                .any(|(scope, offset)| *scope == binding.scope && *offset > binding.span.end.offset)
+            {
+                binding.attributes |= BindingAttributes::EXTERNALLY_CONSUMED;
+            }
+        }
+    }
+
     fn compute_heuristic_unused_assignments(&self) -> Vec<BindingId> {
         self.bindings
             .iter()
@@ -3705,8 +6314,14 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             let deferred_functions = std::mem::take(&mut self.deferred_functions);
             for deferred in deferred_functions {
                 self.rebuild_scope_stack(deferred.scope);
-                let commands =
-                    self.visit_function_like_body(&deferred.function.body, deferred.flow);
+                let commands = match deferred.body {
+                    DeferredFunctionBody::Recursive(function) => {
+                        self.visit_function_like_body(&function.body, deferred.flow)
+                    }
+                    DeferredFunctionBody::Arena(body) => {
+                        self.visit_function_like_body_arena(body, deferred.flow)
+                    }
+                };
                 self.recorded_program
                     .set_function_body(deferred.scope, commands);
                 self.mark_scope_completed(deferred.scope);
@@ -3731,6 +6346,27 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.recorded_program.push_command_ids(vec![command])
             }
         }
+    }
+
+    fn visit_function_like_body_arena(
+        &mut self,
+        body: StmtSeqId,
+        flow: FlowState,
+    ) -> RecordedCommandRange {
+        let flow = FlowState {
+            in_function: true,
+            ..flow
+        };
+        let body = self.arena_stmt_seq(body);
+        if body.stmt_ids().len() == 1 {
+            let stmt = body.stmts().next().expect("single body statement");
+            if let Some(compound) = stmt.command().compound()
+                && let CompoundCommandNode::BraceGroup(inner) = compound.node()
+            {
+                return self.visit_stmt_seq_arena(self.arena_stmt_seq(*inner), flow);
+            }
+        }
+        self.visit_stmt_seq_arena(body, flow)
     }
 
     fn rebuild_scope_stack(&mut self, scope: ScopeId) {
@@ -3916,6 +6552,24 @@ fn declaration_flags(operands: &[DeclOperand], source: &str) -> FxHashSet<char> 
     flags
 }
 
+fn declaration_flags_arena(
+    operands: &[DeclOperandNode],
+    store: &AstStore,
+    source: &str,
+) -> FxHashSet<char> {
+    let mut flags = FxHashSet::default();
+    for operand in operands {
+        if let DeclOperandNode::Flag(word) = operand
+            && let Some(text) = static_word_text_arena(store.word(*word), source)
+        {
+            for flag in text.chars().skip(1) {
+                flags.insert(flag);
+            }
+        }
+    }
+    flags
+}
+
 fn simple_declaration_option_word(text: &str) -> bool {
     let mut chars = text.chars();
     let Some(polarity) = chars.next() else {
@@ -3958,6 +6612,17 @@ fn simple_declaration_flag_operand(word: &Word, text: &str) -> DeclarationOperan
     }
 }
 
+fn simple_declaration_flag_operand_arena(
+    word: shuck_ast::WordView<'_>,
+    text: &str,
+) -> DeclarationOperand {
+    DeclarationOperand::Flag {
+        flag: text.chars().nth(1).unwrap_or('-'),
+        flags: text.to_owned(),
+        span: word.span(),
+    }
+}
+
 fn declaration_flag_is_enabled(
     operands: &[DeclOperand],
     source: &str,
@@ -3987,8 +6652,62 @@ fn declaration_flag_is_enabled(
     enabled
 }
 
+fn declaration_flag_is_enabled_arena(
+    operands: &[DeclOperandNode],
+    store: &AstStore,
+    source: &str,
+    target: char,
+) -> Option<bool> {
+    let mut enabled = None;
+    for operand in operands {
+        if let DeclOperandNode::Flag(word) = operand
+            && let Some(text) = static_word_text_arena(store.word(*word), source)
+        {
+            let mut chars = text.chars();
+            let Some(polarity) = chars.next() else {
+                continue;
+            };
+            let enabled_for_operand = match polarity {
+                '-' => true,
+                '+' => false,
+                _ => continue,
+            };
+            for flag in chars {
+                if flag == target {
+                    enabled = Some(enabled_for_operand);
+                }
+            }
+        }
+    }
+    enabled
+}
+
 fn update_declaration_function_name_mode(word: &Word, source: &str, function_name_mode: &mut bool) {
     let Some(text) = static_word_text(word, source) else {
+        return;
+    };
+    let mut chars = text.chars();
+    let Some(polarity) = chars.next() else {
+        return;
+    };
+    let enabled_for_operand = match polarity {
+        '-' => true,
+        '+' => false,
+        _ => return,
+    };
+    for flag in chars {
+        if matches!(flag, 'f' | 'F') {
+            *function_name_mode = enabled_for_operand;
+        }
+    }
+}
+
+fn update_declaration_function_name_mode_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+    function_name_mode: &mut bool,
+) {
+    let Some(text) = static_word_text_arena(word, source) else {
         return;
     };
     let mut chars = text.chars();
@@ -4035,7 +6754,56 @@ fn declaration_operands(operands: &[DeclOperand], source: &str) -> Vec<Declarati
         .collect()
 }
 
+fn declaration_operands_arena(
+    operands: &[DeclOperandNode],
+    store: &AstStore,
+    source: &str,
+) -> Vec<DeclarationOperand> {
+    operands
+        .iter()
+        .map(|operand| match operand {
+            DeclOperandNode::Flag(word) => {
+                let word = store.word(*word);
+                let text = static_word_text_arena(word, source).unwrap_or_default();
+                let flag = text.chars().nth(1).unwrap_or('-');
+                DeclarationOperand::Flag {
+                    flag,
+                    flags: text.into_owned(),
+                    span: word.span(),
+                }
+            }
+            DeclOperandNode::Name(name) => DeclarationOperand::Name {
+                name: name.name.clone(),
+                span: name.span,
+            },
+            DeclOperandNode::Assignment(assignment) => DeclarationOperand::Assignment {
+                name: assignment.target.name.clone(),
+                name_span: assignment.target.name_span,
+                value_span: assignment_value_span_arena(assignment, store),
+                append: assignment.append,
+            },
+            DeclOperandNode::Dynamic(word) => DeclarationOperand::DynamicWord {
+                span: store.word(*word).span(),
+            },
+        })
+        .collect()
+}
+
 fn binding_attributes_for_var_ref(reference: &VarRef) -> BindingAttributes {
+    match reference
+        .subscript
+        .as_ref()
+        .map(|subscript| subscript.interpretation)
+    {
+        Some(shuck_ast::SubscriptInterpretation::Associative) => {
+            BindingAttributes::ARRAY | BindingAttributes::ASSOC
+        }
+        Some(_) => BindingAttributes::ARRAY,
+        None => BindingAttributes::empty(),
+    }
+}
+
+fn binding_attributes_for_var_ref_arena(reference: &VarRefNode) -> BindingAttributes {
     match reference
         .subscript
         .as_ref()
@@ -4064,10 +6832,28 @@ fn assignment_binding_attributes(assignment: &Assignment) -> BindingAttributes {
     attributes
 }
 
+fn assignment_binding_attributes_arena(assignment: &AssignmentNode) -> BindingAttributes {
+    let mut attributes = binding_attributes_for_var_ref_arena(&assignment.target);
+    if let AssignmentValueNode::Compound(array) = &assignment.value {
+        attributes |= match array.kind {
+            ArrayKind::Associative => BindingAttributes::ARRAY | BindingAttributes::ASSOC,
+            ArrayKind::Indexed | ArrayKind::Contextual => BindingAttributes::ARRAY,
+        };
+    }
+    attributes
+}
+
 fn assignment_value_span(assignment: &Assignment) -> Span {
     match &assignment.value {
         AssignmentValue::Scalar(word) => word.span,
         AssignmentValue::Compound(array) => array.span,
+    }
+}
+
+fn assignment_value_span_arena(assignment: &AssignmentNode, store: &AstStore) -> Span {
+    match &assignment.value {
+        AssignmentValueNode::Scalar(word) => store.word(*word).span(),
+        AssignmentValueNode::Compound(array) => array.span,
     }
 }
 
@@ -4078,11 +6864,35 @@ fn assignment_has_empty_initializer(assignment: &Assignment, source: &str) -> bo
     }
 }
 
+fn assignment_has_empty_initializer_arena(
+    assignment: &AssignmentNode,
+    store: &AstStore,
+    source: &str,
+) -> bool {
+    match &assignment.value {
+        AssignmentValueNode::Scalar(word) => {
+            static_word_text_arena(store.word(*word), source).as_deref() == Some("")
+        }
+        AssignmentValueNode::Compound(array) => store.array_elems(array.elements).is_empty(),
+    }
+}
+
 fn indirect_target_hint(assignment: &Assignment, source: &str) -> Option<IndirectTargetHint> {
     let AssignmentValue::Scalar(word) = &assignment.value else {
         return None;
     };
     indirect_target_hint_from_word(word, source)
+}
+
+fn indirect_target_hint_arena(
+    assignment: &AssignmentNode,
+    store: &AstStore,
+    source: &str,
+) -> Option<IndirectTargetHint> {
+    let AssignmentValueNode::Scalar(word) = &assignment.value else {
+        return None;
+    };
+    indirect_target_hint_from_word_arena(store.word(*word), store, source)
 }
 
 fn indirect_target_hint_from_word(word: &Word, source: &str) -> Option<IndirectTargetHint> {
@@ -4099,6 +6909,52 @@ fn indirect_target_hint_from_word(word: &Word, source: &str) -> Option<IndirectT
     let mut saw_variable = false;
     if !collect_indirect_pattern_parts(
         &word.parts,
+        source,
+        &mut prefix,
+        &mut suffix,
+        &mut saw_variable,
+    ) {
+        return None;
+    }
+
+    if !saw_variable {
+        return None;
+    }
+
+    let (suffix, array_like) = strip_array_like_suffix(suffix.as_str());
+    if (!prefix.is_empty() && !is_name_fragment(&prefix)) || !is_name_fragment(suffix) {
+        return None;
+    }
+    if prefix.is_empty() && suffix.is_empty() {
+        return None;
+    }
+
+    Some(IndirectTargetHint::Pattern {
+        prefix,
+        suffix: suffix.to_string(),
+        array_like,
+    })
+}
+
+fn indirect_target_hint_from_word_arena(
+    word: shuck_ast::WordView<'_>,
+    store: &AstStore,
+    source: &str,
+) -> Option<IndirectTargetHint> {
+    if let Some(text) = static_word_text_arena(word, source) {
+        let (name, array_like) = parse_indirect_target_name(&text)?;
+        return Some(IndirectTargetHint::Exact {
+            name: Name::from(name),
+            array_like,
+        });
+    }
+
+    let mut prefix = String::new();
+    let mut suffix = String::new();
+    let mut saw_variable = false;
+    if !collect_indirect_pattern_parts_arena(
+        word.parts(),
+        store,
         source,
         &mut prefix,
         &mut suffix,
@@ -4167,10 +7023,67 @@ fn collect_indirect_pattern_parts(
     true
 }
 
+fn collect_indirect_pattern_parts_arena(
+    parts: &[WordPartArenaNode],
+    store: &AstStore,
+    source: &str,
+    prefix: &mut String,
+    suffix: &mut String,
+    saw_variable: &mut bool,
+) -> bool {
+    for part in parts {
+        match &part.kind {
+            WordPartArena::Literal(text) => {
+                if *saw_variable {
+                    suffix.push_str(text.as_str(source, part.span));
+                } else {
+                    prefix.push_str(text.as_str(source, part.span));
+                }
+            }
+            WordPartArena::SingleQuoted { value, .. } => {
+                if *saw_variable {
+                    suffix.push_str(value.slice(source));
+                } else {
+                    prefix.push_str(value.slice(source));
+                }
+            }
+            WordPartArena::DoubleQuoted { parts, .. } => {
+                if !collect_indirect_pattern_parts_arena(
+                    store.word_parts(*parts),
+                    store,
+                    source,
+                    prefix,
+                    suffix,
+                    saw_variable,
+                ) {
+                    return false;
+                }
+            }
+            WordPartArena::Variable(_) if !*saw_variable => *saw_variable = true,
+            WordPartArena::Parameter(parameter)
+                if !*saw_variable && parameter_is_indirect_pattern_variable_arena(parameter) =>
+            {
+                *saw_variable = true;
+            }
+            _ => return false,
+        }
+    }
+
+    true
+}
+
 fn parameter_is_indirect_pattern_variable(parameter: &ParameterExpansion) -> bool {
     matches!(
         &parameter.syntax,
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+            if reference.subscript.is_none()
+    )
+}
+
+fn parameter_is_indirect_pattern_variable_arena(parameter: &ParameterExpansionNode) -> bool {
+    matches!(
+        &parameter.syntax,
+        ParameterExpansionSyntaxNode::Bourne(BourneParameterExpansionNode::Access { reference })
             if reference.subscript.is_none()
     )
 }
@@ -4220,6 +7133,30 @@ fn read_assigns_array(args: &[&Word], source: &str) -> bool {
     parse_read_options(args, source).assigns_array
 }
 
+fn iter_read_targets_arena(args: &[WordId], store: &AstStore, source: &str) -> Vec<(Name, Span)> {
+    let options = parse_read_options_arena(args, store, source);
+    let mut targets = Vec::new();
+
+    if let Some(array_target) = options.array_target {
+        targets.push(array_target);
+    }
+
+    if options.assigns_array {
+        return targets;
+    }
+
+    targets.extend(
+        args[options.target_start_index..]
+            .iter()
+            .filter_map(|word| named_target_word_arena(store.word(*word), source)),
+    );
+    targets
+}
+
+fn read_assigns_array_arena(args: &[WordId], store: &AstStore, source: &str) -> bool {
+    parse_read_options_arena(args, store, source).assigns_array
+}
+
 #[derive(Debug, Clone)]
 struct ParsedReadOptions {
     assigns_array: bool,
@@ -4257,6 +7194,64 @@ fn parse_read_options(args: &[&Word], source: &str) -> ParsedReadOptions {
                 } else if let Some(target) = args
                     .get(index + 1)
                     .and_then(|word| named_target_word(word, source))
+                {
+                    array_target = Some(target);
+                    index += 1;
+                }
+                stop_after_array_target = true;
+                break;
+            }
+            if read_flag_takes_value(flag) {
+                if offset + flag.len_utf8() == flags.len() {
+                    index += 1;
+                }
+                break;
+            }
+        }
+        index += 1;
+        if stop_after_array_target {
+            break;
+        }
+    }
+
+    ParsedReadOptions {
+        assigns_array,
+        target_start_index: index.min(args.len()),
+        array_target,
+    }
+}
+
+fn parse_read_options_arena(args: &[WordId], store: &AstStore, source: &str) -> ParsedReadOptions {
+    let mut assigns_array = false;
+    let mut array_target = None;
+    let mut index = 0;
+    while let Some(word_id) = args.get(index) {
+        let word = store.word(*word_id);
+        let Some(text) = static_word_text_arena(word, source) else {
+            break;
+        };
+        if text == "--" {
+            index += 1;
+            break;
+        }
+        let Some(flags) = text.strip_prefix('-') else {
+            break;
+        };
+        if flags.is_empty() || flags.starts_with('-') {
+            break;
+        }
+
+        let mut stop_after_array_target = false;
+        for (offset, flag) in flags.char_indices() {
+            if flag == 'a' {
+                assigns_array = true;
+                let attached_offset = offset + flag.len_utf8();
+                if attached_offset < flags.len() {
+                    array_target =
+                        read_attached_array_target_arena(word, source, &flags[attached_offset..]);
+                } else if let Some(target) = args
+                    .get(index + 1)
+                    .and_then(|word| named_target_word_arena(store.word(*word), source))
                 {
                     array_target = Some(target);
                     index += 1;
@@ -4331,6 +7326,44 @@ fn mapfile_target(args: &[&Word], source: &str) -> Option<MapfileTarget> {
     args.get(index).is_none().then_some(MapfileTarget::Implicit)
 }
 
+fn mapfile_target_arena(args: &[WordId], store: &AstStore, source: &str) -> Option<MapfileTarget> {
+    let mut index = 0;
+    while let Some(word_id) = args.get(index) {
+        let word = store.word(*word_id);
+        let Some(text) = static_word_text_arena(word, source) else {
+            break;
+        };
+        if text == "--" {
+            index += 1;
+            break;
+        }
+        let Some(flags) = text.strip_prefix('-') else {
+            break;
+        };
+        if flags.is_empty() || flags.starts_with('-') {
+            break;
+        }
+        for (offset, flag) in flags.char_indices() {
+            if mapfile_flag_takes_value(flag) {
+                if offset + flag.len_utf8() == flags.len() {
+                    index += 1;
+                }
+                break;
+            }
+        }
+        index += 1;
+    }
+
+    if let Some((name, span)) = args[index..]
+        .iter()
+        .find_map(|word| named_target_word_arena(store.word(*word), source))
+    {
+        return Some(MapfileTarget::Explicit(name, span));
+    }
+
+    args.get(index).is_none().then_some(MapfileTarget::Implicit)
+}
+
 fn mapfile_flag_takes_value(flag: char) -> bool {
     matches!(flag, 'C' | 'c' | 'd' | 'n' | 'O' | 's' | 'u')
 }
@@ -4343,8 +7376,21 @@ fn printf_v_target(args: &[&Word], source: &str) -> Option<(Name, Span)> {
     })
 }
 
+fn printf_v_target_arena(args: &[WordId], store: &AstStore, source: &str) -> Option<(Name, Span)> {
+    args.windows(2).find_map(|window| {
+        (static_word_text_arena(store.word(window[0]), source).as_deref() == Some("-v"))
+            .then_some(window[1])
+            .and_then(|word| named_target_word_arena(store.word(word), source))
+    })
+}
+
 fn getopts_target(args: &[&Word], source: &str) -> Option<(Name, Span)> {
     args.get(1).and_then(|word| named_target_word(word, source))
+}
+
+fn getopts_target_arena(args: &[WordId], store: &AstStore, source: &str) -> Option<(Name, Span)> {
+    args.get(1)
+        .and_then(|word| named_target_word_arena(store.word(*word), source))
 }
 
 fn variable_set_test_operand_name(
@@ -4515,12 +7561,67 @@ fn conditional_arithmetic_operand_name(
     }
 }
 
+fn conditional_arithmetic_operand_name_arena(
+    expression: &ConditionalExprArena,
+    store: &AstStore,
+    source: &str,
+) -> Option<(Name, Span)> {
+    match strip_parenthesized_conditional_arena(expression) {
+        ConditionalExprArena::Word(word) | ConditionalExprArena::Regex(word) => {
+            let word = store.word(*word);
+            conditional_static_word_text_arena(word, source).and_then(|text| {
+                is_name(text.as_ref()).then(|| (Name::from(text.as_ref()), word.span()))
+            })
+        }
+        ConditionalExprArena::Pattern(pattern) => {
+            let text = pattern.span.slice(source).trim();
+            is_name(text).then(|| (Name::from(text), pattern.span))
+        }
+        ConditionalExprArena::VarRef(_)
+        | ConditionalExprArena::Unary { .. }
+        | ConditionalExprArena::Binary { .. }
+        | ConditionalExprArena::Parenthesized { .. } => None,
+    }
+}
+
 fn strip_parenthesized_conditional(expression: &ConditionalExpr) -> &ConditionalExpr {
     let mut current = expression;
     while let ConditionalExpr::Parenthesized(paren) = current {
         current = &paren.expr;
     }
     current
+}
+
+fn strip_parenthesized_conditional_arena(
+    expression: &ConditionalExprArena,
+) -> &ConditionalExprArena {
+    let mut current = expression;
+    while let ConditionalExprArena::Parenthesized { expr, .. } = current {
+        current = expr;
+    }
+    current
+}
+
+fn variable_set_test_operand_name_arena(
+    expression: &ConditionalExprArena,
+    store: &AstStore,
+    source: &str,
+) -> Option<(Name, Span)> {
+    match strip_parenthesized_conditional_arena(expression) {
+        ConditionalExprArena::Word(word) | ConditionalExprArena::Regex(word) => {
+            let word = store.word(*word);
+            variable_name_operand_from_source(word.span().slice(source), word.span())
+        }
+        ConditionalExprArena::Pattern(pattern) => {
+            variable_name_operand_from_source(pattern.span.slice(source), pattern.span)
+        }
+        ConditionalExprArena::VarRef(reference) => {
+            Some((reference.name.clone(), reference.name_span))
+        }
+        ConditionalExprArena::Unary { .. }
+        | ConditionalExprArena::Binary { .. }
+        | ConditionalExprArena::Parenthesized { .. } => None,
+    }
 }
 
 fn variable_name_operand_from_source(text: &str, span: Span) -> Option<(Name, Span)> {
@@ -4592,9 +7693,33 @@ fn eval_argument_reference_names(word: &Word, source: &str) -> Vec<(Name, Span)>
     )
 }
 
+fn eval_argument_reference_names_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+) -> Vec<(Name, Span)> {
+    let span = word.span();
+    let source_text = span.slice(source);
+    let decoded = decode_eval_word_text(source_text);
+    scan_parameter_reference_names(&decoded.text, source_text, &decoded.source_offsets, span)
+}
+
 fn trap_action_argument<'a>(args: &[&'a Word], source: &str) -> Option<&'a Word> {
     let argument = *args.first()?;
     let text = static_word_text(argument, source)?;
+
+    if text == "--" {
+        return args.get(1).copied();
+    }
+    if is_trap_inspection_option(&text) {
+        return None;
+    }
+
+    Some(argument)
+}
+
+fn trap_action_argument_arena(args: &[WordId], store: &AstStore, source: &str) -> Option<WordId> {
+    let argument = *args.first()?;
+    let text = static_word_text_arena(store.word(argument), source)?;
 
     if text == "--" {
         return args.get(1).copied();
@@ -4623,11 +7748,32 @@ fn trap_action_reference_names(word: &Word, source: &str) -> Vec<Name> {
         .collect()
 }
 
+fn trap_action_reference_names_arena(word: shuck_ast::WordView<'_>, source: &str) -> Vec<Name> {
+    let Some(text) = static_word_text_arena(word, source) else {
+        return Vec::new();
+    };
+
+    scan_parameter_reference_name_ranges(&text)
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect()
+}
+
 fn prompt_assignment_reference_names(word: &Word, source: &str) -> Vec<(Name, Span)> {
     let Some(text) = static_word_text(word, source) else {
         return Vec::new();
     };
     scan_prompt_parameter_reference_names(text.as_ref(), word.span)
+}
+
+fn prompt_assignment_reference_names_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+) -> Vec<(Name, Span)> {
+    let Some(text) = static_word_text_arena(word, source) else {
+        return Vec::new();
+    };
+    scan_prompt_parameter_reference_names(text.as_ref(), word.span())
 }
 
 fn escaped_prompt_assignment_reference_names(word: &Word, source: &str) -> Vec<Name> {
@@ -4651,6 +7797,28 @@ fn escaped_prompt_assignment_reference_names(word: &Word, source: &str) -> Vec<N
         }
     }
 
+    names
+}
+
+fn escaped_prompt_assignment_reference_names_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+) -> Vec<Name> {
+    let text = word.span().slice(source);
+    let mut names = Vec::new();
+    let mut search_start = 0;
+
+    while let Some(start_rel) = text[search_start..].find("\\${") {
+        let start = search_start + start_rel;
+        let after_dollar = start + "\\$".len();
+        if let Some((name_start, name_end)) = parameter_name_bounds_after_dollar(text, after_dollar)
+        {
+            names.push(Name::from(&text[name_start..name_end]));
+            search_start = name_end;
+        } else {
+            search_start = start + "\\${".len();
+        }
+    }
     names
 }
 
@@ -4890,9 +8058,190 @@ fn resolved_command_can_affect_current_shell(command: &NormalizedCommand<'_>) ->
     })
 }
 
+fn normalize_command_words_arena<'a>(
+    store: &'a AstStore,
+    words: &[WordId],
+    command_span: Span,
+    source: &'a str,
+) -> Option<ArenaNormalizedCommand<'a>> {
+    let first_id = words.first().copied()?;
+    let first_word = store.word(first_id);
+    let literal_name = static_command_name_text_arena(first_word, source);
+    let mut effective_name = literal_name.clone();
+    let mut wrappers = Vec::new();
+    let mut body_word_span = Some(first_word.span());
+    let mut body_start = literal_name.as_ref().map(|_| 0usize);
+    let mut current_index = 0usize;
+
+    while let Some(current_name) = effective_name.as_deref() {
+        match static_command_wrapper_target_index(
+            words.len(),
+            current_index,
+            current_name,
+            |word_index| static_word_text_arena(store.word(words[word_index]), source),
+        ) {
+            StaticCommandWrapperTarget::NotWrapper => break,
+            StaticCommandWrapperTarget::Wrapper { target_index } => {
+                let kind = match current_name {
+                    "noglob" => WrapperKind::Noglob,
+                    "command" => WrapperKind::Command,
+                    "builtin" => WrapperKind::Builtin,
+                    "exec" => WrapperKind::Exec,
+                    _ => WrapperKind::Command,
+                };
+                wrappers.push(kind);
+                let Some(target_index) = target_index else {
+                    effective_name = None;
+                    body_word_span = None;
+                    body_start = None;
+                    break;
+                };
+                let target = store.word(words[target_index]);
+                body_word_span = Some(target.span());
+                effective_name = static_command_name_text_arena(target, source);
+                body_start = effective_name.as_ref().map(|_| target_index);
+                current_index = target_index;
+                if effective_name.is_none() {
+                    break;
+                }
+            }
+        }
+    }
+
+    Some(ArenaNormalizedCommand {
+        literal_name,
+        effective_name,
+        wrappers,
+        body_word_span,
+        body_words: body_start.map_or_else(Vec::new, |start| words[start..].to_vec()),
+        command_span,
+    })
+}
+
+fn static_word_text_arena<'a>(
+    word: shuck_ast::WordView<'_>,
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    try_static_word_parts_text_arena(word.parts(), word.store(), source)
+}
+
+fn conditional_static_word_text_arena<'a>(
+    word: shuck_ast::WordView<'_>,
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    static_word_text_arena(word, source).or_else(|| {
+        let text = word.span().slice(source);
+        (text.len() >= 2 && text.starts_with('"') && text.ends_with('"'))
+            .then(|| Cow::Owned(text[1..text.len() - 1].to_owned()))
+    })
+}
+
+fn static_command_name_text_arena<'a>(
+    word: shuck_ast::WordView<'_>,
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    try_static_command_name_parts_text_arena(word.parts(), source, StaticNameContext::Unquoted)
+}
+
+#[derive(Clone, Copy)]
+enum StaticNameContext {
+    Unquoted,
+}
+
+fn try_static_word_parts_text_arena<'a>(
+    parts: &[WordPartArenaNode],
+    store: &AstStore,
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    if parts.is_empty() {
+        return Some(Cow::Borrowed(""));
+    }
+    let mut owned = None::<String>;
+    for part in parts {
+        let text = match &part.kind {
+            WordPartArena::Literal(text) => text.as_str(source, part.span),
+            WordPartArena::SingleQuoted { value, .. } => value.slice(source),
+            WordPartArena::DoubleQuoted { parts, .. } => {
+                let text =
+                    try_static_word_parts_text_arena(store.word_parts(*parts), store, source)?;
+                owned.get_or_insert_with(String::new).push_str(&text);
+                continue;
+            }
+            _ => return None,
+        };
+        owned.get_or_insert_with(String::new).push_str(text);
+    }
+    owned.map(Cow::Owned)
+}
+
+fn try_static_command_name_parts_text_arena<'a>(
+    parts: &[WordPartArenaNode],
+    source: &'a str,
+    context: StaticNameContext,
+) -> Option<Cow<'a, str>> {
+    if parts.is_empty() {
+        return Some(Cow::Borrowed(""));
+    }
+    let mut result = String::new();
+    for part in parts {
+        match &part.kind {
+            WordPartArena::Literal(text) => {
+                append_decoded_static_command_literal_arena(
+                    text.as_str(source, part.span),
+                    context,
+                    &mut result,
+                );
+            }
+            WordPartArena::SingleQuoted { value, .. } => result.push_str(value.slice(source)),
+            WordPartArena::DoubleQuoted { .. } => return None,
+            _ => return None,
+        }
+    }
+    Some(Cow::Owned(result))
+}
+
+fn append_decoded_static_command_literal_arena(
+    text: &str,
+    context: StaticNameContext,
+    out: &mut String,
+) {
+    let mut chars = text.char_indices().peekable();
+    while let Some((_, ch)) = chars.next() {
+        if ch != '\\' {
+            out.push(ch);
+            continue;
+        }
+        let Some((_, next)) = chars.next() else {
+            out.push('\\');
+            return;
+        };
+        match context {
+            StaticNameContext::Unquoted => {
+                if next != '\n' {
+                    out.push(next);
+                }
+            }
+        }
+    }
+}
+
+fn resolved_command_can_affect_current_shell_arena(command: &ArenaNormalizedCommand<'_>) -> bool {
+    command.wrappers.iter().all(|wrapper| {
+        matches!(
+            wrapper,
+            WrapperKind::Command | WrapperKind::Builtin | WrapperKind::Noglob
+        )
+    })
+}
+
 fn named_target_word(word: &Word, source: &str) -> Option<(Name, Span)> {
     let text = static_word_text(word, source)?;
     is_name(&text).then_some((Name::from(text.as_ref()), word.span))
+}
+
+fn named_target_word_arena(word: shuck_ast::WordView<'_>, source: &str) -> Option<(Name, Span)> {
+    let text = static_word_text_arena(word, source)?;
+    is_name(&text).then_some((Name::from(text.as_ref()), word.span()))
 }
 
 fn declaration_assignment_text<'a>(word: &'a Word, source: &'a str) -> Cow<'a, str> {
@@ -4912,6 +8261,22 @@ struct SimpleDeclarationAssignment {
 
 fn parse_simple_declaration_assignment(
     word: &Word,
+    text: &str,
+    source: &str,
+) -> Option<SimpleDeclarationAssignment> {
+    parse_simple_declaration_assignment_from_span(word.span, text, source)
+}
+
+fn parse_simple_declaration_assignment_from_text(
+    span: Span,
+    text: &str,
+    source: &str,
+) -> Option<SimpleDeclarationAssignment> {
+    parse_simple_declaration_assignment_from_span(span, text, source)
+}
+
+fn parse_simple_declaration_assignment_from_span(
+    span: Span,
     text: &str,
     source: &str,
 ) -> Option<SimpleDeclarationAssignment> {
@@ -4938,10 +8303,10 @@ fn parse_simple_declaration_assignment(
     }
 
     let value_start = index + 1;
-    let name_span = word_text_offset_span(word.span, source, 0, name_end);
+    let name_span = word_text_offset_span(span, source, 0, name_end);
     let target_span =
-        word_text_offset_span(word.span, source, 0, if append { index - 1 } else { index });
-    let value_span = word_text_offset_span(word.span, source, value_start, text.len());
+        word_text_offset_span(span, source, 0, if append { index - 1 } else { index });
+    let value_span = word_text_offset_span(span, source, value_start, text.len());
     let value_origin = if text[value_start..].trim_start().starts_with('(') {
         AssignmentValueOrigin::ArrayOrCompound
     } else {
@@ -4968,6 +8333,22 @@ fn let_arithmetic_assignment_target(word: &Word, source: &str) -> Option<(Name, 
     Some((
         Name::from(&text[..name_end]),
         word_text_offset_span(word.span, source, 0, name_end),
+    ))
+}
+
+fn let_arithmetic_assignment_target_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+) -> Option<(Name, Span)> {
+    let span = word.span();
+    let text = span.slice(source);
+    let name_end = variable_name_end(text)?;
+    let rest = text[name_end..].trim_start();
+    arithmetic_assignment_operator(rest)?;
+
+    Some((
+        Name::from(&text[..name_end]),
+        word_text_offset_span(span, source, 0, name_end),
     ))
 }
 
@@ -5027,6 +8408,27 @@ fn read_attached_array_target(
     Some((Name::from(target_text), target_span))
 }
 
+fn read_attached_array_target_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+    target_text: &str,
+) -> Option<(Name, Span)> {
+    if !is_name(target_text) {
+        return None;
+    }
+
+    let span = word.span();
+    let target_span = span
+        .slice(source)
+        .rfind(target_text)
+        .map(|start| {
+            read_option_attached_target_span(span, source, start, start + target_text.len())
+        })
+        .unwrap_or(span);
+
+    Some((Name::from(target_text), target_span))
+}
+
 fn read_option_attached_target_span(span: Span, source: &str, start: usize, end: usize) -> Span {
     let start_pos = span
         .start
@@ -5055,6 +8457,143 @@ fn recorded_command_info(
     }
 }
 
+fn recorded_command_info_arena(
+    command: CommandView<'_>,
+    source: &str,
+    bash_runtime_vars_enabled: bool,
+) -> RecordedCommandInfo {
+    let command_span = command.span();
+    let Some(command) = command.simple() else {
+        let text = command.span().slice(source);
+        let words = text
+            .split_whitespace()
+            .map(|word| Some(word.to_owned()))
+            .collect::<Vec<_>>();
+        let Some(Some(static_callee)) = words.first() else {
+            return RecordedCommandInfo::default();
+        };
+        if !matches!(
+            static_callee.as_str(),
+            "emulate" | "setopt" | "unsetopt" | "set"
+        ) {
+            return RecordedCommandInfo::default();
+        }
+        let static_args = words
+            .iter()
+            .skip(1)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        let mut info = RecordedCommandInfo {
+            static_callee: Some(static_callee.clone()),
+            static_args,
+            source_path_template: None,
+            zsh_effects: Vec::new(),
+        };
+        let args = words.get(1..).unwrap_or(&[]);
+        match static_callee.as_str() {
+            "emulate" => info.zsh_effects = parse_emulate_effects_static(args),
+            "setopt" => {
+                info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions {
+                    updates: parse_setopt_updates_static(args, true),
+                }];
+            }
+            "unsetopt" => {
+                info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions {
+                    updates: parse_setopt_updates_static(args, false),
+                }];
+            }
+            _ => {}
+        }
+        info.zsh_effects.retain(|effect| match effect {
+            RecordedZshCommandEffect::Emulate { .. } => true,
+            RecordedZshCommandEffect::SetOptions { updates } => !updates.is_empty(),
+        });
+        return info;
+    };
+    let word_ids = std::iter::once(command.name().id())
+        .chain(command.args().map(|word| word.id()))
+        .collect::<Vec<_>>();
+    let normalized =
+        normalize_command_words_arena(command.name().store(), &word_ids, command_span, source);
+    let mut static_callee = normalized
+        .as_ref()
+        .and_then(|command| command.effective_name.as_ref())
+        .map(|name| name.to_string())
+        .or_else(|| {
+            static_command_name_text_arena(command.name(), source).map(|name| name.into_owned())
+        });
+    let body_words = normalized
+        .as_ref()
+        .map(|command| command.body_words.as_slice())
+        .unwrap_or(word_ids.as_slice());
+    let static_args = body_words
+        .iter()
+        .skip(1)
+        .map(|word| {
+            static_word_text_arena(command.name().store().word(*word), source)
+                .map(|text| text.into_owned())
+        })
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
+    let source_path_template = static_callee
+        .as_deref()
+        .filter(|name| matches!(*name, "source" | "."))
+        .and_then(|_| body_words.get(1).copied())
+        .map(|word| command.name().store().word(word))
+        .and_then(|word| source_path_template_arena(word, source, bash_runtime_vars_enabled));
+
+    if static_callee.as_deref() == Some("noglob") {
+        static_callee = command.args().next().and_then(|word| {
+            static_command_name_text_arena(word, source).map(|name| name.into_owned())
+        });
+    }
+
+    let mut info = RecordedCommandInfo {
+        static_callee,
+        static_args,
+        source_path_template,
+        zsh_effects: Vec::new(),
+    };
+
+    let static_words = std::iter::once(command.name())
+        .chain(command.args())
+        .map(|word| static_word_text_arena(word, source).map(|text| text.into_owned()))
+        .collect::<Vec<_>>();
+    let Some((effect_callee, effect_index)) =
+        normalize_recorded_zsh_effect_command_arena(&static_words)
+    else {
+        return info;
+    };
+    let args = static_words.get(effect_index + 1..).unwrap_or(&[]);
+    match effect_callee.as_str() {
+        "emulate" => info.zsh_effects = parse_emulate_effects_static(args),
+        "setopt" => {
+            info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions {
+                updates: parse_setopt_updates_static(args, true),
+            }];
+        }
+        "unsetopt" => {
+            info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions {
+                updates: parse_setopt_updates_static(args, false),
+            }];
+        }
+        "set" => {
+            let updates = parse_set_builtin_option_updates_static(args);
+            if !updates.is_empty() {
+                info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions { updates }];
+            }
+        }
+        _ => {}
+    }
+
+    info.zsh_effects.retain(|effect| match effect {
+        RecordedZshCommandEffect::Emulate { .. } => true,
+        RecordedZshCommandEffect::SetOptions { updates } => !updates.is_empty(),
+    });
+    info
+}
+
 fn recorded_simple_command_info(
     command: &shuck_ast::SimpleCommand,
     source: &str,
@@ -5071,11 +8610,7 @@ fn recorded_simple_command_info(
         .map(|word| static_word_text(word, source).map(|text| text.into_owned()))
         .collect::<Vec<_>>()
         .into_boxed_slice();
-    let source_path_template = static_callee
-        .as_deref()
-        .filter(|name| matches!(*name, "source" | "."))
-        .and_then(|_| command.args.first())
-        .and_then(|word| source_path_template(word, source, bash_runtime_vars_enabled));
+    let _ = bash_runtime_vars_enabled;
 
     if static_callee.as_deref() == Some("noglob") {
         static_callee = words
@@ -5086,7 +8621,7 @@ fn recorded_simple_command_info(
     let mut info = RecordedCommandInfo {
         static_callee,
         static_args,
-        source_path_template,
+        source_path_template: None,
         zsh_effects: Vec::new(),
     };
     let Some((effect_callee, effect_index)) = normalize_recorded_zsh_effect_command(&words, source)
@@ -5123,6 +8658,322 @@ fn recorded_simple_command_info(
     info
 }
 
+fn source_path_template_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+    bash_runtime_vars_enabled: bool,
+) -> Option<SourcePathTemplate> {
+    if static_word_text_arena(word, source).is_some() {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    let mut ignored_root = false;
+    let mut saw_dynamic = false;
+
+    collect_source_template_parts_arena(
+        word.parts(),
+        word.store(),
+        source,
+        bash_runtime_vars_enabled,
+        &mut parts,
+        &mut ignored_root,
+        &mut saw_dynamic,
+    )
+    .then_some(())?;
+
+    (saw_dynamic && !parts.is_empty()).then_some(SourcePathTemplate::Interpolated(parts))
+}
+
+fn collect_source_template_parts_arena(
+    word_parts: &[WordPartArenaNode],
+    store: &AstStore,
+    source: &str,
+    bash_runtime_vars_enabled: bool,
+    parts: &mut Vec<TemplatePart>,
+    ignored_root: &mut bool,
+    saw_dynamic: &mut bool,
+) -> bool {
+    for part in word_parts {
+        match &part.kind {
+            WordPartArena::Literal(text) => {
+                let text = text.as_str(source, part.span);
+                if !text.is_empty() {
+                    push_source_template_literal_arena(parts, text.to_owned());
+                }
+            }
+            WordPartArena::SingleQuoted { value, .. } => {
+                let text = value.slice(source);
+                if !text.is_empty() {
+                    push_source_template_literal_arena(parts, text.to_owned());
+                }
+            }
+            WordPartArena::DoubleQuoted { parts: inner, .. } => {
+                if !collect_source_template_parts_arena(
+                    store.word_parts(*inner),
+                    store,
+                    source,
+                    bash_runtime_vars_enabled,
+                    parts,
+                    ignored_root,
+                    saw_dynamic,
+                ) {
+                    return false;
+                }
+            }
+            WordPartArena::Variable(name) => {
+                if let Some(index) = source_template_positional_index_arena(name) {
+                    *saw_dynamic = true;
+                    parts.push(TemplatePart::Arg(index));
+                } else if bash_runtime_vars_enabled
+                    && source_template_is_bash_source_var_arena(name)
+                {
+                    *saw_dynamic = true;
+                    parts.push(TemplatePart::SourceFile);
+                } else if !*ignored_root && parts.is_empty() {
+                    *ignored_root = true;
+                    *saw_dynamic = true;
+                } else {
+                    return false;
+                }
+            }
+            WordPartArena::Parameter(parameter)
+                if bash_runtime_vars_enabled
+                    && source_template_parameter_is_current_source_file_arena(
+                        parameter, source,
+                    ) =>
+            {
+                *saw_dynamic = true;
+                parts.push(TemplatePart::SourceFile);
+            }
+            WordPartArena::ArrayAccess(reference)
+                if bash_runtime_vars_enabled
+                    && source_template_is_bash_source_index_ref_arena(reference, source) =>
+            {
+                *saw_dynamic = true;
+                parts.push(TemplatePart::SourceFile);
+            }
+            WordPartArena::CommandSubstitution { body, .. } => {
+                if bash_runtime_vars_enabled
+                    && let Some(template_part) =
+                        dirname_source_template_part_arena(store.stmt_seq(*body), store, source)
+                {
+                    *saw_dynamic = true;
+                    parts.push(template_part);
+                } else {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+
+    true
+}
+
+fn push_source_template_literal_arena(parts: &mut Vec<TemplatePart>, text: String) {
+    if let Some(TemplatePart::Literal(existing)) = parts.last_mut() {
+        existing.push_str(&text);
+    } else {
+        parts.push(TemplatePart::Literal(text));
+    }
+}
+
+fn source_template_positional_index_arena(name: &Name) -> Option<usize> {
+    name.as_str().parse().ok()
+}
+
+fn source_template_is_bash_source_var_arena(name: &Name) -> bool {
+    name.as_str() == "BASH_SOURCE"
+}
+
+fn source_template_parameter_is_current_source_file_arena(
+    parameter: &ParameterExpansionNode,
+    source: &str,
+) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntaxNode::Bourne(BourneParameterExpansionNode::Access {
+            reference,
+        }) => source_template_is_current_source_reference_arena(reference, source),
+        ParameterExpansionSyntaxNode::Bourne(
+            BourneParameterExpansionNode::Length { .. }
+            | BourneParameterExpansionNode::Indices { .. }
+            | BourneParameterExpansionNode::Indirect { .. }
+            | BourneParameterExpansionNode::PrefixMatch { .. }
+            | BourneParameterExpansionNode::Slice { .. }
+            | BourneParameterExpansionNode::Operation { .. }
+            | BourneParameterExpansionNode::Transformation { .. },
+        )
+        | ParameterExpansionSyntaxNode::Zsh(_) => false,
+    }
+}
+
+fn source_template_is_current_source_reference_arena(reference: &VarRefNode, source: &str) -> bool {
+    source_template_is_bash_source_var_arena(&reference.name)
+        && reference.subscript.as_ref().is_none_or(|subscript| {
+            source_template_subscript_is_semantic_zero_arena(subscript, None, source)
+        })
+}
+
+fn source_template_is_bash_source_index_ref_arena(reference: &VarRefNode, source: &str) -> bool {
+    source_template_is_bash_source_var_arena(&reference.name)
+        && reference.subscript.as_ref().is_some_and(|subscript| {
+            source_template_subscript_is_semantic_zero_arena(subscript, None, source)
+        })
+}
+
+fn source_template_subscript_is_semantic_zero_arena(
+    subscript: &SubscriptNode,
+    store: Option<&AstStore>,
+    source: &str,
+) -> bool {
+    subscript.arithmetic_ast.as_ref().is_some_and(|expr| {
+        source_template_arithmetic_expr_is_semantic_zero_arena(expr, store, source)
+    })
+}
+
+fn source_template_arithmetic_expr_is_semantic_zero_arena(
+    expr: &ArithmeticExprArenaNode,
+    store: Option<&AstStore>,
+    source: &str,
+) -> bool {
+    match &expr.kind {
+        ArithmeticExprArena::Number(text) => {
+            source_template_shell_zero_literal_arena(text.slice(source))
+        }
+        ArithmeticExprArena::ShellWord(word) => store
+            .map(|store| {
+                source_template_word_is_semantic_zero_arena(store.word(*word), store, source)
+            })
+            .unwrap_or(false),
+        ArithmeticExprArena::Parenthesized { expression } => {
+            source_template_arithmetic_expr_is_semantic_zero_arena(expression, store, source)
+        }
+        ArithmeticExprArena::Unary { expr, .. } => {
+            source_template_arithmetic_expr_is_semantic_zero_arena(expr, store, source)
+        }
+        _ => false,
+    }
+}
+
+fn source_template_word_is_semantic_zero_arena(
+    word: shuck_ast::WordView<'_>,
+    store: &AstStore,
+    source: &str,
+) -> bool {
+    matches!(
+        word.parts(),
+        [part] if source_template_word_part_is_semantic_zero_arena(part, store, source)
+    )
+}
+
+fn source_template_word_part_is_semantic_zero_arena(
+    part: &WordPartArenaNode,
+    store: &AstStore,
+    source: &str,
+) -> bool {
+    match &part.kind {
+        WordPartArena::Literal(text) => {
+            source_template_shell_zero_literal_arena(text.as_str(source, part.span))
+        }
+        WordPartArena::SingleQuoted { value, .. } => {
+            source_template_shell_zero_literal_arena(value.slice(source))
+        }
+        WordPartArena::DoubleQuoted { parts, .. } => {
+            matches!(
+                store.word_parts(*parts),
+                [part] if source_template_word_part_is_semantic_zero_arena(part, store, source)
+            )
+        }
+        WordPartArena::ArithmeticExpansion {
+            expression_ast: Some(expr),
+            ..
+        } => source_template_arithmetic_expr_is_semantic_zero_arena(expr, Some(store), source),
+        _ => false,
+    }
+}
+
+fn source_template_shell_zero_literal_arena(text: &str) -> bool {
+    let text = text.trim();
+    if text.is_empty() {
+        return false;
+    }
+
+    let digits = text
+        .strip_prefix('+')
+        .or_else(|| text.strip_prefix('-'))
+        .unwrap_or(text);
+    if digits.is_empty() {
+        return false;
+    }
+
+    if let Some((base, value)) = digits.split_once('#') {
+        return base.parse::<u32>().is_ok_and(|base| {
+            (2..=64).contains(&base) && !value.is_empty() && value.chars().all(|ch| ch == '0')
+        });
+    }
+
+    let digits = digits
+        .strip_prefix("0x")
+        .or_else(|| digits.strip_prefix("0X"))
+        .unwrap_or(digits);
+    !digits.is_empty() && digits.chars().all(|ch| ch == '0')
+}
+
+fn dirname_source_template_part_arena(
+    commands: StmtSeqView<'_>,
+    store: &AstStore,
+    source: &str,
+) -> Option<TemplatePart> {
+    let mut stmts = commands.stmts();
+    let stmt = stmts.next()?;
+    if stmts.next().is_some() {
+        return None;
+    }
+    let command = stmt.command().simple()?;
+    if stmt.negated() || !stmt.redirects().is_empty() || !command.assignments().is_empty() {
+        return None;
+    }
+    let args = command.args().collect::<Vec<_>>();
+    if args.len() != 1 {
+        return None;
+    }
+    if static_word_text_arena(command.name(), source).as_deref() != Some("dirname") {
+        return None;
+    }
+    current_source_file_word_arena(args[0], store, source).then_some(TemplatePart::SourceDir)
+}
+
+fn current_source_file_word_arena(
+    word: shuck_ast::WordView<'_>,
+    store: &AstStore,
+    source: &str,
+) -> bool {
+    matches!(
+        word.parts(),
+        [part] if is_current_source_part_arena(&part.kind, store, source)
+    )
+}
+
+fn is_current_source_part_arena(part: &WordPartArena, store: &AstStore, source: &str) -> bool {
+    match part {
+        WordPartArena::Variable(name) => source_template_is_bash_source_var_arena(name),
+        WordPartArena::Parameter(parameter) => {
+            source_template_parameter_is_current_source_file_arena(parameter, source)
+        }
+        WordPartArena::ArrayAccess(reference) => {
+            source_template_is_bash_source_index_ref_arena(reference, source)
+        }
+        WordPartArena::DoubleQuoted { parts, .. } => {
+            matches!(
+                store.word_parts(*parts),
+                [part] if is_current_source_part_arena(&part.kind, store, source)
+            )
+        }
+        _ => false,
+    }
+}
+
 fn normalize_recorded_zsh_effect_command(words: &[&Word], source: &str) -> Option<(String, usize)> {
     let mut index = 0usize;
 
@@ -5137,6 +8988,34 @@ fn normalize_recorded_zsh_effect_command(words: &[&Word], source: &str) -> Optio
             static_word_text(words[word_index], source)
         }) {
             StaticCommandWrapperTarget::NotWrapper => return Some((text.into_owned(), index)),
+            StaticCommandWrapperTarget::Wrapper {
+                target_index: Some(target_index),
+            } => {
+                index = target_index;
+                continue;
+            }
+            StaticCommandWrapperTarget::Wrapper { target_index: None } => return None,
+        }
+    }
+
+    None
+}
+
+fn normalize_recorded_zsh_effect_command_arena(
+    words: &[Option<String>],
+) -> Option<(String, usize)> {
+    let mut index = 0usize;
+
+    while let Some(text) = words.get(index).and_then(|text| text.as_deref()) {
+        if is_recorded_assignment_word(text) {
+            index += 1;
+            continue;
+        }
+
+        match static_command_wrapper_target_index(words.len(), index, text, |word_index| {
+            words[word_index].as_deref().map(Cow::Borrowed)
+        }) {
+            StaticCommandWrapperTarget::NotWrapper => return Some((text.to_owned(), index)),
             StaticCommandWrapperTarget::Wrapper {
                 target_index: Some(target_index),
             } => {
@@ -5235,6 +9114,69 @@ fn parse_emulate_effects(args: &[&Word], source: &str) -> Vec<RecordedZshCommand
     effects
 }
 
+fn parse_emulate_effects_static(args: &[Option<String>]) -> Vec<RecordedZshCommandEffect> {
+    let mut local = false;
+    let mut mode = None;
+    let mut updates = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(Some(text)) = args.get(index) {
+        match text.as_str() {
+            "--" => break,
+            "-o" | "+o" => {
+                let enable = text.starts_with('-');
+                if let Some(Some(option)) = args.get(index + 1)
+                    && let Some(update) = parse_recorded_zsh_option_update(option, enable)
+                {
+                    updates.push(update);
+                }
+                index += 2;
+                continue;
+            }
+            _ => {}
+        }
+
+        if text.starts_with("-o") || text.starts_with("+o") {
+            let enable = text.starts_with('-');
+            if let Some(update) = parse_recorded_zsh_option_update(&text[2..], enable) {
+                updates.push(update);
+            }
+            index += 1;
+            continue;
+        }
+
+        if let Some(flags) = text.strip_prefix('-') {
+            for flag in flags.chars() {
+                if flag == 'L' {
+                    local = true;
+                }
+            }
+            index += 1;
+            continue;
+        }
+
+        if mode.is_none() {
+            mode = match text.to_ascii_lowercase().as_str() {
+                "zsh" => Some(ZshEmulationMode::Zsh),
+                "sh" => Some(ZshEmulationMode::Sh),
+                "ksh" => Some(ZshEmulationMode::Ksh),
+                "csh" => Some(ZshEmulationMode::Csh),
+                _ => None,
+            };
+        }
+        index += 1;
+    }
+
+    let mut effects = Vec::new();
+    if let Some(mode) = mode {
+        effects.push(RecordedZshCommandEffect::Emulate { mode, local });
+    }
+    if !updates.is_empty() {
+        effects.push(RecordedZshCommandEffect::SetOptions { updates });
+    }
+    effects
+}
+
 fn parse_setopt_updates(
     args: &[&Word],
     source: &str,
@@ -5244,6 +9186,17 @@ fn parse_setopt_updates(
         .filter_map(|word| static_word_text(word, source))
         .filter(|text| text != "--")
         .filter_map(|text| parse_recorded_zsh_option_update(&text, enable))
+        .collect()
+}
+
+fn parse_setopt_updates_static(
+    args: &[Option<String>],
+    enable: bool,
+) -> Vec<RecordedZshOptionUpdate> {
+    args.iter()
+        .filter_map(|text| text.as_deref())
+        .filter(|text| *text != "--")
+        .filter_map(|text| parse_recorded_zsh_option_update(text, enable))
         .collect()
 }
 
@@ -5264,6 +9217,37 @@ fn parse_set_builtin_option_updates(args: &[&Word], source: &str) -> Vec<Recorde
                     .get(index + 1)
                     .and_then(|word| static_word_text(word, source))
                     && let Some(update) = parse_recorded_zsh_option_update(&name, enable)
+                {
+                    updates.push(update);
+                }
+                index += 2;
+            }
+            _ if text.starts_with("-o") || text.starts_with("+o") => {
+                let enable = text.starts_with('-');
+                if let Some(update) = parse_recorded_zsh_option_update(&text[2..], enable) {
+                    updates.push(update);
+                }
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    updates
+}
+
+fn parse_set_builtin_option_updates_static(
+    args: &[Option<String>],
+) -> Vec<RecordedZshOptionUpdate> {
+    let mut updates = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(Some(text)) = args.get(index) {
+        match text.as_str() {
+            "-o" | "+o" => {
+                let enable = text.starts_with('-');
+                if let Some(Some(name)) = args.get(index + 1)
+                    && let Some(update) = parse_recorded_zsh_option_update(name, enable)
                 {
                     updates.push(update);
                 }
@@ -5340,6 +9324,30 @@ fn classify_dynamic_source_word(word: &Word, source: &str) -> SourceRefKind {
     SourceRefKind::Dynamic
 }
 
+fn classify_dynamic_source_word_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+) -> SourceRefKind {
+    let mut variable = None;
+    let mut tail = String::new();
+
+    for part in word.parts() {
+        match &part.kind {
+            WordPartArena::Literal(text) => tail.push_str(text.as_str(source, part.span)),
+            WordPartArena::Variable(name) if variable.is_none() && tail.is_empty() => {
+                variable = Some(name.clone());
+            }
+            _ => return SourceRefKind::Dynamic,
+        }
+    }
+
+    if let Some(variable) = variable {
+        return SourceRefKind::SingleVariableStaticTail { variable, tail };
+    }
+
+    SourceRefKind::Dynamic
+}
+
 fn classify_source_ref_diagnostic_class(
     word: &Word,
     source: &str,
@@ -5352,6 +9360,24 @@ fn classify_source_ref_diagnostic_class(
             SourceRefDiagnosticClass::DynamicPath
         }
         SourceRefKind::Dynamic if dynamic_root_with_slash_tail(word, source) => {
+            SourceRefDiagnosticClass::UntrackedFile
+        }
+        _ => default_diagnostic_class(kind),
+    }
+}
+
+fn classify_source_ref_diagnostic_class_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+    kind: &SourceRefKind,
+) -> SourceRefDiagnosticClass {
+    match kind {
+        SourceRefKind::Literal(path)
+            if literal_uses_current_user_home_tilde_arena(word, source, path) =>
+        {
+            SourceRefDiagnosticClass::DynamicPath
+        }
+        SourceRefKind::Dynamic if dynamic_root_with_slash_tail_arena(word, source) => {
             SourceRefDiagnosticClass::UntrackedFile
         }
         _ => default_diagnostic_class(kind),
@@ -5378,6 +9404,31 @@ fn literal_uses_current_user_home_tilde(word: &Word, source: &str, path: &str) -
     }
 }
 
+fn literal_uses_current_user_home_tilde_arena(
+    word: shuck_ast::WordView<'_>,
+    source: &str,
+    path: &str,
+) -> bool {
+    if !path.starts_with("~/") {
+        return false;
+    }
+
+    let Some((first, tail)) = word.parts().split_first() else {
+        return false;
+    };
+
+    match &first.kind {
+        WordPartArena::Literal(_) => {
+            let text = first.span.slice(source);
+            text.starts_with("~/")
+                || (text == "~"
+                    && static_parts_text_arena(tail, source)
+                        .is_some_and(|tail| tail.starts_with('/')))
+        }
+        _ => false,
+    }
+}
+
 fn dynamic_root_with_slash_tail(word: &Word, source: &str) -> bool {
     let Some((root, tail)) = word.parts.split_first() else {
         return false;
@@ -5399,6 +9450,28 @@ fn dynamic_root_with_slash_tail(word: &Word, source: &str) -> bool {
     }
 }
 
+fn dynamic_root_with_slash_tail_arena(word: shuck_ast::WordView<'_>, source: &str) -> bool {
+    let Some((root, tail)) = word.parts().split_first() else {
+        return false;
+    };
+
+    match &root.kind {
+        WordPartArena::DoubleQuoted { parts, .. } => {
+            let Some((inner_root, inner_tail)) = word.store().word_parts(*parts).split_first()
+            else {
+                return false;
+            };
+
+            root_word_part_is_dynamic_root_arena(&inner_root.kind)
+                && static_tail_text_starts_with_slash_arena(inner_tail, tail, source)
+        }
+        _ => {
+            root_word_part_is_dynamic_root_arena(&root.kind)
+                && static_tail_text_starts_with_slash_arena(tail, &[], source)
+        }
+    }
+}
+
 fn root_word_part_is_dynamic_root(part: &WordPart) -> bool {
     matches!(
         part,
@@ -5409,8 +9482,33 @@ fn root_word_part_is_dynamic_root(part: &WordPart) -> bool {
     )
 }
 
+fn root_word_part_is_dynamic_root_arena(part: &WordPartArena) -> bool {
+    matches!(
+        part,
+        WordPartArena::Variable(_)
+            | WordPartArena::ArrayAccess(_)
+            | WordPartArena::Parameter(_)
+            | WordPartArena::CommandSubstitution { .. }
+    )
+}
+
 fn static_parts_text(parts: &[WordPartNode], source: &str) -> Option<String> {
     try_static_word_parts_text(parts, source).map(|text| text.into_owned())
+}
+
+fn static_parts_text_arena(parts: &[WordPartArenaNode], source: &str) -> Option<String> {
+    // This helper is only used for tails already paired with a `WordView`; callers that
+    // need nested double-quoted tails should use `static_tail_text_starts_with_slash_arena`.
+    parts
+        .iter()
+        .map(|part| match &part.kind {
+            WordPartArena::Literal(text) => Some(text.as_str(source, part.span)),
+            WordPartArena::SingleQuoted { value, .. } => Some(value.slice(source)),
+            WordPartArena::DoubleQuoted { .. } => None,
+            _ => None,
+        })
+        .collect::<Option<Vec<_>>>()
+        .map(|parts| parts.concat())
 }
 
 fn static_tail_text_starts_with_slash(
@@ -5426,6 +9524,40 @@ fn static_tail_text_starts_with_slash(
     }
 
     try_static_word_parts_text(trailing, source).is_some_and(|text| text.starts_with('/'))
+}
+
+fn static_tail_text_starts_with_slash_arena(
+    parts: &[WordPartArenaNode],
+    trailing: &[WordPartArenaNode],
+    source: &str,
+) -> bool {
+    let Some(prefix) = try_static_tail_parts_text_arena(parts, source) else {
+        return false;
+    };
+    if !prefix.is_empty() {
+        return prefix.starts_with('/');
+    }
+
+    try_static_tail_parts_text_arena(trailing, source).is_some_and(|text| text.starts_with('/'))
+}
+
+fn try_static_tail_parts_text_arena<'a>(
+    parts: &[WordPartArenaNode],
+    source: &'a str,
+) -> Option<Cow<'a, str>> {
+    if parts.is_empty() {
+        return Some(Cow::Borrowed(""));
+    }
+    let mut text = String::new();
+    for part in parts {
+        match &part.kind {
+            WordPartArena::Literal(literal) => text.push_str(literal.as_str(source, part.span)),
+            WordPartArena::SingleQuoted { value, .. } => text.push_str(value.slice(source)),
+            WordPartArena::DoubleQuoted { .. } => return None,
+            _ => return None,
+        }
+    }
+    Some(Cow::Owned(text))
 }
 
 fn unset_flags_are_valid(flags: &str) -> bool {
@@ -5494,6 +9626,15 @@ fn arithmetic_lvalue_span(target: &ArithmeticLvalue, span: Span) -> Span {
     }
 }
 
+fn arithmetic_lvalue_span_arena(target: &ArithmeticLvalueArena, span: Span) -> Span {
+    match target {
+        ArithmeticLvalueArena::Variable(name) => arithmetic_name_span(span, name),
+        ArithmeticLvalueArena::Indexed { index, .. } => {
+            Span::from_positions(span.start, index.span.end.advanced_by("]"))
+        }
+    }
+}
+
 fn is_name(value: &str) -> bool {
     let mut chars = value.chars();
     let Some(first) = chars.next() else {
@@ -5508,6 +9649,28 @@ fn depth_from_word(word: Option<&Word>) -> usize {
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|depth| *depth > 0)
         .unwrap_or(1)
+}
+
+fn depth_from_static_text(text: Option<Cow<'_, str>>) -> usize {
+    text.as_deref()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|depth| *depth > 0)
+        .unwrap_or(1)
+}
+
+fn subscript_selector_arena(subscript: &SubscriptNode) -> Option<shuck_ast::SubscriptSelector> {
+    match subscript.kind {
+        shuck_ast::SubscriptKind::Ordinary => None,
+        shuck_ast::SubscriptKind::Selector(selector) => Some(selector),
+    }
+}
+
+fn subscript_span_arena(subscript: &SubscriptNode) -> Span {
+    subscript.text.span()
+}
+
+fn subscript_syntax_source_text_arena(subscript: &SubscriptNode) -> &SourceText {
+    subscript.raw.as_ref().unwrap_or(&subscript.text)
 }
 
 fn single_literal_word(word: &Word) -> Option<&str> {
@@ -5538,12 +9701,53 @@ fn binding_origin_for_assignment(assignment: &Assignment, source: &str) -> Bindi
     }
 }
 
+fn binding_origin_for_assignment_arena(
+    assignment: &AssignmentNode,
+    store: &AstStore,
+    source: &str,
+) -> BindingOrigin {
+    let value = if assignment.target.subscript.is_some() {
+        AssignmentValueOrigin::ArrayOrCompound
+    } else {
+        match &assignment.value {
+            AssignmentValueNode::Scalar(word) => {
+                assignment_value_origin_for_word_arena(store.word(*word))
+            }
+            AssignmentValueNode::Compound(_) => AssignmentValueOrigin::ArrayOrCompound,
+        }
+    };
+
+    BindingOrigin::Assignment {
+        definition_span: assignment_target_span_arena(assignment, source),
+        value,
+    }
+}
+
 fn assignment_target_span(assignment: &Assignment, source: &str) -> Span {
     let Some(subscript) = assignment.target.subscript.as_deref() else {
         return assignment.target.name_span;
     };
 
     let subscript_end = subscript.syntax_source_text().span().end;
+    if source
+        .get(subscript_end.offset..)
+        .is_some_and(|rest| rest.starts_with(']'))
+    {
+        return Span::from_positions(
+            assignment.target.name_span.start,
+            subscript_end.advanced_by("]"),
+        );
+    }
+
+    assignment.target.name_span
+}
+
+fn assignment_target_span_arena(assignment: &AssignmentNode, source: &str) -> Span {
+    let Some(subscript) = assignment.target.subscript.as_ref() else {
+        return assignment.target.name_span;
+    };
+
+    let subscript_end = subscript_syntax_source_text_arena(subscript).span().end;
     if source
         .get(subscript_end.offset..)
         .is_some_and(|rest| rest.starts_with(']'))
@@ -5569,6 +9773,16 @@ fn loop_binding_origin_for_words(words: Option<&[Word]>) -> LoopValueOrigin {
     }
 }
 
+fn loop_binding_origin_for_static_texts<'a>(
+    words: impl IntoIterator<Item = Option<Cow<'a, str>>>,
+) -> LoopValueOrigin {
+    if words.into_iter().all(|word| word.is_some()) {
+        LoopValueOrigin::StaticWords
+    } else {
+        LoopValueOrigin::ExpandedWords
+    }
+}
+
 fn assignment_value_origin_for_word(word: &Word) -> AssignmentValueOrigin {
     if !word.brace_syntax.is_empty() {
         return AssignmentValueOrigin::MixedDynamic;
@@ -5579,6 +9793,30 @@ fn assignment_value_origin_for_word(word: &Word) -> AssignmentValueOrigin {
 
     let mut scan = AssignmentWordOriginScan::default();
     scan_assignment_word_parts(&word.parts, &mut scan);
+
+    if scan.category_count() == 0 {
+        return AssignmentValueOrigin::PlainScalarAccess;
+    }
+    if scan.mixed_dynamic || scan.category_count() > 1 {
+        return AssignmentValueOrigin::MixedDynamic;
+    }
+
+    scan.primary_origin()
+        .unwrap_or(AssignmentValueOrigin::Unknown)
+}
+
+fn assignment_value_origin_for_word_arena(word: shuck_ast::WordView<'_>) -> AssignmentValueOrigin {
+    if !word.brace_syntax().is_empty() {
+        return AssignmentValueOrigin::MixedDynamic;
+    }
+    if word_is_static_binding_literal_arena(word) {
+        return AssignmentValueOrigin::StaticLiteral;
+    }
+
+    let mut scan = AssignmentWordOriginScan::default();
+    for part in word.parts() {
+        scan_assignment_word_part_arena(&part.kind, word.store(), &mut scan);
+    }
 
     if scan.category_count() == 0 {
         return AssignmentValueOrigin::PlainScalarAccess;
@@ -5643,6 +9881,14 @@ fn word_is_static_binding_literal(word: &Word) -> bool {
             .all(|part| binding_literal_part_is_static(&part.kind))
 }
 
+fn word_is_static_binding_literal_arena(word: shuck_ast::WordView<'_>) -> bool {
+    word.brace_syntax().is_empty()
+        && word
+            .parts()
+            .iter()
+            .all(|part| binding_literal_part_is_static_arena(&part.kind, word.store()))
+}
+
 fn binding_literal_part_is_static(part: &WordPart) -> bool {
     match part {
         WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
@@ -5668,9 +9914,95 @@ fn binding_literal_part_is_static(part: &WordPart) -> bool {
     }
 }
 
+fn binding_literal_part_is_static_arena(part: &WordPartArena, store: &AstStore) -> bool {
+    match part {
+        WordPartArena::Literal(_) | WordPartArena::SingleQuoted { .. } => true,
+        WordPartArena::DoubleQuoted { parts, .. } => store
+            .word_parts(*parts)
+            .iter()
+            .all(|part| binding_literal_part_is_static_arena(&part.kind, store)),
+        WordPartArena::ZshQualifiedGlob(_)
+        | WordPartArena::Variable(_)
+        | WordPartArena::CommandSubstitution { .. }
+        | WordPartArena::ArithmeticExpansion { .. }
+        | WordPartArena::Parameter(_)
+        | WordPartArena::ParameterExpansion { .. }
+        | WordPartArena::Length(_)
+        | WordPartArena::ArrayAccess(_)
+        | WordPartArena::ArrayLength(_)
+        | WordPartArena::ArrayIndices(_)
+        | WordPartArena::Substring { .. }
+        | WordPartArena::ArraySlice { .. }
+        | WordPartArena::IndirectExpansion { .. }
+        | WordPartArena::PrefixMatch { .. }
+        | WordPartArena::ProcessSubstitution { .. }
+        | WordPartArena::Transformation { .. } => false,
+    }
+}
+
 fn scan_assignment_word_parts(parts: &[WordPartNode], scan: &mut AssignmentWordOriginScan) {
     for part in parts {
         scan_assignment_word_part(&part.kind, scan);
+    }
+}
+
+fn scan_assignment_word_part_arena(
+    part: &WordPartArena,
+    store: &AstStore,
+    scan: &mut AssignmentWordOriginScan,
+) {
+    match part {
+        WordPartArena::Literal(_)
+        | WordPartArena::SingleQuoted { .. }
+        | WordPartArena::Variable(_)
+        | WordPartArena::ArithmeticExpansion { .. } => {}
+        WordPartArena::DoubleQuoted { parts, .. } => {
+            for part in store.word_parts(*parts) {
+                scan_assignment_word_part_arena(&part.kind, store, scan);
+            }
+        }
+        WordPartArena::ParameterExpansion { reference, .. } => {
+            if reference.subscript.is_some() {
+                scan.array_or_compound = true;
+            } else {
+                scan.parameter_operator = true;
+            }
+        }
+        WordPartArena::Transformation { .. } => scan.transformation = true,
+        WordPartArena::IndirectExpansion { .. } | WordPartArena::ArrayIndices(_) => {
+            scan.indirect_expansion = true;
+        }
+        WordPartArena::CommandSubstitution { .. } | WordPartArena::ProcessSubstitution { .. } => {
+            scan.command_or_process_substitution = true;
+        }
+        WordPartArena::ArrayAccess(_)
+        | WordPartArena::ArrayLength(_)
+        | WordPartArena::Substring { .. }
+        | WordPartArena::ArraySlice { .. } => scan.array_or_compound = true,
+        WordPartArena::Parameter(parameter) => match &parameter.syntax {
+            ParameterExpansionSyntaxNode::Bourne(BourneParameterExpansionNode::Access {
+                ..
+            }) => {}
+            ParameterExpansionSyntaxNode::Bourne(
+                BourneParameterExpansionNode::Transformation { .. },
+            ) => scan.transformation = true,
+            ParameterExpansionSyntaxNode::Bourne(BourneParameterExpansionNode::Indirect {
+                ..
+            }) => scan.indirect_expansion = true,
+            ParameterExpansionSyntaxNode::Bourne(BourneParameterExpansionNode::Operation {
+                ..
+            }) => scan.parameter_operator = true,
+            ParameterExpansionSyntaxNode::Bourne(
+                BourneParameterExpansionNode::Length { .. }
+                | BourneParameterExpansionNode::Indices { .. }
+                | BourneParameterExpansionNode::PrefixMatch { .. }
+                | BourneParameterExpansionNode::Slice { .. },
+            )
+            | ParameterExpansionSyntaxNode::Zsh(_) => scan.mixed_dynamic = true,
+        },
+        WordPartArena::ZshQualifiedGlob(_)
+        | WordPartArena::Length(_)
+        | WordPartArena::PrefixMatch { .. } => scan.mixed_dynamic = true,
     }
 }
 
@@ -5735,6 +10067,12 @@ fn case_arm_matches_anything(patterns: &[Pattern]) -> bool {
     patterns.iter().any(pattern_matches_anything)
 }
 
+fn case_arm_matches_anything_arena(patterns: &[PatternNode], store: &AstStore) -> bool {
+    patterns
+        .iter()
+        .any(|pattern| pattern_matches_anything_arena(pattern, store))
+}
+
 fn pattern_matches_anything(pattern: &Pattern) -> bool {
     !pattern.parts.is_empty()
         && pattern
@@ -5747,11 +10085,29 @@ fn pattern_matches_anything(pattern: &Pattern) -> bool {
             .any(|part| pattern_part_matches_anything(&part.kind))
 }
 
+fn pattern_matches_anything_arena(pattern: &PatternNode, store: &AstStore) -> bool {
+    let parts = store.pattern_parts(pattern.parts);
+    !parts.is_empty()
+        && parts
+            .iter()
+            .all(|part| pattern_part_can_match_empty_arena(&part.kind, store))
+        && parts
+            .iter()
+            .any(|part| pattern_part_matches_anything_arena(&part.kind, store))
+}
+
 fn pattern_can_match_empty(pattern: &Pattern) -> bool {
     pattern
         .parts
         .iter()
         .all(|part| pattern_part_can_match_empty(&part.kind))
+}
+
+fn pattern_can_match_empty_arena(pattern: &PatternNode, store: &AstStore) -> bool {
+    store
+        .pattern_parts(pattern.parts)
+        .iter()
+        .all(|part| pattern_part_can_match_empty_arena(&part.kind, store))
 }
 
 fn pattern_part_matches_anything(part: &PatternPart) -> bool {
@@ -5762,6 +10118,19 @@ fn pattern_part_matches_anything(part: &PatternPart) -> bool {
         | PatternPart::AnyChar
         | PatternPart::CharClass(_)
         | PatternPart::Word(_) => false,
+    }
+}
+
+fn pattern_part_matches_anything_arena(part: &PatternPartArena, store: &AstStore) -> bool {
+    match part {
+        PatternPartArena::AnyString => true,
+        PatternPartArena::Group { kind, patterns } => {
+            pattern_group_matches_anything_arena(*kind, store.patterns(*patterns), store)
+        }
+        PatternPartArena::Literal(_)
+        | PatternPartArena::AnyChar
+        | PatternPartArena::CharClass(_)
+        | PatternPartArena::Word(_) => false,
     }
 }
 
@@ -5776,12 +10145,41 @@ fn pattern_part_can_match_empty(part: &PatternPart) -> bool {
     }
 }
 
+fn pattern_part_can_match_empty_arena(part: &PatternPartArena, store: &AstStore) -> bool {
+    match part {
+        PatternPartArena::AnyString => true,
+        PatternPartArena::Group { kind, patterns } => {
+            pattern_group_can_match_empty_arena(*kind, store.patterns(*patterns), store)
+        }
+        PatternPartArena::Literal(_)
+        | PatternPartArena::AnyChar
+        | PatternPartArena::CharClass(_)
+        | PatternPartArena::Word(_) => false,
+    }
+}
+
 fn pattern_group_matches_anything(kind: PatternGroupKind, patterns: &[Pattern]) -> bool {
     match kind {
         PatternGroupKind::ZeroOrOne
         | PatternGroupKind::ZeroOrMore
         | PatternGroupKind::OneOrMore
         | PatternGroupKind::ExactlyOne => patterns.iter().any(pattern_matches_anything),
+        PatternGroupKind::NoneOf => false,
+    }
+}
+
+fn pattern_group_matches_anything_arena(
+    kind: PatternGroupKind,
+    patterns: &[PatternNode],
+    store: &AstStore,
+) -> bool {
+    match kind {
+        PatternGroupKind::ZeroOrOne
+        | PatternGroupKind::ZeroOrMore
+        | PatternGroupKind::OneOrMore
+        | PatternGroupKind::ExactlyOne => patterns
+            .iter()
+            .any(|pattern| pattern_matches_anything_arena(pattern, store)),
         PatternGroupKind::NoneOf => false,
     }
 }
@@ -5796,10 +10194,30 @@ fn pattern_group_can_match_empty(kind: PatternGroupKind, patterns: &[Pattern]) -
     }
 }
 
+fn pattern_group_can_match_empty_arena(
+    kind: PatternGroupKind,
+    patterns: &[PatternNode],
+    store: &AstStore,
+) -> bool {
+    match kind {
+        PatternGroupKind::ZeroOrOne | PatternGroupKind::ZeroOrMore => true,
+        PatternGroupKind::OneOrMore | PatternGroupKind::ExactlyOne => patterns
+            .iter()
+            .any(|pattern| pattern_can_match_empty_arena(pattern, store)),
+        PatternGroupKind::NoneOf => false,
+    }
+}
+
 fn word_is_semantically_inert(word: &Word) -> bool {
     word.parts
         .iter()
         .all(|part| word_part_is_semantically_inert(&part.kind))
+}
+
+fn word_is_semantically_inert_arena(word: shuck_ast::WordView<'_>, store: &AstStore) -> bool {
+    word.parts()
+        .iter()
+        .all(|part| word_part_is_semantically_inert_arena(&part.kind, store))
 }
 
 fn heredoc_body_is_semantically_inert(body: &HeredocBody, source: &str) -> bool {
@@ -5830,6 +10248,42 @@ fn word_part_is_semantically_inert(part: &WordPart) -> bool {
         | WordPart::PrefixMatch { .. }
         | WordPart::ProcessSubstitution { .. }
         | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn word_part_is_semantically_inert_arena(part: &WordPartArena, store: &AstStore) -> bool {
+    match part {
+        WordPartArena::Literal(_) | WordPartArena::SingleQuoted { .. } => true,
+        WordPartArena::ZshQualifiedGlob(glob) => {
+            store
+                .zsh_glob_segments(glob.segments)
+                .iter()
+                .all(|segment| match segment {
+                    shuck_ast::ZshGlobSegmentNode::Pattern(pattern) => {
+                        pattern_is_semantically_inert_arena(pattern, store)
+                    }
+                    shuck_ast::ZshGlobSegmentNode::InlineControl(_) => true,
+                })
+        }
+        WordPartArena::DoubleQuoted { parts, .. } => store
+            .word_parts(*parts)
+            .iter()
+            .all(|part| word_part_is_semantically_inert_arena(&part.kind, store)),
+        WordPartArena::ArithmeticExpansion { expression_ast, .. } => expression_ast.is_none(),
+        WordPartArena::Variable(_)
+        | WordPartArena::CommandSubstitution { .. }
+        | WordPartArena::Parameter(_)
+        | WordPartArena::ParameterExpansion { .. }
+        | WordPartArena::Length(_)
+        | WordPartArena::ArrayAccess(_)
+        | WordPartArena::ArrayLength(_)
+        | WordPartArena::ArrayIndices(_)
+        | WordPartArena::Substring { .. }
+        | WordPartArena::ArraySlice { .. }
+        | WordPartArena::IndirectExpansion { .. }
+        | WordPartArena::PrefixMatch { .. }
+        | WordPartArena::ProcessSubstitution { .. }
+        | WordPartArena::Transformation { .. } => false,
     }
 }
 
@@ -5864,6 +10318,13 @@ fn pattern_is_semantically_inert(pattern: &Pattern) -> bool {
         .all(|part| pattern_part_is_semantically_inert(&part.kind))
 }
 
+fn pattern_is_semantically_inert_arena(pattern: &PatternNode, store: &AstStore) -> bool {
+    store
+        .pattern_parts(pattern.parts)
+        .iter()
+        .all(|part| pattern_part_is_semantically_inert_arena(&part.kind, store))
+}
+
 fn pattern_part_is_semantically_inert(part: &PatternPart) -> bool {
     match part {
         PatternPart::Literal(_)
@@ -5872,6 +10333,20 @@ fn pattern_part_is_semantically_inert(part: &PatternPart) -> bool {
         | PatternPart::CharClass(_) => true,
         PatternPart::Group { patterns, .. } => patterns.iter().all(pattern_is_semantically_inert),
         PatternPart::Word(word) => word_is_semantically_inert(word),
+    }
+}
+
+fn pattern_part_is_semantically_inert_arena(part: &PatternPartArena, store: &AstStore) -> bool {
+    match part {
+        PatternPartArena::Literal(_)
+        | PatternPartArena::AnyString
+        | PatternPartArena::AnyChar
+        | PatternPartArena::CharClass(_) => true,
+        PatternPartArena::Group { patterns, .. } => store
+            .patterns(*patterns)
+            .iter()
+            .all(|pattern| pattern_is_semantically_inert_arena(pattern, store)),
+        PatternPartArena::Word(word) => word_is_semantically_inert_arena(store.word(*word), store),
     }
 }
 
@@ -5944,6 +10419,21 @@ fn collect_pipeline_segments<'a>(stmt: &'a Stmt, out: &mut SmallVec<[&'a Stmt; 4
     }
 }
 
+fn collect_pipeline_segments_arena<'a>(
+    seq: StmtSeqView<'a>,
+    out: &mut SmallVec<[StmtView<'a>; 4]>,
+) {
+    for stmt in seq.stmts() {
+        match stmt.command().binary() {
+            Some(command) if matches!(command.op(), BinaryOp::Pipe | BinaryOp::PipeAll) => {
+                collect_pipeline_segments_arena(command.left(), out);
+                collect_pipeline_segments_arena(command.right(), out);
+            }
+            _ => out.push(stmt),
+        }
+    }
+}
+
 fn collect_logical_segments<'a>(
     stmt: &'a Stmt,
     commands: &mut SmallVec<[&'a Stmt; 4]>,
@@ -5956,6 +10446,23 @@ fn collect_logical_segments<'a>(
             collect_logical_segments(&command.right, commands, operators);
         }
         _ => commands.push(stmt),
+    }
+}
+
+fn collect_logical_segments_arena<'a>(
+    seq: StmtSeqView<'a>,
+    commands: &mut SmallVec<[StmtView<'a>; 4]>,
+    operators: &mut SmallVec<[RecordedListOperator; 4]>,
+) {
+    for stmt in seq.stmts() {
+        match stmt.command().binary() {
+            Some(command) if matches!(command.op(), BinaryOp::And | BinaryOp::Or) => {
+                collect_logical_segments_arena(command.left(), commands, operators);
+                operators.push(recorded_list_operator(command.op()));
+                collect_logical_segments_arena(command.right(), commands, operators);
+            }
+            _ => commands.push(stmt),
+        }
     }
 }
 

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -65,7 +65,7 @@ pub use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionSta
 pub use source_ref::{SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution};
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{Command, File, Name, Span};
+use shuck_ast::{ArenaFile, Command, File, Name, Span};
 use shuck_indexer::Indexer;
 use smallvec::{Array, SmallVec};
 use std::path::{Path, PathBuf};
@@ -515,8 +515,17 @@ impl SemanticModel {
     }
 
     pub fn build_arena(ast: &shuck_ast::ArenaFile, source: &str, indexer: &Indexer) -> Self {
-        let file = ast.to_file();
-        Self::build(&file, source, indexer)
+        Self::build_arena_with_options(ast, source, indexer, SemanticBuildOptions::default())
+    }
+
+    pub fn build_arena_with_options(
+        ast: &ArenaFile,
+        source: &str,
+        indexer: &Indexer,
+        options: SemanticBuildOptions<'_>,
+    ) -> Self {
+        let mut observer = NoopTraversalObserver;
+        build_with_observer_arena_with_options(ast, source, indexer, &mut observer, options)
     }
 
     pub fn build_with_options(
@@ -2848,6 +2857,17 @@ pub fn build_with_observer_with_options(
 }
 
 #[doc(hidden)]
+pub fn build_with_observer_arena_with_options(
+    ast: &ArenaFile,
+    source: &str,
+    indexer: &Indexer,
+    observer: &mut dyn TraversalObserver,
+    options: SemanticBuildOptions<'_>,
+) -> SemanticModel {
+    build_semantic_model_arena(ast, source, indexer, observer, options)
+}
+
+#[doc(hidden)]
 pub fn build_with_observer_at_path(
     file: &File,
     source: &str,
@@ -2881,6 +2901,42 @@ pub fn build_with_observer_at_path_with_resolver(
             resolve_source_closure: true,
         },
     )
+}
+
+#[doc(hidden)]
+pub fn build_with_observer_arena_at_path_with_resolver(
+    ast: &ArenaFile,
+    source: &str,
+    indexer: &Indexer,
+    observer: &mut dyn TraversalObserver,
+    source_path: Option<&Path>,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+) -> SemanticModel {
+    build_semantic_model_arena(
+        ast,
+        source,
+        indexer,
+        observer,
+        SemanticBuildOptions {
+            source_path,
+            source_path_resolver,
+            file_entry_contract: None,
+            analyzed_paths: None,
+            shell_profile: None,
+            resolve_source_closure: true,
+        },
+    )
+}
+
+fn build_semantic_model_arena(
+    ast: &ArenaFile,
+    source: &str,
+    indexer: &Indexer,
+    observer: &mut dyn TraversalObserver,
+    options: SemanticBuildOptions<'_>,
+) -> SemanticModel {
+    let file = ast.to_file();
+    build_semantic_model(&file, source, indexer, observer, options)
 }
 
 fn build_semantic_model(
@@ -3487,7 +3543,7 @@ mod tests {
     fn model_with_dialect(source: &str, dialect: ShellDialect) -> SemanticModel {
         let output = Parser::with_dialect(source, dialect).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        SemanticModel::build(&output.file, source, &indexer)
+        SemanticModel::build_arena(&output.arena_file, source, &indexer)
     }
 
     fn model_with_profile(source: &str, profile: ShellProfile) -> SemanticModel {
@@ -3495,8 +3551,8 @@ mod tests {
             .parse()
             .unwrap();
         let indexer = Indexer::new(source, &output);
-        SemanticModel::build_with_options(
-            &output.file,
+        SemanticModel::build_arena_with_options(
+            &output.arena_file,
             source,
             &indexer,
             SemanticBuildOptions {
@@ -3511,8 +3567,8 @@ mod tests {
         let output = Parser::with_dialect(&source, dialect).parse().unwrap();
         let indexer = Indexer::new(&source, &output);
         let mut observer = NoopTraversalObserver;
-        build_with_observer_at_path_with_resolver(
-            &output.file,
+        build_with_observer_arena_at_path_with_resolver(
+            &output.arena_file,
             &source,
             &indexer,
             &mut observer,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1023,6 +1023,14 @@ impl SemanticModel {
     }
 
     pub(crate) fn apply_file_entry_contract(&mut self, contract: FileContract, file: &File) {
+        self.apply_file_entry_contract_at_span(contract, file.span);
+    }
+
+    pub(crate) fn apply_file_entry_contract_at_span(
+        &mut self,
+        contract: FileContract,
+        file_span: Span,
+    ) {
         if contract.required_reads.is_empty()
             && contract.provided_bindings.is_empty()
             && contract.provided_functions.is_empty()
@@ -1039,12 +1047,12 @@ impl SemanticModel {
         for name in contract.required_reads {
             synthetic_reads.push(SyntheticRead {
                 scope: ScopeId(0),
-                span: file.span,
+                span: file_span,
                 name,
             });
         }
 
-        let entry_span = Span::from_positions(file.span.start, file.span.start);
+        let entry_span = Span::from_positions(file_span.start, file_span.start);
         let mut entry_bindings = self.entry_bindings.clone();
         let function_origin_paths = contract
             .provided_functions
@@ -2935,8 +2943,56 @@ fn build_semantic_model_arena(
     observer: &mut dyn TraversalObserver,
     options: SemanticBuildOptions<'_>,
 ) -> SemanticModel {
-    let file = ast.to_file();
-    build_semantic_model(&file, source, indexer, observer, options)
+    let mut model = build_semantic_model_base_arena(
+        ast,
+        source,
+        indexer,
+        observer,
+        options.source_path,
+        options.shell_profile.clone(),
+    );
+    if let Some(contract) = options.file_entry_contract {
+        model.apply_file_entry_contract_at_span(contract, ast.view().span());
+    }
+    if let Some(source_path) = options.source_path {
+        let (
+            synthetic_reads,
+            imported_bindings,
+            source_ref_resolutions,
+            source_ref_explicitness,
+            source_ref_diagnostic_classes,
+        ) = if options.resolve_source_closure {
+            source_closure::collect_source_closure_contracts_from_model(
+                &model,
+                source_path,
+                options.source_path_resolver,
+                options.analyzed_paths,
+            )
+        } else {
+            let (source_ref_resolutions, source_ref_explicitness, source_ref_diagnostic_classes) =
+                source_closure::collect_source_ref_metadata(
+                    &model,
+                    source_path,
+                    options.source_path_resolver,
+                    options.analyzed_paths,
+                );
+            (
+                Vec::new(),
+                Vec::new(),
+                source_ref_resolutions,
+                source_ref_explicitness,
+                source_ref_diagnostic_classes,
+            )
+        };
+        model.apply_source_contracts(
+            synthetic_reads,
+            imported_bindings,
+            source_ref_resolutions,
+            source_ref_explicitness,
+            source_ref_diagnostic_classes,
+        );
+    }
+    model
 }
 
 fn build_semantic_model(
@@ -3011,6 +3067,26 @@ pub(crate) fn build_semantic_model_base(
     let shell_profile = shell_profile.unwrap_or_else(|| infer_shell_profile(source, source_path));
     let built = SemanticModelBuilder::build(
         file,
+        source,
+        indexer,
+        observer,
+        bash_runtime_vars_enabled(source, source_path),
+        shell_profile,
+    );
+    SemanticModel::from_build_output(built)
+}
+
+pub(crate) fn build_semantic_model_base_arena(
+    ast: &ArenaFile,
+    source: &str,
+    indexer: &Indexer,
+    observer: &mut dyn TraversalObserver,
+    source_path: Option<&Path>,
+    shell_profile: Option<ShellProfile>,
+) -> SemanticModel {
+    let shell_profile = shell_profile.unwrap_or_else(|| infer_shell_profile(source, source_path));
+    let built = SemanticModelBuilder::build_arena(
+        ast,
         source,
         indexer,
         observer,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -65,7 +65,7 @@ pub use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionSta
 pub use source_ref::{SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution};
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{ArenaFile, Command, File, Name, Span};
+use shuck_ast::{ArenaFile, Name, Span};
 use shuck_indexer::Indexer;
 use smallvec::{Array, SmallVec};
 use std::path::{Path, PathBuf};
@@ -160,10 +160,6 @@ impl SyntheticRead {
 
 #[doc(hidden)]
 pub trait TraversalObserver {
-    fn enter_command(&mut self, _command: &Command, _scope: ScopeId, _flow: FlowContext) {}
-
-    fn exit_command(&mut self, _command: &Command, _scope: ScopeId) {}
-
     fn record_binding(&mut self, _binding: &Binding) {}
 
     fn record_reference(&mut self, _reference: &Reference, _resolved: Option<&Binding>) {}
@@ -510,10 +506,6 @@ struct FunctionReachWindow<'a> {
 
 #[allow(missing_docs)]
 impl SemanticModel {
-    pub fn build(file: &File, source: &str, indexer: &Indexer) -> Self {
-        Self::build_with_options(file, source, indexer, SemanticBuildOptions::default())
-    }
-
     pub fn build_arena(ast: &shuck_ast::ArenaFile, source: &str, indexer: &Indexer) -> Self {
         Self::build_arena_with_options(ast, source, indexer, SemanticBuildOptions::default())
     }
@@ -526,16 +518,6 @@ impl SemanticModel {
     ) -> Self {
         let mut observer = NoopTraversalObserver;
         build_with_observer_arena_with_options(ast, source, indexer, &mut observer, options)
-    }
-
-    pub fn build_with_options(
-        file: &File,
-        source: &str,
-        indexer: &Indexer,
-        options: SemanticBuildOptions<'_>,
-    ) -> Self {
-        let mut observer = NoopTraversalObserver;
-        build_with_observer_with_options(file, source, indexer, &mut observer, options)
     }
 
     fn from_build_output(built: builder::BuildOutput) -> Self {
@@ -1022,10 +1004,6 @@ impl SemanticModel {
         id
     }
 
-    pub(crate) fn apply_file_entry_contract(&mut self, contract: FileContract, file: &File) {
-        self.apply_file_entry_contract_at_span(contract, file.span);
-    }
-
     pub(crate) fn apply_file_entry_contract_at_span(
         &mut self,
         contract: FileContract,
@@ -1131,6 +1109,7 @@ impl SemanticModel {
         let mut merged_reads = self.synthetic_reads.clone();
         merged_reads.extend(synthetic_reads);
         self.set_synthetic_reads(dedup_synthetic_reads(merged_reads));
+        self.mark_synthetic_read_bindings_consumed();
 
         if !source_ref_resolutions.is_empty() {
             debug_assert_eq!(source_ref_resolutions.len(), self.source_refs.len());
@@ -1175,6 +1154,27 @@ impl SemanticModel {
             &self.functions,
             &self.call_sites,
         );
+    }
+
+    fn mark_synthetic_read_bindings_consumed(&mut self) {
+        if self.synthetic_reads.is_empty() {
+            return;
+        }
+        let names = self
+            .synthetic_reads
+            .iter()
+            .map(|read| read.name.clone())
+            .collect::<FxHashSet<_>>();
+        for binding in &mut self.bindings {
+            if names.contains(&binding.name) {
+                binding.attributes |= BindingAttributes::EXTERNALLY_CONSUMED;
+            }
+        }
+        self.heuristic_unused_assignments.retain(|binding_id| {
+            !self.bindings[binding_id.index()]
+                .attributes
+                .contains(BindingAttributes::EXTERNALLY_CONSUMED)
+        });
     }
 
     fn resolve_unresolved_references(&mut self) {
@@ -2838,33 +2838,6 @@ impl<'model> SemanticAnalysis<'model> {
 }
 
 #[doc(hidden)]
-pub fn build_with_observer(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    observer: &mut dyn TraversalObserver,
-) -> SemanticModel {
-    build_with_observer_with_options(
-        file,
-        source,
-        indexer,
-        observer,
-        SemanticBuildOptions::default(),
-    )
-}
-
-#[doc(hidden)]
-pub fn build_with_observer_with_options(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    observer: &mut dyn TraversalObserver,
-    options: SemanticBuildOptions<'_>,
-) -> SemanticModel {
-    build_semantic_model(file, source, indexer, observer, options)
-}
-
-#[doc(hidden)]
 pub fn build_with_observer_arena_with_options(
     ast: &ArenaFile,
     source: &str,
@@ -2873,42 +2846,6 @@ pub fn build_with_observer_arena_with_options(
     options: SemanticBuildOptions<'_>,
 ) -> SemanticModel {
     build_semantic_model_arena(ast, source, indexer, observer, options)
-}
-
-#[doc(hidden)]
-pub fn build_with_observer_at_path(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    observer: &mut dyn TraversalObserver,
-    source_path: Option<&Path>,
-) -> SemanticModel {
-    build_with_observer_at_path_with_resolver(file, source, indexer, observer, source_path, None)
-}
-
-#[doc(hidden)]
-pub fn build_with_observer_at_path_with_resolver(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    observer: &mut dyn TraversalObserver,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-) -> SemanticModel {
-    build_semantic_model(
-        file,
-        source,
-        indexer,
-        observer,
-        SemanticBuildOptions {
-            source_path,
-            source_path_resolver,
-            file_entry_contract: None,
-            analyzed_paths: None,
-            shell_profile: None,
-            resolve_source_closure: true,
-        },
-    )
 }
 
 #[doc(hidden)]
@@ -2993,87 +2930,6 @@ fn build_semantic_model_arena(
         );
     }
     model
-}
-
-fn build_semantic_model(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    observer: &mut dyn TraversalObserver,
-    options: SemanticBuildOptions<'_>,
-) -> SemanticModel {
-    let mut model = build_semantic_model_base(
-        file,
-        source,
-        indexer,
-        observer,
-        options.source_path,
-        options.shell_profile.clone(),
-    );
-    if let Some(contract) = options.file_entry_contract {
-        model.apply_file_entry_contract(contract, file);
-    }
-    if let Some(source_path) = options.source_path {
-        let (
-            synthetic_reads,
-            imported_bindings,
-            source_ref_resolutions,
-            source_ref_explicitness,
-            source_ref_diagnostic_classes,
-        ) = if options.resolve_source_closure {
-            source_closure::collect_source_closure_contracts(
-                &model,
-                file,
-                source,
-                source_path,
-                options.source_path_resolver,
-                options.analyzed_paths,
-            )
-        } else {
-            let (source_ref_resolutions, source_ref_explicitness, source_ref_diagnostic_classes) =
-                source_closure::collect_source_ref_metadata(
-                    &model,
-                    source_path,
-                    options.source_path_resolver,
-                    options.analyzed_paths,
-                );
-            (
-                Vec::new(),
-                Vec::new(),
-                source_ref_resolutions,
-                source_ref_explicitness,
-                source_ref_diagnostic_classes,
-            )
-        };
-        model.apply_source_contracts(
-            synthetic_reads,
-            imported_bindings,
-            source_ref_resolutions,
-            source_ref_explicitness,
-            source_ref_diagnostic_classes,
-        );
-    }
-    model
-}
-
-pub(crate) fn build_semantic_model_base(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    observer: &mut dyn TraversalObserver,
-    source_path: Option<&Path>,
-    shell_profile: Option<ShellProfile>,
-) -> SemanticModel {
-    let shell_profile = shell_profile.unwrap_or_else(|| infer_shell_profile(source, source_path));
-    let built = SemanticModelBuilder::build(
-        file,
-        source,
-        indexer,
-        observer,
-        bash_runtime_vars_enabled(source, source_path),
-        shell_profile,
-    );
-    SemanticModel::from_build_output(built)
 }
 
 pub(crate) fn build_semantic_model_base_arena(
@@ -3605,7 +3461,7 @@ fn indirect_target_matches(hint: &IndirectTargetHint, binding: &Binding) -> bool
 mod tests {
     use super::*;
     use crate::cfg::{RecordedCommandKind, build_control_flow_graph};
-    use shuck_ast::{Command, CompoundCommand};
+    use shuck_ast::{BuiltinCommandNodeKind, CompoundCommandNode};
     use shuck_indexer::Indexer;
     use shuck_parser::parser::{Parser, ShellDialect};
     use std::fs;
@@ -3665,8 +3521,8 @@ mod tests {
         let output = Parser::new(&source).parse().unwrap();
         let indexer = Indexer::new(&source, &output);
         let mut observer = NoopTraversalObserver;
-        build_with_observer_at_path_with_resolver(
-            &output.file,
+        build_with_observer_arena_at_path_with_resolver(
+            &output.arena_file,
             &source,
             &indexer,
             &mut observer,
@@ -4314,8 +4170,8 @@ printf '%s\\n' \"$pkgname\"
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build_with_options(
-            &output.file,
+        let model = SemanticModel::build_arena_with_options(
+            &output.arena_file,
             source,
             &indexer,
             SemanticBuildOptions {
@@ -5618,27 +5474,52 @@ done
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build(&output.file, source, &indexer);
+        let model = SemanticModel::build_arena(&output.arena_file, source, &indexer);
 
-        let Command::Compound(CompoundCommand::If(if_command)) = &output.file.body[0].command
-        else {
+        let mut top_level = output.arena_file.view().body().stmts();
+        let if_stmt = top_level.next().expect("expected if statement");
+        let for_stmt = top_level.next().expect("expected for statement");
+
+        let Some(if_command) = if_stmt.command().compound() else {
             panic!("expected if command");
         };
-        let condition_span = match &if_command.condition[0].command {
-            Command::Simple(command) => command.span,
-            other => panic!("unexpected condition command: {other:?}"),
+        let CompoundCommandNode::If { condition, .. } = if_command.node() else {
+            panic!("expected if command");
         };
+        let condition_span = output
+            .arena_file
+            .store
+            .stmt_seq(*condition)
+            .stmts()
+            .next()
+            .and_then(|stmt| {
+                let command = stmt.command();
+                command.simple().map(|_| command.span())
+            })
+            .expect("expected simple condition command");
         let condition_context = model.flow_context_at(&condition_span).unwrap();
         assert!(condition_context.exit_status_checked);
 
-        let Command::Compound(CompoundCommand::For(for_command)) = &output.file.body[1].command
-        else {
+        let Some(for_command) = for_stmt.command().compound() else {
             panic!("expected for command");
         };
-        let break_span = match &for_command.body[0].command {
-            Command::Builtin(shuck_ast::BuiltinCommand::Break(command)) => command.span,
-            other => panic!("unexpected loop body command: {other:?}"),
+        let CompoundCommandNode::For { body, .. } = for_command.node() else {
+            panic!("expected for command");
         };
+        let break_span = output
+            .arena_file
+            .store
+            .stmt_seq(*body)
+            .stmts()
+            .next()
+            .and_then(|stmt| {
+                let command = stmt.command();
+                command
+                    .builtin()
+                    .filter(|builtin| builtin.kind() == BuiltinCommandNodeKind::Break)
+                    .map(|_| command.span())
+            })
+            .expect("expected break command");
         let break_context = model.flow_context_at(&break_span).unwrap();
         assert_eq!(break_context.loop_depth, 1);
     }
@@ -6017,8 +5898,8 @@ echo $value
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build_with_options(
-            &output.file,
+        let model = SemanticModel::build_arena_with_options(
+            &output.arena_file,
             source,
             &indexer,
             SemanticBuildOptions {
@@ -10593,8 +10474,8 @@ printf '%s\\n' \"$flag\"
         let source = "printf '%s\\n' \"$pkgname\" \"$pkgver\" \"$wrksrc\"\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build_with_options(
-            &output.file,
+        let model = SemanticModel::build_arena_with_options(
+            &output.arena_file,
             source,
             &indexer,
             SemanticBuildOptions {
@@ -10658,8 +10539,8 @@ build() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build_with_options(
-            &output.file,
+        let model = SemanticModel::build_arena_with_options(
+            &output.arena_file,
             source,
             &indexer,
             SemanticBuildOptions {
@@ -10731,8 +10612,8 @@ hook() {
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build_with_options(
-            &output.file,
+        let model = SemanticModel::build_arena_with_options(
+            &output.arena_file,
             source,
             &indexer,
             SemanticBuildOptions {
@@ -10804,8 +10685,8 @@ hook() {
         let source = "printf '%s\\n' \"$theme_color\"\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build_with_options(
-            &output.file,
+        let model = SemanticModel::build_arena_with_options(
+            &output.arena_file,
             source,
             &indexer,
             SemanticBuildOptions {
@@ -10842,8 +10723,8 @@ hook() {
         let source = "published=1\n";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build_with_options(
-            &output.file,
+        let model = SemanticModel::build_arena_with_options(
+            &output.arena_file,
             source,
             &indexer,
             SemanticBuildOptions {
@@ -11335,7 +11216,7 @@ echo done
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build(&output.file, source, &indexer);
+        let model = SemanticModel::build_arena(&output.arena_file, source, &indexer);
 
         let file_commands = model
             .recorded_program
@@ -11380,7 +11261,7 @@ echo done
 ";
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build(&output.file, source, &indexer);
+        let model = SemanticModel::build_arena(&output.arena_file, source, &indexer);
 
         let file_commands = model
             .recorded_program

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -514,6 +514,11 @@ impl SemanticModel {
         Self::build_with_options(file, source, indexer, SemanticBuildOptions::default())
     }
 
+    pub fn build_arena(ast: &shuck_ast::ArenaFile, source: &str, indexer: &Indexer) -> Self {
+        let file = ast.to_file();
+        Self::build(&file, source, indexer)
+    }
+
     pub fn build_with_options(
         file: &File,
         source: &str,

--- a/crates/shuck-semantic/src/runtime.rs
+++ b/crates/shuck-semantic/src/runtime.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Name, Word};
+use shuck_ast::Name;
 
 const COMMON_PREINITIALIZED: &[&str] = &[
     "IFS",
@@ -137,8 +137,6 @@ impl RuntimePrelude {
     pub(crate) fn implicit_reads_for_simple_command(
         &self,
         command_name: &Name,
-        _args: &[&Word],
-        _source: &str,
     ) -> &'static [&'static str] {
         match command_name.as_str() {
             "read" => READ_IMPLICIT_READS,

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -3,11 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{
-    ArithmeticExpr, ArithmeticExprNode, BourneParameterExpansion, Command, File, Name,
-    ParameterExpansion, ParameterExpansionSyntax, Span, StmtSeq, VarRef, Word, WordPart,
-    WordPartNode, static_word_text,
-};
+use shuck_ast::{Name, Span};
 use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile, ZshOptionState};
@@ -16,7 +12,7 @@ use crate::{
     Binding, BindingId, BindingKind, ContractCertainty, FileContract, FunctionContract,
     FunctionScopeKind, ProvidedBinding, ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel,
     SourcePathResolver, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution, SpanKey,
-    SyntheticRead, build_semantic_model_base, infer_explicit_parse_dialect_from_source,
+    SyntheticRead, build_semantic_model_base_arena, infer_explicit_parse_dialect_from_source,
 };
 
 #[derive(Debug, Clone)]
@@ -93,22 +89,6 @@ struct ImportedFunctionContractSite {
     certainty: ContractCertainty,
     trust_provided_bindings: bool,
     contract: FunctionContract,
-}
-
-pub(crate) fn collect_source_closure_contracts(
-    model: &SemanticModel,
-    _file: &File,
-    _source: &str,
-    source_path: &Path,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    analyzed_paths: Option<&FxHashSet<PathBuf>>,
-) -> SourceClosureContractResult {
-    collect_source_closure_contracts_from_model(
-        model,
-        source_path,
-        source_path_resolver,
-        analyzed_paths,
-    )
 }
 
 pub(crate) fn collect_source_closure_contracts_from_model(
@@ -686,281 +666,6 @@ fn source_template_uses_positional_args(template: &SourcePathTemplate) -> bool {
     }
 }
 
-pub(crate) fn source_path_template(
-    word: &Word,
-    source: &str,
-    bash_runtime_vars_enabled: bool,
-) -> Option<SourcePathTemplate> {
-    if static_word_text(word, source).is_some() {
-        return None;
-    }
-
-    let mut parts = Vec::new();
-    let mut ignored_root = false;
-    let mut saw_dynamic = false;
-
-    if !collect_source_template_parts(
-        &word.parts,
-        source,
-        bash_runtime_vars_enabled,
-        &mut parts,
-        &mut ignored_root,
-        &mut saw_dynamic,
-    ) {
-        return None;
-    }
-
-    (saw_dynamic && !parts.is_empty()).then_some(SourcePathTemplate::Interpolated(parts))
-}
-
-fn collect_source_template_parts(
-    word_parts: &[WordPartNode],
-    source: &str,
-    bash_runtime_vars_enabled: bool,
-    parts: &mut Vec<TemplatePart>,
-    ignored_root: &mut bool,
-    saw_dynamic: &mut bool,
-) -> bool {
-    for part in word_parts {
-        match &part.kind {
-            WordPart::Literal(text) => {
-                let text = text.as_str(source, part.span);
-                if !text.is_empty() {
-                    push_literal(parts, text.to_owned());
-                }
-            }
-            WordPart::SingleQuoted { value, .. } => {
-                let text = value.slice(source);
-                if !text.is_empty() {
-                    push_literal(parts, text.to_owned());
-                }
-            }
-            WordPart::DoubleQuoted { parts: inner, .. } => {
-                if !collect_source_template_parts(
-                    inner,
-                    source,
-                    bash_runtime_vars_enabled,
-                    parts,
-                    ignored_root,
-                    saw_dynamic,
-                ) {
-                    return false;
-                }
-            }
-            WordPart::Variable(name) => {
-                if let Some(index) = positional_index(name) {
-                    *saw_dynamic = true;
-                    parts.push(TemplatePart::Arg(index));
-                } else if bash_runtime_vars_enabled && is_bash_source_var(name) {
-                    *saw_dynamic = true;
-                    parts.push(TemplatePart::SourceFile);
-                } else if !*ignored_root && parts.is_empty() {
-                    *ignored_root = true;
-                    *saw_dynamic = true;
-                } else {
-                    return false;
-                }
-            }
-            WordPart::Parameter(parameter)
-                if bash_runtime_vars_enabled
-                    && parameter_is_current_source_file(parameter, source) =>
-            {
-                *saw_dynamic = true;
-                parts.push(TemplatePart::SourceFile);
-            }
-            WordPart::ArrayAccess(reference)
-                if bash_runtime_vars_enabled && is_bash_source_index_ref(reference, source) =>
-            {
-                *saw_dynamic = true;
-                parts.push(TemplatePart::SourceFile);
-            }
-            WordPart::CommandSubstitution { body, .. } => {
-                if bash_runtime_vars_enabled
-                    && let Some(template_part) = dirname_source_template_part(body, source)
-                {
-                    *saw_dynamic = true;
-                    parts.push(template_part);
-                } else {
-                    return false;
-                }
-            }
-            _ => return false,
-        }
-    }
-
-    true
-}
-
-fn push_literal(parts: &mut Vec<TemplatePart>, text: String) {
-    if let Some(TemplatePart::Literal(existing)) = parts.last_mut() {
-        existing.push_str(&text);
-    } else {
-        parts.push(TemplatePart::Literal(text));
-    }
-}
-
-fn positional_index(name: &Name) -> Option<usize> {
-    name.as_str().parse().ok()
-}
-
-fn is_bash_source_var(name: &Name) -> bool {
-    name.as_str() == "BASH_SOURCE"
-}
-
-fn parameter_is_current_source_file(parameter: &ParameterExpansion, source: &str) -> bool {
-    match &parameter.syntax {
-        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
-            is_current_source_reference(reference, source)
-        }
-        ParameterExpansionSyntax::Bourne(
-            BourneParameterExpansion::Length { .. }
-            | BourneParameterExpansion::Indices { .. }
-            | BourneParameterExpansion::Indirect { .. }
-            | BourneParameterExpansion::PrefixMatch { .. }
-            | BourneParameterExpansion::Slice { .. }
-            | BourneParameterExpansion::Operation { .. }
-            | BourneParameterExpansion::Transformation { .. },
-        )
-        | ParameterExpansionSyntax::Zsh(_) => false,
-    }
-}
-
-fn is_current_source_reference(reference: &VarRef, source: &str) -> bool {
-    is_bash_source_var(&reference.name)
-        && reference
-            .subscript
-            .as_ref()
-            .is_none_or(|subscript| subscript_is_semantic_zero(subscript, source))
-}
-
-fn is_bash_source_index_ref(reference: &VarRef, source: &str) -> bool {
-    is_bash_source_var(&reference.name)
-        && reference
-            .subscript
-            .as_ref()
-            .is_some_and(|subscript| subscript_is_semantic_zero(subscript, source))
-}
-
-fn subscript_is_semantic_zero(subscript: &shuck_ast::Subscript, source: &str) -> bool {
-    subscript
-        .arithmetic_ast
-        .as_ref()
-        .is_some_and(|expr| arithmetic_expr_is_semantic_zero(expr, source))
-}
-
-fn arithmetic_expr_is_semantic_zero(expr: &ArithmeticExprNode, source: &str) -> bool {
-    match &expr.kind {
-        ArithmeticExpr::Number(text) => shell_zero_literal(text.slice(source)),
-        ArithmeticExpr::ShellWord(word) => word_is_semantic_zero(word, source),
-        ArithmeticExpr::Parenthesized { expression } => {
-            arithmetic_expr_is_semantic_zero(expression, source)
-        }
-        ArithmeticExpr::Unary { expr, .. } => arithmetic_expr_is_semantic_zero(expr, source),
-        _ => false,
-    }
-}
-
-fn word_is_semantic_zero(word: &Word, source: &str) -> bool {
-    matches!(
-        word.parts.as_slice(),
-        [part] if match &part.kind {
-            WordPart::Literal(text) => shell_zero_literal(text.as_str(source, part.span)),
-            WordPart::SingleQuoted { value, .. } => shell_zero_literal(value.slice(source)),
-            WordPart::DoubleQuoted { parts, .. } => matches!(
-                parts.as_slice(),
-                [part] if word_part_is_semantic_zero(&part.kind, part.span, source)
-            ),
-            WordPart::ArithmeticExpansion {
-                expression_ast: Some(expr),
-                ..
-            } => arithmetic_expr_is_semantic_zero(expr, source),
-            _ => false,
-        }
-    )
-}
-
-fn word_part_is_semantic_zero(part: &WordPart, span: Span, source: &str) -> bool {
-    match part {
-        WordPart::Literal(text) => shell_zero_literal(text.as_str(source, span)),
-        WordPart::SingleQuoted { value, .. } => shell_zero_literal(value.slice(source)),
-        WordPart::DoubleQuoted { parts, .. } => matches!(
-            parts.as_slice(),
-            [part] if word_part_is_semantic_zero(&part.kind, part.span, source)
-        ),
-        WordPart::ArithmeticExpansion {
-            expression_ast: Some(expr),
-            ..
-        } => arithmetic_expr_is_semantic_zero(expr, source),
-        _ => false,
-    }
-}
-
-fn shell_zero_literal(text: &str) -> bool {
-    let text = text.trim();
-    if text.is_empty() {
-        return false;
-    }
-
-    let digits = text
-        .strip_prefix('+')
-        .or_else(|| text.strip_prefix('-'))
-        .unwrap_or(text);
-    if digits.is_empty() {
-        return false;
-    }
-
-    if let Some((base, value)) = digits.split_once('#') {
-        return base.parse::<u32>().is_ok_and(|base| {
-            (2..=64).contains(&base) && !value.is_empty() && value.chars().all(|ch| ch == '0')
-        });
-    }
-
-    let digits = digits
-        .strip_prefix("0x")
-        .or_else(|| digits.strip_prefix("0X"))
-        .unwrap_or(digits);
-    !digits.is_empty() && digits.chars().all(|ch| ch == '0')
-}
-
-fn dirname_source_template_part(commands: &StmtSeq, source: &str) -> Option<TemplatePart> {
-    let [stmt] = commands.as_slice() else {
-        return None;
-    };
-    let Command::Simple(command) = &stmt.command else {
-        return None;
-    };
-    if stmt.negated
-        || !stmt.redirects.is_empty()
-        || !command.assignments.is_empty()
-        || command.args.len() != 1
-    {
-        return None;
-    }
-    if static_word_text(&command.name, source).as_deref() != Some("dirname") {
-        return None;
-    }
-    current_source_file_word(&command.args[0], source).then_some(TemplatePart::SourceDir)
-}
-
-fn current_source_file_word(word: &Word, source: &str) -> bool {
-    matches!(
-        word.parts.as_slice(),
-        [part] if is_current_source_part(&part.kind, source)
-    )
-}
-
-fn is_current_source_part(part: &WordPart, source: &str) -> bool {
-    match part {
-        WordPart::Variable(name) => is_bash_source_var(name),
-        WordPart::Parameter(parameter) => parameter_is_current_source_file(parameter, source),
-        WordPart::ArrayAccess(reference) => is_bash_source_index_ref(reference, source),
-        WordPart::DoubleQuoted { parts, .. } => {
-            matches!(parts.as_slice(), [part] if is_current_source_part(&part.kind, source))
-        }
-        _ => false,
-    }
-}
-
 fn source_candidates(
     kind: &SourceRefKind,
     template: Option<&SourcePathTemplate>,
@@ -1291,8 +996,8 @@ fn summarize_helper_uncached(
     }
     let indexer = Indexer::new(source, &output);
     let mut observer = crate::NoopTraversalObserver;
-    let mut semantic = build_semantic_model_base(
-        &output.file,
+    let mut semantic = build_semantic_model_base_arena(
+        &output.arena_file,
         source,
         &indexer,
         &mut observer,
@@ -1474,7 +1179,7 @@ mod tests {
             .parse()
             .unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build(&output.file, source, &indexer);
+        let model = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let facts = collect_ast_facts(&model);
         let call_names = facts
             .calls
@@ -1498,7 +1203,7 @@ coproc loader { . \"$2\"; }
             .parse()
             .unwrap();
         let indexer = Indexer::new(source, &output);
-        let model = SemanticModel::build(&output.file, source, &indexer);
+        let model = SemanticModel::build_arena(&output.arena_file, source, &indexer);
         let facts = collect_ast_facts(&model);
         let source_call_count = facts
             .calls

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -97,8 +97,22 @@ struct ImportedFunctionContractSite {
 
 pub(crate) fn collect_source_closure_contracts(
     model: &SemanticModel,
-    file: &File,
-    source: &str,
+    _file: &File,
+    _source: &str,
+    source_path: &Path,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+    analyzed_paths: Option<&FxHashSet<PathBuf>>,
+) -> SourceClosureContractResult {
+    collect_source_closure_contracts_from_model(
+        model,
+        source_path,
+        source_path_resolver,
+        analyzed_paths,
+    )
+}
+
+pub(crate) fn collect_source_closure_contracts_from_model(
+    model: &SemanticModel,
     source_path: &Path,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
     analyzed_paths: Option<&FxHashSet<PathBuf>>,
@@ -113,8 +127,6 @@ pub(crate) fn collect_source_closure_contracts(
     };
     let contracts = collect_source_closure_contracts_with_cache(
         model,
-        file,
-        source,
         source_path,
         &mut summaries,
         &mut active,
@@ -178,8 +190,6 @@ pub(crate) fn collect_source_ref_metadata(
 
 fn collect_source_closure_contracts_with_cache(
     model: &SemanticModel,
-    _file: &File,
-    _source: &str,
     source_path: &Path,
     summaries: &mut FxHashMap<HelperSummaryKey, FileContract>,
     active: &mut FxHashSet<HelperSummaryKey>,
@@ -1291,8 +1301,6 @@ fn summarize_helper_uncached(
     );
     let collected = collect_source_closure_contracts_with_cache(
         &semantic,
-        &output.file,
-        source,
         path,
         summaries,
         active,

--- a/specs/016-ast-arenas.md
+++ b/specs/016-ast-arenas.md
@@ -20,11 +20,11 @@ The goal is not to make every AST consumer switch in one patch. The goal is to i
 
 ## Implementation Status
 
-The first implementation pass adds an `ArenaFile` sidecar to `ParseResult`, backed by `AstStore` and borrowed view types in `shuck-ast`. The parser lowers the existing recursive tree into the store after parsing, and `shuck check` now builds its index and lint diagnostics through arena-aware entry points. The indexer, semantic model, and linter have arena entry points that materialize the current recursive compatibility shape internally while downstream logic migrates.
+The first implementation pass adds an `ArenaFile` sidecar to `ParseResult`, backed by `AstStore` and borrowed view types in `shuck-ast`. The parser now moves the parsed root `StmtSeq` into `ArenaFile::from_body` after comment attachment and materializes the legacy `File` from that arena for compatibility. `shuck check` builds its index and lint diagnostics through arena-aware entry points. The indexer, semantic model, and linter have arena entry points that materialize the current recursive compatibility shape internally while downstream logic migrates.
 
 Still remaining:
 
-- direct parser construction into `AstStore`
+- pushing arena construction deeper into parser command/word builders instead of moving the completed root body at the end
 - replacing linter fact references with stable AST IDs
 - native arena traversal in semantic analysis instead of compatibility materialization
 - formatter-native arena support, intentionally deferred while the formatter is being reworked

--- a/specs/016-ast-arenas.md
+++ b/specs/016-ast-arenas.md
@@ -22,7 +22,7 @@ The goal is not to make every AST consumer switch in one patch. The goal is to i
 
 The first implementation pass adds an `ArenaFile` sidecar to `ParseResult`, backed by `AstStore` and borrowed view types in `shuck-ast`. The parser now moves the parsed root `StmtSeq` into `ArenaFile::from_body` after comment attachment and materializes the legacy `File` from that arena for compatibility. `shuck check` builds its index and lint diagnostics through arena-aware entry points. The indexer, semantic model, and linter have arena entry points that materialize the current recursive compatibility shape internally while downstream logic migrates.
 
-The arena is now beginning to replace command payloads with native data rather than only carrying graph links plus a legacy escape hatch. Simple commands and typed builtins (`break`, `continue`, `return`, and `exit`) have arena-native payloads and borrowed views. Compatibility materialization for those command families is rebuilt from the arena payloads; other command families still materialize from the legacy command stored on `CommandNode`.
+The arena is now beginning to replace command payloads with native data rather than only carrying graph links plus a legacy escape hatch. Simple commands, typed builtins (`break`, `continue`, `return`, and `exit`), declaration commands, binary commands, named functions, and anonymous functions have arena-native payloads and borrowed views. Compatibility materialization for those command families is rebuilt from the arena payloads; compound command variants still materialize from the legacy command stored on `CommandNode`.
 
 Still remaining:
 

--- a/specs/016-ast-arenas.md
+++ b/specs/016-ast-arenas.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Partially Implemented
 
 ## Summary
 
@@ -17,6 +17,17 @@ The current `shuck_ast::File` is direct and pleasant to pattern-match, but it al
 - Derived stores such as linter facts can be compact, but still need to point back to borrowed AST nodes until the AST itself has stable identity.
 
 The goal is not to make every AST consumer switch in one patch. The goal is to introduce the store and IDs in a way that lets parser, indexer, semantic analysis, lint facts, and formatter move independently without changing observable diagnostics or formatted output.
+
+## Implementation Status
+
+The first implementation pass adds an `ArenaFile` sidecar to `ParseResult`, backed by `AstStore` and borrowed view types in `shuck-ast`. The parser lowers the existing recursive tree into the store after parsing, and `shuck check` now builds its index and lint diagnostics through arena-aware entry points. The indexer, semantic model, and linter have arena entry points that materialize the current recursive compatibility shape internally while downstream logic migrates.
+
+Still remaining:
+
+- direct parser construction into `AstStore`
+- replacing linter fact references with stable AST IDs
+- native arena traversal in semantic analysis instead of compatibility materialization
+- formatter-native arena support, intentionally deferred while the formatter is being reworked
 
 ## Design
 

--- a/specs/016-ast-arenas.md
+++ b/specs/016-ast-arenas.md
@@ -22,9 +22,12 @@ The goal is not to make every AST consumer switch in one patch. The goal is to i
 
 The first implementation pass adds an `ArenaFile` sidecar to `ParseResult`, backed by `AstStore` and borrowed view types in `shuck-ast`. The parser now moves the parsed root `StmtSeq` into `ArenaFile::from_body` after comment attachment and materializes the legacy `File` from that arena for compatibility. `shuck check` builds its index and lint diagnostics through arena-aware entry points. The indexer, semantic model, and linter have arena entry points that materialize the current recursive compatibility shape internally while downstream logic migrates.
 
+The arena is now beginning to replace command payloads with native data rather than only carrying graph links plus a legacy escape hatch. Simple commands and typed builtins (`break`, `continue`, `return`, and `exit`) have arena-native payloads and borrowed views. Compatibility materialization for those command families is rebuilt from the arena payloads; other command families still materialize from the legacy command stored on `CommandNode`.
+
 Still remaining:
 
 - pushing arena construction deeper into parser command/word builders instead of moving the completed root body at the end
+- migrating the remaining command families off `CommandNode::legacy`
 - replacing linter fact references with stable AST IDs
 - native arena traversal in semantic analysis instead of compatibility materialization
 - formatter-native arena support, intentionally deferred while the formatter is being reworked


### PR DESCRIPTION
## Summary
- add an arena-backed AST sidecar with stable IDs, views, list arenas, and round-trip materialization
- thread the arena parse result through parser, CLI, indexer, semantic, and linter entry points
- update the AST arena spec with current implementation status and remaining native migration work

Formatter code intentionally left untouched per request.

## Tests
- cargo check -p shuck-ast
- cargo check -p shuck-parser
- cargo check -p shuck-indexer
- cargo check -p shuck-semantic
- cargo check -p shuck-linter
- cargo check -p shuck-cli
- cargo test -p shuck-ast
- cargo test -p shuck-parser
- cargo test -p shuck-indexer
- cargo test -p shuck-semantic
- cargo test -p shuck-linter
- cargo test -p shuck-cli
- make test