### PR TITLE
fix(linter): ratchet S001 quote exposure parity

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -539,27 +539,6 @@ reviewed_divergences:
     end_column: 51
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__requirements__rvm_pkg"
-    line: 17
-    end_line: 17
-    column: 17
-    end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__requirements__unknown"
-    line: 74
-    end_line: 74
-    column: 17
-    end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "scop__bash-completion__completions-core__geoiplookup.bash"
-    line: 29
-    end_line: 29
-    column: 31
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "super-linter__super-linter__test__run-super-linter-tests.sh"
     line: 724
     end_line: 724

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -287,13 +287,6 @@ reviewed_divergences:
     end_column: 51
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "super-linter__super-linter__test__run-super-linter-tests.sh"
-    line: 724
-    end_line: 724
-    column: 36
-    end_column: 57
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "swoodford__aws__vpc-sg-import-rules-cloudflare.sh"
     line: 281
     end_line: 281

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -112,13 +112,6 @@ reviewed_divergences:
     end_column: 19
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__archlinux-vm.sh"
-    line: 547
-    end_line: 547
-    column: 31
-    end_column: 44
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__debian-13-vm.sh"
     line: 615
     end_line: 615
@@ -127,24 +120,10 @@ reviewed_divergences:
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__debian-13-vm.sh"
-    line: 616
-    end_line: 616
-    column: 25
-    end_column: 38
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__debian-13-vm.sh"
     line: 622
     end_line: 622
     column: 27
     end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__debian-13-vm.sh"
-    line: 623
-    end_line: 623
-    column: 25
-    end_column: 38
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__debian-vm.sh"
@@ -155,24 +134,10 @@ reviewed_divergences:
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__debian-vm.sh"
-    line: 557
-    end_line: 557
-    column: 25
-    end_column: 38
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__debian-vm.sh"
     line: 563
     end_line: 563
     column: 27
     end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__debian-vm.sh"
-    line: 564
-    end_line: 564
-    column: 25
-    end_column: 38
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__haos-vm.sh"
@@ -196,32 +161,11 @@ reviewed_divergences:
     end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__nextcloud-vm.sh"
-    line: 543
-    end_line: 543
-    column: 23
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__nextcloud-vm.sh"
-    line: 544
-    end_line: 544
-    column: 23
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__opnsense-vm.sh"
     line: 744
     end_line: 744
     column: 25
     end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__opnsense-vm.sh"
-    line: 745
-    end_line: 745
-    column: 23
-    end_column: 36
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__owncloud-vm.sh"
@@ -231,20 +175,6 @@ reviewed_divergences:
     end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__owncloud-vm.sh"
-    line: 556
-    end_line: 556
-    column: 23
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__owncloud-vm.sh"
-    line: 557
-    end_line: 557
-    column: 23
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2204-vm.sh"
     line: 537
     end_line: 537
@@ -252,13 +182,6 @@ reviewed_divergences:
     end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2204-vm.sh"
-    line: 538
-    end_line: 538
-    column: 23
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh"
     line: 539
     end_line: 539
@@ -266,25 +189,11 @@ reviewed_divergences:
     end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh"
-    line: 540
-    end_line: 540
-    column: 23
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh"
     line: 538
     end_line: 538
     column: 25
     end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh"
-    line: 539
-    end_line: 539
-    column: 23
-    end_column: 36
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "dehydrated-io__dehydrated__dehydrated"
@@ -539,25 +448,11 @@ reviewed_divergences:
     end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__debian-vm.sh"
-    line: 410
-    end_line: 410
-    column: 23
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "tteck__Proxmox__vm__haos-vm.sh"
     line: 451
     end_line: 451
     column: 25
     end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__haos-vm.sh"
-    line: 452
-    end_line: 452
-    column: 23
-    end_column: 36
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "tteck__Proxmox__vm__nextcloud-vm.sh"
@@ -574,13 +469,6 @@ reviewed_divergences:
     end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__nextcloud-vm.sh"
-    line: 409
-    end_line: 409
-    column: 23
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "tteck__Proxmox__vm__owncloud-vm.sh"
     line: 408
     end_line: 408
@@ -588,25 +476,11 @@ reviewed_divergences:
     end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__owncloud-vm.sh"
-    line: 409
-    end_line: 409
-    column: 23
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "tteck__Proxmox__vm__ubuntu2204-vm.sh"
     line: 409
     end_line: 409
     column: 25
     end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__ubuntu2204-vm.sh"
-    line: 410
-    end_line: 410
-    column: 23
-    end_column: 36
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "tteck__Proxmox__vm__ubuntu2404-vm.sh"
@@ -614,13 +488,6 @@ reviewed_divergences:
     end_line: 399
     column: 25
     end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__ubuntu2404-vm.sh"
-    line: 400
-    end_line: 400
-    column: 23
-    end_column: 36
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "v1s1t0r1sh3r3__airgeddon__airgeddon.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -28,27 +28,6 @@ reviewed_divergences:
     end_column: 17
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "acmesh-official__acme.sh__dnsapi__dns_tencent.sh"
-    line: 113
-    end_line: 113
-    column: 32
-    end_column: 40
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "acmesh-official__acme.sh__dnsapi__dns_tencent.sh"
-    line: 116
-    end_line: 116
-    column: 40
-    end_column: 48
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "acmesh-official__acme.sh__dnsapi__dns_tencent.sh"
-    line: 116
-    end_line: 116
-    column: 49
-    end_column: 57
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd"
     line: 245
     end_line: 245

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -132,20 +132,6 @@ reviewed_divergences:
     column: 7
     end_column: 13
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "google__oss-fuzz__projects__threetenbp__build.sh"
-    line: 56
-    end_line: 56
-    column: 89
-    end_column: 99
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "google__oss-fuzz__projects__threetenbp__build.sh"
-    line: 57
-    end_line: 57
-    column: 37
-    end_column: 47
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
     line: 651

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -189,13 +189,6 @@ reviewed_divergences:
     end_column: 39
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "kward__shunit2__.githooks__generic"
-    line: 30
-    end_line: 30
-    column: 11
-    end_column: 22
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "masonr__yet-another-bench-script__yabs.sh"
     line: 991
     end_line: 991

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -154,13 +154,6 @@ reviewed_divergences:
     end_column: 19
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
-    path_suffix: "megastep__makeself__test__variabletest"
-    line: 15
-    end_line: 15
-    column: 56
-    end_column: 60
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
     path_suffix: "nvm-sh__nvm__test__slow__nvm_get_latest__nvm_get_latest"
     line: 26
     end_line: 26

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -153,13 +153,6 @@ reviewed_divergences:
     column: 12
     end_column: 19
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "nvm-sh__nvm__test__slow__nvm_get_latest__nvm_get_latest"
-    line: 26
-    end_line: 26
-    column: 10
-    end_column: 14
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "pi-hole__pi-hole__automated install__basic-install.sh"
     line: 1833

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -29,13 +29,6 @@ reviewed_divergences:
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bats-core__bats-core__libexec__bats-core__bats-format-pretty"
-    line: 67
-    end_line: 67
-    column: 16
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bats-core__bats-core__libexec__bats-core__bats-format-pretty"
     line: 78
     end_line: 78
     column: 13

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -55,13 +55,6 @@ reviewed_divergences:
     column: 29
     end_column: 31
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 362
-    end_line: 362
-    column: 40
-    end_column: 58
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
     line: 2096
@@ -89,13 +82,6 @@ reviewed_divergences:
     end_line: 110
     column: 7
     end_column: 15
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-monitoring__send_sms.sh"
-    line: 145
-    end_line: 145
-    column: 10
-    end_column: 19
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__haos-vm.sh"
@@ -264,20 +250,6 @@ reviewed_divergences:
     end_line: 196
     column: 40
     end_column: 49
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "termux__termux-packages__packages__lazygit__build.sh"
-    line: 25
-    end_line: 25
-    column: 41
-    end_column: 61
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "termux__termux-packages__packages__lazygit__build.sh"
-    line: 26
-    end_line: 26
-    column: 30
-    end_column: 50
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "tteck__Proxmox__vm__nextcloud-vm.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -602,20 +602,6 @@ reviewed_divergences:
     end_column: 50
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "tteck__Proxmox__misc__glances.sh"
-    line: 100
-    end_line: 100
-    column: 37
-    end_column: 49
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__misc__glances.sh"
-    line: 100
-    end_line: 100
-    column: 73
-    end_column: 85
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "tteck__Proxmox__vm__debian-vm.sh"
     line: 409
     end_line: 409

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -244,13 +244,6 @@ reviewed_divergences:
     column: 101
     end_column: 106
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "swoodford__aws__wafv2-web-acl-pingdom.sh"
-    line: 196
-    end_line: 196
-    column: 40
-    end_column: 49
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "tteck__Proxmox__vm__nextcloud-vm.sh"
     line: 210

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -14,20 +14,6 @@ reviewed_divergences:
     end_column: 38
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh"
-    line: 19
-    end_line: 19
-    column: 8
-    end_column: 12
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh"
-    line: 19
-    end_line: 19
-    column: 13
-    end_column: 17
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd"
     line: 245
     end_line: 245
@@ -335,27 +321,6 @@ reviewed_divergences:
     column: 37
     end_column: 47
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "juewuy__ShellCrash__scripts__menus__2_settings.sh"
-    line: 360
-    end_line: 360
-    column: 41
-    end_column: 51
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "juewuy__ShellCrash__scripts__menus__2_settings.sh"
-    line: 368
-    end_line: 368
-    column: 41
-    end_column: 51
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "juewuy__ShellCrash__scripts__menus__2_settings.sh"
-    line: 377
-    end_line: 377
-    column: 41
-    end_column: 51
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
     line: 651
@@ -404,13 +369,6 @@ reviewed_divergences:
     end_line: 15
     column: 56
     end_column: 60
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "nvm-sh__nvm__nvm.sh"
-    line: 3785
-    end_line: 3785
-    column: 16
-    end_column: 25
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "nvm-sh__nvm__test__slow__nvm_get_latest__nvm_get_latest"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -62,13 +62,6 @@ reviewed_divergences:
     column: 6
     end_column: 27
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-monitoring__ping_counter.sh"
-    line: 110
-    end_line: 110
-    column: 7
-    end_column: 15
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__haos-vm.sh"
     line: 636

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -70,13 +70,6 @@ reviewed_divergences:
     end_column: 31
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__net"
-    line: 2620
-    end_line: 2620
-    column: 79
-    end_column: 81
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
     line: 362
     end_line: 362

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -111,34 +111,6 @@ reviewed_divergences:
     column: 10
     end_column: 19
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__debian-13-vm.sh"
-    line: 615
-    end_line: 615
-    column: 27
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__debian-13-vm.sh"
-    line: 622
-    end_line: 622
-    column: 27
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__debian-vm.sh"
-    line: 556
-    end_line: 556
-    column: 27
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__debian-vm.sh"
-    line: 563
-    end_line: 563
-    column: 27
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "community-scripts__ProxmoxVE__vm__haos-vm.sh"
     line: 636
@@ -152,48 +124,6 @@ reviewed_divergences:
     end_line: 655
     column: 25
     end_column: 37
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__nextcloud-vm.sh"
-    line: 542
-    end_line: 542
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__opnsense-vm.sh"
-    line: 744
-    end_line: 744
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__owncloud-vm.sh"
-    line: 555
-    end_line: 555
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2204-vm.sh"
-    line: 537
-    end_line: 537
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh"
-    line: 539
-    end_line: 539
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh"
-    line: 538
-    end_line: 538
-    column: 25
-    end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "dehydrated-io__dehydrated__dehydrated"
@@ -440,54 +370,12 @@ reviewed_divergences:
     column: 30
     end_column: 50
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__debian-vm.sh"
-    line: 409
-    end_line: 409
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__haos-vm.sh"
-    line: 451
-    end_line: 451
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "tteck__Proxmox__vm__nextcloud-vm.sh"
     line: 210
     end_line: 210
     column: 96
     end_column: 99
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__nextcloud-vm.sh"
-    line: 408
-    end_line: 408
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__owncloud-vm.sh"
-    line: 408
-    end_line: 408
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__ubuntu2204-vm.sh"
-    line: 409
-    end_line: 409
-    column: 25
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "tteck__Proxmox__vm__ubuntu2404-vm.sh"
-    line: 399
-    end_line: 399
-    column: 25
-    end_column: 34
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "v1s1t0r1sh3r3__airgeddon__airgeddon.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -217,27 +217,6 @@ reviewed_divergences:
     end_column: 14
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh"
-    line: 191
-    end_line: 191
-    column: 14
-    end_column: 30
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh"
-    line: 215
-    end_line: 215
-    column: 18
-    end_column: 34
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh"
-    line: 221
-    end_line: 221
-    column: 20
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "pi-hole__pi-hole__automated install__basic-install.sh"
     line: 1833
     end_line: 1833

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -28,13 +28,6 @@ reviewed_divergences:
     end_column: 43
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "awslabs__git-secrets__git-secrets"
-    line: 124
-    end_line: 124
-    column: 5
-    end_column: 17
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "bats-core__bats-core__libexec__bats-core__bats-format-pretty"
     line: 67
     end_line: 67

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -251,27 +251,6 @@ reviewed_divergences:
     column: 24
     end_column: 48
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__extras__chruby.sh"
-    line: 31
-    end_line: 31
-    column: 10
-    end_column: 21
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__build_requirements"
-    line: 160
-    end_line: 160
-    column: 10
-    end_column: 29
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__manage__base_fetch"
-    line: 45
-    end_line: 45
-    column: 12
-    end_column: 24
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__base_fetch"
     line: 223
@@ -306,13 +285,6 @@ reviewed_divergences:
     end_line: 145
     column: 14
     end_column: 21
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__requirements__openbsd"
-    line: 35
-    end_line: 35
-    column: 12
-    end_column: 23
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__requirements__osx_brew"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -76,20 +76,6 @@ reviewed_divergences:
     column: 33
     end_column: 36
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_map.sh"
-    line: 263
-    end_line: 263
-    column: 70
-    end_column: 75
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_netjson.sh"
-    line: 577
-    end_line: 577
-    column: 70
-    end_column: 75
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
     line: 3374

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -83,13 +83,6 @@ reviewed_divergences:
     column: 85
     end_column: 109
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "gentoo__gentoo__eclass__tests__toolchain-funcs.sh"
-    line: 61
-    end_line: 61
-    column: 6
-    end_column: 12
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__toolchain.sh"
     line: 155
@@ -116,13 +109,6 @@ reviewed_divergences:
     line: 442
     end_line: 442
     column: 15
-    end_column: 39
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "ko1nksm__shellspec__lib__libexec__shellspec.sh"
-    line: 94
-    end_line: 94
-    column: 37
     end_column: 39
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2611,6 +2611,14 @@ fn collect_binding_values<'a>(
         }
     }
 
+    for (name, name_span, word) in simple_declaration_assignment_value_words(command, source) {
+        if let Some(binding_id) =
+            binding_value_definition_id_for_name(semantic, &name, name_span)
+        {
+            binding_values.insert(binding_id, BindingValueFact::scalar(word));
+        }
+    }
+
     match command {
         Command::Compound(CompoundCommand::For(command)) => {
             let Some(words) = &command.words else {
@@ -2659,6 +2667,56 @@ fn collect_binding_values<'a>(
         }
         _ => {}
     }
+}
+
+fn simple_declaration_assignment_value_words<'a>(
+    command: &'a Command,
+    source: &str,
+) -> Vec<(Name, Span, &'a Word)> {
+    let Command::Simple(command) = command else {
+        return Vec::new();
+    };
+    let Some(command_name) = static_command_name_text(&command.name, source) else {
+        return Vec::new();
+    };
+    let command_name = command_name
+        .as_ref()
+        .strip_prefix('\\')
+        .unwrap_or(command_name.as_ref());
+    if simple_command_declaration_kind(Some(command_name)).is_none() {
+        return Vec::new();
+    }
+
+    let mut values = Vec::new();
+    let mut parsing_options = true;
+    for word in &command.args {
+        let Some(text) = static_word_text(word, source) else {
+            parsing_options = false;
+            continue;
+        };
+
+        if parsing_options {
+            if text == "--" {
+                parsing_options = false;
+                continue;
+            }
+            if simple_command_declaration_option_word(&text) {
+                continue;
+            }
+            parsing_options = false;
+        }
+
+        let Some(parsed) = parse_assignment_word(&text) else {
+            continue;
+        };
+        let name_span = Span::from_positions(
+            word.span.start,
+            word.span.start.advanced_by(parsed.name),
+        );
+        values.push((Name::from(parsed.name), name_span, word));
+    }
+
+    values
 }
 
 fn binding_value_definition_id_for_name(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -793,6 +793,19 @@ impl<'a> LinterFactsBuilder<'a> {
         });
         let backtick_escaped_parameters =
             word_spans::backtick_escaped_parameters(source, &backtick_substitution_spans);
