### PR TITLE
refactor(linter): remove shellspec context

### DIFF
--- a/crates/shuck-linter/src/context.rs
+++ b/crates/shuck-linter/src/context.rs
@@ -6,7 +6,6 @@ use crate::ShellDialect;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FileContextTag {
-    ShellSpec,
     ProjectClosure,
     DirectiveHandling,
 }
@@ -14,7 +13,6 @@ pub enum FileContextTag {
 impl FileContextTag {
     pub const fn label(self) -> &'static str {
         match self {
-            Self::ShellSpec => "shellspec",
             Self::ProjectClosure => "project-closure",
             Self::DirectiveHandling => "directive-handling",
         }
@@ -91,9 +89,7 @@ pub fn classify_file_context(
     });
 
     let mut tags = Vec::new();
-    if has_shellspec_path && has_shellspec_dsl {
-        tags.push(FileContextTag::ShellSpec);
-    }
+    let is_shellspec = has_shellspec_path && has_shellspec_dsl;
 
     if lines.iter().any(|line| {
         let trimmed = line.trimmed;
@@ -113,7 +109,7 @@ pub fn classify_file_context(
         tags.push(FileContextTag::DirectiveHandling);
     }
 
-    let regions = if tags.contains(&FileContextTag::ShellSpec) {
+    let regions = if is_shellspec {
         shellspec_parameter_regions(&lines)
     } else {
         Vec::new()
@@ -273,7 +269,7 @@ mod tests {
     use crate::ShellDialect;
 
     #[test]
-    fn classifies_shellspec_files_and_parameter_regions() {
+    fn classifies_shellspec_parameter_regions() {
         let source = "\
 Describe 'clone'
 Parameters
@@ -290,7 +286,6 @@ It 'still shell'
             ShellDialect::Sh,
         );
 
-        assert!(context.has_tag(FileContextTag::ShellSpec));
         assert_eq!(context.regions().len(), 1);
         assert_eq!(
             context.regions()[0].kind,

--- a/crates/shuck-linter/src/context.rs
+++ b/crates/shuck-linter/src/context.rs
@@ -1,7 +1,5 @@
 use std::path::Path;
 
-use shuck_ast::{Position, Span};
-
 use crate::ShellDialect;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -19,77 +17,37 @@ impl FileContextTag {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ContextRegionKind {
-    ShellSpecParametersBlock,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ContextRegion {
-    pub kind: ContextRegionKind,
-    pub span: Span,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct FileContext {
     tags: Vec<FileContextTag>,
-    regions: Vec<ContextRegion>,
 }
 
 impl FileContext {
-    pub fn new(tags: Vec<FileContextTag>, mut regions: Vec<ContextRegion>) -> Self {
+    pub fn new(tags: Vec<FileContextTag>) -> Self {
         let mut tags = tags;
         tags.sort_unstable();
         tags.dedup();
-        regions.sort_unstable_by_key(|region| (region.span.start.offset, region.span.end.offset));
 
-        Self { tags, regions }
+        Self { tags }
     }
 
     pub fn tags(&self) -> &[FileContextTag] {
         &self.tags
     }
 
-    pub fn regions(&self) -> &[ContextRegion] {
-        &self.regions
-    }
-
     pub fn has_tag(&self, tag: FileContextTag) -> bool {
         self.tags.contains(&tag)
-    }
-
-    pub fn span_intersects_kind(&self, kind: ContextRegionKind, span: Span) -> bool {
-        self.regions.iter().any(|region| {
-            region.kind == kind
-                && region.span.start.offset < span.end.offset
-                && span.start.offset < region.span.end.offset
-        })
     }
 }
 
 pub fn classify_file_context(
     source: &str,
-    path: Option<&Path>,
+    _path: Option<&Path>,
     _shell: ShellDialect,
 ) -> FileContext {
-    let path_lower = path.map(|path| path.to_string_lossy().to_ascii_lowercase());
     let lines = collect_lines(source);
 
-    let has_shellspec_path = path_lower
-        .as_deref()
-        .is_some_and(|value| value.contains("shellspec"))
-        || path
-            .and_then(Path::file_name)
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.to_ascii_lowercase().ends_with("_spec.sh"));
-    let has_shellspec_dsl = lines.iter().any(|line| {
-        line.indent == 0
-            && !line.trimmed.starts_with('#')
-            && shellspec_header_kind(line.trimmed).is_some()
-    });
-
     let mut tags = Vec::new();
-    let is_shellspec = has_shellspec_path && has_shellspec_dsl;
 
     if lines.iter().any(|line| {
         let trimmed = line.trimmed;
@@ -109,58 +67,27 @@ pub fn classify_file_context(
         tags.push(FileContextTag::DirectiveHandling);
     }
 
-    let regions = if is_shellspec {
-        shellspec_parameter_regions(&lines)
-    } else {
-        Vec::new()
-    };
-
-    FileContext::new(tags, regions)
+    FileContext::new(tags)
 }
 
 #[derive(Debug, Clone)]
 struct LineInfo<'a> {
-    indent: usize,
-    text: &'a str,
     trimmed: &'a str,
-    span: Span,
 }
 
 fn collect_lines(source: &str) -> Vec<LineInfo<'_>> {
     let mut lines = Vec::new();
-    let mut line_number = 1usize;
-    let mut offset = 0usize;
 
     for raw_line in source.split_inclusive('\n') {
         let text = raw_line.strip_suffix('\n').unwrap_or(raw_line);
         let trimmed_start = text.trim_start_matches([' ', '\t']);
         let trimmed = trimmed_start.trim_end_matches([' ', '\t']);
-        let indent = text.len() - trimmed_start.len();
-        let start = Position {
-            line: line_number,
-            column: 1,
-            offset,
-        };
-        let end = start.advanced_by(text);
 
-        lines.push(LineInfo {
-            indent,
-            text,
-            trimmed,
-            span: Span::from_positions(start, end),
-        });
-
-        line_number += 1;
-        offset += raw_line.len();
+        lines.push(LineInfo { trimmed });
     }
 
     if source.is_empty() {
-        lines.push(LineInfo {
-            indent: 0,
-            text: "",
-            trimmed: "",
-            span: Span::new(),
-        });
+        lines.push(LineInfo { trimmed: "" });
     }
 
     lines
@@ -178,124 +105,12 @@ fn starts_project_closure_command(trimmed: &str) -> bool {
         || trimmed.starts_with("\\. ")
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ShellSpecHeaderKind {
-    Parameters,
-    Other,
-}
-
-fn shellspec_header_kind(trimmed: &str) -> Option<ShellSpecHeaderKind> {
-    let leading = trimmed
-        .split_whitespace()
-        .next()
-        .unwrap_or_default()
-        .trim_matches(|char| matches!(char, '"' | '\''));
-
-    match leading {
-        "Describe" | "Context" | "It" | "Specify" | "When" | "Mock" => {
-            Some(ShellSpecHeaderKind::Other)
-        }
-        "Parameters" => Some(ShellSpecHeaderKind::Parameters),
-        _ if leading.starts_with("Before") || leading.starts_with("After") => {
-            Some(ShellSpecHeaderKind::Other)
-        }
-        _ => None,
-    }
-}
-
-fn shellspec_parameter_regions(lines: &[LineInfo<'_>]) -> Vec<ContextRegion> {
-    let mut regions = Vec::new();
-    let mut index = 0usize;
-
-    while index < lines.len() {
-        let line = &lines[index];
-        let Some(ShellSpecHeaderKind::Parameters) = (line.indent == 0)
-            .then(|| shellspec_header_kind(line.trimmed))
-            .flatten()
-        else {
-            index += 1;
-            continue;
-        };
-
-        let mut span = line.span;
-        let mut next = index + 1;
-
-        while next < lines.len() {
-            let line = &lines[next];
-
-            if line.trimmed.is_empty() {
-                next += 1;
-                continue;
-            }
-
-            if line.indent == 0 {
-                if line.trimmed == "End" {
-                    span = span.merge(line.span);
-                }
-                break;
-            }
-
-            if line.indent > 0 || quoted_parameter_line(line.text) {
-                span = span.merge(line.span);
-                next += 1;
-                continue;
-            }
-
-            break;
-        }
-
-        regions.push(ContextRegion {
-            kind: ContextRegionKind::ShellSpecParametersBlock,
-            span,
-        });
-        index = next;
-    }
-
-    regions
-}
-
-fn quoted_parameter_line(text: &str) -> bool {
-    let trimmed = text.trim_start_matches([' ', '\t']);
-    trimmed.starts_with('"') || trimmed.starts_with('\'')
-}
-
 #[cfg(test)]
 mod tests {
     use std::path::Path;
 
-    use super::{
-        ContextRegionKind, FileContextTag, classify_file_context, shellspec_parameter_regions,
-    };
+    use super::{FileContextTag, classify_file_context};
     use crate::ShellDialect;
-
-    #[test]
-    fn classifies_shellspec_parameter_regions() {
-        let source = "\
-Describe 'clone'
-Parameters
-  \"test\"
-  \"test$SHELLSPEC_LF\"
-End
-It 'still shell'
-";
-        let context = classify_file_context(
-            source,
-            Some(Path::new(
-                "/tmp/ko1nksm__shellspec__spec__core__clone_spec.sh",
-            )),
-            ShellDialect::Sh,
-        );
-
-        assert_eq!(context.regions().len(), 1);
-        assert_eq!(
-            context.regions()[0].kind,
-            ContextRegionKind::ShellSpecParametersBlock
-        );
-        assert_eq!(
-            context.regions()[0].span.slice(source),
-            "Parameters\n  \"test\"\n  \"test$SHELLSPEC_LF\"\nEnd"
-        );
-    }
 
     #[test]
     fn classifies_project_and_directive_contexts() {
@@ -339,26 +154,5 @@ helper() { :; }
         );
 
         assert!(context.tags().is_empty());
-        assert!(context.regions().is_empty());
-    }
-
-    #[test]
-    fn shellspec_parameter_regions_stop_at_next_top_level_header() {
-        let lines = super::collect_lines(
-            "\
-Parameters
-  \"a\"
-Describe 'next'
-",
-        );
-        let regions = shellspec_parameter_regions(&lines);
-
-        assert_eq!(regions.len(), 1);
-        assert_eq!(
-            regions[0]
-                .span
-                .slice("Parameters\n  \"a\"\nDescribe 'next'\n"),
-            "Parameters\n  \"a\""
-        );
     }
 }

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -41,7 +41,6 @@ use self::{
         rewrite_word_as_single_double_quoted_string,
     },
 };
-use crate::context::ContextRegionKind;
 use crate::suppression::shellcheck_directive_can_apply_to_following_command;
 use crate::{AmbientShellOptions, FileContext, ShellDialect};
 use rustc_hash::{FxHashMap, FxHashSet};

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -260,7 +260,7 @@ fn simple_test_operands<'a>(command: &'a SimpleCommand, source: &str) -> Option<
 fn build_simple_test_fact<'a>(
     command: &'a Command,
     source: &str,
-    file_context: &FileContext,
+    _file_context: &FileContext,
 ) -> Option<SimpleTestFact<'a>> {
     let Command::Simple(command) = command else {
         return None;
@@ -305,8 +305,7 @@ fn build_simple_test_fact<'a>(
         effective_shape,
         effective_operator_family,
         operand_classes,
-        empty_test_suppressed: file_context
-            .span_intersects_kind(ContextRegionKind::ShellSpecParametersBlock, command.span),
+        empty_test_suppressed: false,
     })
 }
 

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -1175,36 +1175,6 @@ true && `echo and_redirect` 2>/dev/null
 }
 
 #[test]
-fn marks_shellspec_parameter_region_empty_tests_as_suppressed() {
-    let source = "\
-Describe 'clone'
-Parameters
-  test
-End
-
-test
-";
-
-    with_facts(
-        source,
-        Some(Path::new(
-            "/tmp/ko1nksm__shellspec__spec__core__clone_spec.sh",
-        )),
-        |_, facts| {
-            let mut tests = facts
-                .structural_commands()
-                .filter_map(|fact| fact.simple_test().map(|simple| (fact.span(), simple)))
-                .collect::<Vec<_>>();
-            tests.sort_by_key(|(span, _)| span.start.line);
-
-            assert_eq!(tests.len(), 2);
-            assert!(tests[0].1.empty_test_suppressed());
-            assert!(!tests[1].1.empty_test_suppressed());
-        },
-    );
-}
-
-#[test]
 fn builds_loop_header_pipeline_and_list_facts() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -49,9 +49,7 @@ pub mod test;
 /// Primary checker API for walking facts and emitting diagnostics.
 pub use checker::Checker;
 /// File-context classification types.
-pub use context::{
-    ContextRegion, ContextRegionKind, FileContext, FileContextTag, classify_file_context,
-};
+pub use context::{FileContext, FileContextTag, classify_file_context};
 /// Rule diagnostics and severity levels.
 pub use diagnostic::{Diagnostic, Severity};
 /// Command-substitution classification exposed by fact APIs.
@@ -724,24 +722,6 @@ mod tests {
                 rules: RuleSet::EMPTY,
                 ..LinterSettings::default()
             },
-        );
-
-        assert!(diagnostics.is_empty());
-    }
-
-    #[test]
-    fn path_sensitive_context_classification_uses_the_supplied_path() {
-        let shellspec_path = Path::new("/tmp/project/spec/clone_spec.sh");
-        let source = "\
-Describe 'clone'
-Parameters
-  \"test\"
-End
-";
-        let diagnostics = lint_named_source(
-            shellspec_path,
-            source,
-            &LinterSettings::for_rule(Rule::EmptyTest),
         );
 
         assert!(diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,4 +1,3 @@
-use crate::context::FileContextTag;
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::static_word_text;
@@ -1918,7 +1917,6 @@ fn should_suppress_overwrite(
     checker: &Checker<'_>,
     overwritten: &SemanticOverwrittenFunction,
 ) -> bool {
-    let file_context = checker.file_context();
     let compat_mode = checker
         .rule_options()
         .c063
@@ -1936,23 +1934,6 @@ fn should_suppress_overwrite(
 
     if compat_mode {
         return false;
-    }
-
-    if file_context.has_tag(FileContextTag::ShellSpec)
-        && checker
-            .semantic()
-            .call_sites_for(&overwritten.name)
-            .iter()
-            .any(|site| {
-                site.name_span.start.offset > first.span.end.offset
-                    && site.name_span.start.offset < second.span.start.offset
-            })
-    {
-        return true;
-    }
-
-    if file_context.has_tag(FileContextTag::ShellSpec) {
-        return true;
     }
 
     false
@@ -1982,11 +1963,6 @@ fn should_suppress_unreached(checker: &Checker<'_>, unreached: &SemanticUnreache
                     )
                 },
             ))
-        || (!checker
-            .rule_options()
-            .c063
-            .report_unreached_nested_definitions
-            && checker.file_context().has_tag(FileContextTag::ShellSpec))
         || (matches!(
             unreached.reason,
             UnreachedFunctionReason::EnclosingFunctionUnreached
@@ -2407,45 +2383,6 @@ mod tests {
 
     use crate::test::{test_path_with_fix, test_snippet_at_path, test_snippet_with_fix};
     use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
-
-    #[test]
-    fn shellspec_nested_helper_factories_are_suppressed() {
-        let source = "\
-Describe 'matcher'
-factory() {
-  shellspec_matcher__match() { :; }
-  shellspec_matcher__match() { :; }
-}
-";
-        let diagnostics = test_snippet_at_path(
-            Path::new("/tmp/ko1nksm__shellspec__spec__core__matcher_spec.sh"),
-            source,
-            &LinterSettings::for_rule(Rule::OverwrittenFunction),
-        );
-
-        assert!(diagnostics.is_empty());
-    }
-
-    #[test]
-    fn shellspec_top_level_example_helpers_are_suppressed() {
-        let source = "\
-Describe 'matcher'
-  Specify 'first'
-    helper() { return 0; }
-  End
-
-  Specify 'second'
-    helper() { return 1; }
-  End
-";
-        let diagnostics = test_snippet_at_path(
-            Path::new("/tmp/ko1nksm__shellspec__spec__core__matcher_spec.sh"),
-            source,
-            &LinterSettings::for_rule(Rule::OverwrittenFunction),
-        );
-
-        assert!(diagnostics.is_empty());
-    }
 
     #[test]
     fn ordinary_overwrites_still_report() {


### PR DESCRIPTION
## Summary

- remove the `FileContextTag::ShellSpec` tag and label
- remove the remaining ShellSpec parameter-region context machinery
- remove the C063 and EmptyTest suppression paths that depended on ShellSpec context
- delete the unit tests that only asserted the removed ShellSpec context behavior

## Validation

- cargo fmt
- cargo test -p shuck-linter
- make test-large-corpus

Large corpus summary:

```text
blocking=0 warnings=64 fixtures=34593 unsupported_shells=887 implementation_diffs=0 mapping_issues=0 reviewed_divergences=64 harness_warnings=0 harness_failures=0
```
