### PR TITLE
test(linter): remove autoconf fixture names

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -834,11 +834,11 @@ done
 
     #[test]
     fn eval_single_quoted_strings_do_not_keep_assignments_live() {
-        let source = "#!/bin/sh\nas_lineno_1=$LINENO\neval 'test \"$as_lineno_1\"'\n";
+        let source = "#!/bin/sh\nsaved_line1=$LINENO\neval 'test \"$saved_line1\"'\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "as_lineno_1");
+        assert_eq!(diagnostics[0].span.slice(source), "saved_line1");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -364,8 +364,8 @@ find $TERMUX_PKG_SRCDIR -mindepth 1 -maxdepth 1 -exec cp -a \\{\\} ./ \\;
         let source = "\
 #!/bin/bash
 local args=${*:1:${#@}-1}
-eval ac_env_${ac_var}_set=\\${${ac_var}+set}
-if eval \\${ac_cv_prog_make_${ac_make}_set+:} false; then :
+eval xx_env_${xx_var}_set=\\${${xx_var}+set}
+if eval \\${xx_cv_prog_make_${xx_make}_set+:} false; then :
   :
 fi
 __rvm_find \"${rvm_bin_path:=$rvm_path/bin}\" -name \\*${ruby_at_gemset} -exec rm -rf '{}' \\;


### PR DESCRIPTION
## Summary

- rename Autoconf-shaped variable names in linter test fixtures to neutral names
- keep the fixture shapes and assertions otherwise unchanged

## Validation

- cargo fmt
- cargo test -p shuck-linter
- make test-large-corpus

Large corpus summary:

```text
blocking=0 warnings=64 fixtures=34593 unsupported_shells=887 implementation_diffs=0 mapping_issues=0 reviewed_divergences=64 harness_warnings=0 harness_failures=0
```
