### PR TITLE
refactor(linter): use semantic declaration operands

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2332,7 +2332,6 @@ fn build_declaration_assignment_probes<'a>(
         .filter_map(|operand| {
             let SemanticDeclarationOperand::Assignment {
                 name,
-                operand_span,
                 name_span,
                 value_span,
                 value_origin,
@@ -2349,7 +2348,7 @@ fn build_declaration_assignment_probes<'a>(
                 target_name_span: *name_span,
                 has_command_substitution: *has_command_or_process_substitution
                     || *value_origin == AssignmentValueOrigin::CommandOrProcessSubstitution,
-                status_capture: single_word_for_declaration_operand_span(command, *operand_span)
+                status_capture: word_for_declaration_value_span(command, *value_span)
                     .is_some_and(|word| word_span_is_standalone_status_capture(word, *value_span)),
             })
         })
@@ -2395,29 +2394,15 @@ fn semantic_declaration_readonly_flag(declaration: &Declaration) -> bool {
     })
 }
 
-fn single_word_for_declaration_operand_span<'a>(
-    command: &'a Command,
-    span: Span,
-) -> Option<&'a Word> {
-    let words = words_for_declaration_operand_span(command, span);
-    match words.as_slice() {
-        [word] => Some(*word),
-        _ => None,
-    }
-}
-
-fn words_for_declaration_operand_span<'a>(command: &'a Command, span: Span) -> Vec<&'a Word> {
+fn word_for_declaration_value_span(command: &Command, span: Span) -> Option<&Word> {
     let Command::Simple(command) = command else {
-        return Vec::new();
+        return None;
     };
 
     command
         .args
         .iter()
-        .filter(|word| {
-            span.start.offset <= word.span.start.offset && word.span.end.offset <= span.end.offset
-        })
-        .collect()
+        .find(|word| span.start.offset >= word.span.start.offset && span.end.offset <= word.span.end.offset)
 }
 
 fn word_span_is_standalone_status_capture(word: &Word, span: Span) -> bool {
@@ -2545,7 +2530,6 @@ fn collect_binding_values<'a>(
         for operand in &declaration.operands {
             let SemanticDeclarationOperand::Assignment {
                 name,
-                operand_span,
                 name_span,
                 value_span,
                 ..
@@ -2553,7 +2537,7 @@ fn collect_binding_values<'a>(
             else {
                 continue;
             };
-            let Some(word) = single_word_for_declaration_operand_span(command, *operand_span) else {
+            let Some(word) = word_for_declaration_value_span(command, *value_span) else {
                 continue;
             };
             let standalone_status_or_pid_capture =

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2334,8 +2334,7 @@ fn build_declaration_assignment_probes<'a>(
                 name,
                 name_span,
                 value_span,
-                value_origin,
-                has_command_or_process_substitution,
+                has_command_substitution,
                 ..
             } = operand
             else {
@@ -2346,8 +2345,7 @@ fn build_declaration_assignment_probes<'a>(
                 readonly_flag,
                 target_name: name.as_str().into(),
                 target_name_span: *name_span,
-                has_command_substitution: *has_command_or_process_substitution
-                    || *value_origin == AssignmentValueOrigin::CommandOrProcessSubstitution,
+                has_command_substitution: *has_command_substitution,
                 status_capture: word_for_declaration_value_span(command, *value_span)
                     .is_some_and(|word| word_span_is_standalone_status_capture(word, *value_span)),
             })

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2283,6 +2283,7 @@ fn collect_dollar_question_after_command_spans_in_function_body(
 fn build_declaration_assignment_probes<'a>(
     command: &'a Command,
     normalized: &NormalizedCommand<'a>,
+    semantic: &SemanticModel,
     source: &str,
     zsh_options: Option<&ZshOptionState>,
 ) -> Vec<DeclarationAssignmentProbe> {
@@ -2311,15 +2312,6 @@ fn build_declaration_assignment_probes<'a>(
             .collect();
     }
 
-    build_simple_command_declaration_assignment_probes(command, normalized, source, zsh_options)
-}
-
-fn build_simple_command_declaration_assignment_probes<'a>(
-    command: &'a Command,
-    normalized: &NormalizedCommand<'a>,
-    source: &str,
-    zsh_options: Option<&ZshOptionState>,
-) -> Vec<DeclarationAssignmentProbe> {
     let Command::Simple(_) = command else {
         return Vec::new();
     };
@@ -2328,52 +2320,138 @@ fn build_simple_command_declaration_assignment_probes<'a>(
         return Vec::new();
     }
 
