### PR TITLE
fix(linter): clear S001 declaration default divergence

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -496,13 +496,6 @@ reviewed_divergences:
     column: 10
     end_column: 29
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__manage__base_fetch"
-    line: 45
-    end_line: 45
-    column: 12
-    end_column: 24
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_fetch"
     line: 223

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -6,6 +6,7 @@ pub struct DeclarationAssignmentProbe {
     target_name_span: Span,
     has_command_substitution: bool,
     status_capture: bool,
+    field_safe_literal: bool,
 }
 
 impl DeclarationAssignmentProbe {
@@ -31,6 +32,10 @@ impl DeclarationAssignmentProbe {
 
     pub fn status_capture(&self) -> bool {
         self.status_capture
+    }
+
+    pub fn field_safe_literal(&self) -> bool {
+        self.field_safe_literal
     }
 }
 
@@ -2281,6 +2286,8 @@ fn build_declaration_assignment_probes<'a>(
                         zsh_options,
                     ),
                     status_capture: word_is_standalone_status_capture(word),
+                    field_safe_literal: static_word_text(word, source)
+                        .is_some_and(|text| literal_is_field_safe(&text)),
                 })
             })
             .collect();
@@ -2335,6 +2342,7 @@ fn build_simple_command_declaration_assignment_probes<'a>(
                     zsh_options,
                 ),
                 status_capture: assignment_value_text_is_standalone_status_capture(value_text),
+                field_safe_literal: assignment_value_text_is_field_safe_literal(value_text),
             })
         })
         .collect()
@@ -2342,6 +2350,42 @@ fn build_simple_command_declaration_assignment_probes<'a>(
 
 fn assignment_value_text_is_standalone_status_capture(text: &str) -> bool {
     matches!(text, "$?" | "${?}" | "\"$?\"" | "\"${?}\"")
+}
+
+fn assignment_value_text_is_field_safe_literal(text: &str) -> bool {
+    let Some(value) = assignment_literal_value(text) else {
+        return false;
+    };
+    literal_is_field_safe(value)
+}
+
+fn assignment_literal_value(text: &str) -> Option<&str> {
+    if !text
+        .chars()
+        .any(|character| matches!(character, '$' | '`' | '\\' | '\'' | '"'))
+    {
+        return Some(text);
+    }
+    if let Some(inner) = text.strip_prefix('"').and_then(|text| text.strip_suffix('"'))
+        && !inner
+            .chars()
+            .any(|character| matches!(character, '$' | '`' | '\\' | '"'))
+    {
+        return Some(inner);
+    }
+    if let Some(inner) = text.strip_prefix('\'').and_then(|text| text.strip_suffix('\''))
+        && !inner.contains('\'')
+    {
+        return Some(inner);
+    }
+    None
+}
+
+fn literal_is_field_safe(text: &str) -> bool {
+    !text.is_empty()
+        && !text
+            .chars()
+            .any(|character| character.is_whitespace() || matches!(character, '*' | '?' | '['))
 }
 
 fn contiguous_word_groups<'a>(words: &'a [&'a Word]) -> Vec<&'a [&'a Word]> {

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -3055,11 +3055,33 @@ demo() {
                     probe.target_name(),
                     probe.readonly_flag(),
                     probe.has_command_substitution(),
+                    probe.field_safe_literal(),
                 )
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(probes, vec![("out", false, true)]);
+        assert_eq!(probes, vec![("out", false, true, false)]);
+    });
+}
+
+#[test]
+fn marks_escaped_declaration_literal_assignment_probes_as_field_safe() {
+    let source = "\
+#!/bin/bash
+demo() {
+  \\typeset result=0
+  local empty=
+}
+";
+
+    with_facts(source, None, |_, facts| {
+        let probes = facts
+            .structural_commands()
+            .flat_map(|fact| fact.declaration_assignment_probes().iter())
+            .map(|probe| (probe.target_name(), probe.field_safe_literal()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(probes, vec![("result", true), ("empty", false)]);
     });
 }
 

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -219,6 +219,7 @@ impl<'a> SafeValueIndex<'a> {
                             &reference.name,
                             operator,
                             operand.as_ref(),
+                            reference.name_span,
                             span,
                             query,
                         )
@@ -1430,6 +1431,26 @@ impl<'a> SafeValueIndex<'a> {
                     .declaration_assignment_probes()
                     .iter()
                     .any(|probe| probe.status_capture() && probe.target_name() == name.as_str())
+        })
+    }
+
+    fn field_safe_declaration_probe_covers_reference(
+        &self,
+        name: &Name,
+        at: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        if !query.is_field_context() {
+            return false;
+        }
+
+        self.facts.structural_commands().any(|command| {
+            command.span().end.offset <= at.start.offset
+                && self.command_blocks_cover_all_paths_to_reference(command, name, at)
+                && command
+                    .declaration_assignment_probes()
+                    .iter()
+                    .any(|probe| probe.field_safe_literal() && probe.target_name() == name.as_str())
         })
     }
 
@@ -3063,6 +3084,7 @@ impl<'a> SafeValueIndex<'a> {
                                 &reference.name,
                                 operator,
                                 operand.as_ref(),
+                                reference.name_span,
                                 at,
                                 query,
                             )
