### PR TITLE
perf(linter): index possible misspelling candidates

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -789,7 +789,6 @@ impl<'a> LinterFactsBuilder<'a> {
                 source,
                 &backtick_substitution_spans,
             );
-
         LinterFacts {
             source,
             commands,
@@ -814,6 +813,9 @@ impl<'a> LinterFactsBuilder<'a> {
             c006_suppressing_reference_offsets_by_name,
             presence_test_references_by_name: presence_tested_names.references_by_name,
             presence_test_names_by_name: presence_tested_names.names_by_name,
+            possible_variable_misspelling_use_scan: OnceLock::new(),
+            possible_variable_misspelling_index: OnceLock::new(),
+            possible_variable_misspelling_scope_compat_name_uses: OnceLock::new(),
             suppressed_subscript_reference_spans,
             subscript_later_suppression_reference_spans,
             compound_assignment_value_word_spans,

--- a/crates/shuck-linter/src/facts/misspelling.rs
+++ b/crates/shuck-linter/src/facts/misspelling.rs
@@ -1,0 +1,524 @@
+use super::*;
+
+const INDEX_BUILD_THRESHOLD: usize = 1024;
+
+#[derive(Debug)]
+pub(crate) struct PossibleVariableMisspellingIndex {
+    bindings: MisspellingCandidateSet,
+    presence_tests: MisspellingCandidateSet,
+}
+
+impl PossibleVariableMisspellingIndex {
+    pub(crate) fn candidate_name(&self, target_name: &str) -> Option<&str> {
+        self.bindings
+            .candidate_name(target_name, CandidateTieBreak::Binding)
+            .or_else(|| {
+                self.presence_tests
+                    .candidate_name(target_name, CandidateTieBreak::PresenceTest)
+            })
+    }
+}
+
+#[derive(Debug)]
+struct MisspellingCandidateSet {
+    entries: Vec<MisspellingCandidate>,
+    lookup: OnceLock<MisspellingCandidateLookup>,
+}
+
+impl MisspellingCandidateSet {
+    fn new(entries: Vec<MisspellingCandidate>) -> Self {
+        Self {
+            entries,
+            lookup: OnceLock::new(),
+        }
+    }
+
+    fn candidate_name(&self, target_name: &str, tie_break: CandidateTieBreak) -> Option<&str> {
+        if self.entries.is_empty() {
+            return None;
+        }
+        if self.entries.len() < INDEX_BUILD_THRESHOLD {
+            return scan_candidate_entries(&self.entries, target_name, tie_break);
+        }
+
+        self.lookup
+            .get_or_init(|| MisspellingCandidateLookup::from_entries(&self.entries))
+            .candidate_name(&self.entries, target_name, tie_break)
+    }
+}
+
+#[derive(Debug)]
+struct MisspellingCandidateLookup {
+    casefold_exact: FxHashMap<Box<str>, SmallVec<[usize; 2]>>,
+    deletions: FxHashMap<Box<str>, SmallVec<[usize; 4]>>,
+}
+
+impl MisspellingCandidateLookup {
+    fn from_entries(entries: &[MisspellingCandidate]) -> Self {
+        let mut index = Self {
+            casefold_exact: FxHashMap::default(),
+            deletions: FxHashMap::default(),
+        };
+
+        for (id, entry) in entries.iter().enumerate() {
+            let name = entry.name.as_str();
+            index
+                .casefold_exact
+                .entry(canonical_ascii_uppercase(name).into_boxed_str())
+                .or_default()
+                .push(id);
+
+            if !is_environment_style_name(name) || name.len() < 4 {
+                continue;
+            }
+
+            for key in deletion_keys(name) {
+                index.deletions.entry(key).or_default().push(id);
+            }
+        }
+
+        index
+    }
+
+    fn candidate_name<'a>(
+        &self,
+        entries: &'a [MisspellingCandidate],
+        target_name: &str,
+        tie_break: CandidateTieBreak,
+    ) -> Option<&'a str> {
+        let mut ids = SmallVec::<[usize; 16]>::new();
+        if target_name.len() >= 4
+            && let Some(exact_ids) = self
+                .casefold_exact
+                .get(canonical_ascii_uppercase(target_name).as_str())
+        {
+            ids.extend_from_slice(exact_ids);
+        }
+
+        if target_name.len() >= 3 {
+            for key in deletion_keys(target_name) {
+                if let Some(key_ids) = self.deletions.get(&key) {
+                    ids.extend_from_slice(key_ids);
+                }
+            }
+        }
+
+        if ids.is_empty() {
+            return None;
+        }
+        ids.sort_unstable();
+        ids.dedup();
+
+        ids.into_iter()
+            .filter_map(|id| {
+                let entry = &entries[id];
+                if entry.name == target_name {
+                    return None;
+                }
+                let rank = candidate_match_rank(target_name, entry.name.as_str())?;
+                Some((id, rank, entry))
+            })
+            .min_by(|left, right| compare_candidates(*left, *right, tie_break))
+            .map(|(_, _, entry)| entry.name.as_str())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MisspellingCandidate {
+    name: String,
+    first_span: Span,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CandidateTieBreak {
+    Binding,
+    PresenceTest,
+}
+
+pub(super) fn build_possible_variable_misspelling_index(
+    semantic: &SemanticModel,
+    presence_test_references_by_name: &FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
+    presence_test_names_by_name: &FxHashMap<Name, Vec<PresenceTestNameFact>>,
+) -> PossibleVariableMisspellingIndex {
+    let binding_entries = semantic
+        .bindings()
+        .iter()
+        .filter(|binding| is_sc2154_defining_binding(binding.kind))
+        .filter(|binding| binding.name.as_str().len() >= 4)
+        .map(|binding| MisspellingCandidate {
+            name: binding.name.to_string(),
+            first_span: binding.span,
+        })
+        .collect();
+    let presence_entries = build_presence_test_entries(
+        semantic,
+        presence_test_references_by_name,
+        presence_test_names_by_name,
+    );
+
+    PossibleVariableMisspellingIndex {
+        bindings: MisspellingCandidateSet::new(binding_entries),
+        presence_tests: MisspellingCandidateSet::new(presence_entries),
+    }
+}
+
+pub(super) fn should_scan_possible_variable_misspelling_candidates(
+    semantic: &SemanticModel,
+    presence_test_references_by_name: &FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
+    presence_test_names_by_name: &FxHashMap<Name, Vec<PresenceTestNameFact>>,
+) -> bool {
+    let raw_candidate_count = semantic.bindings().len()
+        + presence_test_references_by_name.len()
+        + presence_test_names_by_name.len();
+    if raw_candidate_count < INDEX_BUILD_THRESHOLD {
+        return true;
+    }
+
+    let binding_count = semantic
+        .bindings()
+        .iter()
+        .filter(|binding| is_sc2154_defining_binding(binding.kind))
+        .filter(|binding| binding.name.as_str().len() >= 4)
+        .take(INDEX_BUILD_THRESHOLD)
+        .count();
+    if binding_count >= INDEX_BUILD_THRESHOLD {
+        return false;
+    }
+
+    binding_count + presence_test_references_by_name.len() + presence_test_names_by_name.len()
+        < INDEX_BUILD_THRESHOLD
+}
+
+pub(super) fn scan_possible_variable_misspelling_candidate(
+    semantic: &SemanticModel,
+    presence_test_references_by_name: &FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
+    presence_test_names_by_name: &FxHashMap<Name, Vec<PresenceTestNameFact>>,
+    target_name: &str,
+) -> Option<String> {
+    semantic
+        .bindings()
+        .iter()
+        .filter(|binding| is_sc2154_defining_binding(binding.kind))
+        .filter(|binding| binding.name.as_str() != target_name)
+        .filter(|binding| binding.name.as_str().len() >= 4)
+        .filter_map(|binding| {
+            candidate_match_rank(target_name, binding.name.as_str()).map(|rank| {
+                (
+                    rank,
+                    binding.span.start.offset,
+                    binding.span.end.offset,
+                    binding.name.as_str(),
+                )
+            })
+        })
+        .min_by_key(|(rank, start, end, _)| (*rank, *start, *end))
+        .map(|(_, _, _, name)| name.to_owned())
+        .or_else(|| {
+            scan_presence_tested_candidate_name(
+                semantic,
+                presence_test_references_by_name,
+                presence_test_names_by_name,
+                target_name,
+            )
+            .map(ToOwned::to_owned)
+        })
+}
+
+fn scan_presence_tested_candidate_name<'a>(
+    semantic: &SemanticModel,
+    presence_test_references_by_name: &'a FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
+    presence_test_names_by_name: &'a FxHashMap<Name, Vec<PresenceTestNameFact>>,
+    target_name: &str,
+) -> Option<&'a str> {
+    presence_test_references_by_name
+        .keys()
+        .chain(presence_test_names_by_name.keys())
+        .filter(|candidate_name| candidate_name.as_str() != target_name)
+        .filter_map(|candidate_name| {
+            let first_span = first_presence_test_span(
+                semantic,
+                candidate_name,
+                presence_test_references_by_name,
+                presence_test_names_by_name,
+            )?;
+            candidate_match_rank(target_name, candidate_name.as_str()).map(|rank| {
+                (
+                    rank,
+                    first_span.start.offset,
+                    first_span.end.offset,
+                    candidate_name.as_str(),
+                )
+            })
+        })
+        .min_by(|left, right| {
+            (left.0, left.1, left.2)
+                .cmp(&(right.0, right.1, right.2))
+                .then_with(|| left.3.cmp(right.3))
+        })
+        .map(|(_, _, _, name)| name)
+}
+
+fn scan_candidate_entries<'a>(
+    entries: &'a [MisspellingCandidate],
+    target_name: &str,
+    tie_break: CandidateTieBreak,
+) -> Option<&'a str> {
+    entries
+        .iter()
+        .enumerate()
+        .filter_map(|(id, entry)| {
+            if entry.name == target_name {
+                return None;
+            }
+            let rank = candidate_match_rank(target_name, entry.name.as_str())?;
+            Some((id, rank, entry))
+        })
+        .min_by(|left, right| compare_candidates(*left, *right, tie_break))
+        .map(|(_, _, entry)| entry.name.as_str())
+}
+
+fn build_presence_test_entries(
+    semantic: &SemanticModel,
+    presence_test_references_by_name: &FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
+    presence_test_names_by_name: &FxHashMap<Name, Vec<PresenceTestNameFact>>,
+) -> Vec<MisspellingCandidate> {
+    let mut names = FxHashSet::<Name>::default();
+    names.extend(presence_test_references_by_name.keys().cloned());
+    names.extend(presence_test_names_by_name.keys().cloned());
+
+    names
+        .into_iter()
+        .filter_map(|name| {
+            let first_span = first_presence_test_span(
+                semantic,
+                &name,
+                presence_test_references_by_name,
+                presence_test_names_by_name,
+            )?;
+            Some(MisspellingCandidate {
+                name: name.to_string(),
+                first_span,
+            })
+        })
+        .collect()
+}
+
+fn first_presence_test_span(
+    semantic: &SemanticModel,
+    candidate_name: &Name,
+    presence_test_references_by_name: &FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
+    presence_test_names_by_name: &FxHashMap<Name, Vec<PresenceTestNameFact>>,
+) -> Option<Span> {
+    presence_test_references_by_name
+        .get(candidate_name)
+        .into_iter()
+        .flatten()
+        .map(|presence| semantic.reference(presence.reference_id()).span)
+        .chain(
+            presence_test_names_by_name
+                .get(candidate_name)
+                .into_iter()
+                .flatten()
+                .map(|presence| presence.tested_span()),
+        )
+        .min_by_key(|span| (span.start.offset, span.end.offset))
+}
+
+fn compare_candidates(
+    left: (usize, u8, &MisspellingCandidate),
+    right: (usize, u8, &MisspellingCandidate),
+    tie_break: CandidateTieBreak,
+) -> std::cmp::Ordering {
+    let (_, left_rank, left_entry) = left;
+    let (_, right_rank, right_entry) = right;
+    let ordering = (
+        left_rank,
+        left_entry.first_span.start.offset,
+        left_entry.first_span.end.offset,
+    )
+        .cmp(&(
+            right_rank,
+            right_entry.first_span.start.offset,
+            right_entry.first_span.end.offset,
+        ));
+    if !ordering.is_eq() {
+        return ordering;
+    }
+
+    match tie_break {
+        CandidateTieBreak::Binding => left.0.cmp(&right.0),
+        CandidateTieBreak::PresenceTest => left_entry.name.cmp(&right_entry.name),
+    }
+}
+
+fn candidate_match_rank(target_name: &str, candidate_name: &str) -> Option<u8> {
+    if target_name.len() >= 4
+        && target_name.len() == candidate_name.len()
+        && candidate_name
+            .as_bytes()
+            .eq_ignore_ascii_case(target_name.as_bytes())
+    {
+        return Some(0);
+    }
+
+    if !is_environment_style_name(candidate_name)
+        || target_name.len() < 3
+        || candidate_name.len() < 4
+    {
+        return None;
+    }
+
+    let distance =
+        bounded_ascii_edit_distance(target_name.as_bytes(), candidate_name.as_bytes(), 2)?;
+    if distance == 0 {
+        return None;
+    }
+    if distance == 2 && !has_strong_two_edit_shape(target_name, candidate_name) {
+        return None;
+    }
+    Some(distance + 1)
+}
+
+fn has_strong_two_edit_shape(target_name: &str, candidate_upper: &str) -> bool {
+    let common_prefix = common_prefix_len(target_name.as_bytes(), candidate_upper.as_bytes());
+    let common_suffix = common_suffix_len(
+        &target_name.as_bytes()[common_prefix..],
+        &candidate_upper.as_bytes()[common_prefix..],
+    );
+
+    matches!((target_name, candidate_upper), ("CFLAGS", "CXXFLAGS"))
+        || matches!((target_name, candidate_upper), ("OS_NAME", "HOSTNAME"))
+        || has_separator_plural_compaction(target_name, candidate_upper)
+        || common_prefix >= 5
+        || common_suffix >= 5
+        || (common_prefix >= 4 && common_suffix >= 4)
+}
+
+fn has_separator_plural_compaction(left: &str, right: &str) -> bool {
+    compacted_plural_matches(left, right) || compacted_plural_matches(right, left)
+}
+
+fn compacted_plural_matches(pluralish_name: &str, compact_singular_name: &str) -> bool {
+    let Some((prefix, last_segment)) = pluralish_name.rsplit_once('_') else {
+        return false;
+    };
+    let Some(singular_segment) = last_segment.strip_suffix('S') else {
+        return false;
+    };
+    if compacted_len(prefix) < 4 || singular_segment.len() < 4 {
+        return false;
+    }
+
+    let compacted = pluralish_name
+        .chars()
+        .filter(|char| *char != '_')
+        .collect::<String>();
+    compacted
+        .strip_suffix('S')
+        .is_some_and(|singular| singular == compact_singular_name)
+}
+
+fn compacted_len(name: &str) -> usize {
+    name.chars().filter(|char| *char != '_').count()
+}
+
+fn common_prefix_len(left: &[u8], right: &[u8]) -> usize {
+    left.iter()
+        .zip(right)
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+fn common_suffix_len(left: &[u8], right: &[u8]) -> usize {
+    left.iter()
+        .rev()
+        .zip(right.iter().rev())
+        .take_while(|(left, right)| left == right)
+        .count()
+}
+
+fn bounded_ascii_edit_distance(left: &[u8], right: &[u8], max_distance: u8) -> Option<u8> {
+    let max_distance = usize::from(max_distance);
+    if left.len().abs_diff(right.len()) > max_distance {
+        return None;
+    }
+
+    let mut previous = (0..=right.len()).collect::<SmallVec<[usize; 32]>>();
+    let mut current = SmallVec::<[usize; 32]>::new();
+    current.resize(right.len() + 1, 0);
+
+    for (left_index, left_byte) in left.iter().enumerate() {
+        current[0] = left_index + 1;
+        let mut row_min = current[0];
+
+        for (right_index, right_byte) in right.iter().enumerate() {
+            let deletion = previous[right_index + 1] + 1;
+            let insertion = current[right_index] + 1;
+            let substitution = previous[right_index] + usize::from(left_byte != right_byte);
+            let value = deletion.min(insertion).min(substitution);
+            current[right_index + 1] = value;
+            row_min = row_min.min(value);
+        }
+
+        if row_min > max_distance {
+            return None;
+        }
+
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    let distance = previous[right.len()];
+    (distance <= max_distance).then_some(distance as u8)
+}
+
+fn deletion_keys(name: &str) -> Vec<Box<str>> {
+    let mut keys = Vec::new();
+    let mut scratch = Vec::with_capacity(name.len());
+    collect_deletion_keys(name.as_bytes(), 0, 2, &mut scratch, &mut keys);
+    keys.sort_unstable();
+    keys.dedup();
+    keys
+}
+
+fn collect_deletion_keys(
+    bytes: &[u8],
+    offset: usize,
+    remaining_deletions: usize,
+    scratch: &mut Vec<u8>,
+    keys: &mut Vec<Box<str>>,
+) {
+    if offset == bytes.len() {
+        keys.push(
+            String::from_utf8(scratch.clone())
+                .expect("shell names should be ASCII")
+                .into_boxed_str(),
+        );
+        return;
+    }
+
+    scratch.push(bytes[offset]);
+    collect_deletion_keys(bytes, offset + 1, remaining_deletions, scratch, keys);
+    scratch.pop();
+
+    if remaining_deletions > 0 {
+        collect_deletion_keys(bytes, offset + 1, remaining_deletions - 1, scratch, keys);
+    }
+}
+
+fn canonical_ascii_uppercase(name: &str) -> String {
+    name.chars().map(|char| char.to_ascii_uppercase()).collect()
+}
+
+fn is_environment_style_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|char| char.is_ascii_uppercase() || char.is_ascii_digit() || char == '_')
+}
+
+fn is_sc2154_defining_binding(kind: BindingKind) -> bool {
+    !matches!(
+        kind,
+        BindingKind::FunctionDefinition | BindingKind::Imported
+    )
+}

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -9,6 +9,7 @@
 
 mod conditional_portability;
 mod escape_scan;
