### PR TITLE
fix(linter): align S001 indirect expansion parity

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -364,13 +364,6 @@ reviewed_divergences:
     end_column: 109
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "gentoo__gentoo__dev-libs__kpathsea__files__texmf-update-r2"
-    line: 28
-    end_line: 28
-    column: 15
-    end_column: 25
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "gentoo__gentoo__eclass__tests__toolchain-funcs.sh"
     line: 61
     end_line: 61
@@ -383,13 +376,6 @@ reviewed_divergences:
     end_line: 155
     column: 7
     end_column: 13
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__net-vpn__derper__files__derper-pre.sh"
-    line: 44
-    end_line: 44
-    column: 12
-    end_column: 19
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "google__oss-fuzz__projects__threetenbp__build.sh"

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1600,27 +1600,7 @@ impl<'a> SafeValueIndex<'a> {
         if query != SafeValueQuery::Quoted && reference.has_array_selector() {
             return false;
         }
-        if self.maybe_uninitialized_refs.contains(&FactSpan::new(at)) {
-            return false;
-        }
-
-        let bindings = self.safe_bindings_for_name(&reference.name, at);
-        if bindings.is_empty() {
-            return false;
-        }
-        let case_cli_scope = query
-            .is_field_context()
-            .then(|| self.case_cli_dispatch_scope_at(at.start.offset))
-            .flatten();
-
-        bindings.into_iter().all(|binding_id| {
-            let targets = self.semantic.indirect_targets_for_binding(binding_id);
-            !targets.is_empty()
-                && targets
-                    .iter()
-                    .copied()
-                    .all(|target| self.binding_is_safe(target, at, query, case_cli_scope))
-        })
+        self.reference_is_safe(reference, at, query)
     }
 
     fn safe_bindings_for_name(&mut self, name: &Name, at: Span) -> Vec<BindingId> {

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -4126,7 +4126,31 @@ printf '%s\\n' ${!name} $a
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["${!name}", "$a"]
+            vec!["$a"]
+        );
+    }
+
+    #[test]
+    fn indirect_expansions_follow_visible_name_safety() {
+        let source = "\
+#!/bin/bash
+target='a b'
+name=target
+printf '%s\\n' ${!name}
+for loop_name in target unset_name; do
+  printf '%s\\n' ${!loop_name}
+done
+dynamic=$1
+printf '%s\\n' ${!dynamic}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${!dynamic}"]
         );
     }
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -1,0 +1,163 @@
+# S001 Reviewed Divergence Bugs
+
+This file classifies the current reviewed S001/SC2086 large-corpus divergences.
+The source of truth was a fresh `make large-corpus-report SHUCK_LARGE_CORPUS_RULES=S001`
+run with ShellCheck 0.11.0.
+
+Current summary from `target/large-corpus-report/latest.log`:
+
+- `implementation_diffs=0`
+- `mapping_issues=0`
+- `reviewed_divergences=70`
+- Individual reviewed records classified below: 111 total (`shellcheck-only=23`, `shuck-only=88`).
+
+The harness summary counts reviewed divergence groups. This document lists the individual
+diagnostic records that need to be cleared.
+
+When a record is fixed, remove the matching entry from
+`crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml` in the same change.
+Resolved records should not remain as reviewed divergences.
+
+## [ ] ShellCheck-only: status/return operand shuck marked safe (7)
+
+- `bittorf__kalua__openwrt-addons__etc__kalua__watch:2096:10-15` `$good`
+- `rvm__rvm__scripts__functions__manage__base_fetch:223:18-25` `$result`
+- `rvm__rvm__scripts__functions__manage__base_fetch:243:24-31` `$result`
+- `rvm__rvm__scripts__functions__manage__base_fetch:251:18-25` `$result`
+- `rvm__rvm__scripts__functions__manage__macruby:145:14-21` `$result`
+- `rvm__rvm__scripts__functions__requirements__osx_brew:485:55-74` `$homebrew_installer`
+- `rvm__rvm__scripts__functions__requirements__osx_brew:486:32-51` `$homebrew_installer`
+
+## [ ] ShellCheck-only: embedded path/URL/composite word (6)
+
+- `233boy__v2ray__src__core.sh:1254:39-43` `$net`
+- `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:651:70-80` `${project}`
+- `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:867:52-62` `${db_type}`
+- `megastep__makeself__test__variabletest:15:56-60` `${1}`
+- `rvm__rvm__scripts__functions__requirements__osx_brew:491:35-51` `${homebrew_repo}`
+- `termux__termux-packages__packages__lazygit__build.sh:26:30-50` `${SOURCE_DATE_EPOCH}`
+
+## [ ] ShellCheck-only: plain command argument (5)
+
+- `RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh:235:32-38` `$group`
+- `community-scripts__ProxmoxVE__vm__haos-vm.sh:636:23-35` `${DISK_SIZE}`
+- `community-scripts__ProxmoxVE__vm__mikrotik-routeros.sh:655:25-37` `${DISK_SIZE}`
+- `gentoo__gentoo__eclass__tests__toolchain.sh:155:7-13` `${ret}`
+- `nvm-sh__nvm__test__slow__nvm_get_latest__nvm_get_latest:26:10-14` `$URL`
+
+## [ ] ShellCheck-only: nested command substitution / here-string argument (3)
+
+- `bittorf__kalua__openwrt-monitoring__meshrdf_generate_map.sh:263:70-75` `$LINE`
+- `bittorf__kalua__openwrt-monitoring__meshrdf_generate_netjson.sh:577:70-75` `$LINE`
+- `google__oss-fuzz__projects__threetenbp__build.sh:57:37-47` `$JAVA_HOME`
+
+## [ ] ShellCheck-only: test/probe command operand (2)
+
+- `rvm__rvm__binscripts__rvm-installer:89:24-48` `${rvm_tar_command:-gtar}`
+- `tteck__Proxmox__vm__nextcloud-vm.sh:210:96-99` `$HN`
+
+## [ ] Shuck-only: embedded safe literal/composite word (38)
+
+- `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
+- `community-scripts__ProxmoxVE__vm__archlinux-vm.sh:547:31-44` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:615:27-36` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:616:25-38` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:622:27-36` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:623:25-38` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__debian-vm.sh:556:27-36` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__debian-vm.sh:557:25-38` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__debian-vm.sh:563:27-36` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__debian-vm.sh:564:25-38` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__nextcloud-vm.sh:542:25-34` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__nextcloud-vm.sh:543:23-36` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__nextcloud-vm.sh:544:23-36` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__opnsense-vm.sh:744:25-34` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__opnsense-vm.sh:745:23-36` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__owncloud-vm.sh:555:25-34` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__owncloud-vm.sh:556:23-36` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__owncloud-vm.sh:557:23-36` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__ubuntu2204-vm.sh:537:25-34` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__ubuntu2204-vm.sh:538:23-36` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh:539:25-34` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh:540:23-36` `${DISK_CACHE}`
+- `community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh:538:25-34` `${FORMAT}`
+- `community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh:539:23-36` `${DISK_CACHE}`
+- `rvm__rvm__scripts__functions__requirements__rvm_pkg:17:17-35` `${_read_char_flag}`
+- `rvm__rvm__scripts__functions__requirements__unknown:74:17-35` `${_read_char_flag}`
+- `tteck__Proxmox__vm__debian-vm.sh:409:25-34` `${FORMAT}`
+- `tteck__Proxmox__vm__debian-vm.sh:410:23-36` `${DISK_CACHE}`
+- `tteck__Proxmox__vm__haos-vm.sh:451:25-34` `${FORMAT}`
+- `tteck__Proxmox__vm__haos-vm.sh:452:23-36` `${DISK_CACHE}`
+- `tteck__Proxmox__vm__nextcloud-vm.sh:408:25-34` `${FORMAT}`
+- `tteck__Proxmox__vm__nextcloud-vm.sh:409:23-36` `${DISK_CACHE}`
+- `tteck__Proxmox__vm__owncloud-vm.sh:408:25-34` `${FORMAT}`
+- `tteck__Proxmox__vm__owncloud-vm.sh:409:23-36` `${DISK_CACHE}`
+- `tteck__Proxmox__vm__ubuntu2204-vm.sh:409:25-34` `${FORMAT}`
+- `tteck__Proxmox__vm__ubuntu2204-vm.sh:410:23-36` `${DISK_CACHE}`
+- `tteck__Proxmox__vm__ubuntu2404-vm.sh:399:25-34` `${FORMAT}`
+- `tteck__Proxmox__vm__ubuntu2404-vm.sh:400:23-36` `${DISK_CACHE}`
+
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (18)
+
+- `SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh:19:8-12` `$OLD`
+- `SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh:19:13-17` `$NEW`
+- `awslabs__git-secrets__git-secrets:124:5-17` `${RECURSIVE}`
+- `bats-core__bats-core__libexec__bats-core__bats-format-pretty:67:16-34` `$count_column_left`
+- `bats-core__bats-core__libexec__bats-core__bats-format-pretty:78:13-32` `$line_backoff_count`
+- `bittorf__kalua__openwrt-monitoring__ping_counter.sh:110:7-15` `$fileage`
+- `gentoo__gentoo__eclass__tests__toolchain-funcs.sh:61:6-12` `${ret}`
+- `google__oss-fuzz__projects__threetenbp__build.sh:56:89-99` `LD_LIBRARY_PATH`
+- `juewuy__ShellCrash__scripts__menus__2_settings.sh:360:41-51` `$redir_mod`
+- `juewuy__ShellCrash__scripts__menus__2_settings.sh:368:41-51` `$redir_mod`
+- `juewuy__ShellCrash__scripts__menus__2_settings.sh:377:41-51` `$redir_mod`
+- `ko1nksm__shellspec__lib__general.sh:442:15-39` `$shellspec_readfile_data`
+- `ko1nksm__shellspec__lib__libexec__shellspec.sh:94:37-39` `$c`
+- `kward__shunit2__.githooks__generic:30:11-22` `${basename}`
+- `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`
+- `pi-hole__pi-hole__automated install__basic-install.sh:1833:21-39` `${webInterfaceDir}`
+- `scop__bash-completion__completions-core__geoiplookup.bash:29:31-36` `$ipvx`
+- `termux__termux-packages__packages__lazygit__build.sh:25:41-61` `-ldflags`
+
+## [ ] Shuck-only: command-substitution initializer argument (13)
+
+- `CISOfy__lynis__include__functions:2690:38-50` `${TIME_DIFF}`
+- `SlackBuildsOrg__slackbuilds__libraries__libvirt__rc.libvirt:130:16-22` `$check`
+- `acmesh-official__acme.sh__dnsapi__dns_tencent.sh:113:32-40` `$service`
+- `acmesh-official__acme.sh__dnsapi__dns_tencent.sh:116:40-48` `$service`
+- `acmesh-official__acme.sh__dnsapi__dns_tencent.sh:116:49-57` `$version`
+- `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:245:36-43` `$tarpid`
+- `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`
+- `alpinelinux__aports__main__syslinux__update-extlinux:96:18-26` `$timeout`
+- `bittorf__kalua__openwrt-addons__etc__kalua__tool:87:36-45` `$UP_HOURS`
+- `juewuy__ShellCrash__scripts__menus__running_status.sh:11:28-35` `${time}`
+- `juewuy__ShellCrash__tools__tg_bot.sh:70:23-30` `${time}`
+- `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
+- `swoodford__aws__wafv2-web-acl-pingdom.sh:196:40-49` `$WAFSCOPE`
+
+## [ ] Shuck-only: numeric/test operand (9)
+
+- `bittorf__kalua__openwrt-addons__etc__kalua__watch:362:40-58` `${overall:-$count}`
+- `bittorf__kalua__openwrt-monitoring__send_sms.sh:145:10-19` `${pos:-0}`
+- `nvm-sh__nvm__nvm.sh:3785:16-25` `$nosource`
+- `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:191:14-30` `$download_status`
+- `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:215:18-34` `$download_status`
+- `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:221:20-36` `$download_status`
+- `super-linter__super-linter__test__run-super-linter-tests.sh:724:36-57` `${EXPECTED_EXIT_CODE}`
+- `tteck__Proxmox__misc__glances.sh:100:37-49` `$SPINNER_PID`
+- `tteck__Proxmox__misc__glances.sh:100:73-85` `$SPINNER_PID`
+
+## [ ] Shuck-only: status/return/exit operand (8)
+
+- `bittorf__kalua__openwrt-addons__etc__kalua__net:2620:79-81` `$?`
+- `bittorf__kalua__openwrt-addons__etc__profile.d__kalua.sh:11:33-36` `$rc`
+- `rvm__rvm__scripts__extras__chruby.sh:31:10-21` `${__result}`
+- `rvm__rvm__scripts__functions__build_requirements:160:10-29` `${__summary_status}`
+- `rvm__rvm__scripts__functions__manage__base_fetch:45:12-24` `${result:-0}`
+- `rvm__rvm__scripts__functions__manage__macruby:23:10-21` `${__result}`
+- `rvm__rvm__scripts__functions__requirements__openbsd:35:12-23` `${__result}`
+- `v1s1t0r1sh3r3__airgeddon__airgeddon.sh:16442:11-23` `${exit_code}`
+
+## [ ] Shuck-only: arithmetic/parameter-operator form (2)
+
+- `bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh:3374:6-27` `${inet_offer_down:-0}`
+- `dehydrated-io__dehydrated__dehydrated:1077:85-109` `${account_key_sigalgo:2}`


