### PR TITLE
perf(linter): reuse command relationships in facts

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -87,6 +87,9 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut structural_command_ids = Vec::with_capacity(capacity.structural_commands);
         let mut command_ids_by_span =
             CommandLookupIndex::with_capacity_and_hasher(capacity.commands, Default::default());
+        let mut command_parent_ids = Vec::with_capacity(capacity.commands);
+        let mut command_child_ids_by_parent = Vec::<Vec<CommandId>>::with_capacity(capacity.commands);
+        let mut active_parent_commands = Vec::<OpenParentCommand>::new();
         let mut if_condition_command_ids =
             FxHashSet::with_capacity_and_hasher(capacity.commands / 4, Default::default());
         let mut elif_condition_command_ids =
@@ -132,6 +135,23 @@ impl<'a> LinterFactsBuilder<'a> {
             &mut |visit, context| {
                 let key = FactSpan::new(command_span(visit.command));
                 let id = CommandId::new(commands.len());
+                let span = command_span(visit.command);
+                while active_parent_commands
+                    .last()
+                    .is_some_and(|candidate| candidate.end_offset < span.end.offset)
+                {
+                    active_parent_commands.pop();
+                }
+                let parent_id = active_parent_commands.last().map(|command| command.id);
+                command_parent_ids.push(parent_id);
+                command_child_ids_by_parent.push(Vec::new());
+                if let Some(parent_id) = parent_id {
+                    command_child_ids_by_parent[parent_id.index()].push(id);
+                }
+                active_parent_commands.push(OpenParentCommand {
+                    id,
+                    end_offset: span.end.offset,
+                });
                 let lookup_kind = command_lookup_kind(visit.command);
                 let entries = command_ids_by_span.entry(key).or_default();
                 let previous = entries.iter().find(|entry| entry.kind == lookup_kind);
@@ -397,11 +417,33 @@ impl<'a> LinterFactsBuilder<'a> {
         fact_store.declaration_assignment_probes = declaration_assignment_probe_store;
         fact_store.word_spans = word_spans;
 
+        let command_facts_require_source_order = !command_facts_are_source_ordered(&commands);
+        let (command_parent_ids, command_child_index) = if !command_facts_require_source_order {
+            (
+                command_parent_ids,
+                CommandChildIndex::from_parent_lists(command_child_ids_by_parent),
+            )
+        } else {
+            let command_parent_ids =
+                build_command_parent_ids(&commands, command_facts_require_source_order);
+            let mut command_child_ids_by_parent = vec![Vec::new(); commands.len()];
+            for (index, parent_id) in command_parent_ids.iter().copied().enumerate() {
+                if let Some(parent_id) = parent_id {
+                    command_child_ids_by_parent[parent_id.index()].push(CommandId::new(index));
+                }
+            }
+            (
+                command_parent_ids,
+                CommandChildIndex::from_parent_lists(command_child_ids_by_parent),
+            )
+        };
+
         populate_linebreak_in_test_facts(&mut commands, self.source);
         populate_substitution_fact_ranges(
             &mut commands,
             &mut fact_store,
             &command_ids_by_span,
+            &command_child_index,
             self.source,
         );
 
@@ -448,7 +490,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let case_pattern_shadows = build_case_pattern_shadow_facts(&commands, self.source);
         let case_pattern_impossible_spans =
             build_case_pattern_impossible_spans(&commands, self.source);
-        let pipelines = build_pipeline_facts(&commands, &command_ids_by_span);
+        let pipelines = build_pipeline_facts(&commands, &command_ids_by_span, &command_child_index);
         populate_scope_fact_ranges(
             &mut commands,
             &mut fact_store,
@@ -456,7 +498,12 @@ impl<'a> LinterFactsBuilder<'a> {
             &if_condition_command_ids,
             source,
         );
-        let lists = build_list_facts(&commands, &command_ids_by_span, self.source);
+        let lists = build_list_facts(
+            &commands,
+            &command_ids_by_span,
+            &command_child_index,
+            self.source,
+        );
         let completion_registered_function_command_flags =
             build_completion_registered_function_command_flags(
                 self.semantic,
@@ -470,9 +517,19 @@ impl<'a> LinterFactsBuilder<'a> {
         let background_semicolon_spans =
             build_background_semicolon_spans(&commands, &case_items, self.source);
         let single_test_subshell_spans =
-            build_single_test_subshell_spans(&commands, &command_ids_by_span, self.source);
+            build_single_test_subshell_spans(
+                &commands,
+                &command_ids_by_span,
+                &command_child_index,
+                self.source,
+            );
         let subshell_test_group_spans =
-            build_subshell_test_group_spans(&commands, &command_ids_by_span, self.source);
+            build_subshell_test_group_spans(
+                &commands,
+                &command_ids_by_span,
+                &command_child_index,
+                self.source,
+            );
         let shebang_header_facts = build_shebang_header_facts(self.source);
         let errexit_enabled_anywhere = self.ambient_shell_options.errexit
             || shebang_header_facts.enables_errexit
@@ -498,7 +555,6 @@ impl<'a> LinterFactsBuilder<'a> {
         let backtick_command_name_spans = build_backtick_command_name_spans(&commands);
         let dollar_question_after_command_spans =
             build_dollar_question_after_command_spans(&self.file.body, self.source);
-        let command_facts_require_source_order = !command_facts_are_source_ordered(&commands);
         let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(
             self.semantic,
             &commands,
@@ -707,8 +763,6 @@ impl<'a> LinterFactsBuilder<'a> {
                 .collect(),
             command_facts_require_source_order,
         );
-        let command_parent_ids =
-            build_command_parent_ids(&commands, command_facts_require_source_order);
         let command_dominance_barrier_flags = build_command_dominance_barrier_flags(&commands);
         let c006_suppressing_reference_offsets_by_name =
             build_c006_suppressing_reference_offsets_by_name(

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1308,9 +1308,6 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
             .or_else(|| self.fact_for_stmt(stmt))
     }
 
-    fn child_ids(self, parent_id: CommandId) -> &'facts [CommandId] {
-        self.command_child_index.child_ids(parent_id)
-    }
 }
 
 fn build_command_parent_ids(

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1250,6 +1250,69 @@ fn command_fact_ref<'facts, 'a>(
         .unwrap_or_else(|| panic!("command id {} must exist", id.index()))
 }
 
+#[derive(Clone, Copy)]
+struct CommandRelationshipContext<'facts, 'a> {
+    commands: &'facts [CommandFact<'a>],
+    command_ids_by_span: &'facts CommandLookupIndex,
+    command_child_index: &'facts CommandChildIndex,
+}
+
+impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
+    fn new(
+        commands: &'facts [CommandFact<'a>],
+        command_ids_by_span: &'facts CommandLookupIndex,
+        command_child_index: &'facts CommandChildIndex,
+    ) -> Self {
+        Self {
+            commands,
+            command_ids_by_span,
+            command_child_index,
+        }
+    }
+
+    fn fact(self, id: CommandId) -> &'facts CommandFact<'a> {
+        &self.commands[id.index()]
+    }
+
+    fn id_for_command(self, command: &Command) -> Option<CommandId> {
+        command_id_for_command(command, self.command_ids_by_span)
+    }
+
+    fn fact_for_command(self, command: &Command) -> Option<&'facts CommandFact<'a>> {
+        self.id_for_command(command).map(|id| self.fact(id))
+    }
+
+    fn fact_for_stmt(self, stmt: &Stmt) -> Option<&'facts CommandFact<'a>> {
+        self.fact_for_command(&stmt.command)
+    }
+
+    fn child_id_for_command(self, parent_id: CommandId, command: &Command) -> Option<CommandId> {
+        child_command_id_for_command(parent_id, command, self.commands, self.command_child_index)
+    }
+
+    fn child_fact_for_stmt(
+        self,
+        parent_id: CommandId,
+        stmt: &Stmt,
+    ) -> Option<&'facts CommandFact<'a>> {
+        self.child_id_for_command(parent_id, &stmt.command)
+            .map(|id| self.fact(id))
+    }
+
+    fn child_or_lookup_fact(
+        self,
+        parent_id: CommandId,
+        stmt: &Stmt,
+    ) -> Option<&'facts CommandFact<'a>> {
+        self.child_fact_for_stmt(parent_id, stmt)
+            .or_else(|| self.fact_for_stmt(stmt))
+    }
+
+    fn child_ids(self, parent_id: CommandId) -> &'facts [CommandId] {
+        self.command_child_index.child_ids(parent_id)
+    }
+}
+
 fn build_command_parent_ids(
     commands: &[CommandFact<'_>],
     require_source_order: bool,
@@ -1379,6 +1442,19 @@ fn command_fact_for_stmt<'a>(
     command_ids_by_span: &CommandLookupIndex,
 ) -> Option<&'a CommandFact<'a>> {
     command_fact_for_command(&stmt.command, commands, command_ids_by_span)
+}
+
+fn child_command_id_for_command(
+    parent_id: CommandId,
+    command: &Command,
+    commands: &[CommandFact<'_>],
+    command_child_index: &CommandChildIndex,
+) -> Option<CommandId> {
+    command_child_index
+        .child_ids(parent_id)
+        .iter()
+        .copied()
+        .find(|id| std::ptr::eq(command_fact(commands, *id).command(), command))
 }
 
 fn command_fact_ref_for_stmt<'facts, 'a>(

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -133,6 +133,33 @@ struct FactStore<'a> {
     word_spans: ListArena<Span>,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct CommandChildIndex {
+    ids: ListArena<CommandId>,
+    by_parent: Vec<IdRange<CommandId>>,
+}
+
+impl CommandChildIndex {
+    fn from_parent_lists(children_by_parent: Vec<Vec<CommandId>>) -> Self {
+        let total_children = children_by_parent.iter().map(Vec::len).sum();
+        let mut ids = ListArena::with_capacity(total_children);
+        let mut by_parent = Vec::with_capacity(children_by_parent.len());
+
+        for children in children_by_parent {
+            by_parent.push(ids.push_many(children));
+        }
+
+        Self { ids, by_parent }
+    }
+
+    fn child_ids(&self, id: CommandId) -> &[CommandId] {
+        self.by_parent
+            .get(id.index())
+            .copied()
+            .map_or(&[], |range| self.ids.get(range))
+    }
+}
+
 impl<'a> FactStore<'a> {
     fn empty() -> Self {
         Self {

--- a/crates/shuck-linter/src/facts/lists.rs
+++ b/crates/shuck-linter/src/facts/lists.rs
@@ -108,8 +108,11 @@ impl<'a> ListFact<'a> {
 pub(super) fn build_list_facts<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
+    command_child_index: &CommandChildIndex,
     source: &str,
 ) -> Vec<ListFact<'a>> {
+    let command_relationships =
+        CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     let mut nested_list_commands = FxHashSet::default();
 
     for fact in commands {
@@ -120,15 +123,14 @@ pub(super) fn build_list_facts<'a>(
             continue;
         }
 
-        if matches!(&command.left.command, Command::Binary(left) if matches!(left.op, BinaryOp::And | BinaryOp::Or))
-            && let Some(id) = command_id_for_command(&command.left.command, command_ids_by_span)
-        {
-            nested_list_commands.insert(id);
-        }
-        if matches!(&command.right.command, Command::Binary(right) if matches!(right.op, BinaryOp::And | BinaryOp::Or))
-            && let Some(id) = command_id_for_command(&command.right.command, command_ids_by_span)
-        {
-            nested_list_commands.insert(id);
+        for child_id in command_relationships.child_ids(fact.id()) {
+            let child = command_relationships.fact(*child_id);
+            if matches!(
+                child.command(),
+                Command::Binary(child) if matches!(child.op, BinaryOp::And | BinaryOp::Or)
+            ) {
+                nested_list_commands.insert(*child_id);
+            }
         }
     }
 
@@ -146,8 +148,12 @@ pub(super) fn build_list_facts<'a>(
 
             let mut operators = Vec::new();
             collect_short_circuit_operators(command, &mut operators);
-            let segments =
-                build_list_segment_facts(command, commands, command_ids_by_span, source)?;
+            let segments = build_list_segment_facts(
+                command,
+                command_relationships,
+                fact.id(),
+                source,
+            )?;
             let mixed_short_circuit_span = mixed_short_circuit_operator_span(&operators);
             let mixed_short_circuit_kind = mixed_short_circuit_span
                 .map(|_| classify_mixed_short_circuit_kind(&segments, &operators));
@@ -167,15 +173,15 @@ pub(super) fn build_list_facts<'a>(
 
 fn build_list_segment_facts<'a>(
     command: &BinaryCommand,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
+    parent_id: CommandId,
     source: &str,
 ) -> Option<Box<[ListSegmentFact]>> {
     let mut segments = Vec::new();
     collect_list_segment_facts(
         command,
-        commands,
-        command_ids_by_span,
+        command_relationships,
+        parent_id,
         source,
         &mut segments,
     )?;
@@ -184,22 +190,22 @@ fn build_list_segment_facts<'a>(
 
 fn collect_list_segment_facts<'a>(
     command: &BinaryCommand,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
+    parent_id: CommandId,
     source: &str,
     segments: &mut Vec<ListSegmentFact>,
 ) -> Option<()> {
     collect_list_stmt_segment_facts(
         &command.left,
-        commands,
-        command_ids_by_span,
+        command_relationships,
+        parent_id,
         source,
         segments,
     )?;
     collect_list_stmt_segment_facts(
         &command.right,
-        commands,
-        command_ids_by_span,
+        command_relationships,
+        parent_id,
         source,
         segments,
     )?;
@@ -208,19 +214,25 @@ fn collect_list_segment_facts<'a>(
 
 fn collect_list_stmt_segment_facts<'a>(
     stmt: &Stmt,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
+    parent_id: CommandId,
     source: &str,
     segments: &mut Vec<ListSegmentFact>,
 ) -> Option<()> {
     if let Command::Binary(binary) = &stmt.command
         && matches!(binary.op, BinaryOp::And | BinaryOp::Or)
     {
-        return collect_list_segment_facts(binary, commands, command_ids_by_span, source, segments);
+        return collect_list_segment_facts(
+            binary,
+            command_relationships,
+            parent_id,
+            source,
+            segments,
+        );
     }
 
-    let id = command_id_for_command(&stmt.command, command_ids_by_span)?;
-    let fact = command_fact(commands, id);
+    let fact = command_relationships.child_or_lookup_fact(parent_id, stmt)?;
+    let id = fact.id();
     let assignment_info = list_segment_assignment_info(fact);
     let assignment_target = assignment_info
         .as_ref()

--- a/crates/shuck-linter/src/facts/lists.rs
+++ b/crates/shuck-linter/src/facts/lists.rs
@@ -123,15 +123,18 @@ pub(super) fn build_list_facts<'a>(
             continue;
         }
 
-        for child_id in command_relationships.child_ids(fact.id()) {
-            let child = command_relationships.fact(*child_id);
-            if matches!(
-                child.command(),
-                Command::Binary(child) if matches!(child.op, BinaryOp::And | BinaryOp::Or)
-            ) {
-                nested_list_commands.insert(*child_id);
-            }
-        }
+        record_nested_list_command(
+            &command.left,
+            fact.id(),
+            command_relationships,
+            &mut nested_list_commands,
+        );
+        record_nested_list_command(
+            &command.right,
+            fact.id(),
+            command_relationships,
+            &mut nested_list_commands,
+        );
     }
 
     commands
@@ -170,6 +173,20 @@ pub(super) fn build_list_facts<'a>(
         .collect()
 }
 
+fn record_nested_list_command(
+    stmt: &Stmt,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, '_>,
+    nested_list_commands: &mut FxHashSet<CommandId>,
+) {
+    if matches!(
+        &stmt.command,
+        Command::Binary(child) if matches!(child.op, BinaryOp::And | BinaryOp::Or)
+    ) && let Some(child) = command_relationships.child_or_lookup_fact(parent_id, stmt)
+    {
+        nested_list_commands.insert(child.id());
+    }
+}
 
 fn build_list_segment_facts<'a>(
     command: &BinaryCommand,
@@ -222,10 +239,13 @@ fn collect_list_stmt_segment_facts<'a>(
     if let Command::Binary(binary) = &stmt.command
         && matches!(binary.op, BinaryOp::And | BinaryOp::Or)
     {
+        let nested_parent_id = command_relationships
+            .child_or_lookup_fact(parent_id, stmt)?
+            .id();
         return collect_list_segment_facts(
             binary,
             command_relationships,
-            parent_id,
+            nested_parent_id,
             source,
             segments,
         );

--- a/crates/shuck-linter/src/facts/pipelines.rs
+++ b/crates/shuck-linter/src/facts/pipelines.rs
@@ -102,7 +102,10 @@ impl<'a> PipelineFact<'a> {
 pub(super) fn build_pipeline_facts<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
+    command_child_index: &CommandChildIndex,
 ) -> Vec<PipelineFact<'a>> {
+    let command_relationships =
+        CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     let mut nested_pipeline_commands = FxHashSet::default();
 
     for fact in commands {
@@ -113,19 +116,14 @@ pub(super) fn build_pipeline_facts<'a>(
             continue;
         }
 
-        if matches!(
-            &command.left.command,
-            Command::Binary(left) if matches!(left.op, BinaryOp::Pipe | BinaryOp::PipeAll)
-        ) && let Some(id) = command_id_for_command(&command.left.command, command_ids_by_span)
-        {
-            nested_pipeline_commands.insert(id);
-        }
-        if matches!(
-            &command.right.command,
-            Command::Binary(right) if matches!(right.op, BinaryOp::Pipe | BinaryOp::PipeAll)
-        ) && let Some(id) = command_id_for_command(&command.right.command, command_ids_by_span)
-        {
-            nested_pipeline_commands.insert(id);
+        for child_id in command_relationships.child_ids(fact.id()) {
+            let child = command_relationships.fact(*child_id);
+            if matches!(
+                child.command(),
+                Command::Binary(child) if matches!(child.op, BinaryOp::Pipe | BinaryOp::PipeAll)
+            ) {
+                nested_pipeline_commands.insert(*child_id);
+            }
         }
     }
 
@@ -147,7 +145,13 @@ pub(super) fn build_pipeline_facts<'a>(
                 command,
                 segments: segments
                     .into_iter()
-                    .map(|stmt| build_pipeline_segment_fact(stmt, commands, command_ids_by_span))
+                    .map(|stmt| {
+                        build_pipeline_segment_fact(
+                            stmt,
+                            command_relationships,
+                            fact.id(),
+                        )
+                    })
                     .collect::<Vec<_>>()
                     .into_boxed_slice(),
                 operators: pipeline_operator_facts(command),
@@ -212,10 +216,10 @@ fn collect_pipeline_operator_facts(command: &BinaryCommand, out: &mut Vec<Pipeli
 
 fn build_pipeline_segment_fact<'a>(
     stmt: &'a Stmt,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
+    parent_id: CommandId,
 ) -> PipelineSegmentFact<'a> {
-    let Some(fact) = command_fact_for_stmt(stmt, commands, command_ids_by_span) else {
+    let Some(fact) = command_relationships.child_or_lookup_fact(parent_id, stmt) else {
         unreachable!("pipeline segment should have a corresponding command fact");
     };
 

--- a/crates/shuck-linter/src/facts/pipelines.rs
+++ b/crates/shuck-linter/src/facts/pipelines.rs
@@ -116,15 +116,18 @@ pub(super) fn build_pipeline_facts<'a>(
             continue;
         }
 
-        for child_id in command_relationships.child_ids(fact.id()) {
-            let child = command_relationships.fact(*child_id);
-            if matches!(
-                child.command(),
-                Command::Binary(child) if matches!(child.op, BinaryOp::Pipe | BinaryOp::PipeAll)
-            ) {
-                nested_pipeline_commands.insert(*child_id);
-            }
-        }
+        record_nested_pipeline_command(
+            &command.left,
+            fact.id(),
+            command_relationships,
+            &mut nested_pipeline_commands,
+        );
+        record_nested_pipeline_command(
+            &command.right,
+            fact.id(),
+            command_relationships,
+            &mut nested_pipeline_commands,
+        );
     }
 
     commands
@@ -158,6 +161,21 @@ pub(super) fn build_pipeline_facts<'a>(
             })
         })
         .collect()
+}
+
+fn record_nested_pipeline_command(
+    stmt: &Stmt,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, '_>,
+    nested_pipeline_commands: &mut FxHashSet<CommandId>,
+) {
+    if matches!(
+        &stmt.command,
+        Command::Binary(child) if matches!(child.op, BinaryOp::Pipe | BinaryOp::PipeAll)
+    ) && let Some(child) = command_relationships.child_or_lookup_fact(parent_id, stmt)
+    {
+        nested_pipeline_commands.insert(child.id());
+    }
 }
 
 fn pipeline_segments(command: &Command) -> Option<Vec<&Stmt>> {

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -929,29 +929,34 @@ fn simple_test_is_numeric_binary_operator(text: &str) -> bool {
 pub(super) fn build_single_test_subshell_spans<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
+    command_child_index: &CommandChildIndex,
     source: &str,
 ) -> Vec<Span> {
+    let command_relationships =
+        CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     commands
         .iter()
-        .filter_map(|fact| single_test_subshell_span(fact, commands, command_ids_by_span, source))
+        .filter_map(|fact| single_test_subshell_span(fact, command_relationships, source))
         .collect()
 }
 
 pub(super) fn build_subshell_test_group_spans<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
+    command_child_index: &CommandChildIndex,
     source: &str,
 ) -> Vec<Span> {
+    let command_relationships =
+        CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     commands
         .iter()
-        .filter_map(|fact| subshell_test_group_span(fact, commands, command_ids_by_span, source))
+        .filter_map(|fact| subshell_test_group_span(fact, command_relationships, source))
         .collect()
 }
 
 fn single_test_subshell_span<'a>(
     fact: &CommandFact<'a>,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
 ) -> Option<Span> {
     let condition = match fact.command() {
@@ -965,7 +970,7 @@ fn single_test_subshell_span<'a>(
         return None;
     };
 
-    let condition_fact = command_fact_for_stmt(stmt, commands, command_ids_by_span)?;
+    let condition_fact = command_relationships.child_or_lookup_fact(fact.id(), stmt)?;
     let Command::Compound(CompoundCommand::Subshell(body)) = condition_fact.command() else {
         return None;
     };
@@ -974,15 +979,13 @@ fn single_test_subshell_span<'a>(
         return None;
     };
 
