### PR TITLE
perf(indexer): fold continuation discovery into line scan

### DIFF
--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -54,6 +54,10 @@ name = "parser"
 harness = false
 
 [[bench]]
+name = "indexer"
+harness = false
+
+[[bench]]
 name = "arithmetic"
 harness = false
 

--- a/crates/shuck-benchmark/benches/indexer.rs
+++ b/crates/shuck-benchmark/benches/indexer.rs
@@ -1,0 +1,51 @@
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixture};
+use shuck_indexer::Indexer;
+use shuck_parser::parser::ParseResult;
+
+configure_benchmark_allocator!();
+
+struct PreparedInput {
+    source: &'static str,
+    output: ParseResult,
+}
+
+fn prepare_input(source: &'static str) -> PreparedInput {
+    let output = parse_fixture(source);
+    PreparedInput { source, output }
+}
+
+fn build_indexer(input: &PreparedInput) -> usize {
+    let indexer = Indexer::new(input.source, &input.output);
+    black_box(
+        indexer.line_index().line_count()
+            + indexer.comment_index().comments().len()
+            + indexer.continuation_line_starts().len(),
+    )
+}
+
+fn bench_indexer(c: &mut Criterion) {
+    let mut group = c.benchmark_group("indexer");
+
+    for case in benchmark_cases() {
+        group.sample_size(case.speed.sample_size());
+        group.throughput(Throughput::Bytes(case.total_bytes()));
+        group.bench_with_input(BenchmarkId::from_parameter(case.name), &case, |b, case| {
+            let inputs = case
+                .files
+                .iter()
+                .map(|file| prepare_input(file.source))
+                .collect::<Vec<_>>();
+
+            b.iter(|| {
+                let indexed_size: usize = inputs.iter().map(build_indexer).sum();
+                black_box(indexed_size);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_indexer);
+criterion_main!(benches);

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -36,7 +36,8 @@ impl Indexer {
         let line_index = LineIndex::new(source);
         let comment_index = CommentIndex::new(source, &line_index, &output.file);
         let region_index = RegionIndex::new(source, &output.file);
-        let continuation_lines = collect_continuation_lines(source, &comment_index, &region_index);
+        let continuation_lines =
+            collect_continuation_lines(&line_index, &comment_index, &region_index);
 
         Self {
             line_index,
@@ -78,19 +79,14 @@ impl Indexer {
 }
 
 fn collect_continuation_lines(
-    source: &str,
+    line_index: &LineIndex,
     comment_index: &CommentIndex,
     region_index: &RegionIndex,
 ) -> Vec<TextSize> {
-    let bytes = source.as_bytes();
     let mut continuation_lines = Vec::new();
 
-    for index in 1..bytes.len() {
-        if bytes[index] != b'\n' || bytes[index - 1] != b'\\' {
-            continue;
-        }
-
-        let backslash_offset = TextSize::new((index - 1) as u32);
+    for line_start in line_index.raw_continuation_line_starts() {
+        let backslash_offset = TextSize::new(line_start.to_u32() - 2);
         if comment_index.is_comment(backslash_offset)
             || region_index.is_heredoc(backslash_offset)
             || region_index.is_quoted(backslash_offset)
@@ -98,7 +94,7 @@ fn collect_continuation_lines(
             continue;
         }
 
-        continuation_lines.push(TextSize::new((index + 1) as u32));
+        continuation_lines.push(*line_start);
     }
 
     continuation_lines

--- a/crates/shuck-indexer/src/line_index.rs
+++ b/crates/shuck-indexer/src/line_index.rs
@@ -4,22 +4,31 @@ use shuck_ast::{TextRange, TextSize};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LineIndex {
     line_starts: Vec<TextSize>,
+    raw_continuation_line_starts: Vec<TextSize>,
 }
 
 impl LineIndex {
     /// Build from source text.
     pub fn new(source: &str) -> Self {
-        let mut line_starts =
-            Vec::with_capacity(source.bytes().filter(|byte| *byte == b'\n').count() + 1);
+        let bytes = source.as_bytes();
+        let mut line_starts = Vec::new();
+        let mut raw_continuation_line_starts = Vec::new();
         line_starts.push(TextSize::new(0));
 
-        for (index, byte) in source.bytes().enumerate() {
+        for (index, byte) in bytes.iter().copied().enumerate() {
             if byte == b'\n' {
-                line_starts.push(TextSize::new((index + 1) as u32));
+                let next_line_start = TextSize::new((index + 1) as u32);
+                line_starts.push(next_line_start);
+                if index > 0 && bytes[index - 1] == b'\\' {
+                    raw_continuation_line_starts.push(next_line_start);
+                }
             }
         }
 
-        Self { line_starts }
+        Self {
+            line_starts,
+            raw_continuation_line_starts,
+        }
     }
 
     /// Return the 1-based line number containing `offset`.
@@ -57,6 +66,10 @@ impl LineIndex {
     pub fn line_count(&self) -> usize {
         self.line_starts.len()
     }
+
+    pub(crate) fn raw_continuation_line_starts(&self) -> &[TextSize] {
+        &self.raw_continuation_line_starts
+    }
 }
 
 #[cfg(test)]
@@ -82,6 +95,17 @@ mod tests {
         assert_eq!(index.line_number(TextSize::new(4)), 2);
         assert_eq!(index.line_number(TextSize::new(source.len() as u32)), 3);
         assert_eq!(index.line_range(2, source).unwrap().slice(source), "two");
+    }
+
+    #[test]
+    fn tracks_raw_continuation_candidates_while_collecting_lines() {
+        let source = "echo foo \\\n  bar\necho \"foo\\\nbar\"\n";
+        let index = LineIndex::new(source);
+
+        assert_eq!(
+            index.raw_continuation_line_starts(),
+            &[TextSize::new(11), TextSize::new(28)]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- folds raw line-continuation candidate discovery into the existing `LineIndex::new` newline scan
- keeps comment, quoted-region, and heredoc filtering in the indexer using the existing AST-backed indexes
- adds a dedicated Criterion benchmark for `Indexer::new`

## Validation

- `cargo test -p shuck-indexer`
- `cargo bench -p shuck-benchmark --bench indexer -- --save-baseline before-continuation-line-refactor`
- `cargo bench -p shuck-benchmark --bench indexer -- --baseline before-continuation-line-refactor`

Final Criterion comparison showed `Indexer::new` improving across the bundled fixtures, with the aggregate `all` case about 22% faster by mean estimate.