+mod misspelling;
 mod normalized_commands;
 mod presence;
 pub(crate) mod surface;
@@ -21,6 +22,11 @@ use self::word_spans::{expansion_part_spans, word_unbraced_variable_before_brack
 use self::{
     conditional_portability::{ConditionalPortabilityInputs, build_conditional_portability_facts},
     escape_scan::{EscapeScanContext, EscapeScanInputs, build_escape_scan_matches},
+    misspelling::{
+        PossibleVariableMisspellingIndex, build_possible_variable_misspelling_index,
+        scan_possible_variable_misspelling_candidate,
+        should_scan_possible_variable_misspelling_candidates,
+    },
     normalized_commands as command,
     presence::{PresenceTestNameFact, PresenceTestReferenceFact, build_presence_tested_names},
     surface::{
@@ -61,7 +67,7 @@ use shuck_semantic::{
     ReferenceId, ReferenceKind, ScopeId, SemanticModel, ZshOptionState,
 };
 use smallvec::SmallVec;
-use std::{borrow::Cow, ops::ControlFlow};
+use std::{borrow::Cow, ops::ControlFlow, sync::OnceLock};
 
 pub use self::conditional_portability::ConditionalPortabilityFacts;
 pub(crate) use self::escape_scan::{EscapeScanMatch, EscapeScanSourceKind};

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -22,6 +22,9 @@ pub struct LinterFacts<'a> {
     c006_suppressing_reference_offsets_by_name: FxHashMap<Name, Vec<usize>>,
     presence_test_references_by_name: FxHashMap<Name, Vec<PresenceTestReferenceFact>>,
     presence_test_names_by_name: FxHashMap<Name, Vec<PresenceTestNameFact>>,
+    possible_variable_misspelling_use_scan: OnceLock<bool>,
+    possible_variable_misspelling_index: OnceLock<PossibleVariableMisspellingIndex>,
+    possible_variable_misspelling_scope_compat_name_uses: OnceLock<Vec<ComparableNameUse>>,
     suppressed_subscript_reference_spans: FxHashSet<FactSpan>,
     subscript_later_suppression_reference_spans: FxHashSet<FactSpan>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
@@ -324,6 +327,38 @@ impl<'a> LinterFacts<'a> {
         self.presence_test_references_by_name
             .keys()
             .chain(self.presence_test_names_by_name.keys())
+    }
+
+    pub(crate) fn possible_variable_misspelling_candidate(
+        &self,
+        semantic: &SemanticModel,
+        target_name: &str,
+    ) -> Option<String> {
+        if *self.possible_variable_misspelling_use_scan.get_or_init(|| {
+            should_scan_possible_variable_misspelling_candidates(
+                semantic,
+                &self.presence_test_references_by_name,
+                &self.presence_test_names_by_name,
+            )
+        }) {
+            return scan_possible_variable_misspelling_candidate(
+                semantic,
+                &self.presence_test_references_by_name,
+                &self.presence_test_names_by_name,
+                target_name,
+            );
+        }
+
+        self.possible_variable_misspelling_index
+            .get_or_init(|| {
+                build_possible_variable_misspelling_index(
+                    semantic,
+                    &self.presence_test_references_by_name,
+                    &self.presence_test_names_by_name,
+                )
+            })
+            .candidate_name(target_name)
+            .map(ToOwned::to_owned)
     }
 
     pub fn is_presence_tested_name(&self, name: &Name, span: Span) -> bool {
@@ -830,58 +865,65 @@ impl<'a> LinterFacts<'a> {
 
     pub(crate) fn possible_variable_misspelling_scope_compat_name_uses(
         &self,
-    ) -> Vec<ComparableNameUse> {
-        let mut uses = Vec::new();
-        for word_fact in self
-            .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
-            .chain(self.expansion_word_facts(ExpansionContext::AssignmentValue))
-            .chain(self.case_subject_facts())
-        {
-            uses.extend(
-                comparable_name_uses(word_fact.word(), self.source)
-                    .into_vec()
-                    .into_iter()
-                    .filter(|name_use| name_use.kind() == ComparableNameUseKind::Parameter),
-            );
-        }
-        for command in self.commands() {
-            visit_command_words_for_substitutions(
-                command.command(),
-                command.redirects(),
-                self.source,
-                &mut |word| {
-                    uses.extend(
-                        comparable_name_uses(word, self.source)
-                            .into_vec()
-                            .into_iter()
-                            .filter(|name_use| name_use.kind() == ComparableNameUseKind::Derived),
-                    );
-                },
-            );
-        }
-        for word in self
-            .for_headers()
-            .iter()
-            .flat_map(|header| header.words())
-            .chain(self.select_headers().iter().flat_map(|header| header.words()))
-        {
-            uses.extend(
-                comparable_name_uses(word.word(), self.source)
-                    .into_vec()
-                    .into_iter()
-                    .filter_map(|mut name_use| {
-                        if name_use.kind() == ComparableNameUseKind::Parameter {
-                            name_use.mark_derived();
-                            Some(name_use)
-                        } else {
-                            None
-                        }
-                    }),
-            );
-        }
-        uses.extend(build_flag_for_loop_source_name_uses(self.source));
-        uses
+    ) -> &[ComparableNameUse] {
+        self.possible_variable_misspelling_scope_compat_name_uses
+            .get_or_init(|| build_possible_variable_misspelling_scope_compat_name_uses(self))
     }
+}
+
+fn build_possible_variable_misspelling_scope_compat_name_uses(
+    facts: &LinterFacts<'_>,
+) -> Vec<ComparableNameUse> {
+    let mut uses = Vec::new();
+    for word_fact in facts
+        .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
+        .chain(facts.expansion_word_facts(ExpansionContext::AssignmentValue))
+        .chain(facts.case_subject_facts())
+    {
+        uses.extend(
+            comparable_name_uses(word_fact.word(), facts.source)
+                .into_vec()
+                .into_iter()
+                .filter(|name_use| name_use.kind() == ComparableNameUseKind::Parameter),
+        );
+    }
+    for command in facts.commands() {
+        visit_command_words_for_substitutions(
+            command.command(),
+            command.redirects(),
+            facts.source,
+            &mut |word| {
+                uses.extend(
+                    comparable_name_uses(word, facts.source)
+                        .into_vec()
+                        .into_iter()
+                        .filter(|name_use| name_use.kind() == ComparableNameUseKind::Derived),
+                );
+            },
+        );
+    }
+    for word in facts
+        .for_headers()
+        .iter()
+        .flat_map(|header| header.words())
+        .chain(facts.select_headers().iter().flat_map(|header| header.words()))
+    {
+        uses.extend(
+            comparable_name_uses(word.word(), facts.source)
+                .into_vec()
+                .into_iter()
+                .filter_map(|mut name_use| {
+                    if name_use.kind() == ComparableNameUseKind::Parameter {
+                        name_use.mark_derived();
+                        Some(name_use)
+                    } else {
+                        None
+                    }
+                }),
+        );
+    }
+    uses.extend(build_flag_for_loop_source_name_uses(facts.source));
+    uses
 }
 
 fn populate_array_assignment_split_scalar_expansion_spans(

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -384,7 +384,7 @@ fn build_flag_scope_candidate_name(checker: &Checker<'_>, reference_name: &str) 
             checker
                 .facts()
                 .possible_variable_misspelling_scope_compat_name_uses()
-                .into_iter()
+                .iter()
                 .filter_map(|name_use| {
                     let candidate_name = name_use.key().as_str();
                     if candidate_name == reference_name
@@ -483,6 +483,12 @@ fn looks_like_case_mismatch_reference(name: &str) -> bool {
 }
 
 fn preferred_candidate_name(checker: &Checker<'_>, target_name: &str) -> Option<String> {
+    if checker.semantic().bindings().len() >= 1024 {
+        return checker
+            .facts()
+            .possible_variable_misspelling_candidate(checker.semantic(), target_name);
+    }
+
     let binding_candidates = checker
         .semantic()
         .bindings()
@@ -988,6 +994,72 @@ echo \"$FOO1\"
                 .collect::<Vec<_>>(),
             vec!["$PACKAGE_NAME", "$FOOBAR", "$FOO1"]
         );
+    }
+
+    #[test]
+    fn prefers_exact_case_fold_candidate_over_edit_distance_candidate() {
+        let source = "\
+#!/bin/sh
+package_name=demo
+PACKAG_NAME=demo
+echo \"$PACKAGE_NAME\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("`package_name`"));
+    }
+
+    #[test]
+    fn prefers_binding_candidates_over_presence_test_candidates() {
+        let source = "\
+#!/bin/sh
+PACKAG_NAME=demo
+if [ -n \"$package_name\" ]; then :; fi
+echo \"$PACKAGE_NAME\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("`PACKAG_NAME`"));
+    }
+
+    #[test]
+    fn keeps_binding_tie_breaking_by_first_span() {
+        let source = "\
+#!/bin/sh
+ALPHA_VALUF=demo
+ALPHA_VALUE=demo
+echo \"$ALPHA_VALUG\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("`ALPHA_VALUF`"));
+    }
+
+    #[test]
+    fn rejects_weak_two_edit_shapes() {
+        let source = "\
+#!/bin/sh
+ABCDEF=demo
+echo \"$ABXYEF\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a facts-owned deletion-key index for possible-variable-misspelling candidates
- preserve binding vs presence-test priority and existing tie-breaking semantics
- precompute scope-compat name uses in `LinterFacts` so the rule does not rebuild that traversal result

## Validation
- `cargo test -p shuck-linter possible_variable_misspelling`
- `cargo test -p shuck-linter c156 -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C156`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- `git diff --check`
- `cargo bench -p shuck-benchmark --features large-corpus-hotspots --bench large_corpus_hotspots -- large_corpus_linter_rule_splits`
- `scripts/profiling/profile_large_corpus.sh xwmx__nb__package.sh .cache/profiles 2000 1 12000`

## Profiling Note
The `xwmx__nb__package.sh` warm profile averaged `0.077 ms` over 12,000 iterations. The possible-variable-misspelling rule no longer appears as a rule-local hotspot in the top rows; remaining visible cost is mostly broad fact construction plus a small `MisspellingCandidateIndex` drop row.