-    let Some(kind) = simple_command_declaration_kind(normalized.effective_or_literal_name()) else {
+    let Some(declaration) = semantic_declaration_for_command(semantic, command) else {
         return Vec::new();
     };
-    let word_groups = contiguous_word_groups(normalized.body_args());
-    let readonly_flag = matches!(
-        kind,
-        DeclarationKind::Local | DeclarationKind::Declare | DeclarationKind::Typeset
-    ) && simple_command_declaration_readonly_flag(&word_groups, source);
+    let kind = declaration_kind_from_semantic(declaration.builtin);
+    let readonly_flag = semantic_declaration_readonly_flag(declaration);
 
-    word_groups
+    declaration
+        .operands
         .iter()
-        .filter_map(|words| {
-            let first = *words.first()?;
-            let text = words
-                .iter()
-                .map(|word| word.span.slice(source))
-                .collect::<String>();
-            let parsed = parse_assignment_word(&text)?;
-            let value_text = &text[parsed.value_offset..];
+        .filter_map(|operand| {
+            let SemanticDeclarationOperand::Assignment {
+                name,
+                operand_span,
+                name_span,
+                value_span,
+                value_origin,
+                has_command_or_process_substitution,
+                ..
+            } = operand
+            else {
+                return None;
+            };
             Some(DeclarationAssignmentProbe {
                 kind: kind.clone(),
                 readonly_flag,
-                target_name: parsed.name.into(),
-                target_name_span: Span::from_positions(
-                    first.span.start,
-                    first.span.start.advanced_by(parsed.name),
-                ),
-                has_command_substitution: parsed_assignment_value_has_command_substitution(
-                    value_text,
-                    zsh_options,
-                ),
-                status_capture: assignment_value_text_is_standalone_status_capture(value_text),
+                target_name: name.as_str().into(),
+                target_name_span: *name_span,
+                has_command_substitution: *has_command_or_process_substitution
+                    || *value_origin == AssignmentValueOrigin::CommandOrProcessSubstitution,
+                status_capture: single_word_for_declaration_operand_span(command, *operand_span)
+                    .is_some_and(|word| word_span_is_standalone_status_capture(word, *value_span)),
             })
         })
         .collect()
 }
 
-fn assignment_value_text_is_standalone_status_capture(text: &str) -> bool {
-    matches!(text, "$?" | "${?}" | "\"$?\"" | "\"${?}\"")
+fn semantic_declaration_for_command<'a>(
+    semantic: &'a SemanticModel,
+    command: &Command,
+) -> Option<&'a Declaration> {
+    let span = command_span(command);
+    semantic.declarations().iter().find(|declaration| {
+        declaration.span.start.offset == span.start.offset
+            && declaration.span.end.offset == span.end.offset
+    })
 }
 
-fn assignment_value_text_is_standalone_status_or_pid_capture(text: &str) -> bool {
-    matches!(
-        text,
-        "$?" | "${?}" | "\"$?\"" | "\"${?}\"" | "$!" | "${!}" | "\"$!\"" | "\"${!}\""
-    )
+fn declaration_kind_from_semantic(builtin: DeclarationBuiltin) -> DeclarationKind {
+    match builtin {
+        DeclarationBuiltin::Export => DeclarationKind::Export,
+        DeclarationBuiltin::Local => DeclarationKind::Local,
+        DeclarationBuiltin::Declare => DeclarationKind::Declare,
+        DeclarationBuiltin::Typeset => DeclarationKind::Typeset,
+        DeclarationBuiltin::Readonly => DeclarationKind::Other("readonly".to_owned()),
+    }
+}
+
+fn semantic_declaration_readonly_flag(declaration: &Declaration) -> bool {
+    if !matches!(
+        declaration.builtin,
+        DeclarationBuiltin::Local | DeclarationBuiltin::Declare | DeclarationBuiltin::Typeset
+    ) {
+        return false;
+    }
+
+    declaration.operands.iter().any(|operand| match operand {
+        SemanticDeclarationOperand::Flag { flags, .. } => {
+            flags.starts_with('-') && flags.contains('r')
+        }
+        SemanticDeclarationOperand::Name { .. }
+        | SemanticDeclarationOperand::Assignment { .. }
+        | SemanticDeclarationOperand::DynamicWord { .. } => false,
+    })
+}
+
+fn single_word_for_declaration_operand_span<'a>(
+    command: &'a Command,
+    span: Span,
+) -> Option<&'a Word> {
+    let words = words_for_declaration_operand_span(command, span);
+    match words.as_slice() {
+        [word] => Some(*word),
+        _ => None,
+    }
+}
+
+fn words_for_declaration_operand_span<'a>(command: &'a Command, span: Span) -> Vec<&'a Word> {
+    let Command::Simple(command) = command else {
+        return Vec::new();
+    };
+
+    command
+        .args
+        .iter()
+        .filter(|word| {
+            span.start.offset <= word.span.start.offset && word.span.end.offset <= span.end.offset
+        })
+        .collect()
+}
+
+fn word_span_is_standalone_status_capture(word: &Word, span: Span) -> bool {
+    let parts = word_parts_in_span(word, span);
+    matches!(parts.as_slice(), [part] if part_is_standalone_status_capture(&part.kind))
+}
+
+fn word_span_is_standalone_status_or_pid_capture(word: &Word, span: Span) -> bool {
+    let parts = word_parts_in_span(word, span);
+    matches!(parts.as_slice(), [part] if part_is_standalone_status_or_pid_capture(&part.kind))
+}
+
+fn word_parts_in_span(word: &Word, span: Span) -> Vec<&WordPartNode> {
+    word.parts
+        .iter()
+        .filter(|part| {
+            span.start.offset <= part.span.start.offset && part.span.end.offset <= span.end.offset
+        })
+        .collect()
+}
+
+fn part_is_standalone_status_capture(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => name.as_str() == "?",
+        WordPart::DoubleQuoted { parts, .. } => {
+            matches!(parts.as_slice(), [part] if part_is_standalone_status_capture(&part.kind))
+        }
+        WordPart::Parameter(parameter) => matches!(
+            parameter.bourne(),
+            Some(BourneParameterExpansion::Access { reference })
+                if reference.name.as_str() == "?" && reference.subscript.is_none()
+        ),
+        _ => false,
+    }
 }
 
 fn word_is_standalone_status_or_pid_capture(word: &Word) -> bool {
@@ -2398,206 +2476,6 @@ fn part_is_standalone_status_or_pid_capture(part: &WordPart) -> bool {
     }
 }
 
