### PR TITLE
perf(semantic): cache sparse reaching name lookups

### DIFF
--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -2207,28 +2207,8 @@ fn compute_interprocedural_read_sets(
     scopes: &[Scope],
     name_count: usize,
 ) -> InterproceduralReadSets {
-    let nested_child_scopes = nested_non_function_child_scopes(scopes);
-    let mut transitive_reads = vec![DenseBitSet::new(name_count); read_plans.len()];
+    let transitive_reads = compute_transitive_reads_by_scc(read_plans, scopes, name_count);
     let mut reads = DenseBitSet::new(name_count);
-    loop {
-        let mut changed = false;
-        for (scope_index, plan) in read_plans.iter().enumerate() {
-            reads.copy_from(&plan.direct_reads);
-            for &child_scope in &nested_child_scopes[scope_index] {
-                reads.union_with(&transitive_reads[child_scope.index()]);
-            }
-            for call in &plan.calls {
-                reads.union_with(&transitive_reads[call.callee_scope.index()]);
-            }
-            if transitive_reads[scope_index].replace_if_changed(&reads) {
-                changed = true;
-            }
-        }
-        if !changed {
-            break;
-        }
-    }
-
     let future_reads = build_future_read_summaries(read_plans, &transitive_reads, name_count);
     let mut escape_reads = vec![DenseBitSet::new(name_count); read_plans.len()];
     loop {
@@ -2277,6 +2257,165 @@ fn nested_non_function_child_scopes(scopes: &[Scope]) -> Vec<Vec<ScopeId>> {
         children[parent.index()].push(scope.id);
     }
     children
+}
+
+fn compute_transitive_reads_by_scc(
+    read_plans: &[ScopeReadPlan],
+    scopes: &[Scope],
+    name_count: usize,
+) -> Vec<DenseBitSet> {
+    let graph = build_scope_read_graph(read_plans, scopes);
+    let (sccs, scope_to_scc) = strongly_connected_components(&graph);
+    let mut reads_by_scc = vec![DenseBitSet::new(name_count); sccs.len()];
+
+    for (scc_index, scope_indexes) in sccs.iter().enumerate() {
+        for &scope_index in scope_indexes {
+            reads_by_scc[scc_index].union_with(&read_plans[scope_index].direct_reads);
+        }
+    }
+
+    let scc_graph = build_scc_graph(&graph, &scope_to_scc, sccs.len());
+    for scc_index in reverse_topological_order(&scc_graph) {
+        for &successor in &scc_graph[scc_index] {
+            let successor_reads = reads_by_scc[successor].clone();
+            reads_by_scc[scc_index].union_with(&successor_reads);
+        }
+    }
+
+    (0..read_plans.len())
+        .map(|scope_index| reads_by_scc[scope_to_scc[scope_index]].clone())
+        .collect()
+}
+
+fn build_scope_read_graph(read_plans: &[ScopeReadPlan], scopes: &[Scope]) -> Vec<Vec<usize>> {
+    let nested_child_scopes = nested_non_function_child_scopes(scopes);
+    let mut graph = vec![Vec::new(); read_plans.len()];
+    for (scope_index, plan) in read_plans.iter().enumerate() {
+        for &child_scope in &nested_child_scopes[scope_index] {
+            graph[scope_index].push(child_scope.index());
+        }
+        for call in &plan.calls {
+            graph[scope_index].push(call.callee_scope.index());
+        }
+        graph[scope_index].sort_unstable();
+        graph[scope_index].dedup();
+    }
+    graph
+}
+
+fn build_scc_graph(
+    graph: &[Vec<usize>],
+    node_to_scc: &[usize],
+    scc_count: usize,
+) -> Vec<Vec<usize>> {
+    let mut scc_graph = vec![Vec::new(); scc_count];
+    for (node, successors) in graph.iter().enumerate() {
+        let source_scc = node_to_scc[node];
+        for &successor in successors {
+            let successor_scc = node_to_scc[successor];
+            if source_scc != successor_scc {
+                scc_graph[source_scc].push(successor_scc);
+            }
+        }
+    }
+    for successors in &mut scc_graph {
+        successors.sort_unstable();
+        successors.dedup();
+    }
+    scc_graph
+}
+
+fn reverse_topological_order(graph: &[Vec<usize>]) -> Vec<usize> {
+    fn visit(node: usize, graph: &[Vec<usize>], visited: &mut [bool], order: &mut Vec<usize>) {
+        if visited[node] {
+            return;
+        }
+        visited[node] = true;
+        for &successor in &graph[node] {
+            visit(successor, graph, visited, order);
+        }
+        order.push(node);
+    }
+
+    let mut visited = vec![false; graph.len()];
+    let mut order = Vec::with_capacity(graph.len());
+    for node in 0..graph.len() {
+        visit(node, graph, &mut visited, &mut order);
+    }
+    order
+}
+
+fn strongly_connected_components(graph: &[Vec<usize>]) -> (Vec<Vec<usize>>, Vec<usize>) {
+    struct Tarjan<'a> {
+        graph: &'a [Vec<usize>],
+        next_index: usize,
+        stack: Vec<usize>,
+        on_stack: Vec<bool>,
+        indexes: Vec<Option<usize>>,
+        lowlinks: Vec<usize>,
+        components: Vec<Vec<usize>>,
+        node_to_component: Vec<usize>,
+    }
+
+    impl<'a> Tarjan<'a> {
+        fn new(graph: &'a [Vec<usize>]) -> Self {
+            Self {
+                graph,
+                next_index: 0,
+                stack: Vec::new(),
+                on_stack: vec![false; graph.len()],
+                indexes: vec![None; graph.len()],
+                lowlinks: vec![0; graph.len()],
+                components: Vec::new(),
+                node_to_component: vec![usize::MAX; graph.len()],
+            }
+        }
+
+        fn run(mut self) -> (Vec<Vec<usize>>, Vec<usize>) {
+            for node in 0..self.graph.len() {
+                if self.indexes[node].is_none() {
+                    self.connect(node);
+                }
+            }
+            (self.components, self.node_to_component)
+        }
+
+        fn connect(&mut self, node: usize) {
+            let index = self.next_index;
+            self.next_index += 1;
+            self.indexes[node] = Some(index);
+            self.lowlinks[node] = index;
+            self.stack.push(node);
+            self.on_stack[node] = true;
+
+            for &successor in &self.graph[node] {
+                if self.indexes[successor].is_none() {
+                    self.connect(successor);
+                    self.lowlinks[node] = self.lowlinks[node].min(self.lowlinks[successor]);
+                } else if self.on_stack[successor] {
+                    let successor_index = self.indexes[successor].expect("indexed successor");
+                    self.lowlinks[node] = self.lowlinks[node].min(successor_index);
+                }
+            }
+
+            if self.lowlinks[node] == index {
+                let component_index = self.components.len();
+                let mut component = Vec::new();
+                loop {
+                    let member = self.stack.pop().expect("non-empty SCC stack");
+                    self.on_stack[member] = false;
+                    self.node_to_component[member] = component_index;
+                    component.push(member);
+                    if member == node {
+                        break;
+                    }
+                }
+                self.components.push(component);
+            }
+        }
+    }
+
+    Tarjan::new(graph).run()
 }
 
 fn build_future_read_summaries(

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -576,6 +576,8 @@ fn analyze_unused_assignments_exact(
         }
     }
 
