### PR TITLE
fix(extract): handle GitHub Actions workflow anchors

### DIFF
--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! Extract embedded shell scripts from non-shell host files.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::path::Path;
 
@@ -220,6 +220,7 @@ fn source_has_yaml_anchors_or_aliases(source: &str) -> bool {
 }
 
 fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
+    let anchor_values = collect_yaml_scalar_anchors(source);
     let mut output = source.as_bytes().to_vec();
     let mut offset = 0;
     let mut block_parent_indent = None;
@@ -239,20 +240,51 @@ fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
             block_parent_indent = None;
         }
 
-        sanitize_yaml_anchor_or_alias_line(&mut output, offset, line_content);
+        let delta =
+            sanitize_yaml_anchor_or_alias_line(&mut output, offset, line_content, &anchor_values);
         if line_starts_block_scalar(line_content) {
             block_parent_indent = Some(indent);
         }
 
-        offset += line.len();
+        offset = offset.saturating_add_signed(line.len() as isize + delta);
     }
 
     String::from_utf8(output).expect("YAML anchor sanitization preserved UTF-8")
 }
 
-fn sanitize_yaml_anchor_or_alias_line(output: &mut [u8], line_start: usize, line: &str) {
+fn collect_yaml_scalar_anchors(source: &str) -> HashMap<String, String> {
+    let mut anchors = HashMap::new();
+    let mut block_parent_indent = None;
+
+    for line in source.lines() {
+        let indent = leading_space_count(line);
+        if let Some(parent_indent) = block_parent_indent {
+            if line.trim().is_empty() || indent > parent_indent {
+                continue;
+            }
+            block_parent_indent = None;
+        }
+
+        if let Some((name, value)) = yaml_scalar_anchor_definition(line) {
+            anchors.insert(name.to_owned(), value.to_owned());
+        }
+        if line_starts_block_scalar(line) {
+            block_parent_indent = Some(indent);
+        }
+    }
+
+    anchors
+}
+
+fn sanitize_yaml_anchor_or_alias_line(
+    output: &mut Vec<u8>,
+    line_start: usize,
+    line: &str,
+    anchor_values: &HashMap<String, String>,
+) -> isize {
     let bytes = line.as_bytes();
     let mut index = 0;
+    let mut delta = 0isize;
     let mut quote = YamlLineQuote::Unquoted;
 
     while index < bytes.len() {
@@ -263,10 +295,16 @@ fn sanitize_yaml_anchor_or_alias_line(output: &mut [u8], line_start: usize, line
                 b'&' | b'*' if yaml_anchor_token_starts(bytes, index) => {
                     let token_len = yaml_anchor_token_len(bytes, index);
                     if bytes[index] == b'&' {
-                        output[line_start + index..line_start + index + token_len].fill(b' ');
+                        let output_index = line_start.saturating_add_signed(index as isize + delta);
+                        output[output_index..output_index + token_len].fill(b' ');
                     } else {
-                        output[line_start + index] = b'~';
-                        output[line_start + index + 1..line_start + index + token_len].fill(b' ');
+                        let alias_name = &line[index + 1..index + token_len];
+                        let output_index = line_start.saturating_add_signed(index as isize + delta);
+                        let replacement = anchor_values
+                            .get(alias_name)
+                            .map(String::as_str)
+                            .unwrap_or("~");
+                        delta += replace_yaml_token(output, output_index, token_len, replacement);
                     }
                     index += token_len;
                     continue;
@@ -289,6 +327,75 @@ fn sanitize_yaml_anchor_or_alias_line(output: &mut [u8], line_start: usize, line
 
         index += 1;
     }
+
+    delta
+}
+
+fn yaml_scalar_anchor_definition(line: &str) -> Option<(&str, &str)> {
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    let mut quote = YamlLineQuote::Unquoted;
+
+    while index < bytes.len() {
+        match quote {
+            YamlLineQuote::Unquoted => match bytes[index] {
+                b'\'' => quote = YamlLineQuote::Single,
+                b'"' => quote = YamlLineQuote::Double,
+                b'&' if yaml_anchor_token_starts(bytes, index) => {
+                    let token_len = yaml_anchor_token_len(bytes, index);
+                    let value = line[index + token_len..].trim();
+                    if !yaml_anchor_value_is_aliasable_scalar(value) {
+                        return None;
+                    }
+                    return Some((&line[index + 1..index + token_len], value));
+                }
+                _ => {}
+            },
+            YamlLineQuote::Single => {
+                if bytes[index] == b'\'' {
+                    quote = YamlLineQuote::Unquoted;
+                }
+            }
+            YamlLineQuote::Double => match bytes[index] {
+                b'"' => quote = YamlLineQuote::Unquoted,
+                b'\\' => {
+                    index += 1;
+                }
+                _ => {}
+            },
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+fn yaml_anchor_value_is_aliasable_scalar(value: &str) -> bool {
+    value
+        .as_bytes()
+        .first()
+        .is_some_and(|byte| !matches!(byte, b'&' | b'*' | b'|' | b'>' | b'#'))
+}
+
+fn replace_yaml_token(
+    output: &mut Vec<u8>,
+    output_index: usize,
+    token_len: usize,
+    replacement: &str,
+) -> isize {
+    let replacement = replacement.as_bytes();
+    if replacement.len() <= token_len {
+        output[output_index..output_index + replacement.len()].copy_from_slice(replacement);
+        output[output_index + replacement.len()..output_index + token_len].fill(b' ');
+        return 0;
+    }
+
+    output.splice(
+        output_index..output_index + token_len,
+        replacement.iter().copied(),
+    );
+    replacement.len() as isize - token_len as isize
 }
 
 fn line_has_yaml_anchor_or_alias(line: &str) -> bool {

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -161,14 +161,14 @@ impl Extractor for GitHubActionsExtractor {
     }
 
     fn probe(&self, source: &str) -> bool {
-        parse_yaml(GITHUB_ACTIONS_SOURCE_ID, source)
+        parse_github_actions_yaml(source)
             .ok()
             .and_then(|node| node.as_mapping().cloned())
             .is_some_and(|mapping| is_github_actions_mapping(&mapping))
     }
 
     fn extract(&self, source: &str) -> Result<Vec<EmbeddedScript>> {
-        let root = parse_yaml(GITHUB_ACTIONS_SOURCE_ID, source)
+        let root = parse_github_actions_yaml(source)
             .map_err(|err| anyhow!("parse GitHub Actions YAML: {err}"))?;
         let Some(root) = root.as_mapping() else {
             return Ok(Vec::new());
@@ -183,6 +183,226 @@ impl Extractor for GitHubActionsExtractor {
             extract_workflow(root, source)
         }
     }
+}
+
+fn parse_github_actions_yaml(source: &str) -> std::result::Result<Node, marked_yaml::LoadError> {
+    if source_has_yaml_anchors_or_aliases(source) {
+        let sanitized = sanitize_yaml_anchors_and_aliases(source);
+        parse_yaml(GITHUB_ACTIONS_SOURCE_ID, sanitized)
+    } else {
+        parse_yaml(GITHUB_ACTIONS_SOURCE_ID, source)
+    }
+}
+
+// marked-yaml rejects anchors and aliases, but GHA workflows often use them
+// around env maps or shared steps. Remove only the YAML metadata outside block
+// scalars; aliases become null so alias-only steps are skipped when we cannot
+// preserve a real source span for the referenced node.
+fn source_has_yaml_anchors_or_aliases(source: &str) -> bool {
+    let mut block_parent_indent = None;
+    for line in source.lines() {
+        let indent = leading_space_count(line);
+        if let Some(parent_indent) = block_parent_indent {
+            if line.trim().is_empty() || indent > parent_indent {
+                continue;
+            }
+            block_parent_indent = None;
+        }
+
+        if line_has_yaml_anchor_or_alias(line) {
+            return true;
+        }
+        if line_starts_block_scalar(line) {
+            block_parent_indent = Some(indent);
+        }
+    }
+    false
+}
+
+fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
+    let mut output = source.as_bytes().to_vec();
+    let mut offset = 0;
+    let mut block_parent_indent = None;
+
+    for line in source.split_inclusive('\n') {
+        let line_without_newline = line.strip_suffix('\n').unwrap_or(line);
+        let line_content = line_without_newline
+            .strip_suffix('\r')
+            .unwrap_or(line_without_newline);
+        let indent = leading_space_count(line_content);
+
+        if let Some(parent_indent) = block_parent_indent {
+            if line_content.trim().is_empty() || indent > parent_indent {
+                offset += line.len();
+                continue;
+            }
+            block_parent_indent = None;
+        }
+
+        sanitize_yaml_anchor_or_alias_line(&mut output, offset, line_content);
+        if line_starts_block_scalar(line_content) {
+            block_parent_indent = Some(indent);
+        }
+
+        offset += line.len();
+    }
+
+    String::from_utf8(output).expect("YAML anchor sanitization preserved UTF-8")
+}
+
+fn sanitize_yaml_anchor_or_alias_line(output: &mut [u8], line_start: usize, line: &str) {
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    let mut quote = YamlLineQuote::Unquoted;
+
+    while index < bytes.len() {
+        match quote {
+            YamlLineQuote::Unquoted => match bytes[index] {
+                b'\'' => quote = YamlLineQuote::Single,
+                b'"' => quote = YamlLineQuote::Double,
+                b'&' | b'*' if yaml_anchor_token_starts(bytes, index) => {
+                    let token_len = yaml_anchor_token_len(bytes, index);
+                    if bytes[index] == b'&' {
+                        output[line_start + index..line_start + index + token_len].fill(b' ');
+                    } else {
+                        output[line_start + index] = b'~';
+                        output[line_start + index + 1..line_start + index + token_len].fill(b' ');
+                    }
+                    index += token_len;
+                    continue;
+                }
+                _ => {}
+            },
+            YamlLineQuote::Single => {
+                if bytes[index] == b'\'' {
+                    quote = YamlLineQuote::Unquoted;
+                }
+            }
+            YamlLineQuote::Double => match bytes[index] {
+                b'"' => quote = YamlLineQuote::Unquoted,
+                b'\\' => {
+                    index += 1;
+                }
+                _ => {}
+            },
+        }
+
+        index += 1;
+    }
+}
+
+fn line_has_yaml_anchor_or_alias(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut index = 0;
+    let mut quote = YamlLineQuote::Unquoted;
+
+    while index < bytes.len() {
+        match quote {
+            YamlLineQuote::Unquoted => match bytes[index] {
+                b'\'' => quote = YamlLineQuote::Single,
+                b'"' => quote = YamlLineQuote::Double,
+                b'&' | b'*' if yaml_anchor_token_starts(bytes, index) => return true,
+                _ => {}
+            },
+            YamlLineQuote::Single => {
+                if bytes[index] == b'\'' {
+                    quote = YamlLineQuote::Unquoted;
+                }
+            }
+            YamlLineQuote::Double => match bytes[index] {
+                b'"' => quote = YamlLineQuote::Unquoted,
+                b'\\' => {
+                    index += 1;
+                }
+                _ => {}
+            },
+        }
+
+        index += 1;
+    }
+
+    false
+}
+
+fn yaml_anchor_token_starts(bytes: &[u8], index: usize) -> bool {
+    yaml_anchor_token_boundary_before(bytes, index) && yaml_anchor_token_len(bytes, index) > 1
+}
+
+fn yaml_anchor_token_boundary_before(bytes: &[u8], index: usize) -> bool {
+    bytes[..index]
+        .iter()
+        .rev()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_none_or(|byte| matches!(byte, b':' | b'-' | b'[' | b'{' | b','))
+}
+
+fn yaml_anchor_token_len(bytes: &[u8], index: usize) -> usize {
+    let mut len = 1;
+    while bytes
+        .get(index + len)
+        .is_some_and(|byte| is_yaml_anchor_name_byte(*byte))
+    {
+        len += 1;
+    }
+    len
+}
+
+fn is_yaml_anchor_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.')
+}
+
+fn line_starts_block_scalar(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut quote = YamlLineQuote::Unquoted;
+    let mut index = 0;
+
+    while index < bytes.len() {
+        match quote {
+            YamlLineQuote::Unquoted => match bytes[index] {
+                b'\'' => quote = YamlLineQuote::Single,
+                b'"' => quote = YamlLineQuote::Double,
+                b'|' | b'>' if previous_non_space_byte(bytes, index) == Some(b':') => {
+                    return true;
+                }
+                _ => {}
+            },
+            YamlLineQuote::Single => {
+                if bytes[index] == b'\'' {
+                    quote = YamlLineQuote::Unquoted;
+                }
+            }
+            YamlLineQuote::Double => match bytes[index] {
+                b'"' => quote = YamlLineQuote::Unquoted,
+                b'\\' => {
+                    index += 1;
+                }
+                _ => {}
+            },
+        }
+
+        index += 1;
+    }
+
+    false
+}
+
+fn previous_non_space_byte(bytes: &[u8], index: usize) -> Option<u8> {
+    bytes[..index]
+        .iter()
+        .rev()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .copied()
+}
+
+fn leading_space_count(line: &str) -> usize {
+    line.bytes().take_while(|byte| *byte == b' ').count()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum YamlLineQuote {
+    Unquoted,
+    Single,
+    Double,
 }
 
 fn gha_path_matches(path: &Path) -> bool {

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -240,13 +240,12 @@ fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
             block_parent_indent = None;
         }
 
-        let delta =
-            sanitize_yaml_anchor_or_alias_line(&mut output, offset, line_content, &anchor_values);
+        sanitize_yaml_anchor_or_alias_line(&mut output, offset, line_content, &anchor_values);
         if line_starts_block_scalar(line_content) {
             block_parent_indent = Some(indent);
         }
 
-        offset = offset.saturating_add_signed(line.len() as isize + delta);
+        offset += line.len();
     }
 
     String::from_utf8(output).expect("YAML anchor sanitization preserved UTF-8")
@@ -277,14 +276,13 @@ fn collect_yaml_scalar_anchors(source: &str) -> HashMap<String, String> {
 }
 
 fn sanitize_yaml_anchor_or_alias_line(
-    output: &mut Vec<u8>,
+    output: &mut [u8],
     line_start: usize,
     line: &str,
     anchor_values: &HashMap<String, String>,
-) -> isize {
+) {
     let bytes = line.as_bytes();
     let mut index = 0;
-    let mut delta = 0isize;
     let mut quote = YamlLineQuote::Unquoted;
 
     while index < bytes.len() {
@@ -295,16 +293,14 @@ fn sanitize_yaml_anchor_or_alias_line(
                 b'&' | b'*' if yaml_anchor_token_starts(bytes, index) => {
                     let token_len = yaml_anchor_token_len(bytes, index);
                     if bytes[index] == b'&' {
-                        let output_index = line_start.saturating_add_signed(index as isize + delta);
-                        output[output_index..output_index + token_len].fill(b' ');
+                        output[line_start + index..line_start + index + token_len].fill(b' ');
                     } else {
                         let alias_name = &line[index + 1..index + token_len];
-                        let output_index = line_start.saturating_add_signed(index as isize + delta);
                         let replacement = anchor_values
                             .get(alias_name)
                             .map(String::as_str)
                             .unwrap_or("~");
-                        delta += replace_yaml_token(output, output_index, token_len, replacement);
+                        replace_yaml_token(output, line_start + index, token_len, replacement);
                     }
                     index += token_len;
                     continue;
@@ -327,8 +323,6 @@ fn sanitize_yaml_anchor_or_alias_line(
 
         index += 1;
     }
-
-    delta
 }
 
 fn yaml_scalar_anchor_definition(line: &str) -> Option<(&str, &str)> {
@@ -378,24 +372,15 @@ fn yaml_anchor_value_is_aliasable_scalar(value: &str) -> bool {
         .is_some_and(|byte| !matches!(byte, b'&' | b'*' | b'|' | b'>' | b'#'))
 }
 
-fn replace_yaml_token(
-    output: &mut Vec<u8>,
-    output_index: usize,
-    token_len: usize,
-    replacement: &str,
-) -> isize {
+fn replace_yaml_token(output: &mut [u8], output_index: usize, token_len: usize, replacement: &str) {
     let replacement = replacement.as_bytes();
-    if replacement.len() <= token_len {
-        output[output_index..output_index + replacement.len()].copy_from_slice(replacement);
-        output[output_index + replacement.len()..output_index + token_len].fill(b' ');
-        return 0;
-    }
-
-    output.splice(
-        output_index..output_index + token_len,
-        replacement.iter().copied(),
-    );
-    replacement.len() as isize - token_len as isize
+    let replacement = if replacement.len() <= token_len {
+        replacement
+    } else {
+        b"~".as_slice()
+    };
+    output[output_index..output_index + replacement.len()].copy_from_slice(replacement);
+    output[output_index + replacement.len()..output_index + token_len].fill(b' ');
 }
 
 fn line_has_yaml_anchor_or_alias(line: &str) -> bool {
@@ -468,9 +453,7 @@ fn line_starts_block_scalar(line: &str) -> bool {
             YamlLineQuote::Unquoted => match bytes[index] {
                 b'\'' => quote = YamlLineQuote::Single,
                 b'"' => quote = YamlLineQuote::Double,
-                b'|' | b'>' if previous_non_space_byte(bytes, index) == Some(b':') => {
-                    return true;
-                }
+                b'|' | b'>' if block_scalar_indicator_starts_value(bytes, index) => return true,
                 _ => {}
             },
             YamlLineQuote::Single => {
@@ -491,6 +474,35 @@ fn line_starts_block_scalar(line: &str) -> bool {
     }
 
     false
+}
+
+fn block_scalar_indicator_starts_value(bytes: &[u8], index: usize) -> bool {
+    let Some(previous_index) = previous_non_space_index(bytes, index) else {
+        return false;
+    };
+    if bytes[previous_index] == b':' {
+        return true;
+    }
+
+    let token_start = yaml_anchor_token_start_ending_at(bytes, previous_index);
+    token_start < previous_index
+        && bytes[token_start] == b'&'
+        && previous_non_space_byte(bytes, token_start)
+            .is_some_and(|byte| matches!(byte, b':' | b'-'))
+}
+
+fn yaml_anchor_token_start_ending_at(bytes: &[u8], index: usize) -> usize {
+    let mut start = index;
+    while start > 0 && is_yaml_anchor_name_byte(bytes[start]) {
+        start -= 1;
+    }
+    start
+}
+
+fn previous_non_space_index(bytes: &[u8], index: usize) -> Option<usize> {
+    bytes[..index]
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
 }
 
 fn previous_non_space_byte(bytes: &[u8], index: usize) -> Option<u8> {

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -421,11 +421,15 @@ fn yaml_anchor_token_starts(bytes: &[u8], index: usize) -> bool {
 }
 
 fn yaml_anchor_token_boundary_before(bytes: &[u8], index: usize) -> bool {
-    bytes[..index]
-        .iter()
-        .rev()
-        .find(|byte| !byte.is_ascii_whitespace())
-        .is_none_or(|byte| matches!(byte, b':' | b'-' | b'[' | b'{' | b','))
+    let Some(previous_index) = previous_non_space_index(bytes, index) else {
+        return true;
+    };
+
+    match bytes[previous_index] {
+        b':' | b'[' | b'{' | b',' => true,
+        b'-' => yaml_dash_is_sequence_indicator(bytes, previous_index),
+        _ => false,
+    }
 }
 
 fn yaml_anchor_token_len(bytes: &[u8], index: usize) -> usize {
@@ -487,8 +491,23 @@ fn block_scalar_indicator_starts_value(bytes: &[u8], index: usize) -> bool {
     let token_start = yaml_anchor_token_start_ending_at(bytes, previous_index);
     token_start < previous_index
         && bytes[token_start] == b'&'
-        && previous_non_space_byte(bytes, token_start)
-            .is_some_and(|byte| matches!(byte, b':' | b'-'))
+        && yaml_value_indicator_before(bytes, token_start)
+}
+
+fn yaml_value_indicator_before(bytes: &[u8], index: usize) -> bool {
+    let Some(previous_index) = previous_non_space_index(bytes, index) else {
+        return false;
+    };
+
+    match bytes[previous_index] {
+        b':' => true,
+        b'-' => yaml_dash_is_sequence_indicator(bytes, previous_index),
+        _ => false,
+    }
+}
+
+fn yaml_dash_is_sequence_indicator(bytes: &[u8], dash_index: usize) -> bool {
+    previous_non_space_index(bytes, dash_index).is_none()
 }
 
 fn yaml_anchor_token_start_ending_at(bytes: &[u8], index: usize) -> usize {
@@ -503,14 +522,6 @@ fn previous_non_space_index(bytes: &[u8], index: usize) -> Option<usize> {
     bytes[..index]
         .iter()
         .rposition(|byte| !byte.is_ascii_whitespace())
-}
-
-fn previous_non_space_byte(bytes: &[u8], index: usize) -> Option<u8> {
-    bytes[..index]
-        .iter()
-        .rev()
-        .find(|byte| !byte.is_ascii_whitespace())
-        .copied()
 }
 
 fn leading_space_count(line: &str) -> usize {

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -581,7 +581,18 @@ fn yaml_has_unquoted_colon_before(bytes: &[u8], colon_index: usize) -> bool {
 fn yaml_flow_key_before_colon(bytes: &[u8], colon_index: usize) -> bool {
     let entry_start = yaml_flow_entry_start(bytes, colon_index);
     let key = trim_ascii(&bytes[entry_start..colon_index]);
+    yaml_flow_key_is_plain(key) || yaml_flow_key_is_quoted(key)
+}
+
+fn yaml_flow_key_is_plain(key: &[u8]) -> bool {
     !key.is_empty() && key.iter().all(|byte| is_yaml_anchor_name_byte(*byte))
+}
+
+fn yaml_flow_key_is_quoted(key: &[u8]) -> bool {
+    if key.len() < 2 || !matches!(key[0], b'\'' | b'"') {
+        return false;
+    }
+    key.last() == Some(&key[0]) && yaml_quoted_scalar_end(key, 0) == key.len()
 }
 
 fn yaml_flow_entry_start(bytes: &[u8], target_index: usize) -> usize {

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -424,6 +424,7 @@ fn line_has_run_key_after(line: &str, start: usize) -> bool {
             YamlLineQuote::Unquoted => match bytes[index] {
                 b'\'' => quote = YamlLineQuote::Single,
                 b'"' => quote = YamlLineQuote::Double,
+                b'#' if yaml_hash_starts_comment(bytes, index) => return false,
                 b'r' if yaml_key_starts_at(line, index, "run") => return true,
                 _ => {}
             },
@@ -451,6 +452,9 @@ fn yaml_key_starts_at(line: &str, index: usize, key: &str) -> bool {
     let bytes = line.as_bytes();
     let key_bytes = key.as_bytes();
     if bytes.get(index..index + key_bytes.len()) != Some(key_bytes) {
+        return false;
+    }
+    if index > 0 && is_yaml_anchor_name_byte(bytes[index - 1]) {
         return false;
     }
     let after_key = index + key_bytes.len();

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -200,6 +200,7 @@ fn parse_github_actions_yaml(source: &str) -> std::result::Result<Node, marked_y
 // referenced scalar in place.
 fn source_has_yaml_anchors_or_aliases(source: &str) -> bool {
     let mut block_parent_indent = None;
+    let mut quote = YamlLineQuote::Unquoted;
     for line in source.lines() {
         let indent = leading_space_count(line);
         if let Some(parent_indent) = block_parent_indent {
@@ -209,10 +210,10 @@ fn source_has_yaml_anchors_or_aliases(source: &str) -> bool {
             block_parent_indent = None;
         }
 
-        if line_has_yaml_anchor_or_alias(line) {
+        if line_has_yaml_anchor_or_alias(line, &mut quote) {
             return true;
         }
-        if line_starts_block_scalar(line) {
+        if quote == YamlLineQuote::Unquoted && line_starts_block_scalar(line) {
             block_parent_indent = Some(indent);
         }
     }
@@ -223,6 +224,7 @@ fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
     let mut anchor_values = HashMap::new();
     let mut output = String::with_capacity(source.len());
     let mut block_parent_indent = None;
+    let mut quote = YamlLineQuote::Unquoted;
 
     for line in source.split_inclusive('\n') {
         let line_without_newline = line.strip_suffix('\n').unwrap_or(line);
@@ -248,10 +250,11 @@ fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
         output.push_str(&sanitize_yaml_anchor_or_alias_line(
             line_content,
             &mut anchor_values,
+            &mut quote,
         ));
         output.push_str(carriage_return);
         output.push_str(newline);
-        if line_starts_block_scalar(line_content) {
+        if quote == YamlLineQuote::Unquoted && line_starts_block_scalar(line_content) {
             block_parent_indent = Some(indent);
         }
     }
@@ -262,18 +265,18 @@ fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
 fn sanitize_yaml_anchor_or_alias_line(
     line: &str,
     anchor_values: &mut HashMap<String, String>,
+    quote: &mut YamlLineQuote,
 ) -> String {
     let bytes = line.as_bytes();
     let mut output = String::with_capacity(line.len());
     let mut index = 0;
     let mut copied_until = 0;
-    let mut quote = YamlLineQuote::Unquoted;
 
     while index < bytes.len() {
-        match quote {
+        match *quote {
             YamlLineQuote::Unquoted => match bytes[index] {
-                b'\'' => quote = YamlLineQuote::Single,
-                b'"' => quote = YamlLineQuote::Double,
+                b'\'' => *quote = YamlLineQuote::Single,
+                b'"' => *quote = YamlLineQuote::Double,
                 b'&' | b'*' if yaml_anchor_token_starts(bytes, index) => {
                     let token_len = yaml_anchor_token_len(bytes, index);
                     output.push_str(&line[copied_until..index]);
@@ -306,11 +309,11 @@ fn sanitize_yaml_anchor_or_alias_line(
             },
             YamlLineQuote::Single => {
                 if bytes[index] == b'\'' {
-                    quote = YamlLineQuote::Unquoted;
+                    *quote = YamlLineQuote::Unquoted;
                 }
             }
             YamlLineQuote::Double => match bytes[index] {
-                b'"' => quote = YamlLineQuote::Unquoted,
+                b'"' => *quote = YamlLineQuote::Unquoted,
                 b'\\' => {
                     index += 1;
                 }
@@ -422,6 +425,7 @@ fn line_has_run_key_after(line: &str, start: usize) -> bool {
     while index < bytes.len() {
         match quote {
             YamlLineQuote::Unquoted => match bytes[index] {
+                b'\'' | b'"' if yaml_quoted_key_starts_at(line, index, "run") => return true,
                 b'\'' => quote = YamlLineQuote::Single,
                 b'"' => quote = YamlLineQuote::Double,
                 b'#' if yaml_hash_starts_comment(bytes, index) => return false,
@@ -470,26 +474,40 @@ fn yaml_key_starts_at(line: &str, index: usize, key: &str) -> bool {
         .is_some_and(|offset| bytes[after_key + offset] == b':')
 }
 
-fn line_has_yaml_anchor_or_alias(line: &str) -> bool {
+fn yaml_quoted_key_starts_at(line: &str, index: usize, key: &str) -> bool {
+    let bytes = line.as_bytes();
+    let quote_end = yaml_quoted_scalar_end(bytes, index);
+    if quote_end <= index + 1 || quote_end > bytes.len() {
+        return false;
+    }
+    if &line[index + 1..quote_end - 1] != key {
+        return false;
+    }
+    bytes[quote_end..]
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|offset| bytes[quote_end + offset] == b':')
+}
+
+fn line_has_yaml_anchor_or_alias(line: &str, quote: &mut YamlLineQuote) -> bool {
     let bytes = line.as_bytes();
     let mut index = 0;
-    let mut quote = YamlLineQuote::Unquoted;
 
     while index < bytes.len() {
-        match quote {
+        match *quote {
             YamlLineQuote::Unquoted => match bytes[index] {
-                b'\'' => quote = YamlLineQuote::Single,
-                b'"' => quote = YamlLineQuote::Double,
+                b'\'' => *quote = YamlLineQuote::Single,
+                b'"' => *quote = YamlLineQuote::Double,
                 b'&' | b'*' if yaml_anchor_token_starts(bytes, index) => return true,
                 _ => {}
             },
             YamlLineQuote::Single => {
                 if bytes[index] == b'\'' {
-                    quote = YamlLineQuote::Unquoted;
+                    *quote = YamlLineQuote::Unquoted;
                 }
             }
             YamlLineQuote::Double => match bytes[index] {
-                b'"' => quote = YamlLineQuote::Unquoted,
+                b'"' => *quote = YamlLineQuote::Unquoted,
                 b'\\' => {
                     index += 1;
                 }

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -220,7 +220,7 @@ fn source_has_yaml_anchors_or_aliases(source: &str) -> bool {
 }
 
 fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
-    let anchor_values = collect_yaml_scalar_anchors(source);
+    let mut anchor_values = HashMap::new();
     let mut output = String::with_capacity(source.len());
     let mut block_parent_indent = None;
 
@@ -247,7 +247,7 @@ fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
 
         output.push_str(&sanitize_yaml_anchor_or_alias_line(
             line_content,
-            &anchor_values,
+            &mut anchor_values,
         ));
         output.push_str(carriage_return);
         output.push_str(newline);
@@ -259,33 +259,9 @@ fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
     output
 }
 
-fn collect_yaml_scalar_anchors(source: &str) -> HashMap<String, String> {
-    let mut anchors = HashMap::new();
-    let mut block_parent_indent = None;
-
-    for line in source.lines() {
-        let indent = leading_space_count(line);
-        if let Some(parent_indent) = block_parent_indent {
-            if line.trim().is_empty() || indent > parent_indent {
-                continue;
-            }
-            block_parent_indent = None;
-        }
-
-        if let Some((name, value)) = yaml_scalar_anchor_definition(line) {
-            anchors.insert(name.to_owned(), value.to_owned());
-        }
-        if line_starts_block_scalar(line) {
-            block_parent_indent = Some(indent);
-        }
-    }
-
-    anchors
-}
-
 fn sanitize_yaml_anchor_or_alias_line(
     line: &str,
-    anchor_values: &HashMap<String, String>,
+    anchor_values: &mut HashMap<String, String>,
 ) -> String {
     let bytes = line.as_bytes();
     let mut output = String::with_capacity(line.len());
@@ -302,6 +278,11 @@ fn sanitize_yaml_anchor_or_alias_line(
                     let token_len = yaml_anchor_token_len(bytes, index);
                     output.push_str(&line[copied_until..index]);
                     if bytes[index] == b'&' {
+                        if let Some((name, value)) =
+                            yaml_scalar_anchor_definition_at(line, index, token_len)
+                        {
+                            anchor_values.insert(name.to_owned(), value.to_owned());
+                        }
                         push_padded_replacement(&mut output, "", token_len);
                     } else {
                         let alias_name = &line[index + 1..index + token_len];
@@ -344,51 +325,70 @@ fn sanitize_yaml_anchor_or_alias_line(
     output
 }
 
-fn yaml_scalar_anchor_definition(line: &str) -> Option<(&str, &str)> {
-    let bytes = line.as_bytes();
-    let mut index = 0;
-    let mut quote = YamlLineQuote::Unquoted;
-
-    while index < bytes.len() {
-        match quote {
-            YamlLineQuote::Unquoted => match bytes[index] {
-                b'\'' => quote = YamlLineQuote::Single,
-                b'"' => quote = YamlLineQuote::Double,
-                b'&' if yaml_anchor_token_starts(bytes, index) => {
-                    let token_len = yaml_anchor_token_len(bytes, index);
-                    let value = line[index + token_len..].trim();
-                    if !yaml_anchor_value_is_aliasable_scalar(value) {
-                        return None;
-                    }
-                    return Some((&line[index + 1..index + token_len], value));
-                }
-                _ => {}
-            },
-            YamlLineQuote::Single => {
-                if bytes[index] == b'\'' {
-                    quote = YamlLineQuote::Unquoted;
-                }
-            }
-            YamlLineQuote::Double => match bytes[index] {
-                b'"' => quote = YamlLineQuote::Unquoted,
-                b'\\' => {
-                    index += 1;
-                }
-                _ => {}
-            },
-        }
-
-        index += 1;
-    }
-
-    None
-}
-
 fn yaml_anchor_value_is_aliasable_scalar(value: &str) -> bool {
     value
         .as_bytes()
         .first()
         .is_some_and(|byte| !matches!(byte, b'&' | b'*' | b'|' | b'>' | b'#'))
+}
+
+fn yaml_scalar_anchor_definition_at(
+    line: &str,
+    anchor_start: usize,
+    token_len: usize,
+) -> Option<(&str, &str)> {
+    let value_start = line[anchor_start + token_len..]
+        .bytes()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .map(|offset| anchor_start + token_len + offset)?;
+    let value_end = yaml_anchor_scalar_value_end(line, value_start);
+    let value = line[value_start..value_end].trim_end();
+    if !yaml_anchor_value_is_aliasable_scalar(value) {
+        return None;
+    }
+    Some((&line[anchor_start + 1..anchor_start + token_len], value))
+}
+
+fn yaml_anchor_scalar_value_end(line: &str, value_start: usize) -> usize {
+    let bytes = line.as_bytes();
+    if matches!(bytes[value_start], b'\'' | b'"') {
+        return yaml_quoted_scalar_end(bytes, value_start);
+    }
+
+    let in_flow = yaml_index_is_inside_flow_collection(bytes, value_start);
+    let mut index = value_start;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'#' if yaml_hash_starts_comment(bytes, index) => return index,
+            b',' | b']' | b'}' if in_flow => return index,
+            _ => {}
+        }
+        index += 1;
+    }
+    bytes.len()
+}
+
+fn yaml_quoted_scalar_end(bytes: &[u8], quote_start: usize) -> usize {
+    let quote = bytes[quote_start];
+    let mut index = quote_start + 1;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' if quote == b'\'' && bytes.get(index + 1) == Some(&b'\'') => {
+                index += 1;
+            }
+            byte if byte == quote => return index + 1,
+            b'\\' if quote == b'"' => {
+                index += 1;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+    bytes.len()
+}
+
+fn yaml_hash_starts_comment(bytes: &[u8], index: usize) -> bool {
+    index == 0 || bytes[index - 1].is_ascii_whitespace()
 }
 
 fn push_yaml_alias_replacement(

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -195,9 +195,9 @@ fn parse_github_actions_yaml(source: &str) -> std::result::Result<Node, marked_y
 }
 
 // marked-yaml rejects anchors and aliases, but GHA workflows often use them
-// around env maps or shared steps. Remove only the YAML metadata outside block
-// scalars; aliases become null so alias-only steps are skipped when we cannot
-// preserve a real source span for the referenced node.
+// around env maps, shells, or shared steps. Remove only the YAML metadata
+// outside block scalars; aliases become null when we cannot preserve the
+// referenced scalar in place.
 fn source_has_yaml_anchors_or_aliases(source: &str) -> bool {
     let mut block_parent_indent = None;
     for line in source.lines() {
@@ -221,34 +221,42 @@ fn source_has_yaml_anchors_or_aliases(source: &str) -> bool {
 
 fn sanitize_yaml_anchors_and_aliases(source: &str) -> String {
     let anchor_values = collect_yaml_scalar_anchors(source);
-    let mut output = source.as_bytes().to_vec();
-    let mut offset = 0;
+    let mut output = String::with_capacity(source.len());
     let mut block_parent_indent = None;
 
     for line in source.split_inclusive('\n') {
         let line_without_newline = line.strip_suffix('\n').unwrap_or(line);
+        let newline = if line.ends_with('\n') { "\n" } else { "" };
         let line_content = line_without_newline
             .strip_suffix('\r')
             .unwrap_or(line_without_newline);
+        let carriage_return = if line_without_newline.ends_with('\r') {
+            "\r"
+        } else {
+            ""
+        };
         let indent = leading_space_count(line_content);
 
         if let Some(parent_indent) = block_parent_indent {
             if line_content.trim().is_empty() || indent > parent_indent {
-                offset += line.len();
+                output.push_str(line);
                 continue;
             }
             block_parent_indent = None;
         }
 
-        sanitize_yaml_anchor_or_alias_line(&mut output, offset, line_content, &anchor_values);
+        output.push_str(&sanitize_yaml_anchor_or_alias_line(
+            line_content,
+            &anchor_values,
+        ));
+        output.push_str(carriage_return);
+        output.push_str(newline);
         if line_starts_block_scalar(line_content) {
             block_parent_indent = Some(indent);
         }
-
-        offset += line.len();
     }
 
-    String::from_utf8(output).expect("YAML anchor sanitization preserved UTF-8")
+    output
 }
 
 fn collect_yaml_scalar_anchors(source: &str) -> HashMap<String, String> {
@@ -276,13 +284,13 @@ fn collect_yaml_scalar_anchors(source: &str) -> HashMap<String, String> {
 }
 
 fn sanitize_yaml_anchor_or_alias_line(
-    output: &mut [u8],
-    line_start: usize,
     line: &str,
     anchor_values: &HashMap<String, String>,
-) {
+) -> String {
     let bytes = line.as_bytes();
+    let mut output = String::with_capacity(line.len());
     let mut index = 0;
+    let mut copied_until = 0;
     let mut quote = YamlLineQuote::Unquoted;
 
     while index < bytes.len() {
@@ -292,16 +300,24 @@ fn sanitize_yaml_anchor_or_alias_line(
                 b'"' => quote = YamlLineQuote::Double,
                 b'&' | b'*' if yaml_anchor_token_starts(bytes, index) => {
                     let token_len = yaml_anchor_token_len(bytes, index);
+                    output.push_str(&line[copied_until..index]);
                     if bytes[index] == b'&' {
-                        output[line_start + index..line_start + index + token_len].fill(b' ');
+                        push_padded_replacement(&mut output, "", token_len);
                     } else {
                         let alias_name = &line[index + 1..index + token_len];
                         let replacement = anchor_values
                             .get(alias_name)
                             .map(String::as_str)
                             .unwrap_or("~");
-                        replace_yaml_token(output, line_start + index, token_len, replacement);
+                        push_yaml_alias_replacement(
+                            &mut output,
+                            line,
+                            index,
+                            token_len,
+                            replacement,
+                        );
                     }
+                    copied_until = index + token_len;
                     index += token_len;
                     continue;
                 }
@@ -323,6 +339,9 @@ fn sanitize_yaml_anchor_or_alias_line(
 
         index += 1;
     }
+
+    output.push_str(&line[copied_until..]);
+    output
 }
 
 fn yaml_scalar_anchor_definition(line: &str) -> Option<(&str, &str)> {
@@ -372,15 +391,79 @@ fn yaml_anchor_value_is_aliasable_scalar(value: &str) -> bool {
         .is_some_and(|byte| !matches!(byte, b'&' | b'*' | b'|' | b'>' | b'#'))
 }
 
-fn replace_yaml_token(output: &mut [u8], output_index: usize, token_len: usize, replacement: &str) {
-    let replacement = replacement.as_bytes();
-    let replacement = if replacement.len() <= token_len {
-        replacement
+fn push_yaml_alias_replacement(
+    output: &mut String,
+    line: &str,
+    token_start: usize,
+    token_len: usize,
+    replacement: &str,
+) {
+    if replacement.len() <= token_len {
+        push_padded_replacement(output, replacement, token_len);
+    } else if line_has_run_key_after(line, token_start + token_len) {
+        push_padded_replacement(output, "~", token_len);
     } else {
-        b"~".as_slice()
-    };
-    output[output_index..output_index + replacement.len()].copy_from_slice(replacement);
-    output[output_index + replacement.len()..output_index + token_len].fill(b' ');
+        output.push_str(replacement);
+    }
+}
+
+fn push_padded_replacement(output: &mut String, replacement: &str, token_len: usize) {
+    output.push_str(replacement);
+    for _ in replacement.len()..token_len {
+        output.push(' ');
+    }
+}
+
+fn line_has_run_key_after(line: &str, start: usize) -> bool {
+    let bytes = line.as_bytes();
+    let mut index = start;
+    let mut quote = YamlLineQuote::Unquoted;
+
+    while index < bytes.len() {
+        match quote {
+            YamlLineQuote::Unquoted => match bytes[index] {
+                b'\'' => quote = YamlLineQuote::Single,
+                b'"' => quote = YamlLineQuote::Double,
+                b'r' if yaml_key_starts_at(line, index, "run") => return true,
+                _ => {}
+            },
+            YamlLineQuote::Single => {
+                if bytes[index] == b'\'' {
+                    quote = YamlLineQuote::Unquoted;
+                }
+            }
+            YamlLineQuote::Double => match bytes[index] {
+                b'"' => quote = YamlLineQuote::Unquoted,
+                b'\\' => {
+                    index += 1;
+                }
+                _ => {}
+            },
+        }
+
+        index += 1;
+    }
+
+    false
+}
+
+fn yaml_key_starts_at(line: &str, index: usize, key: &str) -> bool {
+    let bytes = line.as_bytes();
+    let key_bytes = key.as_bytes();
+    if bytes.get(index..index + key_bytes.len()) != Some(key_bytes) {
+        return false;
+    }
+    let after_key = index + key_bytes.len();
+    if bytes
+        .get(after_key)
+        .is_none_or(|byte| is_yaml_anchor_name_byte(*byte))
+    {
+        return false;
+    }
+    bytes[after_key..]
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .is_some_and(|offset| bytes[after_key + offset] == b':')
 }
 
 fn line_has_yaml_anchor_or_alias(line: &str) -> bool {
@@ -426,7 +509,62 @@ fn yaml_anchor_token_boundary_before(bytes: &[u8], index: usize) -> bool {
     };
 
     match bytes[previous_index] {
-        b':' | b'[' | b'{' | b',' => true,
+        b':' => true,
+        b'[' | b'{' | b',' => yaml_index_is_inside_flow_collection(bytes, index),
+        b'-' => yaml_dash_is_sequence_indicator(bytes, previous_index),
+        _ => false,
+    }
+}
+
+fn yaml_index_is_inside_flow_collection(bytes: &[u8], target_index: usize) -> bool {
+    let mut index = 0;
+    let mut quote = YamlLineQuote::Unquoted;
+    let mut flow_depth = 0usize;
+
+    while index < target_index {
+        match quote {
+            YamlLineQuote::Unquoted => match bytes[index] {
+                b'\'' => quote = YamlLineQuote::Single,
+                b'"' => quote = YamlLineQuote::Double,
+                b'[' | b'{' if yaml_flow_collection_can_start(bytes, index, flow_depth) => {
+                    flow_depth += 1;
+                }
+                b']' | b'}' if flow_depth > 0 => {
+                    flow_depth -= 1;
+                }
+                _ => {}
+            },
+            YamlLineQuote::Single => {
+                if bytes[index] == b'\'' {
+                    quote = YamlLineQuote::Unquoted;
+                }
+            }
+            YamlLineQuote::Double => match bytes[index] {
+                b'"' => quote = YamlLineQuote::Unquoted,
+                b'\\' => {
+                    index += 1;
+                }
+                _ => {}
+            },
+        }
+
+        index += 1;
+    }
+
+    flow_depth > 0
+}
+
+fn yaml_flow_collection_can_start(bytes: &[u8], index: usize, flow_depth: usize) -> bool {
+    if flow_depth > 0 {
+        return true;
+    }
+
+    let Some(previous_index) = previous_non_space_index(bytes, index) else {
+        return true;
+    };
+
+    match bytes[previous_index] {
+        b':' => true,
         b'-' => yaml_dash_is_sequence_indicator(bytes, previous_index),
         _ => false,
     }

--- a/crates/shuck-extract/src/lib.rs
+++ b/crates/shuck-extract/src/lib.rs
@@ -509,11 +509,112 @@ fn yaml_anchor_token_boundary_before(bytes: &[u8], index: usize) -> bool {
     };
 
     match bytes[previous_index] {
-        b':' => true,
+        b':' => yaml_colon_is_value_indicator(bytes, previous_index),
         b'[' | b'{' | b',' => yaml_index_is_inside_flow_collection(bytes, index),
         b'-' => yaml_dash_is_sequence_indicator(bytes, previous_index),
         _ => false,
     }
+}
+
+fn yaml_colon_is_value_indicator(bytes: &[u8], colon_index: usize) -> bool {
+    if yaml_index_is_inside_flow_collection(bytes, colon_index) {
+        return yaml_flow_key_before_colon(bytes, colon_index);
+    }
+
+    !yaml_has_unquoted_colon_before(bytes, colon_index)
+}
+
+fn yaml_has_unquoted_colon_before(bytes: &[u8], colon_index: usize) -> bool {
+    let mut index = 0;
+    let mut quote = YamlLineQuote::Unquoted;
+
+    while index < colon_index {
+        match quote {
+            YamlLineQuote::Unquoted => match bytes[index] {
+                b'\'' => quote = YamlLineQuote::Single,
+                b'"' => quote = YamlLineQuote::Double,
+                b':' => return true,
+                _ => {}
+            },
+            YamlLineQuote::Single => {
+                if bytes[index] == b'\'' {
+                    quote = YamlLineQuote::Unquoted;
+                }
+            }
+            YamlLineQuote::Double => match bytes[index] {
+                b'"' => quote = YamlLineQuote::Unquoted,
+                b'\\' => {
+                    index += 1;
+                }
+                _ => {}
+            },
+        }
+
+        index += 1;
+    }
+
+    false
+}
+
+fn yaml_flow_key_before_colon(bytes: &[u8], colon_index: usize) -> bool {
+    let entry_start = yaml_flow_entry_start(bytes, colon_index);
+    let key = trim_ascii(&bytes[entry_start..colon_index]);
+    !key.is_empty() && key.iter().all(|byte| is_yaml_anchor_name_byte(*byte))
+}
+
+fn yaml_flow_entry_start(bytes: &[u8], target_index: usize) -> usize {
+    let mut index = 0;
+    let mut entry_start = 0;
+    let mut quote = YamlLineQuote::Unquoted;
+    let mut flow_depth = 0usize;
+
+    while index < target_index {
+        match quote {
+            YamlLineQuote::Unquoted => match bytes[index] {
+                b'\'' => quote = YamlLineQuote::Single,
+                b'"' => quote = YamlLineQuote::Double,
+                b'[' | b'{' if yaml_flow_collection_can_start(bytes, index, flow_depth) => {
+                    flow_depth += 1;
+                    entry_start = index + 1;
+                }
+                b',' if flow_depth > 0 => {
+                    entry_start = index + 1;
+                }
+                b']' | b'}' if flow_depth > 0 => {
+                    flow_depth -= 1;
+                }
+                _ => {}
+            },
+            YamlLineQuote::Single => {
+                if bytes[index] == b'\'' {
+                    quote = YamlLineQuote::Unquoted;
+                }
+            }
+            YamlLineQuote::Double => match bytes[index] {
+                b'"' => quote = YamlLineQuote::Unquoted,
+                b'\\' => {
+                    index += 1;
+                }
+                _ => {}
+            },
+        }
+
+        index += 1;
+    }
+
+    entry_start
+}
+
+fn trim_ascii(bytes: &[u8]) -> &[u8] {
+    let start = bytes
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .unwrap_or(bytes.len());
+    let end = bytes
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
+        .map_or(start, |index| index + 1);
+    &bytes[start..end]
 }
 
 fn yaml_index_is_inside_flow_collection(bytes: &[u8], target_index: usize) -> bool {
@@ -564,7 +665,7 @@ fn yaml_flow_collection_can_start(bytes: &[u8], index: usize, flow_depth: usize)
     };
 
     match bytes[previous_index] {
-        b':' => true,
+        b':' => yaml_colon_is_value_indicator(bytes, previous_index),
         b'-' => yaml_dash_is_sequence_indicator(bytes, previous_index),
         _ => false,
     }
@@ -638,7 +739,7 @@ fn yaml_value_indicator_before(bytes: &[u8], index: usize) -> bool {
     };
 
     match bytes[previous_index] {
-        b':' => true,
+        b':' => yaml_colon_is_value_indicator(bytes, previous_index),
         b'-' => yaml_dash_is_sequence_indicator(bytes, previous_index),
         _ => false,
     }

--- a/crates/shuck-extract/tests/fixtures/github-actions-composite-action.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-composite-action.yml
@@ -1,0 +1,18 @@
+name: Composite edge cases
+
+runs:
+  using: composite
+  steps:
+    - name: Bash step with env
+      shell: bash
+      env:
+        COMPOSITE_VALUE: ${{ inputs.message }}
+      run: |
+        echo "$COMPOSITE_VALUE"
+        echo "${{ github.sha }}"
+    - name: Sh step with expression
+      shell: sh
+      run: echo "${{ inputs.message }}"
+    - name: Unsupported Windows shell
+      shell: powershell
+      run: Write-Host "skip"

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -11,6 +11,10 @@ x-shells:
   posix: &posix_shell sh
   strict-bash: &b bash --noprofile --norc -e -o pipefail {0}
   powershell: &p pwsh
+  reused: &reused_shell sh
+  commented: &comment_shell sh # shared shell alias
+
+x-flow-shells: { posix: &flow_posix sh, powershell: &flow_pwsh pwsh }
 
 defaults:
   run:
@@ -112,6 +116,23 @@ jobs:
         shell: *p
         run: Write-Host short alias pwsh
 
+  redefined-anchors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Alias before redefinition
+        shell: *reused_shell
+        run: echo reused sh
+      - name: Redefine shell anchor
+        shell: &reused_shell bash
+        run: echo redefine bash
+      - name: Alias after redefinition
+        shell: *reused_shell
+        run: echo reused bash
+
   flow-style:
     runs-on: ubuntu-latest
-    steps: [{ shell: *posix_shell, run: echo flow }]
+    steps:
+      - { shell: *posix_shell, run: echo flow }
+      - { shell: *flow_posix, run: echo flow alias }
+      - { shell: *comment_shell, run: echo comment alias }
+      - { shell: *flow_pwsh, run: echo flow pwsh }

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Short alias unsupported shell
         shell: *p
         run: Write-Host short alias pwsh
+      - name: Short alias with run comment
+        shell: *b # run: keep strict bash
+        run: echo short alias comment
 
   redefined-anchors:
     runs-on: ubuntu-latest

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -88,6 +88,9 @@ jobs:
           case "$WORKFLOW_VALUE" in
             *prod) echo prod ;;
           esac
+      - name: Inline glob after dash
+        shell: bash
+        run: rm -- *.tmp
 
   flow-style:
     runs-on: ubuntu-latest

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -7,6 +7,9 @@ env: &workflow_env
   WORKFLOW_VALUE: from-env
   EXPRESSION_VALUE: ${{ github.ref }}
 
+x-shells:
+  posix: &posix_shell sh
+
 defaults:
   run:
     shell: bash
@@ -23,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: sh
+        shell: *posix_shell
     steps:
       - name: Job default shell
         env: *workflow_env

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -9,6 +9,8 @@ env: &workflow_env
 
 x-shells:
   posix: &posix_shell sh
+  strict-bash: &b bash --noprofile --norc -e -o pipefail {0}
+  powershell: &p pwsh
 
 defaults:
   run:
@@ -91,6 +93,24 @@ jobs:
       - name: Inline glob after dash
         shell: bash
         run: rm -- *.tmp
+      - name: Inline glob after comma
+        shell: bash
+        run: echo foo,*.tmp
+      - name: Inline glob after brace
+        shell: bash
+        run: echo {*.tmp,*.log}
+
+  short-shell-aliases:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: *b
+    steps:
+      - name: Short alias default shell
+        run: echo short alias default
+      - name: Short alias unsupported shell
+        shell: *p
+        run: Write-Host short alias pwsh
 
   flow-style:
     runs-on: ubuntu-latest

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -1,0 +1,81 @@
+name: GitHub Actions edge cases
+
+on:
+  push:
+
+env: &workflow_env
+  WORKFLOW_VALUE: from-env
+  EXPRESSION_VALUE: ${{ github.ref }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  missing-unix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Missing shell on Unix
+        run: |
+          echo "$WORKFLOW_VALUE"
+
+  defaulted:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: sh
+    steps:
+      - name: Job default shell
+        env: *workflow_env
+        run: |
+          echo "$EXPRESSION_VALUE"
+
+  explicit-shells:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Bash shell
+        shell: bash
+        run: |
+          echo "${{ github.sha }}"
+      - name: Sh shell
+        shell: sh
+        env:
+          STEP_VALUE: step-env
+        run: |
+          echo "$STEP_VALUE"
+      - name: Custom bash template
+        shell: bash --noprofile --norc -e -o pipefail {0}
+        run: |
+          printf '%s\n' "${{ github.event.pull_request.title }}"
+      - name: Unsupported PowerShell
+        shell: pwsh
+        run: Write-Host "skip"
+
+  windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: powershell
+    steps:
+      - name: Missing shell on Windows
+        run: echo "default Windows shell"
+      - name: Explicit Windows shell
+        shell: cmd
+        run: echo "cmd shell"
+      - name: Bash on Windows
+        shell: bash
+        run: echo "bash on Windows"
+
+  anchors-and-env:
+    runs-on: ubuntu-latest
+    steps:
+      - &anchored_step
+        name: Anchored run step
+        shell: bash
+        run: |
+          echo "$WORKFLOW_VALUE"
+      - name: Aliased env map
+        env: *workflow_env
+        shell: bash
+        run: |
+          echo "${{ env.WORKFLOW_VALUE }}"

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Inline glob after brace
         shell: bash
         run: echo {*.tmp,*.log}
+      - name: Inline pattern after colon
+        shell: bash
+        run: echo foo:*bar
 
   short-shell-aliases:
     runs-on: ubuntu-latest

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -148,3 +148,4 @@ jobs:
       - { shell: *comment_shell, run: echo comment alias }
       - { shell: *flow_pwsh, run: echo flow pwsh }
       - { shell: *b, "run": echo quoted key }
+      - { "shell": *flow_posix, run: echo quoted shell key }

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -106,6 +106,11 @@ jobs:
       - name: Inline pattern after colon
         shell: bash
         run: echo foo:*bar
+      - name: Quoted multiline pattern
+        shell: bash
+        run: "case \"$WORKFLOW_VALUE\" in
+          *prod) echo quoted prod ;;
+          esac"
 
   short-shell-aliases:
     runs-on: ubuntu-latest
@@ -142,3 +147,4 @@ jobs:
       - { shell: *flow_posix, run: echo flow alias }
       - { shell: *comment_shell, run: echo comment alias }
       - { shell: *flow_pwsh, run: echo flow pwsh }
+      - { shell: *b, "run": echo quoted key }

--- a/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
+++ b/crates/shuck-extract/tests/fixtures/github-actions-edge-cases.yml
@@ -82,3 +82,13 @@ jobs:
         shell: bash
         run: |
           echo "${{ env.WORKFLOW_VALUE }}"
+      - name: Anchored block scalar
+        shell: bash
+        run: &anchored_run |
+          case "$WORKFLOW_VALUE" in
+            *prod) echo prod ;;
+          esac
+
+  flow-style:
+    runs-on: ubuntu-latest
+    steps: [{ shell: *posix_shell, run: echo flow }]

--- a/crates/shuck-extract/tests/github_actions_fixtures.rs
+++ b/crates/shuck-extract/tests/github_actions_fixtures.rs
@@ -1,0 +1,118 @@
+use std::path::Path;
+
+use shuck_extract::{EmbeddedScript, ExpressionTaint, ExtractedDialect, extract_all};
+
+const WORKFLOW_EDGE_CASES: &str = include_str!("fixtures/github-actions-edge-cases.yml");
+const COMPOSITE_ACTION: &str = include_str!("fixtures/github-actions-composite-action.yml");
+
+#[test]
+fn extracts_workflow_edge_case_fixture() {
+    let scripts = extract_all(
+        Path::new(".github/workflows/edge-cases.yml"),
+        WORKFLOW_EDGE_CASES,
+    )
+    .unwrap();
+
+    assert_eq!(scripts.len(), 11);
+
+    let missing_unix = script(&scripts, "jobs.missing-unix.steps[0].run");
+    assert_eq!(missing_unix.dialect, ExtractedDialect::Bash);
+    assert!(missing_unix.implicit_flags.errexit);
+    assert!(missing_unix.implicit_flags.pipefail);
+    assert_eq!(
+        missing_unix.implicit_flags.template.as_deref(),
+        Some("bash --noprofile --norc -eo pipefail {0}")
+    );
+    assert_eq!(missing_unix.source, "echo \"$WORKFLOW_VALUE\"\n");
+
+    let defaulted = script(&scripts, "jobs.defaulted.steps[0].run");
+    assert_eq!(defaulted.dialect, ExtractedDialect::Sh);
+    assert!(defaulted.implicit_flags.errexit);
+    assert!(!defaulted.implicit_flags.pipefail);
+    assert_eq!(
+        defaulted.implicit_flags.template.as_deref(),
+        Some("sh -e {0}")
+    );
+
+    let bash = script(&scripts, "jobs.explicit-shells.steps[0].run");
+    assert_eq!(bash.dialect, ExtractedDialect::Bash);
+    assert_eq!(bash.source, "echo \"${_SHUCK_GHA_1}\"\n");
+    assert_eq!(bash.placeholders[0].expression, "github.sha");
+    assert_eq!(bash.placeholders[0].taint, ExpressionTaint::Trusted);
+
+    let sh = script(&scripts, "jobs.explicit-shells.steps[1].run");
+    assert_eq!(sh.dialect, ExtractedDialect::Sh);
+    assert_eq!(sh.source, "echo \"$STEP_VALUE\"\n");
+
+    let custom = script(&scripts, "jobs.explicit-shells.steps[2].run");
+    assert_eq!(custom.dialect, ExtractedDialect::Bash);
+    assert!(custom.implicit_flags.errexit);
+    assert!(custom.implicit_flags.pipefail);
+    assert_eq!(
+        custom.implicit_flags.template.as_deref(),
+        Some("bash --noprofile --norc -e -o pipefail {0}")
+    );
+    assert_eq!(custom.source, "printf '%s\\n' \"${_SHUCK_GHA_1}\"\n");
+    assert_eq!(
+        custom.placeholders[0].expression,
+        "github.event.pull_request.title"
+    );
+    assert_eq!(
+        custom.placeholders[0].taint,
+        ExpressionTaint::UserControlled
+    );
+
+    let pwsh = script(&scripts, "jobs.explicit-shells.steps[3].run");
+    assert_eq!(pwsh.dialect, ExtractedDialect::Unsupported);
+
+    let windows_default = script(&scripts, "jobs.windows.steps[0].run");
+    assert_eq!(windows_default.dialect, ExtractedDialect::Unsupported);
+
+    let windows_shell = script(&scripts, "jobs.windows.steps[1].run");
+    assert_eq!(windows_shell.dialect, ExtractedDialect::Unsupported);
+
+    let windows_bash = script(&scripts, "jobs.windows.steps[2].run");
+    assert_eq!(windows_bash.dialect, ExtractedDialect::Bash);
+
+    let anchored = script(&scripts, "jobs.anchors-and-env.steps[0].run");
+    assert_eq!(anchored.dialect, ExtractedDialect::Bash);
+    assert_eq!(anchored.source, "echo \"$WORKFLOW_VALUE\"\n");
+
+    let env_alias = script(&scripts, "jobs.anchors-and-env.steps[1].run");
+    assert_eq!(env_alias.dialect, ExtractedDialect::Bash);
+    assert_eq!(env_alias.source, "echo \"${_SHUCK_GHA_1}\"\n");
+    assert_eq!(env_alias.placeholders[0].expression, "env.WORKFLOW_VALUE");
+    assert_eq!(env_alias.placeholders[0].taint, ExpressionTaint::Trusted);
+}
+
+#[test]
+fn extracts_composite_action_edge_case_fixture() {
+    let scripts = extract_all(Path::new("action.yml"), COMPOSITE_ACTION).unwrap();
+
+    assert_eq!(scripts.len(), 3);
+
+    let bash = script(&scripts, "runs.steps[0].run");
+    assert_eq!(bash.dialect, ExtractedDialect::Bash);
+    assert_eq!(
+        bash.source,
+        "echo \"$COMPOSITE_VALUE\"\necho \"${_SHUCK_GHA_1}\"\n"
+    );
+    assert_eq!(bash.placeholders[0].expression, "github.sha");
+    assert_eq!(bash.placeholders[0].taint, ExpressionTaint::Trusted);
+
+    let sh = script(&scripts, "runs.steps[1].run");
+    assert_eq!(sh.dialect, ExtractedDialect::Sh);
+    assert_eq!(sh.source, "echo \"${_SHUCK_GHA_1}\"");
+    assert_eq!(sh.placeholders[0].expression, "inputs.message");
+    assert_eq!(sh.placeholders[0].taint, ExpressionTaint::Unknown);
+
+    let unsupported = script(&scripts, "runs.steps[2].run");
+    assert_eq!(unsupported.dialect, ExtractedDialect::Unsupported);
+}
+
+fn script<'a>(scripts: &'a [EmbeddedScript], label: &str) -> &'a EmbeddedScript {
+    scripts
+        .iter()
+        .find(|script| script.label == label)
+        .unwrap_or_else(|| panic!("missing extracted script `{label}`"))
+}

--- a/crates/shuck-extract/tests/github_actions_fixtures.rs
+++ b/crates/shuck-extract/tests/github_actions_fixtures.rs
@@ -13,7 +13,7 @@ fn extracts_workflow_edge_case_fixture() {
     )
     .unwrap();
 
-    assert_eq!(scripts.len(), 26);
+    assert_eq!(scripts.len(), 28);
 
     let missing_unix = script(&scripts, "jobs.missing-unix.steps[0].run");
     assert_eq!(missing_unix.dialect, ExtractedDialect::Bash);
@@ -104,6 +104,10 @@ fn extracts_workflow_edge_case_fixture() {
     assert_eq!(colon_pattern.dialect, ExtractedDialect::Bash);
     assert_eq!(colon_pattern.source, "echo foo:*bar");
 
+    let quoted_pattern = script(&scripts, "jobs.anchors-and-env.steps[7].run");
+    assert_eq!(quoted_pattern.dialect, ExtractedDialect::Bash);
+    assert!(quoted_pattern.source.contains("*prod) echo quoted prod ;;"));
+
     let short_alias_default = script(&scripts, "jobs.short-shell-aliases.steps[0].run");
     assert_eq!(short_alias_default.dialect, ExtractedDialect::Bash);
     assert!(short_alias_default.implicit_flags.errexit);
@@ -155,6 +159,10 @@ fn extracts_workflow_edge_case_fixture() {
 
     let flow_pwsh = script(&scripts, "jobs.flow-style.steps[3].run");
     assert_eq!(flow_pwsh.dialect, ExtractedDialect::Unsupported);
+
+    let quoted_run_key = script(&scripts, "jobs.flow-style.steps[4].run");
+    assert_eq!(quoted_run_key.source, "echo quoted key");
+    assert_eq!(quoted_run_key.host_start_column, 29);
 }
 
 #[test]

--- a/crates/shuck-extract/tests/github_actions_fixtures.rs
+++ b/crates/shuck-extract/tests/github_actions_fixtures.rs
@@ -13,7 +13,7 @@ fn extracts_workflow_edge_case_fixture() {
     )
     .unwrap();
 
-    assert_eq!(scripts.len(), 13);
+    assert_eq!(scripts.len(), 14);
 
     let missing_unix = script(&scripts, "jobs.missing-unix.steps[0].run");
     assert_eq!(missing_unix.dialect, ExtractedDialect::Bash);
@@ -87,6 +87,10 @@ fn extracts_workflow_edge_case_fixture() {
     let anchored_block = script(&scripts, "jobs.anchors-and-env.steps[2].run");
     assert_eq!(anchored_block.dialect, ExtractedDialect::Bash);
     assert!(anchored_block.source.contains("*prod) echo prod ;;"));
+
+    let inline_glob = script(&scripts, "jobs.anchors-and-env.steps[3].run");
+    assert_eq!(inline_glob.dialect, ExtractedDialect::Bash);
+    assert_eq!(inline_glob.source, "rm -- *.tmp");
 
     let flow_style = script(&scripts, "jobs.flow-style.steps[0].run");
     assert_eq!(flow_style.dialect, ExtractedDialect::Sh);

--- a/crates/shuck-extract/tests/github_actions_fixtures.rs
+++ b/crates/shuck-extract/tests/github_actions_fixtures.rs
@@ -13,7 +13,7 @@ fn extracts_workflow_edge_case_fixture() {
     )
     .unwrap();
 
-    assert_eq!(scripts.len(), 11);
+    assert_eq!(scripts.len(), 13);
 
     let missing_unix = script(&scripts, "jobs.missing-unix.steps[0].run");
     assert_eq!(missing_unix.dialect, ExtractedDialect::Bash);
@@ -83,6 +83,15 @@ fn extracts_workflow_edge_case_fixture() {
     assert_eq!(env_alias.source, "echo \"${_SHUCK_GHA_1}\"\n");
     assert_eq!(env_alias.placeholders[0].expression, "env.WORKFLOW_VALUE");
     assert_eq!(env_alias.placeholders[0].taint, ExpressionTaint::Trusted);
+
+    let anchored_block = script(&scripts, "jobs.anchors-and-env.steps[2].run");
+    assert_eq!(anchored_block.dialect, ExtractedDialect::Bash);
+    assert!(anchored_block.source.contains("*prod) echo prod ;;"));
+
+    let flow_style = script(&scripts, "jobs.flow-style.steps[0].run");
+    assert_eq!(flow_style.dialect, ExtractedDialect::Sh);
+    assert_eq!(flow_style.source, "echo flow");
+    assert_eq!(flow_style.host_start_column, 41);
 }
 
 #[test]

--- a/crates/shuck-extract/tests/github_actions_fixtures.rs
+++ b/crates/shuck-extract/tests/github_actions_fixtures.rs
@@ -13,7 +13,7 @@ fn extracts_workflow_edge_case_fixture() {
     )
     .unwrap();
 
-    assert_eq!(scripts.len(), 24);
+    assert_eq!(scripts.len(), 25);
 
     let missing_unix = script(&scripts, "jobs.missing-unix.steps[0].run");
     assert_eq!(missing_unix.dialect, ExtractedDialect::Bash);
@@ -99,6 +99,10 @@ fn extracts_workflow_edge_case_fixture() {
     let brace_glob = script(&scripts, "jobs.anchors-and-env.steps[5].run");
     assert_eq!(brace_glob.dialect, ExtractedDialect::Bash);
     assert_eq!(brace_glob.source, "echo {*.tmp,*.log}");
+
+    let colon_pattern = script(&scripts, "jobs.anchors-and-env.steps[6].run");
+    assert_eq!(colon_pattern.dialect, ExtractedDialect::Bash);
+    assert_eq!(colon_pattern.source, "echo foo:*bar");
 
     let short_alias_default = script(&scripts, "jobs.short-shell-aliases.steps[0].run");
     assert_eq!(short_alias_default.dialect, ExtractedDialect::Bash);

--- a/crates/shuck-extract/tests/github_actions_fixtures.rs
+++ b/crates/shuck-extract/tests/github_actions_fixtures.rs
@@ -13,7 +13,7 @@ fn extracts_workflow_edge_case_fixture() {
     )
     .unwrap();
 
-    assert_eq!(scripts.len(), 14);
+    assert_eq!(scripts.len(), 18);
 
     let missing_unix = script(&scripts, "jobs.missing-unix.steps[0].run");
     assert_eq!(missing_unix.dialect, ExtractedDialect::Bash);
@@ -91,6 +91,29 @@ fn extracts_workflow_edge_case_fixture() {
     let inline_glob = script(&scripts, "jobs.anchors-and-env.steps[3].run");
     assert_eq!(inline_glob.dialect, ExtractedDialect::Bash);
     assert_eq!(inline_glob.source, "rm -- *.tmp");
+
+    let comma_glob = script(&scripts, "jobs.anchors-and-env.steps[4].run");
+    assert_eq!(comma_glob.dialect, ExtractedDialect::Bash);
+    assert_eq!(comma_glob.source, "echo foo,*.tmp");
+
+    let brace_glob = script(&scripts, "jobs.anchors-and-env.steps[5].run");
+    assert_eq!(brace_glob.dialect, ExtractedDialect::Bash);
+    assert_eq!(brace_glob.source, "echo {*.tmp,*.log}");
+
+    let short_alias_default = script(&scripts, "jobs.short-shell-aliases.steps[0].run");
+    assert_eq!(short_alias_default.dialect, ExtractedDialect::Bash);
+    assert!(short_alias_default.implicit_flags.errexit);
+    assert!(short_alias_default.implicit_flags.pipefail);
+    assert_eq!(
+        short_alias_default.implicit_flags.template.as_deref(),
+        Some("bash --noprofile --norc -e -o pipefail {0}")
+    );
+
+    let short_alias_unsupported = script(&scripts, "jobs.short-shell-aliases.steps[1].run");
+    assert_eq!(
+        short_alias_unsupported.dialect,
+        ExtractedDialect::Unsupported
+    );
 
     let flow_style = script(&scripts, "jobs.flow-style.steps[0].run");
     assert_eq!(flow_style.dialect, ExtractedDialect::Sh);

--- a/crates/shuck-extract/tests/github_actions_fixtures.rs
+++ b/crates/shuck-extract/tests/github_actions_fixtures.rs
@@ -13,7 +13,7 @@ fn extracts_workflow_edge_case_fixture() {
     )
     .unwrap();
 
-    assert_eq!(scripts.len(), 28);
+    assert_eq!(scripts.len(), 29);
 
     let missing_unix = script(&scripts, "jobs.missing-unix.steps[0].run");
     assert_eq!(missing_unix.dialect, ExtractedDialect::Bash);
@@ -163,6 +163,10 @@ fn extracts_workflow_edge_case_fixture() {
     let quoted_run_key = script(&scripts, "jobs.flow-style.steps[4].run");
     assert_eq!(quoted_run_key.source, "echo quoted key");
     assert_eq!(quoted_run_key.host_start_column, 29);
+
+    let quoted_shell_key = script(&scripts, "jobs.flow-style.steps[5].run");
+    assert_eq!(quoted_shell_key.dialect, ExtractedDialect::Sh);
+    assert_eq!(quoted_shell_key.source, "echo quoted shell key");
 }
 
 #[test]

--- a/crates/shuck-extract/tests/github_actions_fixtures.rs
+++ b/crates/shuck-extract/tests/github_actions_fixtures.rs
@@ -13,7 +13,7 @@ fn extracts_workflow_edge_case_fixture() {
     )
     .unwrap();
 
-    assert_eq!(scripts.len(), 25);
+    assert_eq!(scripts.len(), 26);
 
     let missing_unix = script(&scripts, "jobs.missing-unix.steps[0].run");
     assert_eq!(missing_unix.dialect, ExtractedDialect::Bash);
@@ -117,6 +117,15 @@ fn extracts_workflow_edge_case_fixture() {
     assert_eq!(
         short_alias_unsupported.dialect,
         ExtractedDialect::Unsupported
+    );
+
+    let short_alias_comment = script(&scripts, "jobs.short-shell-aliases.steps[2].run");
+    assert_eq!(short_alias_comment.dialect, ExtractedDialect::Bash);
+    assert!(short_alias_comment.implicit_flags.errexit);
+    assert!(short_alias_comment.implicit_flags.pipefail);
+    assert_eq!(
+        short_alias_comment.implicit_flags.template.as_deref(),
+        Some("bash --noprofile --norc -e -o pipefail {0}")
     );
 
     let reused_before = script(&scripts, "jobs.redefined-anchors.steps[0].run");

--- a/crates/shuck-extract/tests/github_actions_fixtures.rs
+++ b/crates/shuck-extract/tests/github_actions_fixtures.rs
@@ -13,7 +13,7 @@ fn extracts_workflow_edge_case_fixture() {
     )
     .unwrap();
 
-    assert_eq!(scripts.len(), 18);
+    assert_eq!(scripts.len(), 24);
 
     let missing_unix = script(&scripts, "jobs.missing-unix.steps[0].run");
     assert_eq!(missing_unix.dialect, ExtractedDialect::Bash);
@@ -115,10 +115,33 @@ fn extracts_workflow_edge_case_fixture() {
         ExtractedDialect::Unsupported
     );
 
+    let reused_before = script(&scripts, "jobs.redefined-anchors.steps[0].run");
+    assert_eq!(reused_before.dialect, ExtractedDialect::Sh);
+    assert_eq!(reused_before.source, "echo reused sh");
+
+    let redefined = script(&scripts, "jobs.redefined-anchors.steps[1].run");
+    assert_eq!(redefined.dialect, ExtractedDialect::Bash);
+    assert_eq!(redefined.source, "echo redefine bash");
+
+    let reused_after = script(&scripts, "jobs.redefined-anchors.steps[2].run");
+    assert_eq!(reused_after.dialect, ExtractedDialect::Bash);
+    assert_eq!(reused_after.source, "echo reused bash");
+
     let flow_style = script(&scripts, "jobs.flow-style.steps[0].run");
     assert_eq!(flow_style.dialect, ExtractedDialect::Sh);
     assert_eq!(flow_style.source, "echo flow");
-    assert_eq!(flow_style.host_start_column, 41);
+    assert_eq!(flow_style.host_start_column, 37);
+
+    let flow_alias = script(&scripts, "jobs.flow-style.steps[1].run");
+    assert_eq!(flow_alias.dialect, ExtractedDialect::Sh);
+    assert_eq!(flow_alias.source, "echo flow alias");
+
+    let comment_alias = script(&scripts, "jobs.flow-style.steps[2].run");
+    assert_eq!(comment_alias.dialect, ExtractedDialect::Sh);
+    assert_eq!(comment_alias.source, "echo comment alias");
+
+    let flow_pwsh = script(&scripts, "jobs.flow-style.steps[3].run");
+    assert_eq!(flow_pwsh.dialect, ExtractedDialect::Unsupported);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add GitHub Actions fixture coverage for shell resolution edge cases, missing shells, Windows shells, composite actions, YAML anchors, expressions, `env:`, and `defaults.run.shell`.
- Teach the GitHub Actions extractor to tolerate YAML anchors and aliases even though `marked-yaml` rejects them natively.
- Preserve source offsets by sanitizing anchor metadata length-preservingly and skipping alias-only nodes that cannot provide a real run-block span.

## Root Cause

`marked-yaml` rejects YAML anchors and aliases before extraction, so otherwise valid GitHub Actions workflows with shared `env:` maps or anchored steps could fail with a YAML parse error instead of linting their `run:` blocks.

## Validation

- `cargo test -p shuck-extract`
- `cargo test -p shuck-cli workflow`
- `cargo clippy -p shuck-extract --all-targets -- -D warnings`