### PR TITLE
refactor(linter): remove test harness context

### DIFF
--- a/crates/shuck-linter/src/context.rs
+++ b/crates/shuck-linter/src/context.rs
@@ -8,7 +8,6 @@ use crate::ShellDialect;
 pub enum FileContextTag {
     ShellSpec,
     HelperLibrary,
-    TestHarness,
     ProjectClosure,
     DirectiveHandling,
 }
@@ -18,7 +17,6 @@ impl FileContextTag {
         match self {
             Self::ShellSpec => "shellspec",
             Self::HelperLibrary => "helper-library",
-            Self::TestHarness => "test-harness",
             Self::ProjectClosure => "project-closure",
             Self::DirectiveHandling => "directive-handling",
         }
@@ -118,20 +116,6 @@ pub fn classify_file_context(
         && source_defines_function(&lines)
     {
         tags.push(FileContextTag::HelperLibrary);
-    }
-
-    if path_tokens
-        .iter()
-        .any(|token| matches!(token.as_str(), "test" | "tests" | "spec"))
-        || path
-            .and_then(Path::file_name)
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| {
-                let lower = name.to_ascii_lowercase();
-                lower.contains("_test.") || lower.contains("_spec.")
-            })
-    {
-        tags.push(FileContextTag::TestHarness);
     }
 
     if lines.iter().any(|line| {
@@ -360,7 +344,6 @@ It 'still shell'
         );
 
         assert!(context.has_tag(FileContextTag::ShellSpec));
-        assert!(context.has_tag(FileContextTag::TestHarness));
         assert_eq!(context.regions().len(), 1);
         assert_eq!(
             context.regions()[0].kind,
@@ -387,7 +370,6 @@ source ./lib.sh
         );
 
         assert!(context.has_tag(FileContextTag::HelperLibrary));
-        assert!(context.has_tag(FileContextTag::TestHarness));
         assert!(context.has_tag(FileContextTag::ProjectClosure));
         assert!(context.has_tag(FileContextTag::DirectiveHandling));
     }
@@ -405,7 +387,6 @@ helper() { :; }
         );
 
         assert!(context.has_tag(FileContextTag::ProjectClosure));
-        assert!(context.has_tag(FileContextTag::TestHarness));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1955,8 +1955,7 @@ fn should_suppress_overwrite(
         return true;
     }
 
-    (file_context.has_tag(FileContextTag::TestHarness)
-        || file_context.has_tag(FileContextTag::HelperLibrary))
+    file_context.has_tag(FileContextTag::HelperLibrary)
         && (unset_function_between(
             checker,
             overwritten.name.as_str(),
@@ -2525,23 +2524,6 @@ Describe 'matcher'
 ";
         let diagnostics = test_snippet_at_path(
             Path::new("/tmp/ko1nksm__shellspec__spec__core__matcher_spec.sh"),
-            source,
-            &LinterSettings::for_rule(Rule::OverwrittenFunction),
-        );
-
-        assert!(diagnostics.is_empty());
-    }
-
-    #[test]
-    fn test_double_swaps_after_unset_are_suppressed() {
-        let source = "\
-curl() { printf '%s\\n' first; }
-unset -f curl
-curl() { printf '%s\\n' second; }
-curl
-";
-        let diagnostics = test_snippet_at_path(
-            Path::new("/tmp/project/tests/nvm_compare_checksum_test.sh"),
             source,
             &LinterSettings::for_rule(Rule::OverwrittenFunction),
         );
@@ -3820,31 +3802,6 @@ factory_two
     }
 
     #[test]
-    fn cleanup_unset_elsewhere_suppresses_test_double_swaps() {
-        let source = "\
-cleanup() {
-  unset -f nvm_compute_checksum
-}
-nvm_compute_checksum() {
-  echo first
-}
-try_err nvm_compare_checksum
-nvm_compute_checksum() {
-  echo second
-}
-try_err nvm_compare_checksum
-cleanup
-";
-        let diagnostics = test_snippet_at_path(
-            Path::new("/tmp/project/tests/nvm_compare_checksum_test.sh"),
-            source,
-            &LinterSettings::for_rule(Rule::OverwrittenFunction),
-        );
-
-        assert!(diagnostics.is_empty());
-    }
-
-    #[test]
     fn transitive_direct_calls_before_redefinition_do_not_report() {
         let source = "\
 \\. ./helpers.sh
@@ -3883,23 +3840,6 @@ helper() { printf '%s\\n' second; }
 
         assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
-    }
-
-    #[test]
-    fn opaque_helper_calls_before_redefinition_are_suppressed() {
-        let source = "\
-\\. ./helpers.sh
-helper() { printf '%s\\n' first; }
-run_case
-helper() { printf '%s\\n' second; }
-";
-        let diagnostics = test_snippet_at_path(
-            Path::new("/tmp/project/tests/helper_swap_test.sh"),
-            source,
-            &LinterSettings::for_rule(Rule::OverwrittenFunction),
-        );
-
-        assert!(diagnostics.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove the unused TestHarness file-context tag and path classifier
- stop using test-path context to suppress C063 overwritten-function diagnostics
- delete unit tests that only encoded that test-path suppression behavior

## Validation

- cargo fmt
- cargo test -p shuck-linter overwritten_function
- cargo test -p shuck-linter
- make test-large-corpus

Large corpus completed with blocking=0, implementation_diffs=0, mapping_issues=0, and harness_failures=0.