### PR TITLE
refactor(linter): remove helper library context

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use shuck_ast::Name;
 use shuck_semantic::{ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind};
 
-use crate::{FileContext, FileContextTag, ShellDialect};
+use crate::{FileContext, ShellDialect};
 
 struct AmbientContractProvider {
     matches: fn(source: &str, path: &Path, shell: ShellDialect, file_context: &FileContext) -> bool,
@@ -122,11 +122,10 @@ fn sourced_runtime_path_shape(lower: &str) -> bool {
 
 fn sourced_runtime_source_shape(
     source: &str,
-    file_context: &FileContext,
+    _file_context: &FileContext,
     lower_path: &str,
 ) -> bool {
-    file_context.has_tag(FileContextTag::HelperLibrary)
-        || has_probable_function_definition(source)
+    has_probable_function_definition(source)
         || has_source_command(source)
         || source.contains("PROMPT_COMMAND")
         || source.contains("COMPREPLY")

--- a/crates/shuck-linter/src/context.rs
+++ b/crates/shuck-linter/src/context.rs
@@ -7,7 +7,6 @@ use crate::ShellDialect;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FileContextTag {
     ShellSpec,
-    HelperLibrary,
     ProjectClosure,
     DirectiveHandling,
 }
@@ -16,7 +15,6 @@ impl FileContextTag {
     pub const fn label(self) -> &'static str {
         match self {
             Self::ShellSpec => "shellspec",
-            Self::HelperLibrary => "helper-library",
             Self::ProjectClosure => "project-closure",
             Self::DirectiveHandling => "directive-handling",
         }
@@ -77,11 +75,6 @@ pub fn classify_file_context(
     _shell: ShellDialect,
 ) -> FileContext {
     let path_lower = path.map(|path| path.to_string_lossy().to_ascii_lowercase());
-    let path_tokens = path
-        .map(path_tokens)
-        .unwrap_or_default()
-        .into_iter()
-        .collect::<Vec<_>>();
     let lines = collect_lines(source);
 
     let has_shellspec_path = path_lower
@@ -100,22 +93,6 @@ pub fn classify_file_context(
     let mut tags = Vec::new();
     if has_shellspec_path && has_shellspec_dsl {
         tags.push(FileContextTag::ShellSpec);
-    }
-
-    if (path_tokens.iter().any(|token| {
-        matches!(
-            token.as_str(),
-            "lib" | "libexec" | "completion" | "plugins" | "helpers"
-        )
-    }) || path_lower.as_deref().is_some_and(|value| {
-        value.contains("completions-core") || value.contains("completions-fallback")
-    }) || path
-        .and_then(Path::file_name)
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.to_ascii_lowercase().ends_with(".func")))
-        && source_defines_function(&lines)
-    {
-        tags.push(FileContextTag::HelperLibrary);
     }
 
     if lines.iter().any(|line| {
@@ -193,18 +170,6 @@ fn collect_lines(source: &str) -> Vec<LineInfo<'_>> {
     lines
 }
 
-fn path_tokens(path: &Path) -> Vec<String> {
-    path.iter()
-        .filter_map(|part| part.to_str())
-        .flat_map(|part| {
-            part.split(|char: char| !char.is_ascii_alphanumeric())
-                .filter(|token| !token.is_empty())
-                .map(|token| token.to_ascii_lowercase())
-                .collect::<Vec<_>>()
-        })
-        .collect()
-}
-
 fn matches_directive(body: &str) -> bool {
     let lower = body.to_ascii_lowercase();
     lower.starts_with("shellcheck ") || lower == "shellcheck" || lower.starts_with("shuck:")
@@ -215,24 +180,6 @@ fn starts_project_closure_command(trimmed: &str) -> bool {
         || trimmed.starts_with(". ")
         || trimmed.starts_with("\\source ")
         || trimmed.starts_with("\\. ")
-}
-
-fn source_defines_function(lines: &[LineInfo<'_>]) -> bool {
-    lines
-        .iter()
-        .any(|line| probable_function_definition(line.trimmed))
-}
-
-fn probable_function_definition(trimmed: &str) -> bool {
-    if trimmed.starts_with('#') || trimmed.is_empty() {
-        return false;
-    }
-
-    if let Some(rest) = trimmed.strip_prefix("function ") {
-        return rest.contains('{');
-    }
-
-    trimmed.contains("() {") || trimmed.contains("(){")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -356,7 +303,7 @@ It 'still shell'
     }
 
     #[test]
-    fn classifies_helper_test_project_and_directive_contexts() {
+    fn classifies_project_and_directive_contexts() {
         let source = "\
 # shellcheck source=./lib.sh
 # shuck: disable=SH-001
@@ -369,7 +316,6 @@ source ./lib.sh
             ShellDialect::Bash,
         );
 
-        assert!(context.has_tag(FileContextTag::HelperLibrary));
         assert!(context.has_tag(FileContextTag::ProjectClosure));
         assert!(context.has_tag(FileContextTag::DirectiveHandling));
     }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -761,17 +761,6 @@ End
     }
 
     #[test]
-    fn helper_library_context_uses_path_tokens() {
-        let context = classify_file_context(
-            "helper() { :; }\n",
-            Some(Path::new("/tmp/repo/libexec/plugins/tool.func")),
-            ShellDialect::Sh,
-        );
-
-        assert!(context.has_tag(FileContextTag::HelperLibrary));
-    }
-
-    #[test]
     fn project_specific_paths_do_not_suppress_undefined_variables() {
         let diagnostics = lint_named_source(
             Path::new("/tmp/void-packages/common/build-style/void-cross.sh"),

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1955,34 +1955,7 @@ fn should_suppress_overwrite(
         return true;
     }
 
-    file_context.has_tag(FileContextTag::HelperLibrary)
-        && (unset_function_between(
-            checker,
-            overwritten.name.as_str(),
-            first.span.end.offset,
-            second.span.start.offset,
-        ) || (unset_function_anywhere(checker, overwritten.name.as_str())
-            && has_intervening_executable_command(
-                checker,
-                first.span.end.offset,
-                second.span.start.offset,
-            ))
-            || (file_context.has_tag(FileContextTag::ProjectClosure)
-                && (checker
-                    .semantic()
-                    .call_sites_for(&overwritten.name)
-                    .is_empty()
-                    || has_only_indirect_call_sites_between(
-                        checker,
-                        overwritten,
-                        first.span.end.offset,
-                        second.span.start.offset,
-                    ))
-                && has_intervening_executable_command(
-                    checker,
-                    first.span.end.offset,
-                    second.span.start.offset,
-                )))
+    false
 }
 
 fn should_suppress_unreached(checker: &Checker<'_>, unreached: &SemanticUnreachedFunction) -> bool {
@@ -2424,63 +2397,6 @@ fn compat_cutoff_would_report_binding(
     };
 
     !has_direct_call_to_binding_before_offset_cached(checker, binding_id, cutoff.offset, &mut reach)
-}
-
-fn unset_function_between(
-    checker: &Checker<'_>,
-    name: &str,
-    start_offset: usize,
-    end_offset: usize,
-) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        fact.effective_name_is("unset")
-            && fact.body_span().start.offset > start_offset
-            && fact.body_span().start.offset < end_offset
-            && fact
-                .options()
-                .unset()
-                .is_some_and(|unset| unset.targets_function_name(checker.source(), name))
-    })
-}
-
-fn unset_function_anywhere(checker: &Checker<'_>, name: &str) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        fact.effective_name_is("unset")
-            && fact
-                .options()
-                .unset()
-                .is_some_and(|unset| unset.targets_function_name(checker.source(), name))
-    })
-}
-
-fn has_intervening_executable_command(
-    checker: &Checker<'_>,
-    start_offset: usize,
-    end_offset: usize,
-) -> bool {
-    checker.facts().structural_commands().any(|fact| {
-        fact.body_span().start.offset > start_offset
-            && fact.body_span().start.offset < end_offset
-            && !matches!(fact.command(), shuck_ast::Command::Function(_))
-    })
-}
-
-fn has_only_indirect_call_sites_between(
-    checker: &Checker<'_>,
-    overwritten: &SemanticOverwrittenFunction,
-    start_offset: usize,
-    end_offset: usize,
-) -> bool {
-    let first = checker.semantic().binding(overwritten.first);
-    let call_sites = checker.semantic().call_sites_for(&overwritten.name);
-    let has_nested_call_site = call_sites.iter().any(|site| site.scope != first.scope);
-    let has_same_scope_call_between = call_sites.iter().any(|site| {
-        site.scope == first.scope
-            && site.span.start.offset > start_offset
-            && site.span.start.offset < end_offset
-    });
-
-    has_nested_call_site && !has_same_scope_call_between
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- remove the unused `FileContextTag::HelperLibrary` classifier and label
- drop the path/function helper detection that only fed that tag
- remove stale C063 suppression logic that was gated on `HelperLibrary`
- keep ambient contract matching on its direct source-shape checks

## Validation

- cargo fmt
- cargo test -p shuck-linter
- make test-large-corpus

Large corpus summary:

```text
blocking=0 warnings=64 fixtures=34593 unsupported_shells=887 implementation_diffs=0 mapping_issues=0 reviewed_divergences=64 harness_warnings=0 harness_failures=0
```
