### PR TITLE
perf(linter): index C063 activation windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
  "shuck-semantic",
  "tempfile",
  "tikv-jemallocator",
+ "walkdir",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-large-corpus-hotspots bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
+.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-large-corpus-hotspots bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view profile-large-corpus profile-large-corpus-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
 
 ARGS ?= --help
 BENCH_FILE ?=
@@ -15,6 +15,8 @@ PROFILE_FILE ?= crates/shuck-benchmark/resources/files/$(PROFILE_CASE).sh
 PROFILE_DIR ?= .cache/profiles
 PROFILE_RATE ?= 1000
 PROFILE_ITERATIONS ?= 1
+PROFILE_CORPUS_FIXTURE ?= xwmx__nb__nb
+PROFILE_CORPUS_ITERATIONS ?= 1
 SHUCK_LARGE_CORPUS_TIMEOUT_SECS ?= 300
 SHUCK_LARGE_CORPUS_SHUCK_TIMEOUT_SECS ?=
 SHUCK_LARGE_CORPUS_SAMPLE_PERCENT ?= 100
@@ -239,6 +241,12 @@ profile-cli:
 
 profile-cli-view:
 	SAMPLY_VIEW=1 $(NIX_DEVELOP) ./scripts/profiling/profile_cli.sh "$(PROFILE_FILE)" "$(PROFILE_DIR)" "$(PROFILE_RATE)" "$(PROFILE_ITERATIONS)"
+
+profile-large-corpus: ensure-cache
+	$(NIX_DEVELOP) ./scripts/profiling/profile_large_corpus.sh "$(PROFILE_CORPUS_FIXTURE)" "$(PROFILE_DIR)" "$(PROFILE_RATE)" "$(PROFILE_ITERATIONS)" "$(PROFILE_CORPUS_ITERATIONS)"
+
+profile-large-corpus-view: ensure-cache
+	SAMPLY_VIEW=1 $(NIX_DEVELOP) ./scripts/profiling/profile_large_corpus.sh "$(PROFILE_CORPUS_FIXTURE)" "$(PROFILE_DIR)" "$(PROFILE_RATE)" "$(PROFILE_ITERATIONS)" "$(PROFILE_CORPUS_ITERATIONS)"
 
 flame-parser:
 	@mkdir -p $(PROFILE_DIR)

--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -21,6 +21,7 @@ shuck-indexer = { workspace = true }
 shuck-linter = { workspace = true, features = ["benchmarking"] }
 shuck-parser = { workspace = true }
 shuck-semantic = { workspace = true }
+walkdir = "2"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 tikv-jemallocator = "0.6"
@@ -35,6 +36,10 @@ tempfile = { workspace = true }
 [[example]]
 name = "parser_counts"
 required-features = ["parser-benchmarking"]
+
+[[example]]
+name = "large_corpus_profile"
+required-features = ["large-corpus-hotspots"]
 
 [[bench]]
 name = "lexer"