-fn contiguous_word_groups<'a>(words: &'a [&'a Word]) -> Vec<&'a [&'a Word]> {
-    let mut groups = Vec::new();
-    let mut start = 0usize;
-
-    while start < words.len() {
-        let mut end = start + 1;
-        while let Some(next) = words.get(end).copied() {
-            if words[end - 1].span.end.offset != next.span.start.offset {
-                break;
-            }
-            end += 1;
-        }
-        groups.push(&words[start..end]);
-        start = end;
-    }
-
-    groups
-}
-
-fn simple_command_declaration_kind(name: Option<&str>) -> Option<DeclarationKind> {
-    match name? {
-        "export" => Some(DeclarationKind::Export),
-        "local" => Some(DeclarationKind::Local),
-        "declare" => Some(DeclarationKind::Declare),
-        "typeset" => Some(DeclarationKind::Typeset),
-        "readonly" => Some(DeclarationKind::Other("readonly".to_owned())),
-        _ => None,
-    }
-}
-
-fn simple_command_declaration_readonly_flag(word_groups: &[&[&Word]], source: &str) -> bool {
-    let mut readonly_flag = false;
-
-    for words in word_groups {
-        let [word] = words else {
-            break;
-        };
-        let Some(text) = static_word_text(word, source) else {
-            break;
-        };
-
-        // Bash stops parsing declaration options after the first name[=value] operand,
-        // so later "-r" words must not retroactively mark earlier assignments readonly.
-        if text == "--" {
-            break;
-        }
-
-        if !simple_command_declaration_option_word(&text) {
-            break;
-        }
-
-        if declaration_flag_sets_readonly_text(&text) {
-            readonly_flag = true;
-        }
-    }
-
-    readonly_flag
-}
-
-fn simple_command_declaration_option_word(text: &str) -> bool {
-    let mut chars = text.chars();
-    let Some(prefix) = chars.next() else {
-        return false;
-    };
-
-    if !matches!(prefix, '-' | '+') {
-        return false;
-    }
-
-    let rest = chars.as_str();
-    !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_alphabetic())
-}
-
-fn declaration_flag_sets_readonly_text(text: &str) -> bool {
-    text.starts_with('-') && text.contains('r')
-}
-
-#[derive(Debug, Clone, Copy)]
-struct ParsedAssignmentWord<'a> {
-    name: &'a str,
-    value_offset: usize,
-}
-
-fn parse_assignment_word(word: &str) -> Option<ParsedAssignmentWord<'_>> {
-    if !word.contains('=') {
-        return None;
-    }
-
-    let mut chars = word.char_indices();
-    let (_, first) = chars.next()?;
-    if !first.is_ascii_alphabetic() && first != '_' {
-        return None;
-    }
-
-    let mut ident_end = first.len_utf8();
-    for (index, ch) in chars {
-        if ch.is_ascii_alphanumeric() || ch == '_' {
-            ident_end = index + ch.len_utf8();
-        } else {
-            break;
-        }
-    }
-
-    let name = &word[..ident_end];
-    let mut cursor = ident_end;
-
-    if word[cursor..].starts_with('[') {
-        let bytes = word.as_bytes();
-        let mut close_index = None;
-        let mut bracket_depth = 0usize;
-        let mut index = cursor + 1;
-
-        while index < bytes.len() {
-            if bytes[index] == b'\\' {
-                index = advance_escaped_char_boundary(word, index);
-                continue;
-            }
-
-            if index + 2 < bytes.len()
-                && is_unescaped_dollar(bytes, index)
-                && bytes[index + 1] == b'('
-                && bytes[index + 2] == b'('
-            {
-                index = find_wrapped_arithmetic_end(bytes, index)?;
-                continue;
-            }
-
-            if index + 1 < bytes.len()
-                && is_unescaped_dollar(bytes, index)
-                && bytes[index + 1] == b'('
-            {
-                index = find_command_substitution_end(bytes, index)?;
-                continue;
-            }
-
-            if index + 1 < bytes.len()
-                && is_unescaped_dollar(bytes, index)
-                && bytes[index + 1] == b'{'
-            {
-                index = find_runtime_parameter_closing_brace(word, index)?;
-                continue;
-            }
-
-            if index + 1 < bytes.len()
-                && matches!(bytes[index], b'<' | b'>')
-                && bytes[index + 1] == b'('
-            {
-                index = find_process_substitution_end(bytes, index)?;
-                continue;
-            }
-
-            match bytes[index] {
-                b'\'' => index = skip_single_quoted(bytes, index + 1)?,
-                b'"' => index = skip_double_quoted(bytes, index + 1)?,
-                b'`' => index = skip_backticks(bytes, index + 1)?,
-                b'[' => {
-                    bracket_depth += 1;
-                    index += 1;
-                }
-                b']' if bracket_depth == 0 => {
-                    close_index = Some(index);
-                    break;
-                }
-                b']' => {
-                    bracket_depth -= 1;
-                    index += 1;
-                }
-                _ => {
-                    index += word[index..].chars().next()?.len_utf8();
-                }
-            }
-        }
-
-        cursor = close_index? + 1;
-    }
-
-    if word[cursor..].starts_with("+=") || word[cursor..].starts_with('=') {
-        Some(ParsedAssignmentWord {
-            name,
-            value_offset: cursor
-                + if word[cursor..].starts_with("+=") {
-                    2
-                } else {
-                    1
-                },
-        })
-    } else {
-        None
-    }
-}
-
-fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
-    let next = start + '\\'.len_utf8();
-    if next >= text.len() {
-        return next;
-    }
-
-    next + text[next..].chars().next().map_or(0, char::len_utf8)
-}
-
 fn word_has_command_substitution(
     word: &Word,
     source: &str,
@@ -2607,17 +2485,13 @@ fn word_has_command_substitution(
         .has_command_substitution()
 }
 
-fn parsed_assignment_value_has_command_substitution(
-    value_text: &str,
-    zsh_options: Option<&ZshOptionState>,
-) -> bool {
-    if value_text.is_empty() {
-        return false;
+fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
+    let next = start + '\\'.len_utf8();
+    if next >= text.len() {
+        return next;
     }
 
-    let word = Parser::parse_word_string(value_text);
-    word_classification_from_analysis(analyze_word(&word, value_text, zsh_options))
-        .has_command_substitution()
+    next + text[next..].chars().next().map_or(0, char::len_utf8)
 }
 
 fn collect_binding_values<'a>(
@@ -2665,19 +2539,36 @@ fn collect_binding_values<'a>(
         }
     }
 
