### PR TITLE
fix(linter): share shell dialect parsing policy

### DIFF
--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -231,27 +231,9 @@ fn resolve_large_corpus_shell(path: &Path, source: &[u8]) -> String {
     }
 }
 
-fn parser_dialect_for_large_corpus_shell(shell: &str) -> shuck_parser::ShellDialect {
-    match ShellDialect::from_name(shell) {
-        ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => {
-            shuck_parser::ShellDialect::Posix
-        }
-        ShellDialect::Mksh => shuck_parser::ShellDialect::Mksh,
-        ShellDialect::Zsh => shuck_parser::ShellDialect::Zsh,
-        ShellDialect::Unknown | ShellDialect::Bash => shuck_parser::ShellDialect::Bash,
-    }
-}
-
-fn shell_profile_for_large_corpus_shell(shell: &str) -> shuck_parser::ShellProfile {
-    shuck_parser::ShellProfile::native(parser_dialect_for_large_corpus_shell(shell))
-}
-
 fn parse_large_corpus_fixture(fixture: &LargeCorpusFixture) -> ParseResult {
-    Parser::with_dialect(
-        &fixture.source,
-        parser_dialect_for_large_corpus_shell(&fixture.shell),
-    )
-    .parse()
+    let shell = ShellDialect::from_name(&fixture.shell);
+    Parser::with_dialect(&fixture.source, shell.parser_dialect()).parse()
 }
 
 fn prepare_word_facts_input(
@@ -269,7 +251,7 @@ fn prepare_word_facts_input(
             source_path_resolver: resolver,
             file_entry_contract: None,
             analyzed_paths: None,
-            shell_profile: Some(shell_profile_for_large_corpus_shell(&fixture.shell)),
+            shell_profile: Some(ShellDialect::from_name(&fixture.shell).shell_profile()),
             resolve_source_closure: true,
         },
     );

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1372,14 +1372,7 @@ fn analyze_shell_file(
 ) -> Result<FileCheckResult> {
     let mut source = read_shared_source(&pending.file.absolute_path)?;
     let inferred_shell = ShellDialect::infer(&source, Some(&pending.file.absolute_path));
-    let parse_dialect = match inferred_shell {
-        ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => {
-            shuck_parser::ShellDialect::Posix
-        }
-        ShellDialect::Mksh => shuck_parser::ShellDialect::Mksh,
-        ShellDialect::Zsh => shuck_parser::ShellDialect::Zsh,
-        ShellDialect::Unknown | ShellDialect::Bash => shuck_parser::ShellDialect::Bash,
-    };
+    let parse_dialect = inferred_shell.parser_dialect();
 
     let linter_settings = base_linter_settings.clone().with_shell(inferred_shell);
     let mut parse_result = Parser::with_dialect(&source, parse_dialect).parse();

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -16,7 +16,6 @@ use shuck_linter::{
     LinterSettings, Rule, RuleSet, Severity, ShellCheckCodeMap, ShellCheckLevel, ShellDialect,
     SuppressionIndex, first_statement_line, parse_directives, rule_metadata,
 };
-use shuck_parser::ShellProfile;
 use shuck_parser::parser::Parser;
 use shuck_semantic::SourcePathResolver;
 use shuck_semantic::SourceRefKind;
@@ -931,7 +930,7 @@ fn lint_with_context(
         .transpose()?
         .unwrap_or_else(|| ShellDialect::infer(source, Some(path)));
 
-    let parse_result = Parser::with_profile(source, shell_profile(shell)).parse();
+    let parse_result = Parser::with_profile(source, shell.shell_profile()).parse();
     let indexer = Indexer::new(source, &parse_result);
     let shellcheck_map = &options.shellcheck_map;
     let directives = parse_directives(
@@ -1185,19 +1184,6 @@ fn validate_shell(value: &str) -> Result<(), CompatCliError> {
             4,
             format!("unsupported shell `{value}`"),
         )),
-    }
-}
-
-fn shell_profile(shell: ShellDialect) -> ShellProfile {
-    match shell {
-        ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => {
-            ShellProfile::native(shuck_parser::ShellDialect::Posix)
-        }
-        ShellDialect::Mksh => ShellProfile::native(shuck_parser::ShellDialect::Mksh),
-        ShellDialect::Zsh => ShellProfile::native(shuck_parser::ShellDialect::Zsh),
-        ShellDialect::Unknown | ShellDialect::Bash => {
-            ShellProfile::native(shuck_parser::ShellDialect::Bash)
-        }
     }
 }
 

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -2365,23 +2365,6 @@ fn unsupported_large_corpus_shebang_shell(first_line: &str) -> Option<&str> {
 // Shuck runner
 // ---------------------------------------------------------------------------
 
-fn parser_dialect_for_large_corpus_shell(shell: &str) -> shuck_parser::ShellDialect {
-    match shuck_linter::ShellDialect::from_name(shell) {
-        shuck_linter::ShellDialect::Sh
-        | shuck_linter::ShellDialect::Dash
-        | shuck_linter::ShellDialect::Ksh => shuck_parser::ShellDialect::Posix,
-        shuck_linter::ShellDialect::Mksh => shuck_parser::ShellDialect::Mksh,
-        shuck_linter::ShellDialect::Zsh => shuck_parser::ShellDialect::Zsh,
-        shuck_linter::ShellDialect::Unknown | shuck_linter::ShellDialect::Bash => {
-            shuck_parser::ShellDialect::Bash
-        }
-    }
-}
-
-fn shell_profile_for_large_corpus_shell(shell: &str) -> shuck_parser::ShellProfile {
-    shuck_parser::ShellProfile::native(parser_dialect_for_large_corpus_shell(shell))
-}
-
 fn run_shuck_with_parse_dialect(
     fixture: &LargeCorpusFixture,
     linter_settings: &shuck_linter::LinterSettings,
@@ -2460,7 +2443,7 @@ fn run_shuck(
         fixture,
         linter_settings,
         source_path_resolver,
-        shuck_parser::ShellDialect::Bash,
+        shuck_linter::ShellDialect::from_name(&fixture.shell).parser_dialect(),
         &fixture.shell,
     )
 }
@@ -2493,7 +2476,7 @@ fn parse_fixture_for_effective_large_corpus_shell_with_timeout(
     let timeout = effective_shuck_timeout(source.as_bytes(), timeout);
     run_with_timeout("shuck", timeout, move || {
         let shell = effective_large_corpus_shell(&fixture);
-        let shell_profile = shell_profile_for_large_corpus_shell(shell);
+        let shell_profile = shuck_linter::ShellDialect::from_name(shell).shell_profile();
         let parsed =
             shuck_parser::parser::Parser::with_profile(&source, shell_profile.clone()).parse();
         if parsed.is_err() {
@@ -3289,7 +3272,7 @@ mod tests {
     #[test]
     fn parser_dialect_for_large_corpus_zsh_shell_is_zsh() {
         assert_eq!(
-            parser_dialect_for_large_corpus_shell("zsh"),
+            shuck_linter::ShellDialect::from_name("zsh").parser_dialect(),
             shuck_parser::ShellDialect::Zsh
         );
     }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -119,7 +119,6 @@ use rustc_hash::FxHashSet;
 use shuck_ast::{File, Position, Span, TextSize};
 use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::{ParseResult, Parser};
-use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile};
 use shuck_semantic::{
     SemanticBuildOptions, SemanticModel, SourcePathResolver, TraversalObserver,
     build_with_observer_with_options,
@@ -241,7 +240,7 @@ fn analyze_file_at_path_with_resolver_and_shell(
         .or(analyzed_paths_fallback.as_ref());
 
     let mut observer = LintTraversalObserver::default();
-    let shell_profile = inferred_shell_profile(shell);
+    let shell_profile = shell.shell_profile();
     let semantic = build_with_observer_with_options(
         file,
         source,
@@ -303,18 +302,8 @@ fn resolve_shell(
     }
 }
 
-fn inferred_shell_profile(shell: ShellDialect) -> ShellProfile {
-    let dialect = match shell {
-        ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => ParseShellDialect::Posix,
-        ShellDialect::Mksh => ParseShellDialect::Mksh,
-        ShellDialect::Zsh => ParseShellDialect::Zsh,
-        ShellDialect::Unknown | ShellDialect::Bash => ParseShellDialect::Bash,
-    };
-    ShellProfile::native(dialect)
-}
-
 fn parse_for_lint(source: &str, shell: ShellDialect) -> ParseResult {
-    Parser::with_profile(source, inferred_shell_profile(shell)).parse()
+    Parser::with_profile(source, shell.shell_profile()).parse()
 }
 
 fn parse_error_position(parse_result: &ParseResult) -> Option<(usize, usize)> {

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -13,6 +13,28 @@ pub enum ShellDialect {
 }
 
 impl ShellDialect {
+    pub fn parser_dialect(self) -> shuck_parser::ShellDialect {
+        match self {
+            Self::Zsh => shuck_parser::ShellDialect::Zsh,
+            Self::Unknown | Self::Sh | Self::Bash | Self::Dash | Self::Ksh | Self::Mksh => {
+                shuck_parser::ShellDialect::Bash
+            }
+        }
+    }
+
+    pub fn semantic_dialect(self) -> shuck_parser::ShellDialect {
+        match self {
+            Self::Sh | Self::Dash | Self::Ksh => shuck_parser::ShellDialect::Posix,
+            Self::Mksh => shuck_parser::ShellDialect::Mksh,
+            Self::Zsh => shuck_parser::ShellDialect::Zsh,
+            Self::Unknown | Self::Bash => shuck_parser::ShellDialect::Bash,
+        }
+    }
+
+    pub fn shell_profile(self) -> shuck_parser::ShellProfile {
+        shuck_parser::ShellProfile::native(self.semantic_dialect())
+    }
+
     pub fn from_name(name: &str) -> Self {
         match name.trim().to_ascii_lowercase().as_str() {
             "sh" => Self::Sh,
@@ -116,5 +138,69 @@ mod tests {
             Some(Path::new("/tmp/example.sh")),
         );
         assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn parser_dialect_matches_linter_shell_policy() {
+        assert_eq!(
+            ShellDialect::Unknown.parser_dialect(),
+            shuck_parser::ShellDialect::Bash
+        );
+        assert_eq!(
+            ShellDialect::Bash.parser_dialect(),
+            shuck_parser::ShellDialect::Bash
+        );
+        assert_eq!(
+            ShellDialect::Sh.parser_dialect(),
+            shuck_parser::ShellDialect::Bash
+        );
+        assert_eq!(
+            ShellDialect::Dash.parser_dialect(),
+            shuck_parser::ShellDialect::Bash
+        );
+        assert_eq!(
+            ShellDialect::Ksh.parser_dialect(),
+            shuck_parser::ShellDialect::Bash
+        );
+        assert_eq!(
+            ShellDialect::Mksh.parser_dialect(),
+            shuck_parser::ShellDialect::Bash
+        );
+        assert_eq!(
+            ShellDialect::Zsh.parser_dialect(),
+            shuck_parser::ShellDialect::Zsh
+        );
+    }
+
+    #[test]
+    fn semantic_dialect_matches_linter_shell_policy() {
+        assert_eq!(
+            ShellDialect::Unknown.semantic_dialect(),
+            shuck_parser::ShellDialect::Bash
+        );
+        assert_eq!(
+            ShellDialect::Bash.semantic_dialect(),
+            shuck_parser::ShellDialect::Bash
+        );
+        assert_eq!(
+            ShellDialect::Sh.semantic_dialect(),
+            shuck_parser::ShellDialect::Posix
+        );
+        assert_eq!(
+            ShellDialect::Dash.semantic_dialect(),
+            shuck_parser::ShellDialect::Posix
+        );
+        assert_eq!(
+            ShellDialect::Ksh.semantic_dialect(),
+            shuck_parser::ShellDialect::Posix
+        );
+        assert_eq!(
+            ShellDialect::Mksh.semantic_dialect(),
+            shuck_parser::ShellDialect::Mksh
+        );
+        assert_eq!(
+            ShellDialect::Zsh.semantic_dialect(),
+            shuck_parser::ShellDialect::Zsh
+        );
     }
 }

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -15,8 +15,9 @@ pub enum ShellDialect {
 impl ShellDialect {
     pub fn parser_dialect(self) -> shuck_parser::ShellDialect {
         match self {
+            Self::Mksh => shuck_parser::ShellDialect::Mksh,
             Self::Zsh => shuck_parser::ShellDialect::Zsh,
-            Self::Unknown | Self::Sh | Self::Bash | Self::Dash | Self::Ksh | Self::Mksh => {
+            Self::Unknown | Self::Sh | Self::Bash | Self::Dash | Self::Ksh => {
                 shuck_parser::ShellDialect::Bash
             }
         }
@@ -164,7 +165,7 @@ mod tests {
         );
         assert_eq!(
             ShellDialect::Mksh.parser_dialect(),
-            shuck_parser::ShellDialect::Bash
+            shuck_parser::ShellDialect::Mksh
         );
         assert_eq!(
             ShellDialect::Zsh.parser_dialect(),

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -178,7 +178,7 @@ fn resolve_shell(
 }
 
 fn parse_for_lint(source: &str, shell: ShellDialect) -> ParseResult {
-    Parser::with_profile(source, shell.shell_profile()).parse()
+    Parser::with_dialect(source, shell.parser_dialect()).parse()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -601,6 +601,16 @@ mod tests {
         assert!(result.diagnostics.is_empty());
         assert!(result.parse_error.is_some());
         assert_eq!(updated, "#!/bin/bash\necho \"unterminated\n");
+    }
+
+    #[test]
+    fn parses_sh_files_with_shared_lint_dialect_policy() {
+        let source = "# shellcheck shell=sh\narr=(one)\necho $foo\n";
+        let (result, updated) = run_add_ignore(source, None);
+
+        assert!(result.directives_added > 0);
+        assert!(result.parse_error.is_none());
+        assert!(updated.contains("echo $foo  # shuck: ignore=C006\n"));
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap;
 use shuck_ast::{TextRange, TextSize};
 use shuck_indexer::Indexer;
 use shuck_parser::{
-    Error as ParseError, ShellDialect as ParseShellDialect, ShellProfile,
+    Error as ParseError,
     parser::{ParseResult, Parser},
 };
 
@@ -177,18 +177,8 @@ fn resolve_shell(
     }
 }
 
-fn inferred_shell_profile(shell: ShellDialect) -> ShellProfile {
-    let dialect = match shell {
-        ShellDialect::Sh | ShellDialect::Dash | ShellDialect::Ksh => ParseShellDialect::Posix,
-        ShellDialect::Mksh => ParseShellDialect::Mksh,
-        ShellDialect::Zsh => ParseShellDialect::Zsh,
-        ShellDialect::Unknown | ShellDialect::Bash => ParseShellDialect::Bash,
-    };
-    ShellProfile::native(dialect)
-}
-
 fn parse_for_lint(source: &str, shell: ShellDialect) -> ParseResult {
-    Parser::with_profile(source, inferred_shell_profile(shell)).parse()
+    Parser::with_profile(source, shell.shell_profile()).parse()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -9,16 +9,15 @@ use similar::TextDiff;
 use crate::{Applicability, Diagnostic, LinterSettings, ShellDialect, apply_fixes, lint_file};
 
 fn infer_shell(source: &str, settings: &LinterSettings, path: Option<&Path>) -> ShellDialect {
-    let shell = if settings.shell == crate::ShellDialect::Unknown {
+    if settings.shell == crate::ShellDialect::Unknown {
         crate::ShellDialect::infer(source, path)
     } else {
         settings.shell
-    };
-    shell
+    }
 }
 
 fn parse_for_lint(source: &str, settings: &LinterSettings, path: Option<&Path>) -> ParseResult {
-    Parser::with_profile(source, infer_shell(source, settings, path).shell_profile()).parse()
+    Parser::with_dialect(source, infer_shell(source, settings, path).parser_dialect()).parse()
 }
 
 #[derive(Debug, Clone)]

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -3,36 +3,22 @@ use std::fs;
 use std::path::Path;
 
 use shuck_indexer::Indexer;
-use shuck_parser::ShellProfile;
-use shuck_parser::parser::{ParseResult, Parser, ShellDialect as ParseShellDialect};
+use shuck_parser::parser::{ParseResult, Parser};
 use similar::TextDiff;
 
-use crate::{Applicability, Diagnostic, LinterSettings, apply_fixes, lint_file};
+use crate::{Applicability, Diagnostic, LinterSettings, ShellDialect, apply_fixes, lint_file};
 
-fn inferred_shell_profile(
-    source: &str,
-    settings: &LinterSettings,
-    path: Option<&Path>,
-) -> ShellProfile {
+fn infer_shell(source: &str, settings: &LinterSettings, path: Option<&Path>) -> ShellDialect {
     let shell = if settings.shell == crate::ShellDialect::Unknown {
         crate::ShellDialect::infer(source, path)
     } else {
         settings.shell
     };
-    let dialect = match shell {
-        crate::ShellDialect::Zsh => ParseShellDialect::Zsh,
-        crate::ShellDialect::Unknown
-        | crate::ShellDialect::Sh
-        | crate::ShellDialect::Dash
-        | crate::ShellDialect::Ksh
-        | crate::ShellDialect::Mksh
-        | crate::ShellDialect::Bash => ParseShellDialect::Bash,
-    };
-    ShellProfile::native(dialect)
+    shell
 }
 
 fn parse_for_lint(source: &str, settings: &LinterSettings, path: Option<&Path>) -> ParseResult {
-    Parser::with_profile(source, inferred_shell_profile(source, settings, path)).parse()
+    Parser::with_profile(source, infer_shell(source, settings, path).shell_profile()).parse()
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

- centralize linter shell-to-parser and shell-to-semantic dialect policy on `ShellDialect`
- update CLI, shellcheck compat, large corpus, benchmark, suppression, and test helper paths to use the shared policy
- keep non-zsh parsing permissive while preserving POSIX/ksh/zsh semantic profiles for lint behavior

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-linter shell::tests`
- `cargo check -p shuck-cli -p shuck-benchmark --benches --examples`
- `make test-large-corpus`