--- a/crates/shuck-benchmark/examples/large_corpus_profile.rs
+++ b/crates/shuck-benchmark/examples/large_corpus_profile.rs
@@ -1,0 +1,561 @@
+use std::collections::HashMap;
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::time::Instant;
+
+use shuck_indexer::Indexer;
+use shuck_linter::{
+    LinterSettings, RuleSelector, RuleSet, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
+    first_statement_line, lint_file_at_path_with_resolver_and_parse_result, parse_directives,
+};
+use shuck_parser::parser::Parser;
+use shuck_semantic::SourcePathResolver;
+
+const LARGE_CORPUS_ROOT_ENV: &str = "SHUCK_LARGE_CORPUS_ROOT";
+const LARGE_CORPUS_CACHE_DIR_NAME: &str = ".cache/large-corpus";
+const LARGE_CORPUS_STATIC_IGNORE_SUFFIXES: &[&str] = &[
+    "super-linter__super-linter__test__linters__bash__shell_bad_1.sh",
+    "super-linter__super-linter__test__linters__bash_exec__shell_bad_1.sh",
+    "alpinelinux__aports__community__starship__starship.plugin.zsh",
+    "CISOfy__lynis__include__tests_ports_packages",
+    "google__oss-fuzz__infra__chronos__coverage_test_collection.py",
+    "moovweb__gvm__examples__native__configure",
+    "moovweb__gvm__examples__native__ltmain.sh",
+    "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh",
+];
+const LARGE_CORPUS_STATIC_ZSH_OVERRIDE_SUFFIXES: &[&str] = &[
+    "ohmyzsh__ohmyzsh__oh-my-zsh.sh",
+    "ohmyzsh__ohmyzsh__tools__check_for_upgrade.sh",
+];
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+#[derive(Debug)]
+struct Args {
+    fixture: String,
+    iterations: usize,
+    corpus_root: Option<PathBuf>,
+    rules: Option<RuleSet>,
+    resolve_source_closure: bool,
+}
+
+#[derive(Debug, Clone)]
+struct LargeCorpusFixture {
+    path: PathBuf,
+    cache_rel_path: PathBuf,
+    shell: String,
+}
+
+impl LargeCorpusFixture {
+    fn cache_rel_path_key(&self) -> String {
+        normalize_cache_rel_path(&self.cache_rel_path)
+    }
+}
+
+#[derive(Debug)]
+struct LargeCorpusPathResolver {
+    cache_rel_by_path: HashMap<PathBuf, PathBuf>,
+    path_by_cache_rel: HashMap<PathBuf, PathBuf>,
+}
+
+impl LargeCorpusPathResolver {
+    fn new(fixtures: &[LargeCorpusFixture]) -> Self {
+        let mut cache_rel_by_path = HashMap::new();
+        let mut path_by_cache_rel = HashMap::new();
+
+        for fixture in fixtures {
+            let canonical_path =
+                fs::canonicalize(&fixture.path).unwrap_or_else(|_| fixture.path.clone());
+            cache_rel_by_path.insert(fixture.path.clone(), fixture.cache_rel_path.clone());
+            cache_rel_by_path.insert(canonical_path.clone(), fixture.cache_rel_path.clone());
+            path_by_cache_rel.insert(fixture.cache_rel_path.clone(), canonical_path);
+        }
+
+        Self {
+            cache_rel_by_path,
+            path_by_cache_rel,
+        }
+    }
+}
+
+impl SourcePathResolver for LargeCorpusPathResolver {
+    fn resolve_candidate_paths(&self, source_path: &Path, candidate: &str) -> Vec<PathBuf> {
+        let Some(source_cache_rel_path) = self.cache_rel_by_path.get(source_path) else {
+            return Vec::new();
+        };
+
+        let mut resolved = Vec::new();
+        for candidate_cache_rel_path in [
+            resolve_large_corpus_candidate_cache_rel_path(source_cache_rel_path, candidate),
+            resolve_large_corpus_repo_relative_candidate_cache_rel_path(
+                source_cache_rel_path,
+                candidate,
+            ),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if let Some(path) = self.path_by_cache_rel.get(&candidate_cache_rel_path)
+                && !resolved.contains(path)
+            {
+                resolved.push(path.clone());
+            }
+        }
+
+        resolved
+    }
+}
+
+fn main() -> Result<()> {
+    let Some(args) = parse_args()? else {
+        return Ok(());
+    };
+    let corpus_dir = resolve_large_corpus_root(args.corpus_root.as_deref()).ok_or_else(|| {
+        format!(
+            "large corpus not found; set {LARGE_CORPUS_ROOT_ENV}, populate ./{LARGE_CORPUS_CACHE_DIR_NAME}, or pass --root"
+        )
+    })?;
+    let fixtures = collect_fixtures(&corpus_dir);
+    if fixtures.is_empty() {
+        return Err(format!(
+            "no fixtures found in {}",
+            corpus_dir.join("scripts").display()
+        )
+        .into());
+    }
+
+    let fixture = find_fixture(&fixtures, &args.fixture)
+        .ok_or_else(|| format!("fixture `{}` not found in large corpus", args.fixture))?
+        .clone();
+    let resolver = LargeCorpusPathResolver::new(&fixtures);
+    let settings = build_linter_settings(args.rules, args.resolve_source_closure);
+
+    eprintln!(
+        "profiling {} ({}) for {} iteration(s)",
+        fixture.cache_rel_path_key(),
+        fixture.shell,
+        args.iterations
+    );
+    eprintln!("corpus root: {}", corpus_dir.display());
+
+    let start = Instant::now();
+    let mut diagnostics_len = 0usize;
+    for _ in 0..args.iterations {
+        diagnostics_len = black_box(run_large_corpus_fixture(&fixture, &settings, &resolver)?);
+    }
+    let elapsed = start.elapsed();
+
+    eprintln!(
+        "done: diagnostics={} elapsed={:.3}s avg={:.3}ms",
+        diagnostics_len,
+        elapsed.as_secs_f64(),
+        elapsed.as_secs_f64() * 1000.0 / args.iterations as f64
+    );
+
+    Ok(())
+}
+
+fn parse_args() -> Result<Option<Args>> {
+    let mut fixture = None;
+    let mut iterations = 1usize;
+    let mut corpus_root = None;
+    let mut rules = None;
+    let mut resolve_source_closure = true;
+    let mut values = env::args().skip(1);
+
+    while let Some(arg) = values.next() {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                print_usage();
+                return Ok(None);
+            }
+            "--iterations" => {
+                iterations = parse_positive_usize("--iterations", values.next())?;
+            }
+            "--root" => {
+                corpus_root = Some(PathBuf::from(
+                    values.next().ok_or("missing value after --root")?,
+                ));
+            }
+            "--rules" => {
+                rules = Some(parse_rule_set(
+                    &values.next().ok_or("missing value after --rules")?,
+                )?);
+            }
+            "--no-source-closure" => {
+                resolve_source_closure = false;
+            }
+            _ if arg.starts_with('-') => {
+                return Err(format!("unknown option `{arg}`").into());
+            }
+            _ => {
+                if fixture.replace(arg).is_some() {
+                    return Err("only one fixture may be provided".into());
+                }
+            }
+        }
+    }
+
+    let fixture = fixture.ok_or("missing fixture name")?;
+    Ok(Some(Args {
+        fixture,
+        iterations,
+        corpus_root,
+        rules,
+        resolve_source_closure,
+    }))
+}
+
+fn print_usage() {
+    eprintln!(
+        "Usage: large_corpus_profile <fixture> [--iterations N] [--root PATH] [--rules SELECTORS] [--no-source-closure]"
+    );
+    eprintln!();
+    eprintln!("Examples:");
+    eprintln!("  large_corpus_profile xwmx__nb__nb --iterations 10");
+    eprintln!("  large_corpus_profile xwmx__nb__nb --rules C063");
+}
+
+fn parse_positive_usize(name: &str, value: Option<String>) -> Result<usize> {
+    let value = value.ok_or_else(|| format!("missing value after {name}"))?;
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|err| format!("invalid {name} value `{value}`: {err}"))?;
+    if parsed == 0 {
+        return Err(format!("{name} must be greater than zero").into());
+    }
+    Ok(parsed)
+}
+
+fn parse_rule_set(value: &str) -> Result<RuleSet> {
+    let mut rules = RuleSet::EMPTY;
+    for selector in value
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+    {
+        let selector = RuleSelector::from_str(selector)?;
+        rules = rules.union(&selector.into_rule_set());
+    }
+    Ok(rules)
+}
+
+fn build_linter_settings(rules: Option<RuleSet>, resolve_source_closure: bool) -> LinterSettings {
+    let settings = rules.map_or_else(LinterSettings::default, |rules| {
+        LinterSettings::for_rules(rules.iter())
+    });
+    settings
+        .with_c063_report_unreached_nested_definitions(true)
+        .with_resolve_source_closure(resolve_source_closure)
+}
+
+fn run_large_corpus_fixture(
+    fixture: &LargeCorpusFixture,
+    base_settings: &LinterSettings,
+    resolver: &LargeCorpusPathResolver,
+) -> Result<usize> {
+    let source = fs::read_to_string(&fixture.path)
+        .map_err(|err| format!("failed to read {}: {err}", fixture.path.display()))?;
+    let settings = base_settings
+        .clone()
+        .with_shell(ShellDialect::from_name(&fixture.shell))
+        .with_analyzed_paths([fixture.path.clone()]);
+    let parsed = Parser::with_dialect(&source, shuck_parser::ShellDialect::Bash).parse();
+    let indexer = Indexer::new(&source, &parsed);
+    let shellcheck_map = ShellCheckCodeMap::default();
+    let directives = parse_directives(
+        &source,
+        &parsed.file,
+        indexer.comment_index(),
+        &shellcheck_map,
+    );
+    let suppression_index = (!directives.is_empty()).then(|| {
+        SuppressionIndex::new(
+            &directives,
+            &parsed.file,
+            first_statement_line(&parsed.file).unwrap_or(u32::MAX),
+        )
+    });
+    let diagnostics = lint_file_at_path_with_resolver_and_parse_result(
+        &parsed,
+        &source,
+        &indexer,
+        &settings,
+        suppression_index.as_ref(),
+        Some(&fixture.path),
+        Some(resolver),
+    );
+
+    Ok(diagnostics.len())
+}
+
+fn find_fixture<'a>(
+    fixtures: &'a [LargeCorpusFixture],
+    requested: &str,
+) -> Option<&'a LargeCorpusFixture> {
+    let requested_path = Path::new(requested);
+    fixtures
+        .iter()
+        .find(|fixture| fixture.cache_rel_path == requested_path)
+        .or_else(|| {
+            fixtures
+                .iter()
+                .find(|fixture| fixture.cache_rel_path_key() == requested)
+        })
+        .or_else(|| {
+            fixtures.iter().find(|fixture| {
+                fixture.path.file_name().and_then(|name| name.to_str()) == Some(requested)
+            })
+        })
+}
+
+fn resolve_large_corpus_root(root_hint: Option<&Path>) -> Option<PathBuf> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let Some(repo_root) = manifest_dir.ancestors().nth(2) else {
+        unreachable!("crates/shuck-benchmark should live two levels below repo root");
+    };
+
+    let env_hint = env::var(LARGE_CORPUS_ROOT_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let candidates = root_hint
+        .map(|hint| vec![hint.to_path_buf()])
+        .or_else(|| env_hint.map(|hint| vec![hint]))
+        .unwrap_or_else(|| {
+            vec![
+                repo_root.join(LARGE_CORPUS_CACHE_DIR_NAME),
+                repo_root.join("..").join("shell-checks"),
+            ]
+        });
+
+    candidates
+        .into_iter()
+        .find_map(|candidate| normalize_large_corpus_root(&candidate))
+}
+
+fn normalize_large_corpus_root(root: &Path) -> Option<PathBuf> {
+    if !root.is_dir() {
+        return None;
+    }
+
+    let repo_corpus = root.join("corpus");
+    if corpus_dir_looks_valid(&repo_corpus) {
+        return Some(repo_corpus);
+    }
+    if corpus_dir_looks_valid(root) {
+        return Some(root.to_path_buf());
+    }
+
+    None
+}
+
+fn corpus_dir_looks_valid(root: &Path) -> bool {
+    root.join("scripts").is_dir()
+}
+
+fn collect_fixtures(corpus_dir: &Path) -> Vec<LargeCorpusFixture> {
+    let scripts_dir = corpus_dir.join("scripts");
+    let mut fixtures = Vec::new();
+
+    for entry in walkdir::WalkDir::new(&scripts_dir)
+        .into_iter()
+        .filter_entry(|entry| {
+            let name = entry.file_name().to_string_lossy();
+            name != ".shuck_cache" && name != ".shellck_cache"
+        })
+    {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.path().to_path_buf();
+        if path_is_statically_ignored_large_corpus_fixture(&path)
+            || path_is_sample_file(&path)
+            || path_is_fish_file(&path)
+            || path_is_patch_file(&path)
+            || path_is_appledouble_file(&path)
+            || path_is_guess_file(&path)
+            || path_is_config_sub_file(&path)
+        {
+            continue;
+        }
+
+        let Ok(source) = fs::read(&path) else {
+            continue;
+        };
+        let cache_rel_path = path
+            .strip_prefix(&scripts_dir)
+            .unwrap_or(path.as_path())
+            .to_path_buf();
+        let shell = resolve_shell(&path, &source);
+
+        fixtures.push(LargeCorpusFixture {
+            path,
+            cache_rel_path,
+            shell,
+        });
+    }
+
+    fixtures.sort_by(|left, right| left.path.cmp(&right.path));
+    fixtures
+}
+
+fn resolve_shell(path: &Path, src: &[u8]) -> String {
+    let source = String::from_utf8_lossy(src);
+    let source = source.strip_prefix('\u{feff}').unwrap_or(source.as_ref());
+    let trimmed_first_line = source
+        .lines()
+        .next()
+        .map(|line| line.trim_start().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if trimmed_first_line.starts_with("#compdef") || trimmed_first_line.starts_with("#autoload") {
+        return "zsh".into();
+    }
+    if path_has_large_corpus_static_zsh_override(path) {
+        return "zsh".into();
+    }
+
+    match ShellDialect::infer(source, Some(path)) {
+        ShellDialect::Bash => "bash".into(),
+        ShellDialect::Ksh | ShellDialect::Mksh => "ksh".into(),
+        ShellDialect::Zsh => "zsh".into(),
+        ShellDialect::Sh | ShellDialect::Dash => "sh".into(),
+        ShellDialect::Unknown => "sh".into(),
+    }
+}
+
+fn resolve_large_corpus_candidate_cache_rel_path(
+    source_cache_rel_path: &Path,
+    candidate: &str,
+) -> Option<PathBuf> {
+    let candidate_path = Path::new(candidate);
+    if candidate_path.is_absolute() {
+        return None;
+    }
+
+    let mut resolved = source_cache_rel_path
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_default();
+    let mut saw_component = false;
+
+    for component in candidate_path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !resolved.pop() {
+                    return None;
+                }
+                saw_component = true;
+            }
+            std::path::Component::Normal(part) => {
+                resolved.push(part);
+                saw_component = true;
+            }
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => return None,
+        }
+    }
+
+    saw_component.then_some(resolved)
+}
+
+fn resolve_large_corpus_repo_relative_candidate_cache_rel_path(
+    source_cache_rel_path: &Path,
+    candidate: &str,
+) -> Option<PathBuf> {
+    if source_cache_rel_path.components().count() != 1 {
+        return None;
+    }
+
+    let source_name = source_cache_rel_path.file_name()?.to_str()?;
+    let mut source_parts = source_name.split("__");
+    let owner = source_parts.next()?;
+    let repo = source_parts.next()?;
+
+    let candidate_path = Path::new(candidate);
+    if candidate_path.is_absolute() {
+        return None;
+    }
+
+    let mut flattened = Vec::new();
+    for component in candidate_path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => return None,
+            std::path::Component::Normal(part) => {
+                flattened.push(part.to_string_lossy().into_owned());
+            }
+            std::path::Component::RootDir | std::path::Component::Prefix(_) => return None,
+        }
+    }
+
+    (!flattened.is_empty())
+        .then(|| PathBuf::from(format!("{owner}__{repo}__{}", flattened.join("__"))))
+}
+
+fn normalize_cache_rel_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => Some(part.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn path_is_statically_ignored_large_corpus_fixture(path: &Path) -> bool {
+    path_matches_large_corpus_suffix(path, LARGE_CORPUS_STATIC_IGNORE_SUFFIXES)
+}
+
+fn path_has_large_corpus_static_zsh_override(path: &Path) -> bool {
+    path_matches_large_corpus_suffix(path, LARGE_CORPUS_STATIC_ZSH_OVERRIDE_SUFFIXES)
+}
+
+fn path_matches_large_corpus_suffix(path: &Path, suffixes: &[&str]) -> bool {
+    let path = path.to_string_lossy();
+    suffixes.iter().any(|suffix| path.ends_with(suffix))
+}
+
+fn path_is_sample_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".sample"))
+}
+
+fn path_is_patch_file(path: &Path) -> bool {
+    let path = path.to_string_lossy().to_lowercase();
+    path.ends_with(".patch") || path.ends_with(".diff") || path.ends_with(".dpatch")
+}
+
+fn path_is_fish_file(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("fish"))
+}
+
+fn path_is_appledouble_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("._"))
+}
+
+fn path_is_guess_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.to_ascii_lowercase().ends_with(".guess"))
+}
+
+fn path_is_config_sub_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.to_ascii_lowercase().ends_with("config.sub"))
+}

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -277,6 +277,8 @@ impl<'a> LinterFactsBuilder<'a> {
                 );
                 let redirect_fact_range = redirect_fact_store.push_many(redirect_facts);
                 let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