### PR DESCRIPTION
## Summary

- Align S001 indirect expansion handling with the ShellCheck SC2086 oracle: visible safe indirection names such as `name=target; echo ${!name}` are now treated as safe for S001, while dynamic names such as `name=$1; echo ${!name}` still report.
- Remove the two resolved indirect-expansion records from `crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml`.
- Add regression coverage for literal, loop-provided, and dynamic indirect expansion names.
- Add `docs/S001_BUGS.md` to classify the current reviewed S001 divergence buckets and track the remaining work, including the rule that fixed records must also be removed from S001 corpus metadata.

## Root Cause

S001 was checking whether the resolved indirect target value was safe. Black-box ShellCheck probes show SC2086 instead suppresses based on whether the visible indirection carrier is field-safe.

## Remaining Arithmetic/Operator Notes

The remaining two records in the arithmetic/operator bucket are still open and remain in metadata. Follow-up probing showed they are separate shapes:

- `meshrdf_generate_table.sh:3374`: likely needs a narrow field-safe rule for assignments whose whole RHS is an arithmetic expansion, not any value that merely contains arithmetic.
- `dehydrated:1077`: likely depends on helper/call-order value knowledge for safe literal assignments before substring expansion, not a broad substring suppression.

## Validation

- `cargo test -p shuck-linter indirect_ -- --nocapture`
- `cargo test -p shuck-linter unquoted_expansion`
- `cargo fmt --check`
- `make large-corpus-report SHUCK_LARGE_CORPUS_RULES=S001`

The targeted corpus report remains structurally clean with `implementation_diffs=0` and `mapping_issues=0`; reviewed divergences dropped from 72 to 70.
