### PR TITLE
fix(linter): clear S001 initializer self-reference divergences

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -6,26 +6,12 @@ reviewed_divergences:
     column: 39
     end_column: 43
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "CISOfy__lynis__include__functions"
-    line: 2690
-    end_line: 2690
-    column: 38
-    end_column: 50
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
     line: 235
     end_line: 235
     column: 32
     end_column: 38
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__libraries__libvirt__rc.libvirt"
-    line: 130
-    end_line: 130
-    column: 16
-    end_column: 22
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh"
@@ -77,13 +63,6 @@ reviewed_divergences:
     end_column: 43
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "alpinelinux__aports__main__syslinux__update-extlinux"
-    line: 96
-    end_line: 96
-    column: 18
-    end_column: 26
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "awslabs__git-secrets__git-secrets"
     line: 124
     end_line: 124
@@ -117,13 +96,6 @@ reviewed_divergences:
     end_line: 2620
     column: 79
     end_column: 81
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__tool"
-    line: 87
-    end_line: 87
-    column: 36
-    end_column: 45
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
@@ -425,20 +397,6 @@ reviewed_divergences:
     end_line: 867
     column: 52
     end_column: 62
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "juewuy__ShellCrash__scripts__menus__running_status.sh"
-    line: 11
-    end_line: 11
-    column: 28
-    end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "juewuy__ShellCrash__tools__tg_bot.sh"
-    line: 70
-    end_line: 70
-    column: 23
-    end_column: 30
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "ko1nksm__shellspec__lib__general.sh"

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -284,6 +284,100 @@ impl<'a> SafeValueIndex<'a> {
         self.name_is_safe(name, at, query)
     }
 
