### PR TITLE
perf(bench): enable all rules in benchmarks

### DIFF
--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -4,7 +4,7 @@ use criterion::{
 use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixture};
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    LinterFacts, LinterSettings, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
+    LinterFacts, LinterSettings, RuleSet, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
     benchmark_collect_word_facts, benchmark_normalize_commands, classify_file_context,
     first_statement_line, lint_file, parse_directives,
 };
@@ -185,7 +185,10 @@ fn bench_linter_word_facts(c: &mut Criterion) {
 
 fn bench_linter(c: &mut Criterion) {
     let mut group = c.benchmark_group("linter");
-    let settings = LinterSettings::default();
+    let settings = LinterSettings {
+        rules: RuleSet::all(),
+        ..LinterSettings::default()
+    };
     let shellcheck_map = ShellCheckCodeMap::default();
 
     for case in benchmark_cases() {

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1323,7 +1323,10 @@ pub(crate) fn benchmark_check_paths(
             output_format,
             watch: false,
             paths: paths.to_vec(),
-            rule_selection: RuleSelectionArgs::default(),
+            rule_selection: RuleSelectionArgs {
+                select: Some(vec![RuleSelector::All]),
+                ..RuleSelectionArgs::default()
+            },
             file_selection: FileSelectionArgs::default(),
             exit_zero: false,
             exit_non_zero_on_fix: false,

--- a/scripts/benchmarks/export_website_data.py
+++ b/scripts/benchmarks/export_website_data.py
@@ -404,9 +404,11 @@ def main() -> int:
             "warmupRuns": args.warmup_runs,
             "measuredRuns": args.measured_runs,
             "ignoreFailure": True,
-            "shuckCommand": "shuck check --no-cache <fixture>",
+            "shuckCommand": "shuck check --no-cache --select ALL <fixture>",
             "comparisonCommand": (
-                "shellcheck --severity=style <fixture>" if comparison_tool else None
+                "shellcheck --enable=all --severity=style <fixture>"
+                if comparison_tool
+                else None
             ),
             "notes": args.notes or None,
         },

--- a/scripts/benchmarks/run.sh
+++ b/scripts/benchmarks/run.sh
@@ -7,6 +7,8 @@ target_dir=${CARGO_TARGET_DIR:-"$repo_root/target"}
 shuck=${SHUCK_BENCHMARK_SHUCK_BIN:-"$target_dir/release/shuck"}
 cache_dir=${SHUCK_BENCHMARK_OUTPUT_DIR:-"$repo_root/.cache"}
 benchmark_mode=${SHUCK_BENCHMARK_MODE:-compare}
+shuck_check="$shuck check --no-cache --select ALL"
+shellcheck_check="shellcheck --enable=all --severity=style"
 
 mkdir -p "$cache_dir"
 
@@ -20,8 +22,8 @@ for file in "$fixtures_dir"/*.sh; do
                 --warmup 3 \
                 --runs 10 \
                 --export-json "$cache_dir/bench-$name.json" \
-                -n "shuck/$name" "$shuck check --no-cache $file" \
-                -n "shellcheck/$name" "shellcheck --severity=style $file"
+                -n "shuck/$name" "$shuck_check $file" \
+                -n "shellcheck/$name" "$shellcheck_check $file"
             ;;
         shuck-only)
             hyperfine \
@@ -29,7 +31,7 @@ for file in "$fixtures_dir"/*.sh; do
                 --warmup 3 \
                 --runs 10 \
                 --export-json "$cache_dir/bench-$name.json" \
-                -n "shuck/$name" "$shuck check --no-cache $file"
+                -n "shuck/$name" "$shuck_check $file"
             ;;
         *)
             echo "ERROR: unsupported SHUCK_BENCHMARK_MODE=$benchmark_mode" >&2
@@ -49,8 +51,8 @@ case "$benchmark_mode" in
             --runs 10 \
             --export-json "$cache_dir/bench-all.json" \
             --export-markdown "$cache_dir/bench-all.md" \
-            -n "shuck/all" "$shuck check --no-cache $*" \
-            -n "shellcheck/all" "shellcheck --severity=style $*"
+            -n "shuck/all" "$shuck_check $*" \
+            -n "shellcheck/all" "$shellcheck_check $*"
         ;;
     shuck-only)
         hyperfine \
@@ -59,7 +61,7 @@ case "$benchmark_mode" in
             --runs 10 \
             --export-json "$cache_dir/bench-all.json" \
             --export-markdown "$cache_dir/bench-all.md" \
-            -n "shuck/all" "$shuck check --no-cache $*"
+            -n "shuck/all" "$shuck_check $*"
         ;;
     *)
         echo "ERROR: unsupported SHUCK_BENCHMARK_MODE=$benchmark_mode" >&2

--- a/scripts/benchmarks/run_single.sh
+++ b/scripts/benchmarks/run_single.sh
@@ -4,10 +4,12 @@ set -eu
 repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
 shuck="$repo_root/target/release/shuck"
 file=${1:?Usage: run_single.sh <path-to-script>}
+shuck_check="$shuck check --no-cache --select ALL"
+shellcheck_check="shellcheck --enable=all --severity=style"
 
 hyperfine \
     --ignore-failure \
     --warmup 5 \
     --runs 20 \
-    -n "shuck" "$shuck check --no-cache $file" \
-    -n "shellcheck" "shellcheck --severity=style $file"
+    -n "shuck" "$shuck_check $file" \
+    -n "shellcheck" "$shellcheck_check $file"

--- a/website/app/lib/benchmarks.test.ts
+++ b/website/app/lib/benchmarks.test.ts
@@ -41,8 +41,8 @@ const baseDataset: BenchmarkDataset = {
     warmupRuns: 3,
     measuredRuns: 10,
     ignoreFailure: true,
-    shuckCommand: "shuck check --no-cache <fixture>",
-    comparisonCommand: "shellcheck --severity=style <fixture>",
+    shuckCommand: "shuck check --no-cache --select ALL <fixture>",
+    comparisonCommand: "shellcheck --enable=all --severity=style <fixture>",
     notes: null,
   },
   corpus: {

--- a/website/content/performance/benchmarks.tsx
+++ b/website/content/performance/benchmarks.tsx
@@ -301,7 +301,8 @@ export default function BenchmarksDoc() {
         </li>
         <li>
           The comparison command is{" "}
-          <code>shellcheck --severity=style &lt;fixture&gt;</code> on the same input.
+          <code>shellcheck --enable=all --severity=style &lt;fixture&gt;</code> on
+          the same input.
         </li>
         <li>
           <code>--ignore-failure</code> is intentional. These fixtures contain lint

--- a/website/generated/benchmarks/ci-latest.json
+++ b/website/generated/benchmarks/ci-latest.json
@@ -33,8 +33,8 @@
     "warmupRuns": 3,
     "measuredRuns": 10,
     "ignoreFailure": true,
-    "shuckCommand": "shuck check --no-cache <fixture>",
-    "comparisonCommand": "shellcheck --severity=style <fixture>",
+    "shuckCommand": "shuck check --no-cache --select ALL <fixture>",
+    "comparisonCommand": "shellcheck --enable=all --severity=style <fixture>",
     "notes": "The website deploy for the latest published release overwrites this placeholder with a fresh benchmark snapshot."
   },
   "corpus": {


### PR DESCRIPTION
## Summary
- run CI macro CLI benchmarks with `--select ALL`
- make the in-process CLI benchmark helper select all rules
- make the shuck-linter Criterion benchmark use `RuleSet::all()`
- pair ShellCheck comparison runs with `--enable=all --severity=style` and update benchmark metadata/docs

## Why
The benchmark paths were using default rule selection, so style and any other disabled-by-default rules were not represented in the measured CLI and linter workload. The ShellCheck comparison now enables all optional checks too, keeping the macro comparison closer to an all-rules apples-to-apples run.

## Validation
- `cargo fmt`
- `cargo check -p shuck-benchmark --benches`
- `cargo test -p shuck-cli benchmark_check_paths --lib`
- `sh -n scripts/benchmarks/run.sh && sh -n scripts/benchmarks/run_single.sh`
- `python3 -m unittest scripts.benchmarks.test_run`

Note: `pnpm --dir website test` could not run in this environment because `pnpm` resolves to a Bazel-backed wrapper from another local monorepo and fails outside that workspace.
