### PR TITLE
refactor(semantic): collect file-entry contracts during traversal

### DIFF
--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -250,6 +250,7 @@ fn prepare_word_facts_input(
             source_path: Some(&fixture.path),
             source_path_resolver: resolver,
             file_entry_contract: None,
+            file_entry_contract_collector: None,
             analyzed_paths: None,
             shell_profile: Some(ShellDialect::from_name(&fixture.shell).shell_profile()),
             resolve_source_closure: true,

--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -2,37 +2,62 @@ use std::collections::BTreeSet;
 use std::path::Path;
 
 use shuck_ast::{
-    BuiltinCommand, Command, CompoundCommand, File, Name, SimpleCommand,
-    StaticCommandWrapperTarget, Stmt, StmtSeq, Word, static_command_name_text,
-    static_command_wrapper_target_index, static_word_text,
+    Name, NormalizedCommand, Word, WrapperKind, normalize_command_words, static_word_text,
 };
-use shuck_semantic::{ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind};
+use shuck_semantic::{
+    ContractCertainty, FileContract, FileEntryContractCollector, ProvidedBinding,
+    ProvidedBindingKind,
+};
 
 use crate::ShellDialect;
 
 struct AmbientContractProvider {
-    matches: fn(file: &File, source: &str, path: &Path, shell: ShellDialect) -> bool,
-    build: fn(file: &File, source: &str, path: &Path, shell: ShellDialect) -> FileContract,
+    matches: fn(&AmbientContractCollector<'_>, &Path, ShellDialect) -> bool,
+    build: fn(&AmbientContractCollector<'_>, &Path, ShellDialect) -> FileContract,
 }
 
-pub(crate) fn file_entry_contract(
-    file: &File,
-    source: &str,
-    path: Option<&Path>,
+pub(crate) struct AmbientContractCollector<'a> {
+    source: &'a str,
+    path: Option<&'a Path>,
     shell: ShellDialect,
-) -> Option<FileContract> {
-    let path = path?;
-    let mut merged = FileContract::default();
-    let mut matched = false;
+    completion_initializer_invoked: bool,
+}
 
-    for provider in providers() {
-        if (provider.matches)(file, source, path, shell) {
-            matched = true;
-            merge_contract(&mut merged, (provider.build)(file, source, path, shell));
+impl<'a> AmbientContractCollector<'a> {
+    pub(crate) fn new(source: &'a str, path: Option<&'a Path>, shell: ShellDialect) -> Self {
+        Self {
+            source,
+            path,
+            shell,
+            completion_initializer_invoked: false,
         }
     }
 
-    matched.then_some(merged)
+    fn file_entry_contract(&self) -> Option<FileContract> {
+        let path = self.path?;
+        let mut merged = FileContract::default();
+        let mut matched = false;
+
+        for provider in providers() {
+            if (provider.matches)(self, path, self.shell) {
+                matched = true;
+                merge_contract(&mut merged, (provider.build)(self, path, self.shell));
+            }
+        }
+
+        matched.then_some(merged)
+    }
+}
+
+impl FileEntryContractCollector for AmbientContractCollector<'_> {
+    fn observe_simple_command(&mut self, command: &NormalizedCommand<'_>) {
+        self.completion_initializer_invoked |=
+            normalized_command_invokes_completion_initializer(command, self.source);
+    }
+
+    fn finish(&self) -> Option<FileContract> {
+        self.file_entry_contract()
+    }
 }
 
 fn providers() -> &'static [AmbientContractProvider] {
@@ -56,25 +81,23 @@ fn merge_contract(merged: &mut FileContract, contract: FileContract) {
 }
 
 fn matches_sourced_runtime_contract(
-    file: &File,
-    source: &str,
+    collector: &AmbientContractCollector<'_>,
     path: &Path,
     _shell: ShellDialect,
 ) -> bool {
     let lower = lower_path(path);
-    sourced_runtime_path_shape(&lower) && sourced_runtime_source_shape(file, source, &lower)
+    sourced_runtime_path_shape(&lower) && sourced_runtime_source_shape(collector, &lower)
 }
 
 fn build_sourced_runtime_contract(
-    file: &File,
-    source: &str,
+    collector: &AmbientContractCollector<'_>,
     path: &Path,
     _shell: ShellDialect,
 ) -> FileContract {
     let lower = lower_path(path);
     let mut names = BTreeSet::new();
 
-    for name in runtime_names_for_source_path(file, source, &lower) {
+    for name in runtime_names_for_source_path(collector, &lower) {
         names.insert((*name).to_owned());
     }
 
@@ -116,21 +139,25 @@ fn sourced_runtime_path_shape(lower: &str) -> bool {
     )
 }
 
-fn sourced_runtime_source_shape(file: &File, source: &str, lower_path: &str) -> bool {
+fn sourced_runtime_source_shape(
+    collector: &AmbientContractCollector<'_>,
+    lower_path: &str,
+) -> bool {
+    let source = collector.source;
     has_probable_function_definition(source)
         || has_source_command(source)
         || source.contains("PROMPT_COMMAND")
         || source.contains("COMPREPLY")
         || source.contains("about-completion")
         || (lower_path.contains("termux-packages") && source.contains("TERMUX_"))
-        || completion_runtime_source_shape(file, source)
+        || collector.completion_initializer_invoked
 }
 
 fn runtime_names_for_source_path(
-    file: &File,
-    source: &str,
+    collector: &AmbientContractCollector<'_>,
     lower: &str,
 ) -> &'static [&'static str] {
+    let source = collector.source;
     if bash_it_theme_runtime_shape(source, lower) {
         return &[
             "black",
@@ -156,7 +183,7 @@ fn runtime_names_for_source_path(
         ];
     }
 
-    if completion_runtime_shape(file, source, lower) {
+    if completion_runtime_shape(collector, lower) {
         return &["cur", "prev", "words", "cword", "comp_args", "split"];
     }
 
@@ -194,8 +221,8 @@ fn bash_it_theme_runtime_shape(source: &str, lower: &str) -> bool {
             ))
 }
 
-fn completion_runtime_shape(file: &File, source: &str, lower: &str) -> bool {
-    completion_runtime_path_shape(lower) && completion_runtime_source_shape(file, source)
+fn completion_runtime_shape(collector: &AmbientContractCollector<'_>, lower: &str) -> bool {
+    completion_runtime_path_shape(lower) && collector.completion_initializer_invoked
 }
 
 fn completion_runtime_path_shape(lower: &str) -> bool {
@@ -212,151 +239,56 @@ fn completion_runtime_path_shape(lower: &str) -> bool {
     )
 }
 
-fn completion_runtime_source_shape(file: &File, source: &str) -> bool {
-    stmt_seq_invokes_completion_initializer(&file.body, source)
-}
-
-fn stmt_seq_invokes_completion_initializer(sequence: &StmtSeq, source: &str) -> bool {
-    sequence
-        .iter()
-        .any(|stmt| stmt_invokes_completion_initializer(stmt, source))
-}
-
-fn stmt_invokes_completion_initializer(stmt: &Stmt, source: &str) -> bool {
-    command_invokes_completion_initializer(&stmt.command, source)
-}
-
-fn command_invokes_completion_initializer(command: &Command, source: &str) -> bool {
-    match command {
-        Command::Simple(command) => simple_command_invokes_completion_initializer(command, source),
-        Command::Builtin(command) => builtin_invokes_completion_initializer(command, source),
-        Command::Decl(_) => false,
-        Command::Binary(command) => {
-            stmt_invokes_completion_initializer(&command.left, source)
-                || stmt_invokes_completion_initializer(&command.right, source)
-        }
-        Command::Compound(command) => compound_invokes_completion_initializer(command, source),
-        Command::Function(function) => stmt_invokes_completion_initializer(&function.body, source),
-        Command::AnonymousFunction(function) => {
-            stmt_invokes_completion_initializer(&function.body, source)
-        }
-    }
-}
-
-fn simple_command_invokes_completion_initializer(command: &SimpleCommand, source: &str) -> bool {
-    let words = std::iter::once(&command.name)
-        .chain(command.args.iter())
-        .collect::<Vec<_>>();
-    word_chain_invokes_completion_initializer(&words, source)
-}
-
-fn builtin_invokes_completion_initializer(_command: &BuiltinCommand, _source: &str) -> bool {
-    false
-}
-
-fn word_chain_invokes_completion_initializer(words: &[&Word], source: &str) -> bool {
-    let mut index = 0;
-
-    while let Some(word) = words.get(index) {
-        let Some(name) = static_command_name_text(word, source) else {
-            return false;
-        };
-
-        if is_completion_initializer_command(name.as_ref()) {
-            return true;
-        }
-
-        if name == "env" {
-            let Some(target_index) = env_wrapper_target_index(words, source, index) else {
-                return false;
-            };
-            index = target_index;
-            continue;
-        }
-
-        match static_command_wrapper_target_index(words.len(), index, name.as_ref(), |index| {
-            static_word_text(words[index], source)
-        }) {
-            StaticCommandWrapperTarget::Wrapper {
-                target_index: Some(target_index),
-            } => index = target_index,
-            StaticCommandWrapperTarget::Wrapper { target_index: None }
-            | StaticCommandWrapperTarget::NotWrapper => return false,
-        }
+fn normalized_command_invokes_completion_initializer(
+    command: &NormalizedCommand<'_>,
+    source: &str,
+) -> bool {
+    if command
+        .effective_name
+        .as_deref()
+        .is_some_and(is_completion_initializer_command)
+        && command
+            .wrappers
+            .iter()
+            .all(wrapper_can_affect_current_shell)
+    {
+        return true;
     }
 
-    false
-}
+    if command.effective_name.as_deref() != Some("env")
+        || !command
+            .wrappers
+            .iter()
+            .all(wrapper_can_affect_current_shell)
+    {
+        return false;
+    }
 
-fn env_wrapper_target_index(words: &[&Word], source: &str, current_index: usize) -> Option<usize> {
-    current_index
-        .checked_add(1)
-        .and_then(|start| words.get(start..))?
+    command
+        .body_args()
         .iter()
         .enumerate()
-        .find_map(|(relative_index, word)| {
+        .find_map(|(index, word)| {
             let text = static_word_text(word, source)?;
-            (!shell_assignment_token(text.as_ref())).then_some(current_index + 1 + relative_index)
+            (!shell_assignment_token(text.as_ref())).then_some(index)
         })
+        .and_then(|index| command.body_args().get(index..))
+        .and_then(|words| normalized_words_invoke_completion_initializer(words, source))
+        .unwrap_or(false)
 }
 
-fn compound_invokes_completion_initializer(command: &CompoundCommand, source: &str) -> bool {
-    match command {
-        CompoundCommand::If(command) => {
-            stmt_seq_invokes_completion_initializer(&command.condition, source)
-                || stmt_seq_invokes_completion_initializer(&command.then_branch, source)
-                || command.elif_branches.iter().any(|(condition, body)| {
-                    stmt_seq_invokes_completion_initializer(condition, source)
-                        || stmt_seq_invokes_completion_initializer(body, source)
-                })
-                || command
-                    .else_branch
-                    .as_ref()
-                    .is_some_and(|branch| stmt_seq_invokes_completion_initializer(branch, source))
-        }
-        CompoundCommand::For(command) => {
-            stmt_seq_invokes_completion_initializer(&command.body, source)
-        }
-        CompoundCommand::Repeat(command) => {
-            stmt_seq_invokes_completion_initializer(&command.body, source)
-        }
-        CompoundCommand::Foreach(command) => {
-            stmt_seq_invokes_completion_initializer(&command.body, source)
-        }
-        CompoundCommand::ArithmeticFor(command) => {
-            stmt_seq_invokes_completion_initializer(&command.body, source)
-        }
-        CompoundCommand::While(command) => {
-            stmt_seq_invokes_completion_initializer(&command.condition, source)
-                || stmt_seq_invokes_completion_initializer(&command.body, source)
-        }
-        CompoundCommand::Until(command) => {
-            stmt_seq_invokes_completion_initializer(&command.condition, source)
-                || stmt_seq_invokes_completion_initializer(&command.body, source)
-        }
-        CompoundCommand::Case(command) => command
-            .cases
-            .iter()
-            .any(|case| stmt_seq_invokes_completion_initializer(&case.body, source)),
-        CompoundCommand::Select(command) => {
-            stmt_seq_invokes_completion_initializer(&command.body, source)
-        }
-        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
-            stmt_seq_invokes_completion_initializer(commands, source)
-        }
-        CompoundCommand::Arithmetic(_) | CompoundCommand::Conditional(_) => false,
-        CompoundCommand::Time(command) => command
-            .command
-            .as_ref()
-            .is_some_and(|stmt| stmt_invokes_completion_initializer(stmt, source)),
-        CompoundCommand::Coproc(command) => {
-            stmt_invokes_completion_initializer(&command.body, source)
-        }
-        CompoundCommand::Always(command) => {
-            stmt_seq_invokes_completion_initializer(&command.body, source)
-                || stmt_seq_invokes_completion_initializer(&command.always_body, source)
-        }
-    }
+fn normalized_words_invoke_completion_initializer(words: &[&Word], source: &str) -> Option<bool> {
+    let command = normalize_command_words(words, source)?;
+    Some(normalized_command_invokes_completion_initializer(
+        &command, source,
+    ))
+}
+
+fn wrapper_can_affect_current_shell(wrapper: &WrapperKind) -> bool {
+    matches!(
+        wrapper,
+        WrapperKind::Command | WrapperKind::Builtin | WrapperKind::Exec | WrapperKind::Noglob
+    )
 }
 
 fn is_completion_initializer_command(token: &str) -> bool {
@@ -428,11 +360,29 @@ fn source_mentions_name(source: &str, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use shuck_indexer::Indexer;
     use shuck_parser::parser::Parser;
+    use shuck_semantic::{
+        FileEntryContractCollector, NoopTraversalObserver, SemanticBuildOptions,
+        build_with_observer_with_options,
+    };
 
     fn contract_for(path: &Path, source: &str) -> Option<FileContract> {
         let output = Parser::new(source).parse().unwrap();
-        file_entry_contract(&output.file, source, Some(path), ShellDialect::Sh)
+        let indexer = Indexer::new(source, &output);
+        let mut observer = NoopTraversalObserver;
+        let mut collector = AmbientContractCollector::new(source, Some(path), ShellDialect::Sh);
+        let _semantic = build_with_observer_with_options(
+            &output.file,
+            source,
+            &indexer,
+            &mut observer,
+            SemanticBuildOptions {
+                file_entry_contract_collector: Some(&mut collector),
+                ..SemanticBuildOptions::default()
+            },
+        );
+        collector.finish()
     }
 
     fn has_initialized_binding(contract: &FileContract, name: &str) -> bool {
@@ -589,6 +539,66 @@ _example() {
 
         assert!(has_ambient_binding(&contract, "cur"));
         assert!(has_ambient_binding(&contract, "cword"));
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_with_env_then_shell_wrapper_get_ambient_completion_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+_example() {
+  env LC_ALL=C command _init_completion || return
+  env LC_ALL=\"$locale\" _get_comp_words_by_ref cur || return
+  env LC_ALL=C env _comp_initialize || return
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(has_ambient_binding(&contract, "cur"));
+        assert!(has_ambient_binding(&contract, "cword"));
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_with_external_initializer_wrappers_do_not_initialize_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+_example() {
+  sudo _init_completion || return
+  sudo env _init_completion || return
+  env LC_ALL=C sudo _get_comp_words_by_ref || return
+  printf '%s\\n' \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_ambient_binding(&contract, "cur"));
+        assert!(!has_ambient_binding(&contract, "cword"));
+        assert!(!has_initialized_binding(&contract, "cur"));
+        assert!(!has_initialized_binding(&contract, "cword"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn bash_completion_paths_with_subshell_initializer_do_not_initialize_contracts() {
+        let path = Path::new("/tmp/bash-completion/completions/example.bash");
+        let source = "\
+_example() {
+  printf '%s\\n' \"$(_init_completion)\" \"$cur\" \"$cword\"
+}
+";
+
+        let contract = contract_for(path, source).unwrap();
+
+        assert!(!has_ambient_binding(&contract, "cur"));
+        assert!(!has_ambient_binding(&contract, "cword"));
         assert!(!has_initialized_binding(&contract, "cur"));
         assert!(!has_initialized_binding(&contract, "cword"));
         assert!(!contract.externally_consumed_bindings);

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -222,8 +222,8 @@ fn analyze_file_at_path_with_resolver_and_shell(
     shell: ShellDialect,
     first_parse_error: Option<(usize, usize)>,
 ) -> AnalysisResult {
-    let file_entry_contract =
-        ambient_contracts::file_entry_contract(file, source, source_path, shell);
+    let mut file_entry_contract_collector =
+        ambient_contracts::AmbientContractCollector::new(source, source_path, shell);
     let analyzed_paths_fallback =
         source_path.map(|path| FxHashSet::from_iter([path.to_path_buf()]));
     let analyzed_paths = settings
@@ -241,7 +241,8 @@ fn analyze_file_at_path_with_resolver_and_shell(
         SemanticBuildOptions {
             source_path,
             source_path_resolver,
-            file_entry_contract,
+            file_entry_contract: None,
+            file_entry_contract_collector: Some(&mut file_entry_contract_collector),
             analyzed_paths,
             shell_profile: Some(shell_profile),
             resolve_source_closure: settings.resolve_source_closure,

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -6505,8 +6505,7 @@ move_up $count
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
         let analysis = semantic.analysis();
-        let file_context = classify_file_context(source, None, ShellDialect::Bash);
-        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
 
         let word_fact = facts

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -38,8 +38,8 @@ use crate::source_ref::{
     default_diagnostic_class,
 };
 use crate::{
-    BindingId, FunctionScopeKind, IndirectTargetHint, ReferenceId, Scope, ScopeId, ScopeKind,
-    SourceDirectiveOverride, SpanKey, TraversalObserver,
+    BindingId, FileEntryContractCollector, FunctionScopeKind, IndirectTargetHint, ReferenceId,
+    Scope, ScopeId, ScopeKind, SourceDirectiveOverride, SpanKey, TraversalObserver,
 };
 
 pub(crate) struct BuildOutput {
@@ -74,6 +74,7 @@ pub(crate) struct BuildOutput {
 
 pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     source: &'a str,
+    file_entry_contract_collector: Option<&'observer mut dyn FileEntryContractCollector>,
     line_start_offsets: Vec<usize>,
     shell_profile: ShellProfile,
     observer: &'observer mut dyn TraversalObserver,
@@ -167,6 +168,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         source: &'a str,
         indexer: &'a Indexer,
         observer: &'observer mut dyn TraversalObserver,
+        file_entry_contract_collector: Option<&'observer mut dyn FileEntryContractCollector>,
         bash_runtime_vars_enabled: bool,
         shell_profile: ShellProfile,
     ) -> BuildOutput {
@@ -180,6 +182,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let runtime = RuntimePrelude::new(bash_runtime_vars_enabled);
         let mut builder = Self {
             source,
+            file_entry_contract_collector,
             line_start_offsets: source_line_start_offsets(source),
             shell_profile: shell_profile.clone(),
             observer,
@@ -386,6 +389,11 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             .collect::<Vec<_>>();
         let normalized = normalize_command_words(&command_words, self.source)
             .expect("simple commands always have a name");
+        if !flow.in_subshell
+            && let Some(collector) = self.file_entry_contract_collector.as_deref_mut()
+        {
+            collector.observe_simple_command(&normalized);
+        }
 
         if let Some(name) = normalized.literal_name.as_deref()
             && !name.is_empty()

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -1,5 +1,5 @@
 use rustc_hash::FxHashMap;
-use shuck_ast::Name;
+use shuck_ast::{Name, NormalizedCommand};
 use shuck_parser::ShellProfile;
 use std::path::{Path, PathBuf};
 
@@ -171,6 +171,19 @@ pub struct FileContract {
     pub externally_consumed_bindings: bool,
 }
 
+/// Build-time collector for file-entry contracts discovered during semantic traversal.
+///
+/// Implementors can observe the normalized command stream while the semantic
+/// builder is already walking the file, then return a contract that should be
+/// applied before final reference resolution, dataflow, and call-graph use.
+pub trait FileEntryContractCollector {
+    /// Observe one simple command after semantic command normalization.
+    fn observe_simple_command(&mut self, command: &NormalizedCommand<'_>);
+
+    /// Return the collected file-entry contract, when this file needs one.
+    fn finish(&self) -> Option<FileContract>;
+}
+
 impl FileContract {
     pub fn add_required_read(&mut self, name: Name) {
         if !self.required_reads.contains(&name) {
@@ -274,11 +287,11 @@ impl FileContract {
     }
 }
 
-#[derive(Clone)]
 pub struct SemanticBuildOptions<'a> {
     pub source_path: Option<&'a Path>,
     pub source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
     pub file_entry_contract: Option<FileContract>,
+    pub file_entry_contract_collector: Option<&'a mut dyn FileEntryContractCollector>,
     pub analyzed_paths: Option<&'a rustc_hash::FxHashSet<PathBuf>>,
     pub shell_profile: Option<ShellProfile>,
     pub resolve_source_closure: bool,
@@ -290,6 +303,7 @@ impl Default for SemanticBuildOptions<'_> {
             source_path: None,
             source_path_resolver: None,
             file_entry_contract: None,
+            file_entry_contract_collector: None,
             analyzed_paths: None,
             shell_profile: None,
             resolve_source_closure: true,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -45,8 +45,8 @@ pub use call_graph::{
 pub use cfg::{BasicBlock, BlockId, ControlFlowGraph, EdgeKind, FlowContext, UnreachableCauseKind};
 /// Contract and build-option types used when constructing semantic models.
 pub use contract::{
-    ContractCertainty, FileContract, FileEntryBindingInitialization, FunctionContract,
-    ProvidedBinding, ProvidedBindingKind, SemanticBuildOptions,
+    ContractCertainty, FileContract, FileEntryBindingInitialization, FileEntryContractCollector,
+    FunctionContract, ProvidedBinding, ProvidedBindingKind, SemanticBuildOptions,
 };
 /// Dataflow results surfaced by the semantic analysis layer.
 pub use dataflow::{
@@ -2871,6 +2871,7 @@ pub fn build_with_observer_at_path_with_resolver(
             source_path,
             source_path_resolver,
             file_entry_contract: None,
+            file_entry_contract_collector: None,
             analyzed_paths: None,
             shell_profile: None,
             resolve_source_closure: true,
@@ -2885,40 +2886,58 @@ fn build_semantic_model(
     observer: &mut dyn TraversalObserver,
     options: SemanticBuildOptions<'_>,
 ) -> SemanticModel {
+    let SemanticBuildOptions {
+        source_path,
+        source_path_resolver,
+        file_entry_contract,
+        mut file_entry_contract_collector,
+        analyzed_paths,
+        shell_profile,
+        resolve_source_closure,
+    } = options;
     let mut model = build_semantic_model_base(
         file,
         source,
         indexer,
         observer,
-        options.source_path,
-        options.shell_profile.clone(),
+        source_path,
+        shell_profile.clone(),
+        file_entry_contract_collector
+            .as_mut()
+            .map(|collector| &mut **collector as &mut dyn FileEntryContractCollector),
     );
-    if let Some(contract) = options.file_entry_contract {
+    if let Some(contract) = file_entry_contract {
         model.apply_file_entry_contract(contract, file);
     }
-    if let Some(source_path) = options.source_path {
+    if let Some(contract) = file_entry_contract_collector
+        .as_ref()
+        .and_then(|collector| collector.finish())
+    {
+        model.apply_file_entry_contract(contract, file);
+    }
+    if let Some(source_path) = source_path {
         let (
             synthetic_reads,
             imported_bindings,
             source_ref_resolutions,
             source_ref_explicitness,
             source_ref_diagnostic_classes,
-        ) = if options.resolve_source_closure {
+        ) = if resolve_source_closure {
             source_closure::collect_source_closure_contracts(
                 &model,
                 file,
                 source,
                 source_path,
-                options.source_path_resolver,
-                options.analyzed_paths,
+                source_path_resolver,
+                analyzed_paths,
             )
         } else {
             let (source_ref_resolutions, source_ref_explicitness, source_ref_diagnostic_classes) =
                 source_closure::collect_source_ref_metadata(
                     &model,
                     source_path,
-                    options.source_path_resolver,
-                    options.analyzed_paths,
+                    source_path_resolver,
+                    analyzed_paths,
                 );
             (
                 Vec::new(),
@@ -2939,13 +2958,14 @@ fn build_semantic_model(
     model
 }
 
-pub(crate) fn build_semantic_model_base(
+pub(crate) fn build_semantic_model_base<'a>(
     file: &File,
     source: &str,
     indexer: &Indexer,
-    observer: &mut dyn TraversalObserver,
+    observer: &'a mut dyn TraversalObserver,
     source_path: Option<&Path>,
     shell_profile: Option<ShellProfile>,
+    file_entry_contract_collector: Option<&'a mut dyn FileEntryContractCollector>,
 ) -> SemanticModel {
     let shell_profile = shell_profile.unwrap_or_else(|| infer_shell_profile(source, source_path));
     let built = SemanticModelBuilder::build(
@@ -2953,6 +2973,7 @@ pub(crate) fn build_semantic_model_base(
         source,
         indexer,
         observer,
+        file_entry_contract_collector,
         bash_runtime_vars_enabled(source, source_path),
         shell_profile,
     );

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -1288,6 +1288,7 @@ fn summarize_helper_uncached(
         &mut observer,
         Some(path),
         Some(shell_profile.clone()),
+        None,
     );
     let collected = collect_source_closure_contracts_with_cache(
         &semantic,


### PR DESCRIPTION
## Summary
- add a semantic traversal collector hook for file-entry contracts
- move ambient completion contract detection onto normalized command observation
- apply collected contracts before source-closure/dataflow consumers run

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p shuck-linter ambient_contracts
- make test
- make test-large-corpus
  - blocking=0 warnings=64 fixtures=34593 unsupported_shells=887 implementation_diffs=0 mapping_issues=0 reviewed_divergences=64 harness_warnings=0 harness_failures=0