+    let mut read_use_queries =
+        Vec::with_capacity(context.references.len() + context.synthetic_reads.len());
     for (reference_index, reference) in context.references.iter().enumerate() {
         let Some(block_id) = exact.reference_blocks[reference_index] else {
             continue;
@@ -595,14 +597,17 @@ fn analyze_unused_assignments_exact(
                 &context.bindings[resolved_binding_id.index()],
             ))
         {
-            reaching_name_cache.mark_used_for_name(
-                &mut used_bindings,
+            read_use_queries.push(ReadUseQuery {
                 block_id,
                 name_id,
-                Some(resolved_binding_id),
-            );
+                except: Some(resolved_binding_id),
+            });
         } else {
-            reaching_name_cache.mark_used_for_name(&mut used_bindings, block_id, name_id, None);
+            read_use_queries.push(ReadUseQuery {
+                block_id,
+                name_id,
+                except: None,
+            });
         }
 
         let Some(resolved_binding_id) = resolved_binding_id else {
@@ -645,11 +650,27 @@ fn analyze_unused_assignments_exact(
         {
             continue;
         }
+        read_use_queries.push(ReadUseQuery {
+            block_id,
+            name_id: synthetic_read_name_ids[read_index],
+            except: None,
+        });
+    }
+
+    read_use_queries.sort_unstable_by_key(|query| {
+        (
+            query.block_id.index(),
+            query.name_id.index(),
+            query.except.map(|binding| binding.index()),
+        )
+    });
+    read_use_queries.dedup();
+    for query in read_use_queries {
         reaching_name_cache.mark_used_for_name(
             &mut used_bindings,
-            block_id,
-            synthetic_read_name_ids[read_index],
-            None,
+            query.block_id,
+            query.name_id,
+            query.except,
         );
     }
 
@@ -1163,6 +1184,13 @@ struct DenseBindingData {
     bindings_for_name_list: Vec<Vec<BindingId>>,
     bindings_in_scope: Vec<DenseBitSet>,
     next_overwrite: Vec<Option<BindingId>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReadUseQuery {
+    block_id: BlockId,
+    name_id: NameId,
+    except: Option<BindingId>,
 }
 
 struct ReachingNameCache<'a> {

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -154,13 +154,10 @@ impl ExactVariableDataflow {
     fn scope_components<'a>(&'a self, context: &DataflowContext<'_>) -> &'a [ExactScopeComponent] {
         self.scope_components
             .get_or_init(|| {
-                let reaching_definitions = self.reaching_definitions(context);
                 compute_scope_components_dense(
                     context.cfg,
                     context.scopes.len(),
                     context.cfg.blocks().len(),
-                    context.bindings.len(),
-                    &reaching_definitions.reaching_out,
                 )
             })
             .as_slice()
@@ -535,7 +532,12 @@ fn analyze_unused_assignments_exact(
             name_id
         })
         .collect::<Vec<_>>();
-    let scope_components = exact.scope_components(context);
+    let scope_component_cache = ScopeComponentCache::new(
+        context.cfg,
+        context.scopes.len(),
+        context.bindings.len(),
+        &reaching_definitions.reaching_out,
+    );
     let mut reaching_name_cache = ReachingNameCache::new(
         &reaching_definitions.reaching_in,
         &exact.binding_data.bindings_for_name,
@@ -619,10 +621,10 @@ fn analyze_unused_assignments_exact(
             continue;
         };
         let resolved_binding = &context.bindings[resolved_binding_id.index()];
-        let component = &scope_components[resolved_binding.scope.index()];
-        if !component.blocks.contains(block_id.index()) {
+        if !scope_component_cache.contains_block(resolved_binding.scope, block_id) {
+            let exit_defs = scope_component_cache.exit_defs(resolved_binding.scope);
             used_bindings.or_intersection3_with(
-                &component.exit_defs,
+                exit_defs,
                 &exact.binding_data.bindings_for_name[name_id.index()],
                 &exact.binding_data.bindings_in_scope[resolved_binding.scope.index()],
             );
@@ -636,10 +638,10 @@ fn analyze_unused_assignments_exact(
             && !candidates.is_empty()
         {
             mark_reaching_candidate_bindings_used(&mut used_bindings, incoming, candidates);
-            if !component.blocks.contains(block_id.index()) {
+            if !scope_component_cache.contains_block(resolved_binding.scope, block_id) {
                 mark_reaching_candidate_bindings_used(
                     &mut used_bindings,
-                    &component.exit_defs,
+                    scope_component_cache.exit_defs(resolved_binding.scope),
                     candidates,
                 );
             }
@@ -1345,15 +1347,89 @@ struct DenseInitializedNameStates {
 #[derive(Debug, Clone)]
 struct ExactScopeComponent {
     blocks: DenseBitSet,
-    exit_defs: DenseBitSet,
 }
 
 impl ExactScopeComponent {
-    fn new(block_count: usize, binding_count: usize) -> Self {
+    fn new(block_count: usize) -> Self {
         Self {
             blocks: DenseBitSet::new(block_count),
-            exit_defs: DenseBitSet::new(binding_count),
         }
+    }
+}
+
+struct ScopeComponentCache<'a> {
+    cfg: &'a ControlFlowGraph,
+    block_count: usize,
+    binding_count: usize,
+    reaching_out: &'a [DenseBitSet],
+    components: Vec<LazyScopeComponent>,
+}
+
+struct LazyScopeComponent {
+    blocks: OnceLock<DenseBitSet>,
+    exit_defs: OnceLock<DenseBitSet>,
+}
+
+impl<'a> ScopeComponentCache<'a> {
+    fn new(
+        cfg: &'a ControlFlowGraph,
+        scope_count: usize,
+        binding_count: usize,
+        reaching_out: &'a [DenseBitSet],
+    ) -> Self {
+        Self {
+            cfg,
+            block_count: cfg.blocks().len(),
+            binding_count,
+            reaching_out,
+            components: (0..scope_count)
+                .map(|_| LazyScopeComponent {
+                    blocks: OnceLock::new(),
+                    exit_defs: OnceLock::new(),
+                })
+                .collect(),
+        }
+    }
+
+    fn contains_block(&self, scope: ScopeId, block: BlockId) -> bool {
+        self.blocks(scope).contains(block.index())
+    }
+
+    fn exit_defs(&self, scope: ScopeId) -> &DenseBitSet {
+        self.components[scope.index()]
+            .exit_defs
+            .get_or_init(|| self.compute_exit_defs(scope))
+    }
+
+    fn blocks(&self, scope: ScopeId) -> &DenseBitSet {
+        self.components[scope.index()]
+            .blocks
+            .get_or_init(|| self.compute_blocks(scope))
+    }
+
+    fn compute_blocks(&self, scope: ScopeId) -> DenseBitSet {
+        self.cfg
+            .scope_entry(scope)
+            .map(|entry| reachable_blocks_dense(self.cfg, entry, self.block_count))
+            .unwrap_or_else(|| DenseBitSet::new(self.block_count))
+    }
+
+    fn compute_exit_defs(&self, scope: ScopeId) -> DenseBitSet {
+        let blocks = self.blocks(scope);
+        let mut exit_defs = DenseBitSet::new(self.binding_count);
+        if let Some(scope_exits) = self.cfg.scope_exits(scope) {
+            for exit in scope_exits {
+                exit_defs.union_with(&self.reaching_out[exit.index()]);
+            }
+        } else {
+            for block_index in blocks.iter_ones() {
+                let block_id = BlockId(block_index as u32);
+                if block_exits_component(self.cfg, blocks, block_id) {
+                    exit_defs.union_with(&self.reaching_out[block_index]);
+                }
+            }
+        }
+        exit_defs
     }
 }
 
@@ -1800,29 +1876,14 @@ fn compute_scope_components_dense(
     cfg: &ControlFlowGraph,
     scope_count: usize,
     block_count: usize,
-    binding_count: usize,
-    reaching_out: &[DenseBitSet],
 ) -> Vec<ExactScopeComponent> {
     let mut components = (0..scope_count)
-        .map(|_| ExactScopeComponent::new(block_count, binding_count))
+        .map(|_| ExactScopeComponent::new(block_count))
         .collect::<Vec<_>>();
 
     for (scope, entry) in &cfg.scope_entries {
         let blocks = reachable_blocks_dense(cfg, *entry, block_count);
-        let mut exit_defs = DenseBitSet::new(binding_count);
-        if let Some(scope_exits) = cfg.scope_exits(*scope) {
-            for exit in scope_exits {
-                exit_defs.union_with(&reaching_out[exit.index()]);
-            }
-        } else {
-            for block_index in blocks.iter_ones() {
-                let block_id = BlockId(block_index as u32);
-                if block_exits_component(cfg, &blocks, block_id) {
-                    exit_defs.union_with(&reaching_out[block_index]);
-                }
-            }
-        }
-        components[scope.index()] = ExactScopeComponent { blocks, exit_defs };
+        components[scope.index()] = ExactScopeComponent { blocks };
     }
 
     components

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -532,6 +532,11 @@ fn analyze_unused_assignments_exact(
         })
         .collect::<Vec<_>>();
     let scope_components = exact.scope_components(context);
+    let mut reaching_name_cache = ReachingNameCache::new(
+        &reaching_definitions.reaching_in,
+        &exact.binding_data.bindings_for_name,
+        &exact.binding_data.bindings_for_name_list,
+    );
     let interprocedural_reads = if context.call_sites.is_empty() {
         None
     } else {
@@ -590,17 +595,14 @@ fn analyze_unused_assignments_exact(
                 &context.bindings[resolved_binding_id.index()],
             ))
         {
-            mark_reaching_defs_used_except(
+            reaching_name_cache.mark_used_for_name(
                 &mut used_bindings,
-                incoming,
-                &exact.binding_data.bindings_for_name[name_id.index()],
-                resolved_binding_id,
+                block_id,
+                name_id,
+                Some(resolved_binding_id),
             );
         } else {
-            used_bindings.or_intersection_with(
-                incoming,
-                &exact.binding_data.bindings_for_name[name_id.index()],
-            );
+            reaching_name_cache.mark_used_for_name(&mut used_bindings, block_id, name_id, None);
         }
 
         let Some(resolved_binding_id) = resolved_binding_id else {
@@ -643,9 +645,11 @@ fn analyze_unused_assignments_exact(
         {
             continue;
         }
-        used_bindings.or_intersection_with(
-            &reaching_definitions.reaching_in[block_id.index()],
-            &exact.binding_data.bindings_for_name[synthetic_read_name_ids[read_index].index()],
+        reaching_name_cache.mark_used_for_name(
+            &mut used_bindings,
+            block_id,
+            synthetic_read_name_ids[read_index],
+            None,
         );
     }
 
@@ -1070,16 +1074,6 @@ impl DenseBitSet {
         }
     }
 
-    fn or_intersection_with(&mut self, left: &Self, right: &Self) {
-        debug_assert_eq!(self.words.len(), left.words.len());
-        debug_assert_eq!(self.words.len(), right.words.len());
-        for ((word, left_word), right_word) in
-            self.words.iter_mut().zip(&left.words).zip(&right.words)
-        {
-            *word |= *left_word & *right_word;
-        }
-    }
-
     fn or_intersection3_with(&mut self, first: &Self, second: &Self, third: &Self) {
         debug_assert_eq!(self.words.len(), first.words.len());
         debug_assert_eq!(self.words.len(), second.words.len());
@@ -1166,8 +1160,100 @@ impl NameTable {
 struct DenseBindingData {
     binding_name_ids: Vec<NameId>,
     bindings_for_name: Vec<DenseBitSet>,
+    bindings_for_name_list: Vec<Vec<BindingId>>,
     bindings_in_scope: Vec<DenseBitSet>,
     next_overwrite: Vec<Option<BindingId>>,
+}
+
+struct ReachingNameCache<'a> {
+    reaching_in: &'a [DenseBitSet],
+    bindings_for_name: &'a [DenseBitSet],
+    bindings_for_name_list: &'a [Vec<BindingId>],
+    binding_word_count: usize,
+    memo: FxHashMap<(u32, u32), SmallVec<[BindingId; 4]>>,
+}
+
+impl<'a> ReachingNameCache<'a> {
+    fn new(
+        reaching_in: &'a [DenseBitSet],
+        bindings_for_name: &'a [DenseBitSet],
+        bindings_for_name_list: &'a [Vec<BindingId>],
+    ) -> Self {
+        Self {
+            reaching_in,
+            bindings_for_name,
+            bindings_for_name_list,
+            binding_word_count: reaching_in
+                .first()
+                .map_or(0, |definitions| definitions.words.len()),
+            memo: FxHashMap::default(),
+        }
+    }
+
+    fn reaching_defs_for_name(&mut self, block: BlockId, name: NameId) -> &[BindingId] {
+        let key = (block.index() as u32, name.index() as u32);
+        if !self.memo.contains_key(&key) {
+            let incoming = &self.reaching_in[block.index()];
+            let reaching = self.bindings_for_name_list[name.index()]
+                .iter()
+                .copied()
+                .filter(|binding| incoming.contains(binding.index()))
+                .collect();
+            self.memo.insert(key, reaching);
+        }
+
+        self.memo
+            .get(&key)
+            .expect("cached reaching defs")
+            .as_slice()
+    }
+
+    fn mark_used_for_name(
+        &mut self,
+        used: &mut DenseBitSet,
+        block: BlockId,
+        name: NameId,
+        except: Option<BindingId>,
+    ) {
+        if self.should_use_sparse_cache(name) {
+            for binding in self.reaching_defs_for_name(block, name) {
+                if Some(*binding) != except {
+                    used.insert(binding.index());
+                }
+            }
+        } else if self.should_use_sparse_direct(name) {
+            let incoming = &self.reaching_in[block.index()];
+            for binding in &self.bindings_for_name_list[name.index()] {
+                if Some(*binding) != except && incoming.contains(binding.index()) {
+                    used.insert(binding.index());
+                }
+            }
+        } else {
+            let incoming = &self.reaching_in[block.index()];
+            let candidates = &self.bindings_for_name[name.index()];
+            for binding_index in incoming.iter_ones() {
+                if except.is_some_and(|binding| binding.index() == binding_index) {
+                    continue;
+                }
+                if candidates.contains(binding_index) {
+                    used.insert(binding_index);
+                }
+            }
+        }
+    }
+
+    fn should_use_sparse_cache(&self, name: NameId) -> bool {
+        // Dense bitset scans are faster for small and medium scripts; only pay
+        // for sparse lookup/caching once the binding universe is very large.
+        self.binding_word_count > 512
+            && self.bindings_for_name_list[name.index()].len() > 8
+            && self.should_use_sparse_direct(name)
+    }
+
+    fn should_use_sparse_direct(&self, name: NameId) -> bool {
+        self.binding_word_count > 512
+            && self.bindings_for_name_list[name.index()].len() * 4 < self.binding_word_count
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1332,7 +1418,7 @@ fn build_dense_binding_data_for_scope_count(
     let mut bindings_for_name = (0..name_count)
         .map(|_| DenseBitSet::new(binding_count))
         .collect::<Vec<_>>();
-    let mut bindings_by_name = vec![Vec::new(); name_count];
+    let mut bindings_for_name_list = vec![Vec::new(); name_count];
     let mut bindings_in_scope = (0..scope_count)
         .map(|_| DenseBitSet::new(binding_count))
         .collect::<Vec<_>>();
@@ -1343,14 +1429,14 @@ fn build_dense_binding_data_for_scope_count(
         };
         binding_name_ids.push(name_id);
         bindings_for_name[name_id.index()].insert(binding.id.index());
-        bindings_by_name[name_id.index()].push(binding.id);
+        bindings_for_name_list[name_id.index()].push(binding.id);
         if let Some(bindings_in_scope) = bindings_in_scope.get_mut(binding.scope.index()) {
             bindings_in_scope.insert(binding.id.index());
         }
     }
 
     let mut next_overwrite = vec![None; binding_count];
-    for binding_ids in bindings_by_name {
+    for binding_ids in &bindings_for_name_list {
         for pair in binding_ids.windows(2) {
             next_overwrite[pair[0].index()] = Some(pair[1]);
         }
@@ -1359,6 +1445,7 @@ fn build_dense_binding_data_for_scope_count(
     DenseBindingData {
         binding_name_ids,
         bindings_for_name,
+        bindings_for_name_list,
         bindings_in_scope,
         next_overwrite,
     }
@@ -2283,19 +2370,6 @@ fn mark_reaching_defs_for_names_used(
 ) {
     for binding_index in incoming.iter_ones() {
         if used_names.contains(binding_name_ids[binding_index].index()) {
-            used_bindings.insert(binding_index);
-        }
-    }
-}
-
-fn mark_reaching_defs_used_except(
-    used_bindings: &mut DenseBitSet,
-    incoming: &DenseBitSet,
-    candidates: &DenseBitSet,
-    excluded: BindingId,
-) {
-    for binding_index in incoming.iter_ones() {
-        if binding_index != excluded.index() && candidates.contains(binding_index) {
             used_bindings.insert(binding_index);
         }
     }

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -88,6 +88,7 @@ pub(crate) struct ExactVariableDataflow {
     binding_data: DenseBindingData,
     binding_blocks: Vec<Option<BlockId>>,
     reference_blocks: Vec<Option<BlockId>>,
+    synthetic_read_blocks: Vec<Option<BlockId>>,
     unreachable_blocks: DenseBitSet,
     reaching_definitions: OnceLock<DenseReachingDefinitions>,
     initialized_name_states: OnceLock<DenseInitializedNameStates>,
@@ -245,6 +246,8 @@ pub(crate) fn build_exact_variable_dataflow(
     let binding_data = build_dense_binding_data(context.bindings, context.scopes, &names);
     let binding_blocks = build_binding_block_index(context.cfg, context.bindings.len());
     let reference_blocks = build_reference_block_index(context.cfg, context.references.len());
+    let synthetic_read_blocks =
+        build_synthetic_read_block_index(context.cfg, context.synthetic_reads);
     let unreachable_blocks = build_unreachable_block_set(context.cfg);
 
     ExactVariableDataflow {
@@ -252,6 +255,7 @@ pub(crate) fn build_exact_variable_dataflow(
         binding_data,
         binding_blocks,
         reference_blocks,
+        synthetic_read_blocks,
         unreachable_blocks,
         reaching_definitions: OnceLock::new(),
         initialized_name_states: OnceLock::new(),
@@ -547,6 +551,7 @@ fn analyze_unused_assignments_exact(
             context.references,
             context.synthetic_reads,
             &exact.reference_blocks,
+            &exact.synthetic_read_blocks,
             &reference_name_ids,
             &synthetic_read_name_ids,
             context.call_sites,
@@ -641,8 +646,8 @@ fn analyze_unused_assignments_exact(
         }
     }
 
-    for (read_index, synthetic_read) in context.synthetic_reads.iter().enumerate() {
-        let Some(block_id) = command_block_for_span(context.cfg, synthetic_read.span) else {
+    for read_index in 0..context.synthetic_reads.len() {
+        let Some(block_id) = exact.synthetic_read_blocks[read_index] else {
             continue;
         };
         if exact.unreachable_blocks.contains(block_id.index())
@@ -677,7 +682,7 @@ fn analyze_unused_assignments_exact(
     if let Some((read_plans, interprocedural)) = &interprocedural_reads {
         for plan in read_plans {
             for call in &plan.calls {
-                let Some(block_id) = command_block_for_span(context.cfg, call.span) else {
+                let Some(block_id) = call.block else {
                     continue;
                 };
                 if exact.unreachable_blocks.contains(block_id.index())
@@ -1355,7 +1360,7 @@ impl ExactScopeComponent {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ResolvedCallSite {
     offset: usize,
-    span: Span,
+    block: Option<BlockId>,
     callee_scope: ScopeId,
 }
 
@@ -1500,6 +1505,16 @@ fn build_reference_block_index(
         }
     }
     blocks
+}
+
+fn build_synthetic_read_block_index(
+    cfg: &ControlFlowGraph,
+    synthetic_reads: &[SyntheticRead],
+) -> Vec<Option<BlockId>> {
+    synthetic_reads
+        .iter()
+        .map(|read| command_block_for_span(cfg, read.span))
+        .collect()
 }
 
 fn build_unreachable_block_set(cfg: &ControlFlowGraph) -> DenseBitSet {
@@ -2023,13 +2038,15 @@ fn build_scope_read_plans(
     references: &[Reference],
     synthetic_reads: &[SyntheticRead],
     reference_blocks: &[Option<BlockId>],
+    synthetic_read_blocks: &[Option<BlockId>],
     reference_name_ids: &[NameId],
     synthetic_read_name_ids: &[NameId],
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
     name_count: usize,
 ) -> (Vec<ScopeReadPlan>, Vec<Vec<CallerReadSite>>) {
     let function_scopes = function_scopes_by_binding(scopes, bindings);
-    let calls_by_scope = resolved_calls_by_scope(scopes, bindings, call_sites, &function_scopes);
+    let calls_by_scope =
+        resolved_calls_by_scope(cfg, scopes, bindings, call_sites, &function_scopes);
     let mut plans = scopes
         .iter()
         .map(|scope| ScopeReadPlan::new(name_count, matches!(scope.kind, ScopeKind::Function(_))))
@@ -2053,7 +2070,7 @@ fn build_scope_read_plans(
         plan.direct_reads.insert(name_id.index());
         plan.events.push(ScopeReadEvent {
             offset: synthetic_read.span.start.offset,
-            block: command_block_for_span(cfg, synthetic_read.span),
+            block: synthetic_read_blocks[read_index],
             kind: ScopeReadEventKind::Direct(name_id),
         });
     }
@@ -2067,7 +2084,7 @@ fn build_scope_read_plans(
             });
             plan.events.push(ScopeReadEvent {
                 offset: call.offset,
-                block: command_block_for_span(cfg, call.span),
+                block: call.block,
                 kind: ScopeReadEventKind::Call(call.callee_scope),
             });
         }
@@ -2520,6 +2537,7 @@ fn function_scopes_by_binding(
 }
 
 fn resolved_calls_by_scope(
+    cfg: &ControlFlowGraph,
     scopes: &[Scope],
     bindings: &[Binding],
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
@@ -2545,7 +2563,7 @@ fn resolved_calls_by_scope(
                 .or_default()
                 .push(ResolvedCallSite {
                     offset: site.span.start.offset,
-                    span: site.span,
+                    block: command_block_for_span(cfg, site.span),
                     callee_scope,
                 });
         }

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -538,6 +538,11 @@ fn analyze_unused_assignments_exact(
         context.bindings.len(),
         &reaching_definitions.reaching_out,
     );
+    let mut scope_exit_name_cache = ScopeExitNameCache::new(
+        &scope_component_cache,
+        &exact.binding_data.bindings_for_name_list,
+        &exact.binding_data.bindings_in_scope,
+    );
     let mut reaching_name_cache = ReachingNameCache::new(
         &reaching_definitions.reaching_in,
         &exact.binding_data.bindings_for_name,
@@ -622,11 +627,10 @@ fn analyze_unused_assignments_exact(
         };
         let resolved_binding = &context.bindings[resolved_binding_id.index()];
         if !scope_component_cache.contains_block(resolved_binding.scope, block_id) {
-            let exit_defs = scope_component_cache.exit_defs(resolved_binding.scope);
-            used_bindings.or_intersection3_with(
-                exit_defs,
-                &exact.binding_data.bindings_for_name[name_id.index()],
-                &exact.binding_data.bindings_in_scope[resolved_binding.scope.index()],
+            scope_exit_name_cache.mark_exit_defs_for_scope_name(
+                &mut used_bindings,
+                resolved_binding.scope,
+                name_id,
             );
         }
 
@@ -701,23 +705,16 @@ fn analyze_unused_assignments_exact(
             }
         }
 
-        for binding in context.bindings {
-            if is_function_escape_candidate(binding, context.scopes)
-                && binding_has_future_reads_before_local_shadow(
-                    binding,
-                    exact.binding_data.binding_name_ids[binding.id.index()],
-                    context.bindings,
-                    context.cfg,
-                    &exact.binding_blocks,
-                    read_plans,
-                    &interprocedural.transitive_reads,
-                    &interprocedural.future_reads,
-                    &interprocedural.escape_reads,
-                )
-            {
-                used_bindings.insert(binding.id.index());
-            }
-        }
+        mark_function_escape_bindings_with_future_reads(
+            &mut used_bindings,
+            context,
+            exact,
+            &scope_component_cache,
+            read_plans,
+            &interprocedural.transitive_reads,
+            &interprocedural.future_reads,
+            &interprocedural.escape_reads,
+        );
     }
 
     let mut unused_assignments = Vec::new();
@@ -1054,6 +1051,12 @@ impl DenseBitSet {
         self.words[word] |= 1usize << bit;
     }
 
+    fn remove(&mut self, index: usize) {
+        let word = index / Self::WORD_BITS;
+        let bit = index % Self::WORD_BITS;
+        self.words[word] &= !(1usize << bit);
+    }
+
     fn contains(&self, index: usize) -> bool {
         let word = index / Self::WORD_BITS;
         let bit = index % Self::WORD_BITS;
@@ -1099,21 +1102,6 @@ impl DenseBitSet {
         debug_assert_eq!(self.words.len(), other.words.len());
         for (word, other_word) in self.words.iter_mut().zip(&other.words) {
             *word &= *other_word;
-        }
-    }
-
-    fn or_intersection3_with(&mut self, first: &Self, second: &Self, third: &Self) {
-        debug_assert_eq!(self.words.len(), first.words.len());
-        debug_assert_eq!(self.words.len(), second.words.len());
-        debug_assert_eq!(self.words.len(), third.words.len());
-        for (((word, first_word), second_word), third_word) in self
-            .words
-            .iter_mut()
-            .zip(&first.words)
-            .zip(&second.words)
-            .zip(&third.words)
-        {
-            *word |= *first_word & *second_word & *third_word;
         }
     }
 
@@ -1430,6 +1418,60 @@ impl<'a> ScopeComponentCache<'a> {
             }
         }
         exit_defs
+    }
+}
+
+struct ScopeExitNameCache<'a, 'data> {
+    components: &'a ScopeComponentCache<'data>,
+    bindings_for_name_list: &'data [Vec<BindingId>],
+    bindings_in_scope: &'data [DenseBitSet],
+    memo: FxHashMap<(u32, u32), SmallVec<[BindingId; 4]>>,
+}
+
+impl<'a, 'data> ScopeExitNameCache<'a, 'data> {
+    fn new(
+        components: &'a ScopeComponentCache<'data>,
+        bindings_for_name_list: &'data [Vec<BindingId>],
+        bindings_in_scope: &'data [DenseBitSet],
+    ) -> Self {
+        Self {
+            components,
+            bindings_for_name_list,
+            bindings_in_scope,
+            memo: FxHashMap::default(),
+        }
+    }
+
+    fn exit_defs_for_scope_name(&mut self, scope: ScopeId, name: NameId) -> &[BindingId] {
+        let key = (scope.index() as u32, name.index() as u32);
+        if !self.memo.contains_key(&key) {
+            let exit_defs = self.components.exit_defs(scope);
+            let in_scope = &self.bindings_in_scope[scope.index()];
+            let defs = self.bindings_for_name_list[name.index()]
+                .iter()
+                .copied()
+                .filter(|binding| {
+                    exit_defs.contains(binding.index()) && in_scope.contains(binding.index())
+                })
+                .collect();
+            self.memo.insert(key, defs);
+        }
+
+        self.memo
+            .get(&key)
+            .expect("cached scope exit defs")
+            .as_slice()
+    }
+
+    fn mark_exit_defs_for_scope_name(
+        &mut self,
+        used: &mut DenseBitSet,
+        scope: ScopeId,
+        name: NameId,
+    ) {
+        for binding in self.exit_defs_for_scope_name(scope, name) {
+            used.insert(binding.index());
+        }
     }
 }
 
@@ -2293,6 +2335,278 @@ fn future_reads_contain_after(
     let index = plan.events.partition_point(|event| event.offset <= offset);
     future_reads[scope.index()].suffix_reads[index].contains(name_id.index())
         || (plan.is_function && escape_reads[scope.index()].contains(name_id.index()))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FutureLiveEventKind {
+    LocalShadow(NameId),
+    DirectRead(NameId),
+    CallRead(ScopeId),
+    Binding(BindingId, NameId),
+}
+
+impl FutureLiveEventKind {
+    fn order(self) -> u8 {
+        match self {
+            FutureLiveEventKind::LocalShadow(_) => 0,
+            FutureLiveEventKind::DirectRead(_) | FutureLiveEventKind::CallRead(_) => 1,
+            FutureLiveEventKind::Binding(_, _) => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FutureLiveEvent {
+    offset: usize,
+    block: BlockId,
+    kind: FutureLiveEventKind,
+}
+
+impl FutureLiveEvent {
+    fn sort_key(self) -> (usize, u8) {
+        (self.offset, self.kind.order())
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn mark_function_escape_bindings_with_future_reads(
+    used_bindings: &mut DenseBitSet,
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
+    scope_components: &ScopeComponentCache<'_>,
+    read_plans: &[ScopeReadPlan],
+    transitive_reads: &[DenseBitSet],
+    future_reads: &[ScopeFutureReads],
+    escape_reads: &[DenseBitSet],
+) {
+    let scope_count = context.scopes.len();
+    let name_count = exact.names.len();
+    let block_count = context.cfg.blocks().len();
+    let mut events_by_scope = vec![Vec::<FutureLiveEvent>::new(); scope_count];
+    let mut candidate_scopes = DenseBitSet::new(scope_count);
+    let mut fallback_scopes = DenseBitSet::new(scope_count);
+
+    for binding in context.bindings {
+        if !is_function_escape_candidate(binding, context.scopes) {
+            continue;
+        }
+
+        let scope = binding.scope;
+        let name_id = exact.binding_data.binding_name_ids[binding.id.index()];
+        if read_plans[scope.index()].is_function
+            && escape_reads[scope.index()].contains(name_id.index())
+        {
+            used_bindings.insert(binding.id.index());
+        }
+
+        candidate_scopes.insert(scope.index());
+        let Some(block) = exact.binding_blocks[binding.id.index()] else {
+            fallback_scopes.insert(scope.index());
+            continue;
+        };
+        events_by_scope[scope.index()].push(FutureLiveEvent {
+            offset: binding.span.start.offset,
+            block,
+            kind: FutureLiveEventKind::Binding(binding.id, name_id),
+        });
+    }
+
+    for scope_index in candidate_scopes.iter_ones() {
+        let scope = ScopeId(scope_index as u32);
+        for event in &read_plans[scope_index].events {
+            let Some(block) = event.block else {
+                fallback_scopes.insert(scope_index);
+                continue;
+            };
+            let kind = match event.kind {
+                ScopeReadEventKind::Direct(name_id) => FutureLiveEventKind::DirectRead(name_id),
+                ScopeReadEventKind::Call(callee_scope) => {
+                    FutureLiveEventKind::CallRead(callee_scope)
+                }
+            };
+            events_by_scope[scope_index].push(FutureLiveEvent {
+                offset: event.offset,
+                block,
+                kind,
+            });
+        }
+
+        for binding in context.bindings {
+            if binding.scope != scope
+                || !matches!(binding.kind, BindingKind::Declaration(_))
+                || !binding.attributes.contains(BindingAttributes::LOCAL)
+            {
+                continue;
+            }
+            let name_id = exact.binding_data.binding_name_ids[binding.id.index()];
+            let Some(block) = exact.binding_blocks[binding.id.index()] else {
+                fallback_scopes.insert(scope_index);
+                continue;
+            };
+            events_by_scope[scope_index].push(FutureLiveEvent {
+                offset: binding.span.start.offset,
+                block,
+                kind: FutureLiveEventKind::LocalShadow(name_id),
+            });
+        }
+    }
+
+    for scope_index in candidate_scopes.iter_ones() {
+        let scope = ScopeId(scope_index as u32);
+        if fallback_scopes.contains(scope_index) {
+            mark_function_escape_bindings_with_future_reads_fallback(
+                used_bindings,
+                context,
+                exact,
+                scope,
+                read_plans,
+                transitive_reads,
+                future_reads,
+                escape_reads,
+            );
+            continue;
+        }
+
+        mark_function_escape_bindings_with_future_live_scope(
+            used_bindings,
+            context.cfg,
+            context.bindings,
+            context.scopes,
+            scope_components.blocks(scope),
+            &mut events_by_scope[scope_index],
+            transitive_reads,
+            name_count,
+            block_count,
+        );
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn mark_function_escape_bindings_with_future_reads_fallback(
+    used_bindings: &mut DenseBitSet,
+    context: &DataflowContext<'_>,
+    exact: &ExactVariableDataflow,
+    scope: ScopeId,
+    read_plans: &[ScopeReadPlan],
+    transitive_reads: &[DenseBitSet],
+    future_reads: &[ScopeFutureReads],
+    escape_reads: &[DenseBitSet],
+) {
+    for binding in context.bindings {
+        if binding.scope == scope
+            && is_function_escape_candidate(binding, context.scopes)
+            && binding_has_future_reads_before_local_shadow(
+                binding,
+                exact.binding_data.binding_name_ids[binding.id.index()],
+                context.bindings,
+                context.cfg,
+                &exact.binding_blocks,
+                read_plans,
+                transitive_reads,
+                future_reads,
+                escape_reads,
+            )
+        {
+            used_bindings.insert(binding.id.index());
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn mark_function_escape_bindings_with_future_live_scope(
+    used_bindings: &mut DenseBitSet,
+    cfg: &ControlFlowGraph,
+    bindings: &[Binding],
+    scopes: &[Scope],
+    scope_blocks: &DenseBitSet,
+    events: &mut [FutureLiveEvent],
+    transitive_reads: &[DenseBitSet],
+    name_count: usize,
+    block_count: usize,
+) {
+    events.sort_by_key(|event| event.sort_key());
+    let mut events_by_block = vec![Vec::<FutureLiveEvent>::new(); block_count];
+    for event in events.iter().copied() {
+        events_by_block[event.block.index()].push(event);
+    }
+
+    let mut future_live_in = vec![DenseBitSet::new(name_count); block_count];
+    let mut future_live_out = vec![DenseBitSet::new(name_count); block_count];
+    let mut outgoing = DenseBitSet::new(name_count);
+    let mut incoming = DenseBitSet::new(name_count);
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for block_index in scope_blocks.iter_ones() {
+            let block_id = BlockId(block_index as u32);
+            outgoing.clear();
+            for (successor, _) in cfg.successors(block_id) {
+                if scope_blocks.contains(successor.index()) {
+                    outgoing.union_with(&future_live_in[successor.index()]);
+                }
+            }
+
+            incoming.copy_from(&outgoing);
+            apply_future_live_events(
+                &mut incoming,
+                &events_by_block[block_index],
+                transitive_reads,
+            );
+
+            if future_live_out[block_index].replace_if_changed(&outgoing) {
+                changed = true;
+            }
+            if future_live_in[block_index].replace_if_changed(&incoming) {
+                changed = true;
+            }
+        }
+    }
+
+    for block_index in scope_blocks.iter_ones() {
+        let mut live = future_live_out[block_index].clone();
+        for event in events_by_block[block_index].iter().rev() {
+            match event.kind {
+                FutureLiveEventKind::Binding(binding_id, name_id) => {
+                    let binding = &bindings[binding_id.index()];
+                    if is_function_escape_candidate(binding, scopes)
+                        && live.contains(name_id.index())
+                    {
+                        used_bindings.insert(binding_id.index());
+                    }
+                }
+                FutureLiveEventKind::LocalShadow(name_id) => {
+                    live.remove(name_id.index());
+                }
+                FutureLiveEventKind::DirectRead(name_id) => {
+                    live.insert(name_id.index());
+                }
+                FutureLiveEventKind::CallRead(callee_scope) => {
+                    live.union_with(&transitive_reads[callee_scope.index()]);
+                }
+            }
+        }
+    }
+}
+
+fn apply_future_live_events(
+    live: &mut DenseBitSet,
+    events: &[FutureLiveEvent],
+    transitive_reads: &[DenseBitSet],
+) {
+    for event in events.iter().rev() {
+        match event.kind {
+            FutureLiveEventKind::LocalShadow(name_id) => {
+                live.remove(name_id.index());
+            }
+            FutureLiveEventKind::DirectRead(name_id) => {
+                live.insert(name_id.index());
+            }
+            FutureLiveEventKind::CallRead(callee_scope) => {
+                live.union_with(&transitive_reads[callee_scope.index()]);
+            }
+            FutureLiveEventKind::Binding(_, _) => {}
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -798,15 +798,14 @@ fn collapse_redundant_branch_unused_assignment_ids(
         .iter()
         .map(|unused| unused.binding)
         .collect::<FxHashSet<_>>();
-    let mut reachability_cache = vec![None; cfg.blocks().len()];
+    let block_reachability = BlockReachability::new(cfg);
     let mut suppression_context = RedundantBranchUnusedAssignmentContext {
-        cfg,
         bindings,
         bindings_by_name: &bindings_by_name,
         binding_blocks,
         unreachable_blocks,
         unused_binding_ids: &unused_binding_ids,
-        reachability_cache: &mut reachability_cache,
+        block_reachability: &block_reachability,
     };
 
     unused_assignments
@@ -833,13 +832,12 @@ fn cfg_has_no_branching_edges(cfg: &ControlFlowGraph) -> bool {
 }
 
 struct RedundantBranchUnusedAssignmentContext<'a> {
-    cfg: &'a ControlFlowGraph,
     bindings: &'a [Binding],
     bindings_by_name: &'a FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     binding_blocks: &'a [Option<BlockId>],
     unreachable_blocks: &'a DenseBitSet,
     unused_binding_ids: &'a FxHashSet<BindingId>,
-    reachability_cache: &'a mut [Option<DenseBitSet>],
+    block_reachability: &'a BlockReachability,
 }
 
 fn should_suppress_redundant_branch_unused_assignment(
@@ -877,12 +875,10 @@ fn should_suppress_redundant_branch_unused_assignment(
         return false;
     };
 
-    if block_can_reach(
-        context.cfg,
-        binding_block,
-        next_binding_block,
-        context.reachability_cache,
-    ) {
+    if context
+        .block_reachability
+        .can_reach(binding_block, next_binding_block)
+    {
         return false;
     }
 
@@ -960,43 +956,55 @@ fn resolved_binding_shadows_name_without_initializing(binding: Option<&Binding>)
     )
 }
 
-fn block_can_reach(
-    cfg: &ControlFlowGraph,
-    from: BlockId,
-    to: BlockId,
-    reachability_cache: &mut [Option<DenseBitSet>],
-) -> bool {
-    if from == to {
-        return true;
-    }
+struct BlockReachability {
+    block_to_scc: Vec<usize>,
+    reachable_sccs: Vec<DenseBitSet>,
+}
 
-    if cfg
-        .successors(from)
-        .iter()
-        .any(|(successor, _)| *successor == to)
-    {
-        return true;
-    }
-
-    if let Some(reachable) = &reachability_cache[from.index()] {
-        return reachable.contains(to.index());
-    }
-
-    let mut reachable = DenseBitSet::new(cfg.blocks().len());
-    let mut stack = vec![from];
-    while let Some(block_id) = stack.pop() {
-        for &(successor, _) in cfg.successors(block_id) {
-            if reachable.contains(successor.index()) {
-                continue;
+impl BlockReachability {
+    fn new(cfg: &ControlFlowGraph) -> Self {
+        let graph = build_cfg_block_graph(cfg);
+        let (_sccs, block_to_scc) = strongly_connected_components(&graph);
+        let scc_graph = build_scc_graph(
+            &graph,
+            &block_to_scc,
+            block_to_scc.iter().max().map_or(0, |max| max + 1),
+        );
+        let mut reachable_sccs = vec![DenseBitSet::new(scc_graph.len()); scc_graph.len()];
+        for scc in reverse_topological_order(&scc_graph) {
+            reachable_sccs[scc].insert(scc);
+            for &successor in &scc_graph[scc] {
+                let successor_reachable = reachable_sccs[successor].clone();
+                reachable_sccs[scc].union_with(&successor_reachable);
             }
-            reachable.insert(successor.index());
-            stack.push(successor);
+        }
+        Self {
+            block_to_scc,
+            reachable_sccs,
         }
     }
 
-    let can_reach = reachable.contains(to.index());
-    reachability_cache[from.index()] = Some(reachable);
-    can_reach
+    fn can_reach(&self, from: BlockId, to: BlockId) -> bool {
+        let from_scc = self.block_to_scc[from.index()];
+        let to_scc = self.block_to_scc[to.index()];
+        self.reachable_sccs[from_scc].contains(to_scc)
+    }
+}
+
+fn build_cfg_block_graph(cfg: &ControlFlowGraph) -> Vec<Vec<usize>> {
+    cfg.blocks()
+        .iter()
+        .map(|block| {
+            let mut successors = cfg
+                .successors(block.id)
+                .iter()
+                .map(|(successor, _)| successor.index())
+                .collect::<Vec<_>>();
+            successors.sort_unstable();
+            successors.dedup();
+            successors
+        })
+        .collect()
 }
 
 fn is_straight_line_overwrite(cfg: &ControlFlowGraph, from: BlockId, to: BlockId) -> bool {


### PR DESCRIPTION
## Summary

- add a sparse `bindings_for_name_list` alongside the dense per-name binding bitsets
- route unused-assignment same-name reaching-definition marking through `ReachingNameCache`
- keep the old dense path for small/medium binding sets and only use sparse lookup/cache for very large binding universes

## Verification

- `cargo fmt --check`
- `cargo test -q -p shuck-semantic`
- `git diff --check`

## Benchmark notes

Saved pre-change baseline with:

```bash
env CARGO_TARGET_DIR="$SCRATCH/target" cargo bench -p shuck-benchmark --bench semantic --bench unused_assignment --bench linter -- --save-baseline=before --noplot
```

Initial full after-run was interrupted during the long Criterion tail, but it produced partial signal. Focused `unused_assignment` reruns showed medium-fixture regressions when the sparse/hash path was too eager, so this PR keeps the optimization behind a conservative large-binding threshold.

Final focused rerun:

```bash
env CARGO_TARGET_DIR="$SCRATCH/target" cargo bench -p shuck-benchmark --bench unused_assignment -- --baseline=before --noplot
```

Selected final deltas:

| Benchmark | Change |
| --- | ---: |
| `unused_assignment/all` | -0.35% |
| `variable_dataflow_combined/all` | -0.30% |
| `variable_dataflow_combined/nvm` | -2.59% |
| `variable_dataflow_combined/bashtop` | -0.60% |
