### PR TITLE
fix(linter): align S001 safe optional values

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -13,13 +13,6 @@ reviewed_divergences:
     column: 38
     end_column: 50
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "HariSekhon__DevOps-Bash-tools__lib__docker.sh"
-    line: 125
-    end_line: 125
-    column: 56
-    end_column: 77
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
     line: 235
@@ -33,13 +26,6 @@ reviewed_divergences:
     end_line: 130
     column: 16
     end_column: 22
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__multimedia__ytdlp-gui__ytdlp-gui.SlackBuild"
-    line: 83
-    end_line: 83
-    column: 14
-    end_column: 21
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh"
@@ -126,53 +112,11 @@ reviewed_divergences:
     end_column: 31
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__db"
-    line: 1258
-    end_line: 1258
-    column: 4
-    end_column: 17
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
-    line: 585
-    end_line: 585
-    column: 7
-    end_column: 27
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
-    line: 591
-    end_line: 591
-    column: 5
-    end_column: 25
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
     line: 2620
     end_line: 2620
     column: 79
     end_column: 81
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__rrd"
-    line: 340
-    end_line: 340
-    column: 45
-    end_column: 55
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__speedtest"
-    line: 83
-    end_line: 83
-    column: 8
-    end_column: 10
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__speedtest"
-    line: 341
-    end_line: 341
-    column: 48
-    end_column: 60
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__tool"
@@ -182,67 +126,11 @@ reviewed_divergences:
     end_column: 45
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__vpn"
-    line: 396
-    end_line: 396
-    column: 28
-    end_column: 45
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
     line: 362
     end_line: 362
     column: 40
     end_column: 58
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 1289
-    end_line: 1289
-    column: 83
-    end_column: 90
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 1294
-    end_line: 1294
-    column: 12
-    end_column: 19
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 1299
-    end_line: 1299
-    column: 16
-    end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 1300
-    end_line: 1300
-    column: 77
-    end_column: 84
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 1438
-    end_line: 1438
-    column: 15
-    end_column: 24
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 1439
-    end_line: 1439
-    column: 9
-    end_column: 21
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 1442
-    end_line: 1442
-    column: 9
-    end_column: 21
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
@@ -252,25 +140,11 @@ reviewed_divergences:
     end_column: 15
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__wifi"
-    line: 2448
-    end_line: 2448
-    column: 9
-    end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__profile.d__kalua.sh"
     line: 11
     end_line: 11
     column: 33
     end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-build__mybuild.sh"
-    line: 1192
-    end_line: 1192
-    column: 41
-    end_column: 48
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_map.sh"
@@ -285,13 +159,6 @@ reviewed_divergences:
     end_line: 577
     column: 70
     end_column: 75
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
-    line: 1662
-    end_line: 1662
-    column: 8
-    end_column: 16
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
@@ -313,13 +180,6 @@ reviewed_divergences:
     end_line: 145
     column: 10
     end_column: 19
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__tests__test_all.sh"
-    line: 231
-    end_line: 231
-    column: 4
-    end_column: 6
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__archlinux-vm.sh"
@@ -631,31 +491,10 @@ reviewed_divergences:
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "nvm-sh__nvm__nvm.sh"
-    line: 104
-    end_line: 104
-    column: 28
-    end_column: 53
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "nvm-sh__nvm__nvm.sh"
     line: 3785
     end_line: 3785
     column: 16
     end_column: 25
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "nvm-sh__nvm__nvm.sh"
-    line: 4700
-    end_line: 4700
-    column: 8
-    end_column: 18
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "nvm-sh__nvm__nvm.sh"
-    line: 4701
-    end_line: 4701
-    column: 12
-    end_column: 22
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "nvm-sh__nvm__test__slow__nvm_get_latest__nvm_get_latest"
@@ -805,41 +644,6 @@ reviewed_divergences:
     end_column: 36
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "scop__bash-completion__completions-core__ping.bash"
-    line: 67
-    end_line: 67
-    column: 31
-    end_column: 39
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "scop__bash-completion__completions-core__ssh-keyscan.bash"
-    line: 49
-    end_line: 49
-    column: 31
-    end_column: 39
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "scop__bash-completion__completions-core__tracepath.bash"
-    line: 21
-    end_line: 21
-    column: 31
-    end_column: 39
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "scop__bash-completion__completions-fallback__mount.bash"
-    line: 37
-    end_line: 37
-    column: 26
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "scop__bash-completion__completions-fallback__mount.linux.bash"
-    line: 224
-    end_line: 224
-    column: 26
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "super-linter__super-linter__test__run-super-linter-tests.sh"
     line: 724
     end_line: 724
@@ -859,13 +663,6 @@ reviewed_divergences:
     end_line: 196
     column: 40
     end_column: 49
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__dart__build.sh"
-    line: 56
-    end_line: 56
-    column: 25
-    end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "termux__termux-packages__packages__lazygit__build.sh"
@@ -992,11 +789,4 @@ reviewed_divergences:
     end_line: 16442
     column: 11
     end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "void-linux__void-packages__common__build-style__void-cross.sh"
