### PR TITLE
refactor(linter): move status capture values into facts

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -37,6 +37,7 @@ impl DeclarationAssignmentProbe {
 #[derive(Debug, Clone)]
 pub struct BindingValueFact<'a> {
     kind: BindingValueKind<'a>,
+    standalone_status_or_pid_capture: bool,
     conditional_assignment_shortcut: bool,
     one_sided_short_circuit_assignment: bool,
 }
@@ -49,8 +50,16 @@ enum BindingValueKind<'a> {
 
 impl<'a> BindingValueFact<'a> {
     fn scalar(word: &'a Word) -> Self {
+        Self::scalar_with_status_or_pid_capture(word, word_is_standalone_status_or_pid_capture(word))
+    }
+
+    fn scalar_with_status_or_pid_capture(
+        word: &'a Word,
+        standalone_status_or_pid_capture: bool,
+    ) -> Self {
         Self {
             kind: BindingValueKind::Scalar(word),
+            standalone_status_or_pid_capture,
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
         }
@@ -59,6 +68,7 @@ impl<'a> BindingValueFact<'a> {
     fn from_loop_words(words: Box<[&'a Word]>) -> Self {
         Self {
             kind: BindingValueKind::Loop(words),
+            standalone_status_or_pid_capture: false,
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
         }
@@ -84,6 +94,10 @@ impl<'a> BindingValueFact<'a> {
 
     pub fn one_sided_short_circuit_assignment(&self) -> bool {
         self.one_sided_short_circuit_assignment
+    }
+
+    pub fn standalone_status_or_pid_capture(&self) -> bool {
+        self.standalone_status_or_pid_capture
     }
 
     fn mark_conditional_assignment_shortcut(&mut self) {
@@ -2355,6 +2369,35 @@ fn assignment_value_text_is_standalone_status_capture(text: &str) -> bool {
     matches!(text, "$?" | "${?}" | "\"$?\"" | "\"${?}\"")
 }
 
+fn assignment_value_text_is_standalone_status_or_pid_capture(text: &str) -> bool {
+    matches!(
+        text,
+        "$?" | "${?}" | "\"$?\"" | "\"${?}\"" | "$!" | "${!}" | "\"$!\"" | "\"${!}\""
+    )
+}
+
+fn word_is_standalone_status_or_pid_capture(word: &Word) -> bool {
+    matches!(word.parts.as_slice(), [part] if part_is_standalone_status_or_pid_capture(&part.kind))
+}
+
+fn part_is_standalone_status_or_pid_capture(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => matches!(name.as_str(), "?" | "!"),
+        WordPart::DoubleQuoted { parts, .. } => {
+            matches!(
+                parts.as_slice(),
+                [part] if part_is_standalone_status_or_pid_capture(&part.kind)
+            )
+        }
+        WordPart::Parameter(parameter) => matches!(
+            parameter.bourne(),
+            Some(BourneParameterExpansion::Access { reference })
+                if matches!(reference.name.as_str(), "?" | "!") && reference.subscript.is_none()
+        ),
+        _ => false,
+    }
+}
+
 fn contiguous_word_groups<'a>(words: &'a [&'a Word]) -> Vec<&'a [&'a Word]> {
     let mut groups = Vec::new();
     let mut start = 0usize;
@@ -2622,11 +2665,19 @@ fn collect_binding_values<'a>(
         }
     }
 
-    for (name, name_span, word) in simple_declaration_assignment_value_words(command, source) {
+    for (name, name_span, word, standalone_status_or_pid_capture) in
+        simple_declaration_assignment_value_words(command, source)
+    {
         if let Some(binding_id) =
             binding_value_definition_id_for_name(semantic, &name, name_span)
         {
-            binding_values.insert(binding_id, BindingValueFact::scalar(word));
+            binding_values.insert(
+                binding_id,
+                BindingValueFact::scalar_with_status_or_pid_capture(
+                    word,
+                    standalone_status_or_pid_capture,
+                ),
+            );
         }
     }
 
@@ -2683,7 +2734,7 @@ fn collect_binding_values<'a>(
 fn simple_declaration_assignment_value_words<'a>(
     command: &'a Command,
     source: &str,
-) -> Vec<(Name, Span, &'a Word)> {
+) -> Vec<(Name, Span, &'a Word, bool)> {
     let Command::Simple(command) = command else {
         return Vec::new();
     };
@@ -2701,10 +2752,10 @@ fn simple_declaration_assignment_value_words<'a>(
     let mut values = Vec::new();
     let mut parsing_options = true;
     for word in &command.args {
-        let Some(text) = static_word_text(word, source) else {
-            parsing_options = false;
-            continue;
-        };
+        let static_text = static_word_text(word, source);
+        let text = static_text
+            .as_deref()
+            .unwrap_or_else(|| word.span.slice(source));
 
         if parsing_options {
             if text == "--" {
@@ -2720,11 +2771,22 @@ fn simple_declaration_assignment_value_words<'a>(
         let Some(parsed) = parse_assignment_word(&text) else {
             continue;
         };
+        let value_text = &text[parsed.value_offset..];
+        let standalone_status_or_pid_capture =
+            assignment_value_text_is_standalone_status_or_pid_capture(value_text);
+        if static_text.is_none() && !standalone_status_or_pid_capture {
+            continue;
+        }
         let name_span = Span::from_positions(
             word.span.start,
             word.span.start.advanced_by(parsed.name),
         );
-        values.push((Name::from(parsed.name), name_span, word));
+        values.push((
+            Name::from(parsed.name),
+            name_span,
+            word,
+            standalone_status_or_pid_capture,
+        ));
     }
 
     values

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2762,13 +2762,13 @@ fn simple_declaration_assignment_value_words<'a>(
                 parsing_options = false;
                 continue;
             }
-            if simple_command_declaration_option_word(&text) {
+            if simple_command_declaration_option_word(text) {
                 continue;
             }
             parsing_options = false;
         }
 
-        let Some(parsed) = parse_assignment_word(&text) else {
+        let Some(parsed) = parse_assignment_word(text) else {
             continue;
         };
         let value_text = &text[parsed.value_offset..];

--- a/crates/shuck-linter/src/facts/tests/assignments.rs
+++ b/crates/shuck-linter/src/facts/tests/assignments.rs
@@ -40,6 +40,31 @@ fn indexes_scalar_bindings_from_assignments_and_declarations() {
 }
 
 #[test]
+fn marks_status_capture_binding_values() {
+    let source = "\
+#!/bin/bash
+status=$?
+pid=$!
+\\typeset ret=$?
+\\local child=$!
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = SemanticModel::build(&output.file, source, &indexer);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+
+    for name in ["status", "pid", "ret", "child"] {
+        let binding_id = semantic.bindings_for(&Name::from(name))[0];
+        assert!(
+            facts
+                .binding_value(binding_id)
+                .is_some_and(|value| value.standalone_status_or_pid_capture()),
+            "expected {name} binding value to be a status or pid capture"
+        );
+    }
+}
+
+#[test]
 fn indexes_loop_bindings_from_for_words() {
     let source = "#!/bin/bash\nfor i in 16 32 64; do printf '%s\\n' \"$i\"; done\n";
     let output = Parser::new(source).parse().unwrap();

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -2108,27 +2108,9 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn binding_value_is_standalone_status_capture(&self, binding_id: BindingId) -> bool {
-        if self
-            .facts
+        self.facts
             .binding_value(binding_id)
-            .filter(|value| !value.conditional_assignment_shortcut())
-            .and_then(|value| value.scalar_word())
-            .is_some_and(word_is_standalone_status_or_pid_capture)
-        {
-            return true;
-        }
-
-        let binding = self.semantic.binding(binding_id);
-        let definition_span = match &binding.origin {
-            BindingOrigin::Assignment {
-                definition_span,
-                value: AssignmentValueOrigin::PlainScalarAccess | AssignmentValueOrigin::Unknown,
-            }
-            | BindingOrigin::Declaration { definition_span } => *definition_span,
-            _ => return false,
-        };
-        assignment_value_after_definition(self.source, definition_span)
-            .is_some_and(assignment_value_text_is_standalone_status_capture)
+            .is_some_and(|value| value.standalone_status_or_pid_capture())
     }
 
     fn status_capture_declaration_probe_covers_reference(
@@ -4430,44 +4412,6 @@ fn part_is_safe_special_parameter_access(part: &WordPart) -> bool {
     }
 }
 
-fn assignment_value_after_definition(source: &str, definition_span: Span) -> Option<&str> {
-    let rest = source.get(definition_span.end.offset..)?;
-    let rest = rest.strip_prefix('=')?;
-    let value_len = rest
-        .find(|char: char| char.is_ascii_whitespace() || matches!(char, ';' | '&' | '|'))
-        .unwrap_or(rest.len());
-    rest.get(..value_len)
-}
-
-fn assignment_value_text_is_standalone_status_capture(text: &str) -> bool {
-    matches!(
-        text,
-        "$?" | "${?}" | "\"$?\"" | "\"${?}\"" | "$!" | "${!}" | "\"$!\"" | "\"${!}\""
-    )
-}
-
-fn word_is_standalone_status_or_pid_capture(word: &Word) -> bool {
-    matches!(word.parts.as_slice(), [part] if part_is_standalone_status_or_pid_capture(&part.kind))
-}
-
-fn part_is_standalone_status_or_pid_capture(part: &WordPart) -> bool {
-    match part {
-        WordPart::Variable(name) => matches!(name.as_str(), "?" | "!"),
-        WordPart::DoubleQuoted { parts, .. } => {
-            matches!(
-                parts.as_slice(),
-                [part] if part_is_standalone_status_or_pid_capture(&part.kind)
-            )
-        }
-        WordPart::Parameter(parameter) => matches!(
-            parameter.bourne(),
-            Some(BourneParameterExpansion::Access { reference })
-                if matches!(reference.name.as_str(), "?" | "!") && reference.subscript.is_none()
-        ),
-        _ => false,
-    }
-}
-
 fn safe_numeric_shell_variable(name: &Name) -> bool {
     matches!(
         name.as_str(),
@@ -6482,6 +6426,38 @@ move_up $count
             .expect("expected count expansion part");
 
         assert!(!safe_values.part_has_s001_standalone_numeric_argv_exposure(part, part_span));
+    }
+
+    #[test]
+    fn escaped_declaration_status_capture_return_stays_safe() {
+        let source = "\
+#!/bin/bash
+run() {
+  make install ||
+  {
+    \\typeset ret=$?
+    warn failed
+    return $ret
+  }
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$ret"
+            })
+            .expect("expected return status argument fact");
+
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- move standalone status/pid capture classification onto BindingValueFact
- preserve that classification for escaped/simple declaration assignments like \typeset ret=$?
- remove safe_value's rule-local assignment-value source slicing fallback

## Validation
- cargo fmt --check
- cargo test -p shuck-linter safe_value --lib
- cargo test -p shuck-linter assignments --lib
- make test-large-corpus (blocking=0, implementation_diffs=0)
