### PR TITLE
chore(profiling): isolate large corpus sampled loop

### DIFF
--- a/.claude/skills/profile-shuck-script/SKILL.md
+++ b/.claude/skills/profile-shuck-script/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: profile-shuck-script
+description: Profile shuck scripts and large-corpus fixtures, especially requests to profile a corpus script/fixture, reprofile after a shuck performance change, or produce a hotspot table from a samply profile. Use when Codex needs to run the shuck large-corpus profiling harness, avoid corpus setup artifacts, interpret sampled profiles, and return an attributed-exclusive hotspot table.
+---
+
+# Profile Shuck Script
+
+## Workflow
+
+1. Work from the current `shuck` checkout. If the user asks for a fresh branch, create it from `main` before editing.
+2. Ensure the profiling harness profiles the lint loop, not corpus setup:
+   - Prefer `scripts/profiling/profile_large_corpus.sh <fixture> .cache/profiles 2000 1 12`.
+   - The script should build the profiling binary, prepare any large-corpus fixture manifest before `samply record`, then run the sampled process using that manifest.
+   - If the sampled profile includes corpus discovery, fixture-table construction, or resolver canonicalization, call that out as a setup artifact and fix the harness or exclude it before presenting hotspots.
+3. Run the profile at least once after a rebuild and again warm if the first run includes rebuild/cold-start noise.
+4. Summarize the newest saved profile with `scripts/summarize_samply_hotspots.py`.
+5. Return an attributed-exclusive table, not a raw inclusive table.
+
+## Commands
+
+Build/profile a large-corpus fixture:
+
+```bash
+scripts/profiling/profile_large_corpus.sh xwmx__nb__nb .cache/profiles 2000 1 12
+```
+
+Summarize the latest samply profile:
+
+```bash
+python3 ~/.codex/skills/profile-shuck-script/scripts/summarize_samply_hotspots.py \
+  .cache/profiles/large-corpus/xwmx__nb__nb.json.gz \
+  target/profiling/examples/large_corpus_profile \
+  --limit 12
+```
+
+Use the profile output's reported average from the harness stderr, not a profile-wide estimate, when stating wall-clock time.
+
+## Table Style
+
+Use "attributed exclusive" samples:
+
+- Count each sample once.
+- Attribute generic frames such as iterator adapters, `OnceLock`, `memchr`, allocation, and syscalls to the nearest meaningful shuck/semantic/parser caller when possible.
+- Keep separate rows for setup artifacts only when they are truly inside the sampled workload.
+- Do not lead with parent orchestration frames such as `main`, `Checker::check`, or `lint_file_at_path...`; those are usually inclusive wrappers.
+
+Return a concise table like:
+
+```markdown
+Latest profile: `<fixture>`, 12 iterations, avg `<N> ms`.
+
+| Rank | Hotspot | Attributed Exclusive | Representative Frame | Read |
+|---:|---|---:|---|---|
+| 1 | Linter facts builder | 55.8% | `facts::LinterFactsBuilder::build` | Clear next big target |
+| 2 | Possible-variable-misspelling rule | 5.2% | `possible_variable_misspelling` | Rule-local matching |
+```
+
+If the user is debugging whether a row is real, add a short note after the table explaining the evidence from stack context.
+
+## Interpretation Rules
+
+- Treat unexpectedly large file open/read/canonicalization rows with suspicion. In this workflow they often mean the profiler captured corpus discovery or resolver setup, not linting.
+- If I/O remains after loop-only profiling, split it into target fixture source read, source-closure sibling reads, manifest load, and path canonicalization.
+- If C063 appears, mention whether it is still material after the activation-window index. Around 1-2% is no longer the main target.
+- If `LinterFactsBuilder::build` dominates, identify it as the next broad optimization area rather than a single rule hotspot.
+
+## Validation
+
+For harness edits, run:
+
+```bash
+cargo fmt --check
+cargo build --profile profiling -p shuck-benchmark --features large-corpus-hotspots --example large_corpus_profile
+git diff --check
+```
+
+For rule-performance edits, also run the targeted rule tests and corpus gate relevant to the changed rule.

