### PR TITLE
perf(linter): index unset commands for safe values

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -658,6 +658,8 @@ impl<'a> LinterFactsBuilder<'a> {
             assignment_scope_spans: env_prefix_assignment_scope_spans,
             expansion_scope_spans: env_prefix_expansion_scope_spans,
         } = build_env_prefix_scope_spans(self.source, &commands);
+        let unset_command_ids_by_target_name =
+            build_unset_command_ids_by_target_name(&commands, &structural_command_ids, source);
         word_occurrences.extend(
             pending_arithmetic_word_occurrences
                 .into_iter()
@@ -825,6 +827,7 @@ impl<'a> LinterFactsBuilder<'a> {
             ifs_literal_backslash_assignment_value_spans,
             env_prefix_assignment_scope_spans,
             env_prefix_expansion_scope_spans,
+            unset_command_ids_by_target_name,
             presence_tested_names: presence_tested_names.global_names,
             nested_presence_test_spans: presence_tested_names.nested_command_spans_by_name,
             c006_presence_tested_names: presence_tested_names.c006_global_names,
@@ -1111,6 +1114,38 @@ fn linebreak_in_test_insert_offset(span: Span, source: &str) -> Option<usize> {
     } else {
         None
     }
+}
+
+fn build_unset_command_ids_by_target_name(
+    commands: &[CommandFact<'_>],
+    structural_command_ids: &[CommandId],
+    source: &str,
+) -> FxHashMap<Name, Vec<CommandId>> {
+    let mut command_ids_by_name = FxHashMap::<Name, Vec<CommandId>>::default();
+
+    for command_id in structural_command_ids.iter().copied() {
+        let command = &commands[command_id.index()];
+        let Some(unset) = command.options().unset() else {
+            continue;
+        };
+        if unset.function_mode || unset.nameref_mode() || !unset.options_parseable() {
+            continue;
+        }
+
+        for operand in unset.operand_facts() {
+            if operand.array_subscript().is_some() {
+                continue;
+            }
+            if let Some(text) = static_word_text(operand.word(), source) {
+                command_ids_by_name
+                    .entry(Name::from(text.as_ref()))
+                    .or_default()
+                    .push(command_id);
+            }
+        }
+    }
+
+    command_ids_by_name
 }
 
 fn sort_and_dedup_case_pattern_expansions(expansions: &mut Vec<CasePatternExpansionFact>) {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -16,6 +16,7 @@ pub struct LinterFacts<'a> {
     ifs_literal_backslash_assignment_value_spans: Vec<Span>,
     env_prefix_assignment_scope_spans: Vec<Span>,
     env_prefix_expansion_scope_spans: Vec<Span>,
+    unset_command_ids_by_target_name: FxHashMap<Name, Vec<CommandId>>,
     presence_tested_names: FxHashSet<Name>,
     nested_presence_test_spans: FxHashMap<Name, Vec<Span>>,
     c006_presence_tested_names: FxHashSet<Name>,
@@ -233,6 +234,18 @@ impl<'a> LinterFacts<'a> {
     pub fn structural_commands(&self) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
         self.structural_command_ids
             .iter()
+            .copied()
+            .map(|id| self.command(id))
+    }
+
+    pub(crate) fn unset_commands_for_name(
+        &self,
+        name: &Name,
+    ) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
+        self.unset_command_ids_by_target_name
+            .get(name)
+            .into_iter()
+            .flatten()
             .copied()
             .map(|id| self.command(id))
     }

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -2215,14 +2215,10 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn unset_command_covers_reference(&self, name: &Name, at: Span) -> bool {
-        self.facts.structural_commands().any(|command| {
+        self.facts.unset_commands_for_name(name).any(|command| {
             command.span().end.offset <= at.start.offset
                 && self.command_runs_in_persistent_shell_context(command.id())
                 && self.command_runs_in_unconditional_flow(command.id(), at)
-                && command
-                    .options()
-                    .unset()
-                    .is_some_and(|unset| self.unset_targets_variable_name(unset, name))
                 && self.command_blocks_cover_all_paths_to_reference(command, name, at)
         })
     }
@@ -2234,15 +2230,11 @@ impl<'a> SafeValueIndex<'a> {
         at: Span,
     ) -> bool {
         let binding = self.semantic.binding(binding_id);
-        self.facts.structural_commands().any(|command| {
+        self.facts.unset_commands_for_name(name).any(|command| {
             command.span().start.offset >= binding.span.end.offset
                 && command.span().end.offset <= at.start.offset
                 && self.command_runs_in_persistent_shell_context(command.id())
                 && !self.command_is_in_background_context(command.id())
-                && command
-                    .options()
-                    .unset()
-                    .is_some_and(|unset| self.unset_targets_variable_name(unset, name))
                 && self.command_blocks_cover_all_paths_to_reference(command, name, at)
         })
     }
@@ -2252,10 +2244,9 @@ impl<'a> SafeValueIndex<'a> {
         command_id: crate::facts::CommandId,
     ) -> bool {
         let command = self.facts.command(command_id);
-        let scope = self.semantic.scope_at(command.span().start.offset);
 
         self.semantic
-            .ancestor_scopes(scope)
+            .ancestor_scopes(command.scope())
             .next()
             .is_none_or(|scope| {
                 matches!(
@@ -2263,21 +2254,6 @@ impl<'a> SafeValueIndex<'a> {
                     ScopeKind::Function(_) | ScopeKind::File
                 )
             })
-    }
-
-    fn unset_targets_variable_name(
-        &self,
-        unset: &crate::facts::UnsetCommandFacts<'a>,
-        name: &Name,
-    ) -> bool {
-        if unset.function_mode || unset.nameref_mode() || !unset.options_parseable() {
-            return false;
-        }
-
-        unset.operand_facts().iter().any(|operand| {
-            operand.array_subscript().is_none()
-                && static_word_text(operand.word(), self.source).as_deref() == Some(name.as_str())
-        })
     }
 
     fn reference_is_safe(&mut self, reference: &VarRef, at: Span, query: SafeValueQuery) -> bool {
@@ -3624,7 +3600,7 @@ impl<'a> SafeValueIndex<'a> {
         at: Span,
     ) -> FxHashSet<BlockId> {
         self.facts
-            .structural_commands()
+            .unset_commands_for_name(name)
             .filter(|command| {
                 command.span().end.offset <= at.start.offset
                     && self.enclosing_function_scope_at(command.span().start.offset)
@@ -3632,10 +3608,6 @@ impl<'a> SafeValueIndex<'a> {
                     && self.command_runs_in_persistent_shell_context(command.id())
                     && !self.command_is_in_background_context(command.id())
                     && !self.command_is_in_boolean_list(command.id())
-                    && command
-                        .options()
-                        .unset()
-                        .is_some_and(|unset| self.unset_targets_variable_name(unset, name))
             })
             .flat_map(|command| {
                 self.analysis


### PR DESCRIPTION
## Summary

- Add a `LinterFacts` index from unset target name to structural unset command ids.
- Use that index in `safe_value` instead of scanning every structural command per reference.
- Reuse the command's precomputed scope in the persistent-shell check, avoiding repeated `scope_at` lookups on the same hot path.

## Root Cause

`binding_is_cleared_by_dominating_unset` and related safe-value queries walked all structural commands for each reference check. On large scripts such as `bashtop.sh`, that made unset dominance checks scale as references times commands and amplified downstream scope/flow checks.

## Validation

- `cargo fmt`
- `cargo test -p shuck-linter safe_value --lib`
- `make test`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- `make test-large-corpus`

Large corpus summary: `blocking=0 implementation_diffs=0 mapping_issues=0 harness_failures=0 reviewed_divergences=23`.