+                let scope =
+                    (!nested_word_command).then(|| self.semantic.scope_at(normalized.body_span.start.offset));
                 let declaration_assignment_probes = build_declaration_assignment_probes(
                     visit.command,
                     &normalized,
@@ -297,6 +299,7 @@ impl<'a> LinterFactsBuilder<'a> {
                     key,
                     visit,
                     nested_word_command,
+                    scope,
                     normalized,
                     zsh_options: command_zsh_options,
                     redirect_facts: redirect_fact_range,

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -4,6 +4,7 @@ pub struct CommandFact<'a> {
     key: FactSpan,
     visit: CommandVisit<'a>,
     nested_word_command: bool,
+    scope: Option<ScopeId>,
     normalized: NormalizedCommand<'a>,
     zsh_options: Option<ZshOptionState>,
     redirect_facts: IdRange<RedirectFact<'a>>,
@@ -33,6 +34,10 @@ impl<'a> CommandFact<'a> {
 
     pub fn is_nested_word_command(&self) -> bool {
         self.nested_word_command
+    }
+
+    pub fn scope(&self) -> Option<ScopeId> {
+        self.scope
     }
 
     pub fn stmt(&self) -> &'a Stmt {
@@ -198,6 +203,10 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
 
     pub fn is_nested_word_command(self) -> bool {
         self.fact.is_nested_word_command()
+    }
+
+    pub fn scope(self) -> Option<ScopeId> {
+        self.fact.scope()
     }
 
     pub fn stmt(self) -> &'a Stmt {

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -155,6 +155,44 @@ struct CompatUnsetCommandFact {
     offset: usize,
 }
 
+#[derive(Clone, Copy)]
+struct CompatScriptTerminatorFact {
+    scope: ScopeId,
+    offset: usize,
+    starts_function_definition: bool,
+    starts_return: bool,
+}
+
+struct CompatTopLevelControlFacts {
+    apparent_infinite_loop_offsets: Vec<usize>,
+    return_offsets: Vec<usize>,
+}
+
+struct CompatStructuralFacts {
+    call_facts_by_name: CompatCallFactsByName,
+    unset_commands_by_target: CompatUnsetCommandsByTarget,
+    scopes_by_offset: FxHashMap<usize, ScopeId>,
+    function_definition_offsets: FxHashSet<usize>,
+    return_offsets: FxHashSet<usize>,
+    top_level_control: CompatTopLevelControlFacts,
+}
+
+#[derive(Clone, Copy)]
+struct CompatLoopCandidate {
+    offset: usize,
+    body_span: shuck_ast::Span,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct CompatCallResolutionKey {
+    binding: shuck_semantic::BindingId,
+    call_scope: ScopeId,
+    visibility_start: usize,
+    visibility_end: usize,
+    cfg_start: usize,
+    cfg_end: usize,
+}
+
 type CompatCallFactsByName = FxHashMap<String, Vec<CompatCallFact>>;
 type CompatFunctionBindingsByScope = FxHashMap<ScopeId, Vec<shuck_semantic::BindingId>>;
 type CompatUnsetCommandsByTarget = FxHashMap<String, Vec<CompatUnsetCommandFact>>;
@@ -168,8 +206,10 @@ struct CompatUnsetFacts {
 struct CompatReachState<'a> {
     scope_run_cache: &'a mut FxHashMap<(ScopeId, usize), bool>,
     scope_between_cache: &'a mut FxHashMap<(ScopeId, usize, usize), bool>,
+    call_resolution_cache: &'a mut FxHashMap<CompatCallResolutionKey, bool>,
     call_facts_by_name: &'a CompatCallFactsByName,
     function_bindings_by_scope: &'a CompatFunctionBindingsByScope,
+    activation_index: Option<&'a CompatActivationIndex>,
 }
 
 #[derive(Clone, Copy)]
@@ -179,24 +219,144 @@ struct BoundaryCallWindow {
     boundary_scope: ScopeId,
 }
 
-fn build_compat_call_facts_by_name(checker: &Checker<'_>) -> CompatCallFactsByName {
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct CompatScopeActivation {
+    activation_offset: usize,
+    required_before_offset: usize,
+    persistent: bool,
+}
+
+struct CompatActivationIndex {
+    activations_by_scope: FxHashMap<ScopeId, Vec<CompatScopeActivation>>,
+}
+
+#[derive(Clone, Copy)]
+struct CompatActivationEdge {
+    target_scope: ScopeId,
+    target_binding_offset: usize,
+    call_offset: usize,
+    persistent: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct CompatActivationEdgeKey {
+    target_binding: shuck_semantic::BindingId,
+    target_scope: ScopeId,
+    call_scope: ScopeId,
+    call_offset: usize,
+}
+
+fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts {
     let mut calls = CompatCallFactsByName::default();
+    let mut unset_commands_by_target = CompatUnsetCommandsByTarget::default();
+    let mut scopes_by_offset = FxHashMap::<usize, ScopeId>::default();
+    let mut function_definition_offsets = FxHashSet::<usize>::default();
+    let mut return_offsets = FxHashSet::<usize>::default();
+    let mut top_level_return_offsets = Vec::new();
+    let mut top_level_loop_candidates = Vec::new();
+    let mut break_offsets = Vec::new();
+
     for fact in checker.facts().structural_commands() {
-        if matches!(fact.command(), shuck_ast::Command::Function(_)) {
-            continue;
+        let offset = fact.body_span().start.offset;
+        let known_scope = fact.scope();
+        if let Some(scope) = known_scope {
+            scopes_by_offset.entry(offset).or_insert(scope);
         }
-        let Some(name) = fact.effective_name() else {
-            continue;
-        };
-        calls
-            .entry(name.to_owned())
-            .or_default()
-            .push(CompatCallFact {
-                scope: checker.semantic().scope_at(fact.body_span().start.offset),
-                span: fact.body_span(),
-            });
+        let is_function = matches!(fact.command(), shuck_ast::Command::Function(_));
+        if is_function {
+            function_definition_offsets.insert(offset);
+        }
+
+        if matches!(
+            fact.command(),
+            shuck_ast::Command::Builtin(shuck_ast::BuiltinCommand::Break(_))
+        ) {
+            break_offsets.push(offset);
+        }
+
+        let is_return = fact.effective_name_is("return");
+        if is_return {
+            return_offsets.insert(offset);
+        }
+
+        if !is_function && let Some(name) = fact.effective_name() {
+            let scope = known_scope.unwrap_or_else(|| checker.semantic().scope_at(offset));
+            calls
+                .entry(name.to_owned())
+                .or_default()
+                .push(CompatCallFact {
+                    scope,
+                    span: fact.body_span(),
+                });
+        }
+
+        if fact.effective_name_is("unset")
+            && let Some(unset) = fact.options().unset()
+            && unset.function_mode
+            && unset.options_parseable()
+        {
+            let mut targets = Vec::new();
+            for word in unset.operand_words() {
+                let Some(text) = static_word_text(word, checker.source()) else {
+                    break;
+                };
+                let target = text.into_owned();
+                if !targets.contains(&target) {
+                    targets.push(target);
+                }
+            }
+
+            if !targets.is_empty()
+                && !command_offset_is_under_dominance_barrier(checker, offset)
+                && !command_offset_is_unreachable(checker, offset)
+            {
+                let scope = known_scope.unwrap_or_else(|| checker.semantic().scope_at(offset));
+                let command_fact = CompatUnsetCommandFact { scope, offset };
+                for target in targets {
+                    unset_commands_by_target
+                        .entry(target)
+                        .or_default()
+                        .push(command_fact);
+                }
+            }
+        }
+
+        let apparent_loop_body_span = apparent_infinite_loop_body_span(checker, fact.command());
+        if is_return || apparent_loop_body_span.is_some() {
+            let scope = known_scope.unwrap_or_else(|| checker.semantic().scope_at(offset));
+            if scope_is_file_scope(checker, scope) {
+                if is_return {
+                    top_level_return_offsets.push(offset);
+                }
+                if let Some(body_span) = apparent_loop_body_span {
+                    top_level_loop_candidates.push(CompatLoopCandidate { offset, body_span });
+                }
+            }
+        }
     }
-    calls
+
+    let apparent_infinite_loop_offsets = top_level_loop_candidates
+        .into_iter()
+        .filter(|candidate| {
+            !break_offsets.iter().any(|break_offset| {
+                *break_offset >= candidate.body_span.start.offset
+                    && *break_offset <= candidate.body_span.end.offset
+            })
+        })
+        .map(|candidate| candidate.offset)
+        .collect();
+
+    CompatStructuralFacts {
+        call_facts_by_name: calls,
+        unset_commands_by_target,
+        scopes_by_offset,
+        function_definition_offsets,
+        return_offsets,
+        top_level_control: CompatTopLevelControlFacts {
+            apparent_infinite_loop_offsets,
+            return_offsets: top_level_return_offsets,
+        },
+    }
 }
 
 fn build_compat_function_bindings_by_scope(checker: &Checker<'_>) -> CompatFunctionBindingsByScope {
@@ -210,9 +370,285 @@ fn build_compat_function_bindings_by_scope(checker: &Checker<'_>) -> CompatFunct
     bindings
 }
 
+fn build_compat_activation_index(
+    checker: &Checker<'_>,
+    call_facts_by_name: &CompatCallFactsByName,
+    function_bindings_by_scope: &CompatFunctionBindingsByScope,
+    call_resolution_cache: &mut FxHashMap<CompatCallResolutionKey, bool>,
+) -> CompatActivationIndex {
+    let edges_by_caller = build_compat_activation_edges_by_caller(
+        checker,
+        call_facts_by_name,
+        function_bindings_by_scope,
+        call_resolution_cache,
+    );
+    let mut index = CompatActivationIndex {
+        activations_by_scope: FxHashMap::default(),
+    };
+    let mut pending = Vec::new();
+
+    for edge in edges_by_caller
+        .get(&None)
+        .into_iter()
+        .flat_map(|edges| edges.iter())
+    {
+        if edge.call_offset <= edge.target_binding_offset {
+            continue;
+        }
+        let activation = CompatScopeActivation {
+            activation_offset: edge.call_offset,
+            required_before_offset: edge.call_offset,
+            persistent: edge.persistent,
+        };
+        if index.insert(edge.target_scope, activation) {
+            pending.push((edge.target_scope, activation));
+        }
+    }
+
+    while let Some((scope, activation)) = pending.pop() {
+        if !index.contains(scope, activation) {
+            continue;
+        }
+        for edge in edges_by_caller
+            .get(&Some(scope))
+            .into_iter()
+            .flat_map(|edges| edges.iter())
+        {
+            if activation.activation_offset <= edge.target_binding_offset {
+                continue;
+            }
+            let next = CompatScopeActivation {
+                activation_offset: activation.activation_offset,
+                required_before_offset: activation.required_before_offset.max(edge.call_offset),
+                persistent: activation.persistent && edge.persistent,
+            };
+            if index.insert(edge.target_scope, next) {
+                pending.push((edge.target_scope, next));
+            }
+        }
+    }
+
+    index
+}
+
+fn build_compat_activation_edges_by_caller(
+    checker: &Checker<'_>,
+    call_facts_by_name: &CompatCallFactsByName,
+    function_bindings_by_scope: &CompatFunctionBindingsByScope,
+    call_resolution_cache: &mut FxHashMap<CompatCallResolutionKey, bool>,
+) -> FxHashMap<Option<ScopeId>, Vec<CompatActivationEdge>> {
+    let mut edges_by_caller = FxHashMap::<Option<ScopeId>, Vec<CompatActivationEdge>>::default();
+    let mut seen_edges = FxHashSet::<CompatActivationEdgeKey>::default();
+
+    for (target_scope, binding_ids) in function_bindings_by_scope {
+        for target_binding in binding_ids {
+            let binding = checker.semantic().binding(*target_binding);
+            for fact in call_facts_by_name
+                .get(binding.name.as_str())
+                .into_iter()
+                .flat_map(|facts| facts.iter())
+            {
+                add_compat_activation_edge(
+                    checker,
+                    *target_binding,
+                    *target_scope,
+                    binding.span.start.offset,
+                    fact.scope,
+                    fact.span.start.offset,
+                    fact.span,
+                    fact.span,
+                    call_resolution_cache,
+                    &mut seen_edges,
+                    &mut edges_by_caller,
+                );
+            }
+            for site in checker.semantic().call_sites_for(&binding.name) {
+                add_compat_activation_edge(
+                    checker,
+                    *target_binding,
+                    *target_scope,
+                    binding.span.start.offset,
+                    site.scope,
+                    site.name_span.start.offset,
+                    site.name_span,
+                    site.span,
+                    call_resolution_cache,
+                    &mut seen_edges,
+                    &mut edges_by_caller,
+                );
+            }
+        }
+    }
+
+    edges_by_caller
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "keeps activation edge construction local"
+)]
+fn add_compat_activation_edge(
+    checker: &Checker<'_>,
+    target_binding: shuck_semantic::BindingId,
+    target_scope: ScopeId,
+    target_binding_offset: usize,
+    call_scope: ScopeId,
+    call_offset: usize,
+    visibility_span: shuck_ast::Span,
+    cfg_span: shuck_ast::Span,
+    call_resolution_cache: &mut FxHashMap<CompatCallResolutionKey, bool>,
+    seen_edges: &mut FxHashSet<CompatActivationEdgeKey>,
+    edges_by_caller: &mut FxHashMap<Option<ScopeId>, Vec<CompatActivationEdge>>,
+) {
+    if !call_may_resolve_to_binding_cached_in(
+        call_resolution_cache,
+        checker,
+        target_binding,
+        call_scope,
+        visibility_span,
+        cfg_span,
+    ) {
+        return;
+    }
+
+    let key = CompatActivationEdgeKey {
+        target_binding,
+        target_scope,
+        call_scope,
+        call_offset,
+    };
+    if !seen_edges.insert(key) {
+        return;
+    }
+
+    let edge = CompatActivationEdge {
+        target_scope,
+        target_binding_offset,
+        call_offset,
+        persistent: !scope_has_transient_ancestor(checker, call_scope),
+    };
+    edges_by_caller
+        .entry(enclosing_function_scope(checker, call_scope))
+        .or_default()
+        .push(edge);
+}
+
+impl CompatActivationIndex {
+    fn insert(&mut self, scope: ScopeId, activation: CompatScopeActivation) -> bool {
+        let activations = self.activations_by_scope.entry(scope).or_default();
+        if activations
+            .iter()
+            .any(|existing| activation_dominates(*existing, activation))
+        {
+            return false;
+        }
+        activations.retain(|existing| !activation_dominates(activation, *existing));
+        activations.push(activation);
+        true
+    }
+
+    fn contains(&self, scope: ScopeId, activation: CompatScopeActivation) -> bool {
+        self.activations_by_scope
+            .get(&scope)
+            .is_some_and(|activations| activations.contains(&activation))
+    }
+
+    fn scope_can_run_before_offset(
+        &self,
+        checker: &Checker<'_>,
+        scope: ScopeId,
+        before_offset: usize,
+        persistent: bool,
+    ) -> bool {
+        let Some(function_scope) = enclosing_function_scope(checker, scope) else {
+            return true;
+        };
+        self.activations_by_scope
+            .get(&function_scope)
+            .is_some_and(|activations| {
+                activations.iter().any(|activation| {
+                    activation.required_before_offset <= before_offset
+                        && (!persistent || activation.persistent)
+                })
+            })
+    }
+
+    fn scope_can_run_between_offsets(
+        &self,
+        checker: &Checker<'_>,
+        scope: ScopeId,
+        after_offset: usize,
+        before_offset: usize,
+        persistent: bool,
+    ) -> bool {
+        let Some(function_scope) = enclosing_function_scope(checker, scope) else {
+            return true;
+        };
+        self.activations_by_scope
+            .get(&function_scope)
+            .is_some_and(|activations| {
+                activations.iter().any(|activation| {
+                    activation.activation_offset > after_offset
+                        && activation.required_before_offset <= before_offset
+                        && (!persistent || activation.persistent)
+                })
+            })
+    }
+}
+
+fn activation_dominates(left: CompatScopeActivation, right: CompatScopeActivation) -> bool {
+    left.activation_offset >= right.activation_offset
+        && left.required_before_offset <= right.required_before_offset
+        && (left.persistent || !right.persistent)
+}
+
+fn build_compat_script_terminator_facts(
+    checker: &Checker<'_>,
+    structural_facts: &CompatStructuralFacts,
+) -> Vec<CompatScriptTerminatorFact> {
+    let cfg = checker.semantic_analysis().cfg();
+    let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+    cfg.script_terminators()
+        .iter()
+        .filter(|block_id| !unreachable.contains(block_id))
+        .flat_map(|block_id| cfg.block(*block_id).commands.iter())
+        .filter_map(|span| {
+            let offset = span.start.offset;
+            let scope = structural_facts
+                .scopes_by_offset
+                .get(&offset)
+                .copied()
+                .unwrap_or_else(|| checker.semantic().scope_at(offset));
+            (!scope_has_transient_ancestor(checker, scope)).then_some(CompatScriptTerminatorFact {
+                scope,
+                offset,
+                starts_function_definition: structural_facts
+                    .function_definition_offsets
+                    .contains(&offset),
+                starts_return: structural_facts.return_offsets.contains(&offset),
+            })
+        })
+        .collect()
+}
+
+impl CompatTopLevelControlFacts {
+    fn has_apparent_infinite_loop_between(&self, start_offset: usize, end_offset: usize) -> bool {
+        self.apparent_infinite_loop_offsets
+            .iter()
+            .any(|offset| *offset > start_offset && *offset < end_offset)
+    }
+
+    fn has_return_between(&self, start_offset: usize, end_offset: usize) -> bool {
+        self.return_offsets
+            .iter()
+            .any(|offset| *offset > start_offset && *offset < end_offset)
+    }
+}
+
 fn build_compat_unset_facts(
     checker: &Checker<'_>,
     function_bindings_by_scope: &CompatFunctionBindingsByScope,
+    unset_commands_by_target: &CompatUnsetCommandsByTarget,
 ) -> CompatUnsetFacts {
     let mut function_names_by_scope = FxHashMap::<ScopeId, Vec<shuck_ast::Name>>::default();
     for (scope, binding_ids) in function_bindings_by_scope {
@@ -225,48 +661,10 @@ fn build_compat_unset_facts(
         }
     }
 
-    let mut commands_by_target = CompatUnsetCommandsByTarget::default();
     let mut function_targets = FxHashMap::<String, FxHashSet<shuck_ast::Name>>::default();
-    for fact in checker.facts().structural_commands() {
-        if !fact.effective_name_is("unset") {
-            continue;
-        }
-        let Some(unset) = fact.options().unset() else {
-            continue;
-        };
-        if !unset.function_mode || !unset.options_parseable() {
-            continue;
-        }
-
-        let mut targets = Vec::new();
-        for word in unset.operand_words() {
-            let Some(text) = static_word_text(word, checker.source()) else {
-                break;
-            };
-            let target = text.into_owned();
-            if !targets.contains(&target) {
-                targets.push(target);
-            }
-        }
-
-        if targets.is_empty() {
-            continue;
-        }
-
-        let offset = fact.body_span().start.offset;
-        if command_offset_is_under_dominance_barrier(checker, offset)
-            || command_offset_is_unreachable(checker, offset)
-        {
-            continue;
-        }
-        let scope = checker.semantic().scope_at(offset);
-        let command_fact = CompatUnsetCommandFact { scope, offset };
-        for target in targets {
-            commands_by_target
-                .entry(target.clone())
-                .or_default()
-                .push(command_fact);
-            if let Some(function_scope) = enclosing_function_scope(checker, scope)
+    for (target, command_facts) in unset_commands_by_target {
+        for command_fact in command_facts {
+            if let Some(function_scope) = enclosing_function_scope(checker, command_fact.scope)
                 && let Some(function_names) = function_names_by_scope.get(&function_scope)
             {
                 function_targets
@@ -283,7 +681,7 @@ fn build_compat_unset_facts(
         .collect();
 
     CompatUnsetFacts {
-        commands_by_target,
+        commands_by_target: unset_commands_by_target.clone(),
         functions_by_target,
     }
 }
@@ -291,14 +689,28 @@ fn build_compat_unset_facts(
 fn report_compat_cutoff_function_definitions(checker: &mut Checker<'_>) {
     let mut scope_run_cache = FxHashMap::default();
     let mut scope_between_cache = FxHashMap::default();
-    let call_facts_by_name = build_compat_call_facts_by_name(checker);
+    let mut call_resolution_cache = FxHashMap::default();
+    let structural_facts = build_compat_structural_facts(checker);
     let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
-    let unset_facts = build_compat_unset_facts(checker, &function_bindings_by_scope);
+    let unset_facts = build_compat_unset_facts(
+        checker,
+        &function_bindings_by_scope,
+        &structural_facts.unset_commands_by_target,
+    );
+    let script_terminators = build_compat_script_terminator_facts(checker, &structural_facts);
+    let activation_index = build_compat_activation_index(
+        checker,
+        &structural_facts.call_facts_by_name,
+        &function_bindings_by_scope,
+        &mut call_resolution_cache,
+    );
     let mut reach = CompatReachState {
         scope_run_cache: &mut scope_run_cache,
         scope_between_cache: &mut scope_between_cache,
-        call_facts_by_name: &call_facts_by_name,
+        call_resolution_cache: &mut call_resolution_cache,
+        call_facts_by_name: &structural_facts.call_facts_by_name,
         function_bindings_by_scope: &function_bindings_by_scope,
+        activation_index: Some(&activation_index),
     };
     let candidates = checker
         .semantic()
@@ -307,8 +719,14 @@ fn report_compat_cutoff_function_definitions(checker: &mut Checker<'_>) {
         .filter(|binding| matches!(binding.kind, BindingKind::FunctionDefinition))
         .filter(|binding| !matches!(binding.kind, BindingKind::Imported))
         .filter_map(|binding| {
-            let cutoff =
-                first_compat_cutoff_after_binding(checker, binding.id, &mut reach, &unset_facts)?;
+            let cutoff = first_compat_cutoff_after_binding(
+                checker,
+                binding.id,
+                &mut reach,
+                &unset_facts,
+                &script_terminators,
+                &structural_facts.top_level_control,
+            )?;
             (!has_direct_call_to_binding_before_offset_cached(
                 checker,
                 binding.id,
@@ -383,6 +801,8 @@ fn first_compat_cutoff_after_binding(
     binding_id: shuck_semantic::BindingId,
     reach: &mut CompatReachState<'_>,
     unset_facts: &CompatUnsetFacts,
+    script_terminators: &[CompatScriptTerminatorFact],
+    top_level_control: &CompatTopLevelControlFacts,
 ) -> Option<FunctionCutoff> {
     let binding = checker.semantic().binding(binding_id);
     let binding_offset = binding.span.start.offset;
@@ -403,21 +823,27 @@ fn first_compat_cutoff_after_binding(
         }),
     );
     cutoffs.extend(
-        compat_script_terminator_offsets(checker, binding_id, binding_offset, reach)
-            .into_iter()
-            .map(|offset| FunctionCutoff {
-                offset,
-                reason: FunctionNotReachedReason::ScriptTerminates,
-            }),
+        compat_script_terminator_offsets(
+            checker,
+            binding_id,
+            binding_offset,
+            reach,
+            script_terminators,
+        )
+        .into_iter()
+        .map(|offset| FunctionCutoff {
+            offset,
+            reason: FunctionNotReachedReason::ScriptTerminates,
+        }),
     );
     let cutoff = cutoffs.into_iter().min_by_key(|cutoff| cutoff.offset)?;
     if matches!(cutoff.reason, FunctionNotReachedReason::ScriptTerminates)
-        && has_apparent_infinite_loop_between(checker, binding_offset, cutoff.offset)
+        && top_level_control.has_apparent_infinite_loop_between(binding_offset, cutoff.offset)
     {
         return None;
     }
     if matches!(cutoff.reason, FunctionNotReachedReason::ScriptTerminates)
-        && has_top_level_return_between(checker, binding_offset, cutoff.offset)
+        && top_level_control.has_return_between(binding_offset, cutoff.offset)
     {
         return None;
     }
@@ -513,32 +939,26 @@ fn compat_script_terminator_offsets(
     binding_id: shuck_semantic::BindingId,
     after_offset: usize,
     reach: &mut CompatReachState<'_>,
+    script_terminators: &[CompatScriptTerminatorFact],
 ) -> Vec<usize> {
-    let cfg = checker.semantic_analysis().cfg();
-    let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
     let binding = checker.semantic().binding(binding_id);
     let binding_is_file_scope = scope_is_file_scope(checker, binding.scope);
 
-    cfg.script_terminators()
+    script_terminators
         .iter()
-        .filter(|block_id| !unreachable.contains(block_id))
-        .flat_map(|block_id| cfg.block(*block_id).commands.iter())
-        .filter_map(|span| {
-            let offset = span.start.offset;
-            let terminator_scope = checker.semantic().scope_at(offset);
-            (offset > after_offset
-                && !scope_has_transient_ancestor(checker, terminator_scope)
+        .filter_map(|terminator| {
+            (terminator.offset > after_offset
                 && terminator_scope_can_cut_off_binding(
                     checker,
                     binding.scope,
                     binding_is_file_scope,
-                    terminator_scope,
-                    offset,
+                    terminator.scope,
+                    terminator.offset,
                     reach,
                 )
-                && !span_starts_function_definition_command(checker, offset)
-                && !span_starts_command_named(checker, offset, "return"))
-            .then_some(offset)
+                && !terminator.starts_function_definition
+                && !terminator.starts_return)
+                .then_some(terminator.offset)
         })
         .max()
         .into_iter()
@@ -585,20 +1005,6 @@ fn scope_has_transient_ancestor(checker: &Checker<'_>, scope: ScopeId) -> bool {
     })
 }
 
-fn span_starts_function_definition_command(checker: &Checker<'_>, offset: usize) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        fact.body_span().start.offset == offset
-            && matches!(fact.command(), shuck_ast::Command::Function(_))
-    })
-}
-
-fn span_starts_command_named(checker: &Checker<'_>, offset: usize, name: &str) -> bool {
-    checker
-        .facts()
-        .structural_commands()
-        .any(|fact| fact.body_span().start.offset == offset && fact.effective_name_is(name))
-}
-
 fn has_direct_call_to_binding_before_offset(
     checker: &Checker<'_>,
     binding_id: shuck_semantic::BindingId,
@@ -606,13 +1012,16 @@ fn has_direct_call_to_binding_before_offset(
 ) -> bool {
     let mut scope_run_cache = FxHashMap::default();
     let mut scope_between_cache = FxHashMap::default();
-    let call_facts_by_name = build_compat_call_facts_by_name(checker);
+    let mut call_resolution_cache = FxHashMap::default();
+    let structural_facts = build_compat_structural_facts(checker);
     let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
     let mut reach = CompatReachState {
         scope_run_cache: &mut scope_run_cache,
         scope_between_cache: &mut scope_between_cache,
-        call_facts_by_name: &call_facts_by_name,
+        call_resolution_cache: &mut call_resolution_cache,
+        call_facts_by_name: &structural_facts.call_facts_by_name,
         function_bindings_by_scope: &function_bindings_by_scope,
+        activation_index: None,
     };
     has_direct_call_to_binding_before_offset_cached(checker, binding_id, before_offset, &mut reach)
 }
@@ -631,24 +1040,26 @@ fn has_direct_call_to_binding_before_offset_cached(
         .into_iter()
         .flat_map(|facts| facts.iter())
         .any(|fact| {
-            call_may_resolve_to_binding(checker, binding_id, fact.scope, fact.span, fact.span)
-                && call_can_reach_binding_before_offset(
-                    checker,
-                    fact.scope,
-                    fact.span.start.offset,
-                    binding.span.start.offset,
-                    before_offset,
-                    reach,
-                    &mut visiting,
-                )
+            call_may_resolve_to_binding_cached(
+                checker, reach, binding_id, fact.scope, fact.span, fact.span,
+            ) && call_can_reach_binding_before_offset(
+                checker,
+                fact.scope,
+                fact.span.start.offset,
+                binding.span.start.offset,
+                before_offset,
+                reach,
+                &mut visiting,
+            )
         })
         || checker
             .semantic()
             .call_sites_for(&binding.name)
             .iter()
             .any(|site| {
-                call_may_resolve_to_binding(
+                call_may_resolve_to_binding_cached(
                     checker,
+                    reach,
                     binding_id,
                     site.scope,
                     site.name_span,
@@ -673,13 +1084,16 @@ fn has_non_transient_direct_call_to_binding_between_offsets(
 ) -> bool {
     let mut scope_run_cache = FxHashMap::default();
     let mut scope_between_cache = FxHashMap::default();
-    let call_facts_by_name = build_compat_call_facts_by_name(checker);
+    let mut call_resolution_cache = FxHashMap::default();
+    let structural_facts = build_compat_structural_facts(checker);
     let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
     let mut reach = CompatReachState {
         scope_run_cache: &mut scope_run_cache,
         scope_between_cache: &mut scope_between_cache,
-        call_facts_by_name: &call_facts_by_name,
+        call_resolution_cache: &mut call_resolution_cache,
+        call_facts_by_name: &structural_facts.call_facts_by_name,
         function_bindings_by_scope: &function_bindings_by_scope,
+        activation_index: None,
     };
     let mut visiting = FxHashSet::default();
     let binding = checker.semantic().binding(binding_id);
@@ -693,8 +1107,8 @@ fn has_non_transient_direct_call_to_binding_between_offsets(
             let call_offset = fact.span.start.offset;
             call_offset <= before_offset
                 && !scope_has_transient_ancestor(checker, fact.scope)
-                && call_may_resolve_to_binding(
-                    checker, binding_id, fact.scope, fact.span, fact.span,
+                && call_may_resolve_to_binding_cached(
+                    checker, &mut reach, binding_id, fact.scope, fact.span, fact.span,
                 )
                 && call_scope_can_execute_after_offset_before_offset(
                     checker,
@@ -714,8 +1128,9 @@ fn has_non_transient_direct_call_to_binding_between_offsets(
                 let call_offset = site.name_span.start.offset;
                 call_offset <= before_offset
                     && !scope_has_transient_ancestor(checker, site.scope)
-                    && call_may_resolve_to_binding(
+                    && call_may_resolve_to_binding_cached(
                         checker,
+                        &mut reach,
                         binding_id,
                         site.scope,
                         site.name_span,
@@ -765,6 +1180,16 @@ fn command_scope_can_run_between_offsets(
     reach: &mut CompatReachState<'_>,
     visiting: &mut FxHashSet<ScopeId>,
 ) -> bool {
+    if let Some(activation_index) = reach.activation_index {
+        return activation_index.scope_can_run_between_offsets(
+            checker,
+            scope,
+            after_offset,
+            before_offset,
+            false,
+        );
+    }
+
     let Some(function_scope) = enclosing_function_scope(checker, scope) else {
         return true;
     };
@@ -821,8 +1246,9 @@ fn has_call_to_function_binding_between_offsets(
         .any(|fact| {
             let call_offset = fact.span.start.offset;
             call_offset <= before_offset
-                && call_may_resolve_to_binding(
+                && call_may_resolve_to_binding_cached(
                     checker,
+                    reach,
                     function_binding,
                     fact.scope,
                     fact.span,
@@ -845,8 +1271,9 @@ fn has_call_to_function_binding_between_offsets(
             .any(|site| {
                 let call_offset = site.name_span.start.offset;
                 call_offset <= before_offset
-                    && call_may_resolve_to_binding(
+                    && call_may_resolve_to_binding_cached(
                         checker,
+                        reach,
                         function_binding,
                         site.scope,
                         site.name_span,
@@ -871,6 +1298,10 @@ fn command_scope_can_run_before_offset(
     reach: &mut CompatReachState<'_>,
     visiting: &mut FxHashSet<ScopeId>,
 ) -> bool {
+    if let Some(activation_index) = reach.activation_index {
+        return activation_index.scope_can_run_before_offset(checker, scope, before_offset, false);
+    }
+
     let Some(function_scope) = enclosing_function_scope(checker, scope) else {
         return true;
     };
@@ -915,6 +1346,10 @@ fn command_scope_can_run_persistently_before_offset(
     if scope_has_transient_ancestor(checker, scope) {
         return false;
     }
+    if let Some(activation_index) = reach.activation_index {
+        return activation_index.scope_can_run_before_offset(checker, scope, before_offset, true);
+    }
+
     let Some(function_scope) = enclosing_function_scope(checker, scope) else {
         return true;
     };
@@ -956,8 +1391,9 @@ fn has_persistent_call_to_function_binding_before_offset(
         .flat_map(|facts| facts.iter())
         .any(|fact| {
             fact.span.start.offset <= before_offset
-                && call_may_resolve_to_binding(
+                && call_may_resolve_to_binding_cached(
                     checker,
+                    reach,
                     function_binding,
                     fact.scope,
                     fact.span,
@@ -979,8 +1415,9 @@ fn has_persistent_call_to_function_binding_before_offset(
             .iter()
             .any(|site| {
                 site.name_span.start.offset <= before_offset
-                    && call_may_resolve_to_binding(
+                    && call_may_resolve_to_binding_cached(
                         checker,
+                        reach,
                         function_binding,
                         site.scope,
                         site.name_span,
@@ -1009,6 +1446,16 @@ fn command_scope_can_run_persistently_between_offsets(
     if scope_has_transient_ancestor(checker, scope) {
         return false;
     }
+    if let Some(activation_index) = reach.activation_index {
+        return activation_index.scope_can_run_between_offsets(
+            checker,
+            scope,
+            after_offset,
+            before_offset,
+            true,
+        );
+    }
+
     let Some(function_scope) = enclosing_function_scope(checker, scope) else {
         return true;
     };
@@ -1054,8 +1501,9 @@ fn has_persistent_call_to_function_binding_between_offsets(
         .any(|fact| {
             let call_offset = fact.span.start.offset;
             call_offset <= before_offset
-                && call_may_resolve_to_binding(
+                && call_may_resolve_to_binding_cached(
                     checker,
+                    reach,
                     function_binding,
                     fact.scope,
                     fact.span,
@@ -1078,8 +1526,9 @@ fn has_persistent_call_to_function_binding_between_offsets(
             .any(|site| {
                 let call_offset = site.name_span.start.offset;
                 call_offset <= before_offset
-                    && call_may_resolve_to_binding(
+                    && call_may_resolve_to_binding_cached(
                         checker,
+                        reach,
                         function_binding,
                         site.scope,
                         site.name_span,
@@ -1139,8 +1588,9 @@ fn has_call_to_function_binding_before_offset(
         .flat_map(|facts| facts.iter())
         .any(|fact| {
             fact.span.start.offset <= before_offset
-                && call_may_resolve_to_binding(
+                && call_may_resolve_to_binding_cached(
                     checker,
+                    reach,
                     function_binding,
                     fact.scope,
                     fact.span,
@@ -1162,8 +1612,9 @@ fn has_call_to_function_binding_before_offset(
             .iter()
             .any(|site| {
                 site.name_span.start.offset <= before_offset
-                    && call_may_resolve_to_binding(
+                    && call_may_resolve_to_binding_cached(
                         checker,
+                        reach,
                         function_binding,
                         site.scope,
                         site.name_span,
@@ -1179,6 +1630,50 @@ fn has_call_to_function_binding_before_offset(
                         visiting,
                     )
             })
+}
+
+fn call_may_resolve_to_binding_cached(
+    checker: &Checker<'_>,
+    reach: &mut CompatReachState<'_>,
+    binding_id: shuck_semantic::BindingId,
+    call_scope: ScopeId,
+    visibility_span: shuck_ast::Span,
+    cfg_span: shuck_ast::Span,
+) -> bool {
+    call_may_resolve_to_binding_cached_in(
+        reach.call_resolution_cache,
+        checker,
+        binding_id,
+        call_scope,
+        visibility_span,
+        cfg_span,
+    )
+}
+
+fn call_may_resolve_to_binding_cached_in(
+    call_resolution_cache: &mut FxHashMap<CompatCallResolutionKey, bool>,
+    checker: &Checker<'_>,
+    binding_id: shuck_semantic::BindingId,
+    call_scope: ScopeId,
+    visibility_span: shuck_ast::Span,
+    cfg_span: shuck_ast::Span,
+) -> bool {
+    let key = CompatCallResolutionKey {
+        binding: binding_id,
+        call_scope,
+        visibility_start: visibility_span.start.offset,
+        visibility_end: visibility_span.end.offset,
+        cfg_start: cfg_span.start.offset,
+        cfg_end: cfg_span.end.offset,
+    };
+    if let Some(cached) = call_resolution_cache.get(&key) {
+        return *cached;
+    }
+
+    let resolved =
+        call_may_resolve_to_binding(checker, binding_id, call_scope, visibility_span, cfg_span);
+    call_resolution_cache.insert(key, resolved);
+    resolved
 }
 
 fn call_may_resolve_to_binding(
@@ -1575,13 +2070,16 @@ fn enclosing_function_scope_can_run_persistently(checker: &Checker<'_>, scope: S
 
     let mut scope_run_cache = FxHashMap::default();
     let mut scope_between_cache = FxHashMap::default();
-    let call_facts_by_name = build_compat_call_facts_by_name(checker);
+    let mut call_resolution_cache = FxHashMap::default();
+    let structural_facts = build_compat_structural_facts(checker);
     let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
     let mut reach = CompatReachState {
         scope_run_cache: &mut scope_run_cache,
         scope_between_cache: &mut scope_between_cache,
-        call_facts_by_name: &call_facts_by_name,
+        call_resolution_cache: &mut call_resolution_cache,
+        call_facts_by_name: &structural_facts.call_facts_by_name,
         function_bindings_by_scope: &function_bindings_by_scope,
+        activation_index: None,
     };
 
     command_scope_can_run_persistently_before_offset(
@@ -1604,13 +2102,16 @@ fn has_direct_call_inside_enclosing_function(
 
     let mut scope_run_cache = FxHashMap::default();
     let mut scope_between_cache = FxHashMap::default();
-    let call_facts_by_name = build_compat_call_facts_by_name(checker);
+    let mut call_resolution_cache = FxHashMap::default();
+    let structural_facts = build_compat_structural_facts(checker);
     let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
     let mut reach = CompatReachState {
         scope_run_cache: &mut scope_run_cache,
         scope_between_cache: &mut scope_between_cache,
-        call_facts_by_name: &call_facts_by_name,
+        call_resolution_cache: &mut call_resolution_cache,
+        call_facts_by_name: &structural_facts.call_facts_by_name,
         function_bindings_by_scope: &function_bindings_by_scope,
+        activation_index: None,
     };
     let mut visiting = FxHashSet::default();
     let window = BoundaryCallWindow {
@@ -1626,8 +2127,8 @@ fn has_direct_call_inside_enclosing_function(
         .flat_map(|facts| facts.iter())
         .any(|fact| {
             call_is_inside_scope(checker, fact.scope, enclosing_scope)
-                && call_may_resolve_to_binding(
-                    checker, binding_id, fact.scope, fact.span, fact.span,
+                && call_may_resolve_to_binding_cached(
+                    checker, &mut reach, binding_id, fact.scope, fact.span, fact.span,
                 )
                 && call_scope_can_execute_inside_boundary_after_offset_before_offset(
                     checker,
@@ -1644,8 +2145,9 @@ fn has_direct_call_inside_enclosing_function(
             .iter()
             .any(|site| {
                 call_is_inside_scope(checker, site.scope, enclosing_scope)
-                    && call_may_resolve_to_binding(
+                    && call_may_resolve_to_binding_cached(
                         checker,
+                        &mut reach,
                         binding_id,
                         site.scope,
                         site.name_span,
@@ -1754,8 +2256,9 @@ fn has_call_to_function_binding_inside_boundary_between_offsets(
             let call_offset = fact.span.start.offset;
             call_offset <= window.before_offset
                 && call_is_inside_scope(checker, fact.scope, window.boundary_scope)
-                && call_may_resolve_to_binding(
+                && call_may_resolve_to_binding_cached(
                     checker,
+                    reach,
                     function_binding,
                     fact.scope,
                     fact.span,
@@ -1778,8 +2281,9 @@ fn has_call_to_function_binding_inside_boundary_between_offsets(
                 let call_offset = site.name_span.start.offset;
                 call_offset <= window.before_offset
                     && call_is_inside_scope(checker, site.scope, window.boundary_scope)
-                    && call_may_resolve_to_binding(
+                    && call_may_resolve_to_binding_cached(
                         checker,
+                        reach,
                         function_binding,
                         site.scope,
                         site.name_span,
@@ -1796,22 +2300,6 @@ fn has_call_to_function_binding_inside_boundary_between_offsets(
             })
 }
 
-fn has_top_level_return_between(
-    checker: &Checker<'_>,
-    after_offset: usize,
-    before_offset: usize,
-) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        fact.body_span().start.offset > after_offset
-            && fact.body_span().start.offset < before_offset
-            && scope_is_file_scope(
-                checker,
-                checker.semantic().scope_at(fact.body_span().start.offset),
-            )
-            && fact.effective_name_is("return")
-    })
-}
-
 fn has_apparent_infinite_loop_after(checker: &Checker<'_>, offset: usize) -> bool {
     checker.facts().structural_commands().any(|fact| {
         fact.body_span().start.offset > offset
@@ -1823,34 +2311,26 @@ fn has_apparent_infinite_loop_after(checker: &Checker<'_>, offset: usize) -> boo
     })
 }
 
-fn has_apparent_infinite_loop_between(
-    checker: &Checker<'_>,
-    start_offset: usize,
-    end_offset: usize,
-) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        fact.body_span().start.offset > start_offset
-            && fact.body_span().start.offset < end_offset
-            && scope_is_file_scope(
-                checker,
-                checker.semantic().scope_at(fact.body_span().start.offset),
-            )
-            && command_is_apparent_infinite_loop(checker, fact.command())
-    })
+fn command_is_apparent_infinite_loop(checker: &Checker<'_>, command: &shuck_ast::Command) -> bool {
+    apparent_infinite_loop_body_span(checker, command)
+        .is_some_and(|body_span| !loop_body_contains_break(checker, body_span))
 }
 
-fn command_is_apparent_infinite_loop(checker: &Checker<'_>, command: &shuck_ast::Command) -> bool {
+fn apparent_infinite_loop_body_span(
+    checker: &Checker<'_>,
+    command: &shuck_ast::Command,
+) -> Option<shuck_ast::Span> {
     let source = checker.source();
     match command {
         shuck_ast::Command::Compound(shuck_ast::CompoundCommand::While(command)) => {
             condition_text_is(source, command.condition.span, &["true", ":"])
-                && !loop_body_contains_break(checker, command.body.span)
+                .then_some(command.body.span)
         }
         shuck_ast::Command::Compound(shuck_ast::CompoundCommand::Until(command)) => {
             condition_text_is(source, command.condition.span, &["false"])
-                && !loop_body_contains_break(checker, command.body.span)
+                .then_some(command.body.span)
         }
-        _ => false,
+        _ => None,
     }
 }
 
@@ -1916,18 +2396,31 @@ fn compat_cutoff_would_report_binding(
 ) -> bool {
     let mut scope_run_cache = FxHashMap::default();
     let mut scope_between_cache = FxHashMap::default();
-    let call_facts_by_name = build_compat_call_facts_by_name(checker);
+    let mut call_resolution_cache = FxHashMap::default();
+    let structural_facts = build_compat_structural_facts(checker);
     let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
-    let unset_facts = build_compat_unset_facts(checker, &function_bindings_by_scope);
+    let unset_facts = build_compat_unset_facts(
+        checker,
+        &function_bindings_by_scope,
+        &structural_facts.unset_commands_by_target,
+    );
+    let script_terminators = build_compat_script_terminator_facts(checker, &structural_facts);
     let mut reach = CompatReachState {
         scope_run_cache: &mut scope_run_cache,
         scope_between_cache: &mut scope_between_cache,
-        call_facts_by_name: &call_facts_by_name,
+        call_resolution_cache: &mut call_resolution_cache,
+        call_facts_by_name: &structural_facts.call_facts_by_name,
         function_bindings_by_scope: &function_bindings_by_scope,
+        activation_index: None,
     };
-    let Some(cutoff) =
-        first_compat_cutoff_after_binding(checker, binding_id, &mut reach, &unset_facts)
-    else {
+    let Some(cutoff) = first_compat_cutoff_after_binding(
+        checker,
+        binding_id,
+        &mut reach,
+        &unset_facts,
+        &script_terminators,
+        &structural_facts.top_level_control,
+    ) else {
         return false;
     };
 

--- a/scripts/profiling/profile_large_corpus.sh
+++ b/scripts/profiling/profile_large_corpus.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+fixture=${1:?Usage: profile_large_corpus.sh <fixture> [output-dir] [rate] [profile-iterations] [fixture-iterations]}
+profile_root=${2:-.cache/profiles}
+rate=${3:-1000}
+profile_iterations=${4:-1}
+fixture_iterations=${5:-1}
+
+repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+output_dir="$repo_root/$profile_root/large-corpus"
+
+mkdir -p "$output_dir"
+
+echo "Building large corpus profiling harness..."
+cargo build \
+    --profile profiling \
+    -p shuck-benchmark \
+    --features large-corpus-hotspots \
+    --example large_corpus_profile \
+    --manifest-path="$repo_root/Cargo.toml"
+
+binary="$repo_root/target/profiling/examples/large_corpus_profile"
+if [ ! -x "$binary" ]; then
+    echo "ERROR: compiled harness not found at $binary"
+    exit 1
+fi
+
+case_name=$(printf '%s' "$fixture" | tr '/:' '__')
+output="$output_dir/$case_name.json.gz"
+
+echo "Recording large-corpus/$fixture to $output"
+samply record \
+    --save-only \
+    --output "$output" \
+    --rate "$rate" \
+    --iteration-count "$profile_iterations" \
+    --profile-name "large-corpus/$fixture" \
+    -- \
+    "$binary" "$fixture" --iterations "$fixture_iterations"
+
+if [ "${SAMPLY_VIEW:-0}" = "1" ]; then
+    echo "Opening profile in samply..."
+    samply load "$output"
+else
+    echo "Saved profile: $output"
+    echo "Open with: samply load $output"
+fi


### PR DESCRIPTION
## Summary

- Add a large-corpus profiling harness that can run corpus fixtures with sibling-file lookup behavior intact.
- Add command-scope facts for structural commands so C063 can avoid repeated semantic scope lookup in common paths.
- Replace recursive C063 activation-window checks with a precomputed activation index, built from a single C063 structural prepass that also feeds unset, terminator, and top-level control facts.

## Impact

The hot `xwmx__nb__nb` corpus fixture now spends far less time in C063 reachability. Warm profiling moved from roughly `672.171 ms` baseline to `508.853 ms` average over 12 iterations, and C063 fell to about `2.3%` inclusive in the final sample.

## Validation

- `cargo fmt --check`
- `cargo test -q -p shuck-linter overwritten_function -- --nocapture`
- `cargo test -q -p shuck-linter c063_option_ -- --nocapture`
- `cargo test -q -p shuck-semantic`
- `cargo clippy -p shuck-linter -- -D warnings`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C063`
- `scripts/profiling/profile_large_corpus.sh xwmx__nb__nb .cache/profiles 2000 1 12`
- `git diff --check`