### PR TITLE
perf(linter): speed up misspelling lookup

### DIFF
--- a/crates/shuck-linter/src/facts/misspelling.rs
+++ b/crates/shuck-linter/src/facts/misspelling.rs
@@ -50,14 +50,102 @@ impl MisspellingCandidateSet {
 #[derive(Debug)]
 struct MisspellingCandidateLookup {
     casefold_exact: FxHashMap<Box<str>, SmallVec<[usize; 2]>>,
-    deletions: FxHashMap<Box<str>, SmallVec<[usize; 4]>>,
+    edit1_deletions: FxHashMap<Box<str>, SmallVec<[usize; 4]>>,
+    env_trie: MisspellingCandidateTrie,
+}
+
+#[derive(Debug)]
+struct MisspellingCandidateTrie {
+    nodes: Vec<MisspellingCandidateTrieNode>,
+}
+
+#[derive(Debug, Default)]
+struct MisspellingCandidateTrieNode {
+    children: SmallVec<[(u8, usize); 4]>,
+    candidate_ids: SmallVec<[usize; 1]>,
+}
+
+impl MisspellingCandidateTrie {
+    fn new() -> Self {
+        Self {
+            nodes: vec![MisspellingCandidateTrieNode::default()],
+        }
+    }
+
+    fn insert(&mut self, name: &str, candidate_id: usize) {
+        let mut node_id = 0;
+        for byte in name.bytes() {
+            if let Some((_, child_id)) = self.nodes[node_id]
+                .children
+                .iter()
+                .find(|(child_byte, _)| *child_byte == byte)
+            {
+                node_id = *child_id;
+                continue;
+            }
+
+            let child_id = self.nodes.len();
+            self.nodes.push(MisspellingCandidateTrieNode::default());
+            self.nodes[node_id].children.push((byte, child_id));
+            node_id = child_id;
+        }
+        self.nodes[node_id].candidate_ids.push(candidate_id);
+    }
+
+    fn edit2_candidate_ids(&self, target_name: &str) -> SmallVec<[usize; 16]> {
+        let target = target_name.as_bytes();
+        let initial_row = (0..=target.len())
+            .map(|index| u8::try_from(index).unwrap_or(3).min(3))
+            .collect::<SmallVec<[u8; 32]>>();
+        let mut ids = SmallVec::<[usize; 16]>::new();
+
+        for (byte, child_id) in self.nodes[0].children.iter().copied() {
+            self.collect_edit2_candidate_ids(child_id, byte, target, &initial_row, &mut ids);
+        }
+
+        ids
+    }
+
+    fn collect_edit2_candidate_ids(
+        &self,
+        node_id: usize,
+        node_byte: u8,
+        target: &[u8],
+        previous_row: &[u8],
+        ids: &mut SmallVec<[usize; 16]>,
+    ) {
+        let mut current_row = SmallVec::<[u8; 32]>::new();
+        current_row.push(previous_row[0].saturating_add(1));
+        let mut row_min = current_row[0];
+
+        for (index, target_byte) in target.iter().enumerate() {
+            let insertion = current_row[index].saturating_add(1);
+            let deletion = previous_row[index + 1].saturating_add(1);
+            let substitution = previous_row[index] + u8::from(*target_byte != node_byte);
+            let value = insertion.min(deletion).min(substitution).min(3);
+            current_row.push(value);
+            row_min = row_min.min(value);
+        }
+
+        if current_row[target.len()] <= 2 {
+            ids.extend_from_slice(&self.nodes[node_id].candidate_ids);
+        }
+        if row_min > 2 {
+            return;
+        }
+
+        for (byte, child_id) in self.nodes[node_id].children.iter().copied() {
+            self.collect_edit2_candidate_ids(child_id, byte, target, &current_row, ids);
+        }
+    }
 }
 
 impl MisspellingCandidateLookup {
     fn from_entries(entries: &[MisspellingCandidate]) -> Self {
         let mut index = Self {
             casefold_exact: FxHashMap::default(),
-            deletions: FxHashMap::default(),
+            edit1_deletions: FxHashMap::default(),
+            env_trie: MisspellingCandidateTrie::new(),
         };
 
         for (id, entry) in entries.iter().enumerate() {
@@ -72,8 +160,9 @@ impl MisspellingCandidateLookup {
                 continue;
             }
 
-            for key in deletion_keys(name) {
-                index.deletions.entry(key).or_default().push(id);
+            index.env_trie.insert(name, id);
+            for key in edit1_deletion_keys(name) {
+                index.edit1_deletions.entry(key).or_default().push(id);
             }
         }
 
@@ -86,29 +175,74 @@ impl MisspellingCandidateLookup {
         target_name: &str,
         tie_break: CandidateTieBreak,
     ) -> Option<&'a str> {
-        let mut ids = SmallVec::<[usize; 16]>::new();
-        if target_name.len() >= 4
-            && let Some(exact_ids) = self
-                .casefold_exact
-                .get(canonical_ascii_uppercase(target_name).as_str())
-        {
-            ids.extend_from_slice(exact_ids);
+        if let Some(best) = self.best_exact(entries, target_name, tie_break) {
+            return Some(best);
         }
-
-        if target_name.len() >= 3 {
-            for key in deletion_keys(target_name) {
-                if let Some(key_ids) = self.deletions.get(&key) {
-                    ids.extend_from_slice(key_ids);
-                }
-            }
-        }
-
-        if ids.is_empty() {
+        if target_name.len() < 3 {
             return None;
+        }
+        if let Some(best) = self.best_edit1(entries, target_name, tie_break) {
+            return Some(best);
+        }
+        self.best_edit2_strong_shape(entries, target_name, tie_break)
+    }
+
+    fn best_exact<'a>(
+        &self,
+        entries: &'a [MisspellingCandidate],
+        target_name: &str,
+        tie_break: CandidateTieBreak,
+    ) -> Option<&'a str> {
+        if target_name.len() < 4 {
+            return None;
+        }
+        let ids = self
+            .casefold_exact
+            .get(canonical_ascii_uppercase(target_name).as_str())?;
+        self.best_from_ids(
+            entries,
+            target_name,
+            tie_break,
+            ids.iter().copied(),
+            Some(0),
+        )
+    }
+
+    fn best_edit1<'a>(
+        &self,
+        entries: &'a [MisspellingCandidate],
+        target_name: &str,
+        tie_break: CandidateTieBreak,
+    ) -> Option<&'a str> {
+        let mut ids = SmallVec::<[usize; 16]>::new();
+        for key in edit1_deletion_keys(target_name) {
+            if let Some(key_ids) = self.edit1_deletions.get(&key) {
+                ids.extend_from_slice(key_ids);
+            }
         }
         ids.sort_unstable();
         ids.dedup();
+        self.best_from_ids(entries, target_name, tie_break, ids.into_iter(), Some(2))
+    }
 
+    fn best_edit2_strong_shape<'a>(
+        &self,
+        entries: &'a [MisspellingCandidate],
+        target_name: &str,
+        tie_break: CandidateTieBreak,
+    ) -> Option<&'a str> {
+        let ids = self.env_trie.edit2_candidate_ids(target_name);
+        self.best_from_ids(entries, target_name, tie_break, ids.into_iter(), Some(3))
+    }
+
+    fn best_from_ids<'a>(
+        &self,
+        entries: &'a [MisspellingCandidate],
+        target_name: &str,
+        tie_break: CandidateTieBreak,
+        ids: impl IntoIterator<Item = usize>,
+        required_rank: Option<u8>,
+    ) -> Option<&'a str> {
         ids.into_iter()
             .filter_map(|id| {
                 let entry = &entries[id];
@@ -116,6 +250,9 @@ impl MisspellingCandidateLookup {
                     return None;
                 }
                 let rank = candidate_match_rank(target_name, entry.name.as_str())?;
+                if required_rank.is_some_and(|required| rank != required) {
+                    return None;
+                }
                 Some((id, rank, entry))
             })
             .min_by(|left, right| compare_candidates(*left, *right, tie_break))
