### PR TITLE
perf(linter): reuse command relationships in more facts

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -483,9 +483,18 @@ impl<'a> LinterFactsBuilder<'a> {
             &structural_command_ids,
             self.source,
         );
-        let for_headers = build_for_header_facts(&commands, &command_ids_by_span, self.source);
-        let select_headers =
-            build_select_header_facts(&commands, &command_ids_by_span, self.source);
+        let for_headers = build_for_header_facts(
+            &commands,
+            &command_ids_by_span,
+            &command_child_index,
+            self.source,
+        );
+        let select_headers = build_select_header_facts(
+            &commands,
+            &command_ids_by_span,
+            &command_child_index,
+            self.source,
+        );
         let case_items = build_case_item_facts(&commands, self.source);
         let case_pattern_shadows = build_case_pattern_shadow_facts(&commands, self.source);
         let case_pattern_impossible_spans =
@@ -513,7 +522,12 @@ impl<'a> LinterFactsBuilder<'a> {
             );
         annotate_conditional_assignment_value_paths(self.semantic, &lists, &mut binding_values);
         let statement_facts =
-            build_statement_facts(&commands, &command_ids_by_span, &self.file.body);
+            build_statement_facts(
+                &commands,
+                &command_ids_by_span,
+                &command_child_index,
+                &self.file.body,
+            );
         let background_semicolon_spans =
             build_background_semicolon_spans(&commands, &case_items, self.source);
         let single_test_subshell_spans =

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1282,6 +1282,30 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
         self.id_for_command(command).map(|id| self.fact(id))
     }
 
+    fn fact_for_command_with_parent(
+        self,
+        parent_id: Option<CommandId>,
+        command: &Command,
+    ) -> Option<&'facts CommandFact<'a>> {
+        parent_id
+            .and_then(|parent_id| self.child_id_for_command(parent_id, command))
+            .map(|id| self.fact(id))
+            .or_else(|| self.fact_for_command(command))
+    }
+
+    fn fact_for_command_lookup_with_parent(
+        self,
+        parent_id: Option<CommandId>,
+        command: &Command,
+    ) -> Option<&'facts CommandFact<'a>> {
+        self.fact_for_command(command).or_else(|| {
+            parent_id.and_then(|parent_id| {
+                self.child_id_for_command(parent_id, command)
+                    .map(|id| self.fact(id))
+            })
+        })
+    }
+
     fn fact_for_stmt(self, stmt: &Stmt) -> Option<&'facts CommandFact<'a>> {
         self.fact_for_command(&stmt.command)
     }
@@ -1308,6 +1332,22 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
             .or_else(|| self.fact_for_stmt(stmt))
     }
 