+        let mut backtick_escaped_parameter_reference_spans =
+            word_spans::backtick_escaped_parameter_reference_spans(
+                source,
+                &backtick_substitution_spans,
+            );
+        backtick_escaped_parameter_reference_spans.extend(
+            backtick_escaped_parameters
+                .iter()
+                .map(|escaped| escaped.reference_span),
+        );
+        backtick_escaped_parameter_reference_spans
+            .sort_by_key(|span| (span.start.offset, span.end.offset));
+        backtick_escaped_parameter_reference_spans.dedup();
         let backtick_double_escaped_parameter_spans =
             word_spans::backtick_double_escaped_parameter_spans(
                 source,
@@ -877,6 +890,7 @@ impl<'a> LinterFactsBuilder<'a> {
             command_substitution_command_spans,
             backtick_substitution_spans,
             backtick_escaped_parameters,
+            backtick_escaped_parameter_reference_spans,
             backtick_double_escaped_parameter_spans,
             backtick_command_name_spans,
             dollar_question_after_command_spans,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -74,6 +74,7 @@ pub struct LinterFacts<'a> {
     command_substitution_command_spans: Vec<Span>,
     backtick_substitution_spans: Vec<Span>,
     backtick_escaped_parameters: Vec<BacktickEscapedParameter>,
+    backtick_escaped_parameter_reference_spans: Vec<Span>,
     backtick_double_escaped_parameter_spans: Vec<Span>,
     backtick_command_name_spans: Vec<Span>,
     dollar_question_after_command_spans: Vec<Span>,
@@ -667,6 +668,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn backtick_escaped_parameters(&self) -> &[BacktickEscapedParameter] {
         &self.backtick_escaped_parameters
+    }
+
+    pub fn backtick_escaped_parameter_reference_spans(&self) -> &[Span] {
+        &self.backtick_escaped_parameter_reference_spans
     }
 
     pub fn is_backtick_double_escaped_parameter_reference(&self, span: Span) -> bool {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -962,6 +962,7 @@ echo $PACKAGE_NAME | sed 's/\\./\\//g'
 echo \"$value\" | sed \\\"s/foo/bar/\\\"
 echo \"$key\" | sed 's/[]\\[^$.*/]/\\\\&/g'
 echo \"${ENTRY}\" | sed 's/\\([/&]\\)/\\\\\\1/g'
+echo \\\"$value\\\" | sed 's/foo/bar/'
 sed 's/[]\\[^$.*/]/\\\\&/g' <<<\"$key\"
 sed 's/\\([/&]\\)/\\\\\\1/g' <<<\"${ENTRY}\"
 printf '%s\\n' \"$value\" | sed 's/foo/bar/'

--- a/crates/shuck-linter/src/facts/word_spans.rs
+++ b/crates/shuck-linter/src/facts/word_spans.rs
@@ -145,7 +145,7 @@ pub fn collect_direct_all_elements_array_expansion_part_spans(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_direct_all_elements_array_expansion_spans(&word.parts, source, spans);
+    collect_direct_all_elements_array_expansion_spans(&word.parts, word.span, source, spans);
 }
 
 pub fn unquoted_all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
@@ -1261,14 +1261,18 @@ fn collect_all_elements_array_slice_spans(
 
 fn collect_direct_all_elements_array_expansion_spans(
     parts: &[WordPartNode],
+    word_span: Span,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
     for part in parts {
+        if span_inside_escaped_parameter_template(word_span, part.span, source) {
+            continue;
+        }
         match &part.kind {
             WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
-                collect_direct_all_elements_array_expansion_spans(parts, source, spans)
+                collect_direct_all_elements_array_expansion_spans(parts, word_span, source, spans)
             }
             _ if part_uses_direct_all_elements_array_expansion(&part.kind) => {
                 if let Some(span) =
@@ -1291,6 +1295,111 @@ fn collect_direct_all_elements_array_expansion_spans(
             _ => {}
         }
     }
+}
+
+fn span_inside_escaped_parameter_template(word_span: Span, span: Span, source: &str) -> bool {
+    if span.start.offset < word_span.start.offset || span.start.offset >= word_span.end.offset {
+        return false;
+    }
+
+    let text = word_span.slice(source);
+    let relative_offset = span.start.offset - word_span.start.offset;
+    let mut index = 0usize;
+
+    while index < text.len() {
+        if text[index..].starts_with("\\${") {
+            let dollar_offset = index + '\\'.len_utf8();
+            if offset_is_backslash_escaped(word_span.start.offset + dollar_offset, source)
+                && let Some(end_offset) = escaped_parameter_template_end(text, dollar_offset)
+            {
+                let body_start = dollar_offset + "${".len();
+                let body_end = end_offset.saturating_sub('}'.len_utf8());
+                if relative_offset >= body_start && relative_offset < body_end {
+                    return true;
+                }
+                index = end_offset;
+                continue;
+            }
+        }
+
+        let Some(ch) = text[index..].chars().next() else {
+            break;
+        };
+        index += ch.len_utf8();
+    }
+
+    false
+}
+
+fn escaped_parameter_template_end(text: &str, dollar_offset: usize) -> Option<usize> {
+    if dollar_offset >= text.len() || !text[dollar_offset..].starts_with("${") {
+        return None;
+    }
+
+    let bytes = text.as_bytes();
+    let mut index = dollar_offset + "${".len();
+    let mut depth = 1usize;
+    let mut quote_state = EscapedTemplateQuote::None;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        match quote_state {
+            EscapedTemplateQuote::Single => {
+                if byte == b'\'' {
+                    quote_state = EscapedTemplateQuote::None;
+                }
+                index += 1;
+                continue;
+            }
+            EscapedTemplateQuote::Double => {
+                if byte == b'\\' {
+                    index += usize::from(index + 1 < bytes.len()) + 1;
+                    continue;
+                }
+                if byte == b'"' {
+                    quote_state = EscapedTemplateQuote::None;
+                }
+                index += 1;
+                continue;
+            }
+            EscapedTemplateQuote::None => {}
+        }
+
+        match byte {
+            b'\\' => {
+                index += usize::from(index + 1 < bytes.len()) + 1;
+            }
+            b'\'' => {
+                quote_state = EscapedTemplateQuote::Single;
+                index += 1;
+            }
+            b'"' => {
+                quote_state = EscapedTemplateQuote::Double;
+                index += 1;
+            }
+            b'$' if bytes.get(index + 1) == Some(&b'{') => {
+                depth += 1;
+                index += "${".len();
+            }
+            b'}' => {
+                depth -= 1;
+                index += '}'.len_utf8();
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => index = advance_shell_char(text, index),
+        }
+    }
+
+    None
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EscapedTemplateQuote {
+    None,
+    Single,
+    Double,
 }
 
 fn collect_quoted_unindexed_bash_source_spans(
@@ -1879,6 +1988,46 @@ pub(crate) fn backtick_escaped_parameters(
             parameter.reference_span.end.offset,
         )
     });
+    spans.dedup();
+    spans
+}
+
+pub(crate) fn backtick_escaped_parameter_reference_spans(
+    source: &str,
+    backtick_spans: &[Span],
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+
+    for backtick_span in backtick_spans {
+        let base_offset = backtick_span.start.offset.saturating_add('`'.len_utf8());
+        let end = backtick_span.end.offset.saturating_sub('`'.len_utf8());
+        let Some(text) = source.get(base_offset..end) else {
+            continue;
+        };
+        let mut index = 0usize;
+
+        while index < text.len() {
+            if text[index..].starts_with("\\${") {
+                let dollar_offset = index + '\\'.len_utf8();
+                if offset_is_backslash_escaped(base_offset + dollar_offset, source)
+                    && let Some(end_offset) = escaped_parameter_template_end(text, dollar_offset)
+                    && let Some(start) = position_at_offset(source, base_offset + dollar_offset)
+                    && let Some(end_position) = position_at_offset(source, base_offset + end_offset)
+                {
+                    spans.push(Span::from_positions(start, end_position));
+                    index = end_offset;
+                    continue;
+                }
+            }
+
+            let Some(ch) = text[index..].chars().next() else {
+                break;
+            };
+            index += ch.len_utf8();
+        }
+    }
+
+    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
     spans.dedup();
     spans
 }

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -2382,7 +2382,7 @@ fn sc2001_like_pipeline_span<'a>(
     }
 
     if command_is_inside_backtick_fragment(right, backticks)
-        && word_occurrence_is_backtick_escaped_double_quoted_dynamic(
+        && word_occurrence_is_escaped_double_quoted_dynamic(
             lookup.nodes,
             word_fact,
             lookup.fact_store,
@@ -2390,6 +2390,15 @@ fn sc2001_like_pipeline_span<'a>(
         )
     {
         return sc2001_like_backtick_pipeline_span(commands, pipeline, right, lookup.source);
+    }
+
+    if word_occurrence_is_escaped_double_quoted_dynamic(
+        lookup.nodes,
+        word_fact,
+        lookup.fact_store,
+        lookup.source,
+    ) {
+        return None;
     }
 
     Some(pipeline_span_with_shellcheck_tail(
@@ -2635,7 +2644,7 @@ fn word_occurrence_is_pure_quoted_dynamic(
         || word_occurrence_is_double_quoted_command_substitution_only(
             nodes, fact, fact_store, source,
         )
-        || word_occurrence_is_backtick_escaped_double_quoted_dynamic(
+        || word_occurrence_is_escaped_double_quoted_dynamic(
             nodes, fact, fact_store, source,
         )
 }
@@ -3299,7 +3308,7 @@ fn word_occurrence_is_double_quoted_command_substitution_only(
         && &word_text[1..word_text.len() - 1] == command_substitution.slice(source)
 }
 
-fn word_occurrence_is_backtick_escaped_double_quoted_dynamic(
+fn word_occurrence_is_escaped_double_quoted_dynamic(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     fact_store: &FactStore<'_>,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -96,7 +96,7 @@ pub use rule_selector::{RuleSelector, SelectorParseError};
 /// Sets of enabled or disabled rules.
 pub use rule_set::RuleSet;
 #[allow(unused_imports)]
-pub(crate) use rules::common::safe_value::{SafeValueIndex, SafeValueQuery};
+pub(crate) use rules::common::safe_value::{S001QuoteExposure, SafeValueIndex, SafeValueQuery};
 #[allow(unused_imports)]
 pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 /// Linter configuration and per-file ignore types.

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -108,6 +108,7 @@ pub struct SafeValueIndex<'a> {
     binding_value_stack: Vec<BindingId>,
     helper_binding_memo: FxHashMap<(Name, ScopeId, FactSpan), Box<[BindingId]>>,
     helper_binding_visiting: FxHashSet<(Name, ScopeId, FactSpan)>,
+    s001_unset_before_call_memo: FxHashMap<ScopeId, bool>,
 }
 
 impl<'a> SafeValueIndex<'a> {
@@ -186,6 +187,7 @@ impl<'a> SafeValueIndex<'a> {
             binding_value_stack: Vec::new(),
             helper_binding_memo: FxHashMap::default(),
             helper_binding_visiting: FxHashSet::default(),
+            s001_unset_before_call_memo: FxHashMap::default(),
         }
     }
 
@@ -369,6 +371,14 @@ impl<'a> SafeValueIndex<'a> {
                 }
             }
         }
+    }
+
+    pub fn span_has_s001_function_unset_exposure(
+        &mut self,
+        span: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        query.is_field_context() && self.s001_reference_function_unset_before_first_call(span)
     }
 
     pub fn part_is_safe_initializer_command_substitution_self_reference(
@@ -809,6 +819,9 @@ impl<'a> SafeValueIndex<'a> {
         if safe_special_parameter(name) {
             return S001QuoteExposure::QuoteInertNonEmpty;
         }
+        if query.is_field_context() && self.s001_reference_function_unset_before_first_call(at) {
+            return S001QuoteExposure::Unsafe;
+        }
         if self.name_is_safe(name, at, query) {
             return S001QuoteExposure::QuoteInertNonEmpty;
         }
@@ -1091,6 +1104,159 @@ impl<'a> SafeValueIndex<'a> {
             .get(&FactSpan::new(span))
             .copied()
             .map(|id| self.facts.command(id))
+    }
+
+    fn function_definition_command_for_scope(
+        &self,
+        scope: ScopeId,
+    ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
+        self.facts
+            .function_headers()
+            .iter()
+            .find(|header| header.function_scope() == Some(scope))
+            .and_then(|header| self.function_definition_command(header.function()))
+    }
+
+    fn s001_reference_function_unset_before_first_call(&mut self, at: Span) -> bool {
+        let Some(scope) = self.enclosing_function_scope_at(at.start.offset) else {
+            return false;
+        };
+        if let Some(result) = self.s001_unset_before_call_memo.get(&scope) {
+            return *result;
+        }
+
+        let result = self.s001_function_unset_before_first_call(scope);
+        self.s001_unset_before_call_memo.insert(scope, result);
+        result
+    }
+
+    fn s001_function_unset_before_first_call(&self, scope: ScopeId) -> bool {
+        let Some(definition_command) = self.function_definition_command_for_scope(scope) else {
+            return false;
+        };
+        let after_offset = definition_command.span_in_source(self.source).end.offset;
+        let Some(first_unset) = self.s001_first_function_unset_event_after(scope, after_offset)
+        else {
+            return false;
+        };
+
+        let first_call = self.s001_first_function_call_event_after(scope, after_offset);
+        first_call.is_none_or(|first_call| first_unset < first_call)
+    }
+
+    fn s001_first_function_call_event_after(
+        &self,
+        scope: ScopeId,
+        after_offset: usize,
+    ) -> Option<usize> {
+        self.s001_first_function_call_event_after_inner(
+            scope,
+            after_offset,
+            &mut FxHashSet::default(),
+        )
+    }
+
+    fn s001_first_function_call_event_after_inner(
+        &self,
+        scope: ScopeId,
+        after_offset: usize,
+        seen_scopes: &mut FxHashSet<ScopeId>,
+    ) -> Option<usize> {
+        if !seen_scopes.insert(scope) {
+            return None;
+        }
+
+        let definition_command = self.function_definition_command_for_scope(scope)?;
+        let function_kind = self.named_function_kind(scope)?;
+        let mut first_offset: Option<usize> = None;
+        for function_name in function_kind.static_names() {
+            for site in self.semantic.call_sites_for(function_name) {
+                if site.scope == scope {
+                    continue;
+                }
+                let call_span = self
+                    .command_for_name_word_span(site.span)
+                    .map_or(site.span, |command| command.span_in_source(self.source));
+                if !self.definition_command_resolves_at_call(definition_command.id(), call_span) {
+                    continue;
+                }
+                let event_offset = match self.enclosing_function_scope_at(call_span.start.offset) {
+                    Some(caller_scope) => self.s001_first_function_call_event_after_inner(
+                        caller_scope,
+                        after_offset,
+                        seen_scopes,
+                    ),
+                    None => {
+                        (call_span.start.offset > after_offset).then_some(call_span.start.offset)
+                    }
+                };
+                if let Some(event_offset) = event_offset {
+                    first_offset = Some(
+                        first_offset.map_or(event_offset, |current| current.min(event_offset)),
+                    );
+                }
+            }
+        }
+
+        first_offset
+    }
+
+    fn s001_first_function_unset_event_after(
+        &self,
+        target_scope: ScopeId,
+        after_offset: usize,
+    ) -> Option<usize> {
+        let target_function = self.named_function_kind(target_scope)?;
+        let mut first_offset: Option<usize> = None;
+
+        for command in self.facts.structural_commands() {
+            if !command.options().unset().is_some_and(|unset| {
+                target_function
+                    .static_names()
+                    .iter()
+                    .any(|name| unset.targets_function_name(self.source, name.as_str()))
+            }) {
+                continue;
+            }
+            if !self.command_runs_in_persistent_shell_context(command.id())
+                || self.command_is_in_background_context(command.id())
+                || self.command_has_dominance_barrier_ancestor(command.id())
+            {
+                continue;
+            }
+
+            let command_span = command.span_in_source(self.source);
+            let event_offset = match self.enclosing_function_scope_at(command_span.start.offset) {
+                Some(unsetter_scope) => {
+                    if unsetter_scope == target_scope {
+                        None
+                    } else {
+                        self.s001_first_function_call_event_after(unsetter_scope, after_offset)
+                    }
+                }
+                None => {
+                    (command_span.start.offset > after_offset).then_some(command_span.start.offset)
+                }
+            };
+
+            if let Some(event_offset) = event_offset {
+                first_offset =
+                    Some(first_offset.map_or(event_offset, |current| current.min(event_offset)));
+            }
+        }
+
+        first_offset
+    }
+
+    fn command_has_dominance_barrier_ancestor(&self, command_id: crate::facts::CommandId) -> bool {
+        let mut current = self.facts.command_parent_id(command_id);
+        while let Some(id) = current {
+            if self.facts.command_is_dominance_barrier(id) {
+                return true;
+            }
+            current = self.facts.command_parent_id(id);
+        }
+        false
     }
 
     fn command_runs_in_unconditional_flow(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -381,7 +381,12 @@ impl<'a> SafeValueIndex<'a> {
     fn span_is_inside_command_substitution_scope(&self, span: Span) -> bool {
         self.semantic
             .ancestor_scopes(self.semantic.scope_at(span.start.offset))
-            .any(|scope| matches!(self.semantic.scope(scope).kind, ScopeKind::CommandSubstitution))
+            .any(|scope| {
+                matches!(
+                    self.semantic.scope(scope).kind,
+                    ScopeKind::CommandSubstitution
+                )
+            })
     }
 
     fn literal_part_is_safe(&self, part: &WordPart, span: Span, query: SafeValueQuery) -> bool {
@@ -1418,7 +1423,7 @@ impl<'a> SafeValueIndex<'a> {
             .binding_value(binding_id)
             .filter(|value| !value.conditional_assignment_shortcut())
             .and_then(|value| value.scalar_word())
-            .is_some_and(word_is_standalone_status_capture)
+            .is_some_and(word_is_standalone_status_or_pid_capture)
         {
             return true;
         }
@@ -3366,7 +3371,32 @@ fn assignment_value_after_definition(source: &str, definition_span: Span) -> Opt
 }
 
 fn assignment_value_text_is_standalone_status_capture(text: &str) -> bool {
-    matches!(text, "$?" | "${?}" | "\"$?\"" | "\"${?}\"")
+    matches!(
+        text,
+        "$?" | "${?}" | "\"$?\"" | "\"${?}\"" | "$!" | "${!}" | "\"$!\"" | "\"${!}\""
+    )
+}
+
+fn word_is_standalone_status_or_pid_capture(word: &Word) -> bool {
+    matches!(word.parts.as_slice(), [part] if part_is_standalone_status_or_pid_capture(&part.kind))
+}
+
+fn part_is_standalone_status_or_pid_capture(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => matches!(name.as_str(), "?" | "!"),
+        WordPart::DoubleQuoted { parts, .. } => {
+            matches!(
+                parts.as_slice(),
+                [part] if part_is_standalone_status_or_pid_capture(&part.kind)
+            )
+        }
+        WordPart::Parameter(parameter) => matches!(
+            parameter.bourne(),
+            Some(BourneParameterExpansion::Access { reference })
+                if matches!(reference.name.as_str(), "?" | "!") && reference.subscript.is_none()
+        ),
+        _ => false,
+    }
 }
 
 fn safe_numeric_shell_variable(name: &Name) -> bool {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -474,7 +474,7 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let mut saw_setup_binding = false;
+        let mut setup_bindings = Vec::new();
         for binding_id in self.semantic.bindings_for(&name).iter().copied() {
             let binding = self.semantic.binding(binding_id);
             if binding.span.start.offset >= span.start.offset {
@@ -498,10 +498,16 @@ impl<'a> SafeValueIndex<'a> {
             if !setup_atom {
                 return false;
             }
-            saw_setup_binding = true;
+            setup_bindings.push(binding_id);
         }
 
-        saw_setup_binding
+        !setup_bindings.is_empty()
+            && (self.bindings_cover_all_paths_to_reference(&setup_bindings, &name, span)
+                || setup_bindings.iter().copied().any(|binding_id| {
+                    let binding = self.semantic.binding(binding_id);
+                    binding.span.end.offset <= span.start.offset
+                        && self.binding_dominates_reference(binding_id, &name, span)
+                }))
     }
 
     fn span_is_inside_initializer_command_substitution(&self, span: Span) -> bool {
@@ -4068,14 +4074,7 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        let mut helper_bindings = self.called_helper_bindings_for_name(name, at);
-        self.retain_value_bindings(&mut helper_bindings);
-        let has_dominating_helper_binding = helper_bindings
-            .iter()
-            .chain(transitive_helper_bindings.iter())
-            .any(|binding_id| bindings.contains(binding_id));
-        let has_covering_binding = has_dominating_helper_binding
-            || self.bindings_cover_all_paths_to_reference(&bindings, name, at)
+        let has_covering_binding = self.bindings_cover_all_paths_to_reference(&bindings, name, at)
             || bindings.iter().copied().any(|binding_id| {
                 let binding = self.semantic.binding(binding_id);
                 binding.span.end.offset <= at.start.offset
@@ -6495,6 +6494,42 @@ render() {
             .expect("expected conditionally helper-initialized argument fact");
 
         assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn guarded_numeric_helper_bindings_do_not_count_as_definite_values() {
+        let source = "\
+#!/bin/bash
+init_count() {
+  if [ \"$1\" = yes ]; then
+    count=0
+  fi
+}
+init_count
+move_up $count
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let file_context = classify_file_context(source, None, ShellDialect::Bash);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$count"
+            })
+            .expect("expected numeric helper argument fact");
+        let (part, part_span) = word_fact
+            .parts_with_spans()
+            .find(|(_, span)| span.slice(source) == "$count")
+            .expect("expected count expansion part");
+
+        assert!(!safe_values.part_has_s001_standalone_numeric_argv_exposure(part, part_span));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -396,6 +396,18 @@ impl<'a> SafeValueIndex<'a> {
         self.s001_name_has_only_numeric_value_bindings(&name, span)
     }
 
+    pub fn part_has_s001_arithmetic_numeric_operand_exposure(
+        &mut self,
+        part: &WordPart,
+        span: Span,
+    ) -> bool {
+        let Some(name) = plain_scalar_reference_name_from_part(part) else {
+            return false;
+        };
+
+        self.s001_name_has_only_arithmetic_numeric_bindings(&name, span)
+    }
+
     pub fn part_is_safe_initializer_command_substitution_self_reference(
         &mut self,
         part: &WordPart,
@@ -4090,6 +4102,52 @@ impl<'a> SafeValueIndex<'a> {
         };
 
         word_static_text_is_shell_integer(word, self.source) || word_is_arithmetic_expansion(word)
+    }
+
+    fn s001_name_has_only_arithmetic_numeric_bindings(&mut self, name: &Name, at: Span) -> bool {
+        let mut bindings = self.safe_bindings_for_name(name, at);
+        self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        self.drop_outer_bindings_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        self.retain_value_bindings(&mut bindings);
+        if bindings.is_empty()
+            || bindings.iter().copied().any(|binding_id| {
+                self.binding_is_one_sided_short_circuit_assignment(binding_id)
+                    || self.facts.binding_value(binding_id).is_some_and(|value| {
+                        value.conditional_assignment_shortcut()
+                            || value.scalar_word().is_some_and(|word| {
+                                static_word_text(word, self.source)
+                                    .is_some_and(|text| text.is_empty())
+                            })
+                    })
+            })
+        {
+            return false;
+        }
+
+        let has_covering_binding = self.bindings_cover_all_paths_to_reference(&bindings, name, at)
+            || bindings.iter().copied().any(|binding_id| {
+                let binding = self.semantic.binding(binding_id);
+                binding.span.end.offset <= at.start.offset
+                    && self.binding_dominates_reference(binding_id, name, at)
+            });
+        has_covering_binding
+            && bindings
+                .into_iter()
+                .all(|binding_id| self.binding_assigns_s001_arithmetic_numeric_value(binding_id))
+    }
+
+    fn binding_assigns_s001_arithmetic_numeric_value(&self, binding_id: BindingId) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        if self.binding_has_effective_integer_attribute(binding_id)
+            || matches!(binding.kind, BindingKind::ArithmeticAssignment)
+        {
+            return true;
+        }
+
+        self.facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())
+            .is_some_and(word_is_arithmetic_expansion)
     }
 
     fn enclosing_while_body_for_condition_span(&self, at: Span) -> Option<Span> {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -4055,9 +4055,11 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
         if bindings.iter().copied().any(|binding_id| {
-            self.binding_is_one_sided_short_circuit_assignment(binding_id)
+            (self.binding_is_one_sided_short_circuit_assignment(binding_id)
+                && !self.binding_assigns_static_integer_literal(binding_id))
                 || self.facts.binding_value(binding_id).is_some_and(|value| {
                     value.conditional_assignment_shortcut()
+                        && !self.binding_assigns_static_integer_literal(binding_id)
                         || value.scalar_word().is_some_and(|word| {
                             static_word_text(word, self.source).is_some_and(|text| text.is_empty())
                         })
@@ -4102,6 +4104,13 @@ impl<'a> SafeValueIndex<'a> {
         };
 
         word_static_text_is_shell_integer(word, self.source) || word_is_arithmetic_expansion(word)
+    }
+
+    fn binding_assigns_static_integer_literal(&self, binding_id: BindingId) -> bool {
+        self.facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())
+            .is_some_and(|word| word_static_text_is_shell_integer(word, self.source))
     }
 
     fn s001_name_has_only_arithmetic_numeric_bindings(&mut self, name: &Name, at: Span) -> bool {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1502,8 +1502,12 @@ impl<'a> SafeValueIndex<'a> {
         {
             return true;
         }
-        if matches!(query, SafeValueQuery::Argv | SafeValueQuery::RedirectTarget)
-            && self.binding_is_standalone_status_capture(binding_id, case_cli_scope)
+        if matches!(
+            query,
+            SafeValueQuery::Argv
+                | SafeValueQuery::RedirectTarget
+                | SafeValueQuery::NumericTestOperand
+        ) && self.binding_is_standalone_status_capture(binding_id, case_cli_scope)
         {
             return true;
         }

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -417,6 +417,75 @@ impl<'a> SafeValueIndex<'a> {
             })
     }
 
+    pub fn part_is_safe_initializer_command_substitution_static_setup_reference(
+        &mut self,
+        part: &WordPart,
+        span: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        if query != SafeValueQuery::Argv {
+            return false;
+        }
+        let Some(name) = plain_scalar_reference_name_from_part(part) else {
+            return false;
+        };
+        if !shell_name_is_uppercase_setup_value(name.as_str())
+            || !self.span_is_inside_initializer_command_substitution(span)
+            || self.span_is_inside_loop_context(span)
+            || self.span_is_inside_if_condition(span)
+        {
+            return false;
+        }
+
+        let mut saw_setup_binding = false;
+        for binding_id in self.semantic.bindings_for(&name).iter().copied() {
+            let binding = self.semantic.binding(binding_id);
+            if binding.span.start.offset >= span.start.offset {
+                continue;
+            }
+            if binding.attributes.contains(BindingAttributes::LOCAL) {
+                return false;
+            }
+            if !matches!(
+                self.semantic.scope(binding.scope).kind,
+                ScopeKind::File | ScopeKind::Function(_)
+            ) {
+                return false;
+            }
+            let setup_atom = self
+                .facts
+                .binding_value(binding_id)
+                .and_then(|value| value.scalar_word())
+                .and_then(|word| static_word_text(word, self.source))
+                .is_some_and(|text| literal_is_setup_atom(&text));
+            if !setup_atom {
+                return false;
+            }
+            saw_setup_binding = true;
+        }
+
+        saw_setup_binding
+    }
+
+    fn span_is_inside_initializer_command_substitution(&self, span: Span) -> bool {
+        self.semantic.bindings().iter().any(|binding| {
+            let Some(word) = self
+                .facts
+                .binding_value(binding.id)
+                .and_then(|value| value.scalar_word())
+            else {
+                return false;
+            };
+            span_contains(word.span, span)
+                && self.facts.any_word_fact(word.span).is_some_and(|fact| {
+                    fact.command_substitution_spans()
+                        .iter()
+                        .copied()
+                        .any(|command_substitution| span_contains(command_substitution, span))
+                })
+        })
+    }
+
     fn span_is_inside_loop_context(&self, span: Span) -> bool {
         let mut current = self
             .facts
@@ -3876,6 +3945,29 @@ fn shell_name_is_plain_scalar(text: &str) -> bool {
     };
     (first == '_' || first.is_ascii_alphabetic())
         && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn shell_name_is_uppercase_setup_value(text: &str) -> bool {
+    let mut saw_uppercase = false;
+    for character in text.chars() {
+        if character.is_ascii_uppercase() {
+            saw_uppercase = true;
+            continue;
+        }
+        if character == '_' || character.is_ascii_digit() {
+            continue;
+        }
+        return false;
+    }
+
+    saw_uppercase
+}
+
+fn literal_is_setup_atom(text: &str) -> bool {
+    !text.is_empty()
+        && text
+            .bytes()
+            .all(|byte| byte == b'_' || byte.is_ascii_uppercase() || byte.is_ascii_digit())
 }
 
 fn build_case_cli_reachable_function_scopes(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -3654,9 +3654,15 @@ impl<'a> SafeValueIndex<'a> {
             | ParameterOp::RemovePrefixLong { .. }
             | ParameterOp::RemoveSuffixShort { .. }
             | ParameterOp::RemoveSuffixLong { .. } => self.name_is_safe(name, at, query),
-            ParameterOp::UseDefault | ParameterOp::AssignDefault | ParameterOp::Error => {
+            ParameterOp::UseDefault | ParameterOp::AssignDefault => {
                 self.name_is_safe(name, at, query)
+                    || (query == SafeValueQuery::NumericTestOperand
+                        && operand.is_some_and(|operand| {
+                            self.source_text_is_safe_numeric_operand(operand, at)
+                        })
+                        && self.name_has_numeric_loop_body_assignment(name, at))
             }
+            ParameterOp::Error => self.name_is_safe(name, at, query),
             ParameterOp::UseReplacement => {
                 operand.is_some_and(|operand| self.source_text_is_safe_literal(operand, query))
             }
@@ -3679,6 +3685,74 @@ impl<'a> SafeValueIndex<'a> {
                 SafeValueQuery::Pattern | SafeValueQuery::Regex => query.literal_is_safe(text),
             },
         })
+    }
+
+    fn source_text_is_safe_numeric_operand(&mut self, text: &SourceText, at: Span) -> bool {
+        let raw = text.slice(self.source).trim();
+        if source_text_literal_value(raw).is_some_and(|literal| match literal {
+            SourceTextLiteral::Bare(text) | SourceTextLiteral::Quoted(text) => {
+                shell_integer_text_is_safe(text)
+            }
+        }) {
+            return true;
+        }
+
+        source_text_plain_scalar_name(raw)
+            .is_some_and(|name| self.name_is_safe(&name, at, SafeValueQuery::NumericTestOperand))
+    }
+
+    fn name_has_numeric_loop_body_assignment(&mut self, name: &Name, at: Span) -> bool {
+        let Some(body_span) = self.enclosing_while_body_for_condition_span(at) else {
+            return false;
+        };
+        let bindings = self.semantic.bindings_for(name).to_vec();
+
+        bindings.into_iter().any(|binding_id| {
+            let binding = self.semantic.binding(binding_id);
+            span_contains(body_span, binding.span)
+                && self.binding_assigns_numeric_operand_value(binding_id, at)
+        })
+    }
+
+    fn enclosing_while_body_for_condition_span(&self, at: Span) -> Option<Span> {
+        self.facts
+            .commands()
+            .iter()
+            .filter_map(|command| match command.command() {
+                Command::Compound(CompoundCommand::While(command))
+                    if span_contains(command.condition.span, at) =>
+                {
+                    Some(command.body.span)
+                }
+                _ => None,
+            })
+            .min_by_key(|span| span.end.offset - span.start.offset)
+    }
+
+    fn binding_assigns_numeric_operand_value(&mut self, binding_id: BindingId, at: Span) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        if self.binding_has_effective_integer_attribute(binding_id)
+            || matches!(binding.kind, BindingKind::ArithmeticAssignment)
+        {
+            return true;
+        }
+
+        let Some(word) = self
+            .facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())
+        else {
+            return false;
+        };
+
+        if word_static_text_is_shell_integer(word, self.source)
+            || word_has_arithmetic_expansion(word)
+        {
+            return true;
+        }
+
+        plain_scalar_reference_name(word)
+            .is_some_and(|name| self.name_is_safe(&name, at, SafeValueQuery::NumericTestOperand))
     }
 }
 
@@ -3780,6 +3854,28 @@ fn source_text_literal_value(text: &str) -> Option<SourceTextLiteral<'_>> {
     }
 
     None
+}
+
+fn source_text_plain_scalar_name(text: &str) -> Option<Name> {
+    if let Some(name) = text.strip_prefix('$') {
+        if shell_name_is_plain_scalar(name) {
+            return Some(Name::new(name));
+        }
+    }
+
+    let inner = text
+        .strip_prefix("${")
+        .and_then(|text| text.strip_suffix('}'))?;
+    shell_name_is_plain_scalar(inner).then(|| Name::new(inner))
+}
+
+fn shell_name_is_plain_scalar(text: &str) -> bool {
+    let mut chars = text.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
 }
 
 fn build_case_cli_reachable_function_scopes(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -625,6 +625,11 @@ impl<'a> SafeValueIndex<'a> {
         if self.case_cli_reachable_call_path_keeps_argument_bindings_unsafe(at, query) {
             return safe_numeric_shell_variable(name);
         }
+        if query == SafeValueQuery::NumericTestOperand
+            && self.s001_function_reference_has_file_scope_integer_bindings(name, at)
+        {
+            return true;
+        }
 
         let mut bindings = self.safe_bindings_for_name(name, at);
         self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
@@ -821,6 +826,11 @@ impl<'a> SafeValueIndex<'a> {
         }
         if query.is_field_context() && self.s001_reference_function_unset_before_first_call(at) {
             return S001QuoteExposure::Unsafe;
+        }
+        if query == SafeValueQuery::NumericTestOperand
+            && self.s001_function_reference_has_file_scope_integer_bindings(name, at)
+        {
+            return S001QuoteExposure::QuoteInertNonEmpty;
         }
         if self.name_is_safe(name, at, query) {
             return S001QuoteExposure::QuoteInertNonEmpty;
@@ -3947,6 +3957,53 @@ impl<'a> SafeValueIndex<'a> {
             span_contains(body_span, binding.span)
                 && self.binding_assigns_numeric_operand_value(binding_id, at)
         })
+    }
+
+    fn s001_function_reference_has_file_scope_integer_bindings(
+        &mut self,
+        name: &Name,
+        at: Span,
+    ) -> bool {
+        let Some(function_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+            return false;
+        };
+        if self
+            .semantic
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .any(|binding_id| {
+                let binding = self.semantic.binding(binding_id);
+                binding.scope == function_scope
+                    && self.binding_can_supply_parameter_value(binding_id)
+            })
+        {
+            return false;
+        }
+
+        let Some(file_scope) = self
+            .semantic
+            .ancestor_scopes(self.semantic.scope_at(at.start.offset))
+            .find(|scope| matches!(self.semantic.scope(*scope).kind, ScopeKind::File))
+        else {
+            return false;
+        };
+
+        let bindings = self
+            .semantic
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .filter(|binding_id| {
+                let binding = self.semantic.binding(*binding_id);
+                binding.scope == file_scope && self.binding_can_supply_parameter_value(*binding_id)
+            })
+            .collect::<Vec<_>>();
+
+        !bindings.is_empty()
+            && bindings
+                .into_iter()
+                .all(|binding_id| self.binding_assigns_numeric_operand_value(binding_id, at))
     }
 
     fn enclosing_while_body_for_condition_span(&self, at: Span) -> Option<Span> {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -378,6 +378,12 @@ impl<'a> SafeValueIndex<'a> {
         false
     }
 
+    fn span_is_inside_command_substitution_scope(&self, span: Span) -> bool {
+        self.semantic
+            .ancestor_scopes(self.semantic.scope_at(span.start.offset))
+            .any(|scope| matches!(self.semantic.scope(scope).kind, ScopeKind::CommandSubstitution))
+    }
+
     fn literal_part_is_safe(&self, part: &WordPart, span: Span, query: SafeValueQuery) -> bool {
         let word = Word {
             parts: vec![WordPartNode::new(part.clone(), span)],
@@ -502,6 +508,13 @@ impl<'a> SafeValueIndex<'a> {
         let direct_bindings_cover_all_paths = needs_arg_path_coverage
             && !direct_bindings.is_empty()
             && self.bindings_cover_all_paths_to_reference(&direct_bindings, name, at);
+        if direct_bindings_cover_all_paths
+            && self.enclosing_function_scope_at(at.start.offset).is_some()
+            && self.span_is_inside_command_substitution_scope(at)
+            && self.covering_direct_field_safe_bindings_can_stay_safe(&direct_bindings, query)
+        {
+            return true;
+        }
         if needs_arg_path_coverage
             && !bindings_cover_all_paths
             && !direct_bindings_cover_all_paths
@@ -941,6 +954,20 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         saw_name_only_declaration && saw_field_safe_value
+    }
+
+    fn covering_direct_field_safe_bindings_can_stay_safe(
+        &mut self,
+        bindings: &[BindingId],
+        query: SafeValueQuery,
+    ) -> bool {
+        if !query.is_field_context() || bindings.is_empty() {
+            return false;
+        }
+
+        let mut visiting = FxHashSet::default();
+        self.field_safe_binding_group_class(bindings, query, &mut visiting)
+            == Some(FieldSafeBindingClass::NonEmpty)
     }
 
     fn covering_optional_field_safe_bindings_can_stay_safe(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1791,7 +1791,7 @@ impl<'a> SafeValueIndex<'a> {
         let definition_span = match &binding.origin {
             BindingOrigin::Assignment {
                 definition_span,
-                value: AssignmentValueOrigin::Unknown,
+                value: AssignmentValueOrigin::PlainScalarAccess | AssignmentValueOrigin::Unknown,
             }
             | BindingOrigin::Declaration { definition_span } => *definition_span,
             _ => return false,

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -183,6 +183,9 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     pub fn part_is_safe(&mut self, part: &WordPart, span: Span, query: SafeValueQuery) -> bool {
+        if part_is_safe_special_parameter_access(part) {
+            return true;
+        }
         if self.span_is_after_unconditional_inline_terminator(span) {
             return false;
         }
@@ -3359,6 +3362,24 @@ fn command_fact_is_standalone_exit(command: crate::facts::CommandFactRef<'_, '_>
 
 fn safe_special_parameter(name: &Name) -> bool {
     matches!(name.as_str(), "@" | "#" | "?" | "$" | "!" | "-")
+}
+
+fn part_is_safe_special_parameter_access(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => safe_special_parameter(name),
+        WordPart::DoubleQuoted { parts, .. } => {
+            matches!(
+                parts.as_slice(),
+                [part] if part_is_safe_special_parameter_access(&part.kind)
+            )
+        }
+        WordPart::Parameter(parameter) => matches!(
+            parameter.bourne(),
+            Some(BourneParameterExpansion::Access { reference })
+                if safe_special_parameter(&reference.name) && reference.subscript.is_none()
+        ),
+        _ => false,
+    }
 }
 
 fn assignment_value_after_definition(source: &str, definition_span: Span) -> Option<&str> {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -757,6 +757,19 @@ impl<'a> SafeValueIndex<'a> {
             !self.binding_is_blocked_by_exit_like_function_call(*binding_id, at)
         });
         if !bindings.is_empty() {
+            let dispatch_bindings = self.s001_top_level_dispatch_helper_bindings_before(name, at);
+            if !dispatch_bindings.is_empty() {
+                let mut combined = bindings.clone();
+                combined.extend(dispatch_bindings);
+                combined
+                    .sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+                combined.dedup();
+                if let Some(exposure) =
+                    self.s001_field_safe_binding_group_exposure(&combined, at, query)
+                {
+                    return exposure;
+                }
+            }
             return S001QuoteExposure::Unsafe;
         }
 

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -35,6 +35,13 @@ enum FieldSafeBindingClass {
     NonEmpty,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum S001QuoteExposure {
+    Unsafe,
+    Empty,
+    QuoteInertNonEmpty,
+}
+
 impl SafeValueQuery {
     pub fn from_context(context: ExpansionContext) -> Option<Self> {
         match context {
@@ -287,6 +294,83 @@ impl<'a> SafeValueIndex<'a> {
         self.name_is_safe(name, at, query)
     }
 
+    pub fn part_s001_quote_exposure(
+        &mut self,
+        part: &WordPart,
+        span: Span,
+        query: SafeValueQuery,
+    ) -> S001QuoteExposure {
+        if !query.is_field_context() {
+            return if self.part_is_safe(part, span, query) {
+                S001QuoteExposure::QuoteInertNonEmpty
+            } else {
+                S001QuoteExposure::Unsafe
+            };
+        }
+        if self.span_is_after_unconditional_inline_terminator(span) {
+            return S001QuoteExposure::Unsafe;
+        }
+
+        match part {
+            WordPart::Literal(_) | WordPart::SingleQuoted { .. } => {
+                self.literal_part_s001_quote_exposure(part, span, query)
+            }
+            WordPart::DoubleQuoted { parts, .. } => {
+                let mut saw_empty = false;
+                for part in parts {
+                    match self.part_s001_quote_exposure(&part.kind, part.span, query) {
+                        S001QuoteExposure::QuoteInertNonEmpty => {
+                            return S001QuoteExposure::QuoteInertNonEmpty;
+                        }
+                        S001QuoteExposure::Empty => saw_empty = true,
+                        S001QuoteExposure::Unsafe => return S001QuoteExposure::Unsafe,
+                    }
+                }
+                if saw_empty {
+                    S001QuoteExposure::Empty
+                } else {
+                    S001QuoteExposure::QuoteInertNonEmpty
+                }
+            }
+            WordPart::Variable(name) => self.name_s001_quote_exposure(name, span, query),
+            WordPart::Parameter(parameter) => {
+                self.parameter_part_s001_quote_exposure(parameter, span, query)
+            }
+            WordPart::ArrayAccess(reference) => {
+                if reference.has_array_selector() {
+                    S001QuoteExposure::Unsafe
+                } else {
+                    self.name_s001_quote_exposure(&reference.name, span, query)
+                }
+            }
+            WordPart::Substring { reference, .. } => {
+                self.name_s001_quote_exposure(&reference.name, span, query)
+            }
+            WordPart::Transformation { reference, .. } => {
+                self.name_s001_quote_exposure(&reference.name, span, query)
+            }
+            WordPart::IndirectExpansion { reference, .. } => {
+                self.name_s001_quote_exposure(&reference.name, span, query)
+            }
+            WordPart::ArithmeticExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayLength(_) => S001QuoteExposure::QuoteInertNonEmpty,
+            WordPart::ZshQualifiedGlob(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArrayIndices(_)
+            | WordPart::ArraySlice { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::ParameterExpansion { .. } => {
+                if self.part_is_safe(part, span, query) {
+                    S001QuoteExposure::QuoteInertNonEmpty
+                } else {
+                    S001QuoteExposure::Unsafe
+                }
+            }
+        }
+    }
+
     pub fn part_is_safe_initializer_command_substitution_self_reference(
         &mut self,
         part: &WordPart,
@@ -405,6 +489,34 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         static_word_text(&word, self.source).is_some_and(|text| query.literal_is_safe(&text))
+    }
+
+    fn literal_part_s001_quote_exposure(
+        &self,
+        part: &WordPart,
+        span: Span,
+        query: SafeValueQuery,
+    ) -> S001QuoteExposure {
+        let word = Word {
+            parts: vec![WordPartNode::new(part.clone(), span)],
+            span,
+            brace_syntax: Vec::new(),
+        };
+        if let Some(context) = query.operand_context()
+            && self.literal_runtime_is_unsafe_for_safe_value(&word, context)
+        {
+            return S001QuoteExposure::Unsafe;
+        }
+
+        static_word_text(&word, self.source).map_or(S001QuoteExposure::Unsafe, |text| {
+            if !query.literal_is_safe(&text) {
+                S001QuoteExposure::Unsafe
+            } else if text.is_empty() {
+                S001QuoteExposure::Empty
+            } else {
+                S001QuoteExposure::QuoteInertNonEmpty
+            }
+        })
     }
 
     fn literal_runtime_is_unsafe_for_safe_value(
@@ -617,6 +729,40 @@ impl<'a> SafeValueIndex<'a> {
         bindings
             .into_iter()
             .all(|binding_id| self.binding_is_safe(binding_id, at, query, case_cli_scope))
+    }
+
+    fn name_s001_quote_exposure(
+        &mut self,
+        name: &Name,
+        at: Span,
+        query: SafeValueQuery,
+    ) -> S001QuoteExposure {
+        if safe_special_parameter(name) {
+            return S001QuoteExposure::QuoteInertNonEmpty;
+        }
+        if self.name_is_safe(name, at, query) {
+            return S001QuoteExposure::QuoteInertNonEmpty;
+        }
+        if !query.is_field_context() {
+            return S001QuoteExposure::Unsafe;
+        }
+
+        let mut bindings = self.safe_bindings_for_name(name, at);
+        self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        self.drop_outer_bindings_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        bindings.retain(|binding_id| {
+            !self.binding_is_cleared_by_dominating_unset(*binding_id, name, at)
+        });
+        bindings.retain(|binding_id| {
+            !self.binding_is_blocked_by_exit_like_function_call(*binding_id, at)
+        });
+        if !bindings.is_empty() {
+            return S001QuoteExposure::Unsafe;
+        }
+
+        let dispatch_bindings = self.s001_top_level_dispatch_helper_bindings_before(name, at);
+        self.s001_field_safe_binding_group_exposure(&dispatch_bindings, at, query)
+            .unwrap_or(S001QuoteExposure::Unsafe)
     }
 
     fn case_cli_dispatch_scope_at(&self, offset: usize) -> Option<ScopeId> {
@@ -1088,14 +1234,19 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         saw_conditional_literal
-            && self.semantic.bindings_for(name).iter().copied().any(|binding_id| {
-                let binding = self.semantic.binding(binding_id);
-                binding.span.end.offset <= first_binding_start
-                    && self.semantic.binding_visible_at(binding_id, at)
-                    && self.binding_is_in_scope_or_descendant(binding_id, function_scope)
-                    && self.binding_is_name_only_declaration(binding_id)
-                    && binding.attributes.contains(BindingAttributes::LOCAL)
-            })
+            && self
+                .semantic
+                .bindings_for(name)
+                .iter()
+                .copied()
+                .any(|binding_id| {
+                    let binding = self.semantic.binding(binding_id);
+                    binding.span.end.offset <= first_binding_start
+                        && self.semantic.binding_visible_at(binding_id, at)
+                        && self.binding_is_in_scope_or_descendant(binding_id, function_scope)
+                        && self.binding_is_name_only_declaration(binding_id)
+                        && binding.attributes.contains(BindingAttributes::LOCAL)
+                })
     }
 
     fn field_safe_binding_group_class(
@@ -1168,6 +1319,109 @@ impl<'a> SafeValueIndex<'a> {
             } => self.plain_scalar_field_safe_binding_class(binding_id, query, visiting),
             _ => None,
         }
+    }
+
+    fn s001_field_safe_binding_group_exposure(
+        &mut self,
+        bindings: &[BindingId],
+        at: Span,
+        query: SafeValueQuery,
+    ) -> Option<S001QuoteExposure> {
+        if bindings.is_empty() || !query.is_field_context() {
+            return None;
+        }
+
+        let mut saw_empty = false;
+        let mut saw_non_empty = false;
+        let mut saw_value = false;
+        let mut visiting = FxHashSet::default();
+        for binding_id in bindings.iter().copied() {
+            match self.field_safe_binding_class(binding_id, query, &mut visiting) {
+                Some(FieldSafeBindingClass::Empty) => {
+                    saw_empty = true;
+                    saw_value = true;
+                }
+                Some(FieldSafeBindingClass::NonEmpty) => {
+                    saw_non_empty = true;
+                    saw_value = true;
+                }
+                None if self
+                    .s001_transient_guard_binding_is_overwritten_by_field_safe_bindings(
+                        binding_id, bindings, at, query,
+                    ) => {}
+                None => return None,
+            }
+        }
+
+        if !saw_value {
+            return None;
+        }
+        Some(if saw_non_empty {
+            S001QuoteExposure::QuoteInertNonEmpty
+        } else if saw_empty {
+            S001QuoteExposure::Empty
+        } else {
+            return None;
+        })
+    }
+
+    fn s001_transient_guard_binding_is_overwritten_by_field_safe_bindings(
+        &mut self,
+        binding_id: BindingId,
+        bindings: &[BindingId],
+        _at: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        if !matches!(
+            binding.origin,
+            BindingOrigin::Assignment { .. } | BindingOrigin::Declaration { .. }
+        ) {
+            return false;
+        }
+        if self
+            .facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())
+            .and_then(|word| static_word_text(word, self.source))
+            .is_some_and(|text| query.literal_is_safe(&text))
+        {
+            return false;
+        }
+        let Some(function_end_span) = self.function_scope_end_span(binding.scope) else {
+            return false;
+        };
+
+        let mut later_field_safe_bindings = Vec::new();
+        let mut visiting = FxHashSet::default();
+        for candidate_id in bindings.iter().copied() {
+            let candidate = self.semantic.binding(candidate_id);
+            if candidate_id == binding_id
+                || candidate.scope != binding.scope
+                || candidate.name != binding.name
+                || candidate.span.start.offset <= binding.span.start.offset
+            {
+                continue;
+            }
+            if self
+                .field_safe_binding_class(candidate_id, query, &mut visiting)
+                .is_some()
+            {
+                later_field_safe_bindings.push(candidate_id);
+            } else {
+                return false;
+            }
+        }
+        if later_field_safe_bindings.is_empty() {
+            return false;
+        }
+
+        self.bindings_cover_all_paths_to_reference(
+            &later_field_safe_bindings,
+            &binding.name,
+            function_end_span,
+        ) || (later_field_safe_bindings.len() >= 2
+            && self.span_is_inside_if_condition(binding.span))
     }
 
     fn static_field_safe_binding_class(
@@ -2378,6 +2632,71 @@ impl<'a> SafeValueIndex<'a> {
         bindings
     }
 
+    fn s001_top_level_dispatch_helper_bindings_before(
+        &mut self,
+        name: &Name,
+        at: Span,
+    ) -> Vec<BindingId> {
+        if self.enclosing_function_scope_at(at.start.offset).is_some() {
+            return Vec::new();
+        }
+
+        let mut bindings = Vec::new();
+        let scope = self.semantic.scope_at(at.start.offset);
+        for dispatcher_scope in self.direct_called_function_scopes_before(scope, at.start.offset) {
+            bindings.extend(self.s001_branch_helper_bindings_in_scope(name, dispatcher_scope));
+        }
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.dedup();
+        bindings
+    }
+
+    fn s001_branch_helper_bindings_in_scope(
+        &mut self,
+        name: &Name,
+        scope: ScopeId,
+    ) -> Vec<BindingId> {
+        let helper_scopes = self.helper_scopes_providing_name(name);
+        if helper_scopes.is_empty() {
+            return Vec::new();
+        }
+
+        let helper_scope_set = helper_scopes.iter().copied().collect::<FxHashSet<_>>();
+        let mut call_sites = Vec::new();
+        for callee_scope in helper_scopes {
+            let Some(function_kind) = self.named_function_kind(callee_scope) else {
+                continue;
+            };
+            for function_name in function_kind.static_names() {
+                for site in self.semantic.call_sites_for(function_name) {
+                    if site.scope == scope {
+                        call_sites.push((callee_scope, site.span));
+                    }
+                }
+            }
+        }
+        call_sites.sort_by_key(|(_, span)| (span.start.offset, span.end.offset));
+        call_sites.dedup_by_key(|(callee_scope, span)| {
+            (*callee_scope, span.start.offset, span.end.offset)
+        });
+        if call_sites.len() < 2 {
+            return Vec::new();
+        }
+
+        let mut bindings = Vec::new();
+        for (callee_scope, _) in call_sites {
+            bindings.extend(self.semantic.bindings_for(name).iter().copied().filter(
+                |binding_id| {
+                    let binding = self.semantic.binding(*binding_id);
+                    binding.scope == callee_scope
+                        && helper_scope_set.contains(&binding.scope)
+                        && !binding.attributes.contains(BindingAttributes::LOCAL)
+                },
+            ));
+        }
+        bindings
+    }
+
     fn top_level_transitive_helper_bindings_before(&self, name: &Name, at: Span) -> Vec<BindingId> {
         if self.enclosing_function_scope_at(at.start.offset).is_some() {
             return Vec::new();
@@ -2700,11 +3019,16 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn function_scope_end_offset(&self, scope: ScopeId) -> Option<usize> {
+        self.function_scope_end_span(scope)
+            .map(|span| span.end.offset)
+    }
+
+    fn function_scope_end_span(&self, scope: ScopeId) -> Option<Span> {
         self.facts
             .function_headers()
             .iter()
             .find(|header| header.function_scope() == Some(scope))
-            .map(|header| header.function().span.end.offset)
+            .map(|header| Span::at(header.function().span.end))
     }
 
     fn call_site_dominates_use(&self, call_span: Span, name: &Name, at: Span) -> bool {
@@ -3217,6 +3541,36 @@ impl<'a> SafeValueIndex<'a> {
                 } => self.transformation_is_safe(reference, *operator, at, query),
             },
             ParameterExpansionSyntax::Zsh(_) => false,
+        }
+    }
+
+    fn parameter_part_s001_quote_exposure(
+        &mut self,
+        parameter: &ParameterExpansion,
+        at: Span,
+        query: SafeValueQuery,
+    ) -> S001QuoteExposure {
+        match &parameter.syntax {
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+                if !reference.has_array_selector() =>
+            {
+                self.name_s001_quote_exposure(&reference.name, at, query)
+            }
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Slice {
+                reference, ..
+            }) if !reference.has_array_selector() => {
+                self.name_s001_quote_exposure(&reference.name, at, query)
+            }
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { .. }) => {
+                S001QuoteExposure::QuoteInertNonEmpty
+            }
+            _ => {
+                if self.parameter_part_is_safe(parameter, at, query) {
+                    S001QuoteExposure::QuoteInertNonEmpty
+                } else {
+                    S001QuoteExposure::Unsafe
+                }
+            }
         }
     }
 

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -16,6 +16,8 @@ use shuck_semantic::{BindingId, BlockId, ReferenceId, ReferenceKind};
 use crate::facts::analyze_literal_runtime;
 use crate::{ExpansionContext, FactSpan, LinterFacts};
 
+type S001FunctionEventKey = Vec<usize>;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SafeValueQuery {
     Argv,
@@ -1198,66 +1200,77 @@ impl<'a> SafeValueIndex<'a> {
         &self,
         scope: ScopeId,
         after_offset: usize,
-    ) -> Option<usize> {
-        self.s001_first_function_call_event_after_inner(
+    ) -> Option<S001FunctionEventKey> {
+        self.s001_function_call_event_keys_after_inner(
             scope,
             after_offset,
             &mut FxHashSet::default(),
         )
+        .into_iter()
+        .min()
     }
 
-    fn s001_first_function_call_event_after_inner(
+    fn s001_function_call_event_keys_after_inner(
         &self,
         scope: ScopeId,
         after_offset: usize,
         seen_scopes: &mut FxHashSet<ScopeId>,
-    ) -> Option<usize> {
+    ) -> Vec<S001FunctionEventKey> {
         if !seen_scopes.insert(scope) {
-            return None;
+            return Vec::new();
         }
 
-        let definition_command = self.function_definition_command_for_scope(scope)?;
-        let function_kind = self.named_function_kind(scope)?;
-        let mut first_offset: Option<usize> = None;
-        for function_name in function_kind.static_names() {
-            for site in self.semantic.call_sites_for(function_name) {
-                if site.scope == scope {
-                    continue;
-                }
-                let call_span = self
-                    .command_for_name_word_span(site.span)
-                    .map_or(site.span, |command| command.span_in_source(self.source));
-                if !self.definition_command_resolves_at_call(definition_command.id(), call_span) {
-                    continue;
-                }
-                let event_offset = match self.enclosing_function_scope_at(call_span.start.offset) {
-                    Some(caller_scope) => self.s001_first_function_call_event_after_inner(
-                        caller_scope,
-                        after_offset,
-                        seen_scopes,
-                    ),
-                    None => {
-                        (call_span.start.offset > after_offset).then_some(call_span.start.offset)
+        let result = (|| {
+            let definition_command = self.function_definition_command_for_scope(scope)?;
+            let function_kind = self.named_function_kind(scope)?;
+            let mut event_keys = Vec::new();
+            for function_name in function_kind.static_names() {
+                for site in self.semantic.call_sites_for(function_name) {
+                    if site.scope == scope {
+                        continue;
                     }
-                };
-                if let Some(event_offset) = event_offset {
-                    first_offset = Some(
-                        first_offset.map_or(event_offset, |current| current.min(event_offset)),
-                    );
+                    let call_span = self
+                        .command_for_name_word_span(site.span)
+                        .map_or(site.span, |command| command.span_in_source(self.source));
+                    if !self.definition_command_resolves_at_call(definition_command.id(), call_span)
+                    {
+                        continue;
+                    }
+                    match self.enclosing_function_scope_at(call_span.start.offset) {
+                        Some(caller_scope) => {
+                            for mut event_key in self.s001_function_call_event_keys_after_inner(
+                                caller_scope,
+                                after_offset,
+                                seen_scopes,
+                            ) {
+                                event_key.push(call_span.start.offset);
+                                event_keys.push(event_key);
+                            }
+                        }
+                        None => {
+                            if call_span.start.offset > after_offset {
+                                event_keys.push(vec![call_span.start.offset]);
+                            }
+                        }
+                    }
                 }
             }
-        }
 
-        first_offset
+            Some(event_keys)
+        })()
+        .unwrap_or_default();
+
+        seen_scopes.remove(&scope);
+        result
     }
 
     fn s001_first_function_unset_event_after(
         &self,
         target_scope: ScopeId,
         after_offset: usize,
-    ) -> Option<usize> {
+    ) -> Option<S001FunctionEventKey> {
         let target_function = self.named_function_kind(target_scope)?;
-        let mut first_offset: Option<usize> = None;
+        let mut first_key: Option<S001FunctionEventKey> = None;
 
         for command in self.facts.structural_commands() {
             if !command.options().unset().is_some_and(|unset| {
@@ -1276,26 +1289,31 @@ impl<'a> SafeValueIndex<'a> {
             }
 
             let command_span = command.span_in_source(self.source);
-            let event_offset = match self.enclosing_function_scope_at(command_span.start.offset) {
+            let event_key = match self.enclosing_function_scope_at(command_span.start.offset) {
                 Some(unsetter_scope) => {
                     if unsetter_scope == target_scope {
                         None
                     } else {
                         self.s001_first_function_call_event_after(unsetter_scope, after_offset)
+                            .map(|mut event_key| {
+                                event_key.push(command_span.start.offset);
+                                event_key
+                            })
                     }
                 }
-                None => {
-                    (command_span.start.offset > after_offset).then_some(command_span.start.offset)
-                }
+                None => (command_span.start.offset > after_offset)
+                    .then(|| vec![command_span.start.offset]),
             };
 
-            if let Some(event_offset) = event_offset {
-                first_offset =
-                    Some(first_offset.map_or(event_offset, |current| current.min(event_offset)));
+            if let Some(event_key) = event_key {
+                first_key = Some(match first_key {
+                    Some(current) => current.min(event_key),
+                    None => event_key,
+                });
             }
         }
 
-        first_offset
+        first_key
     }
 
     fn command_has_dominance_barrier_ancestor(&self, command_id: crate::facts::CommandId) -> bool {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -521,7 +521,7 @@ impl<'a> SafeValueIndex<'a> {
             && self.bindings_cover_all_paths_to_reference(&direct_bindings, name, at);
         if direct_bindings_cover_all_paths
             && self.enclosing_function_scope_at(at.start.offset).is_some()
-            && self.span_is_inside_command_substitution_scope(at)
+            && !self.span_is_exit_or_return_argument(at)
             && self.covering_direct_field_safe_bindings_can_stay_safe(&direct_bindings, query)
         {
             return true;
@@ -711,6 +711,38 @@ impl<'a> SafeValueIndex<'a> {
                     .body_name_word()
                     .is_some_and(word_is_standalone_variable_like)
         })
+    }
+
+    fn span_is_exit_or_return_argument(&self, at: Span) -> bool {
+        self.facts
+            .innermost_command_id_at(at.start.offset)
+            .or_else(|| self.innermost_command_id_containing_offset(at.start.offset))
+            .is_some_and(|command_id| {
+                let command = self.facts.command(command_id);
+                match command.command() {
+                    Command::Builtin(BuiltinCommand::Exit(command)) => {
+                        command
+                            .code
+                            .as_ref()
+                            .is_some_and(|word| span_contains(word.span, at))
+                            || command
+                                .extra_args
+                                .iter()
+                                .any(|word| span_contains(word.span, at))
+                    }
+                    Command::Builtin(BuiltinCommand::Return(command)) => {
+                        command
+                            .code
+                            .as_ref()
+                            .is_some_and(|word| span_contains(word.span, at))
+                            || command
+                                .extra_args
+                                .iter()
+                                .any(|word| span_contains(word.span, at))
+                    }
+                    _ => false,
+                }
+            })
     }
 
     fn span_is_within_command_name(&self, at: Span) -> bool {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -4302,10 +4302,10 @@ fn source_text_literal_value(text: &str) -> Option<SourceTextLiteral<'_>> {
 }
 
 fn source_text_plain_scalar_name(text: &str) -> Option<Name> {
-    if let Some(name) = text.strip_prefix('$') {
-        if shell_name_is_plain_scalar(name) {
-            return Some(Name::new(name));
-        }
+    if let Some(name) = text.strip_prefix('$')
+        && shell_name_is_plain_scalar(name)
+    {
+        return Some(Name::new(name));
     }
 
     let inner = text

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
     BinaryOp, BourneParameterExpansion, BuiltinCommand, Command, CompoundCommand, FunctionDef,
@@ -103,6 +105,8 @@ pub struct SafeValueIndex<'a> {
     reference_ids_by_name_span: FxHashMap<(Name, FactSpan), ReferenceId>,
     block_by_reference: FxHashMap<ReferenceId, BlockId>,
     block_by_binding: FxHashMap<BindingId, BlockId>,
+    unreachable_blocks: FxHashSet<BlockId>,
+    command_cover_memo: RefCell<FxHashMap<(crate::facts::CommandId, Name, FactSpan), bool>>,
     memo: FxHashMap<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>), bool>,
     visiting: FxHashSet<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>)>,
     binding_value_stack: Vec<BindingId>,
@@ -168,6 +172,7 @@ impl<'a> SafeValueIndex<'a> {
                 block_by_binding.insert(*binding_id, block.id);
             }
         }
+        let unreachable_blocks = analysis.cfg().unreachable().iter().copied().collect();
 
         Self {
             semantic,
@@ -182,6 +187,8 @@ impl<'a> SafeValueIndex<'a> {
             reference_ids_by_name_span,
             block_by_reference,
             block_by_binding,
+            unreachable_blocks,
+            command_cover_memo: RefCell::new(FxHashMap::default()),
             memo: FxHashMap::default(),
             visiting: FxHashSet::default(),
             binding_value_stack: Vec::new(),
@@ -2143,6 +2150,22 @@ impl<'a> SafeValueIndex<'a> {
         name: &Name,
         at: Span,
     ) -> bool {
+        let key = (command.id(), name.clone(), FactSpan::new(at));
+        if let Some(result) = self.command_cover_memo.borrow().get(&key) {
+            return *result;
+        }
+
+        let result = self.command_blocks_cover_all_paths_to_reference_uncached(command, name, at);
+        self.command_cover_memo.borrow_mut().insert(key, result);
+        result
+    }
+
+    fn command_blocks_cover_all_paths_to_reference_uncached(
+        &self,
+        command: crate::facts::CommandFactRef<'_, 'a>,
+        name: &Name,
+        at: Span,
+    ) -> bool {
         if self.enclosing_function_scope_at(command.span().start.offset)
             != self.enclosing_function_scope_at(at.start.offset)
         {
@@ -2159,12 +2182,7 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         };
 
-        let cover_blocks = self
-            .analysis
-            .block_ids_for_span(command.span())
-            .iter()
-            .copied()
-            .collect::<FxHashSet<_>>();
+        let cover_blocks = self.analysis.block_ids_for_span(command.span());
         if cover_blocks.is_empty() {
             return false;
         }
@@ -2173,7 +2191,6 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         let cfg = self.analysis.cfg();
-        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
         let entry = self
             .enclosing_function_scope_at(at.start.offset)
             .and_then(|scope| cfg.scope_entry(scope))
@@ -2182,7 +2199,7 @@ impl<'a> SafeValueIndex<'a> {
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
             if cover_blocks.contains(&block_id)
-                || unreachable.contains(&block_id)
+                || self.unreachable_blocks.contains(&block_id)
                 || !seen.insert(block_id)
             {
                 continue;
@@ -2708,8 +2725,7 @@ impl<'a> SafeValueIndex<'a> {
             return Vec::new();
         };
 
-        let cfg = self.analysis.cfg();
-        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let unreachable = &self.unreachable_blocks;
         let candidates = self
             .semantic
             .bindings_for(name)
@@ -2737,7 +2753,7 @@ impl<'a> SafeValueIndex<'a> {
                     *binding_block,
                     reference_block,
                     &candidates,
-                    &unreachable,
+                    unreachable,
                 )
             })
             .map(|(binding_id, _)| binding_id)
@@ -2817,11 +2833,10 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         let cfg = self.analysis.cfg();
-        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
         let mut stack = vec![binding_block];
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
-            if unreachable.contains(&block_id) || !seen.insert(block_id) {
+            if self.unreachable_blocks.contains(&block_id) || !seen.insert(block_id) {
                 continue;
             }
             for (successor, _) in cfg.successors(block_id) {
@@ -3499,7 +3514,6 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         let cfg = self.analysis.cfg();
-        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
         let mut stack = vec![self.flow_entry_block_for_binding_scopes(
             &[self.semantic.binding(binding_id).scope],
             at.start.offset,
@@ -3507,7 +3521,7 @@ impl<'a> SafeValueIndex<'a> {
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
             if block_id == binding_block
-                || unreachable.contains(&block_id)
+                || self.unreachable_blocks.contains(&block_id)
                 || !seen.insert(block_id)
             {
                 continue;
@@ -3579,7 +3593,6 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         let cfg = self.analysis.cfg();
-        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
         let binding_scopes = bindings
             .iter()
             .copied()
@@ -3590,7 +3603,7 @@ impl<'a> SafeValueIndex<'a> {
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
             if cover_blocks.contains(&block_id)
-                || unreachable.contains(&block_id)
+                || self.unreachable_blocks.contains(&block_id)
                 || !seen.insert(block_id)
             {
                 continue;
@@ -3682,7 +3695,6 @@ impl<'a> SafeValueIndex<'a> {
             return true;
         }
 
-        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
         let binding_scopes = bindings
             .iter()
             .copied()
@@ -3693,7 +3705,7 @@ impl<'a> SafeValueIndex<'a> {
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
             if cover_blocks.contains(&block_id)
-                || unreachable.contains(&block_id)
+                || self.unreachable_blocks.contains(&block_id)
                 || !seen.insert(block_id)
             {
                 continue;

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -483,6 +483,9 @@ impl<'a> SafeValueIndex<'a> {
         if self.covering_optional_field_safe_bindings_can_stay_safe(&bindings, name, at, query) {
             return true;
         }
+        if self.local_conditional_literal_bindings_can_stay_safe(&bindings, name, at, query) {
+            return true;
+        }
         if self.optional_field_safe_bindings_can_stay_safe(&bindings, query) {
             return true;
         }
@@ -1007,6 +1010,60 @@ impl<'a> SafeValueIndex<'a> {
         }
 
         saw_empty && saw_non_empty
+    }
+
+    fn local_conditional_literal_bindings_can_stay_safe(
+        &self,
+        bindings: &[BindingId],
+        name: &Name,
+        at: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        if !query.is_field_context() || bindings.is_empty() {
+            return false;
+        }
+        let Some(function_scope) = self.enclosing_function_scope_at(at.start.offset) else {
+            return false;
+        };
+
+        let mut saw_conditional_literal = false;
+        let mut first_binding_start = at.start.offset;
+        for binding_id in bindings.iter().copied() {
+            let binding = self.semantic.binding(binding_id);
+            if binding.span.end.offset > at.start.offset
+                || !self.binding_is_in_scope_or_descendant(binding_id, function_scope)
+            {
+                return false;
+            }
+            first_binding_start = first_binding_start.min(binding.span.start.offset);
+
+            let Some(value) = self.facts.binding_value(binding_id) else {
+                return false;
+            };
+            if !value.conditional_assignment_shortcut() {
+                return false;
+            }
+            let Some(text) = value
+                .scalar_word()
+                .and_then(|word| static_word_text(word, self.source))
+            else {
+                return false;
+            };
+            if text.is_empty() || !query.literal_is_safe(&text) {
+                return false;
+            }
+            saw_conditional_literal = true;
+        }
+
+        saw_conditional_literal
+            && self.semantic.bindings_for(name).iter().copied().any(|binding_id| {
+                let binding = self.semantic.binding(binding_id);
+                binding.span.end.offset <= first_binding_start
+                    && self.semantic.binding_visible_at(binding_id, at)
+                    && self.binding_is_in_scope_or_descendant(binding_id, function_scope)
+                    && self.binding_is_name_only_declaration(binding_id)
+                    && binding.attributes.contains(BindingAttributes::LOCAL)
+            })
     }
 
     fn field_safe_binding_group_class(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -1497,9 +1497,7 @@ impl<'a> SafeValueIndex<'a> {
     ) -> bool {
         let binding = self.semantic.binding(binding_id);
         let binding_key = FactSpan::new(binding.span);
-        if binding.attributes.contains(BindingAttributes::INTEGER)
-            || matches!(binding.kind, BindingKind::ArithmeticAssignment)
-        {
+        if self.binding_has_effective_integer_attribute(binding_id) {
             return true;
         }
         if matches!(
@@ -1598,6 +1596,33 @@ impl<'a> SafeValueIndex<'a> {
         self.visiting.remove(&key);
         self.memo.insert(key, result);
         result
+    }
+
+    fn binding_has_effective_integer_attribute(&self, binding_id: BindingId) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        if binding.attributes.contains(BindingAttributes::INTEGER)
+            || matches!(binding.kind, BindingKind::ArithmeticAssignment)
+        {
+            return true;
+        }
+        if !matches!(
+            binding.kind,
+            BindingKind::Assignment
+                | BindingKind::AppendAssignment
+                | BindingKind::Declaration(_)
+                | BindingKind::ParameterDefaultAssignment
+        ) {
+            return false;
+        }
+
+        self.semantic
+            .previous_visible_binding(&binding.name, binding.span, Some(binding.span))
+            .is_some_and(|previous| {
+                previous.attributes.contains(BindingAttributes::INTEGER)
+                    && !self
+                        .semantic
+                        .binding_cleared_before(previous.id, binding.span)
+            })
     }
 
     fn conditional_assignment_shortcut_value_can_stay_safe(

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -4033,10 +4033,20 @@ impl<'a> SafeValueIndex<'a> {
             })
             .collect::<Vec<_>>();
 
-        !bindings.is_empty()
-            && bindings
-                .into_iter()
+        if bindings.is_empty()
+            || !bindings
+                .iter()
+                .copied()
                 .all(|binding_id| self.binding_assigns_numeric_operand_value(binding_id, at))
+        {
+            return false;
+        }
+
+        let call_sites = self.named_function_call_sites(function_scope);
+        call_sites.is_empty()
+            || call_sites.into_iter().all(|(_, call_span)| {
+                self.bindings_cover_all_paths_to_callsite(&bindings, call_span)
+            })
     }
 
     fn s001_name_has_only_numeric_value_bindings(&mut self, name: &Name, at: Span) -> bool {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -381,6 +381,21 @@ impl<'a> SafeValueIndex<'a> {
         query.is_field_context() && self.s001_reference_function_unset_before_first_call(span)
     }
 
+    pub fn part_has_s001_standalone_numeric_argv_exposure(
+        &mut self,
+        part: &WordPart,
+        span: Span,
+    ) -> bool {
+        if self.span_is_exit_or_return_argument(span) {
+            return false;
+        }
+        let Some(name) = plain_scalar_reference_name_from_part(part) else {
+            return false;
+        };
+
+        self.s001_name_has_only_numeric_value_bindings(&name, span)
+    }
+
     pub fn part_is_safe_initializer_command_substitution_self_reference(
         &mut self,
         part: &WordPart,
@@ -4006,6 +4021,77 @@ impl<'a> SafeValueIndex<'a> {
                 .all(|binding_id| self.binding_assigns_numeric_operand_value(binding_id, at))
     }
 
+    fn s001_name_has_only_numeric_value_bindings(&mut self, name: &Name, at: Span) -> bool {
+        let mut bindings = self.safe_bindings_for_name(name, at);
+        self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        self.drop_outer_bindings_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        self.retain_value_bindings(&mut bindings);
+        let mut transitive_helper_bindings = Vec::new();
+        let mut seen_scopes = FxHashSet::default();
+        self.collect_transitive_helper_bindings_before(
+            name,
+            self.semantic.scope_at(at.start.offset),
+            at.start.offset,
+            &mut seen_scopes,
+            &mut transitive_helper_bindings,
+        );
+        self.retain_value_bindings(&mut transitive_helper_bindings);
+        bindings.extend(transitive_helper_bindings.iter().copied());
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.dedup();
+        if bindings.is_empty() {
+            return false;
+        }
+        if bindings.iter().copied().any(|binding_id| {
+            self.binding_is_one_sided_short_circuit_assignment(binding_id)
+                || self.facts.binding_value(binding_id).is_some_and(|value| {
+                    value.conditional_assignment_shortcut()
+                        || value.scalar_word().is_some_and(|word| {
+                            static_word_text(word, self.source).is_some_and(|text| text.is_empty())
+                        })
+                })
+        }) {
+            return false;
+        }
+
+        let mut helper_bindings = self.called_helper_bindings_for_name(name, at);
+        self.retain_value_bindings(&mut helper_bindings);
+        let has_dominating_helper_binding = helper_bindings
+            .iter()
+            .chain(transitive_helper_bindings.iter())
+            .any(|binding_id| bindings.contains(binding_id));
+        let has_covering_binding = has_dominating_helper_binding
+            || self.bindings_cover_all_paths_to_reference(&bindings, name, at)
+            || bindings.iter().copied().any(|binding_id| {
+                let binding = self.semantic.binding(binding_id);
+                binding.span.end.offset <= at.start.offset
+                    && self.binding_dominates_reference(binding_id, name, at)
+            });
+        has_covering_binding
+            && bindings.into_iter().all(|binding_id| {
+                self.binding_assigns_s001_standalone_numeric_argv_value(binding_id)
+            })
+    }
+
+    fn binding_assigns_s001_standalone_numeric_argv_value(&self, binding_id: BindingId) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        if self.binding_has_effective_integer_attribute(binding_id)
+            || matches!(binding.kind, BindingKind::ArithmeticAssignment)
+        {
+            return true;
+        }
+
+        let Some(word) = self
+            .facts
+            .binding_value(binding_id)
+            .and_then(|value| value.scalar_word())
+        else {
+            return false;
+        };
+
+        word_static_text_is_shell_integer(word, self.source) || word_is_arithmetic_expansion(word)
+    }
+
     fn enclosing_while_body_for_condition_span(&self, at: Span) -> Option<Span> {
         self.facts
             .commands()
@@ -4345,6 +4431,13 @@ fn shell_integer_text_is_safe(text: &str) -> bool {
 
 fn word_has_arithmetic_expansion(word: &Word) -> bool {
     parts_have_arithmetic_expansion(&word.parts)
+}
+
+fn word_is_arithmetic_expansion(word: &Word) -> bool {
+    matches!(
+        word.parts.as_slice(),
+        [part] if matches!(part.kind, WordPart::ArithmeticExpansion { .. })
+    )
 }
 
 fn parts_have_arithmetic_expansion(parts: &[WordPartNode]) -> bool {

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3029,6 +3029,35 @@ scan() {
     }
 
     #[test]
+    fn skips_file_scope_integer_bindings_in_indirectly_called_numeric_tests() {
+        let source = "\
+#!/usr/bin/env bash
+scan() { regular_grep \"$@\"; }
+regular_grep() {
+  [ ${RECURSIVE} -eq 1 ] && action=recurse
+}
+run_named() {
+  local scan_fn=\"$1\"
+  shift
+  $scan_fn \"$@\"
+}
+declare COMMAND=\"$1\" RECURSIVE=0
+while [ \"$#\" -gt 0 ]; do
+  case \"$1\" in
+    -r) RECURSIVE=1 ;;
+  esac
+  shift
+done
+case \"$COMMAND\" in
+  --scan) run_named scan \"$@\" ;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_numeric_defaults_without_loop_carried_updates() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2761,6 +2761,19 @@ cleanup() {
     }
 
     #[test]
+    fn skips_pid_capture_bindings() {
+        let source = "\
+#!/bin/bash
+long_running_task &
+tarpid=$!
+counter=$(ps -A | grep $tarpid | wc -l)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_status_capture_after_escaped_name_only_declarations() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3102,6 +3102,42 @@ esac
     }
 
     #[test]
+    fn reports_file_scope_integer_bindings_after_function_calls() {
+        let source = "\
+#!/bin/bash
+check_count() {
+  [ $count -eq 0 ] && :
+}
+check_count
+count=0
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$count"]
+        );
+    }
+
+    #[test]
+    fn skips_file_scope_integer_bindings_before_function_calls() {
+        let source = "\
+#!/bin/bash
+count=0
+check_count() {
+  [ $count -eq 0 ] && :
+}
+check_count
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_counter_arguments_with_only_numeric_assignments() {
         let source = "\
 #!/usr/bin/env bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2263,6 +2263,23 @@ json=\"$(echo \\\"${items[*]}\\\")\"
     }
 
     #[test]
+    fn reports_nested_substitution_arguments_after_escaped_quote_default_segments() {
+        let source = "\
+#!/bin/sh
+label=\",label=\\\"${fallback:=value}$(render value $line)\\\"\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$line"]
+        );
+    }
+
+    #[test]
     fn reports_decl_assignment_values_in_sh_mode() {
         let source = "\
 local _patch=$TERMUX_PKG_BUILDER_DIR/file.diff

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -379,6 +379,9 @@ fn report_word_expansions<F>(
             if safe_values.part_is_safe(part, part_span, SafeValueQuery::NumericTestOperand) {
                 continue;
             }
+            if safe_values.part_has_s001_arithmetic_numeric_operand_exposure(part, part_span) {
+                continue;
+            }
         } else if context == ExpansionContext::CommandArgument
             && !fact.has_literal_affixes()
             && fact.parts_len() == 1
@@ -3100,6 +3103,27 @@ dynamic_test() {
   quiet=${1:-0}
   if [ ${quiet} -eq 0 ]; then :; fi
 }
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${quiet}"]
+        );
+    }
+
+    #[test]
+    fn skips_arithmetic_numeric_test_operands_without_static_flag_broadening() {
+        let source = "\
+#!/bin/sh
+filetime=$(date +%s -r \"$file\")
+fileage=$(( unixtime - filetime ))
+[ $fileage -lt 86400 ] && :
+quiet=${1:-0}
+[ ${quiet} -eq 0 ] && :
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2280,6 +2280,33 @@ label=\",label=\\\"${fallback:=value}$(render value $line)\\\"\"
     }
 
     #[test]
+    fn anchors_nested_substitution_arguments_to_physical_lines_after_escaped_continuations() {
+        let source = "\
+#!/bin/bash
+echo \"script
+  LEFT=\"$left\":\\$base \\
+    CHILD=\\$base/$(basename $child) \\
+    PATH=$path
+    run\" > out
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (
+                    diagnostic.span.start.line,
+                    diagnostic.span.start.column,
+                    diagnostic.span.end.line,
+                    diagnostic.span.end.column,
+                    diagnostic.span.slice(source),
+                ))
+                .collect::<Vec<_>>(),
+            vec![(3, 9, 3, 14, "$left"), (4, 29, 4, 35, "$child")]
+        );
+    }
+
+    #[test]
     fn reports_decl_assignment_values_in_sh_mode() {
         let source = "\
 local _patch=$TERMUX_PKG_BUILDER_DIR/file.diff

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2566,6 +2566,52 @@ cleanup
     }
 
     #[test]
+    fn reports_function_body_values_when_indirect_unset_precedes_indirect_call() {
+        let source = "\
+#!/bin/sh
+cleanup() { unset -f fetch; }
+version=v1
+URL=\"https://example.invalid/$version\"
+fetch() { echo $URL; }
+wrapper() { fetch; }
+runner() {
+  cleanup
+  wrapper
+}
+runner
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$URL"]
+        );
+    }
+
+    #[test]
+    fn keeps_function_body_values_safe_when_indirect_call_precedes_indirect_unset() {
+        let source = "\
+#!/bin/sh
+cleanup() { unset -f fetch; }
+version=v1
+URL=\"https://example.invalid/$version\"
+fetch() { echo $URL; }
+wrapper() { fetch; }
+runner() {
+  wrapper
+  cleanup
+}
+runner
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_append_assignments_without_safe_prior_values() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2966,6 +2966,41 @@ cleanup() {
     }
 
     #[test]
+    fn skips_escaped_declaration_literal_return_operands() {
+        let source = "\
+#!/bin/bash
+cleanup() {
+  \\typeset __result=0
+  run_task \"$@\" || __result=$?
+  return ${__result}
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_escaped_declaration_dynamic_return_operands() {
+        let source = "\
+#!/bin/bash
+cleanup() {
+  \\typeset __result=$1
+  return ${__result}
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${__result}"]
+        );
+    }
+
+    #[test]
     fn skips_pid_capture_bindings() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2629,6 +2629,59 @@ send_request \"$1\"
     }
 
     #[test]
+    fn skips_local_literal_command_arguments_when_helper_reuses_name() {
+        let source = "\
+#!/bin/bash
+config() {
+  NEW=\"$1\"
+  OLD=\"$(dirname $NEW)/$(basename $NEW .new)\"
+}
+config_blacklist() {
+  NEW=etc/app/blacklist
+  OLD=etc/app/package_blacklist
+  cp $OLD $NEW
+}
+config \"$1\"
+config_blacklist
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$NEW", "$NEW"]
+        );
+    }
+
+    #[test]
+    fn reports_dynamic_command_arguments_when_helper_reuses_name() {
+        let source = "\
+#!/bin/bash
+config() {
+  NEW=etc/app/default
+}
+config_blacklist() {
+  NEW=\"$1\"
+  OLD=etc/app/package_blacklist
+  cp $OLD $NEW
+}
+config
+config_blacklist \"$1\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$NEW"]
+        );
+    }
+
+    #[test]
     fn skips_safe_numeric_shell_variables() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3652,6 +3652,21 @@ if [ $foo -eq 1 ]; then :; fi
     }
 
     #[test]
+    fn skips_status_capture_numeric_test_operands() {
+        let source = "\
+#!/bin/bash
+f() {
+  local status
+  run_task && status=0 || status=$?
+  if [ $status -eq 0 ]; then :; fi
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_conditionally_initialized_bindings_with_unknown_fallbacks() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -1836,6 +1836,26 @@ main
     }
 
     #[test]
+    fn reports_static_setup_references_without_path_coverage() {
+        let source = "\
+#!/bin/bash
+if [ \"$scope\" = global ]; then
+  WAFSCOPE=CLOUDFRONT
+fi
+result=$(aws waf get --scope $WAFSCOPE)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$WAFSCOPE"]
+        );
+    }
+
+    #[test]
     fn reports_dynamic_values_inside_parameter_replacement_command_substitutions() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2902,6 +2902,65 @@ printf '%s\\n' $COLUMNS
     }
 
     #[test]
+    fn skips_loop_carried_numeric_default_operands() {
+        let source = "\
+#!/bin/sh
+encode() {
+  local text=\"$1\"
+  local pos char
+  while [ ${pos:-0} -lt ${#text} ]; do
+    pos=$(( pos + 1 ))
+    char=$(printf '%s' \"$text\" | cut -b $pos)
+    printf '%s' \"$char\"
+  done
+}
+scan() {
+  local count=0 overall file_list
+  file_list=$(printf '%s\\n' item)
+  while [ -n \"$file_list\" -a $count -le ${overall:-$count} ]; do
+    for item in $file_list; do count=$(( count + 1 )); done
+    overall=$count
+  done
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_numeric_defaults_without_loop_carried_updates() {
+        let source = "\
+#!/bin/sh
+plain() {
+  local pos
+  [ ${pos:-0} -lt 3 ] && :
+}
+dynamic_update() {
+  local pos
+  while [ ${pos:-0} -lt 3 ]; do
+    pos=$1
+  done
+}
+dynamic_default() {
+  local pos fallback
+  while [ ${pos:-$fallback} -lt 3 ]; do
+    pos=$(( pos + 1 ))
+  done
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${pos:-0}", "${pos:-0}", "${pos:-$fallback}"]
+        );
+    }
+
+    #[test]
     fn reports_unknown_values_in_uncalled_function_bodies() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2,8 +2,8 @@ use rustc_hash::FxHashSet;
 use shuck_ast::Span;
 
 use crate::{
-    Checker, ExpansionContext, FactSpan, Rule, SafeValueIndex, SafeValueQuery, ShellDialect,
-    Violation, WordOccurrenceRef,
+    Checker, ExpansionContext, FactSpan, Rule, S001QuoteExposure, SafeValueIndex, SafeValueQuery,
+    ShellDialect, Violation, WordOccurrenceRef,
 };
 
 pub struct UnquotedExpansion;
@@ -319,7 +319,6 @@ fn report_word_expansions<F>(
     let Some(query) = SafeValueQuery::from_context(context) else {
         return;
     };
-
     for (part, part_span) in fact.parts_with_spans() {
         let report_unquoted_star = star_spans.contains(&part_span);
         if !scalar_spans.contains(&part_span) && !report_unquoted_star {
@@ -345,6 +344,10 @@ fn report_word_expansions<F>(
         if part_is_in_numeric_test_operand(part_span, numeric_test_operand_spans)
             && safe_values.part_is_safe(part, part_span, SafeValueQuery::NumericTestOperand)
         {
+            continue;
+        }
+        let exposure = safe_values.part_s001_quote_exposure(part, part_span, query);
+        if matches!(exposure, S001QuoteExposure::QuoteInertNonEmpty) {
             continue;
         }
         if safe_values.part_is_safe(part, part_span, query) {
@@ -2678,6 +2681,89 @@ config_blacklist \"$1\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$NEW"]
+        );
+    }
+
+    #[test]
+    fn skips_transitive_helper_composite_quote_inert_values() {
+        let source = "\
+#!/bin/bash
+exit_script() { exit 1; }
+default_settings() {
+  FORMAT=\",efitype=4m\"
+  DISK_CACHE=\"\"
+}
+advanced_settings() {
+  if MACH=$(choose); then
+    if [ \"$MACH\" = q35 ]; then
+      FORMAT=\"\"
+    else
+      FORMAT=\",efitype=4m\"
+    fi
+  else
+    exit_script
+  fi
+  if DISK_CACHE=$(choose); then
+    if [ \"$DISK_CACHE\" = \"1\" ]; then
+      DISK_CACHE=\"cache=writethrough,\"
+    else
+      DISK_CACHE=\"\"
+    fi
+  else
+    exit_script
+  fi
+}
+start_script() {
+  if choose; then
+    default_settings
+  else
+    advanced_settings
+  fi
+}
+start_script
+VMID=100
+STORAGE=local
+THIN=\"discard=on,ssd=1,\"
+DISK0_REF=${STORAGE}:vm-${VMID}-disk-0
+DISK1_REF=${STORAGE}:vm-${VMID}-disk-1
+qm set $VMID \\
+  -efidisk0 ${DISK0_REF}${FORMAT} \\
+  -scsi0 ${DISK1_REF},${DISK_CACHE}${THIN}size=12G
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_transitive_helper_dynamic_composite_values() {
+        let source = "\
+#!/bin/bash
+default_settings() {
+  DISK_CACHE=$1
+}
+advanced_settings() {
+  DISK_CACHE=\"cache=writethrough,\"
+}
+start_script() {
+  if choose; then
+    default_settings \"$1\"
+  else
+    advanced_settings
+  fi
+}
+start_script \"$1\"
+DISK1_REF=local:vm-100-disk-1
+qm set 100 -scsi0 ${DISK1_REF},${DISK_CACHE}size=12G
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${DISK_CACHE}"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3667,6 +3667,26 @@ f() {
     }
 
     #[test]
+    fn skips_declared_integer_default_numeric_test_operands() {
+        let source = "\
+#!/bin/bash
+declare -i expected_status
+expected_status=${expected_status:-0}
+actual_status=$1
+if [ ${actual_status} -ne ${expected_status} ]; then :; fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${actual_status}"]
+        );
+    }
+
+    #[test]
     fn reports_conditionally_initialized_bindings_with_unknown_fallbacks() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3103,6 +3103,11 @@ dynamic_test() {
   quiet=${1:-0}
   if [ ${quiet} -eq 0 ]; then :; fi
 }
+static_status() {
+  ret=0
+  command && ret=1 || ret=0
+  tend ${ret}
+}
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2724,6 +2724,11 @@ start_script
 VMID=100
 STORAGE=local
 THIN=\"discard=on,ssd=1,\"
+case \"$STORAGE\" in
+  btrfs)
+    FORMAT=\",efitype=4m\"
+    ;;
+esac
 DISK0_REF=${STORAGE}:vm-${VMID}-disk-0
 DISK1_REF=${STORAGE}:vm-${VMID}-disk-1
 qm set $VMID \\
@@ -2764,6 +2769,30 @@ qm set 100 -scsi0 ${DISK1_REF},${DISK_CACHE}size=12G
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${DISK_CACHE}"]
+        );
+    }
+
+    #[test]
+    fn reports_top_level_branch_literal_without_dispatch_fallback() {
+        let source = "\
+#!/bin/bash
+STORAGE=local
+case \"$STORAGE\" in
+  btrfs)
+    FORMAT=\",efitype=4m\"
+    ;;
+esac
+DISK0_REF=${STORAGE}:vm-100-disk-0
+qm set 100 -efidisk0 ${DISK0_REF}${FORMAT}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${FORMAT}"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -368,6 +368,11 @@ fn report_word_expansions<F>(
         {
             continue;
         }
+        if safe_values.part_is_safe_initializer_command_substitution_static_setup_reference(
+            part, part_span, query,
+        ) {
+            continue;
+        }
         if part_is_in_numeric_test_operand(part_span, numeric_test_operand_spans)
             && safe_values.part_is_safe(part, part_span, SafeValueQuery::NumericTestOperand)
         {
@@ -1764,6 +1769,43 @@ value=$(echo $value | sed 's/^ //')
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$value"]
+        );
+    }
+
+    #[test]
+    fn skips_static_setup_references_inside_command_substitution_initializers() {
+        let source = "\
+#!/bin/bash
+scope_menu() {
+  case $scope in
+    global) WAFSCOPE=CLOUDFRONT ;;
+    regional) WAFSCOPE=REGIONAL ;;
+    *) exit 1 ;;
+  esac
+}
+get_set() {
+  result=$(aws waf get --scope $WAFSCOPE --profile $profile 2>&1)
+}
+update_set() {
+  get_set
+}
+unused_export() {
+  get_set
+}
+main() {
+  update_set
+}
+scope_menu
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$profile"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2746,6 +2746,42 @@ request() {
     }
 
     #[test]
+    fn skips_local_conditional_literal_option_letters() {
+        let source = "\
+#!/bin/bash
+read_char() {
+  local read_flag anykey
+  [[ -n ${ZSH_VERSION:-} ]] && read_flag=k || read_flag=n
+  builtin read -${read_flag} 1 -s -r anykey
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_local_conditional_dynamic_option_letters() {
+        let source = "\
+#!/bin/bash
+read_char() {
+  local read_flag anykey
+  [[ -n ${ZSH_VERSION:-} ]] && read_flag=$1 || read_flag=n
+  builtin read -${read_flag} 1 -s -r anykey
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${read_flag}"]
+        );
+    }
+
+    #[test]
     fn skips_status_capture_declarations_with_initializers() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -36,19 +36,20 @@ pub fn unquoted_expansion(checker: &mut Checker) {
     let array_assignment_split_spans = collect_array_assignment_split_candidate_spans(checker);
     let numeric_test_operand_spans = collect_numeric_test_operand_spans(checker, source);
     let plain_run_first_arg_spans = collect_plain_run_first_arg_spans(checker);
+    let backtick_escaped_parameter_spans =
+        checker.facts().backtick_escaped_parameter_reference_spans();
 
     let mut spans = Vec::new();
+    let report_context = ReportContext {
+        source,
+        shell: checker.shell(),
+        colon_command_ids: &colon_command_ids,
+        numeric_test_operand_spans: &numeric_test_operand_spans,
+        plain_run_first_arg_spans: &plain_run_first_arg_spans,
+        backtick_escaped_parameter_spans,
+    };
     for fact in checker.facts().word_facts() {
-        collect_word_fact_reports(
-            checker,
-            &colon_command_ids,
-            &mut safe_values,
-            &mut spans,
-            source,
-            fact,
-            &numeric_test_operand_spans,
-            &plain_run_first_arg_spans,
-        );
+        collect_word_fact_reports(&report_context, &mut safe_values, &mut spans, fact);
         collect_array_assignment_split_reports(
             &mut safe_values,
             &mut spans,
@@ -61,11 +62,9 @@ pub fn unquoted_expansion(checker: &mut Checker) {
         checker.facts().arithmetic_command_substitution_spans();
     for fact in checker.facts().arithmetic_command_word_facts() {
         collect_arithmetic_word_fact_reports(
-            checker,
-            &colon_command_ids,
+            &report_context,
             &mut safe_values,
             &mut spans,
-            source,
             fact,
             arithmetic_command_substitution_spans,
         );
@@ -85,50 +84,54 @@ pub fn unquoted_expansion(checker: &mut Checker) {
     }
 }
 
+struct ReportContext<'a> {
+    source: &'a str,
+    shell: ShellDialect,
+    colon_command_ids: &'a FxHashSet<crate::facts::core::CommandId>,
+    numeric_test_operand_spans: &'a [Span],
+    plain_run_first_arg_spans: &'a FxHashSet<FactSpan>,
+    backtick_escaped_parameter_spans: &'a [Span],
+}
+
 fn collect_word_fact_reports(
-    checker: &Checker,
-    colon_command_ids: &FxHashSet<crate::facts::core::CommandId>,
+    context: &ReportContext<'_>,
     safe_values: &mut SafeValueIndex<'_>,
     spans: &mut Vec<shuck_ast::Span>,
-    source: &str,
     fact: WordOccurrenceRef<'_, '_>,
-    numeric_test_operand_spans: &[Span],
-    plain_run_first_arg_spans: &FxHashSet<FactSpan>,
 ) {
-    let Some(context) = fact.host_expansion_context() else {
+    let Some(expansion_context) = fact.host_expansion_context() else {
         return;
     };
-    if !should_check_context(context, checker.shell()) {
+    if !should_check_context(expansion_context, context.shell) {
         return;
     }
     report_word_expansions(
         spans,
         safe_values,
-        source,
+        context.source,
         fact,
         WordReportOptions {
-            context,
-            in_colon_command: colon_command_ids.contains(&fact.command_id()),
-            numeric_test_operand_spans,
-            plain_run_first_arg_spans,
+            context: expansion_context,
+            in_colon_command: context.colon_command_ids.contains(&fact.command_id()),
+            numeric_test_operand_spans: context.numeric_test_operand_spans,
+            plain_run_first_arg_spans: context.plain_run_first_arg_spans,
+            backtick_escaped_parameter_spans: context.backtick_escaped_parameter_spans,
             part_filter: |_| true,
         },
     );
 }
 
 fn collect_arithmetic_word_fact_reports(
-    checker: &Checker,
-    colon_command_ids: &FxHashSet<crate::facts::core::CommandId>,
+    context: &ReportContext<'_>,
     safe_values: &mut SafeValueIndex<'_>,
     spans: &mut Vec<shuck_ast::Span>,
-    source: &str,
     fact: WordOccurrenceRef<'_, '_>,
     arithmetic_command_substitution_spans: &[Span],
 ) {
-    let Some(context) = fact.host_expansion_context() else {
+    let Some(expansion_context) = fact.host_expansion_context() else {
         return;
     };
-    if !should_check_context(context, checker.shell()) {
+    if !should_check_context(expansion_context, context.shell) {
         return;
     }
     let fact_command_substitution_spans = fact.command_substitution_spans();
@@ -136,21 +139,22 @@ fn collect_arithmetic_word_fact_reports(
     report_word_expansions(
         spans,
         safe_values,
-        source,
+        context.source,
         fact,
         WordReportOptions {
-            context,
-            in_colon_command: colon_command_ids.contains(&fact.command_id()),
+            context: expansion_context,
+            in_colon_command: context.colon_command_ids.contains(&fact.command_id()),
             numeric_test_operand_spans: &[],
             plain_run_first_arg_spans: &plain_run_first_arg_spans,
+            backtick_escaped_parameter_spans: context.backtick_escaped_parameter_spans,
             part_filter: |part_span| {
                 arithmetic_word_follows_command_substitution(
                     part_span,
-                    source,
+                    context.source,
                     fact_command_substitution_spans,
                 ) || arithmetic_word_follows_command_substitution(
                     part_span,
-                    source,
+                    context.source,
                     arithmetic_command_substitution_spans,
                 )
             },
@@ -297,6 +301,7 @@ struct WordReportOptions<'a, F> {
     in_colon_command: bool,
     numeric_test_operand_spans: &'a [Span],
     plain_run_first_arg_spans: &'a FxHashSet<FactSpan>,
+    backtick_escaped_parameter_spans: &'a [Span],
     part_filter: F,
 }
 
@@ -314,6 +319,7 @@ fn report_word_expansions<F>(
         in_colon_command,
         numeric_test_operand_spans,
         plain_run_first_arg_spans,
+        backtick_escaped_parameter_spans,
         part_filter,
     } = options;
 
@@ -361,6 +367,13 @@ fn report_word_expansions<F>(
             continue;
         }
         if fact.part_is_inside_backtick_escaped_double_quotes(part_span, source) {
+            continue;
+        }
+        if backtick_escaped_parameter_spans
+            .iter()
+            .copied()
+            .any(|span| span_contains(span, part_span))
+        {
             continue;
         }
         if safe_values
@@ -1279,7 +1292,7 @@ exit $?
         let source = "\
 #!/bin/sh
 start() {
-  local n=0
+  local n=\"$name\"
   echo $n
 }
 
@@ -1304,7 +1317,7 @@ exit $?
         let source = "\
 #!/bin/sh
 start() {
-  local n=0
+  local n=\"$name\"
   echo $n
 }
 
@@ -1329,7 +1342,7 @@ exit 0
         let source = "\
 #!/bin/sh
 foo() {
-  local n=0
+  local n=\"$name\"
   echo $n
 }
 
@@ -1358,7 +1371,7 @@ exit $?
         let source = "\
 #!/bin/sh
 foo() {
-  local n=0
+  local n=\"$name\"
   echo $n
 }
 
@@ -1406,7 +1419,7 @@ esac
         let source = "\
 #!/bin/sh
 start() {
-  local n=0
+  local n=\"$name\"
   echo $n
 }
 exit 0

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2583,6 +2583,51 @@ FILE=$(basename $URL)
     }
 
     #[test]
+    fn skips_local_literal_arguments_when_called_helper_reuses_name() {
+        let source = "\
+#!/bin/bash
+build_payload() {
+  service=$1
+  version=$2
+}
+send_request() {
+  action=$1
+  service=alpha
+  version=2024-01
+  token=$(build_payload $service $version \"$action\")
+}
+send_request \"$1\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_dynamic_arguments_when_called_helper_reuses_name() {
+        let source = "\
+#!/bin/bash
+build_payload() {
+  service=$1
+}
+send_request() {
+  service=$1
+  token=$(build_payload $service)
+}
+send_request \"$1\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$service"]
+        );
+    }
+
+    #[test]
     fn skips_safe_numeric_shell_variables() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -373,8 +373,16 @@ fn report_word_expansions<F>(
         ) {
             continue;
         }
-        if part_is_in_numeric_test_operand(part_span, numeric_test_operand_spans)
-            && safe_values.part_is_safe(part, part_span, SafeValueQuery::NumericTestOperand)
+        let in_numeric_test_operand =
+            part_is_in_numeric_test_operand(part_span, numeric_test_operand_spans);
+        if in_numeric_test_operand {
+            if safe_values.part_is_safe(part, part_span, SafeValueQuery::NumericTestOperand) {
+                continue;
+            }
+        } else if context == ExpansionContext::CommandArgument
+            && !fact.has_literal_affixes()
+            && fact.parts_len() == 1
+            && safe_values.part_has_s001_standalone_numeric_argv_exposure(part, part_span)
         {
             continue;
         }
@@ -3055,6 +3063,53 @@ esac
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_counter_arguments_with_only_numeric_assignments() {
+        let source = "\
+#!/usr/bin/env bash
+update_count_column_width() {
+  count_column_width=$((${#count} * 2 + 2))
+  update_count_column_left
+}
+update_screen_width() {
+  screen_width=\"$(tput cols)\"
+  update_count_column_left
+}
+update_count_column_left() {
+  count_column_left=$((screen_width - count_column_width))
+}
+count=0
+screen_width=80
+update_count_column_width
+begin() {
+  line_backoff_count=0
+  update_count_column_width
+  go_to_column $count_column_left
+}
+finish_test() {
+  move_up $line_backoff_count
+}
+line_backoff_count=0
+bats_tap_stream_comment() {
+  ((++line_backoff_count))
+  ((line_backoff_count += ${#1} / screen_width))
+}
+dynamic_test() {
+  quiet=${1:-0}
+  if [ ${quiet} -eq 0 ]; then :; fi
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${quiet}"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -35,6 +35,7 @@ pub fn unquoted_expansion(checker: &mut Checker) {
     );
     let array_assignment_split_spans = collect_array_assignment_split_candidate_spans(checker);
     let numeric_test_operand_spans = collect_numeric_test_operand_spans(checker, source);
+    let plain_run_first_arg_spans = collect_plain_run_first_arg_spans(checker);
 
     let mut spans = Vec::new();
     for fact in checker.facts().word_facts() {
@@ -46,6 +47,7 @@ pub fn unquoted_expansion(checker: &mut Checker) {
             source,
             fact,
             &numeric_test_operand_spans,
+            &plain_run_first_arg_spans,
         );
         collect_array_assignment_split_reports(
             &mut safe_values,
@@ -91,6 +93,7 @@ fn collect_word_fact_reports(
     source: &str,
     fact: WordOccurrenceRef<'_, '_>,
     numeric_test_operand_spans: &[Span],
+    plain_run_first_arg_spans: &FxHashSet<FactSpan>,
 ) {
     let Some(context) = fact.host_expansion_context() else {
         return;
@@ -107,6 +110,7 @@ fn collect_word_fact_reports(
             context,
             in_colon_command: colon_command_ids.contains(&fact.command_id()),
             numeric_test_operand_spans,
+            plain_run_first_arg_spans,
             part_filter: |_| true,
         },
     );
@@ -128,6 +132,7 @@ fn collect_arithmetic_word_fact_reports(
         return;
     }
     let fact_command_substitution_spans = fact.command_substitution_spans();
+    let plain_run_first_arg_spans = FxHashSet::default();
     report_word_expansions(
         spans,
         safe_values,
@@ -137,6 +142,7 @@ fn collect_arithmetic_word_fact_reports(
             context,
             in_colon_command: colon_command_ids.contains(&fact.command_id()),
             numeric_test_operand_spans: &[],
+            plain_run_first_arg_spans: &plain_run_first_arg_spans,
             part_filter: |part_span| {
                 arithmetic_word_follows_command_substitution(
                     part_span,
@@ -168,6 +174,20 @@ fn collect_numeric_test_operand_spans(checker: &Checker, source: &str) -> Vec<Sp
     spans.sort_by_key(|span| (span.start.offset, span.end.offset));
     spans.dedup_by_key(|span| FactSpan::new(*span));
     spans
+}
+
+fn collect_plain_run_first_arg_spans(checker: &Checker) -> FxHashSet<FactSpan> {
+    checker
+        .facts()
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("run") && fact.wrappers().is_empty())
+        .filter_map(|fact| {
+            fact.body_args()
+                .first()
+                .map(|word| FactSpan::new(word.span))
+        })
+        .collect()
 }
 
 fn collect_array_assignment_split_candidate_spans(checker: &Checker) -> Vec<Span> {
@@ -276,6 +296,7 @@ struct WordReportOptions<'a, F> {
     context: ExpansionContext,
     in_colon_command: bool,
     numeric_test_operand_spans: &'a [Span],
+    plain_run_first_arg_spans: &'a FxHashSet<FactSpan>,
     part_filter: F,
 }
 
@@ -292,6 +313,7 @@ fn report_word_expansions<F>(
         context,
         in_colon_command,
         numeric_test_operand_spans,
+        plain_run_first_arg_spans,
         part_filter,
     } = options;
 
@@ -313,6 +335,11 @@ fn report_word_expansions<F>(
     if context == ExpansionContext::CommandName
         && !fact.has_literal_affixes()
         && fact.parts_len() == 1
+    {
+        return;
+    }
+    if context == ExpansionContext::CommandArgument
+        && plain_run_first_arg_spans.contains(&FactSpan::new(fact.span()))
     {
         return;
     }
@@ -3683,6 +3710,54 @@ if [ ${actual_status} -ne ${expected_status} ]; then :; fi
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${actual_status}"]
+        );
+    }
+
+    #[test]
+    fn skips_plain_run_first_argument() {
+        let source = "\
+#!/bin/bash
+target=$1
+run $target
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_plain_run_later_arguments() {
+        let source = "\
+#!/bin/bash
+target=$1
+run echo $target
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$target"]
+        );
+    }
+
+    #[test]
+    fn reports_wrapped_run_first_arguments() {
+        let source = "\
+#!/bin/bash
+target=$1
+command run $target
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$target"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2305,6 +2305,25 @@ json=\"$(echo \\\"${items[*]}\\\")\"
     }
 
     #[test]
+    fn reports_inner_parameter_inside_escaped_indirect_template() {
+        let source = "\
+#!/bin/sh
+tool=pack
+archive=out
+$tool archive \"${archive}\" \"Test $1\" echo \\\"\\${${1}}\\\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${1}"]
+        );
+    }
+
+    #[test]
     fn reports_nested_substitution_arguments_after_escaped_quote_default_segments() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -382,7 +382,9 @@ fn report_word_expansions<F>(
         if matches!(exposure, S001QuoteExposure::QuoteInertNonEmpty) {
             continue;
         }
-        if safe_values.part_is_safe(part, part_span, query) {
+        if !safe_values.span_has_s001_function_unset_exposure(part_span, query)
+            && safe_values.part_is_safe(part, part_span, query)
+        {
             continue;
         }
 
@@ -2480,6 +2482,43 @@ printf '%s\\n' $n $s $glob $split $copy $alias
                 .collect::<Vec<_>>(),
             vec!["$glob", "$split"]
         );
+    }
+
+    #[test]
+    fn reports_function_body_values_when_function_is_unset_before_first_call() {
+        let source = "\
+#!/bin/sh
+cleanup() { unset -f fetch; }
+version=v1
+URL=\"https://example.invalid/$version\"
+fetch() { echo $URL; }
+cleanup
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$URL"]
+        );
+    }
+
+    #[test]
+    fn keeps_function_body_values_safe_when_function_is_called_before_later_unset() {
+        let source = "\
+#!/bin/sh
+cleanup() { unset -f fetch; }
+version=v1
+URL=\"https://example.invalid/$version\"
+fetch() { echo $URL; }
+fetch
+cleanup
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2311,6 +2311,7 @@ printf '%s\\n' 'prefix:'$name':suffix'
         let source = "\
 #!/bin/bash
 printf '%s\\n' $? $# $$ $! $- $0 $1 $* $@
+run || return $?
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -792,6 +792,10 @@ impl<'a> Lexer<'a> {
         self.position_map.position_uncached(self.offset)
     }
 
+    pub(super) fn position_at_offset(&self, offset: usize) -> Position {
+        self.position_map.position_uncached(offset)
+    }
+
     fn current_position(&mut self) -> Position {
         #[cfg(feature = "benchmarking")]
         self.maybe_record_current_position_call();

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -274,24 +274,29 @@ fn test_parse_escaped_dollar_expansions_stay_literal_in_script_words() {
 }
 
 #[test]
-fn test_parse_escaped_braced_parameter_with_nested_default_stays_literal() {
-    let input = r#"echo \${x:-$HOME}"#;
+fn test_parse_escaped_braced_parameter_keeps_inner_expansions_live() {
+    let input = r#"echo \${x:-$HOME} \${${1}}"#;
     let script = Parser::new(input).parse().unwrap().file;
 
     let AstCommand::Simple(command) = &script.body[0].command else {
         panic!("expected simple command");
     };
-    let word = &command.args[0];
+    assert_eq!(command.args.len(), 2);
 
-    assert_eq!(word.render(input), "${x:-$HOME}");
-    assert_eq!(word.render_syntax(input), r#"\${x:-$HOME}"#);
-    assert!(matches!(
-        word.parts.as_slice(),
-        [WordPartNode {
-            kind: WordPart::Literal(text),
-            ..
-        }] if text.is_source_backed() && text.as_str(input, word.parts[0].span) == "${x:-$HOME}"
+    let default_template = &command.args[0];
+    assert_eq!(default_template.render(input), "${x:-$HOME}");
+    assert_eq!(default_template.render_syntax(input), r#"\${x:-$HOME}"#);
+    assert!(word_part_tree_contains_variable(
+        &default_template.parts,
+        "HOME"
     ));
+
+    let indirect_template = &command.args[1];
+    assert_eq!(indirect_template.render(input), "${${1}}");
+    assert_eq!(indirect_template.render_syntax(input), r#"\${${1}}"#);
+    let mut names = Vec::new();
+    collect_bourne_parameter_names(&indirect_template.parts, &mut names);
+    assert_eq!(names, vec!["1"]);
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -81,6 +81,14 @@ fn collect_bourne_parameter_trim_patterns(
     }
 }
 
+fn first_command_substitution_body(parts: &[WordPartNode]) -> Option<&StmtSeq> {
+    parts.iter().find_map(|part| match &part.kind {
+        WordPart::CommandSubstitution { body, .. } => Some(body),
+        WordPart::DoubleQuoted { parts, .. } => first_command_substitution_body(parts),
+        _ => None,
+    })
+}
+
 #[test]
 fn test_current_word_cache_tracks_token_changes() {
     let input = "\"$foo\" bar\n";
@@ -1867,6 +1875,31 @@ fn test_dollar_paren_command_substitution_inside_quoted_prefix_with_pipeline_kee
     assert_eq!(right.name.span.slice(input), "tr");
     assert_eq!(right.args[0].render(input), "A-Z");
     assert_eq!(right.args[1].render(input), "a-z");
+}
+
+#[test]
+fn test_dollar_paren_command_substitution_after_multiline_escaped_quote_keeps_nested_spans_absolute()
+ {
+    let input = "\
+echo \"script
+  LEFT=\"$left\":\\$base \\
+    CHILD=\\$base/$(basename $child) \\
+    PATH=$path
+    run\" > out
+";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let body = first_command_substitution_body(&command.args[0].parts)
+        .expect("expected nested command substitution");
+    let inner = expect_simple(&body[0]);
+
+    assert_eq!(inner.name.span.slice(input), "basename");
+    assert_eq!(inner.args[0].span.slice(input), "$child");
+    assert_eq!(inner.args[0].span.start.line, 3);
+    assert_eq!(inner.args[0].span.start.column, 29);
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -493,6 +493,30 @@ fn test_parse_escaped_quotes_before_command_substitution_keep_nested_pipeline_li
 }
 
 #[test]
+fn test_parse_escaped_quotes_after_default_expansion_keep_command_substitution_live() {
+    let input = "label=\",label=\\\"${fallback:=value}$(render value $line)\\\"\"\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+
+    let WordPart::DoubleQuoted { parts, .. } = &word.parts[0].kind else {
+        panic!("expected double-quoted assignment value");
+    };
+    let WordPart::CommandSubstitution { body, .. } = &parts[2].kind else {
+        panic!("expected command substitution after default expansion");
+    };
+
+    let inner = expect_simple(&body[0]);
+    assert_eq!(inner.name.render(input), "render");
+    assert_eq!(inner.args[1].render(input), "$line");
+}
+
+#[test]
 fn test_parse_command_substitution_with_piped_tr_after_quoted_variable_keeps_nested_pipeline_live()
 {
     let input = "ATLAS_SHARED=$(echo \"$ATLAS_SHARED\"|cut -b 1|tr a-z A-Z)\n";

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3638,12 +3638,7 @@ impl<'a> Parser<'a> {
                                 Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             }
                             let inner_text = consumed_text.strip_suffix(')').unwrap_or_default();
-                            if had_prefix {
-                                self.nested_stmt_seq_from_source(inner_text, nested_source_base)
-                            } else {
-                                let inner_end = inner_start.advanced_by(inner_text);
-                                self.nested_stmt_seq_from_current_input(inner_start, inner_end)
-                            }
+                            self.nested_stmt_seq_from_source(inner_text, nested_source_base)
                         } else {
                             let mut cmd_str = String::new();
                             let mut depth = 1;
@@ -3664,14 +3659,7 @@ impl<'a> Parser<'a> {
                                     _ => cmd_str.push(c),
                                 }
                             }
-                            if had_prefix {
-                                self.nested_stmt_seq_from_source(&cmd_str, nested_source_base)
-                            } else {
-                                self.nested_stmt_seq_from_current_input(
-                                    inner_start,
-                                    inner_start.advanced_by(&cmd_str),
-                                )
-                            }
+                            self.nested_stmt_seq_from_source(&cmd_str, nested_source_base)
                         }
                     } else {
                         let mut cmd_str = String::new();
@@ -3693,10 +3681,7 @@ impl<'a> Parser<'a> {
                         if had_prefix {
                             self.nested_stmt_seq_from_source(&cmd_str, inner_start)
                         } else {
-                            self.nested_stmt_seq_from_current_input(
-                                inner_start,
-                                inner_start.advanced_by(&cmd_str),
-                            )
+                            self.nested_stmt_seq_from_source(&cmd_str, inner_start)
                         }
                     };
                     Self::push_word_part(

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3601,7 +3601,6 @@ impl<'a> Parser<'a> {
                     );
                 } else {
                     let inner_start = cursor;
-                    let had_prefix = current_start != part_start;
                     let prefix = Span::from_positions(current_start, part_start).slice(self.input);
                     let nested_source_base = if source_backed
                         && (source_prefix_ends_inside_double_quotes(prefix)
@@ -3672,11 +3671,7 @@ impl<'a> Parser<'a> {
                                 cmd_str.push(c);
                             }
                         }
-                        if had_prefix {
-                            self.nested_stmt_seq_from_source(&cmd_str, inner_start)
-                        } else {
-                            self.nested_stmt_seq_from_source(&cmd_str, inner_start)
-                        }
+                        self.nested_stmt_seq_from_source(&cmd_str, inner_start)
                     };
                     Self::push_word_part(
                         parts,

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3638,7 +3638,11 @@ impl<'a> Parser<'a> {
                                 Self::next_word_char_unwrap(&mut chars, &mut cursor);
                             }
                             let inner_text = consumed_text.strip_suffix(')').unwrap_or_default();
-                            self.nested_stmt_seq_from_source(inner_text, nested_source_base)
+                            self.nested_dollar_paren_stmt_seq_from_source_or_text(
+                                inner_text,
+                                part_start,
+                                nested_source_base,
+                            )
                         } else {
                             let mut cmd_str = String::new();
                             let mut depth = 1;
@@ -3659,7 +3663,11 @@ impl<'a> Parser<'a> {
                                     _ => cmd_str.push(c),
                                 }
                             }
-                            self.nested_stmt_seq_from_source(&cmd_str, nested_source_base)
+                            self.nested_dollar_paren_stmt_seq_from_source_or_text(
+                                &cmd_str,
+                                part_start,
+                                nested_source_base,
+                            )
                         }
                     } else {
                         let mut cmd_str = String::new();
@@ -4600,6 +4608,52 @@ impl<'a> Parser<'a> {
                 cursor,
             );
         }
+    }
+
+    fn nested_dollar_paren_stmt_seq_from_source_or_text(
+        &mut self,
+        inner_text: &str,
+        approximate_dollar_start: Position,
+        fallback_base: Position,
+    ) -> StmtSeq {
+        if let Some((body_start, body_end)) =
+            self.source_dollar_paren_body_span(inner_text, approximate_dollar_start)
+        {
+            return self.nested_stmt_seq_from_current_input(body_start, body_end);
+        }
+
+        self.nested_stmt_seq_from_source(inner_text, fallback_base)
+    }
+
+    fn source_dollar_paren_body_span(
+        &self,
+        inner_text: &str,
+        approximate_dollar_start: Position,
+    ) -> Option<(Position, Position)> {
+        let needle = format!("$({inner_text})");
+        let search_start = floor_char_boundary(
+            self.input,
+            approximate_dollar_start.offset.saturating_sub(512),
+        );
+        let search_end = ceil_char_boundary(
+            self.input,
+            (approximate_dollar_start.offset + needle.len() + 4096).min(self.input.len()),
+        );
+        let haystack = self.input.get(search_start..search_end)?;
+        let (relative_start, _) =
+            haystack
+                .match_indices(&needle)
+                .min_by_key(|(relative_start, _)| {
+                    (search_start + relative_start).abs_diff(approximate_dollar_start.offset)
+                })?;
+        let subst_start = search_start + relative_start;
+        let body_start_offset = subst_start + "$(".len();
+        let body_end_offset = subst_start + needle.len() - ")".len();
+
+        Some((
+            Position::new().advanced_by(&self.input[..body_start_offset]),
+            Position::new().advanced_by(&self.input[..body_end_offset]),
+        ))
     }
 
     fn consume_escaped_braced_parameter_literal(
@@ -5710,4 +5764,20 @@ fn source_prefix_has_same_line_escaped_double_quote_fragment(
     }
 
     false
+}
+
+fn floor_char_boundary(source: &str, mut offset: usize) -> usize {
+    offset = offset.min(source.len());
+    while offset > 0 && !source.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn ceil_char_boundary(source: &str, mut offset: usize) -> usize {
+    offset = offset.min(source.len());
+    while offset < source.len() && !source.is_char_boundary(offset) {
+        offset += 1;
+    }
+    offset
 }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4632,8 +4632,8 @@ impl<'a> Parser<'a> {
         let body_end_offset = subst_start + needle.len() - ")".len();
 
         Some((
-            Position::new().advanced_by(&self.input[..body_start_offset]),
-            Position::new().advanced_by(&self.input[..body_end_offset]),
+            self.lexer.position_at_offset(body_start_offset),
+            self.lexer.position_at_offset(body_end_offset),
         ))
     }
 

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -2964,13 +2964,6 @@ impl<'a> Parser<'a> {
                 }
                 if let Some(literal_ch) = Self::next_word_char(&mut chars, &mut cursor) {
                     current.push(literal_ch);
-                    if literal_ch == '$' && chars.peek() == Some(&'{') {
-                        self.consume_escaped_braced_parameter_literal(
-                            &mut chars,
-                            &mut cursor,
-                            &mut current,
-                        );
-                    }
                 }
                 continue;
             }
@@ -2996,13 +2989,6 @@ impl<'a> Parser<'a> {
                 }
                 let literal_ch = Self::next_word_char_unwrap(&mut chars, &mut cursor);
                 current.push(literal_ch);
-                if literal_ch == '$' && chars.peek() == Some(&'{') {
-                    self.consume_escaped_braced_parameter_literal(
-                        &mut chars,
-                        &mut cursor,
-                        &mut current,
-                    );
-                }
                 continue;
             }
 
@@ -4654,80 +4640,6 @@ impl<'a> Parser<'a> {
             Position::new().advanced_by(&self.input[..body_start_offset]),
             Position::new().advanced_by(&self.input[..body_end_offset]),
         ))
-    }
-
-    fn consume_escaped_braced_parameter_literal(
-        &self,
-        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
-        cursor: &mut Position,
-        current: &mut String,
-    ) {
-        if chars.peek() != Some(&'{') {
-            return;
-        }
-
-        current.push(Self::next_word_char_unwrap(chars, cursor));
-
-        let mut depth = 1usize;
-        let mut literal_brace_depth = 0usize;
-        let mut in_single = false;
-        let mut in_double = false;
-        let mut double_quote_depth = 0usize;
-
-        while let Some(&c) = chars.peek() {
-            match c {
-                '\\' if !in_single => {
-                    Self::next_word_char_unwrap(chars, cursor);
-                    if let Some(&escaped) = chars.peek() {
-                        if !in_double || matches!(escaped, '$' | '"' | '\\' | '`' | '\n') {
-                            current.push(Self::next_word_char_unwrap(chars, cursor));
-                        } else {
-                            current.push('\\');
-                        }
-                    } else {
-                        current.push('\\');
-                    }
-                }
-                '\'' if !in_double => {
-                    in_single = !in_single;
-                    current.push(Self::next_word_char_unwrap(chars, cursor));
-                }
-                '"' if !in_single => {
-                    in_double = !in_double;
-                    double_quote_depth = if in_double { depth } else { 0 };
-                    current.push(Self::next_word_char_unwrap(chars, cursor));
-                }
-                '$' if !in_single => {
-                    current.push(Self::next_word_char_unwrap(chars, cursor));
-                    if chars.peek() == Some(&'{') {
-                        depth += 1;
-                        current.push(Self::next_word_char_unwrap(chars, cursor));
-                    }
-                }
-                '{' if !in_single && !in_double => {
-                    literal_brace_depth += 1;
-                    current.push(Self::next_word_char_unwrap(chars, cursor));
-                }
-                '}' if !in_single && (!in_double || depth > double_quote_depth) => {
-                    if depth == 1 && literal_brace_depth > 0 {
-                        let mut remaining = chars.clone();
-                        remaining.next();
-                        if Self::brace_operand_has_later_top_level_closer(remaining, depth) {
-                            literal_brace_depth -= 1;
-                            current.push(Self::next_word_char_unwrap(chars, cursor));
-                            continue;
-                        }
-                    }
-
-                    current.push(Self::next_word_char_unwrap(chars, cursor));
-                    if depth == 1 {
-                        break;
-                    }
-                    depth -= 1;
-                }
-                _ => current.push(Self::next_word_char_unwrap(chars, cursor)),
-            }
-        }
     }
 
     pub(super) fn read_array_index(

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -15,7 +15,7 @@ use shuck_ast::{
     static_word_text, try_static_word_parts_text,
 };
 use shuck_indexer::Indexer;
-use shuck_parser::{ShellProfile, ZshEmulationMode};
+use shuck_parser::{ShellProfile, ZshEmulationMode, parser::Parser};
 use smallvec::SmallVec;
 
 use crate::binding::{
@@ -4841,10 +4841,12 @@ fn parse_simple_declaration_assignment(
     let target_span =
         word_text_offset_span(word.span, source, 0, if append { index - 1 } else { index });
     let value_span = word_text_offset_span(word.span, source, value_start, text.len());
-    let value_origin = if text[value_start..].trim_start().starts_with('(') {
+    let value_text = &text[value_start..];
+    let value_origin = if value_text.trim_start().starts_with('(') {
         AssignmentValueOrigin::ArrayOrCompound
     } else {
-        AssignmentValueOrigin::Unknown
+        let word = Parser::parse_word_string(value_text);
+        assignment_value_origin_for_word(&word)
     };
 
     Some(SimpleDeclarationAssignment {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1316,7 +1316,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         if word_is_semantically_inert(word) {
             return;
         }
-        self.visit_word_part_nodes(&word.parts, kind, flow, nested_regions);
+        self.visit_word_part_nodes(&word.parts, word.span, kind, flow, nested_regions);
     }
 
     fn visit_heredoc_body_into(
@@ -1348,11 +1348,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     fn visit_word_part_nodes(
         &mut self,
         parts: &'a [WordPartNode],
+        word_span: Span,
         kind: WordVisitKind,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
         for part in parts {
+            if span_inside_escaped_parameter_template(word_span, part.span, self.source) {
+                continue;
+            }
             self.visit_word_part(&part.kind, part.span, kind, flow, nested_regions);
         }
     }
@@ -1483,7 +1487,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 {
                     return;
                 }
-                self.visit_word_part_nodes(parts, kind, flow, nested_regions);
+                self.visit_word_part_nodes(parts, span, kind, flow, nested_regions);
             }
             WordPart::Variable(name) => {
                 self.add_reference(
@@ -4387,6 +4391,134 @@ fn escaped_braced_literal_reference_names(text: &str, span: Span) -> Vec<(Name, 
     }
 
     references
+}
+
+fn span_inside_escaped_parameter_template(word_span: Span, span: Span, source: &str) -> bool {
+    if span.start.offset < word_span.start.offset || span.start.offset >= word_span.end.offset {
+        return false;
+    }
+
+    let text = word_span.slice(source);
+    let relative_offset = span.start.offset - word_span.start.offset;
+    let mut index = 0usize;
+
+    while index < text.len() {
+        if text[index..].starts_with("\\${") {
+            let dollar_offset = index + '\\'.len_utf8();
+            if offset_is_backslash_escaped(word_span.start.offset + dollar_offset, source)
+                && let Some(end_offset) = escaped_parameter_template_end(text, dollar_offset)
+            {
+                let body_start = dollar_offset + "${".len();
+                let body_end = end_offset.saturating_sub('}'.len_utf8());
+                if relative_offset >= body_start && relative_offset < body_end {
+                    return true;
+                }
+                index = end_offset;
+                continue;
+            }
+        }
+
+        let Some(ch) = text[index..].chars().next() else {
+            break;
+        };
+        index += ch.len_utf8();
+    }
+
+    false
+}
+
+fn escaped_parameter_template_end(text: &str, dollar_offset: usize) -> Option<usize> {
+    if dollar_offset >= text.len() || !text[dollar_offset..].starts_with("${") {
+        return None;
+    }
+
+    let bytes = text.as_bytes();
+    let mut index = dollar_offset + "${".len();
+    let mut depth = 1usize;
+    let mut quote_state = EscapedTemplateQuote::None;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        match quote_state {
+            EscapedTemplateQuote::Single => {
+                if byte == b'\'' {
+                    quote_state = EscapedTemplateQuote::None;
+                }
+                index += 1;
+                continue;
+            }
+            EscapedTemplateQuote::Double => {
+                if byte == b'\\' {
+                    index += usize::from(index + 1 < bytes.len()) + 1;
+                    continue;
+                }
+                if byte == b'"' {
+                    quote_state = EscapedTemplateQuote::None;
+                }
+                index += 1;
+                continue;
+            }
+            EscapedTemplateQuote::None => {}
+        }
+
+        match byte {
+            b'\\' => {
+                index += usize::from(index + 1 < bytes.len()) + 1;
+            }
+            b'\'' => {
+                quote_state = EscapedTemplateQuote::Single;
+                index += 1;
+            }
+            b'"' => {
+                quote_state = EscapedTemplateQuote::Double;
+                index += 1;
+            }
+            b'$' if bytes.get(index + 1) == Some(&b'{') => {
+                depth += 1;
+                index += "${".len();
+            }
+            b'}' => {
+                depth -= 1;
+                index += '}'.len_utf8();
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => index = advance_text_char(text, index),
+        }
+    }
+
+    None
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EscapedTemplateQuote {
+    None,
+    Single,
+    Double,
+}
+
+fn offset_is_backslash_escaped(offset: usize, source: &str) -> bool {
+    if offset == 0 {
+        return false;
+    }
+
+    let bytes = source.as_bytes();
+    let mut index = offset;
+    let mut backslash_count = 0usize;
+    while index > 0 && bytes[index - 1] == b'\\' {
+        backslash_count += 1;
+        index -= 1;
+    }
+
+    backslash_count % 2 == 1
+}
+
+fn advance_text_char(text: &str, index: usize) -> usize {
+    text[index..]
+        .chars()
+        .next()
+        .map_or(index + 1, |ch| index + ch.len_utf8())
 }
 
 fn escaped_braced_literal_may_contain_reference(text: &str) -> bool {

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1354,7 +1354,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
         for part in parts {
-            if span_inside_escaped_parameter_template(word_span, part.span, self.source) {
+            if span_is_escaped_parameter_template_name(word_span, part.span, self.source) {
                 continue;
             }
             self.visit_word_part(&part.kind, part.span, kind, flow, nested_regions);
@@ -4393,7 +4393,7 @@ fn escaped_braced_literal_reference_names(text: &str, span: Span) -> Vec<(Name, 
     references
 }
 
-fn span_inside_escaped_parameter_template(word_span: Span, span: Span, source: &str) -> bool {
+fn span_is_escaped_parameter_template_name(word_span: Span, span: Span, source: &str) -> bool {
     if span.start.offset < word_span.start.offset || span.start.offset >= word_span.end.offset {
         return false;
     }
@@ -4410,7 +4410,13 @@ fn span_inside_escaped_parameter_template(word_span: Span, span: Span, source: &
             {
                 let body_start = dollar_offset + "${".len();
                 let body_end = end_offset.saturating_sub('}'.len_utf8());
-                if relative_offset >= body_start && relative_offset < body_end {
+                if relative_offset == body_start
+                    && relative_offset < body_end
+                    && text[relative_offset..]
+                        .chars()
+                        .next()
+                        .is_some_and(is_name_start_character)
+                {
                     return true;
                 }
                 index = end_offset;

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -9796,13 +9796,16 @@ printf '%s\\n' \"\\$workdir\"
     }
 
     #[test]
-    fn escaped_parameter_expansion_with_nested_default_stays_inert() {
+    fn escaped_parameter_expansion_keeps_nested_default_reads() {
         let source = "\
 #!/bin/sh
-printf '%s\\n' \\${workdir:-$fallback}
+printf '%s\\n' \\${workdir:-$fallback} \\${other:-${inner}}
 ";
         let model = model(source);
-        assert!(model.analysis().uninitialized_references().is_empty());
+        let unresolved = unresolved_names(&model);
+
+        assert_names_absent(&["workdir", "other"], &unresolved);
+        assert_names_present(&["fallback", "inner"], &unresolved);
     }
 
     #[test]

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=41`
-- Individual reviewed records classified below: 55 total (`shellcheck-only=23`, `shuck-only=32`).
+- `reviewed_divergences=38`
+- Individual reviewed records classified below: 51 total (`shellcheck-only=23`, `shuck-only=28`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -91,14 +91,10 @@ Resolved records should not remain as reviewed divergences.
 - `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:221:20-36` `$download_status`
 - `super-linter__super-linter__test__run-super-linter-tests.sh:724:36-57` `${EXPECTED_EXIT_CODE}`
 
-## [ ] Shuck-only: status/return/exit operand (7)
+## [ ] Shuck-only: status/return/exit operand (3)
 
 - `bittorf__kalua__openwrt-addons__etc__profile.d__kalua.sh:11:33-36` `$rc`
-- `rvm__rvm__scripts__extras__chruby.sh:31:10-21` `${__result}`
-- `rvm__rvm__scripts__functions__build_requirements:160:10-29` `${__summary_status}`
-- `rvm__rvm__scripts__functions__manage__base_fetch:45:12-24` `${result:-0}`
 - `rvm__rvm__scripts__functions__manage__macruby:23:10-21` `${__result}`
-- `rvm__rvm__scripts__functions__requirements__openbsd:35:12-23` `${__result}`
 - `v1s1t0r1sh3r3__airgeddon__airgeddon.sh:16442:11-23` `${exit_code}`
 
 ## [ ] Shuck-only: arithmetic/parameter-operator form (2)

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=37`
-- Individual reviewed records classified below: 48 total (`shellcheck-only=23`, `shuck-only=25`).
+- `reviewed_divergences=36`
+- Individual reviewed records classified below: 47 total (`shellcheck-only=23`, `shuck-only=24`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -82,11 +82,10 @@ Resolved records should not remain as reviewed divergences.
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
 - `swoodford__aws__wafv2-web-acl-pingdom.sh:196:40-49` `$WAFSCOPE`
 
-## [ ] Shuck-only: numeric/test operand (3)
+## [ ] Shuck-only: numeric/test operand (2)
 
 - `bittorf__kalua__openwrt-addons__etc__kalua__watch:362:40-58` `${overall:-$count}`
 - `bittorf__kalua__openwrt-monitoring__send_sms.sh:145:10-19` `${pos:-0}`
-- `super-linter__super-linter__test__run-super-linter-tests.sh:724:36-57` `${EXPECTED_EXIT_CODE}`
 
 ## [ ] Shuck-only: status/return/exit operand (3)
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=36`
-- Individual reviewed records classified below: 47 total (`shellcheck-only=23`, `shuck-only=24`).
+- `reviewed_divergences=35`
+- Individual reviewed records classified below: 46 total (`shellcheck-only=23`, `shuck-only=23`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -60,7 +60,7 @@ Resolved records should not remain as reviewed divergences.
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (12)
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (11)
 
 - `awslabs__git-secrets__git-secrets:124:5-17` `${RECURSIVE}`
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:67:16-34` `$count_column_left`
@@ -70,7 +70,6 @@ Resolved records should not remain as reviewed divergences.
 - `google__oss-fuzz__projects__threetenbp__build.sh:56:89-99` `LD_LIBRARY_PATH`
 - `ko1nksm__shellspec__lib__general.sh:442:15-39` `$shellspec_readfile_data`
 - `ko1nksm__shellspec__lib__libexec__shellspec.sh:94:37-39` `$c`
-- `kward__shunit2__.githooks__generic:30:11-22` `${basename}`
 - `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`
 - `pi-hole__pi-hole__automated install__basic-install.sh:1833:21-39` `${webInterfaceDir}`
 - `termux__termux-packages__packages__lazygit__build.sh:25:41-61` `-ldflags`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=61`
-- Individual reviewed records classified below: 97 total (`shellcheck-only=23`, `shuck-only=74`).
+- `reviewed_divergences=58`
+- Individual reviewed records classified below: 96 total (`shellcheck-only=23`, `shuck-only=73`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -56,7 +56,7 @@ Resolved records should not remain as reviewed divergences.
 - `rvm__rvm__binscripts__rvm-installer:89:24-48` `${rvm_tar_command:-gtar}`
 - `tteck__Proxmox__vm__nextcloud-vm.sh:210:96-99` `$HN`
 
-## [ ] Shuck-only: embedded safe literal/composite word (38)
+## [ ] Shuck-only: embedded safe literal/composite word (36)
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
 - `community-scripts__ProxmoxVE__vm__archlinux-vm.sh:547:31-44` `${DISK_CACHE}`
@@ -82,8 +82,6 @@ Resolved records should not remain as reviewed divergences.
 - `community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh:540:23-36` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh:538:25-34` `${FORMAT}`
 - `community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh:539:23-36` `${DISK_CACHE}`
-- `rvm__rvm__scripts__functions__requirements__rvm_pkg:17:17-35` `${_read_char_flag}`
-- `rvm__rvm__scripts__functions__requirements__unknown:74:17-35` `${_read_char_flag}`
 - `tteck__Proxmox__vm__debian-vm.sh:409:25-34` `${FORMAT}`
 - `tteck__Proxmox__vm__debian-vm.sh:410:23-36` `${DISK_CACHE}`
 - `tteck__Proxmox__vm__haos-vm.sh:451:25-34` `${FORMAT}`
@@ -97,7 +95,7 @@ Resolved records should not remain as reviewed divergences.
 - `tteck__Proxmox__vm__ubuntu2404-vm.sh:399:25-34` `${FORMAT}`
 - `tteck__Proxmox__vm__ubuntu2404-vm.sh:400:23-36` `${DISK_CACHE}`
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (18)
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (17)
 
 - `SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh:19:8-12` `$OLD`
 - `SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh:19:13-17` `$NEW`
@@ -115,7 +113,6 @@ Resolved records should not remain as reviewed divergences.
 - `kward__shunit2__.githooks__generic:30:11-22` `${basename}`
 - `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`
 - `pi-hole__pi-hole__automated install__basic-install.sh:1833:21-39` `${webInterfaceDir}`
-- `scop__bash-completion__completions-core__geoiplookup.bash:29:31-36` `$ipvx`
 - `termux__termux-packages__packages__lazygit__build.sh:25:41-61` `-ldflags`
 
 ## [ ] Shuck-only: command-substitution initializer argument (4 remaining)

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=31`
-- Individual reviewed records classified below: 42 total (`shellcheck-only=20`, `shuck-only=22`).
+- `reviewed_divergences=30`
+- Individual reviewed records classified below: 38 total (`shellcheck-only=19`, `shuck-only=19`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -28,14 +28,13 @@ Resolved records should not remain as reviewed divergences.
 - `rvm__rvm__scripts__functions__requirements__osx_brew:485:55-74` `$homebrew_installer`
 - `rvm__rvm__scripts__functions__requirements__osx_brew:486:32-51` `$homebrew_installer`
 
-## [ ] ShellCheck-only: embedded path/URL/composite word (6)
+## [ ] ShellCheck-only: embedded path/URL/composite word (5)
 
 - `233boy__v2ray__src__core.sh:1254:39-43` `$net`
 - `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:651:70-80` `${project}`
 - `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:867:52-62` `${db_type}`
 - `megastep__makeself__test__variabletest:15:56-60` `${1}`
 - `rvm__rvm__scripts__functions__requirements__osx_brew:491:35-51` `${homebrew_repo}`
-- `termux__termux-packages__packages__lazygit__build.sh:26:30-50` `${SOURCE_DATE_EPOCH}`
 
 ## [ ] ShellCheck-only: plain command argument (5)
 
@@ -54,7 +53,7 @@ Resolved records should not remain as reviewed divergences.
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (10)
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (9)
 
 - `awslabs__git-secrets__git-secrets:124:5-17` `${RECURSIVE}`
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:67:16-34` `$count_column_left`
@@ -65,7 +64,6 @@ Resolved records should not remain as reviewed divergences.
 - `ko1nksm__shellspec__lib__libexec__shellspec.sh:94:37-39` `$c`
 - `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`
 - `pi-hole__pi-hole__automated install__basic-install.sh:1833:21-39` `${webInterfaceDir}`
-- `termux__termux-packages__packages__lazygit__build.sh:25:41-61` `-ldflags`
 
 ## [ ] Shuck-only: command-substitution initializer argument (4 remaining)
 
@@ -73,11 +71,6 @@ Resolved records should not remain as reviewed divergences.
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
 - `swoodford__aws__wafv2-web-acl-pingdom.sh:196:40-49` `$WAFSCOPE`
-
-## [ ] Shuck-only: numeric/test operand (2)
-
-- `bittorf__kalua__openwrt-addons__etc__kalua__watch:362:40-58` `${overall:-$count}`
-- `bittorf__kalua__openwrt-monitoring__send_sms.sh:145:10-19` `${pos:-0}`
 
 ## [ ] Shuck-only: status/return/exit operand (3)
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=29`
-- Individual reviewed records classified below: 37 total (`shellcheck-only=19`, `shuck-only=18`).
+- `reviewed_divergences=28`
+- Individual reviewed records classified below: 36 total (`shellcheck-only=18`, `shuck-only=18`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -28,12 +28,11 @@ Resolved records should not remain as reviewed divergences.
 - `rvm__rvm__scripts__functions__requirements__osx_brew:485:55-74` `$homebrew_installer`
 - `rvm__rvm__scripts__functions__requirements__osx_brew:486:32-51` `$homebrew_installer`
 
-## [ ] ShellCheck-only: embedded path/URL/composite word (5)
+## [ ] ShellCheck-only: embedded path/URL/composite word (4)
 
 - `233boy__v2ray__src__core.sh:1254:39-43` `$net`
 - `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:651:70-80` `${project}`
 - `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:867:52-62` `${db_type}`
-- `megastep__makeself__test__variabletest:15:56-60` `${1}`
 - `rvm__rvm__scripts__functions__requirements__osx_brew:491:35-51` `${homebrew_repo}`
 
 ## [ ] ShellCheck-only: plain command argument (5)
@@ -65,7 +64,7 @@ Resolved records should not remain as reviewed divergences.
 - `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`
 - `pi-hole__pi-hole__automated install__basic-install.sh:1833:21-39` `${webInterfaceDir}`
 
-## [ ] Shuck-only: command-substitution initializer argument (4 remaining)
+## [ ] Shuck-only: command-substitution initializer argument (3 remaining)
 
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:245:36-43` `$tarpid`
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=26`
-- Individual reviewed records classified below: 34 total (`shellcheck-only=17`, `shuck-only=17`).
+- `reviewed_divergences=25`
+- Individual reviewed records classified below: 33 total (`shellcheck-only=17`, `shuck-only=16`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -51,9 +51,8 @@ Resolved records should not remain as reviewed divergences.
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (8)
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (7)
 
-- `bats-core__bats-core__libexec__bats-core__bats-format-pretty:67:16-34` `$count_column_left`
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:78:13-32` `$line_backoff_count`
 - `bittorf__kalua__openwrt-monitoring__ping_counter.sh:110:7-15` `$fileage`
 - `gentoo__gentoo__eclass__tests__toolchain-funcs.sh:61:6-12` `${ret}`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=25`
-- Individual reviewed records classified below: 33 total (`shellcheck-only=17`, `shuck-only=16`).
+- `reviewed_divergences=24`
+- Individual reviewed records classified below: 32 total (`shellcheck-only=17`, `shuck-only=15`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -51,10 +51,9 @@ Resolved records should not remain as reviewed divergences.
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (7)
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (6)
 
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:78:13-32` `$line_backoff_count`
-- `bittorf__kalua__openwrt-monitoring__ping_counter.sh:110:7-15` `$fileage`
 - `gentoo__gentoo__eclass__tests__toolchain-funcs.sh:61:6-12` `${ret}`
 - `ko1nksm__shellspec__lib__general.sh:442:15-39` `$shellspec_readfile_data`
 - `ko1nksm__shellspec__lib__libexec__shellspec.sh:94:37-39` `$c`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=38`
-- Individual reviewed records classified below: 51 total (`shellcheck-only=23`, `shuck-only=28`).
+- `reviewed_divergences=37`
+- Individual reviewed records classified below: 48 total (`shellcheck-only=23`, `shuck-only=25`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -82,13 +82,10 @@ Resolved records should not remain as reviewed divergences.
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
 - `swoodford__aws__wafv2-web-acl-pingdom.sh:196:40-49` `$WAFSCOPE`
 
-## [ ] Shuck-only: numeric/test operand (6)
+## [ ] Shuck-only: numeric/test operand (3)
 
 - `bittorf__kalua__openwrt-addons__etc__kalua__watch:362:40-58` `${overall:-$count}`
 - `bittorf__kalua__openwrt-monitoring__send_sms.sh:145:10-19` `${pos:-0}`
-- `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:191:14-30` `$download_status`
-- `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:215:18-34` `$download_status`
-- `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:221:20-36` `$download_status`
 - `super-linter__super-linter__test__run-super-linter-tests.sh:724:36-57` `${EXPECTED_EXIT_CODE}`
 
 ## [ ] Shuck-only: status/return/exit operand (3)

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=55`
-- Individual reviewed records classified below: 90 total (`shellcheck-only=23`, `shuck-only=67`).
+- `reviewed_divergences=54`
+- Individual reviewed records classified below: 71 total (`shellcheck-only=23`, `shuck-only=48`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -56,44 +56,25 @@ Resolved records should not remain as reviewed divergences.
 - `rvm__rvm__binscripts__rvm-installer:89:24-48` `${rvm_tar_command:-gtar}`
 - `tteck__Proxmox__vm__nextcloud-vm.sh:210:96-99` `$HN`
 
-## [ ] Shuck-only: embedded safe literal/composite word (36)
+## [ ] Shuck-only: embedded safe literal/composite word (17)
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
-- `community-scripts__ProxmoxVE__vm__archlinux-vm.sh:547:31-44` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:615:27-36` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:616:25-38` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:622:27-36` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:623:25-38` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__debian-vm.sh:556:27-36` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__debian-vm.sh:557:25-38` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__debian-vm.sh:563:27-36` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__debian-vm.sh:564:25-38` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__nextcloud-vm.sh:542:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__nextcloud-vm.sh:543:23-36` `${DISK_CACHE}`
-- `community-scripts__ProxmoxVE__vm__nextcloud-vm.sh:544:23-36` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__opnsense-vm.sh:744:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__opnsense-vm.sh:745:23-36` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__owncloud-vm.sh:555:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__owncloud-vm.sh:556:23-36` `${DISK_CACHE}`
-- `community-scripts__ProxmoxVE__vm__owncloud-vm.sh:557:23-36` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__ubuntu2204-vm.sh:537:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__ubuntu2204-vm.sh:538:23-36` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh:539:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh:540:23-36` `${DISK_CACHE}`
 - `community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh:538:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh:539:23-36` `${DISK_CACHE}`
 - `tteck__Proxmox__vm__debian-vm.sh:409:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__debian-vm.sh:410:23-36` `${DISK_CACHE}`
 - `tteck__Proxmox__vm__haos-vm.sh:451:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__haos-vm.sh:452:23-36` `${DISK_CACHE}`
 - `tteck__Proxmox__vm__nextcloud-vm.sh:408:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__nextcloud-vm.sh:409:23-36` `${DISK_CACHE}`
 - `tteck__Proxmox__vm__owncloud-vm.sh:408:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__owncloud-vm.sh:409:23-36` `${DISK_CACHE}`
 - `tteck__Proxmox__vm__ubuntu2204-vm.sh:409:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__ubuntu2204-vm.sh:410:23-36` `${DISK_CACHE}`
 - `tteck__Proxmox__vm__ubuntu2404-vm.sh:399:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__ubuntu2404-vm.sh:400:23-36` `${DISK_CACHE}`
 
 ## [ ] Shuck-only: simple command argument ShellCheck suppresses (12)
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=54`
-- Individual reviewed records classified below: 71 total (`shellcheck-only=23`, `shuck-only=48`).
+- `reviewed_divergences=41`
+- Individual reviewed records classified below: 55 total (`shellcheck-only=23`, `shuck-only=32`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -56,25 +56,9 @@ Resolved records should not remain as reviewed divergences.
 - `rvm__rvm__binscripts__rvm-installer:89:24-48` `${rvm_tar_command:-gtar}`
 - `tteck__Proxmox__vm__nextcloud-vm.sh:210:96-99` `$HN`
 
-## [ ] Shuck-only: embedded safe literal/composite word (17)
+## [ ] Shuck-only: embedded safe literal/composite word (1)
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
-- `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:615:27-36` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__debian-13-vm.sh:622:27-36` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__debian-vm.sh:556:27-36` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__debian-vm.sh:563:27-36` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__nextcloud-vm.sh:542:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__opnsense-vm.sh:744:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__owncloud-vm.sh:555:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__ubuntu2204-vm.sh:537:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__ubuntu2404-vm.sh:539:25-34` `${FORMAT}`
-- `community-scripts__ProxmoxVE__vm__ubuntu2504-vm.sh:538:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__debian-vm.sh:409:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__haos-vm.sh:451:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__nextcloud-vm.sh:408:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__owncloud-vm.sh:408:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__ubuntu2204-vm.sh:409:25-34` `${FORMAT}`
-- `tteck__Proxmox__vm__ubuntu2404-vm.sh:399:25-34` `${FORMAT}`
 
 ## [ ] Shuck-only: simple command argument ShellCheck suppresses (12)
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=62`
-- Individual reviewed records classified below: 98 total (`shellcheck-only=23`, `shuck-only=75`).
+- `reviewed_divergences=61`
+- Individual reviewed records classified below: 97 total (`shellcheck-only=23`, `shuck-only=74`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -135,9 +135,8 @@ Resolved records should not remain as reviewed divergences.
 - `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:221:20-36` `$download_status`
 - `super-linter__super-linter__test__run-super-linter-tests.sh:724:36-57` `${EXPECTED_EXIT_CODE}`
 
-## [ ] Shuck-only: status/return/exit operand (8)
+## [ ] Shuck-only: status/return/exit operand (7)
 
-- `bittorf__kalua__openwrt-addons__etc__kalua__net:2620:79-81` `$?`
 - `bittorf__kalua__openwrt-addons__etc__profile.d__kalua.sh:11:33-36` `$rc`
 - `rvm__rvm__scripts__extras__chruby.sh:31:10-21` `${__result}`
 - `rvm__rvm__scripts__functions__build_requirements:160:10-29` `${__summary_status}`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=35`
-- Individual reviewed records classified below: 46 total (`shellcheck-only=23`, `shuck-only=23`).
+- `reviewed_divergences=33`
+- Individual reviewed records classified below: 44 total (`shellcheck-only=21`, `shuck-only=23`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -45,10 +45,8 @@ Resolved records should not remain as reviewed divergences.
 - `gentoo__gentoo__eclass__tests__toolchain.sh:155:7-13` `${ret}`
 - `nvm-sh__nvm__test__slow__nvm_get_latest__nvm_get_latest:26:10-14` `$URL`
 
-## [ ] ShellCheck-only: nested command substitution / here-string argument (3)
+## [ ] ShellCheck-only: nested command substitution / here-string argument (1)
 
-- `bittorf__kalua__openwrt-monitoring__meshrdf_generate_map.sh:263:70-75` `$LINE`
-- `bittorf__kalua__openwrt-monitoring__meshrdf_generate_netjson.sh:577:70-75` `$LINE`
 - `google__oss-fuzz__projects__threetenbp__build.sh:57:37-47` `$JAVA_HOME`
 
 ## [ ] ShellCheck-only: test/probe command operand (2)

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=63`
-- Individual reviewed records classified below: 100 total (`shellcheck-only=23`, `shuck-only=77`).
+- `reviewed_divergences=62`
+- Individual reviewed records classified below: 98 total (`shellcheck-only=23`, `shuck-only=75`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -125,7 +125,7 @@ Resolved records should not remain as reviewed divergences.
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
 - `swoodford__aws__wafv2-web-acl-pingdom.sh:196:40-49` `$WAFSCOPE`
 
-## [ ] Shuck-only: numeric/test operand (9)
+## [ ] Shuck-only: numeric/test operand (7)
 
 - `bittorf__kalua__openwrt-addons__etc__kalua__watch:362:40-58` `${overall:-$count}`
 - `bittorf__kalua__openwrt-monitoring__send_sms.sh:145:10-19` `${pos:-0}`
@@ -134,8 +134,6 @@ Resolved records should not remain as reviewed divergences.
 - `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:215:18-34` `$download_status`
 - `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:221:20-36` `$download_status`
 - `super-linter__super-linter__test__run-super-linter-tests.sh:724:36-57` `${EXPECTED_EXIT_CODE}`
-- `tteck__Proxmox__misc__glances.sh:100:37-49` `$SPINNER_PID`
-- `tteck__Proxmox__misc__glances.sh:100:73-85` `$SPINNER_PID`
 
 ## [ ] Shuck-only: status/return/exit operand (8)
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=24`
-- Individual reviewed records classified below: 32 total (`shellcheck-only=17`, `shuck-only=15`).
+- `reviewed_divergences=23`
+- Individual reviewed records classified below: 30 total (`shellcheck-only=17`, `shuck-only=13`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -51,12 +51,10 @@ Resolved records should not remain as reviewed divergences.
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (6)
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (4)
 
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:78:13-32` `$line_backoff_count`
-- `gentoo__gentoo__eclass__tests__toolchain-funcs.sh:61:6-12` `${ret}`
 - `ko1nksm__shellspec__lib__general.sh:442:15-39` `$shellspec_readfile_data`
-- `ko1nksm__shellspec__lib__libexec__shellspec.sh:94:37-39` `$c`
 - `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`
 - `pi-hole__pi-hole__automated install__basic-install.sh:1833:21-39` `${webInterfaceDir}`
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=28`
-- Individual reviewed records classified below: 36 total (`shellcheck-only=18`, `shuck-only=18`).
+- `reviewed_divergences=27`
+- Individual reviewed records classified below: 35 total (`shellcheck-only=17`, `shuck-only=18`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -35,13 +35,12 @@ Resolved records should not remain as reviewed divergences.
 - `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:867:52-62` `${db_type}`
 - `rvm__rvm__scripts__functions__requirements__osx_brew:491:35-51` `${homebrew_repo}`
 
-## [ ] ShellCheck-only: plain command argument (5)
+## [ ] ShellCheck-only: plain command argument (4)
 
 - `RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh:235:32-38` `$group`
 - `community-scripts__ProxmoxVE__vm__haos-vm.sh:636:23-35` `${DISK_SIZE}`
 - `community-scripts__ProxmoxVE__vm__mikrotik-routeros.sh:655:25-37` `${DISK_SIZE}`
 - `gentoo__gentoo__eclass__tests__toolchain.sh:155:7-13` `${ret}`
-- `nvm-sh__nvm__test__slow__nvm_get_latest__nvm_get_latest:26:10-14` `$URL`
 
 ## [ ] ShellCheck-only: test/probe command operand (2)
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=33`
-- Individual reviewed records classified below: 44 total (`shellcheck-only=21`, `shuck-only=23`).
+- `reviewed_divergences=31`
+- Individual reviewed records classified below: 42 total (`shellcheck-only=20`, `shuck-only=22`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -45,10 +45,6 @@ Resolved records should not remain as reviewed divergences.
 - `gentoo__gentoo__eclass__tests__toolchain.sh:155:7-13` `${ret}`
 - `nvm-sh__nvm__test__slow__nvm_get_latest__nvm_get_latest:26:10-14` `$URL`
 
-## [ ] ShellCheck-only: nested command substitution / here-string argument (1)
-
-- `google__oss-fuzz__projects__threetenbp__build.sh:57:37-47` `$JAVA_HOME`
-
 ## [ ] ShellCheck-only: test/probe command operand (2)
 
 - `rvm__rvm__binscripts__rvm-installer:89:24-48` `${rvm_tar_command:-gtar}`
@@ -58,14 +54,13 @@ Resolved records should not remain as reviewed divergences.
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (11)
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (10)
 
 - `awslabs__git-secrets__git-secrets:124:5-17` `${RECURSIVE}`
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:67:16-34` `$count_column_left`
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:78:13-32` `$line_backoff_count`
 - `bittorf__kalua__openwrt-monitoring__ping_counter.sh:110:7-15` `$fileage`
 - `gentoo__gentoo__eclass__tests__toolchain-funcs.sh:61:6-12` `${ret}`
-- `google__oss-fuzz__projects__threetenbp__build.sh:56:89-99` `LD_LIBRARY_PATH`
 - `ko1nksm__shellspec__lib__general.sh:442:15-39` `$shellspec_readfile_data`
 - `ko1nksm__shellspec__lib__libexec__shellspec.sh:94:37-39` `$c`
 - `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=64`
-- Individual reviewed records classified below: 103 total (`shellcheck-only=23`, `shuck-only=80`).
+- `reviewed_divergences=63`
+- Individual reviewed records classified below: 100 total (`shellcheck-only=23`, `shuck-only=77`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -118,11 +118,8 @@ Resolved records should not remain as reviewed divergences.
 - `scop__bash-completion__completions-core__geoiplookup.bash:29:31-36` `$ipvx`
 - `termux__termux-packages__packages__lazygit__build.sh:25:41-61` `-ldflags`
 
-## [ ] Shuck-only: command-substitution initializer argument (7 remaining)
+## [ ] Shuck-only: command-substitution initializer argument (4 remaining)
 
-- `acmesh-official__acme.sh__dnsapi__dns_tencent.sh:113:32-40` `$service`
-- `acmesh-official__acme.sh__dnsapi__dns_tencent.sh:116:40-48` `$service`
-- `acmesh-official__acme.sh__dnsapi__dns_tencent.sh:116:49-57` `$version`
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:245:36-43` `$tarpid`
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=27`
-- Individual reviewed records classified below: 35 total (`shellcheck-only=17`, `shuck-only=18`).
+- `reviewed_divergences=26`
+- Individual reviewed records classified below: 34 total (`shellcheck-only=17`, `shuck-only=17`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -51,9 +51,8 @@ Resolved records should not remain as reviewed divergences.
 
 - `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (9)
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (8)
 
-- `awslabs__git-secrets__git-secrets:124:5-17` `${RECURSIVE}`
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:67:16-34` `$count_column_left`
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:78:13-32` `$line_backoff_count`
 - `bittorf__kalua__openwrt-monitoring__ping_counter.sh:110:7-15` `$fileage`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=58`
-- Individual reviewed records classified below: 96 total (`shellcheck-only=23`, `shuck-only=73`).
+- `reviewed_divergences=55`
+- Individual reviewed records classified below: 90 total (`shellcheck-only=23`, `shuck-only=67`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -95,19 +95,14 @@ Resolved records should not remain as reviewed divergences.
 - `tteck__Proxmox__vm__ubuntu2404-vm.sh:399:25-34` `${FORMAT}`
 - `tteck__Proxmox__vm__ubuntu2404-vm.sh:400:23-36` `${DISK_CACHE}`
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (17)
+## [ ] Shuck-only: simple command argument ShellCheck suppresses (12)
 
-- `SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh:19:8-12` `$OLD`
-- `SlackBuildsOrg__slackbuilds__system__sboui__doinst.sh:19:13-17` `$NEW`
 - `awslabs__git-secrets__git-secrets:124:5-17` `${RECURSIVE}`
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:67:16-34` `$count_column_left`
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:78:13-32` `$line_backoff_count`
 - `bittorf__kalua__openwrt-monitoring__ping_counter.sh:110:7-15` `$fileage`
 - `gentoo__gentoo__eclass__tests__toolchain-funcs.sh:61:6-12` `${ret}`
 - `google__oss-fuzz__projects__threetenbp__build.sh:56:89-99` `LD_LIBRARY_PATH`
-- `juewuy__ShellCrash__scripts__menus__2_settings.sh:360:41-51` `$redir_mod`
-- `juewuy__ShellCrash__scripts__menus__2_settings.sh:368:41-51` `$redir_mod`
-- `juewuy__ShellCrash__scripts__menus__2_settings.sh:377:41-51` `$redir_mod`
 - `ko1nksm__shellspec__lib__general.sh:442:15-39` `$shellspec_readfile_data`
 - `ko1nksm__shellspec__lib__libexec__shellspec.sh:94:37-39` `$c`
 - `kward__shunit2__.githooks__generic:30:11-22` `${basename}`
@@ -122,11 +117,10 @@ Resolved records should not remain as reviewed divergences.
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
 - `swoodford__aws__wafv2-web-acl-pingdom.sh:196:40-49` `$WAFSCOPE`
 
-## [ ] Shuck-only: numeric/test operand (7)
+## [ ] Shuck-only: numeric/test operand (6)
 
 - `bittorf__kalua__openwrt-addons__etc__kalua__watch:362:40-58` `${overall:-$count}`
 - `bittorf__kalua__openwrt-monitoring__send_sms.sh:145:10-19` `${pos:-0}`
-- `nvm-sh__nvm__nvm.sh:3785:16-25` `$nosource`
 - `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:191:14-30` `$download_status`
 - `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:215:18-34` `$download_status`
 - `pi-hole__pi-hole__advanced__Scripts__piholeCheckout.sh:221:20-36` `$download_status`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=30`
-- Individual reviewed records classified below: 38 total (`shellcheck-only=19`, `shuck-only=19`).
+- `reviewed_divergences=29`
+- Individual reviewed records classified below: 37 total (`shellcheck-only=19`, `shuck-only=18`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -70,7 +70,6 @@ Resolved records should not remain as reviewed divergences.
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:245:36-43` `$tarpid`
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
-- `swoodford__aws__wafv2-web-acl-pingdom.sh:196:40-49` `$WAFSCOPE`
 
 ## [ ] Shuck-only: status/return/exit operand (3)
 


### PR DESCRIPTION
## Summary

- refines S001 around local exposure to field splitting/pathname expansion, with S001-specific quote-exposure handling alongside the existing safe-value plumbing
- clears ratcheted S001 reviewed divergences across status/numeric/literal/nested-substitution buckets and removes the matching corpus metadata/docs entries
- leaves rejected broad status-origin suppression out of the branch; final committed baseline is 23 reviewed divergence groups with zero blocking implementation diffs

## Validation

- cargo test -p shuck-linter skips_counter_arguments_with_only_numeric_assignments -- --nocapture
- cargo test -p shuck-linter skips_arithmetic_numeric_test_operands_without_static_flag_broadening -- --nocapture
- make large-corpus-report SHUCK_LARGE_CORPUS_RULES=S001 SHUCK_LARGE_CORPUS_KEEP_GOING=1

Final S001 corpus summary: implementation_diffs=0, mapping_issues=0, reviewed_divergences=23.