@@ -3101,7 +3123,7 @@ impl<'a> SafeValueIndex<'a> {
         reference: &VarRef,
         operator: &ParameterOp,
         operand: Option<&SourceText>,
-        _at: Span,
+        at: Span,
         query: SafeValueQuery,
     ) -> bool {
         if query != SafeValueQuery::Quoted && reference.has_array_selector() {
@@ -3113,6 +3135,7 @@ impl<'a> SafeValueIndex<'a> {
             operator,
             operand,
             reference.name_span,
+            at,
             query,
         )
     }
@@ -3122,7 +3145,8 @@ impl<'a> SafeValueIndex<'a> {
         name: &Name,
         operator: &ParameterOp,
         operand: Option<&SourceText>,
-        at: Span,
+        name_span: Span,
+        expansion_span: Span,
         query: SafeValueQuery,
     ) -> bool {
         match operator {
@@ -3133,16 +3157,25 @@ impl<'a> SafeValueIndex<'a> {
             | ParameterOp::RemovePrefixShort { .. }
             | ParameterOp::RemovePrefixLong { .. }
             | ParameterOp::RemoveSuffixShort { .. }
-            | ParameterOp::RemoveSuffixLong { .. } => self.name_is_safe(name, at, query),
-            ParameterOp::UseDefault | ParameterOp::AssignDefault | ParameterOp::Error => {
-                self.name_is_safe(name, at, query)
+            | ParameterOp::RemoveSuffixLong { .. } => self.name_is_safe(name, name_span, query),
+            ParameterOp::UseDefault | ParameterOp::AssignDefault => {
+                self.name_is_safe(name, name_span, query)
+                    || operand.is_some_and(|operand| {
+                        self.source_text_is_safe_literal(operand, query)
+                            && self.field_safe_declaration_probe_covers_reference(
+                                name,
+                                expansion_span,
+                                query,
+                            )
+                    })
             }
+            ParameterOp::Error => self.name_is_safe(name, name_span, query),
             ParameterOp::UseReplacement => {
                 operand.is_some_and(|operand| self.source_text_is_safe_literal(operand, query))
             }
             ParameterOp::ReplaceFirst { replacement, .. }
             | ParameterOp::ReplaceAll { replacement, .. } => {
-                self.name_is_safe(name, at, query)
+                self.name_is_safe(name, name_span, query)
                     && self.source_text_is_safe_literal(replacement, query)
             }
         }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2716,6 +2716,46 @@ cleanup() {
     }
 
     #[test]
+    fn skips_default_expansion_after_escaped_field_safe_declaration_initializers() {
+        let source = "\
+#!/bin/bash
+cleanup() {
+  \\typeset result=0
+  return ${result:-0}
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_resolve_source_closure(false),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_plain_reads_after_escaped_field_safe_declaration_initializers() {
+        let source = "\
+#!/bin/bash
+cleanup() {
+  \\typeset result=0
+  return $result
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_resolve_source_closure(false),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$result"]
+        );
+    }
+
+    #[test]
     fn skips_status_capture_after_escaped_name_only_declarations() {
         let source = "\
 #!/bin/bash

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -9,7 +9,7 @@ Current summary from `target/large-corpus-report/latest.log`:
 - `implementation_diffs=0`
 - `mapping_issues=0`
 - `reviewed_divergences=64`
-- Individual reviewed records classified below: 103 total (`shellcheck-only=23`, `shuck-only=80`).
+- Individual reviewed records classified below: 102 total (`shellcheck-only=23`, `shuck-only=79`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -140,13 +140,12 @@ Resolved records should not remain as reviewed divergences.
 - `tteck__Proxmox__misc__glances.sh:100:37-49` `$SPINNER_PID`
 - `tteck__Proxmox__misc__glances.sh:100:73-85` `$SPINNER_PID`
 
-## [ ] Shuck-only: status/return/exit operand (8)
+## [ ] Shuck-only: status/return/exit operand (7)
 
 - `bittorf__kalua__openwrt-addons__etc__kalua__net:2620:79-81` `$?`
 - `bittorf__kalua__openwrt-addons__etc__profile.d__kalua.sh:11:33-36` `$rc`
 - `rvm__rvm__scripts__extras__chruby.sh:31:10-21` `${__result}`
 - `rvm__rvm__scripts__functions__build_requirements:160:10-29` `${__summary_status}`
-- `rvm__rvm__scripts__functions__manage__base_fetch:45:12-24` `${result:-0}`
 - `rvm__rvm__scripts__functions__manage__macruby:23:10-21` `${__result}`
 - `rvm__rvm__scripts__functions__requirements__openbsd:35:12-23` `${__result}`
 - `v1s1t0r1sh3r3__airgeddon__airgeddon.sh:16442:11-23` `${exit_code}`


### PR DESCRIPTION
## Summary
- add a field-safe declaration probe signal for non-empty static declaration initializers
- allow S001 to treat safe default expansions as safe only when a covering declaration initializer supplies a field-safe value
- remove the resolved S001 reviewed divergence and update the documented bug counts

## Validation
- cargo fmt --check
- cargo test -p shuck-linter escaped_declaration
- cargo test -p shuck-linter escaped_field_safe_declaration
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001
- make test