+    fn fact_for_stmt_with_parent(
+        self,
+        parent_id: Option<CommandId>,
+        stmt: &Stmt,
+    ) -> Option<&'facts CommandFact<'a>> {
+        self.fact_for_command_with_parent(parent_id, &stmt.command)
+    }
+
+    fn fact_for_stmt_lookup_with_parent(
+        self,
+        parent_id: Option<CommandId>,
+        stmt: &Stmt,
+    ) -> Option<&'facts CommandFact<'a>> {
+        self.fact_for_stmt(stmt)
+            .or_else(|| parent_id.and_then(|parent_id| self.child_fact_for_stmt(parent_id, stmt)))
+    }
 }
 
 fn build_command_parent_ids(
@@ -1425,22 +1465,6 @@ fn trim_trailing_whitespace_span(span: Span, source: &str) -> Span {
     Span::from_positions(span.start, span.start.advanced_by(trimmed))
 }
 
-fn command_fact_for_command<'a>(
-    command: &Command,
-    commands: &'a [CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-) -> Option<&'a CommandFact<'a>> {
-    command_id_for_command(command, command_ids_by_span).map(|id| command_fact(commands, id))
-}
-
-fn command_fact_for_stmt<'a>(
-    stmt: &Stmt,
-    commands: &'a [CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-) -> Option<&'a CommandFact<'a>> {
-    command_fact_for_command(&stmt.command, commands, command_ids_by_span)
-}
-
 fn child_command_id_for_command(
     parent_id: CommandId,
     command: &Command,
@@ -1452,14 +1476,6 @@ fn child_command_id_for_command(
         .iter()
         .copied()
         .find(|id| std::ptr::eq(command_fact(commands, *id).command(), command))
-}
-
-fn command_fact_ref_for_stmt<'facts, 'a>(
-    stmt: &Stmt,
-    commands: CommandFacts<'facts, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
-) -> Option<CommandFactRef<'facts, 'a>> {
-    command_id_for_command(&stmt.command, command_ids_by_span).map(|id| command_fact_ref(commands, id))
 }
 
 fn builtin_span(command: &BuiltinCommand) -> Span {

--- a/crates/shuck-linter/src/facts/loop_headers.rs
+++ b/crates/shuck-linter/src/facts/loop_headers.rs
@@ -134,8 +134,11 @@ impl<'a> SelectHeaderFact<'a> {
 pub(super) fn build_for_header_facts<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
+    command_child_index: &CommandChildIndex,
     source: &str,
 ) -> Vec<ForHeaderFact<'a>> {
+    let command_relationships =
+        CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     commands
         .iter()
         .filter_map(|fact| {
@@ -149,8 +152,8 @@ pub(super) fn build_for_header_facts<'a>(
                 nested_word_command: fact.is_nested_word_command(),
                 words: build_loop_header_word_facts(
                     command.words.iter().flat_map(|words| words.iter()),
-                    commands,
-                    command_ids_by_span,
+                    fact.id(),
+                    command_relationships,
                     source,
                 ),
             })
@@ -161,8 +164,11 @@ pub(super) fn build_for_header_facts<'a>(
 pub(super) fn build_select_header_facts<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
+    command_child_index: &CommandChildIndex,
     source: &str,
 ) -> Vec<SelectHeaderFact<'a>> {
+    let command_relationships =
+        CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     commands
         .iter()
         .filter_map(|fact| {
@@ -176,8 +182,8 @@ pub(super) fn build_select_header_facts<'a>(
                 nested_word_command: fact.is_nested_word_command(),
                 words: build_loop_header_word_facts(
                     command.words.iter(),
-                    commands,
-                    command_ids_by_span,
+                    fact.id(),
+                    command_relationships,
                     source,
                 ),
             })
@@ -188,8 +194,8 @@ pub(super) fn build_select_header_facts<'a>(
 
 fn build_loop_header_word_facts<'a>(
     words: impl IntoIterator<Item = &'a Word>,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     source: &str,
 ) -> Box<[LoopHeaderWordFact<'a>]> {
     words
@@ -207,19 +213,19 @@ fn build_loop_header_word_facts<'a>(
                     && !word_spans::unquoted_command_substitution_part_spans(word).is_empty(),
                 contains_line_oriented_substitution: word_contains_line_oriented_substitution(
                     word,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                 ),
                 contains_ls_substitution: word_contains_command_substitution_named(
                     word,
                     "ls",
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                 ),
                 contains_find_substitution: word_contains_find_substitution(
                     word,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                 ),
             }
         })

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -1218,52 +1218,52 @@ fn mixed_short_circuit_operator_span(operators: &[ListOperatorFact]) -> Option<S
 
 fn word_contains_find_substitution<'a>(
     word: &'a Word,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     word.parts
         .iter()
-        .any(|part| part_contains_find_substitution(&part.kind, commands, command_ids_by_span))
+        .any(|part| part_contains_find_substitution(&part.kind, parent_id, command_relationships))
 }
 
 fn word_contains_line_oriented_substitution<'a>(
     word: &'a Word,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     word.parts.iter().any(|part| {
-        part_contains_line_oriented_substitution(&part.kind, commands, command_ids_by_span)
+        part_contains_line_oriented_substitution(&part.kind, parent_id, command_relationships)
     })
 }
 
 fn word_contains_command_substitution_named<'a>(
     word: &'a Word,
     name: &str,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     word.parts.iter().any(|part| {
-        part_contains_command_substitution_named(&part.kind, name, commands, command_ids_by_span)
+        part_contains_command_substitution_named(&part.kind, name, parent_id, command_relationships)
     })
 }
 
 fn part_contains_command_substitution_named<'a>(
     part: &WordPart,
     name: &str,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     match part {
         WordPart::DoubleQuoted { parts, .. } => parts.iter().any(|part| {
             part_contains_command_substitution_named(
                 &part.kind,
                 name,
-                commands,
-                command_ids_by_span,
+                parent_id,
+                command_relationships,
             )
         }),
         WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
-            substitution_body_is_simple_command_named(body, name, commands, command_ids_by_span)
+            substitution_body_is_simple_command_named(body, name, parent_id, command_relationships)
         }
         _ => false,
     }