-    for (name, name_span, word, standalone_status_or_pid_capture) in
-        simple_declaration_assignment_value_words(command, source)
+    if matches!(command, Command::Simple(_))
+        && let Some(declaration) = semantic_declaration_for_command(semantic, command)
     {
-        if let Some(binding_id) =
-            binding_value_definition_id_for_name(semantic, &name, name_span)
-        {
-            binding_values.insert(
-                binding_id,
-                BindingValueFact::scalar_with_status_or_pid_capture(
-                    word,
-                    standalone_status_or_pid_capture,
-                ),
-            );
+        for operand in &declaration.operands {
+            let SemanticDeclarationOperand::Assignment {
+                name,
+                operand_span,
+                name_span,
+                value_span,
+                ..
+            } = operand
+            else {
+                continue;
+            };
+            let Some(word) = single_word_for_declaration_operand_span(command, *operand_span) else {
+                continue;
+            };
+            let standalone_status_or_pid_capture =
+                word_span_is_standalone_status_or_pid_capture(word, *value_span);
+            if let Some(binding_id) =
+                binding_value_definition_id_for_name(semantic, name, *name_span)
+            {
+                binding_values.insert(
+                    binding_id,
+                    BindingValueFact::scalar_with_status_or_pid_capture(
+                        word,
+                        standalone_status_or_pid_capture,
+                    ),
+                );
+            }
         }
     }
 
@@ -2729,67 +2620,6 @@ fn collect_binding_values<'a>(
         }
         _ => {}
     }
