### PR TITLE
perf(semantic): avoid eager reaching map materialization

### DIFF
--- a/crates/shuck-benchmark/examples/semantic_memory.rs
+++ b/crates/shuck-benchmark/examples/semantic_memory.rs
@@ -177,8 +177,10 @@ struct CaseReport {
     command_count: usize,
     semantic_item_count: usize,
     cfg_block_count: usize,
+    dataflow_item_count: usize,
     metrics: MemoryMetrics,
     cfg_metrics: MemoryMetrics,
+    dataflow_metrics: MemoryMetrics,
 }
 
 fn build_semantic(source: &str) -> (SemanticModel, usize, usize, bool) {
@@ -218,9 +220,10 @@ fn single_case_report(case_name: &str) -> Option<CaseReport> {
         (models, recovered_files, command_count, semantic_count)
     });
 
-    let (cfg_frame, cfg_block_count) = measure(|| {
+    let (cfg_frame, (analyses, cfg_block_count)) = measure(|| {
         let mut cfg_block_count = 0usize;
         let mut cfg_edge_count = 0usize;
+        let mut analyses = Vec::with_capacity(models.len());
 
         for model in &models {
             let analysis = model.analysis();
@@ -231,10 +234,23 @@ fn single_case_report(case_name: &str) -> Option<CaseReport> {
                 .iter()
                 .map(|block| cfg.successors(block.id).len())
                 .sum::<usize>();
+            analyses.push(analysis);
         }
 
         std::hint::black_box(cfg_edge_count);
-        cfg_block_count
+        (analyses, cfg_block_count)
+    });
+
+    let (dataflow_frame, dataflow_item_count) = measure(|| {
+        let mut dataflow_item_count = 0usize;
+
+        for analysis in &analyses {
+            dataflow_item_count += analysis.unused_assignments().len();
+            dataflow_item_count += analysis.uninitialized_references().len();
+            dataflow_item_count += analysis.dead_code().len();
+        }
+
+        dataflow_item_count
     });
 
     Some(CaseReport {
@@ -244,8 +260,10 @@ fn single_case_report(case_name: &str) -> Option<CaseReport> {
         command_count,
         semantic_item_count,
         cfg_block_count,
+        dataflow_item_count,
         metrics: frame.into(),
         cfg_metrics: cfg_frame.into(),
+        dataflow_metrics: dataflow_frame.into(),
     })
 }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -51,7 +51,6 @@ pub struct DeadCode {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataflowResult {
-    pub reaching_definitions: ReachingDefinitions,
     pub unused_assignments: Vec<UnusedAssignment>,
     pub uninitialized_references: Vec<UninitializedReference>,
     pub dead_code: Vec<DeadCode>,
@@ -272,10 +271,8 @@ pub(crate) fn analyze(
     );
     let uninitialized_references = analyze_uninitialized_references_exact(context, exact);
     let dead_code = build_dead_code(context.cfg);
-    let reaching_definitions = exact.reaching_definitions(context);
 
     DataflowResult {
-        reaching_definitions: materialize_reaching_definitions(context.cfg, reaching_definitions),
         unused_assignments: unused_assignments.unused_assignments,
         uninitialized_references,
         dead_code,
@@ -1159,7 +1156,16 @@ struct DenseReachingDefinitions {
     reaching_out: Vec<DenseBitSet>,
 }
 
-fn materialize_reaching_definitions(
+#[cfg(test)]
+pub(crate) fn materialize_reaching_definitions(
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
+) -> ReachingDefinitions {
+    materialize_dense_reaching_definitions(context.cfg, exact.reaching_definitions(context))
+}
+
+#[cfg(test)]
+fn materialize_dense_reaching_definitions(
     cfg: &ControlFlowGraph,
     dense: &DenseReachingDefinitions,
 ) -> ReachingDefinitions {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1384,6 +1384,14 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    #[cfg(test)]
+    fn materialized_reaching_definitions(&self) -> ReachingDefinitions {
+        let cfg = self.cfg();
+        let context = self.model.dataflow_context(cfg);
+        let exact = self.exact_variable_dataflow();
+        dataflow::materialize_reaching_definitions(&context, exact)
+    }
+
     /// Returns every binding that dataflow proves is never read again.
     ///
     /// Higher layers may still collapse mutually exclusive branch families down to a single
@@ -5920,7 +5928,7 @@ echo $value
     fn materialized_reaching_definitions_match_dense_exact_results() {
         let model = model("VAR=outer\nif cond; then VAR=inner; fi\necho $VAR\n");
         let analysis = model.analysis();
-        let dataflow = analysis.dataflow();
+        let reaching_definitions = analysis.materialized_reaching_definitions();
         let reference = model
             .references()
             .iter()
@@ -5931,9 +5939,7 @@ echo $value
         assert_eq!(
             sorted_binding_names(
                 &model,
-                dataflow.reaching_definitions.reaching_in[&block_id]
-                    .iter()
-                    .copied()
+                reaching_definitions.reaching_in[&block_id].iter().copied()
             ),
             vec!["VAR", "VAR"]
         );


### PR DESCRIPTION
## Summary

- Stop materializing dense reaching definitions into `FxHashMap<BlockId, FxHashSet<BindingId>>` as part of the default internal `DataflowResult` bundle.
- Keep materialized reaching definitions available only for the invariant test that checks the legacy map view against the dense engine.
- Extend `semantic_memory` with `dataflow_metrics` so CFG and public dataflow accessor allocation can be tracked separately.

## Notes

The public semantic accessors already use dense/query-backed dataflow paths. This keeps that shape explicit by making the expensive hash-set materialization opt-in instead of bundled with `dataflow::analyze`.

Current `semantic_memory --case all` dataflow accessor measurement, reusing the same warmed `SemanticAnalysis` instances from the CFG measurement:

- allocation count: `136,675`
- total allocated bytes: `14,264,335`
- peak live bytes: `6,768,287`
- dataflow items reported: `1,874`

## Validation

- `cargo test -p shuck-semantic`
- `cargo test -p shuck-semantic --lib dataflow -- --nocapture`
- `cargo check -p shuck-benchmark --example semantic_memory`
- `cargo fmt --check`
- `git diff --check`
- `cargo run -p shuck-benchmark --example semantic_memory --release --quiet -- --case all`
