### PR TITLE
docs: add suppression guide

### DIFF
--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -7,6 +7,7 @@ const pages: Record<string, () => Promise<{ default: React.ComponentType; metada
   "getting-started": () => import("@/content/getting-started/index.mdx"),
   "embedded-scripts": () => import("@/content/embedded-scripts/index.mdx"),
   "configuration": () => import("@/content/configuration/index.mdx"),
+  "suppression": () => import("@/content/suppression/index.mdx"),
   "shellcheck-compat": () => import("@/content/shellcheck-compat/index.mdx"),
   "performance/benchmarks": () => import("@/content/performance/benchmarks"),
 };

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -10,6 +10,7 @@ export const docsNavigation: NavItem[] = [
     items: [
       { title: "Overview", href: "/docs/getting-started" },
       { title: "Configuration", href: "/docs/configuration" },
+      { title: "Suppression", href: "/docs/suppression" },
       { title: "ShellCheck Compatibility", href: "/docs/shellcheck-compat" },
       { title: "Embedded Scripts", href: "/docs/embedded-scripts" },
     ],

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -45,6 +45,12 @@ echo 'echo $foo' | shuck check -
 shuck check --fix .
 ```
 
+## Suppression
+
+Use inline comments to suppress warnings for a line, a command, or a whole file. Shuck supports both native `# shuck:` directives and ShellCheck-compatible `# shellcheck` directives, including mapped `SC` codes.
+
+See the dedicated [Suppression guide](/docs/suppression) for examples of both syntaxes.
+
 ## ShellCheck compatibility mode
 
 If you already have tools that invoke `shellcheck`, Shuck can expose a ShellCheck-shaped CLI without changing your primary workflow all at once.

--- a/website/content/suppression/index.mdx
+++ b/website/content/suppression/index.mdx
@@ -1,0 +1,91 @@
+# Suppression
+
+Use suppression comments when a warning is not useful for a specific script, command, or line.
+
+Shuck supports its native `# shuck:` directives and ShellCheck-compatible `# shellcheck` directives. You can use Shuck rule codes such as `C001` and `S001`, or mapped ShellCheck codes such as `SC2034` and `SC2086`.
+
+## Suppress the next command
+
+Place `disable` on its own line immediately before the command you want to silence:
+
+```sh
+# shuck: disable=C001
+unused_var="intentional"
+
+# shellcheck disable=SC2086
+echo $pattern
+```
+
+For a single-line command, this is the usual "suppress the next line" form. If the command spans multiple physical lines, the suppression follows the whole command instead of stopping after one line.
+
+You can list multiple rules with commas:
+
+```sh
+# shuck: disable=C001,S001
+value=$input
+
+# shellcheck disable=SC2034,SC2086
+unused=$value
+```
+
+Native and ShellCheck code namespaces are interchangeable in suppression comments:
+
+```sh
+# shuck: disable=SC2086
+echo $pattern
+
+# shellcheck disable=S001
+echo $pattern
+```
+
+## Suppress a whole file
+
+Use `disable-file` with the native Shuck syntax when a rule should be disabled throughout the file:
+
+```sh
+# shuck: disable-file=S001
+```
+
+A `disable` directive before the first shell statement also applies to the whole file:
+
+```sh
+# shuck: disable=C001
+
+unused_var="intentional"
+```
+
+The same placement rule applies to ShellCheck-compatible directives:
+
+```sh
+# shellcheck disable=SC2034
+
+unused_var="intentional"
+```
+
+ShellCheck-compatible directives also accept `all`:
+
+```sh
+# shellcheck disable=all
+```
+
+## Suppress one line
+
+Use `ignore` with the native Shuck syntax to silence diagnostics that start on the same physical line as the comment:
+
+```sh
+unused_var="intentional" # shuck: ignore=C001
+```
+
+This is the form Shuck writes when you run `shuck check --add-ignore`.
+
+## Embedded scripts
+
+For GitHub Actions workflows and composite actions, put suppression comments inside the extracted shell script:
+
+```yaml
+- run: |
+    # shellcheck disable=SC2086
+    echo $FOO
+```
+
+YAML comments outside the `run:` block are not part of the shell script, so they do not suppress shell diagnostics. See the [Embedded Scripts guide](/docs/embedded-scripts) for more details.


### PR DESCRIPTION
## Summary

- add a dedicated website Suppression guide under Getting Started
- document native `# shuck:` suppression forms and ShellCheck-compatible `# shellcheck` forms
- link the guide from the Getting Started overview and sidebar

## Validation

- `npx next build`
- `git diff --check`