-    line: 377
-    end_line: 377
-    column: 12
-    end_column: 17
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -29,6 +29,12 @@ enum SourceTextLiteral<'a> {
     Quoted(&'a str),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldSafeBindingClass {
+    Empty,
+    NonEmpty,
+}
+
 impl SafeValueQuery {
     pub fn from_context(context: ExpansionContext) -> Option<Self> {
         match context {
@@ -365,6 +371,9 @@ impl<'a> SafeValueIndex<'a> {
         if query.is_field_context() && self.bindings_are_all_plain_empty_static_literals(&bindings)
         {
             return false;
+        }
+        if self.covering_optional_field_safe_bindings_can_stay_safe(&bindings, name, at, query) {
+            return true;
         }
         if self.optional_field_safe_bindings_can_stay_safe(&bindings, query) {
             return true;
@@ -838,6 +847,160 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         saw_name_only_declaration && saw_field_safe_value
+    }
+
+    fn covering_optional_field_safe_bindings_can_stay_safe(
+        &mut self,
+        bindings: &[BindingId],
+        name: &Name,
+        at: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        if !query.is_field_context()
+            || bindings.is_empty()
+            || bindings.iter().copied().any(|binding_id| {
+                self.semantic.binding(binding_id).span.end.offset > at.start.offset
+            })
+            || !self.bindings_cover_all_paths_to_reference(bindings, name, at)
+        {
+            return false;
+        }
+
+        let mut saw_empty = false;
+        let mut saw_non_empty = false;
+        let mut visiting = FxHashSet::default();
+        for binding_id in bindings.iter().copied() {
+            match self.field_safe_binding_class(binding_id, query, &mut visiting) {
+                Some(FieldSafeBindingClass::Empty) => saw_empty = true,
+                Some(FieldSafeBindingClass::NonEmpty) => saw_non_empty = true,
+                None => return false,
+            }
+        }
+
+        saw_empty && saw_non_empty
+    }
+
+    fn field_safe_binding_group_class(
+        &mut self,
+        bindings: &[BindingId],
+        query: SafeValueQuery,
+        visiting: &mut FxHashSet<BindingId>,
+    ) -> Option<FieldSafeBindingClass> {
+        let mut saw_non_empty = false;
+        for binding_id in bindings.iter().copied() {
+            match self.field_safe_binding_class(binding_id, query, visiting)? {
+                FieldSafeBindingClass::Empty => {}
+                FieldSafeBindingClass::NonEmpty => saw_non_empty = true,
+            }
+        }
+
+        Some(if saw_non_empty {
+            FieldSafeBindingClass::NonEmpty
+        } else {
+            FieldSafeBindingClass::Empty
+        })
+    }
+
+    fn field_safe_binding_class(
+        &mut self,
+        binding_id: BindingId,
+        query: SafeValueQuery,
+        visiting: &mut FxHashSet<BindingId>,
+    ) -> Option<FieldSafeBindingClass> {
+        if !visiting.insert(binding_id) {
+            return None;
+        }
+
+        let result = self.field_safe_binding_class_uncached(binding_id, query, visiting);
+        visiting.remove(&binding_id);
+        result
+    }
+
+    fn field_safe_binding_class_uncached(
+        &mut self,
+        binding_id: BindingId,
+        query: SafeValueQuery,
+        visiting: &mut FxHashSet<BindingId>,
+    ) -> Option<FieldSafeBindingClass> {
+        if self.binding_is_name_only_declaration(binding_id) {
+            return Some(FieldSafeBindingClass::Empty);
+        }
+
+        let binding = self.semantic.binding(binding_id);
+        if !matches!(
+            binding.kind,
+            BindingKind::Assignment | BindingKind::Declaration(_)
+        ) || self.facts.binding_value(binding_id).is_some_and(|value| {
+            value.one_sided_short_circuit_assignment() || value.conditional_assignment_shortcut()
+        }) {
+            return None;
+        }
+
+        match binding.origin {
+            BindingOrigin::Assignment {
+                value: AssignmentValueOrigin::StaticLiteral,
+                ..
+            }
+            | BindingOrigin::Declaration { .. } => {
+                self.static_field_safe_binding_class(binding_id, query)
+            }
+            BindingOrigin::Assignment {
+                value: AssignmentValueOrigin::PlainScalarAccess,
+                ..
+            } => self.plain_scalar_field_safe_binding_class(binding_id, query, visiting),
+            _ => None,
+        }
+    }
+
+    fn static_field_safe_binding_class(
+        &self,
+        binding_id: BindingId,
+        query: SafeValueQuery,
+    ) -> Option<FieldSafeBindingClass> {
+        let text = self
+            .facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())
+            .and_then(|word| static_word_text(word, self.source))?;
+        if text.is_empty() {
+            Some(FieldSafeBindingClass::Empty)
+        } else {
+            query
+                .literal_is_safe(&text)
+                .then_some(FieldSafeBindingClass::NonEmpty)
+        }
+    }
+
+    fn plain_scalar_field_safe_binding_class(
+        &mut self,
+        binding_id: BindingId,
+        query: SafeValueQuery,
+        visiting: &mut FxHashSet<BindingId>,
+    ) -> Option<FieldSafeBindingClass> {
+        if let Some(class) = self.static_field_safe_binding_class(binding_id, query) {
+            return Some(class);
+        }
+
+        let word = self
+            .facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())?;
+        let target_name = plain_scalar_reference_name(word)?;
+        let binding_span = self.semantic.binding(binding_id).span;
+        self.binding_value_stack.push(binding_id);
+        let prior_bindings = self.safe_bindings_for_name(&target_name, binding_span);
+        self.binding_value_stack.pop();
+        if prior_bindings.is_empty()
+            || !self.bindings_cover_all_paths_to_reference(
+                &prior_bindings,
+                &target_name,
+                binding_span,
+            )
+        {
+            return None;
+        }
+
+        self.field_safe_binding_group_class(&prior_bindings, query, visiting)
     }
 
     fn binding_is_safe(
@@ -2959,6 +3122,35 @@ fn literal_is_regex_safe(text: &str) -> bool {
     }
 
     !escaped
+}
+
+fn plain_scalar_reference_name(word: &Word) -> Option<Name> {
+    let [part] = word.parts.as_slice() else {
+        return None;
+    };
+    plain_scalar_reference_name_from_part(&part.kind)
+}
+
+fn plain_scalar_reference_name_from_part(part: &WordPart) -> Option<Name> {
+    match part {
+        WordPart::Variable(name) if !matches!(name.as_str(), "@" | "*") => Some(name.clone()),
+        WordPart::DoubleQuoted { parts, .. } => {
+            let [part] = parts.as_slice() else {
+                return None;
+            };
+            plain_scalar_reference_name_from_part(&part.kind)
+        }
+        WordPart::Parameter(parameter) => match &parameter.syntax {
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+                if reference.subscript.is_none()
+                    && !matches!(reference.name.as_str(), "@" | "*") =>
+            {
+                Some(reference.name.clone())
+            }
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 fn span_contains(container: Span, inner: Span) -> bool {

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2447,6 +2447,50 @@ f() {
     }
 
     #[test]
+    fn skips_mixed_empty_and_safe_branch_aliases() {
+        let source = "\
+#!/bin/bash
+SRCNAM64=foo
+SRCNAM32=
+COMPRESS=deb
+if [ \"$ARCH\" = i586 ]; then
+  SRCNAM=\"$SRCNAM32\"
+elif [ \"$ARCH\" = x86_64 ]; then
+  SRCNAM=\"$SRCNAM64\"
+else
+  SRCNAM=
+fi
+ar x \"$CWD\"/$SRCNAM.$COMPRESS
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_all_empty_branch_aliases() {
+        let source = "\
+#!/bin/bash
+empty=
+if [ \"$1\" = yes ]; then
+  value=$empty
+else
+  value=
+fi
+printf '%s\\n' $value
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$value"]
+        );
+    }
+
+    #[test]
     fn reports_name_only_declarations_without_safe_assignments() {
         let source = "\
 #!/bin/bash

--- a/docs/rules/S001.yaml
+++ b/docs/rules/S001.yaml
@@ -10,8 +10,8 @@ shells:
   - bash
   - dash
   - ksh
-description: Ordinary scalar parameter expansions such as $1, $foo, and ${foo:-fallback} can split or match path patterns when they are used unquoted in a shell word.
-rationale: Quote scalar parameter expansions in split-sensitive positions, including inside command substitutions. Array-style splats and the outer $(...) form have their own rules.
+description: Ordinary scalar parameter expansions such as $1, $foo, and ${foo:-fallback} can split or match path patterns when they appear unquoted in argument-like shell words.
+rationale: Quote scalar parameter expansions in split-sensitive command arguments, command names, here-strings, redirect targets, file-descriptor duplication targets, and non-Bash declaration assignment values. This rule intentionally stays scoped to scalar expansions; unquoted command substitutions, @-style splats, and *-style splats are reported by their own ShellCheck-mapped rules.
 safe_fix: false
 fix_description: "Wrap the reported expansion in double quotes."
 source:


### PR DESCRIPTION
## Summary
- match S001/ShellCheck behavior for mixed empty and field-safe scalar branch aliases
- remove stale S001 reviewed-divergence metadata now absent from the refreshed corpus report
- clarify S001 docs around scalar-only scope and sibling ShellCheck-mapped rules

## Verification
- cargo test -p shuck-linter unquoted_expansion
- cargo test -p shuck-linter
- cargo test -p shuck-linter build_script
- make large-corpus-report SHUCK_LARGE_CORPUS_RULES=S001