-}
-
-fn simple_declaration_assignment_value_words<'a>(
-    command: &'a Command,
-    source: &str,
-) -> Vec<(Name, Span, &'a Word, bool)> {
-    let Command::Simple(command) = command else {
-        return Vec::new();
-    };
-    let Some(command_name) = static_command_name_text(&command.name, source) else {
-        return Vec::new();
-    };
-    let command_name = command_name
-        .as_ref()
-        .strip_prefix('\\')
-        .unwrap_or(command_name.as_ref());
-    if simple_command_declaration_kind(Some(command_name)).is_none() {
-        return Vec::new();
-    }
-
-    let mut values = Vec::new();
-    let mut parsing_options = true;
-    for word in &command.args {
-        let static_text = static_word_text(word, source);
-        let text = static_text
-            .as_deref()
-            .unwrap_or_else(|| word.span.slice(source));
-
-        if parsing_options {
-            if text == "--" {
-                parsing_options = false;
-                continue;
-            }
-            if simple_command_declaration_option_word(text) {
-                continue;
-            }
-            parsing_options = false;
-        }
-
-        let Some(parsed) = parse_assignment_word(text) else {
-            continue;
-        };
-        let value_text = &text[parsed.value_offset..];
-        let standalone_status_or_pid_capture =
-            assignment_value_text_is_standalone_status_or_pid_capture(value_text);
-        if static_text.is_none() && !standalone_status_or_pid_capture {
-            continue;
-        }
-        let name_span = Span::from_positions(
-            word.span.start,
-            word.span.start.advanced_by(parsed.name),
-        );
-        values.push((
-            Name::from(parsed.name),
-            name_span,
-            word,
-            standalone_status_or_pid_capture,
-        ));
-    }
-
-    values
 }
 
 fn binding_value_definition_id_for_name(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -281,6 +281,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 let declaration_assignment_probes = build_declaration_assignment_probes(
                     visit.command,
                     &normalized,
+                    self.semantic,
                     self.source,
                     command_zsh_options.as_ref(),
                 );

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -63,9 +63,9 @@ use shuck_indexer::Indexer;
 #[cfg(test)]
 use shuck_parser::parser::Parser;
 use shuck_semantic::{
-    AssignmentValueOrigin, Binding, BindingAttributes, BindingId, BindingKind, Declaration,
-    DeclarationBuiltin, DeclarationOperand as SemanticDeclarationOperand, OptionValue, Reference,
-    ReferenceId, ReferenceKind, ScopeId, SemanticModel, ZshOptionState,
+    Binding, BindingAttributes, BindingId, BindingKind, Declaration, DeclarationBuiltin,
+    DeclarationOperand as SemanticDeclarationOperand, OptionValue, Reference, ReferenceId,
+    ReferenceKind, ScopeId, SemanticModel, ZshOptionState,
 };
 use smallvec::SmallVec;
 use std::{borrow::Cow, ops::ControlFlow, sync::OnceLock};

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -60,9 +60,11 @@ use shuck_ast::{
     static_command_wrapper_target_index, static_word_text, word_is_standalone_status_capture,
 };
 use shuck_indexer::Indexer;
+#[cfg(test)]
 use shuck_parser::parser::Parser;
 use shuck_semantic::{
-    Binding, BindingAttributes, BindingId, BindingKind, DeclarationBuiltin, OptionValue, Reference,
+    AssignmentValueOrigin, Binding, BindingAttributes, BindingId, BindingKind, Declaration,
+    DeclarationBuiltin, DeclarationOperand as SemanticDeclarationOperand, OptionValue, Reference,
     ReferenceId, ReferenceKind, ScopeId, SemanticModel, ZshOptionState,
 };
 use smallvec::SmallVec;

--- a/crates/shuck-linter/src/facts/tests/assignments.rs
+++ b/crates/shuck-linter/src/facts/tests/assignments.rs
@@ -47,13 +47,22 @@ status=$?
 pid=$!
 \\typeset ret=$?
 \\local child=$!
+\\declare -A grouped_status[<(printf '%s' key)]=$?
+\\declare -A grouped_child[<(printf '%s' key)]=$!
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
     let semantic = SemanticModel::build(&output.file, source, &indexer);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
-    for name in ["status", "pid", "ret", "child"] {
+    for name in [
+        "status",
+        "pid",
+        "ret",
+        "child",
+        "grouped_status",
+        "grouped_child",
+    ] {
         let binding_id = semantic.bindings_for(&Name::from(name))[0];
         assert!(
             facts

--- a/crates/shuck-linter/src/facts/tests/mod.rs
+++ b/crates/shuck-linter/src/facts/tests/mod.rs
@@ -12,8 +12,7 @@ use super::{
     ExprStringHelperKind, GrepPatternSourceKind, ListFact, ListSegmentKind, MixedShortCircuitKind,
     SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax, SubstitutionHostKind,
     SubstitutionOutputIntent, SudoFamilyInvoker, WordFactHostKind,
-    build_innermost_command_ids_by_offset, parse_assignment_word,
-    precomputed_command_id_for_offset,
+    build_innermost_command_ids_by_offset, precomputed_command_id_for_offset,
 };
 use crate::WrapperKind;
 use crate::facts::surface::PositionalParameterFragmentKind;

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -3061,12 +3061,3 @@ demo() {
         assert_eq!(probes, vec![("out", false, true)]);
     });
 }
-
-#[test]
-fn parses_assignment_words_with_process_substitution_subscripts() {
-    let word = "arr[<(printf \"]\")]=$(date)";
-    let parsed = super::parse_assignment_word(word)
-        .map(|parsed| (parsed.name, &word[parsed.value_offset..]));
-
-    assert_eq!(parsed, Some(("arr", "$(date)")));
-}

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -3023,6 +3023,7 @@ fn collects_declaration_assignment_probes_for_process_substitution_subscripts() 
     let source = "\
 #!/bin/bash
 \\declare -A arr[<(printf \"]\")]=$(date)
+\\export out=<(printf hi)
 ";
 
     with_facts(source, None, |_, facts| {
@@ -3032,7 +3033,7 @@ fn collects_declaration_assignment_probes_for_process_substitution_subscripts() 
             .map(|probe| (probe.target_name(), probe.has_command_substitution()))
             .collect::<Vec<_>>();
 
-        assert_eq!(probes, vec![("arr", true)]);
+        assert_eq!(probes, vec![("arr", true), ("out", false)]);
     });
 }
 

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -396,4 +396,18 @@ shopt -s extglob
             vec!["arr"]
         );
     }
+
+    #[test]
+    fn ignores_escaped_declaration_process_substitution_values() {
+        let source = "\
+#!/bin/bash
+\\export out=<(printf hi)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2054,6 +2054,40 @@ impl<'a> Parser<'a> {
         )
     }
 
+    /// Classify an already-parsed word as a shell assignment and split its value.
+    ///
+    /// This is the parser-owned entrypoint for downstream analysis that needs
+    /// assignment target/value structure from a `Word` that was parsed as a
+    /// normal command argument.
+    pub fn parse_assignment_word(
+        source: &str,
+        word: Word,
+        explicit_array_kind: Option<ArrayKind>,
+        subscript_interpretation: SubscriptInterpretation,
+    ) -> Option<Assignment> {
+        let mut parser = Parser::new(source);
+        parser.parse_assignment_from_word(word, explicit_array_kind, subscript_interpretation)
+    }
+
+    /// Classify a contiguous group of already-parsed words as a shell assignment.
+    ///
+    /// Some shell syntax, such as process substitution inside an array subscript,
+    /// can produce multiple AST words while still occupying one contiguous
+    /// assignment operand in the source.
+    pub fn parse_assignment_word_group(
+        source: &str,
+        words: &[&Word],
+        explicit_array_kind: Option<ArrayKind>,
+        subscript_interpretation: SubscriptInterpretation,
+    ) -> Option<Assignment> {
+        let first = words.first()?;
+        let last = words.last()?;
+        let span = Span::from_positions(first.span.start, last.span.end);
+        let raw = span.slice(source);
+        let mut parser = Parser::new(source);
+        parser.parse_assignment_from_text(raw, span, explicit_array_kind, subscript_interpretation)
+    }
+
     /// Parse a word string with caller-configured limits.
     /// Prevents bypass of parser limits in parameter expansion contexts.
     pub fn parse_word_string_with_limits(input: &str, max_depth: usize, max_fuel: usize) -> Word {

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -5039,6 +5039,32 @@ fn test_parse_typeset_clause_classifies_flags_and_assignments() {
 }
 
 #[test]
+fn test_parse_assignment_word_handles_process_substitution_subscript() {
+    let input = "\\declare -A arr[<(printf \"]\")]=$(date)\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected escaped declaration to parse as simple command");
+    };
+    let words = command.args[1..].iter().collect::<Vec<_>>();
+    let assignment = Parser::parse_assignment_word_group(
+        input,
+        &words,
+        Some(ArrayKind::Associative),
+        SubscriptInterpretation::Contextual,
+    )
+    .expect("expected assignment word");
+
+    assert_eq!(assignment.target.name, "arr");
+    assert_eq!(assignment.target.name_span.slice(input), "arr");
+    assert!(assignment.target.subscript.is_some());
+    let AssignmentValue::Scalar(value) = &assignment.value else {
+        panic!("expected scalar value");
+    };
+    assert_eq!(value.span.slice(input), "$(date)");
+}
+
+#[test]
 fn test_parse_declaration_name_operand_preserves_nested_arithmetic_subscript() {
     let input = "declare assoc[$((0))]\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -2769,6 +2769,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     value_span: assignment.value_span,
                     append: assignment.append,
                     value_origin: assignment.value_origin,
+                    has_command_substitution: assignment.has_command_substitution,
                     has_command_or_process_substitution: assignment
                         .has_command_or_process_substitution,
                 });
