### PR TITLE
perf(linter): cache command scope to elide per-iteration scope_at

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -723,6 +723,7 @@ fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str)
 fn collect_arithmetic_update_operator_spans_in_command(
     command: &Command,
     semantic: &SemanticModel,
+    scope: ScopeId,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
@@ -730,7 +731,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
         Command::Simple(command) => {
             for assignment in &command.assignments {
                 collect_arithmetic_update_operator_spans_in_assignment(
-                    assignment, semantic, source, spans,
+                    assignment, semantic, scope, source, spans,
                 );
             }
             collect_arithmetic_update_operator_spans_in_word(
@@ -747,7 +748,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Break(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, semantic, source, spans,
+                        assignment, semantic, scope, source, spans,
                     );
                 }
                 if let Some(word) = &command.depth {
@@ -760,7 +761,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Continue(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, semantic, source, spans,
+                        assignment, semantic, scope, source, spans,
                     );
                 }
                 if let Some(word) = &command.depth {
@@ -773,7 +774,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Return(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, semantic, source, spans,
+                        assignment, semantic, scope, source, spans,
                     );
                 }
                 if let Some(word) = &command.code {
@@ -786,7 +787,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Exit(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, semantic, source, spans,
+                        assignment, semantic, scope, source, spans,
                     );
                 }
                 if let Some(word) = &command.code {
@@ -800,7 +801,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
         Command::Decl(command) => {
             for assignment in &command.assignments {
                 collect_arithmetic_update_operator_spans_in_assignment(
-                    assignment, semantic, source, spans,
+                    assignment, semantic, scope, source, spans,
                 );
             }
             for operand in &command.operands {
@@ -812,7 +813,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     }
                     DeclOperand::Assignment(assignment) => {
                         collect_arithmetic_update_operator_spans_in_assignment(
-                            assignment, semantic, source, spans,
+                            assignment, semantic, scope, source, spans,
                         );
                     }
                     DeclOperand::Name(_) => {}
@@ -898,20 +899,19 @@ fn collect_arithmetic_update_operator_spans_in_command(
 fn collect_arithmetic_update_operator_spans_in_assignment(
     assignment: &Assignment,
     semantic: &SemanticModel,
+    scope: ScopeId,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
     collect_arithmetic_update_operator_spans_in_assignment_target(
         &assignment.target,
         semantic,
+        scope,
         source,
         spans,
     );
-    let target_is_contextual_assoc = var_ref_name_has_visible_assoc_binding_at(
-        &assignment.target,
-        semantic,
-        assignment.target.name_span,
-    );
+    let target_is_contextual_assoc =
+        var_ref_name_has_visible_assoc_binding_at(&assignment.target, semantic, scope);
 
     match &assignment.value {
         AssignmentValue::Scalar(word) => {
@@ -951,10 +951,11 @@ fn collect_arithmetic_update_operator_spans_in_assignment(
 fn collect_arithmetic_update_operator_spans_in_assignment_target(
     reference: &VarRef,
     semantic: &SemanticModel,
+    scope: ScopeId,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    if !var_ref_subscript_has_assoc_semantics(reference, semantic) {
+    if !var_ref_subscript_has_assoc_semantics_in_scope(reference, semantic, scope) {
         collect_arithmetic_update_operator_spans_in_subscript(
             reference.subscript.as_deref(),
             source,
@@ -983,40 +984,64 @@ fn var_ref_subscript_has_assoc_semantics(reference: &VarRef, semantic: &Semantic
         return false;
     }
 
-    var_ref_name_has_visible_assoc_binding_at(reference, semantic, subscript.span())
+    let scope = semantic.scope_at(subscript.span().start.offset);
+    var_ref_name_has_visible_assoc_binding_at(reference, semantic, scope)
+}
+
+fn var_ref_subscript_has_assoc_semantics_in_scope(
+    reference: &VarRef,
+    semantic: &SemanticModel,
+    scope: ScopeId,
+) -> bool {
+    let Some(subscript) = reference.subscript.as_deref() else {
+        return false;
+    };
+    if matches!(
+        subscript.interpretation,
+        shuck_ast::SubscriptInterpretation::Associative
+    ) {
+        return true;
+    }
+    if !matches!(
+        subscript.interpretation,
+        shuck_ast::SubscriptInterpretation::Contextual
+    ) {
+        return false;
+    }
+
+    var_ref_name_has_visible_assoc_binding_at(reference, semantic, scope)
 }
 
 fn var_ref_name_has_visible_assoc_binding_at(
     reference: &VarRef,
     semantic: &SemanticModel,
-    scope_span: Span,
+    scope: ScopeId,
 ) -> bool {
     if let Some(visible) =
-        var_ref_name_has_visible_assoc_binding_in_nearest_scope(reference, semantic, scope_span)
+        var_ref_name_has_visible_assoc_binding_in_nearest_scope(reference, semantic, scope)
     {
         return visible;
     }
 
-    var_ref_name_has_visible_assoc_binding_from_named_callers(&reference.name, semantic, scope_span)
+    var_ref_name_has_visible_assoc_binding_from_named_callers(&reference.name, semantic, scope)
 }
 
 fn var_ref_name_has_visible_assoc_binding_in_nearest_scope(
     reference: &VarRef,
     semantic: &SemanticModel,
-    scope_span: Span,
+    scope: ScopeId,
 ) -> Option<bool> {
-    let current_scope = semantic.scope_at(scope_span.start.offset);
     semantic
-        .visible_binding_for_assoc_lookup(&reference.name, current_scope, reference.name_span)
+        .visible_binding_for_assoc_lookup(&reference.name, scope, reference.name_span)
         .map(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
 }
 
 fn var_ref_name_has_visible_assoc_binding_from_named_callers(
     name: &Name,
     semantic: &SemanticModel,
-    scope_span: Span,
+    scope: ScopeId,
 ) -> bool {
-    let Some(function_names) = named_function_scope_names(semantic, scope_span.start.offset) else {
+    let Some(function_names) = named_function_scope_names(semantic, scope) else {
         return false;
     };
 
@@ -1030,19 +1055,18 @@ fn var_ref_name_has_visible_assoc_binding_from_named_callers(
         }
 
         for call_site in semantic.call_sites_for(&function_name) {
-            let current_scope = semantic.scope_at(call_site.name_span.start.offset);
-            if let Some(binding) =
-                semantic.visible_binding_for_assoc_lookup(name, current_scope, call_site.name_span)
-            {
+            if let Some(binding) = semantic.visible_binding_for_assoc_lookup(
+                name,
+                call_site.scope,
+                call_site.name_span,
+            ) {
                 if binding.attributes.contains(BindingAttributes::ASSOC) {
                     return true;
                 }
                 continue;
             }
 
-            if let Some(caller_names) =
-                named_function_scope_names(semantic, call_site.name_span.start.offset)
-            {
+            if let Some(caller_names) = named_function_scope_names(semantic, call_site.scope) {
                 worklist.extend(caller_names.iter().cloned());
             }
         }
@@ -1089,8 +1113,7 @@ impl AssocCallerSeenNames {
     }
 }
 
-fn named_function_scope_names(semantic: &SemanticModel, offset: usize) -> Option<&[Name]> {
-    let scope = semantic.scope_at(offset);
+fn named_function_scope_names(semantic: &SemanticModel, scope: ScopeId) -> Option<&[Name]> {
     semantic
         .ancestor_scopes(scope)
         .find_map(|scope_id| match &semantic.scope(scope_id).kind {
@@ -1227,7 +1250,14 @@ fn collect_arithmetic_update_operator_spans_in_nested_command_body(
             descend_nested_word_commands: true,
         },
     ) {
-        collect_arithmetic_update_operator_spans_in_command(visit.command, semantic, source, spans);
+        let scope = semantic.scope_at(visit.stmt.span.start.offset);
+        collect_arithmetic_update_operator_spans_in_command(
+            visit.command,
+            semantic,
+            scope,
+            source,
+            spans,
+        );
         for redirect in visit.redirects {
             if let Some(word) = redirect.word_target() {
                 collect_arithmetic_update_operator_spans_in_word(word, semantic, source, spans);

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1266,7 +1266,7 @@ fn build_nonpersistent_assignment_spans(
 
         let Some(nonpersistent_scope) = nonpersistent_scope_span_for_assignment(
             semantic,
-            binding.span.start.offset,
+            binding.scope,
             &scope_spans_by_id,
             suppress_bash_pipefail_pipeline_side_effects,
         ) else {
@@ -1487,8 +1487,7 @@ fn build_nonpersistent_assignment_spans(
             .unwrap_or(&[]);
         let event_command_id =
             precomputed_command_id_for_offset(&innermost_command_ids_by_offset, read.span.start.offset);
-        let read_function_scope =
-            enclosing_function_scope_for_scope(semantic, semantic.scope_at(read.span.start.offset));
+        let read_function_scope = enclosing_function_scope_for_scope(semantic, read.scope);
         if let Some(candidate) = candidate_ids.iter().rev().find(|candidate| {
             read.span.start.offset > candidate.subshell_end
                 && candidate_allows_unresolved_later_use(candidate, read_function_scope)
@@ -1503,7 +1502,10 @@ fn build_nonpersistent_assignment_spans(
                 name: read.name.clone(),
                 span: candidate.assignment_span,
             });
-            later_use_sites.push(read);
+            later_use_sites.push(NamedSpan {
+                name: read.name,
+                span: read.span,
+            });
         }
     }
 
@@ -1684,12 +1686,12 @@ struct PersistentReset {
 
 fn nonpersistent_scope_span_for_assignment(
     semantic: &SemanticModel,
-    offset: usize,
+    scope: ScopeId,
     scope_spans_by_id: &FxHashMap<ScopeId, Span>,
     suppress_bash_pipefail_pipeline_side_effects: bool,
 ) -> Option<NonpersistentScopeSpan> {
     semantic
-        .ancestor_scopes(semantic.scope_at(offset))
+        .ancestor_scopes(scope)
         .find(|scope_id| match semantic.scope_kind(*scope_id) {
             shuck_semantic::ScopeKind::Pipeline => !suppress_bash_pipefail_pipeline_side_effects,
             shuck_semantic::ScopeKind::Subshell
@@ -1801,19 +1803,26 @@ fn command_prefix_assignments_reset_name(command: &Command, name: &Name) -> bool
         .any(|assignment| assignment.target.name == *name)
 }
 
+struct PromptRuntimeRead {
+    name: Name,
+    span: Span,
+    scope: ScopeId,
+}
+
 fn build_prompt_runtime_read_spans(
     commands: &[CommandFact<'_>],
     source: &str,
-) -> Vec<NamedSpan> {
+) -> Vec<PromptRuntimeRead> {
     let mut reads = Vec::new();
 
     for command in commands {
+        let scope = command.scope();
         for assignment in command_assignments(command.command()) {
-            collect_prompt_runtime_reads_from_assignment(assignment, source, &mut reads);
+            collect_prompt_runtime_reads_from_assignment(assignment, scope, source, &mut reads);
         }
         for operand in declaration_operands(command.command()) {
             if let DeclOperand::Assignment(assignment) = operand {
-                collect_prompt_runtime_reads_from_assignment(assignment, source, &mut reads);
+                collect_prompt_runtime_reads_from_assignment(assignment, scope, source, &mut reads);
             }
         }
     }
@@ -1825,8 +1834,9 @@ fn build_prompt_runtime_read_spans(
 
 fn collect_prompt_runtime_reads_from_assignment(
     assignment: &Assignment,
+    scope: ScopeId,
     source: &str,
-    reads: &mut Vec<NamedSpan>,
+    reads: &mut Vec<PromptRuntimeRead>,
 ) {
     if assignment.target.name.as_str() != "PS4" {
         return;
@@ -1837,9 +1847,10 @@ fn collect_prompt_runtime_reads_from_assignment(
 
     let target_span = assignment_target_span(assignment);
     for name in escaped_braced_parameter_names(word.span.slice(source)) {
-        reads.push(NamedSpan {
+        reads.push(PromptRuntimeRead {
             name: Name::from(name.as_str()),
             span: target_span,
+            scope,
         });
     }
 }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -194,9 +194,11 @@ impl<'a> LinterFactsBuilder<'a> {
                     &mut ifs_literal_backslash_assignment_value_spans,
                 );
                 let normalized = command::normalize_command(visit.command, self.source);
+                let command_start_offset = command_span(visit.command).start.offset;
+                let scope = self.semantic.scope_at(command_start_offset);
                 let command_zsh_options = effective_command_zsh_options(
                     self.semantic,
-                    command_span(visit.command).start.offset,
+                    command_start_offset,
                     &normalized,
                 );
                 let nested_word_command = context.nested_word_command;
@@ -210,6 +212,7 @@ impl<'a> LinterFactsBuilder<'a> {
                     WordFactCommandContext {
                         command_id: id,
                         nested_word_command,
+                        scope,
                     },
                     &normalized,
                     command_zsh_options.clone(),
@@ -242,6 +245,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 collect_arithmetic_update_operator_spans_in_command(
                     visit.command,
                     self.semantic,
+                    scope,
                     self.source,
                     &mut arithmetic_update_operator_spans,
                 );
@@ -277,8 +281,6 @@ impl<'a> LinterFactsBuilder<'a> {
                 );
                 let redirect_fact_range = redirect_fact_store.push_many(redirect_facts);
                 let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
-                let scope =
-                    (!nested_word_command).then(|| self.semantic.scope_at(normalized.body_span.start.offset));
                 let declaration_assignment_probes = build_declaration_assignment_probes(
                     visit.command,
                     &normalized,

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -4,7 +4,7 @@ pub struct CommandFact<'a> {
     key: FactSpan,
     visit: CommandVisit<'a>,
     nested_word_command: bool,
-    scope: Option<ScopeId>,
+    scope: ScopeId,
     normalized: NormalizedCommand<'a>,
     zsh_options: Option<ZshOptionState>,
     redirect_facts: IdRange<RedirectFact<'a>>,
@@ -36,7 +36,7 @@ impl<'a> CommandFact<'a> {
         self.nested_word_command
     }
 
-    pub fn scope(&self) -> Option<ScopeId> {
+    pub fn scope(&self) -> ScopeId {
         self.scope
     }
 
@@ -205,7 +205,7 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         self.fact.is_nested_word_command()
     }
 
-    pub fn scope(self) -> Option<ScopeId> {
+    pub fn scope(self) -> ScopeId {
         self.fact.scope()
     }
 

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -196,6 +196,7 @@ fn build_function_cli_dispatch_facts(
                 let Some(binding_id) = visible_function_binding_defined_before_offset(
                     semantic,
                     &name,
+                    semantic.scope_at(dispatcher_span.start.offset),
                     dispatcher_span.start.offset,
                 ) else {
                     continue;
@@ -267,7 +268,7 @@ fn build_completion_registered_function_command_flags(
     commands
         .iter()
         .map(|command| {
-            enclosing_function_scope(semantic, command.span().start.offset)
+            enclosing_function_scope(semantic, command.scope())
                 .is_some_and(|scope| registered_scopes.contains(&scope))
         })
         .collect()
@@ -444,6 +445,7 @@ fn build_function_call_arity_facts<'a>(
             let Some(binding_id) = visible_function_binding_for_call_offset(
                 semantic,
                 name,
+                command.scope(),
                 name_word.span.start.offset,
             ) else {
                 continue;
@@ -536,11 +538,10 @@ fn function_header_scope_id(
 fn visible_function_binding_for_call_offset(
     semantic: &SemanticModel,
     name: &Name,
+    site_scope: ScopeId,
     site_offset: usize,
 ) -> Option<BindingId> {
-    let scopes = semantic
-        .ancestor_scopes(semantic.scope_at(site_offset))
-        .collect::<Vec<_>>();
+    let scopes = semantic.ancestor_scopes(site_scope).collect::<Vec<_>>();
 
     scopes
         .iter()
@@ -569,11 +570,10 @@ fn visible_function_binding_for_call_offset(
 fn visible_function_binding_defined_before_offset(
     semantic: &SemanticModel,
     name: &Name,
+    site_scope: ScopeId,
     site_offset: usize,
 ) -> Option<BindingId> {
-    let scopes = semantic
-        .ancestor_scopes(semantic.scope_at(site_offset))
-        .collect::<Vec<_>>();
+    let scopes = semantic.ancestor_scopes(site_scope).collect::<Vec<_>>();
 
     scopes.iter().copied().find_map(|scope| {
         semantic
@@ -798,7 +798,8 @@ fn build_function_positional_parameter_facts(
         }
 
         let offset = command.span().start.offset;
-        if let Some(scope) = innermost_nonpersistent_scope_within_function(semantic, offset) {
+        if let Some(scope) = innermost_nonpersistent_scope_within_function(semantic, command.scope())
+        {
             local_reset_offsets_by_scope
                 .entry(scope)
                 .or_default()
@@ -809,6 +810,7 @@ fn build_function_positional_parameter_facts(
     for reference in semantic.references() {
         if reference_has_local_positional_reset(
             semantic,
+            reference.scope,
             reference.span.start.offset,
             &local_reset_offsets_by_scope,
         ) {
@@ -826,8 +828,7 @@ fn build_function_positional_parameter_facts(
                 continue;
             }
 
-            let Some(scope) = enclosing_function_scope(semantic, reference.span.start.offset)
-            else {
+            let Some(scope) = enclosing_function_scope(semantic, reference.scope) else {
                 continue;
             };
 
@@ -843,7 +844,7 @@ fn build_function_positional_parameter_facts(
             continue;
         }
 
-        let Some(scope) = enclosing_function_scope(semantic, reference.span.start.offset) else {
+        let Some(scope) = enclosing_function_scope(semantic, reference.scope) else {
             continue;
         };
 
@@ -857,15 +858,17 @@ fn build_function_positional_parameter_facts(
             continue;
         }
 
+        let fragment_scope = semantic.scope_at(fragment.span().start.offset);
         if reference_has_local_positional_reset(
             semantic,
+            fragment_scope,
             fragment.span().start.offset,
             &local_reset_offsets_by_scope,
         ) {
             continue;
         }
 
-        let Some(scope) = enclosing_function_scope(semantic, fragment.span().start.offset) else {
+        let Some(scope) = enclosing_function_scope(semantic, fragment_scope) else {
             continue;
         };
 
@@ -877,7 +880,7 @@ fn build_function_positional_parameter_facts(
 
     for command in commands {
         let Some(scope) =
-            enclosing_function_scope_for_positional_reset(semantic, command.span().start.offset)
+            enclosing_function_scope_for_positional_reset(semantic, command.scope())
         else {
             continue;
         };
@@ -894,8 +897,7 @@ fn build_function_positional_parameter_facts(
     facts
 }
 
-fn enclosing_function_scope(semantic: &SemanticModel, offset: usize) -> Option<ScopeId> {
-    let scope = semantic.scope_at(offset);
+fn enclosing_function_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<ScopeId> {
     semantic.ancestor_scopes(scope).find(|scope| {
         matches!(
             semantic.scope_kind(*scope),
@@ -906,10 +908,8 @@ fn enclosing_function_scope(semantic: &SemanticModel, offset: usize) -> Option<S
 
 fn enclosing_function_scope_for_positional_reset(
     semantic: &SemanticModel,
-    offset: usize,
+    scope: ScopeId,
 ) -> Option<ScopeId> {
-    let scope = semantic.scope_at(offset);
-
     for scope in semantic.ancestor_scopes(scope) {
         match semantic.scope_kind(scope) {
             shuck_semantic::ScopeKind::Function(_) => return Some(scope),
@@ -925,10 +925,8 @@ fn enclosing_function_scope_for_positional_reset(
 
 fn innermost_nonpersistent_scope_within_function(
     semantic: &SemanticModel,
-    offset: usize,
+    scope: ScopeId,
 ) -> Option<ScopeId> {
-    let scope = semantic.scope_at(offset);
-
     for scope in semantic.ancestor_scopes(scope) {
         match semantic.scope_kind(scope) {
             shuck_semantic::ScopeKind::Subshell
@@ -944,11 +942,10 @@ fn innermost_nonpersistent_scope_within_function(
 
 fn reference_has_local_positional_reset(
     semantic: &SemanticModel,
+    scope: ScopeId,
     offset: usize,
     local_reset_offsets_by_scope: &FxHashMap<ScopeId, Vec<usize>>,
 ) -> bool {
-    let scope = semantic.scope_at(offset);
-
     for scope in semantic.ancestor_scopes(scope) {
         match semantic.scope_kind(scope) {
             shuck_semantic::ScopeKind::Subshell

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -3397,6 +3397,7 @@ fn build_word_facts_for_command<'a>(
         semantic,
         context.command_id,
         context.nested_word_command,
+        context.scope,
         normalized,
         command_zsh_options,
         outputs,
@@ -3434,9 +3435,11 @@ pub(crate) fn benchmark_collect_word_facts(
         },
         &mut |visit, context| {
             let normalized = command::normalize_command(visit.command, source);
+            let command_start_offset = command_span(visit.command).start.offset;
+            let scope = semantic.scope_at(command_start_offset);
             let command_zsh_options = effective_command_zsh_options(
                 semantic,
-                command_span(visit.command).start.offset,
+                command_start_offset,
                 &normalized,
             );
             build_word_facts_for_command(
@@ -3446,6 +3449,7 @@ pub(crate) fn benchmark_collect_word_facts(
                 WordFactCommandContext {
                     command_id: CommandId::new(next_command_id),
                     nested_word_command: context.nested_word_command,
+                    scope,
                 },
                 &normalized,
                 command_zsh_options,
@@ -3499,6 +3503,7 @@ pub(crate) fn benchmark_collect_word_facts(
 struct WordFactCommandContext {
     command_id: CommandId,
     nested_word_command: bool,
+    scope: ScopeId,
 }
 
 struct WordFactOutputs<'out, 'a> {
@@ -3808,6 +3813,7 @@ struct WordFactCollector<'out, 'a, 'norm> {
     semantic: &'a SemanticModel,
     command_id: CommandId,
     nested_word_command: bool,
+    command_scope: ScopeId,
     surface_command_name: Option<&'norm str>,
     surface_body_arg_start_offset: Option<usize>,
     command_zsh_options: Option<ZshOptionState>,
@@ -3848,11 +3854,13 @@ fn simple_command_word_at(command: &SimpleCommand, index: usize) -> &Word {
 }
 
 impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         source: &'a str,
         semantic: &'a SemanticModel,
         command_id: CommandId,
         nested_word_command: bool,
+        command_scope: ScopeId,
         normalized: &'norm NormalizedCommand<'a>,
         command_zsh_options: Option<ZshOptionState>,
         outputs: WordFactOutputs<'out, 'a>,
@@ -3862,6 +3870,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             semantic,
             command_id,
             nested_word_command,
+            command_scope,
             surface_command_name: normalized.effective_or_literal_name(),
             surface_body_arg_start_offset: normalized
                 .body_args()
@@ -5142,10 +5151,9 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         owner_name_span: Option<Span>,
         subscript: &Subscript,
     ) -> bool {
-        let current_scope = self.semantic.scope_at(subscript.span().start.offset);
         let key = (
             owner_name.clone(),
-            current_scope,
+            self.command_scope,
             owner_name_span.map(FactSpan::new),
         );
         if let Some(result) = self.assoc_binding_visibility_memo.get(&key) {
@@ -5157,7 +5165,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         {
             visible
         } else {
-            self.assoc_binding_visible_from_named_callers(owner_name, subscript.span())
+            self.assoc_binding_visible_from_named_callers(owner_name)
         };
         self.assoc_binding_visibility_memo.insert(key, visible);
         visible
@@ -5170,14 +5178,13 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         subscript: &Subscript,
     ) -> Option<bool> {
         let lookup_span = owner_name_span.unwrap_or(subscript.span());
-        let current_scope = self.semantic.scope_at(subscript.span().start.offset);
         self.semantic
-            .visible_binding_for_assoc_lookup(owner_name, current_scope, lookup_span)
+            .visible_binding_for_assoc_lookup(owner_name, self.command_scope, lookup_span)
             .map(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
     }
 
-    fn assoc_binding_visible_from_named_callers(&self, owner_name: &Name, span: Span) -> bool {
-        let Some(function_names) = self.named_function_scope_names(span.start.offset) else {
+    fn assoc_binding_visible_from_named_callers(&self, owner_name: &Name) -> bool {
+        let Some(function_names) = self.named_function_scope_names(self.command_scope) else {
             return false;
         };
 
@@ -5191,18 +5198,18 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             }
 
             for call_site in self.semantic.call_sites_for(&function_name) {
-                if let Some(binding) =
-                    self.visible_binding_for_caller_assoc_lookup(owner_name, call_site.name_span)
-                {
+                if let Some(binding) = self.semantic.visible_binding_for_assoc_lookup(
+                    owner_name,
+                    call_site.scope,
+                    call_site.name_span,
+                ) {
                     if binding.attributes.contains(BindingAttributes::ASSOC) {
                         return true;
                     }
                     continue;
                 }
 
-                if let Some(caller_names) =
-                    self.named_function_scope_names(call_site.name_span.start.offset)
-                {
+                if let Some(caller_names) = self.named_function_scope_names(call_site.scope) {
                     worklist.extend(caller_names.iter().cloned());
                 }
             }
@@ -5211,18 +5218,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         false
     }
 
-    fn visible_binding_for_caller_assoc_lookup(
-        &self,
-        owner_name: &Name,
-        span: Span,
-    ) -> Option<&shuck_semantic::Binding> {
-        let current_scope = self.semantic.scope_at(span.start.offset);
-        self.semantic
-            .visible_binding_for_assoc_lookup(owner_name, current_scope, span)
-    }
-
-    fn named_function_scope_names(&self, offset: usize) -> Option<&[Name]> {
-        let scope = self.semantic.scope_at(offset);
+    fn named_function_scope_names(&self, scope: ScopeId) -> Option<&[Name]> {
         self.semantic.ancestor_scopes(scope).find_map(|scope_id| {
             match &self.semantic.scope(scope_id).kind {
                 shuck_semantic::ScopeKind::Function(shuck_semantic::FunctionScopeKind::Named(

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -258,10 +258,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
 
     for fact in checker.facts().structural_commands() {
         let offset = fact.body_span().start.offset;
-        let known_scope = fact.scope();
-        if let Some(scope) = known_scope {
-            scopes_by_offset.entry(offset).or_insert(scope);
-        }
+        scopes_by_offset.entry(offset).or_insert(fact.scope());
         let is_function = matches!(fact.command(), shuck_ast::Command::Function(_));
         if is_function {
             function_definition_offsets.insert(offset);
@@ -280,7 +277,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
         }
 
         if !is_function && let Some(name) = fact.effective_name() {
-            let scope = known_scope.unwrap_or_else(|| checker.semantic().scope_at(offset));
+            let scope = fact.scope();
             calls
                 .entry(name.to_owned())
                 .or_default()
@@ -310,7 +307,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
                 && !command_offset_is_under_dominance_barrier(checker, offset)
                 && !command_offset_is_unreachable(checker, offset)
             {
-                let scope = known_scope.unwrap_or_else(|| checker.semantic().scope_at(offset));
+                let scope = fact.scope();
                 let command_fact = CompatUnsetCommandFact { scope, offset };
                 for target in targets {
                     unset_commands_by_target
@@ -323,7 +320,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
 
         let apparent_loop_body_span = apparent_infinite_loop_body_span(checker, fact.command());
         if is_return || apparent_loop_body_span.is_some() {
-            let scope = known_scope.unwrap_or_else(|| checker.semantic().scope_at(offset));
+            let scope = fact.scope();
             if scope_is_file_scope(checker, scope) {
                 if is_return {
                     top_level_return_offsets.push(offset);


### PR DESCRIPTION
## Summary
- Compute the enclosing `ScopeId` once per command in `LinterFactsBuilder` and attach it to `CommandFact`. Thread it through the words, arithmetic, assignments, and functions fact builders so they consume the precomputed scope instead of calling `scope_at` on every word, reference, or assignment they visit.
- Anchor the per-command scope lookup on `command_span(visit.command).start.offset` rather than `normalized.body_span.start.offset`. Assignment-only simple commands (`map[$key]=1`) parse with a synthetic empty name word, so the body-span anchor was resolving to file scope and breaking dynamic-scope assoc-binding visibility checks in `dollar_in_arithmetic`.
- `CommandFact::scope()` now returns `ScopeId` instead of `Option<ScopeId>`. `overwritten_function` and other callers that previously fell back to `scope_at` on the body offset use the attached scope directly.

## Performance
Measured on the `linter/nvm` Criterion benchmark:

| Bench | Change | p-value |
|---|---:|---:|
| `linter/nvm` | -10.1% | <0.05 |
| `linter_word_facts/nvm` | -11.1% | <0.05 |
| `linter_facts/nvm` | -7.0% | 0.22 (noisy) |

This matches the projected `scope_at` hotspot reduction from ~10% to ~3-4% of samples on this fixture.

## Test plan
- [x] `cargo test -p shuck-linter` (3074/3074 pass)
- [x] `cargo test -p shuck-cli -p shuck-cache`
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo bench -p shuck-benchmark --bench linter -- "linter/nvm"`