--- a/.claude/skills/profile-shuck-script/agents/openai.yaml
+++ b/.claude/skills/profile-shuck-script/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Profile Shuck Script"
+  short_description: "Profile shuck scripts and report hotspots"
+  default_prompt: "Use $profile-shuck-script to profile a shuck corpus script and summarize the newest hotspots."

--- a/.claude/skills/profile-shuck-script/scripts/summarize_samply_hotspots.py
+++ b/.claude/skills/profile-shuck-script/scripts/summarize_samply_hotspots.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Summarize a samply profile as attributed-exclusive shuck hotspots."""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import collections
+import gzip
+import json
+import subprocess
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("profile", type=Path, help="samply profile JSON or JSON.GZ")
+    parser.add_argument("binary", type=Path, help="profiled binary for nm/rustfilt symbols")
+    parser.add_argument("--limit", type=int, default=12, help="number of rows to print")
+    parser.add_argument("--min-percent", type=float, default=0.3)
+    return parser.parse_args()
+
+
+def load_profile(path: Path) -> dict:
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt") as handle:
+            return json.load(handle)
+    return json.loads(path.read_text())
+
+
+def load_symbols(binary: Path) -> tuple[list[int], list[str]]:
+    output = subprocess.check_output(["nm", "-an", str(binary)], text=True, errors="ignore")
+    symbols: list[tuple[int, str]] = []
+    for line in output.splitlines():
+        parts = line.split(maxsplit=2)
+        if len(parts) != 3 or parts[1] not in {"t", "T"}:
+            continue
+        name = parts[2]
+        if name.startswith("_") and not name.startswith("__ZN"):
+            name = name[1:]
+        symbols.append((int(parts[0], 16), name))
+    symbols.sort()
+
+    unique = []
+    seen = set()
+    for _, name in symbols:
+        if name not in seen:
+            seen.add(name)
+            unique.append(name)
+    try:
+        demangled = subprocess.check_output(
+            ["rustfilt"],
+            input="\n".join(unique),
+            text=True,
+        ).splitlines()
+        demap = dict(zip(unique, demangled))
+    except (OSError, subprocess.CalledProcessError):
+        demap = {name: name for name in unique}
+
+    return [addr for addr, _ in symbols], [demap.get(name, name) for _, name in symbols]
+
+
+def symbol_for(offset: int, addrs: list[int], names: list[str]) -> str | None:
+    index = bisect.bisect_right(addrs, 0x100000000 + offset) - 1
+    if index < 0:
+        return None
+    return names[index]
+
+
+def clean(name: str | None) -> str:
+    return (name or "<system/unknown>").removeprefix("_")
+
+
+def bucket(chain: list[str | None]) -> tuple[str, str, str]:
+    names = [clean(name) for name in chain]
+    stack = "\n".join(names)
+
+    def has(text: str) -> bool:
+        return text in stack
+
+    if has("large_corpus_profile::read_fixture_manifest"):
+        return ("Fixture manifest load (pre-loop)", "large_corpus_profile::read_fixture_manifest", "Setup artifact if it is large")
+    if has("large_corpus_profile::run_large_corpus_fixture") and (
+        has("std::fs::read_to_string") or has("std::fs::read::inner") or has("File::open_c")
+    ):
+        return ("Target fixture source read", "run_large_corpus_fixture -> fs::read_to_string", "Expected small per-iteration I/O")
+    if has("large_corpus_profile::LargeCorpusPathResolver::new"):
+        return ("Resolver map build (pre-loop)", "LargeCorpusPathResolver::new", "Should be outside sampled loop")
+    if has("shuck_linter::facts::LinterFactsBuilder::build"):
+        return ("Linter facts builder", "facts::LinterFactsBuilder::build", "Broad fact-building cost")
+    if has("possible_variable_misspelling"):
+        return ("Possible-variable-misspelling rule", "rules::possible_variable_misspelling", "Rule-local matching work")
+    if has("shuck_semantic::dataflow::analyze_unused_assignments_exact"):
+        return ("Unused-assignment dataflow", "semantic::dataflow::analyze_unused_assignments_exact", "Semantic dataflow")
+    if has("shuck_semantic::SemanticAnalysis::uninitialized_references"):
+        return ("Uninitialized reference analysis", "semantic::SemanticAnalysis::uninitialized_references", "Lazy semantic analysis")
+    if has("shuck_linter::rules::correctness::local_cross_reference::local_cross_reference"):
+        return ("C064 local cross-reference rule", "rules::local_cross_reference", "Iterator-heavy rule path")
+    if has("shuck_semantic::builder::source_line"):
+        return ("Semantic source-line lookup", "semantic::builder::source_line", "Line lookup/memchr work")
+    if has("shuck_semantic::SemanticModel::scope_at"):
+        return ("Scope lookup", "semantic::SemanticModel::scope_at", "Scope lookup")
+    if has("shuck_semantic::build_semantic_model_base"):
+        return ("Semantic model base build", "semantic::build_semantic_model_base", "Core semantic construction")
+    if has("shuck_semantic::dataflow::compute_initialized_name_states_dense_with_extra_name_gens"):
+        return ("Initialized-name state dataflow", "semantic::dataflow::compute_initialized_name_states_dense_with_extra_name_gens", "Semantic dataflow")
+    if has("shuck_semantic::reachable_blocks_for_binding"):
+        return ("CFG reachability for bindings", "semantic::reachable_blocks_for_binding", "CFG query work")
+    if has("shuck_linter::facts::StaticCasePatternMatcher::advance"):
+        return ("Static case-pattern matcher", "facts::StaticCasePatternMatcher::advance", "Case-pattern matching")
+    if has("shuck_linter::facts::build_innermost_command_ids_by_offset"):
+        return ("Innermost-command offset index", "facts::build_innermost_command_ids_by_offset", "Fact index construction")
+    if has("shuck_linter::rules::correctness::script_scope_local::local_top_level"):
+        return ("Script-scope-local rule", "rules::script_scope_local::local_top_level", "Rule-local scan")
+    if has("shuck_semantic::build_call_graph"):
+        return ("Call graph build", "semantic::build_call_graph", "Call graph construction")
+    if has("array_to_string_conversion"):
+        return ("Array-to-string rule", "rules::array_to_string_conversion", "Rule-local lookup")
+    if has("overwritten_function"):
+        return ("C063 overwritten-function rule", "rules::overwritten_function", "C063 compatibility logic")
+    if has("std::sys::fs::unix::canonicalize") or has("std::sys::fs::canonicalize"):
+        return ("Path canonicalization", "std::sys::fs::unix::canonicalize", "Suspicious if large; check setup capture")
+    if has("std::sys::fs::unix::File::open_c"):
+        return ("Other file opens", "std::sys::fs::unix::File::open_c", "Split source reads from setup")
+    if has("std::fs::read::inner") or has("std::io::default_read_to_end"):
+        return ("Other file reads", "std::fs::read / read_to_end", "Split source reads from setup")
+    if has("alloc::raw_vec::RawVecInner"):
+        return ("Vector growth/allocation", "alloc::raw_vec growth", "Allocation/growth")
+
+    leaf = names[0] if names else "<system/unknown>"
+    return (leaf, leaf, "")
+
+
+def profile_frame_names(profile: dict, addrs: list[int], names: list[str]) -> tuple[dict, list[str | None]]:
+    thread = profile["threads"][0]
+    func_res = thread["funcTable"]["resource"]
+    res_lib = thread["resourceTable"]["lib"]
+    frame_func = thread["frameTable"]["func"]
+    frame_addr = thread["frameTable"]["address"]
+
+    frame_names: list[str | None] = []
+    for frame, func in enumerate(frame_func):
+        lib = res_lib[func_res[func]] if func_res[func] is not None else None
+        offset = frame_addr[frame]
+        if lib == 1 and isinstance(offset, int):
+            frame_names.append(symbol_for(offset, addrs, names))
+        else:
+            frame_names.append(None)
+    return thread, frame_names
+
+
+def main() -> None:
+    args = parse_args()
+    profile = load_profile(args.profile)
+    addrs, names = load_symbols(args.binary)
+    thread, frame_names = profile_frame_names(profile, addrs, names)
+
+    stack_prefix = thread["stackTable"]["prefix"]
+    stack_frame = thread["stackTable"]["frame"]
+    weights = thread["samples"].get("weight") or [1] * thread["samples"]["length"]
+    stacks = thread["samples"]["stack"]
+
+    counts: collections.Counter[str] = collections.Counter()
+    examples: dict[str, tuple[str, str]] = {}
+    total = 0
+    for stack, weight in zip(stacks, weights):
+        if stack is None:
+            continue
+        total += weight
+        chain: list[str | None] = []
+        current = stack
+        while current is not None:
+            chain.append(frame_names[stack_frame[current]])
+            current = stack_prefix[current]
+        label, frame, read = bucket(chain)
+        if label in {
+            "main",
+            "std::rt::lang_start_internal",
+            "large_corpus_profile::main",
+            "std::sys::backtrace::__rust_begin_short_backtrace",
+        }:
+            continue
+        counts[label] += weight
+        examples.setdefault(label, (frame, read))
+
+    print(f"total_samples={total}")
+    print("| Rank | Hotspot | Attributed Exclusive | Representative Frame | Read |")
+    print("|---:|---|---:|---|---|")
+    rank = 1
+    for label, count in counts.most_common():
+        percent = count / total * 100 if total else 0
+        if rank > args.limit or percent < args.min_percent:
+            break
+        frame, read = examples[label]
+        print(f"| {rank} | {label} | {percent:.1f}% | `{frame}` | {read} |")
+        rank += 1
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/shuck-benchmark/examples/large_corpus_profile.rs
+++ b/crates/shuck-benchmark/examples/large_corpus_profile.rs
@@ -36,9 +36,11 @@ type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 #[derive(Debug)]
 struct Args {
-    fixture: String,
+    fixture: Option<String>,
     iterations: usize,
     corpus_root: Option<PathBuf>,
+    fixture_manifest: Option<PathBuf>,
+    write_fixture_manifest: Option<PathBuf>,
     rules: Option<RuleSet>,
     resolve_source_closure: bool,
 }
@@ -46,6 +48,7 @@ struct Args {
 #[derive(Debug, Clone)]
 struct LargeCorpusFixture {
     path: PathBuf,
+    canonical_path: PathBuf,
     cache_rel_path: PathBuf,
     shell: String,
 }
@@ -68,11 +71,15 @@ impl LargeCorpusPathResolver {
         let mut path_by_cache_rel = HashMap::new();
 
         for fixture in fixtures {
-            let canonical_path =
-                fs::canonicalize(&fixture.path).unwrap_or_else(|_| fixture.path.clone());
             cache_rel_by_path.insert(fixture.path.clone(), fixture.cache_rel_path.clone());
-            cache_rel_by_path.insert(canonical_path.clone(), fixture.cache_rel_path.clone());
-            path_by_cache_rel.insert(fixture.cache_rel_path.clone(), canonical_path);
+            cache_rel_by_path.insert(
+                fixture.canonical_path.clone(),
+                fixture.cache_rel_path.clone(),
+            );
+            path_by_cache_rel.insert(
+                fixture.cache_rel_path.clone(),
+                fixture.canonical_path.clone(),
+            );
         }
 
         Self {
@@ -119,7 +126,11 @@ fn main() -> Result<()> {
             "large corpus not found; set {LARGE_CORPUS_ROOT_ENV}, populate ./{LARGE_CORPUS_CACHE_DIR_NAME}, or pass --root"
         )
     })?;
-    let fixtures = collect_fixtures(&corpus_dir);
+    let fixtures = if let Some(manifest) = args.fixture_manifest.as_deref() {
+        read_fixture_manifest(manifest)?
+    } else {
+        collect_fixtures(&corpus_dir)
+    };
     if fixtures.is_empty() {
         return Err(format!(
             "no fixtures found in {}",
@@ -127,9 +138,19 @@ fn main() -> Result<()> {
         )
         .into());
     }
+    if let Some(manifest) = args.write_fixture_manifest.as_deref() {
+        write_fixture_manifest(manifest, &fixtures)?;
+        eprintln!(
+            "wrote {} fixture(s) to {}",
+            fixtures.len(),
+            manifest.display()
+        );
+        return Ok(());
+    }
 
-    let fixture = find_fixture(&fixtures, &args.fixture)
-        .ok_or_else(|| format!("fixture `{}` not found in large corpus", args.fixture))?
+    let fixture_name = args.fixture.as_ref().ok_or("missing fixture name")?;
+    let fixture = find_fixture(&fixtures, fixture_name)
+        .ok_or_else(|| format!("fixture `{fixture_name}` not found in large corpus"))?
         .clone();
     let resolver = LargeCorpusPathResolver::new(&fixtures);
     let settings = build_linter_settings(args.rules, args.resolve_source_closure);
@@ -163,6 +184,8 @@ fn parse_args() -> Result<Option<Args>> {
     let mut fixture = None;
     let mut iterations = 1usize;
     let mut corpus_root = None;
+    let mut fixture_manifest = None;
+    let mut write_fixture_manifest = None;
     let mut rules = None;
     let mut resolve_source_closure = true;
     let mut values = env::args().skip(1);
@@ -179,6 +202,20 @@ fn parse_args() -> Result<Option<Args>> {
             "--root" => {
                 corpus_root = Some(PathBuf::from(
                     values.next().ok_or("missing value after --root")?,
+                ));
+            }
+            "--fixture-manifest" => {
+                fixture_manifest = Some(PathBuf::from(
+                    values
+                        .next()
+                        .ok_or("missing value after --fixture-manifest")?,
+                ));
+            }
+            "--write-fixture-manifest" => {
+                write_fixture_manifest = Some(PathBuf::from(
+                    values
+                        .next()
+                        .ok_or("missing value after --write-fixture-manifest")?,
                 ));
             }
             "--rules" => {
@@ -200,11 +237,15 @@ fn parse_args() -> Result<Option<Args>> {
         }
     }
 
-    let fixture = fixture.ok_or("missing fixture name")?;
+    if fixture.is_none() && write_fixture_manifest.is_none() {
+        return Err("missing fixture name".into());
+    }
     Ok(Some(Args {
         fixture,
         iterations,
         corpus_root,
+        fixture_manifest,
+        write_fixture_manifest,
         rules,
         resolve_source_closure,
     }))
@@ -212,12 +253,13 @@ fn parse_args() -> Result<Option<Args>> {
 
 fn print_usage() {
     eprintln!(
-        "Usage: large_corpus_profile <fixture> [--iterations N] [--root PATH] [--rules SELECTORS] [--no-source-closure]"
+        "Usage: large_corpus_profile <fixture> [--iterations N] [--root PATH] [--fixture-manifest PATH] [--rules SELECTORS] [--no-source-closure]"
     );
     eprintln!();
     eprintln!("Examples:");
     eprintln!("  large_corpus_profile xwmx__nb__nb --iterations 10");
     eprintln!("  large_corpus_profile xwmx__nb__nb --rules C063");
+    eprintln!("  large_corpus_profile --write-fixture-manifest /tmp/large-corpus.tsv");
 }
 
 fn parse_positive_usize(name: &str, value: Option<String>) -> Result<usize> {
@@ -395,10 +437,12 @@ fn collect_fixtures(corpus_dir: &Path) -> Vec<LargeCorpusFixture> {
             .strip_prefix(&scripts_dir)
             .unwrap_or(path.as_path())
             .to_path_buf();
+        let canonical_path = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
         let shell = resolve_shell(&path, &source);
 
         fixtures.push(LargeCorpusFixture {
             path,
+            canonical_path,
             cache_rel_path,
             shell,
         });
@@ -406,6 +450,65 @@ fn collect_fixtures(corpus_dir: &Path) -> Vec<LargeCorpusFixture> {
 
     fixtures.sort_by(|left, right| left.path.cmp(&right.path));
     fixtures
+}
+
+fn write_fixture_manifest(path: &Path, fixtures: &[LargeCorpusFixture]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut contents = String::new();
+    for fixture in fixtures {
+        contents.push_str(&fixture.path.to_string_lossy());
+        contents.push('\t');
+        contents.push_str(&fixture.canonical_path.to_string_lossy());
+        contents.push('\t');
+        contents.push_str(&fixture.cache_rel_path.to_string_lossy());
+        contents.push('\t');
+        contents.push_str(&fixture.shell);
+        contents.push('\n');
+    }
+    fs::write(path, contents)?;
+    Ok(())
+}
+
+fn read_fixture_manifest(path: &Path) -> Result<Vec<LargeCorpusFixture>> {
+    let contents = fs::read_to_string(path)
+        .map_err(|err| format!("failed to read fixture manifest {}: {err}", path.display()))?;
+    let mut fixtures = Vec::new();
+    for (index, line) in contents.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut parts = line.split('\t');
+        let Some(path) = parts.next() else {
+            continue;
+        };
+        let Some(canonical_path) = parts.next() else {
+            return Err(format!(
+                "fixture manifest line {} is missing canonical path",
+                index + 1
+            )
+            .into());
+        };
+        let Some(cache_rel_path) = parts.next() else {
+            return Err(
+                format!("fixture manifest line {} is missing cache path", index + 1).into(),
+            );
+        };
+        let Some(shell) = parts.next() else {
+            return Err(format!("fixture manifest line {} is missing shell", index + 1).into());
+        };
+        if parts.next().is_some() {
+            return Err(format!("fixture manifest line {} has too many fields", index + 1).into());
+        }
+        fixtures.push(LargeCorpusFixture {
+            path: PathBuf::from(path),
+            canonical_path: PathBuf::from(canonical_path),
+            cache_rel_path: PathBuf::from(cache_rel_path),
+            shell: shell.to_owned(),
+        });
+    }
+    Ok(fixtures)
 }
 
 fn resolve_shell(path: &Path, src: &[u8]) -> String {

--- a/scripts/profiling/profile_large_corpus.sh
+++ b/scripts/profiling/profile_large_corpus.sh
@@ -28,6 +28,10 @@ fi
 
 case_name=$(printf '%s' "$fixture" | tr '/:' '__')
 output="$output_dir/$case_name.json.gz"
+manifest="$output_dir/large-corpus-fixtures.tsv"
+
+echo "Preparing large corpus fixture manifest outside the sampled process..."
+"$binary" --write-fixture-manifest "$manifest"
 
 echo "Recording large-corpus/$fixture to $output"
 samply record \
@@ -37,7 +41,9 @@ samply record \
     --iteration-count "$profile_iterations" \
     --profile-name "large-corpus/$fixture" \
     -- \
-    "$binary" "$fixture" --iterations "$fixture_iterations"
+    "$binary" "$fixture" \
+        --iterations "$fixture_iterations" \
+        --fixture-manifest "$manifest"
 
 if [ "${SAMPLY_VIEW:-0}" = "1" ]; then
     echo "Opening profile in samply..."


### PR DESCRIPTION
## Summary

- Add fixture-manifest read/write support to the large-corpus profiling harness.
- Move corpus fixture discovery and resolver canonicalization outside `samply record` in `profile_large_corpus.sh`.
- Keep sampled profiles focused on the fixture lint loop instead of setup work.
- Add a project-local `.claude/skills/profile-shuck-script` skill that documents this workflow and includes a reusable samply hotspot summarizer.

## Why

The previous profile captured corpus setup before the timed loop, which made file opens and path canonicalization look like meaningful hotspots even though they were mostly harness setup artifacts. Preparing a fixture manifest before sampling keeps the saved profile aligned with the harness-reported loop average.

The skill captures the profiling workflow and the attributed-exclusive hotspot table format so future profiling passes can reproduce the same reporting shape without rebuilding the profile parser from scratch.

## Validation

- `cargo fmt --check`
- `cargo build --profile profiling -p shuck-benchmark --features large-corpus-hotspots --example large_corpus_profile`
- `scripts/profiling/profile_large_corpus.sh xwmx__nb__nb .cache/profiles 2000 1 12`
- `git diff --check`
- `uv run --with PyYAML python /Users/ewhauser/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/profile-shuck-script`
- `python3 .claude/skills/profile-shuck-script/scripts/summarize_samply_hotspots.py .cache/profiles/large-corpus/xwmx__nb__nb.json.gz target/profiling/examples/large_corpus_profile --limit 5`

Latest loop-only profile for `xwmx__nb__nb`: 12 iterations, `508.929 ms` average. The attributed table no longer shows path canonicalization as a material hotspot; remaining file open/read samples are effectively noise.