@@ -1271,19 +1271,19 @@ fn part_contains_command_substitution_named<'a>(
 
 fn part_contains_line_oriented_substitution<'a>(
     part: &WordPart,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     match part {
         WordPart::DoubleQuoted { parts, .. } => parts.iter().any(|part| {
             part_contains_line_oriented_substitution(
                 &part.kind,
-                commands,
-                command_ids_by_span,
+                parent_id,
+                command_relationships,
             )
         }),
         WordPart::CommandSubstitution { body, .. } => {
-            substitution_body_is_line_oriented(body, commands, command_ids_by_span)
+            substitution_body_is_line_oriented(body, parent_id, command_relationships)
         }
         _ => false,
     }
@@ -1291,15 +1291,15 @@ fn part_contains_line_oriented_substitution<'a>(
 
 fn part_contains_find_substitution<'a>(
     part: &WordPart,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     match part {
-        WordPart::DoubleQuoted { parts, .. } => parts
-            .iter()
-            .any(|part| part_contains_find_substitution(&part.kind, commands, command_ids_by_span)),
+        WordPart::DoubleQuoted { parts, .. } => parts.iter().any(|part| {
+            part_contains_find_substitution(&part.kind, parent_id, command_relationships)
+        }),
         WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
-            substitution_body_is_find(body, commands, command_ids_by_span)
+            substitution_body_is_find(body, parent_id, command_relationships)
         }
         _ => false,
     }
@@ -1307,75 +1307,93 @@ fn part_contains_find_substitution<'a>(
 
 fn substitution_body_is_find<'a>(
     body: &'a StmtSeq,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
-    matches!(body.as_slice(), [stmt] if stmt_invokes_find(stmt, commands, command_ids_by_span))
+    matches!(body.as_slice(), [stmt] if stmt_invokes_find(stmt, parent_id, command_relationships))
 }
 
 fn substitution_body_is_line_oriented<'a>(
     body: &'a StmtSeq,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     matches!(
         body.as_slice(),
-        [stmt] if command_is_line_oriented_substitution_body(&stmt.command, commands, command_ids_by_span)
+        [stmt] if stmt_is_line_oriented_substitution_body(stmt, parent_id, command_relationships)
     )
 }
 
 fn substitution_body_is_pgrep_lookup<'a>(
     body: &'a StmtSeq,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     matches!(
         body.as_slice(),
         [stmt]
-            if stmt_effective_or_literal_basename_is_ref(stmt, "pgrep", commands, command_ids_by_span)
+            if stmt_effective_or_literal_basename_is_ref(
+                stmt,
+                "pgrep",
+                commands,
+                parent_id,
+                command_relationships,
+            )
     )
 }
 
 fn substitution_body_is_seq_utility<'a>(
     body: &'a StmtSeq,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     matches!(
         body.as_slice(),
-        [stmt] if stmt_effective_or_literal_basename_is_ref(stmt, "seq", commands, command_ids_by_span)
+        [stmt] if stmt_effective_or_literal_basename_is_ref(
+            stmt,
+            "seq",
+            commands,
+            parent_id,
+            command_relationships,
+        )
     )
 }
 
 fn substitution_body_is_simple_command_named<'a>(
     body: &'a StmtSeq,
     name: &str,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