+    pub fn part_is_safe_initializer_command_substitution_self_reference(
+        &mut self,
+        part: &WordPart,
+        span: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        let Some(name) = plain_scalar_reference_name_from_part(part) else {
+            return false;
+        };
+
+        self.semantic
+            .bindings_for(&name)
+            .iter()
+            .copied()
+            .any(|binding_id| {
+                let binding = self.semantic.binding(binding_id);
+                if binding.span.start.offset > span.start.offset {
+                    return false;
+                }
+                let Some(word) = self
+                    .facts
+                    .binding_value(binding_id)
+                    .and_then(|value| value.scalar_word())
+                else {
+                    return false;
+                };
+                if !span_contains(word.span, span) {
+                    return false;
+                }
+
+                self.facts.any_word_fact(word.span).is_some_and(|fact| {
+                    fact.command_substitution_spans()
+                        .iter()
+                        .copied()
+                        .any(|command_substitution| span_contains(command_substitution, span))
+                }) && !self.span_is_inside_loop_context(span)
+                    && !self.span_is_inside_if_condition(span)
+                    && {
+                        self.binding_value_stack.push(binding_id);
+                        let result = self.name_is_safe(&name, span, query);
+                        self.binding_value_stack.pop();
+                        result
+                    }
+            })
+    }
+
+    fn span_is_inside_loop_context(&self, span: Span) -> bool {
+        let mut current = self
+            .facts
+            .innermost_command_id_at(span.start.offset)
+            .or_else(|| self.innermost_command_id_containing_offset(span.start.offset));
+        while let Some(command_id) = current {
+            if matches!(
+                self.facts.command(command_id).command(),
+                Command::Compound(
+                    CompoundCommand::For(_)
+                        | CompoundCommand::Repeat(_)
+                        | CompoundCommand::Foreach(_)
+                        | CompoundCommand::ArithmeticFor(_)
+                        | CompoundCommand::While(_)
+                        | CompoundCommand::Until(_)
+                        | CompoundCommand::Select(_)
+                )
+            ) {
+                return true;
+            }
+            current = self.facts.command_parent_id(command_id);
+        }
+
+        false
+    }
+
+    fn span_is_inside_if_condition(&self, span: Span) -> bool {
+        let mut current = self
+            .facts
+            .innermost_command_id_at(span.start.offset)
+            .or_else(|| self.innermost_command_id_containing_offset(span.start.offset));
+        while let Some(command_id) = current {
+            if let Command::Compound(CompoundCommand::If(command)) =
+                self.facts.command(command_id).command()
+                && (span_contains(command.condition.span, span)
+                    || command
+                        .elif_branches
+                        .iter()
+                        .any(|(condition, _)| span_contains(condition.span, span)))
+            {
+                return true;
+            }
+            current = self.facts.command_parent_id(command_id);
+        }
+
+        false
+    }
+
     fn literal_part_is_safe(&self, part: &WordPart, span: Span, query: SafeValueQuery) -> bool {
         let word = Word {
             parts: vec![WordPartNode::new(part.clone(), span)],

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -337,6 +337,11 @@ fn report_word_expansions<F>(
         if fact.part_is_inside_backtick_escaped_double_quotes(part_span, source) {
             continue;
         }
+        if safe_values
+            .part_is_safe_initializer_command_substitution_self_reference(part, part_span, query)
+        {
+            continue;
+        }
         if part_is_in_numeric_test_operand(part_span, numeric_test_operand_spans)
             && safe_values.part_is_safe(part, part_span, SafeValueQuery::NumericTestOperand)
         {
@@ -1709,6 +1714,26 @@ echo \"MD5SUM=\\\"$( md5sum $PRGNAM-$VERSION.tar.xz | cut -d' ' -f1 )\\\"\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$VERSION"]
+        );
+    }
+
+    #[test]
+    fn skips_self_references_inside_command_substitution_initializers() {
+        let source = "\
+#!/bin/sh
+check=0
+check=$(expr $check + $?)
+value=$1
+value=$(echo $value | sed 's/^ //')
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$value"]
         );
     }
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=70`
-- Individual reviewed records classified below: 111 total (`shellcheck-only=23`, `shuck-only=88`).
+- `reviewed_divergences=64`
+- Individual reviewed records classified below: 103 total (`shellcheck-only=23`, `shuck-only=80`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -118,19 +118,13 @@ Resolved records should not remain as reviewed divergences.
 - `scop__bash-completion__completions-core__geoiplookup.bash:29:31-36` `$ipvx`
 - `termux__termux-packages__packages__lazygit__build.sh:25:41-61` `-ldflags`
 
-## [ ] Shuck-only: command-substitution initializer argument (13)
+## [ ] Shuck-only: command-substitution initializer argument (7 remaining)
 
-- `CISOfy__lynis__include__functions:2690:38-50` `${TIME_DIFF}`
-- `SlackBuildsOrg__slackbuilds__libraries__libvirt__rc.libvirt:130:16-22` `$check`
 - `acmesh-official__acme.sh__dnsapi__dns_tencent.sh:113:32-40` `$service`
 - `acmesh-official__acme.sh__dnsapi__dns_tencent.sh:116:40-48` `$service`
 - `acmesh-official__acme.sh__dnsapi__dns_tencent.sh:116:49-57` `$version`
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:245:36-43` `$tarpid`
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`
-- `alpinelinux__aports__main__syslinux__update-extlinux:96:18-26` `$timeout`
-- `bittorf__kalua__openwrt-addons__etc__kalua__tool:87:36-45` `$UP_HOURS`
-- `juewuy__ShellCrash__scripts__menus__running_status.sh:11:28-35` `${time}`
-- `juewuy__ShellCrash__tools__tg_bot.sh:70:23-30` `${time}`
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
 - `swoodford__aws__wafv2-web-acl-pingdom.sh:196:40-49` `$WAFSCOPE`
 


### PR DESCRIPTION
## Summary
- Treat safe same-variable references inside command-substitution initializers as safe for S001.
- Keep loop and if-condition initializer contexts reporting so we do not suppress real ShellCheck parity cases.
- Remove six now-cleared S001 reviewed divergence metadata entries and update docs/S001_BUGS.md counts.

## Validation
- cargo test -q -p shuck-linter unquoted_expansion -- --nocapture
- make large-corpus-report SHUCK_LARGE_CORPUS_RULES=S001
- cargo fmt
- git diff --check
- make test