@@ -364,19 +501,18 @@ fn candidate_match_rank(target_name: &str, candidate_name: &str) -> Option<u8> {
     if !is_environment_style_name(candidate_name)
         || target_name.len() < 3
         || candidate_name.len() < 4
+        || target_name.len().abs_diff(candidate_name.len()) > 2
     {
         return None;
     }
 
-    let distance =
-        bounded_ascii_edit_distance(target_name.as_bytes(), candidate_name.as_bytes(), 2)?;
-    if distance == 0 {
+    if ascii_edit_distance_at_most(target_name.as_bytes(), candidate_name.as_bytes(), 1) {
+        return Some(2);
+    }
+    if !has_strong_two_edit_shape(target_name, candidate_name) {
         return None;
     }
-    if distance == 2 && !has_strong_two_edit_shape(target_name, candidate_name) {
-        return None;
-    }
-    Some(distance + 1)
+    ascii_edit_distance_at_most(target_name.as_bytes(), candidate_name.as_bytes(), 2).then_some(3)
 }
 
 fn has_strong_two_edit_shape(target_name: &str, candidate_upper: &str) -> bool {
@@ -437,72 +573,59 @@ fn common_suffix_len(left: &[u8], right: &[u8]) -> usize {
         .count()
 }
 
-fn bounded_ascii_edit_distance(left: &[u8], right: &[u8], max_distance: u8) -> Option<u8> {
-    let max_distance = usize::from(max_distance);
-    if left.len().abs_diff(right.len()) > max_distance {
-        return None;
+fn ascii_edit_distance_at_most(left: &[u8], right: &[u8], max_distance: u8) -> bool {
+    if left.len().abs_diff(right.len()) > usize::from(max_distance) {
+        return false;
     }
-
-    let mut previous = (0..=right.len()).collect::<SmallVec<[usize; 32]>>();
-    let mut current = SmallVec::<[usize; 32]>::new();
-    current.resize(right.len() + 1, 0);
-
-    for (left_index, left_byte) in left.iter().enumerate() {
-        current[0] = left_index + 1;
-        let mut row_min = current[0];
-
-        for (right_index, right_byte) in right.iter().enumerate() {
-            let deletion = previous[right_index + 1] + 1;
-            let insertion = current[right_index] + 1;
-            let substitution = previous[right_index] + usize::from(left_byte != right_byte);
-            let value = deletion.min(insertion).min(substitution);
-            current[right_index + 1] = value;
-            row_min = row_min.min(value);
-        }
-
-        if row_min > max_distance {
-            return None;
-        }
-
-        std::mem::swap(&mut previous, &mut current);
-    }
-
-    let distance = previous[right.len()];
-    (distance <= max_distance).then_some(distance as u8)
+    ascii_edit_distance_at_most_inner(left, right, max_distance)
 }
 
-fn deletion_keys(name: &str) -> Vec<Box<str>> {
-    let mut keys = Vec::new();
-    let mut scratch = Vec::with_capacity(name.len());
-    collect_deletion_keys(name.as_bytes(), 0, 2, &mut scratch, &mut keys);
+fn ascii_edit_distance_at_most_inner(mut left: &[u8], mut right: &[u8], edits_left: u8) -> bool {
+    while let (Some((&left_byte, left_rest)), Some((&right_byte, right_rest))) =
+        (left.split_first(), right.split_first())
+    {
+        if left_byte != right_byte {
+            break;
+        }
+        left = left_rest;
+        right = right_rest;
+    }
+
+    while let (Some((&left_byte, left_rest)), Some((&right_byte, right_rest))) =
+        (left.split_last(), right.split_last())
+    {
+        if left_byte != right_byte {
+            break;
+        }
+        left = left_rest;
+        right = right_rest;
+    }
+
+    if left.is_empty() || right.is_empty() {
+        return left.len().max(right.len()) <= usize::from(edits_left);
+    }
+    if edits_left == 0 || left.len().abs_diff(right.len()) > usize::from(edits_left) {
+        return false;
+    }
+
+    ascii_edit_distance_at_most_inner(&left[1..], right, edits_left - 1)
+        || ascii_edit_distance_at_most_inner(left, &right[1..], edits_left - 1)
+        || ascii_edit_distance_at_most_inner(&left[1..], &right[1..], edits_left - 1)
+}
+
+fn edit1_deletion_keys(name: &str) -> Vec<Box<str>> {
+    let bytes = name.as_bytes();
+    let mut keys = Vec::with_capacity(bytes.len() + 1);
+    keys.push(name.into());
+    for skip in 0..bytes.len() {
+        let mut key = String::with_capacity(bytes.len().saturating_sub(1));
+        key.push_str(&name[..skip]);
+        key.push_str(&name[skip + 1..]);
+        keys.push(key.into_boxed_str());
+    }
     keys.sort_unstable();
     keys.dedup();
     keys
-}
-
-fn collect_deletion_keys(
-    bytes: &[u8],
-    offset: usize,
-    remaining_deletions: usize,
-    scratch: &mut Vec<u8>,
-    keys: &mut Vec<Box<str>>,
-) {
-    if offset == bytes.len() {
-        keys.push(
-            String::from_utf8(scratch.clone())
-                .expect("shell names should be ASCII")
-                .into_boxed_str(),
-        );
-        return;
-    }
-
-    scratch.push(bytes[offset]);
-    collect_deletion_keys(bytes, offset + 1, remaining_deletions, scratch, keys);
-    scratch.pop();
-
-    if remaining_deletions > 0 {
-        collect_deletion_keys(bytes, offset + 1, remaining_deletions - 1, scratch, keys);
-    }
 }
 
 fn canonical_ascii_uppercase(name: &str) -> String {

--- a/crates/shuck-linter/src/facts/misspelling.rs
+++ b/crates/shuck-linter/src/facts/misspelling.rs
@@ -222,7 +222,7 @@ impl MisspellingCandidateLookup {
         }
         ids.sort_unstable();
         ids.dedup();
-        self.best_from_ids(entries, target_name, tie_break, ids.into_iter(), Some(2))
+        self.best_from_ids(entries, target_name, tie_break, ids, Some(2))
     }
 
     fn best_edit2_strong_shape<'a>(
@@ -232,7 +232,7 @@ impl MisspellingCandidateLookup {
         tie_break: CandidateTieBreak,
     ) -> Option<&'a str> {
         let ids = self.env_trie.edit2_candidate_ids(target_name);
-        self.best_from_ids(entries, target_name, tie_break, ids.into_iter(), Some(3))
+        self.best_from_ids(entries, target_name, tie_break, ids, Some(3))
     }
 
     fn best_from_ids<'a>(

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -320,12 +320,6 @@ impl<'a> LinterFacts<'a> {
         &self.presence_tested_names
     }
 
-    pub(crate) fn presence_tested_candidate_names(&self) -> impl Iterator<Item = &Name> {
-        self.presence_test_references_by_name
-            .keys()
-            .chain(self.presence_test_names_by_name.keys())
-    }
-
     pub(crate) fn possible_variable_misspelling_candidate(
         &self,
         semantic: &SemanticModel,

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -6505,8 +6505,7 @@ move_up $count
         let indexer = Indexer::new(source, &output);
         let semantic = SemanticModel::build(&output.file, source, &indexer);
         let analysis = semantic.analysis();
-        let file_context = classify_file_context(source, None, ShellDialect::Bash);
-        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer, &file_context);
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
         let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
 
         let word_fact = facts

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -1,14 +1,13 @@
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 use shuck_ast::{Name, Position, Span};
-use smallvec::SmallVec;
 
 use crate::facts::ComparableNameUseKind;
 use crate::{Checker, Rule, Violation};
 
 use super::variable_reference_common::{
     VariableReferenceFilter, has_same_name_defining_bindings, is_environment_style_name,
-    is_reportable_variable_reference, is_sc2154_defining_binding,
+    is_reportable_variable_reference,
 };
 
 pub struct PossibleVariableMisspelling {
@@ -66,93 +65,93 @@ pub fn possible_variable_misspelling(checker: &mut Checker) {
             offsets
         });
 
-    let mut findings = checker
+    let mut candidate_cache = FxHashMap::<String, Option<String>>::default();
+    let mut findings = Vec::new();
+    for uninitialized in checker
         .semantic_analysis()
         .uninitialized_references()
         .iter()
-        .filter_map(|uninitialized| {
-            let reference = checker.semantic().reference(uninitialized.reference);
-            if !is_reportable_variable_reference(
-                checker,
-                reference,
-                VariableReferenceFilter {
-                    suppress_environment_style_names: false,
-                },
-            ) {
-                return None;
-            }
-            if !looks_like_case_mismatch_reference(reference.name.as_str()) {
-                return None;
-            }
-            if is_known_runtime_name(reference.name.as_str()) {
-                return None;
-            }
-            if is_internal_placeholder_name(reference.name.as_str()) {
-                return None;
-            }
-            if has_prior_guarded_reference(
-                &guarded_name_offsets,
-                reference.name.as_str(),
-                reference.span,
-            ) {
-                return None;
-            }
-            if has_same_name_defining_bindings(checker, &reference.name) {
-                return None;
-            }
-            if is_presence_tested_reference_name(checker, reference.name.as_str(), reference.span) {
-                return None;
-            }
-            if is_assignment_target_variant_reference(
-                checker,
-                reference.name.as_str(),
-                reference.span,
-            ) {
-                return None;
-            }
-            if is_build_flag_alias_assignment_value(
-                checker,
-                reference.name.as_str(),
-                reference.span,
-            ) {
-                return None;
-            }
+    {
+        let reference = checker.semantic().reference(uninitialized.reference);
+        if !is_reportable_variable_reference(
+            checker,
+            reference,
+            VariableReferenceFilter {
+                suppress_environment_style_names: false,
+            },
+        ) {
+            continue;
+        }
+        if !looks_like_case_mismatch_reference(reference.name.as_str()) {
+            continue;
+        }
+        if is_known_runtime_name(reference.name.as_str()) {
+            continue;
+        }
+        if is_internal_placeholder_name(reference.name.as_str()) {
+            continue;
+        }
+        if has_prior_guarded_reference(
+            &guarded_name_offsets,
+            reference.name.as_str(),
+            reference.span,
+        ) {
+            continue;
+        }
+        if has_same_name_defining_bindings(checker, &reference.name) {
+            continue;
+        }
+        if is_presence_tested_reference_name(checker, reference.name.as_str(), reference.span) {
+            continue;
+        }
+        if is_assignment_target_variant_reference(checker, reference.name.as_str(), reference.span)
+        {
+            continue;
+        }
+        if is_build_flag_alias_assignment_value(checker, reference.name.as_str(), reference.span) {
+            continue;
+        }
 
-            let candidate = preferred_candidate_name(checker, reference.name.as_str())?;
-            if is_build_flag_family_non_report_pair(reference.name.as_str(), candidate.as_str()) {
-                return None;
-            }
-            if is_hostid_label_echo(reference.name.as_str(), reference.span, checker.source()) {
-                return None;
-            }
-            if is_parallel_c_and_cxx_flag_use(
-                checker,
-                reference.name.as_str(),
-                reference.span,
-                candidate.as_str(),
-            ) {
-                return None;
-            }
-            if is_literal_numbered_suffix_variant(
-                checker.source(),
-                reference.name.as_str(),
-                reference.span,
-                candidate.as_str(),
-            ) {
-                return None;
-            }
-            Some((reference.span, reference.name.to_string(), candidate))
-        })
-        .collect::<Vec<_>>();
+        let Some(candidate) =
+            cached_candidate_name(&mut candidate_cache, checker, reference.name.as_str())
+        else {
+            continue;
+        };
+        if is_build_flag_family_non_report_pair(reference.name.as_str(), candidate.as_str()) {
+            continue;
+        }
+        if is_hostid_label_echo(reference.name.as_str(), reference.span, checker.source()) {
+            continue;
+        }
+        if is_parallel_c_and_cxx_flag_use(
+            checker,
+            reference.name.as_str(),
+            reference.span,
+            candidate.as_str(),
+        ) {
+            continue;
+        }
+        if is_literal_numbered_suffix_variant(
+            checker.source(),
+            reference.name.as_str(),
+            reference.span,
+            candidate.as_str(),
+        ) {
+            continue;
+        }
+        findings.push((reference.span, reference.name.to_string(), candidate));
+    }
     findings.extend(heredoc_findings(
         checker,
         &guarded_name_offsets,
         &suppressed_reference_spans,
+        &mut candidate_cache,
     ));
     findings.extend(scope_compat_findings(
         checker,
         &guarded_name_offsets,
         &suppressed_reference_spans,
+        &mut candidate_cache,
     ));
 
     findings.sort_by_key(|(span, _, _)| (span.start.offset, span.end.offset));
@@ -176,6 +175,7 @@ fn heredoc_findings(
     checker: &Checker<'_>,
     guarded_name_offsets: &FxHashMap<String, Vec<usize>>,
     suppressed_reference_spans: &FxHashMap<String, Vec<Span>>,
+    candidate_cache: &mut FxHashMap<String, Option<String>>,
 ) -> Vec<(Span, String, String)> {
     let mut findings = Vec::new();
     let mut seen = FxHashSet::default();
@@ -196,7 +196,7 @@ fn heredoc_findings(
             {
                 continue;
             }
-            let candidate = match preferred_candidate_name(checker, reference_name) {
+            let candidate = match cached_candidate_name(candidate_cache, checker, reference_name) {
                 Some(candidate) => candidate,
                 None => continue,
             };
@@ -254,6 +254,7 @@ fn scope_compat_findings(
     checker: &Checker<'_>,
     guarded_name_offsets: &FxHashMap<String, Vec<usize>>,
     suppressed_reference_spans: &FxHashMap<String, Vec<Span>>,
+    candidate_cache: &mut FxHashMap<String, Option<String>>,
 ) -> Vec<(Span, String, String)> {
     let mut findings = Vec::new();
     let mut seen = FxHashSet::default();
@@ -298,10 +299,11 @@ fn scope_compat_findings(
             continue;
         }
 
-        let candidate = match preferred_scope_compat_candidate_name(checker, reference_name) {
-            Some(candidate) => candidate,
-            None => continue,
-        };
+        let candidate =
+            match preferred_scope_compat_candidate_name(checker, candidate_cache, reference_name) {
+                Some(candidate) => candidate,
+                None => continue,
+            };
         if !is_scope_compat_pair(checker, reference_name, name_use.span(), candidate.as_str()) {
             continue;
         }
@@ -352,9 +354,10 @@ fn is_braced_parameter_use(source: &str, span: Span) -> bool {
 
 fn preferred_scope_compat_candidate_name(
     checker: &Checker<'_>,
+    candidate_cache: &mut FxHashMap<String, Option<String>>,
     reference_name: &str,
 ) -> Option<String> {
-    preferred_candidate_name(checker, reference_name)
+    cached_candidate_name(candidate_cache, checker, reference_name)
         .or_else(|| build_flag_scope_candidate_name(checker, reference_name))
 }
 
@@ -483,163 +486,24 @@ fn looks_like_case_mismatch_reference(name: &str) -> bool {
 }
 
 fn preferred_candidate_name(checker: &Checker<'_>, target_name: &str) -> Option<String> {
-    if checker.semantic().bindings().len() >= 1024 {
-        return checker
-            .facts()
-            .possible_variable_misspelling_candidate(checker.semantic(), target_name);
-    }
-
-    let binding_candidates = checker
-        .semantic()
-        .bindings()
-        .iter()
-        .filter(|binding| is_sc2154_defining_binding(binding.kind))
-        .filter(|binding| binding.name.as_str() != target_name)
-        .filter(|binding| binding.name.as_str().len() >= 4)
-        .filter_map(|binding| {
-            candidate_match_rank(target_name, binding.name.as_str()).map(|rank| {
-                (
-                    rank,
-                    binding.span.start.offset,
-                    binding.span.end.offset,
-                    binding.name.to_string(),
-                )
-            })
-        });
-    binding_candidates
-        .min_by_key(|(rank, start, end, _)| (*rank, *start, *end))
-        .map(|(_, _, _, name)| name)
-        .or_else(|| presence_tested_candidate_name(checker, target_name))
-}
-
-fn presence_tested_candidate_name(checker: &Checker<'_>, target_name: &str) -> Option<String> {
     checker
         .facts()
-        .presence_tested_candidate_names()
-        .filter(|candidate_name| candidate_name.as_str() != target_name)
-        .filter_map(|candidate_name| {
-            let first_span = first_presence_test_span(checker, candidate_name)?;
-            candidate_match_rank(target_name, candidate_name.as_str()).map(|rank| {
-                (
-                    rank,
-                    first_span.start.offset,
-                    first_span.end.offset,
-                    candidate_name,
-                )
-            })
-        })
-        .min_by(|left, right| {
-            (left.0, left.1, left.2)
-                .cmp(&(right.0, right.1, right.2))
-                .then_with(|| left.3.as_str().cmp(right.3.as_str()))
-        })
-        .map(|(_, _, _, name)| name.to_string())
+        .possible_variable_misspelling_candidate(checker.semantic(), target_name)
 }
 
-fn first_presence_test_span(checker: &Checker<'_>, candidate_name: &Name) -> Option<Span> {
-    checker
-        .facts()
-        .presence_test_references(candidate_name)
-        .iter()
-        .map(|presence| checker.semantic().reference(presence.reference_id()).span)
-        .chain(
-            checker
-                .facts()
-                .presence_test_names(candidate_name)
-                .iter()
-                .map(|presence| presence.tested_span()),
-        )
-        .min_by_key(|span| (span.start.offset, span.end.offset))
+fn cached_candidate_name(
+    cache: &mut FxHashMap<String, Option<String>>,
+    checker: &Checker<'_>,
+    target_name: &str,
+) -> Option<String> {
+    cache
+        .entry(target_name.to_owned())
+        .or_insert_with(|| preferred_candidate_name(checker, target_name))
+        .clone()
 }
 
 fn canonical_uppercase_name(name: &str) -> String {
     name.chars().map(|char| char.to_ascii_uppercase()).collect()
-}
-
-fn candidate_match_rank(target_name: &str, candidate_name: &str) -> Option<u8> {
-    if target_name.len() >= 4
-        && target_name.len() == candidate_name.len()
-        && candidate_name
-            .as_bytes()
-            .eq_ignore_ascii_case(target_name.as_bytes())
-    {
-        return Some(0);
-    }
-
-    if !is_environment_style_name(candidate_name)
-        || target_name.len() < 3
-        || candidate_name.len() < 4
-    {
-        return None;
-    }
-
-    let distance =
-        bounded_ascii_edit_distance(target_name.as_bytes(), candidate_name.as_bytes(), 2)?;
-    if distance == 0 {
-        return None;
-    }
-    if distance == 2 && !has_strong_two_edit_shape(target_name, candidate_name) {
-        return None;
-    }
-    Some(distance + 1)
-}
-
-fn has_strong_two_edit_shape(target_name: &str, candidate_upper: &str) -> bool {
-    let common_prefix = common_prefix_len(target_name.as_bytes(), candidate_upper.as_bytes());
-    let common_suffix = common_suffix_len(
-        &target_name.as_bytes()[common_prefix..],
-        &candidate_upper.as_bytes()[common_prefix..],
-    );
-
-    matches!((target_name, candidate_upper), ("CFLAGS", "CXXFLAGS"))
-        || matches!((target_name, candidate_upper), ("OS_NAME", "HOSTNAME"))
-        || has_separator_plural_compaction(target_name, candidate_upper)
-        || common_prefix >= 5
-        || common_suffix >= 5
-        || (common_prefix >= 4 && common_suffix >= 4)
-}
-
-fn has_separator_plural_compaction(left: &str, right: &str) -> bool {
-    compacted_plural_matches(left, right) || compacted_plural_matches(right, left)
-}
-
-fn compacted_plural_matches(pluralish_name: &str, compact_singular_name: &str) -> bool {
-    let Some((prefix, last_segment)) = pluralish_name.rsplit_once('_') else {
-        return false;
-    };
-    let Some(singular_segment) = last_segment.strip_suffix('S') else {
-        return false;
-    };
-    if compacted_len(prefix) < 4 || singular_segment.len() < 4 {
-        return false;
-    }
-
-    let compacted = pluralish_name
-        .chars()
-        .filter(|char| *char != '_')
-        .collect::<String>();
-    compacted
-        .strip_suffix('S')
-        .is_some_and(|singular| singular == compact_singular_name)
-}
-
-fn compacted_len(name: &str) -> usize {
-    name.chars().filter(|char| *char != '_').count()
-}
-
-fn common_prefix_len(left: &[u8], right: &[u8]) -> usize {
-    left.iter()
-        .zip(right)
-        .take_while(|(left, right)| left == right)
-        .count()
-}
-
-fn common_suffix_len(left: &[u8], right: &[u8]) -> usize {
-    left.iter()
-        .rev()
-        .zip(right.iter().rev())
-        .take_while(|(left, right)| left == right)
-        .count()
 }
 
 fn is_assignment_target_variant_reference(
@@ -836,40 +700,6 @@ fn source_suffix_matches(source: &str, offset: usize, suffix: &str) -> bool {
         .as_bytes()
         .get(offset..offset + suffix.len())
         .is_some_and(|source_suffix| source_suffix.eq_ignore_ascii_case(suffix.as_bytes()))
-}
-
-fn bounded_ascii_edit_distance(left: &[u8], right: &[u8], max_distance: u8) -> Option<u8> {
-    let max_distance = usize::from(max_distance);
-    if left.len().abs_diff(right.len()) > max_distance {
-        return None;
-    }
-
-    let mut previous = (0..=right.len()).collect::<SmallVec<[usize; 32]>>();
-    let mut current = SmallVec::<[usize; 32]>::new();
-    current.resize(right.len() + 1, 0);
-
-    for (left_index, left_byte) in left.iter().enumerate() {
-        current[0] = left_index + 1;
-        let mut row_min = current[0];
-
-        for (right_index, right_byte) in right.iter().enumerate() {
-            let deletion = previous[right_index + 1] + 1;
-            let insertion = current[right_index] + 1;
-            let substitution = previous[right_index] + usize::from(left_byte != right_byte);
-            let value = deletion.min(insertion).min(substitution);
-            current[right_index + 1] = value;
-            row_min = row_min.min(value);
-        }
-
-        if row_min > max_distance {
-            return None;
-        }
-
-        std::mem::swap(&mut previous, &mut current);
-    }
-
-    let distance = previous[right.len()];
-    (distance <= max_distance).then_some(distance as u8)
 }
 
 fn is_known_runtime_name(name: &str) -> bool {


### PR DESCRIPTION
## Summary

- replace the SH-351 2-deletion lookup with staged exact, edit-distance-1, and trie-backed edit-distance-2 lookup
- centralize misspelling candidate matching in linter facts and cache repeated target lookups in the rule
- remove the now-unused presence-tested candidate iterator from facts

## Validation

- `make build`
- `cargo check -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=SH-351`
- `make test-large-corpus`

## Benchmarks

Generated 5,000-candidate SH-351 fixture:

- before: `341.4 ms ± 10.1 ms`
- after: `103.2 ms ± 4.0 ms`