-    matches!(body.as_slice(), [stmt] if stmt_literal_name_is(stmt, name, commands, command_ids_by_span))
+    matches!(body.as_slice(), [stmt] if stmt_literal_name_is(stmt, name, parent_id, command_relationships))
 }
 
 fn command_is_line_oriented_substitution_body<'a>(
     command: &'a Command,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
     match command {
         Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => {
-            command_fact_for_command(command, commands, command_ids_by_span)
+            command_relationships
+                .fact_for_command_lookup_with_parent(Some(parent_id), command)
                 .is_some_and(command_fact_is_line_oriented_utility)
         }
         Command::Binary(binary) => match binary.op {
             BinaryOp::Pipe | BinaryOp::PipeAll => {
+                let child_parent_id = command_relationships
+                    .fact_for_command_lookup_with_parent(Some(parent_id), command)
+                    .map_or(parent_id, CommandFact::id);
                 command_is_line_oriented_substitution_body(
                     &binary.left.command,
-                    commands,
-                    command_ids_by_span,
+                    child_parent_id,
+                    command_relationships,
                 ) && command_is_line_oriented_substitution_body(
                     &binary.right.command,
-                    commands,
-                    command_ids_by_span,
+                    child_parent_id,
+                    command_relationships,
                 )
             }
             BinaryOp::And | BinaryOp::Or => false,
@@ -1384,11 +1402,7 @@ fn command_is_line_oriented_substitution_body<'a>(
             .command
             .as_deref()
             .is_some_and(|stmt| {
-                command_is_line_oriented_substitution_body(
-                    &stmt.command,
-                    commands,
-                    command_ids_by_span,
-                )
+                stmt_is_line_oriented_substitution_body(stmt, parent_id, command_relationships)
             }),
         Command::Compound(
             CompoundCommand::If(_)
@@ -1411,6 +1425,21 @@ fn command_is_line_oriented_substitution_body<'a>(
     }
 }
 
+fn stmt_is_line_oriented_substitution_body<'a>(
+    stmt: &'a Stmt,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
+) -> bool {
+    let child_parent_id = command_relationships
+        .fact_for_stmt_lookup_with_parent(Some(parent_id), stmt)
+        .map_or(parent_id, CommandFact::id);
+    command_is_line_oriented_substitution_body(
+        &stmt.command,
+        child_parent_id,
+        command_relationships,
+    )
+}
+
 fn command_fact_is_line_oriented_utility(fact: &CommandFact<'_>) -> bool {
     if command_fact_invokes_find(fact) {
         return false;
@@ -1426,10 +1455,11 @@ fn command_fact_is_line_oriented_utility(fact: &CommandFact<'_>) -> bool {
 
 fn stmt_invokes_find<'a>(
     stmt: &'a Stmt,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
-    command_fact_for_stmt(stmt, commands, command_ids_by_span)
+    command_relationships
+        .fact_for_stmt_lookup_with_parent(Some(parent_id), stmt)
         .is_some_and(command_fact_invokes_find)
 }
 
@@ -1447,10 +1477,12 @@ fn command_name_matches_basename(name: Option<&str>, expected: &str) -> bool {
 fn stmt_literal_name_is<'a>(
     stmt: &'a Stmt,
     name: &str,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
-    command_fact_for_stmt(stmt, commands, command_ids_by_span).and_then(CommandFact::literal_name)
+    command_relationships
+        .fact_for_stmt_lookup_with_parent(Some(parent_id), stmt)
+        .and_then(CommandFact::literal_name)
         == Some(name)
 }
 
@@ -1458,9 +1490,12 @@ fn stmt_effective_or_literal_basename_is_ref<'a>(
     stmt: &'a Stmt,
     name: &str,
     commands: CommandFacts<'_, 'a>,
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: CommandId,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
 ) -> bool {
-    command_fact_ref_for_stmt(stmt, commands, command_ids_by_span)
+    command_relationships
+        .fact_for_stmt_lookup_with_parent(Some(parent_id), stmt)
+        .map(|fact| command_fact_ref(commands, fact.id()))
         .and_then(CommandFactRef::effective_or_literal_name)
         .is_some_and(|command_name| {
             command_name == name || command_name.rsplit('/').next() == Some(name)

--- a/crates/shuck-linter/src/facts/statements.rs
+++ b/crates/shuck-linter/src/facts/statements.rs
@@ -22,32 +22,36 @@ impl StatementFact {
 pub(super) fn build_statement_facts<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
+    command_child_index: &CommandChildIndex,
     body: &StmtSeq,
 ) -> Vec<StatementFact> {
+    let command_relationships =
+        CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
     let mut facts = Vec::new();
-    collect_statement_facts_in_stmt_seq(body, commands, command_ids_by_span, &mut facts);
+    collect_statement_facts_in_stmt_seq(body, None, command_relationships, &mut facts);
     facts
 }
 
 fn collect_statement_facts_in_stmt_seq<'a>(
     body: &StmtSeq,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: Option<CommandId>,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     facts: &mut Vec<StatementFact>,
 ) {
     for stmt in &body.stmts {
-        if let Some(id) = command_fact_for_stmt(stmt, commands, command_ids_by_span) {
+        let stmt_fact = command_relationships.fact_for_stmt_with_parent(parent_id, stmt);
+        if let Some(fact) = stmt_fact {
             facts.push(StatementFact {
                 body_span: body.span,
                 stmt_span: stmt.span,
-                command_id: id.id(),
+                command_id: fact.id(),
             });
         }
 
         collect_statement_sequence_facts_in_command(
             &stmt.command,
-            commands,
-            command_ids_by_span,
+            stmt_fact.map(CommandFact::id),
+            command_relationships,
             facts,
         );
     }
@@ -55,8 +59,8 @@ fn collect_statement_facts_in_stmt_seq<'a>(
 
 fn collect_statement_sequence_facts_in_command<'a>(
     command: &Command,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: Option<CommandId>,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     facts: &mut Vec<StatementFact>,
 ) {
     match command {
@@ -64,14 +68,14 @@ fn collect_statement_sequence_facts_in_command<'a>(
         Command::Binary(binary) => {
             collect_statement_sequence_facts_in_stmt(
                 &binary.left,
-                commands,
-                command_ids_by_span,
+                parent_id,
+                command_relationships,
                 facts,
             );
             collect_statement_sequence_facts_in_stmt(
                 &binary.right,
-                commands,
-                command_ids_by_span,
+                parent_id,
+                command_relationships,
                 facts,
             );
         }
@@ -79,86 +83,96 @@ fn collect_statement_sequence_facts_in_command<'a>(
             CompoundCommand::If(command) => {
                 collect_statement_facts_in_stmt_seq(
                     &command.condition,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
                 collect_statement_facts_in_stmt_seq(
                     &command.then_branch,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
                 for (condition, body) in &command.elif_branches {
                     collect_statement_facts_in_stmt_seq(
                         condition,
-                        commands,
-                        command_ids_by_span,
+                        parent_id,
+                        command_relationships,
                         facts,
                     );
-                    collect_statement_facts_in_stmt_seq(body, commands, command_ids_by_span, facts);
+                    collect_statement_facts_in_stmt_seq(
+                        body,
+                        parent_id,
+                        command_relationships,
+                        facts,
+                    );
                 }
                 if let Some(body) = &command.else_branch {
-                    collect_statement_facts_in_stmt_seq(body, commands, command_ids_by_span, facts);
+                    collect_statement_facts_in_stmt_seq(
+                        body,
+                        parent_id,
+                        command_relationships,
+                        facts,
+                    );
                 }
             }
             CompoundCommand::For(command) => {
                 collect_statement_facts_in_stmt_seq(
                     &command.body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
             }
             CompoundCommand::Repeat(command) => {
                 collect_statement_facts_in_stmt_seq(
                     &command.body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
             }
             CompoundCommand::Foreach(command) => {
                 collect_statement_facts_in_stmt_seq(
                     &command.body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
             }
             CompoundCommand::ArithmeticFor(command) => {
                 collect_statement_facts_in_stmt_seq(
                     &command.body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
             }
             CompoundCommand::While(command) => {
                 collect_statement_facts_in_stmt_seq(
                     &command.condition,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
                 collect_statement_facts_in_stmt_seq(
                     &command.body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
             }
             CompoundCommand::Until(command) => {
                 collect_statement_facts_in_stmt_seq(
                     &command.condition,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
                 collect_statement_facts_in_stmt_seq(
                     &command.body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
             }
@@ -166,8 +180,8 @@ fn collect_statement_sequence_facts_in_command<'a>(
                 for case in &command.cases {
                     collect_statement_facts_in_stmt_seq(
                         &case.body,
-                        commands,
-                        command_ids_by_span,
+                        parent_id,
+                        command_relationships,
                         facts,
                     );
                 }
@@ -175,21 +189,26 @@ fn collect_statement_sequence_facts_in_command<'a>(
             CompoundCommand::Select(command) => {
                 collect_statement_facts_in_stmt_seq(
                     &command.body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
             }
             CompoundCommand::Subshell(body) | CompoundCommand::BraceGroup(body) => {
-                collect_statement_facts_in_stmt_seq(body, commands, command_ids_by_span, facts);
+                collect_statement_facts_in_stmt_seq(
+                    body,
+                    parent_id,
+                    command_relationships,
+                    facts,
+                );
             }
             CompoundCommand::Arithmetic(_) | CompoundCommand::Conditional(_) => {}
             CompoundCommand::Time(command) => {
                 if let Some(inner) = &command.command {
                     collect_statement_sequence_facts_in_stmt(
                         inner,
-                        commands,
-                        command_ids_by_span,
+                        parent_id,
+                        command_relationships,
                         facts,
                     );
                 }
@@ -197,22 +216,22 @@ fn collect_statement_sequence_facts_in_command<'a>(
             CompoundCommand::Coproc(command) => {
                 collect_statement_sequence_facts_in_stmt(
                     &command.body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
             }
             CompoundCommand::Always(command) => {
                 collect_statement_facts_in_stmt_seq(
                     &command.body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
                 collect_statement_facts_in_stmt_seq(
                     &command.always_body,
-                    commands,
-                    command_ids_by_span,
+                    parent_id,
+                    command_relationships,
                     facts,
                 );
             }
@@ -220,16 +239,16 @@ fn collect_statement_sequence_facts_in_command<'a>(
         Command::Function(function) => {
             collect_statement_sequence_facts_in_stmt(
                 &function.body,
-                commands,
-                command_ids_by_span,
+                parent_id,
+                command_relationships,
                 facts,
             );
         }
         Command::AnonymousFunction(function) => {
             collect_statement_sequence_facts_in_stmt(
                 &function.body,
-                commands,
-                command_ids_by_span,
+                parent_id,
+                command_relationships,
                 facts,
             );
         }
@@ -238,15 +257,15 @@ fn collect_statement_sequence_facts_in_command<'a>(
 
 fn collect_statement_sequence_facts_in_stmt<'a>(
     stmt: &Stmt,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
+    parent_id: Option<CommandId>,
+    command_relationships: CommandRelationshipContext<'_, 'a>,
     facts: &mut Vec<StatementFact>,
 ) {
+    let stmt_fact = command_relationships.fact_for_stmt_with_parent(parent_id, stmt);
     collect_statement_sequence_facts_in_command(
         &stmt.command,
-        commands,
-        command_ids_by_span,
+        stmt_fact.map(CommandFact::id),
+        command_relationships,
         facts,
     );
 }
-

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -574,12 +574,14 @@ fn classify_substitution_body<'a>(
         body_is_pgrep_lookup: substitution_body_is_pgrep_lookup(
             body,
             commands,
-            command_relationships.command_ids_by_span,
+            parent_id,
+            command_relationships,
         ),
         body_is_seq_utility: substitution_body_is_seq_utility(
             body,
             commands,
-            command_relationships.command_ids_by_span,
+            parent_id,
+            command_relationships,
         ),
         body_has_commands: !visits.is_empty(),
         bash_file_slurp: matches!(visits.as_slice(), [visit] if is_bash_file_slurp_command(visit.command, visit.redirects, source)),


### PR DESCRIPTION
## Summary
- thread `CommandRelationshipContext` through statement fact collection and loop-header substitution scans
- use relationship-aware parent context for simple-test substitution helpers and pgrep/seq substitution body checks
- keep `command_ids_by_span` available for compatibility/debug lookup and preserve span-map fallback behavior

## Performance
Fresh focused Criterion comparison against `origin/main` / #592 (`585bbe96`), using a temp main worktree and shared Criterion target dir:
- `linter_facts/all`: main 34.246 ms -> branch 34.888 ms, Criterion change estimate -0.11%, p = 0.94; no change detected
- `linter/all`: main 76.392 ms -> branch 77.068 ms, Criterion change estimate -0.43%, p = 0.76; no change detected

An earlier child-edge-first variant regressed in these hot utility-name paths, so the final version keeps the hot path lookup-first and uses child edges as fallback. Current evidence says the final patch is correctness-preserving and performance-neutral within Criterion noise, not a clear speedup.

## Verification
- `cargo test -p shuck-linter precomputes_command_containment_and_barrier_flags_for_nested_commands -- --nocapture`
- `cargo test -p shuck-linter precomputes_innermost_command_ids_for_nested_offsets -- --nocapture`
- `cargo test -p shuck-linter`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C010 SHUCK_LARGE_CORPUS_KEEP_GOING=0`
- `git diff --check`
