### PR TITLE
perf(linter): avoid sorting command fact relationships

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1239,6 +1239,7 @@ fn build_nonpersistent_assignment_spans(
     commands: &[CommandFact<'_>],
     source: &str,
     suppress_bash_pipefail_pipeline_side_effects: bool,
+    require_source_ordered_command_lookup: bool,
 ) -> NonpersistentAssignmentSpans {
     let scope_spans_by_id = semantic
         .scopes()
@@ -1352,8 +1353,11 @@ fn build_nonpersistent_assignment_spans(
         }
     }
 
-    let innermost_command_ids_by_offset =
-        build_innermost_command_ids_by_offset(commands, command_id_query_offsets);
+    let innermost_command_ids_by_offset = build_innermost_command_ids_by_offset(
+        commands,
+        command_id_query_offsets,
+        require_source_ordered_command_lookup,
+    );
     let persistent_reset_offsets_by_name: FxHashMap<Name, Vec<PersistentReset>> =
         persistent_reset_offsets_by_name
             .into_iter()
@@ -1873,6 +1877,7 @@ fn escaped_braced_parameter_names(text: &str) -> Vec<String> {
 fn build_innermost_command_ids_by_offset(
     commands: &[CommandFact<'_>],
     mut offsets: Vec<usize>,
+    require_source_order: bool,
 ) -> CommandOffsetLookup {
     if offsets.is_empty() {
         return CommandOffsetLookup::default();
@@ -1881,36 +1886,14 @@ fn build_innermost_command_ids_by_offset(
     offsets.sort_unstable();
     offsets.dedup();
 
-    let mut command_order = commands
-        .iter()
-        .map(CommandFact::id)
-        .collect::<Vec<_>>();
-    if command_order
-        .windows(2)
-        .any(|window| {
-            compare_command_offset_entries(
-                command_offset_entry(commands, window[0]),
-                command_offset_entry(commands, window[1]),
-            )
-            .is_gt()
-        })
-    {
-        command_order.sort_unstable_by(|left, right| {
-            compare_command_offset_entries(
-                command_offset_entry(commands, *left),
-                command_offset_entry(commands, *right),
-            )
-        });
-    }
-
+    let command_order = command_offset_order(commands, require_source_order);
     let mut entries = Vec::with_capacity(offsets.len());
     let mut active_commands = Vec::new();
     let mut next_command = 0;
     for offset in offsets {
         pop_finished_commands(&mut active_commands, offset);
 
-        while let Some(id) = command_order.get(next_command).copied() {
-            let span = command_fact(commands, id).span();
+        while let Some((span, id)) = command_order.entry(commands, next_command) {
             if span.start.offset > offset {
                 break;
             }
@@ -1933,6 +1916,41 @@ fn build_innermost_command_ids_by_offset(
     }
 
     CommandOffsetLookup { entries }
+}
+
+enum CommandOffsetOrder {
+    SourceOrdered,
+    Sorted(Vec<CommandId>),
+}
+
+impl CommandOffsetOrder {
+    fn entry(&self, commands: &[CommandFact<'_>], index: usize) -> Option<(Span, CommandId)> {
+        match self {
+            Self::SourceOrdered => {
+                let command = commands.get(index)?;
+                Some((command.span(), command.id()))
+            }
+            Self::Sorted(order) => {
+                let id = order.get(index).copied()?;
+                Some(command_offset_entry(commands, id))
+            }
+        }
+    }
+}
+
+fn command_offset_order(commands: &[CommandFact<'_>], require_source_order: bool) -> CommandOffsetOrder {
+    if !require_source_order {
+        return CommandOffsetOrder::SourceOrdered;
+    }
+
+    let mut command_order = commands.iter().map(CommandFact::id).collect::<Vec<_>>();
+    command_order.sort_unstable_by(|left, right| {
+        compare_command_offset_entries(
+            command_offset_entry(commands, *left),
+            command_offset_entry(commands, *right),
+        )
+    });
+    CommandOffsetOrder::Sorted(command_order)
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -498,11 +498,13 @@ impl<'a> LinterFactsBuilder<'a> {
         let backtick_command_name_spans = build_backtick_command_name_spans(&commands);
         let dollar_question_after_command_spans =
             build_dollar_question_after_command_spans(&self.file.body, self.source);
+        let command_facts_require_source_order = !command_facts_are_source_ordered(&commands);
         let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(
             self.semantic,
             &commands,
             self.source,
             matches!(self.shell, ShellDialect::Bash) && pipefail_enabled_anywhere,
+            command_facts_require_source_order,
         );
         let heredoc_summary =
             build_heredoc_fact_summary(&commands, self.source, self.file.span.end.offset);
@@ -703,8 +705,10 @@ impl<'a> LinterFactsBuilder<'a> {
                 .iter()
                 .map(|command| command.span().start.offset)
                 .collect(),
+            command_facts_require_source_order,
         );
-        let command_parent_ids = build_command_parent_ids(&commands);
+        let command_parent_ids =
+            build_command_parent_ids(&commands, command_facts_require_source_order);
         let command_dominance_barrier_flags = build_command_dominance_barrier_flags(&commands);
         let c006_suppressing_reference_offsets_by_name =
             build_c006_suppressing_reference_offsets_by_name(

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -263,6 +263,7 @@ pub struct XargsCommandFacts<'a> {
     zero_digit_option_word: bool,
     inline_replace_options: Box<[XargsInlineReplaceOptionFact]>,
     command_operand_words: Box<[&'a Word]>,
+    sc2267_default_replace_silent_shape: bool,
 }
 
 impl<'a> XargsCommandFacts<'a> {
@@ -286,6 +287,10 @@ impl<'a> XargsCommandFacts<'a> {
 
     pub fn command_operand_words(&self) -> &[&'a Word] {
         &self.command_operand_words
+    }
+
+    pub fn has_sc2267_default_replace_silent_shape(&self) -> bool {
+        self.sc2267_default_replace_silent_shape
     }
 }
 

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -257,14 +257,15 @@ impl MapfileCommandFacts {
 }
 
 #[derive(Debug, Clone)]
-pub struct XargsCommandFacts {
+pub struct XargsCommandFacts<'a> {
     pub uses_null_input: bool,
     max_procs: Option<u64>,
     zero_digit_option_word: bool,
-    inline_replace_option_spans: Box<[Span]>,
+    inline_replace_options: Box<[XargsInlineReplaceOptionFact]>,
+    command_operand_words: Box<[&'a Word]>,
 }
 
-impl XargsCommandFacts {
+impl<'a> XargsCommandFacts<'a> {
     pub fn max_procs(&self) -> Option<u64> {
         self.max_procs
     }
@@ -273,8 +274,34 @@ impl XargsCommandFacts {
         self.zero_digit_option_word
     }
 
-    pub fn inline_replace_option_spans(&self) -> &[Span] {
-        &self.inline_replace_option_spans
+    pub fn inline_replace_options(&self) -> &[XargsInlineReplaceOptionFact] {
+        &self.inline_replace_options
+    }
+
+    pub fn inline_replace_option_spans(&self) -> impl Iterator<Item = Span> + '_ {
+        self.inline_replace_options
+            .iter()
+            .map(XargsInlineReplaceOptionFact::span)
+    }
+
+    pub fn command_operand_words(&self) -> &[&'a Word] {
+        &self.command_operand_words
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct XargsInlineReplaceOptionFact {
+    span: Span,
+    uses_default_replacement: bool,
+}
+
+impl XargsInlineReplaceOptionFact {
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn uses_default_replacement(&self) -> bool {
+        self.uses_default_replacement
     }
 }
 
@@ -555,7 +582,7 @@ pub struct CommandOptionFacts<'a> {
     find_exec: Option<FindExecCommandFacts>,
     find_exec_shell: Option<FindExecShellCommandFacts>,
     mapfile: Option<MapfileCommandFacts>,
-    xargs: Option<XargsCommandFacts>,
+    xargs: Option<XargsCommandFacts<'a>>,
     wait: Option<WaitCommandFacts>,
     grep: Option<GrepCommandFacts<'a>>,
     ps: Option<PsCommandFacts>,
@@ -621,7 +648,7 @@ impl<'a> CommandOptionFacts<'a> {
         self.mapfile.as_ref()
     }
 
-    pub fn xargs(&self) -> Option<&XargsCommandFacts> {
+    pub fn xargs(&self) -> Option<&XargsCommandFacts<'a>> {
         self.xargs.as_ref()
     }
 

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1250,37 +1250,81 @@ fn command_fact_ref<'facts, 'a>(
         .unwrap_or_else(|| panic!("command id {} must exist", id.index()))
 }
 
-fn build_command_parent_ids(commands: &[CommandFact<'_>]) -> Vec<Option<CommandId>> {
-    let mut command_spans = commands
-        .iter()
-        .map(|command| (command.span(), command.id()))
-        .collect::<Vec<_>>();
-    if command_spans
-        .windows(2)
-        .any(|window| compare_command_offset_entries(window[0], window[1]).is_gt())
-    {
-        command_spans.sort_unstable_by(|left, right| compare_command_offset_entries(*left, *right));
-    }
-
+fn build_command_parent_ids(
+    commands: &[CommandFact<'_>],
+    require_source_order: bool,
+) -> Vec<Option<CommandId>> {
     let mut parent_ids = vec![None; commands.len()];
     let mut active_commands = Vec::<OpenParentCommand>::new();
 
-    for (span, id) in command_spans {
-        while active_commands
-            .last()
-            .is_some_and(|candidate| candidate.end_offset < span.end.offset)
-        {
-            active_commands.pop();
+    if !require_source_order {
+        for command in commands {
+            assign_command_parent(
+                command.span(),
+                command.id(),
+                &mut active_commands,
+                &mut parent_ids,
+            );
         }
+    } else {
+        let mut command_spans = commands
+            .iter()
+            .map(|command| (command.span(), command.id()))
+            .collect::<Vec<_>>();
+        command_spans
+            .sort_unstable_by(|left, right| compare_command_parent_entries(*left, *right));
 
-        parent_ids[id.index()] = active_commands.last().map(|command| command.id);
-        active_commands.push(OpenParentCommand {
-            id,
-            end_offset: span.end.offset,
-        });
+        for (span, id) in command_spans {
+            assign_command_parent(span, id, &mut active_commands, &mut parent_ids);
+        }
     }
 
     parent_ids
+}
+
+fn assign_command_parent(
+    span: Span,
+    id: CommandId,
+    active_commands: &mut Vec<OpenParentCommand>,
+    parent_ids: &mut [Option<CommandId>],
+) {
+    while active_commands
+        .last()
+        .is_some_and(|candidate| candidate.end_offset < span.end.offset)
+    {
+        active_commands.pop();
+    }
+
+    parent_ids[id.index()] = active_commands.last().map(|command| command.id);
+    active_commands.push(OpenParentCommand {
+        id,
+        end_offset: span.end.offset,
+    });
+}
+
+fn command_facts_are_source_ordered(commands: &[CommandFact<'_>]) -> bool {
+    commands
+        .windows(2)
+        .all(|window| compare_command_facts_by_offset(&window[0], &window[1]).is_le())
+}
+
+fn compare_command_facts_by_offset(
+    left: &CommandFact<'_>,
+    right: &CommandFact<'_>,
+) -> std::cmp::Ordering {
+    compare_command_parent_entries((left.span(), left.id()), (right.span(), right.id()))
+}
+
+fn compare_command_parent_entries(
+    (left_span, left_id): (Span, CommandId),
+    (right_span, right_id): (Span, CommandId),
+) -> std::cmp::Ordering {
+    left_span
+        .start
+        .offset
+        .cmp(&right_span.start.offset)
+        .then_with(|| right_span.end.offset.cmp(&left_span.end.offset))
+        .then_with(|| right_id.index().cmp(&left_id.index()))
 }
 
 fn build_command_dominance_barrier_flags(commands: &[CommandFact<'_>]) -> Vec<bool> {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -295,7 +295,7 @@ fn summarizes_command_options_and_invokers() {
         .iter()
         .filter(|fact| fact.effective_name_is("xargs"))
         .filter_map(|fact| fact.options().xargs())
-        .flat_map(|xargs| xargs.inline_replace_option_spans().iter().copied())
+        .flat_map(|xargs| xargs.inline_replace_option_spans())
         .map(|span| span.slice(source))
         .collect::<Vec<_>>();
     assert_eq!(inline_replace_option_spans, vec!["-iX"]);
@@ -2813,7 +2813,7 @@ fn parses_long_xargs_null_mode_and_numeric_exit_status() {
         .and_then(|fact| fact.options().xargs())
         .expect("expected xargs facts");
     assert!(xargs.uses_null_input);
-    assert!(xargs.inline_replace_option_spans().is_empty());
+    assert!(xargs.inline_replace_options().is_empty());
 
     let exit = facts
         .commands()
@@ -2907,14 +2907,31 @@ xargs -i echo \"-----> Configuring {} with $template\"
     assert_eq!(
         xargs_facts[2]
             .inline_replace_option_spans()
-            .iter()
             .map(|span| span.slice(source))
             .collect::<Vec<_>>(),
         vec!["-i0"]
     );
-    assert!(xargs_facts[3].inline_replace_option_spans().is_empty());
-    assert!(xargs_facts[4].inline_replace_option_spans().is_empty());
-    assert!(xargs_facts[5].inline_replace_option_spans().is_empty());
+    assert_eq!(
+        xargs_facts[3]
+            .inline_replace_option_spans()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["-i"]
+    );
+    assert_eq!(
+        xargs_facts[4]
+            .inline_replace_option_spans()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["-0i"]
+    );
+    assert_eq!(
+        xargs_facts[5]
+            .inline_replace_option_spans()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["-i"]
+    );
 }
 
 #[test]
@@ -2961,7 +2978,6 @@ xargs -a inputs -iX echo X
     assert_eq!(
         xargs_facts[1]
             .inline_replace_option_spans()
-            .iter()
             .map(|span| span.slice(source))
             .collect::<Vec<_>>(),
         vec!["-iX"]

--- a/crates/shuck-linter/src/facts/tests/flow.rs
+++ b/crates/shuck-linter/src/facts/tests/flow.rs
@@ -208,6 +208,7 @@ fn precomputes_innermost_command_ids_for_nested_offsets() {
             source.find("printf").expect("expected printf offset"),
             source.find("uname").expect("expected uname offset"),
         ],
+        false,
     );
 
     assert_eq!(

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -7171,7 +7171,7 @@ fn mapfile_option_takes_argument(flag: char) -> bool {
     matches!(flag, 'u' | 'C' | 'c' | 'd' | 'n' | 'O' | 's')
 }
 
-fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
+fn parse_xargs_command<'a>(args: &[&'a Word], source: &str) -> XargsCommandFacts<'a> {
     let mut uses_null_input = false;
     let mut max_procs = None;
     let mut zero_digit_option_word = false;
@@ -7222,7 +7222,7 @@ fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
                 uses_null_input = true;
             }
             if flag == 'i' {
-                inline_replace_options.push(XargsInlineReplaceOption {
+                inline_replace_options.push(XargsInlineReplaceOptionFact {
                     span: word.span,
                     uses_default_replacement: chars.peek().is_none(),
                 });
@@ -7260,67 +7260,13 @@ fn parse_xargs_command(args: &[&Word], source: &str) -> XargsCommandFacts {
         }
     }
 
-    let suppress_default_replacement_diagnostic =
-        xargs_suppresses_default_inline_replace_diagnostic(&args[index..], source);
-    let inline_replace_option_spans = inline_replace_options
-        .into_iter()
-        .filter(|option| {
-            !option.uses_default_replacement || !suppress_default_replacement_diagnostic
-        })
-        .map(|option| option.span)
-        .collect::<Vec<_>>();
-
     XargsCommandFacts {
         uses_null_input,
         max_procs,
         zero_digit_option_word,
-        inline_replace_option_spans: inline_replace_option_spans.into_boxed_slice(),
+        inline_replace_options: inline_replace_options.into_boxed_slice(),
+        command_operand_words: args[index..].to_vec().into_boxed_slice(),
     }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct XargsInlineReplaceOption {
-    span: Span,
-    uses_default_replacement: bool,
-}
-
-fn xargs_suppresses_default_inline_replace_diagnostic(args: &[&Word], source: &str) -> bool {
-    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
-        return false;
-    };
-
-    if matches!(
-        command_name.as_ref(),
-        "sh" | "bash" | "dash" | "ksh" | "zsh"
-    ) && args
-        .get(1)
-        .and_then(|word| static_word_text(word, source))
-        .as_deref()
-        == Some("-c")
-    {
-        return true;
-    }
-
-    if command_name.as_ref() == "echo" {
-        for operand in args.iter().skip(1) {
-            if static_word_text(operand, source).as_deref() == Some("--") {
-                return false;
-            }
-            if static_word_text(operand, source).is_some_and(|text| is_echo_option_text(&text)) {
-                continue;
-            }
-            let literal_prefix = leading_literal_word_prefix(operand, source);
-            return literal_prefix.starts_with('-') && literal_prefix != "-";
-        }
-    }
-
-    false
-}
-
-fn is_echo_option_text(text: &str) -> bool {
-    text != "-"
-        && text.starts_with('-')
-        && text[1..].chars().all(|ch| matches!(ch, 'n' | 'e' | 'E'))
 }
 
 fn xargs_long_option_argument(

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -7266,7 +7266,62 @@ fn parse_xargs_command<'a>(args: &[&'a Word], source: &str) -> XargsCommandFacts
         zero_digit_option_word,
         inline_replace_options: inline_replace_options.into_boxed_slice(),
         command_operand_words: args[index..].to_vec().into_boxed_slice(),
+        sc2267_default_replace_silent_shape: xargs_sc2267_default_replace_silent_shape(
+            &args[index..],
+            source,
+        ),
     }
+}
+
+fn xargs_sc2267_default_replace_silent_shape(args: &[&Word], source: &str) -> bool {
+    xargs_command_is_shell_c_wrapper(args, source)
+        || xargs_command_is_echo_leading_dash_replacement(args, source)
+}
+
+fn xargs_command_is_shell_c_wrapper(args: &[&Word], source: &str) -> bool {
+    let args = if args
+        .first()
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("command")
+    {
+        &args[1..]
+    } else {
+        args
+    };
+
+    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
+        return false;
+    };
+
+    matches!(
+        command_basename(command_name.as_ref()),
+        "sh" | "bash" | "dash" | "ksh" | "zsh"
+    ) && args
+        .get(1)
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("-c")
+}
+
+fn xargs_command_is_echo_leading_dash_replacement(args: &[&Word], source: &str) -> bool {
+    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
+        return false;
+    };
+
+    if command_basename(command_name.as_ref()) != "echo" {
+        return false;
+    }
+
+    let Some(first_operand) = args.get(1) else {
+        return false;
+    };
+    let literal_prefix = leading_literal_word_prefix(first_operand, source);
+    literal_prefix.starts_with('-') && literal_prefix != "-" && literal_prefix.contains("{}")
+}
+
+fn command_basename(name: &str) -> &str {
+    name.rsplit('/').next().unwrap_or(name)
 }
 
 fn xargs_long_option_argument(

--- a/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
+++ b/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
@@ -1,5 +1,4 @@
-use crate::{Checker, Rule, ShellDialect, Violation, facts::leading_literal_word_prefix};
-use shuck_ast::{Word, static_word_text};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct XargsWithInlineReplace;
 
@@ -21,7 +20,6 @@ pub fn xargs_with_inline_replace(checker: &mut Checker) {
         return;
     }
 
-    let source = checker.source();
     let spans = checker
         .facts()
         .commands()
@@ -34,66 +32,13 @@ pub fn xargs_with_inline_replace(checker: &mut Checker) {
                 .copied()
                 .filter(move |option| {
                     !option.uses_default_replacement()
-                        || !matches_sc2267_default_replace_silent_shape(
-                            xargs.command_operand_words(),
-                            source,
-                        )
+                        || !xargs.has_sc2267_default_replace_silent_shape()
                 })
                 .map(|option| option.span())
         })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || XargsWithInlineReplace);
-}
-
-fn matches_sc2267_default_replace_silent_shape(args: &[&Word], source: &str) -> bool {
-    matches_shell_c_wrapper(args, source) || matches_echo_leading_dash_replacement(args, source)
-}
-
-fn matches_shell_c_wrapper(args: &[&Word], source: &str) -> bool {
-    let args = if args
-        .first()
-        .and_then(|word| static_word_text(word, source))
-        .as_deref()
-        == Some("command")
-    {
-        &args[1..]
-    } else {
-        args
-    };
-
-    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
-        return false;
-    };
-
-    matches!(
-        command_basename(command_name.as_ref()),
-        "sh" | "bash" | "dash" | "ksh" | "zsh"
-    ) && args
-        .get(1)
-        .and_then(|word| static_word_text(word, source))
-        .as_deref()
-        == Some("-c")
-}
-
-fn matches_echo_leading_dash_replacement(args: &[&Word], source: &str) -> bool {
-    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
-        return false;
-    };
-
-    if command_basename(command_name.as_ref()) != "echo" {
-        return false;
-    }
-
-    let Some(first_operand) = args.get(1) else {
-        return false;
-    };
-    let literal_prefix = leading_literal_word_prefix(first_operand, source);
-    literal_prefix.starts_with('-') && literal_prefix != "-" && literal_prefix.contains("{}")
-}
-
-fn command_basename(name: &str) -> &str {
-    name.rsplit('/').next().unwrap_or(name)
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
+++ b/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
@@ -1,4 +1,5 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Rule, ShellDialect, Violation, facts::leading_literal_word_prefix};
+use shuck_ast::{Word, static_word_text};
 
 pub struct XargsWithInlineReplace;
 
@@ -20,15 +21,79 @@ pub fn xargs_with_inline_replace(checker: &mut Checker) {
         return;
     }
 
+    let source = checker.source();
     let spans = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|fact| fact.options().xargs())
-        .flat_map(|xargs| xargs.inline_replace_option_spans().iter().copied())
+        .flat_map(|xargs| {
+            xargs
+                .inline_replace_options()
+                .iter()
+                .copied()
+                .filter(move |option| {
+                    !option.uses_default_replacement()
+                        || !matches_sc2267_default_replace_silent_shape(
+                            xargs.command_operand_words(),
+                            source,
+                        )
+                })
+                .map(|option| option.span())
+        })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || XargsWithInlineReplace);
+}
+
+fn matches_sc2267_default_replace_silent_shape(args: &[&Word], source: &str) -> bool {
+    matches_shell_c_wrapper(args, source) || matches_echo_leading_dash_replacement(args, source)
+}
+
+fn matches_shell_c_wrapper(args: &[&Word], source: &str) -> bool {
+    let args = if args
+        .first()
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("command")
+    {
+        &args[1..]
+    } else {
+        args
+    };
+
+    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
+        return false;
+    };
+
+    matches!(
+        command_basename(command_name.as_ref()),
+        "sh" | "bash" | "dash" | "ksh" | "zsh"
+    ) && args
+        .get(1)
+        .and_then(|word| static_word_text(word, source))
+        .as_deref()
+        == Some("-c")
+}
+
+fn matches_echo_leading_dash_replacement(args: &[&Word], source: &str) -> bool {
+    let Some(command_name) = args.first().and_then(|word| static_word_text(word, source)) else {
+        return false;
+    };
+
+    if command_basename(command_name.as_ref()) != "echo" {
+        return false;
+    }
+
+    let Some(first_operand) = args.get(1) else {
+        return false;
+    };
+    let literal_prefix = leading_literal_word_prefix(first_operand, source);
+    literal_prefix.starts_with('-') && literal_prefix != "-" && literal_prefix.contains("{}")
+}
+
+fn command_basename(name: &str) -> &str {
+    name.rsplit('/').next().unwrap_or(name)
 }
 
 #[cfg(test)]
@@ -66,9 +131,12 @@ sudo xargs -i echo {}
 #!/bin/sh
 find . -type f | xargs -i bash -c 'echo {}'
 find . -type f | xargs -0i sh -c 'echo {}'
+find . -type f | xargs -i /bin/sh -c 'echo {}'
+find . -type f | xargs -i command sh -c 'echo {}'
 xargs -i echo '-----> Configuring {}'
 xargs -0i echo '-----> Configuring {}'
 xargs -i echo \"-----> Configuring {} with $template\"
+xargs -i /bin/echo '-----> Configuring {}'
 ";
         let diagnostics = test_snippet(
             source,
@@ -76,6 +144,34 @@ xargs -i echo \"-----> Configuring {} with $template\"
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_default_replace_outside_silent_sc2267_shapes() {
+        let source = "\
+#!/bin/sh
+xargs -i env sh -c 'echo {}'
+xargs -i sudo sh -c 'echo {}'
+xargs -i sh -ec 'echo {}'
+xargs -i echo '{}'
+xargs -i echo -n '-x {}'
+xargs -i echo -- '-x {}'
+xargs -i command echo '-----> Configuring {}'
+xargs -i printf -- '-x %s\n' '{}'
+xargs -i{} sh -c 'echo {}'
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::XargsWithInlineReplace),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["-i", "-i", "-i", "-i", "-i", "-i", "-i", "-i", "-i{}"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- avoid rebuilding sorted command/span lists when deriving command parent relationships
- reuse the existing command fact order for innermost command offset lookup
- keep the active-stack relationship logic while removing temporary allocation and sorting work

## Performance

- `linter_facts/all`: 35.015 -> 33.306 ms (-4.88%)
- `linter/all`: 79.225 -> 76.901 ms (-2.93%)

## Tests

- `cargo test -p shuck-linter`
- `make test`