@@ -3955,6 +3956,9 @@ fn declaration_operands(operands: &[DeclOperand], source: &str) -> Vec<Declarati
                 value_span: assignment_value_span(assignment),
                 append: assignment.append,
                 value_origin: assignment_value_origin(&assignment.value),
+                has_command_substitution: assignment_value_has_command_substitution(
+                    &assignment.value,
+                ),
                 has_command_or_process_substitution:
                     assignment_value_has_command_or_process_substitution(&assignment.value),
             },
@@ -4966,6 +4970,7 @@ struct SimpleDeclarationAssignment {
     append: bool,
     array_like: bool,
     value_origin: AssignmentValueOrigin,
+    has_command_substitution: bool,
     has_command_or_process_substitution: bool,
 }
 
@@ -4985,6 +4990,7 @@ fn parse_simple_declaration_assignment(
     let array_like = assignment.target.subscript.is_some()
         || matches!(assignment.value, AssignmentValue::Compound(_));
     let value_origin = assignment_value_origin(&assignment.value);
+    let has_command_substitution = assignment_value_has_command_substitution(&assignment.value);
     let has_command_or_process_substitution =
         assignment_value_has_command_or_process_substitution(&assignment.value);
 
@@ -4996,6 +5002,7 @@ fn parse_simple_declaration_assignment(
         append: assignment.append,
         array_like,
         value_origin,
+        has_command_substitution,
         has_command_or_process_substitution,
     })
 }
@@ -5625,7 +5632,16 @@ fn assignment_value_has_command_or_process_substitution(value: &AssignmentValue)
     };
     let mut scan = AssignmentWordOriginScan::default();
     scan_assignment_word_parts(&word.parts, &mut scan);