-    let body_fact = command_fact_for_stmt(body_stmt, commands, command_ids_by_span)?;
+    let body_fact = command_relationships.child_or_lookup_fact(condition_fact.id(), body_stmt)?;
     let simple_test = is_test_like_command(body_fact);
     if stmt.negated && !simple_test {
         return None;
     }
 
-    if !simple_test
-        && !is_test_condition_command(body_fact.command(), commands, command_ids_by_span)
-    {
+    if !simple_test && !is_test_condition_fact(body_fact, command_relationships) {
         return None;
     }
 
@@ -1004,32 +1007,37 @@ fn is_test_like_command(fact: &CommandFact<'_>) -> bool {
             ))
 }
 
-fn is_test_condition_command<'a>(
-    command: &'a Command,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+fn is_test_condition_fact<'a>(
+    fact: &CommandFact<'a>,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
-    match command {
+    match fact.command() {
         Command::Binary(binary) if matches!(binary.op, BinaryOp::And | BinaryOp::Or) => {
-            is_test_condition_command(&binary.left.command, commands, command_ids_by_span)
-                && is_test_condition_command(&binary.right.command, commands, command_ids_by_span)
+            let Some(left) = command_relationships.child_or_lookup_fact(fact.id(), &binary.left)
+            else {
+                return false;
+            };
+            let Some(right) = command_relationships.child_or_lookup_fact(fact.id(), &binary.right)
+            else {
+                return false;
+            };
+            is_test_condition_fact(left, command_relationships)
+                && is_test_condition_fact(right, command_relationships)
         }
-        _ => command_fact_for_command(command, commands, command_ids_by_span)
-            .is_some_and(is_test_like_command),
+        _ => is_test_like_command(fact),
     }
 }
 
 fn subshell_test_group_span<'a>(
     fact: &CommandFact<'a>,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
 ) -> Option<Span> {
     let Command::Compound(CompoundCommand::Subshell(body)) = fact.command() else {
         return None;
     };
 
-    if !subshell_body_contains_grouped_tests(body, commands, command_ids_by_span) {
+    if !subshell_body_contains_grouped_tests(body, fact.id(), command_relationships) {
         return None;
     }
 
@@ -1038,10 +1046,10 @@ fn subshell_test_group_span<'a>(
 
 fn subshell_body_contains_grouped_tests<'a>(
     body: &StmtSeq,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
-    subshell_body_analysis(body, commands, command_ids_by_span)
+    subshell_body_analysis(body, parent_id, command_relationships)
         .is_some_and(|analysis| analysis.has_grouping && analysis.test_count > 0)
 }
 
@@ -1053,49 +1061,48 @@ struct GroupedTestAnalysis {
 
 fn subshell_stmt_analysis<'a>(
     stmt: &Stmt,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> Option<GroupedTestAnalysis> {
-    subshell_command_analysis(&stmt.command, commands, command_ids_by_span)
+    let fact = command_relationships.child_or_lookup_fact(parent_id, stmt)?;
+    subshell_command_analysis(fact, command_relationships)
 }
 
 fn subshell_command_analysis<'a>(
-    command: &Command,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    fact: &CommandFact<'a>,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> Option<GroupedTestAnalysis> {
-    match command {
+    match fact.command() {
         Command::Simple(_)
         | Command::Builtin(_)
         | Command::Compound(CompoundCommand::Conditional(_)) => {
-            if let Some(id) = command_id_for_command(command, command_ids_by_span) {
-                let fact = command_fact(commands, id);
-                if is_test_like_command(fact) {
-                    return Some(GroupedTestAnalysis {
-                        test_count: 1,
-                        has_grouping: false,
-                    });
-                }
+            if is_test_like_command(fact) {
+                return Some(GroupedTestAnalysis {
+                    test_count: 1,
+                    has_grouping: false,
+                });
             }
             None
         }
         Command::Compound(CompoundCommand::BraceGroup(body)) => {
-            let inner = subshell_body_analysis(body, commands, command_ids_by_span)?;
+            let inner = subshell_body_analysis(body, fact.id(), command_relationships)?;
             Some(GroupedTestAnalysis {
                 test_count: inner.test_count,
                 has_grouping: true,
             })
         }
         Command::Compound(CompoundCommand::Subshell(body)) => {
-            let inner = subshell_body_analysis(body, commands, command_ids_by_span)?;
+            let inner = subshell_body_analysis(body, fact.id(), command_relationships)?;
             Some(GroupedTestAnalysis {
                 test_count: inner.test_count,
                 has_grouping: inner.has_grouping,
             })
         }
         Command::Binary(binary) if matches!(binary.op, BinaryOp::And | BinaryOp::Or) => {
-            let left = subshell_stmt_analysis(&binary.left, commands, command_ids_by_span)?;
-            let right = subshell_stmt_analysis(&binary.right, commands, command_ids_by_span)?;
+            let left =
+                subshell_stmt_analysis(&binary.left, fact.id(), command_relationships)?;
+            let right =
+                subshell_stmt_analysis(&binary.right, fact.id(), command_relationships)?;
             Some(GroupedTestAnalysis {
                 test_count: left.test_count + right.test_count,
                 has_grouping: true,
@@ -1107,8 +1114,8 @@ fn subshell_command_analysis<'a>(
 
 fn subshell_body_analysis<'a>(
     body: &StmtSeq,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> Option<GroupedTestAnalysis> {
     let mut analysis = GroupedTestAnalysis::default();
 
@@ -1117,7 +1124,7 @@ fn subshell_body_analysis<'a>(
     }
 
     for stmt in &body.stmts {
-        let stmt_analysis = subshell_stmt_analysis(stmt, commands, command_ids_by_span)?;
+        let stmt_analysis = subshell_stmt_analysis(stmt, parent_id, command_relationships)?;
         analysis.test_count += stmt_analysis.test_count;
         analysis.has_grouping |= stmt_analysis.has_grouping;
     }

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -152,6 +152,7 @@ fn populate_substitution_fact_ranges<'a>(
     commands: &mut [CommandFact<'a>],
     fact_store: &mut FactStore<'a>,
     command_ids_by_span: &CommandLookupIndex,
+    command_child_index: &CommandChildIndex,
     source: &str,
 ) {
     for index in 0..commands.len() {
@@ -160,7 +161,13 @@ fn populate_substitution_fact_ranges<'a>(
             let fact = command_facts
                 .get(index)
                 .expect("command index should resolve while populating substitution facts");
-            build_command_substitution_facts(fact, command_facts, command_ids_by_span, source)
+            build_command_substitution_facts(
+                fact,
+                command_facts,
+                command_ids_by_span,
+                command_child_index,
+                source,
+            )
         };
         commands[index].substitution_facts = fact_store.substitution_facts.push_many(substitutions);
     }
@@ -170,13 +177,19 @@ fn build_command_substitution_facts<'a>(
     fact: CommandFactRef<'_, 'a>,
     commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
+    command_child_index: &CommandChildIndex,
     source: &str,
 ) -> Vec<SubstitutionFact> {
     let mut substitutions = Vec::new();
     let mut substitution_index = FxHashMap::default();
     let context = SubstitutionFactBuildContext {
         commands,
-        command_ids_by_span,
+        command_relationships: CommandRelationshipContext::new(
+            commands.commands,
+            command_ids_by_span,
+            command_child_index,
+        ),
+        host_command_id: fact.id(),
         source,
     };
 
@@ -284,7 +297,8 @@ fn collect_or_update_heredoc_body_substitution_facts<'a>(
 #[derive(Clone, Copy)]
 struct SubstitutionFactBuildContext<'a, 'b> {
     commands: CommandFacts<'b, 'a>,
-    command_ids_by_span: &'b CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'b, 'a>,
+    host_command_id: CommandId,
     source: &'b str,
 }
 
@@ -308,7 +322,8 @@ fn collect_or_update_substitution_facts_from_occurrences<'a>(
         let body_facts = classify_substitution_body(
             occurrence.body,
             context.commands,
-            context.command_ids_by_span,
+            context.command_relationships,
+            context.host_command_id,
             context.source,
         );
         substitution_index.insert(key, substitutions.len());
@@ -521,7 +536,8 @@ struct RedirectSummary {
 fn classify_substitution_body<'a>(
     body: &'a StmtSeq,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
+    parent_id: CommandId,
     source: &str,
 ) -> SubstitutionBodyFacts {
     let visits = iter_commands(
@@ -532,7 +548,7 @@ fn classify_substitution_body<'a>(
     )
     .collect::<Vec<_>>();
     let redirect_summary =
-        summarize_stmt_seq_redirects(body, commands, command_ids_by_span, source);
+        summarize_stmt_seq_redirects(body, parent_id, commands, command_relationships, source);
 
     SubstitutionBodyFacts {
         stdout_intent: redirect_summary.stdout_intent,
@@ -542,11 +558,12 @@ fn classify_substitution_body<'a>(
         stdout_dev_null_redirect_spans: redirect_summary
             .stdout_dev_null_redirect_spans
             .into_boxed_slice(),
-        body_contains_ls: substitution_body_contains_ls(body, commands, command_ids_by_span),
+        body_contains_ls: substitution_body_contains_ls(body, parent_id, command_relationships),
         body_processed_ls_pipeline_spans: substitution_body_processed_ls_pipeline_spans(
             body,
+            parent_id,
             commands,
-            command_ids_by_span,
+            command_relationships,
             source,
         )
         .into_boxed_slice(),
@@ -557,9 +574,13 @@ fn classify_substitution_body<'a>(
         body_is_pgrep_lookup: substitution_body_is_pgrep_lookup(
             body,
             commands,
-            command_ids_by_span,
+            command_relationships.command_ids_by_span,
         ),
-        body_is_seq_utility: substitution_body_is_seq_utility(body, commands, command_ids_by_span),
+        body_is_seq_utility: substitution_body_is_seq_utility(
+            body,
+            commands,
+            command_relationships.command_ids_by_span,
+        ),
         body_has_commands: !visits.is_empty(),
         bash_file_slurp: matches!(visits.as_slice(), [visit] if is_bash_file_slurp_command(visit.command, visit.redirects, source)),
     }
@@ -567,8 +588,9 @@ fn classify_substitution_body<'a>(
 
 fn summarize_stmt_seq_redirects<'a>(
     body: &'a StmtSeq,
+    parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
 ) -> RedirectSummary {
     let mut summary = RedirectSummary {
@@ -581,7 +603,8 @@ fn summarize_stmt_seq_redirects<'a>(
     let mut saw_stmt = false;
 
     for stmt in &body.stmts {
-        let stmt_summary = summarize_stmt_redirects(stmt, commands, command_ids_by_span, source);
+        let stmt_summary =
+            summarize_stmt_redirects(stmt, parent_id, commands, command_relationships, source);
         summary = merge_redirect_summaries(summary, stmt_summary, saw_stmt);
         saw_stmt = true;
     }
@@ -591,20 +614,43 @@ fn summarize_stmt_seq_redirects<'a>(
 
 fn summarize_stmt_redirects<'a>(
     stmt: &'a Stmt,
+    parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
 ) -> RedirectSummary {
     match &stmt.command {
         Command::Binary(binary) => match binary.op {
             BinaryOp::Pipe | BinaryOp::PipeAll => {
-                summarize_stmt_redirects(&binary.right, commands, command_ids_by_span, source)
+                let child_parent_id = command_relationships
+                    .child_or_lookup_fact(parent_id, stmt)
+                    .map_or(parent_id, CommandFact::id);
+                summarize_stmt_redirects(
+                    &binary.right,
+                    child_parent_id,
+                    commands,
+                    command_relationships,
+                    source,
+                )
             }
             BinaryOp::And | BinaryOp::Or => {
-                let left =
-                    summarize_stmt_redirects(&binary.left, commands, command_ids_by_span, source);
-                let right =
-                    summarize_stmt_redirects(&binary.right, commands, command_ids_by_span, source);
+                let child_parent_id = command_relationships
+                    .child_or_lookup_fact(parent_id, stmt)
+                    .map_or(parent_id, CommandFact::id);
+                let left = summarize_stmt_redirects(
+                    &binary.left,
+                    child_parent_id,
+                    commands,
+                    command_relationships,
+                    source,
+                );
+                let right = summarize_stmt_redirects(
+                    &binary.right,
+                    child_parent_id,
+                    commands,
+                    command_relationships,
+                    source,
+                );
                 merge_redirect_summaries(left, right, true)
             }
         },
@@ -630,21 +676,30 @@ fn summarize_stmt_redirects<'a>(
             | CompoundCommand::Time(_)
             | CompoundCommand::Coproc(_)
             | CompoundCommand::Always(_),
-        ) => summarize_command_redirects(&stmt.command, &stmt.redirects, commands, command_ids_by_span, source),
+        ) => summarize_command_redirects(
+            stmt,
+            parent_id,
+            commands,
+            command_relationships,
+            source,
+        ),
     }
 }
 
 fn summarize_command_redirects<'a>(
-    command: &Command,
-    redirects: &[Redirect],
+    stmt: &Stmt,
+    parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
 ) -> RedirectSummary {
-    if let Some(id) = command_id_for_command(command, command_ids_by_span) {
+    if let Some(id) = command_relationships
+        .child_id_for_command(parent_id, &stmt.command)
+        .or_else(|| command_relationships.id_for_command(&stmt.command))
+    {
         summarize_redirect_facts(command_fact_ref(commands, id).redirect_facts(), source)
     } else {
-        let redirect_facts = build_redirect_facts(redirects, None, source, None);
+        let redirect_facts = build_redirect_facts(&stmt.redirects, None, source, None);
         summarize_redirect_facts(&redirect_facts, source)
     }
 }
@@ -1008,18 +1063,19 @@ fn leading_dynamic_dash_literal_in_parts(
 
 fn substitution_body_contains_ls<'a>(
     body: &'a StmtSeq,
-    commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     body.stmts
         .iter()
-        .any(|stmt| stmt_contains_raw_ls(stmt, commands, command_ids_by_span))
+        .any(|stmt| stmt_contains_raw_ls(stmt, parent_id, command_relationships))
 }
 
 fn substitution_body_processed_ls_pipeline_spans<'a>(
     body: &'a StmtSeq,
+    parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
 ) -> Vec<Span> {
     let mut spans = Vec::new();
@@ -1031,8 +1087,9 @@ fn substitution_body_processed_ls_pipeline_spans<'a>(
     ) {
         collect_processed_ls_pipeline_spans_in_stmt(
             visit.stmt,
+            parent_id,
             commands,
-            command_ids_by_span,
+            command_relationships,
             source,
             &mut spans,
         );
@@ -1042,8 +1099,9 @@ fn substitution_body_processed_ls_pipeline_spans<'a>(
 
 fn collect_processed_ls_pipeline_spans_in_stmt<'a>(
     stmt: &'a Stmt,
+    parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
@@ -1059,18 +1117,23 @@ fn collect_processed_ls_pipeline_spans_in_stmt<'a>(
     collect_pipeline_parts(binary, &mut segments, &mut operators);
 
     for (index, pair) in segments.windows(2).enumerate() {
-        if stmt_is_raw_ls(pair[0], commands, command_ids_by_span, source)
+        let pipeline_id = command_relationships
+            .child_or_lookup_fact(parent_id, stmt)
+            .map_or(parent_id, CommandFact::id);
+        if stmt_is_raw_ls(pair[0], pipeline_id, commands, command_relationships, source)
             && !stmt_static_utility_name_is(
                 pair[1],
+                pipeline_id,
                 commands,
-                command_ids_by_span,
+                command_relationships,
                 source,
                 "grep",
             )
             && !stmt_static_utility_name_is(
                 pair[1],
+                pipeline_id,
                 commands,
-                command_ids_by_span,
+                command_relationships,
                 source,
                 "xargs",
             )
@@ -1078,8 +1141,9 @@ fn collect_processed_ls_pipeline_spans_in_stmt<'a>(
             spans.push(ls_command_span_before_pipe(
                 pair[0],
                 operators[index],
+                pipeline_id,
                 commands,
-                command_ids_by_span,
+                command_relationships,
                 source,
             ));
         }
@@ -1110,11 +1174,16 @@ fn collect_pipeline_parts<'a>(
 
 fn stmt_is_raw_ls<'a>(
     stmt: &'a Stmt,
+    parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
 ) -> bool {
-    if let Some(fact) = command_fact_ref_for_stmt(stmt, commands, command_ids_by_span) {
+    if let Some(fact) = command_relationships
+        .child_id_for_command(parent_id, &stmt.command)
+        .or_else(|| command_relationships.id_for_command(&stmt.command))
+        .map(|id| command_fact_ref(commands, id))
+    {
         return fact.literal_name() == Some("ls") && fact.wrappers().is_empty();
     }
 
@@ -1124,12 +1193,17 @@ fn stmt_is_raw_ls<'a>(
 
 fn stmt_static_utility_name_is<'a>(
     stmt: &'a Stmt,
+    parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
     name: &str,
 ) -> bool {
-    if let Some(fact) = command_fact_ref_for_stmt(stmt, commands, command_ids_by_span) {
+    if let Some(fact) = command_relationships
+        .child_id_for_command(parent_id, &stmt.command)
+        .or_else(|| command_relationships.id_for_command(&stmt.command))
+        .map(|id| command_fact_ref(commands, id))
+    {
         return fact.static_utility_name() == Some(name);
     }
 
@@ -1139,11 +1213,15 @@ fn stmt_static_utility_name_is<'a>(
 fn ls_command_span_before_pipe<'a>(
     stmt: &'a Stmt,
     operator_span: Span,
+    parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
 ) -> Span {
-    let start = command_fact_ref_for_stmt(stmt, commands, command_ids_by_span)
+    let start = command_relationships
+        .child_id_for_command(parent_id, &stmt.command)
+        .or_else(|| command_relationships.id_for_command(&stmt.command))
+        .map(|id| command_fact_ref(commands, id))
         .and_then(|fact| fact.shellcheck_command_span(source))
         .unwrap_or_else(|| command::normalize_command(&stmt.command, source).body_span)
         .start;
@@ -1168,25 +1246,38 @@ fn substitution_body_contains_grep(body: &StmtSeq, source: &str) -> bool {
 
 fn stmt_contains_raw_ls<'a>(
     stmt: &'a Stmt,
-    commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
-    command_fact_ref_for_stmt(stmt, commands, command_ids_by_span)
+    command_relationships
+        .child_or_lookup_fact(parent_id, stmt)
         .is_some_and(|fact| fact.literal_name() == Some("ls") && fact.wrappers().is_empty())
         || match &stmt.command {
             Command::Binary(binary) => {
-                stmt_contains_raw_ls(&binary.left, commands, command_ids_by_span)
-                    || stmt_contains_raw_ls(&binary.right, commands, command_ids_by_span)
+                let child_parent_id = command_relationships
+                    .child_or_lookup_fact(parent_id, stmt)
+                    .map_or(parent_id, CommandFact::id);
+                stmt_contains_raw_ls(&binary.left, child_parent_id, command_relationships)
+                    || stmt_contains_raw_ls(&binary.right, child_parent_id, command_relationships)
             }
             Command::Compound(CompoundCommand::Subshell(body))
-            | Command::Compound(CompoundCommand::BraceGroup(body)) => body
-                .stmts
-                .iter()
-                .any(|stmt| stmt_contains_raw_ls(stmt, commands, command_ids_by_span)),
-            Command::Compound(CompoundCommand::Time(command)) => command
-                .command
-                .as_deref()
-                .is_some_and(|stmt| stmt_contains_raw_ls(stmt, commands, command_ids_by_span)),
+            | Command::Compound(CompoundCommand::BraceGroup(body)) => {
+                let child_parent_id = command_relationships
+                    .child_or_lookup_fact(parent_id, stmt)
+                    .map_or(parent_id, CommandFact::id);
+                body.stmts
+                    .iter()
+                    .any(|stmt| stmt_contains_raw_ls(stmt, child_parent_id, command_relationships))
+            }
+            Command::Compound(CompoundCommand::Time(command)) => {
+                let child_parent_id = command_relationships
+                    .child_or_lookup_fact(parent_id, stmt)
+                    .map_or(parent_id, CommandFact::id);
+                command
+                    .command
+                    .as_deref()
+                    .is_some_and(|stmt| stmt_contains_raw_ls(stmt, child_parent_id, command_relationships))
+            }
             Command::Compound(
                 CompoundCommand::If(_)
                 | CompoundCommand::For(_)

--- a/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
+++ b/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
@@ -261,6 +261,21 @@ rc=0 && run || fallback && rc=$?
         let source = "\
 check_download_exists \"$path\" && download_status=0 || download_status=$?
 __rvm_select_set_variable_defaults && __rvm_select_after_parse || return $?
+run \"Reloading\" sig USR2 &&
+wait_pid_kill 5 &&
+oldsig QUIT ||
+oldsig TERM ||
+cmd_restart ||
+return $?
+cmd_reload()
+{
+  run \"Reloading\" sig USR2 &&
+  wait_pid_kill 5 &&
+  oldsig QUIT ||
+  oldsig TERM ||
+  cmd_restart ||
+  return $?
+}
 test -d x && mv x y || :
 test -d x && mv x y || true
 test -d x && mv x y || /bin/true


### PR DESCRIPTION
## Summary
- build command parent relationships and compact child edges during facts construction
- add a command relationship context for facts builders to prefer child-edge lookups with span fallback
- route pipeline/list/simple-test/substitution relationship users through the compact child context while keeping command_ids_by_span available

## Verification
- cargo test -p shuck-linter precomputes_command_containment_and_barrier_flags_for_nested_commands -- --nocapture
- cargo test -p shuck-linter precomputes_innermost_command_ids_for_nested_offsets -- --nocapture
- cargo test -p shuck-linter
- make test
- cargo bench -p shuck-benchmark --bench linter -- all --noplot

## Benchmark Notes
- baseline before this branch: linter_facts/all mean ~36.548 ms; linter/all mean ~80.381 ms
- after this branch during local measurement: linter_facts/all mean ~34.668 ms; linter/all mean ~74.669 ms
- local benchmark results were treated as noisy because the machine may have been under load; the focused aggregate cases showed improvement/no regression
