### PR TITLE
perf(linter): specialize scope compat misspelling scan

### DIFF
--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -404,6 +404,43 @@ impl<'a> LinterFacts<'a> {
             .unwrap_or(&[])
     }
 
+    pub(crate) fn presence_test_candidate_spans(
+        &self,
+        semantic: &SemanticModel,
+    ) -> Vec<(Name, Span)> {
+        let mut names = FxHashSet::<Name>::default();
+        names.extend(self.presence_test_references_by_name.keys().cloned());
+        names.extend(self.presence_test_names_by_name.keys().cloned());
+
+        names
+            .into_iter()
+            .filter_map(|name| {
+                let span = self.first_presence_test_candidate_span(semantic, &name)?;
+                Some((name, span))
+            })
+            .collect()
+    }
+
+    fn first_presence_test_candidate_span(
+        &self,
+        semantic: &SemanticModel,
+        candidate_name: &Name,
+    ) -> Option<Span> {
+        self.presence_test_references_by_name
+            .get(candidate_name)
+            .into_iter()
+            .flatten()
+            .map(|presence| semantic.reference(presence.reference_id()).span)
+            .chain(
+                self.presence_test_names_by_name
+                    .get(candidate_name)
+                    .into_iter()
+                    .flatten()
+                    .map(|presence| presence.tested_span()),
+            )
+            .min_by_key(|span| (span.start.offset, span.end.offset))
+    }
+
     pub fn is_suppressed_subscript_reference(&self, span: Span) -> bool {
         self.suppressed_subscript_reference_spans
             .contains(&FactSpan::new(span))
@@ -1110,7 +1147,8 @@ fn is_interesting_scope_compat_name_use(
     name == "SHELLSPEC_EXECDIR"
         || name == "SHELLSPEC_SPECDIR"
         || kind == ComparableNameUseKind::Derived
-            && is_braced_scope_compat_parameter_use(source, span)
+            && (is_braced_scope_compat_parameter_use(source, span)
+                || is_unbraced_scope_compat_parameter_use(source, span))
             && is_reportable_build_flag_family_name(name)
 }
 
@@ -1119,6 +1157,13 @@ fn is_braced_scope_compat_parameter_use(source: &str, span: Span) -> bool {
         .as_bytes()
         .get(span.start.offset..span.start.offset + 2)
         .is_some_and(|prefix| prefix == b"${")
+}
+
+fn is_unbraced_scope_compat_parameter_use(source: &str, span: Span) -> bool {
+    source
+        .as_bytes()
+        .get(span.start.offset)
+        .is_some_and(|byte| *byte == b'$')
 }
 
 fn is_reportable_build_flag_family_name(name: &str) -> bool {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1139,31 +1139,14 @@ fn scope_compat_standalone_derived_name_use(
 }
 
 fn is_interesting_scope_compat_name_use(
-    source: &str,
+    _source: &str,
     name: &str,
     kind: ComparableNameUseKind,
-    span: Span,
+    _span: Span,
 ) -> bool {
     name == "SHELLSPEC_EXECDIR"
         || name == "SHELLSPEC_SPECDIR"
-        || kind == ComparableNameUseKind::Derived
-            && (is_braced_scope_compat_parameter_use(source, span)
-                || is_unbraced_scope_compat_parameter_use(source, span))
-            && is_reportable_build_flag_family_name(name)
-}
-
-fn is_braced_scope_compat_parameter_use(source: &str, span: Span) -> bool {
-    source
-        .as_bytes()
-        .get(span.start.offset..span.start.offset + 2)
-        .is_some_and(|prefix| prefix == b"${")
-}
-
-fn is_unbraced_scope_compat_parameter_use(source: &str, span: Span) -> bool {
-    source
-        .as_bytes()
-        .get(span.start.offset)
-        .is_some_and(|byte| *byte == b'$')
+        || kind == ComparableNameUseKind::Derived && is_reportable_build_flag_family_name(name)
 }
 
 fn is_reportable_build_flag_family_name(name: &str) -> bool {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -869,18 +869,19 @@ impl<'a> LinterFacts<'a> {
 fn build_possible_variable_misspelling_scope_compat_name_uses(
     facts: &LinterFacts<'_>,
 ) -> Vec<ComparableNameUse> {
+    if !source_may_have_scope_compat_misspelling(facts.source) {
+        return Vec::new();
+    }
+
     let mut uses = Vec::new();
     for word_fact in facts
         .expansion_word_facts(ExpansionContext::DeclarationAssignmentValue)
         .chain(facts.expansion_word_facts(ExpansionContext::AssignmentValue))
         .chain(facts.case_subject_facts())
     {
-        uses.extend(
-            comparable_name_uses(word_fact.word(), facts.source)
-                .into_vec()
-                .into_iter()
-                .filter(|name_use| name_use.kind() == ComparableNameUseKind::Parameter),
-        );
+        if let Some(name_use) = scope_compat_standalone_parameter_name_use(word_fact.word()) {
+            uses.push(name_use);
+        }
     }
     for command in facts.commands() {
         visit_command_words_for_substitutions(
@@ -888,12 +889,7 @@ fn build_possible_variable_misspelling_scope_compat_name_uses(
             command.redirects(),
             facts.source,
             &mut |word| {
-                uses.extend(
-                    comparable_name_uses(word, facts.source)
-                        .into_vec()
-                        .into_iter()
-                        .filter(|name_use| name_use.kind() == ComparableNameUseKind::Derived),
-                );
+                collect_scope_compat_derived_name_uses(word, facts.source, &mut uses);
             },
         );
     }
@@ -903,22 +899,247 @@ fn build_possible_variable_misspelling_scope_compat_name_uses(
         .flat_map(|header| header.words())
         .chain(facts.select_headers().iter().flat_map(|header| header.words()))
     {
-        uses.extend(
-            comparable_name_uses(word.word(), facts.source)
-                .into_vec()
-                .into_iter()
-                .filter_map(|mut name_use| {
-                    if name_use.kind() == ComparableNameUseKind::Parameter {
-                        name_use.mark_derived();
-                        Some(name_use)
-                    } else {
-                        None
-                    }
-                }),
-        );
+        if let Some(mut name_use) = scope_compat_standalone_parameter_name_use(word.word()) {
+            name_use.mark_derived();
+            if is_interesting_scope_compat_name_use(
+                facts.source,
+                name_use.key().as_str(),
+                name_use.kind(),
+                name_use.span(),
+            ) {
+                uses.push(name_use);
+            }
+        }
     }
-    uses.extend(build_flag_for_loop_source_name_uses(facts.source));
+    uses.extend(build_flag_for_loop_source_name_uses(facts.source).into_iter().filter(|name_use| {
+        is_interesting_scope_compat_name_use(
+            facts.source,
+            name_use.key().as_str(),
+            name_use.kind(),
+            name_use.span(),
+        )
+    }));
+    dedup_comparable_name_uses(&mut uses);
     uses
+}
+
+fn source_may_have_scope_compat_misspelling(source: &str) -> bool {
+    source.contains("SHELLSPEC_EXECDIR")
+        || source.contains("CFLAGS")
+        || source.contains("CPPFLAGS")
+        || source.contains("CXXFLAGS")
+}
+
+fn scope_compat_standalone_parameter_name_use(word: &Word) -> Option<ComparableNameUse> {
+    let name = standalone_comparable_parameter_name(&word.parts)?;
+    Some(ComparableNameUse {
+        span: word.span,
+        key: ComparableNameKey(name.into()),
+        kind: ComparableNameUseKind::Parameter,
+    })
+}
+
+fn collect_scope_compat_derived_name_uses(
+    word: &Word,
+    source: &str,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    let allow_quoted_derived_words =
+        analyze_word(word, source, None).quote == WordQuote::FullyQuoted;
+    collect_scope_compat_command_substitution_name_uses_in_parts(
+        &word.parts,
+        source,
+        allow_quoted_derived_words,
+        uses,
+    );
+}
+
+fn collect_scope_compat_command_substitution_name_uses_in_parts(
+    parts: &[WordPartNode],
+    source: &str,
+    allow_quoted_derived_words: bool,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => {
+                collect_scope_compat_command_substitution_name_uses_in_parts(
+                    parts,
+                    source,
+                    allow_quoted_derived_words,
+                    uses,
+                );
+            }
+            WordPart::CommandSubstitution { body, .. } => {
+                collect_scope_compat_command_substitution_name_uses(
+                    body,
+                    source,
+                    allow_quoted_derived_words,
+                    uses,
+                );
+            }
+            WordPart::ParameterExpansion {
+                operand_word_ast, ..
+            }
+            | WordPart::IndirectExpansion {
+                operand_word_ast, ..
+            } => {
+                if let Some(word) = operand_word_ast {
+                    collect_scope_compat_command_substitution_name_uses_in_parts(
+                        &word.parts,
+                        source,
+                        allow_quoted_derived_words,
+                        uses,
+                    );
+                }
+            }
+            WordPart::Substring {
+                offset_word_ast,
+                length_word_ast,
+                ..
+            }
+            | WordPart::ArraySlice {
+                offset_word_ast,
+                length_word_ast,
+                ..
+            } => {
+                collect_scope_compat_arithmetic_name_use(offset_word_ast, source, uses);
+                if let Some(word) = length_word_ast {
+                    collect_scope_compat_arithmetic_name_use(word, source, uses);
+                }
+            }
+            WordPart::ArithmeticExpansion {
+                expression_word_ast,
+                ..
+            } => {
+                collect_scope_compat_arithmetic_name_use(expression_word_ast, source, uses);
+            }
+            WordPart::Literal(_)
+            | WordPart::ZshQualifiedGlob(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::Parameter(_)
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. } => {}
+        }
+    }
+}
+
+fn collect_scope_compat_command_substitution_name_uses(
+    body: &StmtSeq,
+    source: &str,
+    allow_quoted_derived_words: bool,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    for visit in iter_commands(
+        body,
+        CommandWalkOptions {
+            descend_nested_word_commands: true,
+        },
+    ) {
+        visit_command_substitution_loop_header_words(visit.command, &mut |word| {
+            push_scope_compat_command_substitution_word_use(
+                word,
+                source,
+                allow_quoted_derived_words,
+                uses,
+            );
+        });
+        visit_command_argument_words_for_substitutions(visit.command, source, &mut |word| {
+            push_scope_compat_command_substitution_word_use(
+                word,
+                source,
+                allow_quoted_derived_words,
+                uses,
+            );
+        });
+    }
+}
+
+fn push_scope_compat_command_substitution_word_use(
+    word: &Word,
+    source: &str,
+    allow_quoted_derived_words: bool,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    if !allow_quoted_derived_words && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
+    {
+        return;
+    }
+    if let Some(name_use) = scope_compat_standalone_derived_name_use(word, source) {
+        uses.push(name_use);
+    }
+}
+
+fn collect_scope_compat_arithmetic_name_use(
+    word: &Word,
+    source: &str,
+    uses: &mut Vec<ComparableNameUse>,
+) {
+    if let Some(name_use) = scope_compat_standalone_derived_name_use(word, source) {
+        uses.push(name_use);
+    }
+}
+
+fn scope_compat_standalone_derived_name_use(
+    word: &Word,
+    source: &str,
+) -> Option<ComparableNameUse> {
+    let mut name_use = scope_compat_standalone_parameter_name_use(word)?;
+    name_use.mark_derived();
+    is_interesting_scope_compat_name_use(
+        source,
+        name_use.key().as_str(),
+        name_use.kind(),
+        name_use.span(),
+    )
+    .then_some(name_use)
+}
+
+fn is_interesting_scope_compat_name_use(
+    source: &str,
+    name: &str,
+    kind: ComparableNameUseKind,
+    span: Span,
+) -> bool {
+    name == "SHELLSPEC_EXECDIR"
+        || name == "SHELLSPEC_SPECDIR"
+        || kind == ComparableNameUseKind::Derived
+            && is_braced_scope_compat_parameter_use(source, span)
+            && is_reportable_build_flag_family_name(name)
+}
+
+fn is_braced_scope_compat_parameter_use(source: &str, span: Span) -> bool {
+    source
+        .as_bytes()
+        .get(span.start.offset..span.start.offset + 2)
+        .is_some_and(|prefix| prefix == b"${")
+}
+
+fn is_reportable_build_flag_family_name(name: &str) -> bool {
+    let Some((_, suffix)) = split_scope_compat_build_flag_family_name(name) else {
+        return false;
+    };
+    matches!(suffix, "CFLAGS" | "CPPFLAGS" | "CXXFLAGS")
+}
+
+fn split_scope_compat_build_flag_family_name(name: &str) -> Option<(&str, &'static str)> {
+    ["CXXFLAGS", "CPPFLAGS", "CFLAGS"]
+        .into_iter()
+        .find_map(|suffix| {
+            if name == suffix {
+                Some(("", suffix))
+            } else {
+                name.strip_suffix(suffix)
+                    .filter(|prefix| prefix.ends_with('_'))
+                    .map(|prefix| (prefix, suffix))
+            }
+        })
 }
 
 fn populate_array_assignment_split_scalar_expansion_spans(

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -260,6 +260,7 @@ fn scope_compat_findings(
     let mut seen = FxHashSet::default();
     let mut index = ScopeCompatIndex::default();
     add_scope_compat_binding_candidates(&mut index, checker);
+    add_scope_compat_presence_test_candidates(&mut index, checker);
     add_scope_compat_name_uses(&mut index, checker);
 
     for name_use in index.references() {
@@ -400,6 +401,18 @@ fn add_scope_compat_binding_candidates(index: &mut ScopeCompatIndex, checker: &C
     }
 }
 
+fn add_scope_compat_presence_test_candidates(index: &mut ScopeCompatIndex, checker: &Checker<'_>) {
+    for (name, span) in checker
+        .facts()
+        .presence_test_candidate_spans(checker.semantic())
+    {
+        let name = name.as_str();
+        if is_reportable_build_flag_family_name(name) {
+            index.add_build_flag_candidate(name, span);
+        }
+    }
+}
+
 fn add_scope_compat_name_uses(index: &mut ScopeCompatIndex, checker: &Checker<'_>) {
     for name_use in checker
         .facts()
@@ -418,13 +431,15 @@ fn add_scope_compat_name_uses(index: &mut ScopeCompatIndex, checker: &Checker<'_
             continue;
         }
         if name_use.kind() != ComparableNameUseKind::Derived
-            || !is_braced_parameter_use(checker.source(), name_use.span())
             || !is_reportable_build_flag_family_name(name)
         {
             continue;
         }
 
         index.add_build_flag_candidate(name, name_use.span());
+        if !is_braced_parameter_use(checker.source(), name_use.span()) {
+            continue;
+        }
         index.build_flag_references.push(ScopeCompatUse {
             name: name.to_owned(),
             span: name_use.span(),
@@ -1292,6 +1307,54 @@ done
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${CFLAGS}", "${MY_CFLAGS}"]
+        );
+    }
+
+    #[test]
+    fn reports_build_flag_scope_compat_with_presence_test_candidate() {
+        let source = "\
+#!/bin/bash
+if [ -n \"${CXXFLAGS}\" ]; then :; fi
+for f in ${CFLAGS}; do
+  echo \"c flag: ${f}\"
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CFLAGS}"]
+        );
+    }
+
+    #[test]
+    fn reports_build_flag_scope_compat_with_unbraced_derived_candidate() {
+        let source = "\
+#!/bin/bash
+for f in $CXXFLAGS; do
+  echo \"cxx flag: ${f}\"
+done
+for f in ${CFLAGS}; do
+  echo \"c flag: ${f}\"
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CFLAGS}"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -147,12 +147,13 @@ pub fn possible_variable_misspelling(checker: &mut Checker) {
         &suppressed_reference_spans,
         &mut candidate_cache,
     ));
-    findings.extend(scope_compat_findings(
-        checker,
-        &guarded_name_offsets,
-        &suppressed_reference_spans,
-        &mut candidate_cache,
-    ));
+    if source_may_have_scope_compat_misspelling(checker.source()) {
+        findings.extend(scope_compat_findings(
+            checker,
+            &guarded_name_offsets,
+            &suppressed_reference_spans,
+        ));
+    }
 
     findings.sort_by_key(|(span, _, _)| (span.start.offset, span.end.offset));
     let mut reported_names = FxHashSet::default();
@@ -254,26 +255,16 @@ fn scope_compat_findings(
     checker: &Checker<'_>,
     guarded_name_offsets: &FxHashMap<String, Vec<usize>>,
     suppressed_reference_spans: &FxHashMap<String, Vec<Span>>,
-    candidate_cache: &mut FxHashMap<String, Option<String>>,
 ) -> Vec<(Span, String, String)> {
     let mut findings = Vec::new();
     let mut seen = FxHashSet::default();
+    let mut index = ScopeCompatIndex::default();
+    add_scope_compat_binding_candidates(&mut index, checker);
+    add_scope_compat_name_uses(&mut index, checker);
 
-    for name_use in checker
-        .facts()
-        .possible_variable_misspelling_scope_compat_name_uses()
-    {
-        let reference_name = name_use.key().as_str();
-        if !seen.insert((reference_name.to_owned(), name_use.span().start.offset)) {
-            continue;
-        }
-        if !is_scope_compat_reference_name(reference_name, name_use.kind()) {
-            continue;
-        }
-        if name_use.kind() == ComparableNameUseKind::Derived
-            && is_build_flag_family_name(reference_name)
-            && !is_braced_parameter_use(checker.source(), name_use.span())
-        {
+    for name_use in index.references() {
+        let reference_name = name_use.name.as_str();
+        if !seen.insert((name_use.name.clone(), name_use.span.start.offset)) {
             continue;
         }
         if !looks_like_case_mismatch_reference(reference_name) {
@@ -282,41 +273,31 @@ fn scope_compat_findings(
         if is_known_runtime_name(reference_name) || is_internal_placeholder_name(reference_name) {
             continue;
         }
-        if has_prior_guarded_reference(guarded_name_offsets, reference_name, name_use.span()) {
+        if has_prior_guarded_reference(guarded_name_offsets, reference_name, name_use.span) {
             continue;
         }
-        if has_suppressed_reference_span(
-            suppressed_reference_spans,
-            reference_name,
-            name_use.span(),
-        ) {
+        if has_suppressed_reference_span(suppressed_reference_spans, reference_name, name_use.span)
+        {
             continue;
         }
         if has_same_name_defining_bindings(checker, &Name::from(reference_name)) {
             continue;
         }
-        if is_presence_tested_reference_name(checker, reference_name, name_use.span()) {
+        if is_presence_tested_reference_name(checker, reference_name, name_use.span) {
             continue;
         }
 
-        let candidate =
-            match preferred_scope_compat_candidate_name(checker, candidate_cache, reference_name) {
-                Some(candidate) => candidate,
-                None => continue,
-            };
-        if !is_scope_compat_pair(checker, reference_name, name_use.span(), candidate.as_str()) {
+        let Some(candidate) = preferred_scope_compat_candidate_name_fast(&index, reference_name)
+        else {
             continue;
-        }
-        if is_build_flag_family_non_report_pair(reference_name, candidate.as_str()) {
-            continue;
-        }
-        if is_hostid_label_echo(reference_name, name_use.span(), checker.source()) {
+        };
+        if is_hostid_label_echo(reference_name, name_use.span, checker.source()) {
             continue;
         }
         if is_parallel_c_and_cxx_flag_use(
             checker,
             reference_name,
-            name_use.span(),
+            name_use.span,
             candidate.as_str(),
         ) {
             continue;
@@ -324,14 +305,14 @@ fn scope_compat_findings(
         if is_literal_numbered_suffix_variant(
             checker.source(),
             reference_name,
-            name_use.span(),
+            name_use.span,
             candidate.as_str(),
         ) {
             continue;
         }
 
         findings.push((
-            parameter_reference_span(checker.source(), name_use.span()),
+            parameter_reference_span(checker.source(), name_use.span),
             reference_name.to_owned(),
             candidate,
         ));
@@ -340,9 +321,157 @@ fn scope_compat_findings(
     findings
 }
 
-fn is_scope_compat_reference_name(reference_name: &str, kind: ComparableNameUseKind) -> bool {
-    reference_name == "SHELLSPEC_EXECDIR"
-        || kind == ComparableNameUseKind::Derived && is_build_flag_family_name(reference_name)
+#[derive(Default)]
+struct ScopeCompatIndex {
+    exact_candidates: FxHashMap<String, ScopeCompatCandidate>,
+    build_flag_candidates: FxHashMap<String, ScopeCompatCandidate>,
+    shellspec_execdir_references: Vec<ScopeCompatUse>,
+    build_flag_references: Vec<ScopeCompatUse>,
+}
+
+#[derive(Clone)]
+struct ScopeCompatCandidate {
+    name: String,
+    span: Span,
+}
+
+struct ScopeCompatUse {
+    name: String,
+    span: Span,
+}
+
+impl ScopeCompatIndex {
+    fn references(&self) -> impl Iterator<Item = &ScopeCompatUse> {
+        self.shellspec_execdir_references
+            .iter()
+            .chain(self.build_flag_references.iter())
+    }
+
+    fn add_exact_candidate(&mut self, name: &str, span: Span) {
+        insert_earliest_candidate(&mut self.exact_candidates, name.to_owned(), name, span);
+    }
+
+    fn add_build_flag_candidate(&mut self, name: &str, span: Span) {
+        insert_earliest_candidate(&mut self.build_flag_candidates, name.to_owned(), name, span);
+    }
+
+    fn best_exact_candidate(&self, name: &str) -> Option<String> {
+        self.exact_candidates
+            .get(name)
+            .map(|candidate| candidate.name.clone())
+    }
+
+    fn best_candidate_by_name(&self, name: &str) -> Option<&ScopeCompatCandidate> {
+        self.build_flag_candidates.get(name)
+    }
+}
+
+fn insert_earliest_candidate(
+    candidates: &mut FxHashMap<String, ScopeCompatCandidate>,
+    key: String,
+    name: &str,
+    span: Span,
+) {
+    let candidate = ScopeCompatCandidate {
+        name: name.to_owned(),
+        span,
+    };
+    candidates
+        .entry(key)
+        .and_modify(|current| {
+            if (span.start.offset, span.end.offset)
+                < (current.span.start.offset, current.span.end.offset)
+            {
+                *current = candidate.clone();
+            }
+        })
+        .or_insert(candidate);
+}
+
+fn add_scope_compat_binding_candidates(index: &mut ScopeCompatIndex, checker: &Checker<'_>) {
+    for binding in checker.semantic().bindings() {
+        let name = binding.name.as_str();
+        if name == "SHELLSPEC_SPECDIR" {
+            index.add_exact_candidate(name, binding.span);
+        }
+        if is_reportable_build_flag_family_name(name) {
+            index.add_build_flag_candidate(name, binding.span);
+        }
+    }
+}
+
+fn add_scope_compat_name_uses(index: &mut ScopeCompatIndex, checker: &Checker<'_>) {
+    for name_use in checker
+        .facts()
+        .possible_variable_misspelling_scope_compat_name_uses()
+    {
+        let name = name_use.key().as_str();
+        if name == "SHELLSPEC_EXECDIR" {
+            index.shellspec_execdir_references.push(ScopeCompatUse {
+                name: name.to_owned(),
+                span: name_use.span(),
+            });
+            continue;
+        }
+        if name == "SHELLSPEC_SPECDIR" {
+            index.add_exact_candidate(name, name_use.span());
+            continue;
+        }
+        if name_use.kind() != ComparableNameUseKind::Derived
+            || !is_braced_parameter_use(checker.source(), name_use.span())
+            || !is_reportable_build_flag_family_name(name)
+        {
+            continue;
+        }
+
+        index.add_build_flag_candidate(name, name_use.span());
+        index.build_flag_references.push(ScopeCompatUse {
+            name: name.to_owned(),
+            span: name_use.span(),
+        });
+    }
+}
+
+fn preferred_scope_compat_candidate_name_fast(
+    index: &ScopeCompatIndex,
+    reference_name: &str,
+) -> Option<String> {
+    if reference_name == "SHELLSPEC_EXECDIR" {
+        return index.best_exact_candidate("SHELLSPEC_SPECDIR");
+    }
+    best_build_flag_candidate(index, reference_name)
+}
+
+fn best_build_flag_candidate(index: &ScopeCompatIndex, reference_name: &str) -> Option<String> {
+    let (prefix, reference_suffix) = split_build_flag_family_name(reference_name)?;
+    compatible_build_flag_candidate_suffixes(reference_suffix)
+        .iter()
+        .filter_map(|candidate_suffix| {
+            let candidate_name = if prefix.is_empty() {
+                (*candidate_suffix).to_owned()
+            } else {
+                format!("{prefix}{candidate_suffix}")
+            };
+            index.best_candidate_by_name(&candidate_name)
+        })
+        .min_by_key(|candidate| (candidate.span.start.offset, candidate.span.end.offset))
+        .map(|candidate| candidate.name.clone())
+}
+
+fn compatible_build_flag_candidate_suffixes(reference_suffix: &str) -> &'static [&'static str] {
+    match reference_suffix {
+        "CFLAGS" => &["CXXFLAGS", "CPPFLAGS"],
+        "CPPFLAGS" => &["CXXFLAGS"],
+        "CXXFLAGS" => &["CPPFLAGS"],
+        _ => &[],
+    }
+}
+
+fn source_may_have_scope_compat_misspelling(source: &str) -> bool {
+    source.contains("SHELLSPEC_EXECDIR")
+        || source.contains("CFLAGS")
+        || source.contains("CPPFLAGS")
+        || source.contains("CXXFLAGS")
 }
 
 fn is_braced_parameter_use(source: &str, span: Span) -> bool {
@@ -350,72 +479,6 @@ fn is_braced_parameter_use(source: &str, span: Span) -> bool {
         .as_bytes()
         .get(span.start.offset..span.start.offset + 2)
         .is_some_and(|prefix| prefix == b"${")
-}
-
-fn preferred_scope_compat_candidate_name(
-    checker: &Checker<'_>,
-    candidate_cache: &mut FxHashMap<String, Option<String>>,
-    reference_name: &str,
-) -> Option<String> {
-    cached_candidate_name(candidate_cache, checker, reference_name)
-        .or_else(|| build_flag_scope_candidate_name(checker, reference_name))
-}
-
-fn build_flag_scope_candidate_name(checker: &Checker<'_>, reference_name: &str) -> Option<String> {
-    if !is_build_flag_family_name(reference_name) {
-        return None;
-    }
-
-    checker
-        .semantic()
-        .bindings()
-        .iter()
-        .filter_map(|binding| {
-            let candidate_name = binding.name.as_str();
-            if candidate_name == reference_name
-                || !is_build_flag_misspelling_report_pair(reference_name, candidate_name)
-            {
-                return None;
-            }
-            Some((
-                binding.span.start.offset,
-                binding.span.end.offset,
-                candidate_name.to_owned(),
-            ))
-        })
-        .chain(
-            checker
-                .facts()
-                .possible_variable_misspelling_scope_compat_name_uses()
-                .iter()
-                .filter_map(|name_use| {
-                    let candidate_name = name_use.key().as_str();
-                    if candidate_name == reference_name
-                        || !is_build_flag_misspelling_report_pair(reference_name, candidate_name)
-                    {
-                        return None;
-                    }
-                    Some((
-                        name_use.span().start.offset,
-                        name_use.span().end.offset,
-                        candidate_name.to_owned(),
-                    ))
-                }),
-        )
-        .min_by_key(|(start, end, _)| (*start, *end))
-        .map(|(_, _, name)| name)
-}
-
-fn is_scope_compat_pair(
-    _checker: &Checker<'_>,
-    reference_name: &str,
-    _reference_span: Span,
-    candidate_name: &str,
-) -> bool {
-    match (reference_name, candidate_name) {
-        ("SHELLSPEC_EXECDIR", "SHELLSPEC_SPECDIR") => true,
-        _ => is_build_flag_misspelling_report_pair(reference_name, candidate_name),
-    }
 }
 
 fn has_prior_guarded_reference(
@@ -591,6 +654,13 @@ fn split_build_flag_family_name(name: &str) -> Option<(&str, &'static str)> {
                     .map(|prefix| (prefix, suffix))
             }
         })
+}
+
+fn is_reportable_build_flag_family_name(name: &str) -> bool {
+    let Some((_, suffix)) = split_build_flag_family_name(name) else {
+        return false;
+    };
+    matches!(suffix, "CFLAGS" | "CPPFLAGS" | "CXXFLAGS")
 }
 
 fn is_build_flag_family_name(name: &str) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -407,6 +407,9 @@ fn add_scope_compat_presence_test_candidates(index: &mut ScopeCompatIndex, check
         .presence_test_candidate_spans(checker.semantic())
     {
         let name = name.as_str();
+        if name == "SHELLSPEC_SPECDIR" {
+            index.add_exact_candidate(name, span);
+        }
         if is_reportable_build_flag_family_name(name) {
             index.add_build_flag_candidate(name, span);
         }
@@ -1394,6 +1397,29 @@ if [ ! \"$SHELLSPEC_PROJECT_ROOT\" ]; then
   esac
 fi
 export SHELLSPEC_SPECDIR=\"$SHELLSPEC_HELPERDIR\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$SHELLSPEC_EXECDIR"]
+        );
+    }
+
+    #[test]
+    fn reports_shellspec_execdir_with_presence_test_candidate() {
+        let source = "\
+#!/bin/sh
+if [ -n \"$SHELLSPEC_SPECDIR\" ]; then :; fi
+case $SHELLSPEC_EXECDIR in (@basedir*)
+  exit 1
+esac
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -433,14 +433,14 @@ fn add_scope_compat_name_uses(index: &mut ScopeCompatIndex, checker: &Checker<'_
             index.add_exact_candidate(name, name_use.span());
             continue;
         }
-        if name_use.kind() != ComparableNameUseKind::Derived
-            || !is_reportable_build_flag_family_name(name)
-        {
+        if !is_reportable_build_flag_family_name(name) {
             continue;
         }
 
         index.add_build_flag_candidate(name, name_use.span());
-        if !is_braced_parameter_use(checker.source(), name_use.span()) {
+        if name_use.kind() != ComparableNameUseKind::Derived
+            || !is_braced_parameter_use(checker.source(), name_use.span())
+        {
             continue;
         }
         index.build_flag_references.push(ScopeCompatUse {
@@ -1346,6 +1346,57 @@ done
 for f in ${CFLAGS}; do
   echo \"c flag: ${f}\"
 done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CFLAGS}"]
+        );
+    }
+
+    #[test]
+    fn reports_build_flag_scope_compat_with_parameter_candidate() {
+        let source = "\
+#!/bin/bash
+tmp=\"${CXXFLAGS}\"
+for f in ${CFLAGS}; do
+  echo \"c flag: ${f}\"
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CFLAGS}"]
+        );
+    }
+
+    #[test]
+    fn reports_build_flag_scope_compat_with_quoted_derived_candidate() {
+        let source = "\
+#!/bin/bash
+declare -r EXTRA_FLAGS=\"\\
+$(
+for f in \"${CXXFLAGS}\"; do
+  echo \"cxx flag: ${f}\"
+done
+for f in ${CFLAGS}; do
+  echo \"c flag: ${f}\"
+done
+)\"
 ";
         let diagnostics = test_snippet(
             source,


### PR DESCRIPTION
## Summary
- add a cheap source gate before running the scope-compat possible-variable-misspelling path
- replace fuzzy scope-compat candidate lookup with a deterministic ShellSpec/build-flag index
- narrow the scope-compat fact collector so it no longer initializes broad comparable-name uses

## Performance
Measured with:
`hyperfine --warmup 3 --runs 20 --ignore-failure 'target/profiling/shuck check --no-cache --output-format concise crates/shuck-benchmark/resources/files/bashtop.sh'`

- Before: `77.9 ms +/- 6.2 ms`
- After: `67.0 ms +/- 1.1 ms`

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter possible_variable_misspelling`
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C156`