-    scan.command_or_process_substitution
+    scan.command_substitution || scan.process_substitution
+}
+
+fn assignment_value_has_command_substitution(value: &AssignmentValue) -> bool {
+    let AssignmentValue::Scalar(word) = value else {
+        return false;
+    };
+    let mut scan = AssignmentWordOriginScan::default();
+    scan_assignment_word_parts(&word.parts, &mut scan);
+    scan.command_substitution
 }
 
 fn binding_origin_for_assignment(assignment: &Assignment, source: &str) -> BindingOrigin {
@@ -5693,7 +5709,8 @@ struct AssignmentWordOriginScan {
     parameter_operator: bool,
     transformation: bool,
     indirect_expansion: bool,
-    command_or_process_substitution: bool,
+    command_substitution: bool,
+    process_substitution: bool,
     array_or_compound: bool,
     mixed_dynamic: bool,
 }
@@ -5704,7 +5721,7 @@ impl AssignmentWordOriginScan {
             self.parameter_operator,
             self.transformation,
             self.indirect_expansion,
-            self.command_or_process_substitution,
+            self.command_substitution || self.process_substitution,
             self.array_or_compound,
             self.mixed_dynamic,
         ]
@@ -5720,7 +5737,7 @@ impl AssignmentWordOriginScan {
             Some(AssignmentValueOrigin::Transformation)
         } else if self.indirect_expansion {
             Some(AssignmentValueOrigin::IndirectExpansion)
-        } else if self.command_or_process_substitution {
+        } else if self.command_substitution || self.process_substitution {
             Some(AssignmentValueOrigin::CommandOrProcessSubstitution)
         } else if self.array_or_compound {
             Some(AssignmentValueOrigin::ArrayOrCompound)
@@ -5779,9 +5796,8 @@ fn scan_assignment_word_part(part: &WordPart, scan: &mut AssignmentWordOriginSca
         | WordPart::ArithmeticExpansion { .. } => {}
         WordPart::DoubleQuoted { parts, .. } => scan_assignment_word_parts(parts, scan),
         WordPart::Parameter(parameter) => scan_parameter_word_part(parameter, scan),
-        WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {
-            scan.command_or_process_substitution = true;
-        }
+        WordPart::CommandSubstitution { .. } => scan.command_substitution = true,
+        WordPart::ProcessSubstitution { .. } => scan.process_substitution = true,
         WordPart::ParameterExpansion { reference, .. } => {
             if reference.has_array_selector() {
                 scan.array_or_compound = true;

--- a/crates/shuck-semantic/src/builder.rs
+++ b/crates/shuck-semantic/src/builder.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::BTreeMap};
+use std::collections::BTreeMap;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
@@ -9,8 +9,8 @@ use shuck_ast::{
     FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, LiteralText, Name,
     NormalizedCommand, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
     PatternGroupKind, PatternPart, PatternPartNode, Position, SourceText, Span,
-    StaticCommandWrapperTarget, Stmt, StmtSeq, Subscript, VarRef, Word, WordPart, WordPartNode,
-    WrapperKind, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
+    StaticCommandWrapperTarget, Stmt, StmtSeq, Subscript, SubscriptInterpretation, VarRef, Word,
+    WordPart, WordPartNode, WrapperKind, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
     normalize_command_words, static_command_name_text, static_command_wrapper_target_index,
     static_word_text, try_static_word_parts_text,
 };
@@ -2690,9 +2690,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let mut parsing_options = true;
         let mut operands = Vec::new();
 
-        for argument in args.iter().copied() {
+        let argument_groups = contiguous_word_groups(args);
+        for arguments in argument_groups {
+            let Some(argument) = arguments.first().copied() else {
+                continue;
+            };
+            let argument_span = word_group_span(arguments);
             if parsing_options {
-                if let Some(text) = static_word_text(argument, self.source) {
+                if arguments.len() == 1
+                    && let Some(text) = static_word_text(argument, self.source)
+                {
                     if text == "--" {
                         parsing_options = false;
                         continue;
@@ -2715,14 +2722,14 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
             if name_operands_are_function_names {
                 operands.push(DeclarationOperand::DynamicWord {
-                    span: argument.span,
+                    span: argument_span,
                 });
                 continue;
             }
 
-            let assignment_text = declaration_assignment_text(argument, self.source);
+            let explicit_array_kind = declaration_explicit_array_kind(&flags);
             if let Some(assignment) =
-                parse_simple_declaration_assignment(argument, assignment_text.as_ref(), self.source)
+                parse_simple_declaration_assignment(arguments, self.source, explicit_array_kind)
             {
                 let (scope, mut attributes) = self.simple_declaration_scope_and_attributes(
                     builtin,
@@ -2756,16 +2763,21 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 );
                 operands.push(DeclarationOperand::Assignment {
                     name: assignment.name,
+                    operand_span: argument_span,
+                    target_span: assignment.target_span,
                     name_span: assignment.name_span,
                     value_span: assignment.value_span,
                     append: assignment.append,
+                    value_origin: assignment.value_origin,
+                    has_command_or_process_substitution: assignment
+                        .has_command_or_process_substitution,
                 });
                 continue;
             }
 
-            if static_word_text(argument, self.source).is_none() {
+            if arguments.len() != 1 || static_word_text(argument, self.source).is_none() {
                 operands.push(DeclarationOperand::DynamicWord {
-                    span: argument.span,
+                    span: argument_span,
                 });
                 continue;
             }
@@ -2782,7 +2794,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 operands.push(DeclarationOperand::Name { name, span });
             } else {
                 operands.push(DeclarationOperand::DynamicWord {
-                    span: argument.span,
+                    span: argument_span,
                 });
             }
         }
@@ -3937,9 +3949,14 @@ fn declaration_operands(operands: &[DeclOperand], source: &str) -> Vec<Declarati
             },
             DeclOperand::Assignment(assignment) => DeclarationOperand::Assignment {
                 name: assignment.target.name.clone(),
+                operand_span: assignment.span,
+                target_span: assignment_target_span(assignment, source),
                 name_span: assignment.target.name_span,
                 value_span: assignment_value_span(assignment),
                 append: assignment.append,
+                value_origin: assignment_value_origin(&assignment.value),
+                has_command_or_process_substitution:
+                    assignment_value_has_command_or_process_substitution(&assignment.value),
             },
             DeclOperand::Dynamic(word) => DeclarationOperand::DynamicWord { span: word.span },
         })
@@ -4940,10 +4957,6 @@ fn named_target_word(word: &Word, source: &str) -> Option<(Name, Span)> {
     is_name(&text).then_some((Name::from(text.as_ref()), word.span))
 }
 
-fn declaration_assignment_text<'a>(word: &'a Word, source: &'a str) -> Cow<'a, str> {
-    static_word_text(word, source).unwrap_or_else(|| Cow::Borrowed(word.span.slice(source)))
-}
-
 #[derive(Debug, Clone)]
 struct SimpleDeclarationAssignment {
     name: Name,
@@ -4953,57 +4966,73 @@ struct SimpleDeclarationAssignment {
     append: bool,
     array_like: bool,
     value_origin: AssignmentValueOrigin,
+    has_command_or_process_substitution: bool,
 }
 
 fn parse_simple_declaration_assignment(
-    word: &Word,
-    text: &str,
+    words: &[&Word],
     source: &str,
+    explicit_array_kind: Option<ArrayKind>,
 ) -> Option<SimpleDeclarationAssignment> {
-    let name_end = variable_name_end(text)?;
-    let name = &text[..name_end];
-    let mut index = name_end;
-    let mut array_like = false;
-
-    if text.as_bytes().get(index) == Some(&b'[') {
-        let subscript_end = text[index..].find(']')? + index + 1;
-        index = subscript_end;
-        array_like = true;
-    }
-
-    let append = if text.as_bytes().get(index) == Some(&b'+') {
-        index += 1;
-        true
-    } else {
-        false
-    };
-
-    if text.as_bytes().get(index) != Some(&b'=') {
-        return None;
-    }
-
-    let value_start = index + 1;
-    let name_span = word_text_offset_span(word.span, source, 0, name_end);
-    let target_span =
-        word_text_offset_span(word.span, source, 0, if append { index - 1 } else { index });
-    let value_span = word_text_offset_span(word.span, source, value_start, text.len());
-    let value_text = &text[value_start..];
-    let value_origin = if value_text.trim_start().starts_with('(') {
-        AssignmentValueOrigin::ArrayOrCompound
-    } else {
-        let word = Parser::parse_word_string(value_text);
-        assignment_value_origin_for_word(&word)
-    };
+    let assignment = Parser::parse_assignment_word_group(
+        source,
+        words,
+        explicit_array_kind,
+        SubscriptInterpretation::Contextual,
+    )?;
+    let target_span = assignment_target_span(&assignment, source);
+    let value_span = assignment_value_span(&assignment);
+    let array_like = assignment.target.subscript.is_some()
+        || matches!(assignment.value, AssignmentValue::Compound(_));
+    let value_origin = assignment_value_origin(&assignment.value);
+    let has_command_or_process_substitution =
+        assignment_value_has_command_or_process_substitution(&assignment.value);
 
     Some(SimpleDeclarationAssignment {
-        name: Name::from(name),
-        name_span,
+        name: assignment.target.name,
+        name_span: assignment.target.name_span,
         target_span,
         value_span,
-        append,
+        append: assignment.append,
         array_like,
         value_origin,
+        has_command_or_process_substitution,
     })
+}
+
+fn contiguous_word_groups<'a>(words: &'a [&'a Word]) -> Vec<&'a [&'a Word]> {
+    let mut groups = Vec::new();
+    let mut start = 0usize;
+
+    while start < words.len() {
+        let mut end = start + 1;
+        while let Some(next) = words.get(end).copied() {
+            if words[end - 1].span.end.offset != next.span.start.offset {
+                break;
+            }
+            end += 1;
+        }
+        groups.push(&words[start..end]);
+        start = end;
+    }
+
+    groups
+}
+
+fn word_group_span(words: &[&Word]) -> Span {
+    let first = words.first().expect("word groups are non-empty");
+    let last = words.last().expect("word groups are non-empty");
+    Span::from_positions(first.span.start, last.span.end)
+}
+
+fn declaration_explicit_array_kind(flags: &FxHashSet<char>) -> Option<ArrayKind> {
+    if flags.contains(&'A') {
+        Some(ArrayKind::Associative)
+    } else if flags.contains(&'a') {
+        Some(ArrayKind::Indexed)
+    } else {
+        None
+    }
 }
 
 fn let_arithmetic_assignment_target(word: &Word, source: &str) -> Option<(Name, Span)> {
@@ -5569,19 +5598,40 @@ fn single_literal_word(word: &Word) -> Option<&str> {
     }
 }
 
-fn binding_origin_for_assignment(assignment: &Assignment, source: &str) -> BindingOrigin {
-    let value = if assignment.target.subscript.is_some() {
+fn assignment_value_origin_for_assignment(
+    assignment: &Assignment,
+    _source: &str,
+) -> AssignmentValueOrigin {
+    if assignment.target.subscript.is_some() {
         AssignmentValueOrigin::ArrayOrCompound
     } else {
         match &assignment.value {
             AssignmentValue::Scalar(word) => assignment_value_origin_for_word(word),
             AssignmentValue::Compound(_) => AssignmentValueOrigin::ArrayOrCompound,
         }
-    };
+    }
+}
 
+fn assignment_value_origin(value: &AssignmentValue) -> AssignmentValueOrigin {
+    match value {
+        AssignmentValue::Scalar(word) => assignment_value_origin_for_word(word),
+        AssignmentValue::Compound(_) => AssignmentValueOrigin::ArrayOrCompound,
+    }
+}
+
+fn assignment_value_has_command_or_process_substitution(value: &AssignmentValue) -> bool {
+    let AssignmentValue::Scalar(word) = value else {
+        return false;
+    };
+    let mut scan = AssignmentWordOriginScan::default();
+    scan_assignment_word_parts(&word.parts, &mut scan);
+    scan.command_or_process_substitution
+}
+
+fn binding_origin_for_assignment(assignment: &Assignment, source: &str) -> BindingOrigin {
     BindingOrigin::Assignment {
         definition_span: assignment_target_span(assignment, source),
-        value,
+        value: assignment_value_origin_for_assignment(assignment, source),
     }
 }
 

--- a/crates/shuck-semantic/src/declaration.rs
+++ b/crates/shuck-semantic/src/declaration.rs
@@ -1,5 +1,7 @@
 use shuck_ast::{Name, Span};
 
+use crate::AssignmentValueOrigin;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeclarationBuiltin {
     Declare,
@@ -29,9 +31,13 @@ pub enum DeclarationOperand {
     },
     Assignment {
         name: Name,
+        operand_span: Span,
+        target_span: Span,
         name_span: Span,
         value_span: Span,
         append: bool,
+        value_origin: AssignmentValueOrigin,
+        has_command_or_process_substitution: bool,
     },
     DynamicWord {
         span: Span,

--- a/crates/shuck-semantic/src/declaration.rs
+++ b/crates/shuck-semantic/src/declaration.rs
@@ -37,6 +37,7 @@ pub enum DeclarationOperand {
         value_span: Span,
         append: bool,
         value_origin: AssignmentValueOrigin,
+        has_command_substitution: bool,
         has_command_or_process_substitution: bool,
     },
     DynamicWord {


### PR DESCRIPTION
## Summary

- add a parser-owned assignment word-group classifier for contiguous declaration operands
- expose canonical declaration assignment spans and value metadata from semantic analysis
- refactor linter facts to consume semantic declaration operands instead of reparsing assignment source text

## Validation

- cargo test -p shuck-parser test_parse_assignment_word_handles_process_substitution_subscript -- --nocapture
- cargo test -p shuck-linter declaration_assignment -- --nocapture
- cargo test -p shuck-linter status_capture -- --nocapture
- cargo test -p shuck-linter export_command_substitution -- --nocapture
- make test
- make test-large-corpus

Large corpus summary: blocking=0, implementation_diffs=0, mapping_issues=0, reviewed_divergences=23.
