### PR TITLE
refactor(linter): add profiler frames for fact building

### DIFF
--- a/crates/shuck-linter/build.rs
+++ b/crates/shuck-linter/build.rs
@@ -86,6 +86,25 @@ fn parse_rule_metadata(
 }
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(shuck_profiling)");
+    println!("cargo:rerun-if-env-changed=PROFILE");
+    println!("cargo:rerun-if-env-changed=OUT_DIR");
+    let profile = env::var("PROFILE").unwrap_or_default();
+    let out_dir = env::var_os("OUT_DIR").map(PathBuf::from);
+    let out_dir_uses_profiling_profile = out_dir.as_ref().is_some_and(|path| {
+        let mut previous = None;
+        for component in path.components() {
+            if component.as_os_str() == "build" {
+                return previous == Some("profiling");
+            }
+            previous = component.as_os_str().to_str();
+        }
+        false
+    });
+    if profile == "profiling" || out_dir_uses_profiling_profile {
+        println!("cargo:rustc-cfg=shuck_profiling");
+    }
+
     let manifest_dir = PathBuf::from(match env::var("CARGO_MANIFEST_DIR") {
         Ok(value) => value,
         Err(err) => panic!("CARGO_MANIFEST_DIR: {err}"),

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -109,6 +109,7 @@ impl<'a> BindingValueFact<'a> {
     }
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_bare_command_name_assignment_spans<'a>(
     commands: &[CommandFact<'a>],
     word_nodes: &[WordNode<'a>],
@@ -130,6 +131,7 @@ fn build_bare_command_name_assignment_spans<'a>(
         .collect()
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_assignment_like_command_name_spans<'a>(
     commands: &[CommandFact<'a>],
     source: &str,
@@ -408,6 +410,7 @@ struct EnvPrefixScopeSpans {
     expansion_scope_spans: Vec<Span>,
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_env_prefix_scope_spans(source: &str, commands: &[CommandFact<'_>]) -> EnvPrefixScopeSpans {
     let mut scope_spans = EnvPrefixScopeSpans::default();
     let mut seen_assignment_scope_spans = FxHashSet::default();
@@ -1248,6 +1251,7 @@ fn collect_plus_equals_assignment_span(assignment: &Assignment, spans: &mut Vec<
     spans.push(Span::from_positions(target.name_span.start, end));
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_nonpersistent_assignment_spans(
     semantic: &SemanticModel,
     commands: &[CommandFact<'_>],
@@ -1899,6 +1903,7 @@ fn escaped_braced_parameter_names(text: &str) -> Vec<String> {
     names
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_innermost_command_ids_by_offset(
     commands: &[CommandFact<'_>],
     mut offsets: Vec<usize>,

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_literal_brace_spans(
     nodes: &[WordNode<'_>],
     occurrences: &[WordOccurrence],

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -33,6 +33,7 @@ struct HeredocFactSummary {
     spaced_tabstrip_close_spans: Vec<Span>,
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn estimate_fact_build_capacity(file: &File) -> FactBuildCapacity {
     let mut capacity = FactBuildCapacity::default();
     walk_commands(
@@ -661,59 +662,13 @@ impl<'a> LinterFactsBuilder<'a> {
         } = build_env_prefix_scope_spans(self.source, &commands);
         let unset_command_ids_by_target_name =
             build_unset_command_ids_by_target_name(&commands, &structural_command_ids, source);
-        word_occurrences.extend(
-            pending_arithmetic_word_occurrences
-                .into_iter()
-                .map(|pending| WordOccurrence {
-                    node_id: pending.node_id,
-                    command_id: pending.command_id,
-                    nested_word_command: pending.nested_word_command,
-                    context: WordFactContext::ArithmeticCommand,
-                    host_kind: pending.host_kind,
-                    runtime_literal: RuntimeLiteralAnalysis::default(),
-                    operand_class: None,
-                    enclosing_expansion_context: Some(pending.enclosing_expansion_context),
-                    array_assignment_split_scalar_expansion_spans: IdRange::empty(),
-                }),
+        let word_index = build_word_occurrence_index(
+            &commands,
+            &word_nodes,
+            &mut word_occurrences,
+            pending_arithmetic_word_occurrences,
+            &mut fact_store,
         );
-        let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
-        word_index.reserve(word_occurrences.len());
-        let mut word_occurrence_offsets_by_command = vec![0usize; commands.len()];
-        for fact in &word_occurrences {
-            word_occurrence_offsets_by_command[fact.command_id.index()] += 1;
-        }
-        let mut next_word_occurrence_offset = 0usize;
-        let word_occurrence_ids_by_command = word_occurrence_offsets_by_command
-            .iter_mut()
-            .map(|count| {
-                let range = IdRange::from_start_len(next_word_occurrence_offset, *count);
-                *count = next_word_occurrence_offset;
-                next_word_occurrence_offset = range.end_index();
-                range
-            })
-            .collect::<Vec<_>>();
-        let mut word_occurrence_ids =
-            vec![WordOccurrenceId::new(0); next_word_occurrence_offset];
-        for (index, fact) in word_occurrences.iter().enumerate() {
-            let id = WordOccurrenceId::new(index);
-            word_index
-                .entry(occurrence_key(&word_nodes, fact))
-                .or_default()
-                .push(id);
-            let command_index = fact.command_id.index();
-            let offset = word_occurrence_offsets_by_command[command_index];
-            word_occurrence_ids[offset] = id;
-            word_occurrence_offsets_by_command[command_index] += 1;
-        }
-        let mut word_occurrence_id_store = ListArena::with_capacity(word_occurrence_ids.len());
-        let all_word_occurrence_ids = word_occurrence_id_store.push_many(word_occurrence_ids);
-        debug_assert_eq!(all_word_occurrence_ids.start_index(), 0);
-        debug_assert_eq!(
-            all_word_occurrence_ids.end_index(),
-            next_word_occurrence_offset
-        );
-        fact_store.word_occurrence_ids = word_occurrence_id_store;
-        fact_store.word_occurrence_ids_by_command = word_occurrence_ids_by_command;
         populate_array_assignment_split_scalar_expansion_spans(
             self.shell,
             &commands,
@@ -947,6 +902,75 @@ impl<'a> LinterFactsBuilder<'a> {
             conditional_portability,
         }
     }
+}
+
+#[cfg_attr(shuck_profiling, inline(never))]
+fn build_word_occurrence_index(
+    commands: &[CommandFact<'_>],
+    word_nodes: &[WordNode<'_>],
+    word_occurrences: &mut Vec<WordOccurrence>,
+    pending_arithmetic_word_occurrences: Vec<PendingArithmeticWordOccurrence>,
+    fact_store: &mut FactStore<'_>,
+) -> FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>> {
+    word_occurrences.extend(
+        pending_arithmetic_word_occurrences
+            .into_iter()
+            .map(|pending| WordOccurrence {
+                node_id: pending.node_id,
+                command_id: pending.command_id,
+                nested_word_command: pending.nested_word_command,
+                context: WordFactContext::ArithmeticCommand,
+                host_kind: pending.host_kind,
+                runtime_literal: RuntimeLiteralAnalysis::default(),
+                operand_class: None,
+                enclosing_expansion_context: Some(pending.enclosing_expansion_context),
+                array_assignment_split_scalar_expansion_spans: IdRange::empty(),
+            }),
+    );
+
+    let mut word_index = FxHashMap::<FactSpan, SmallVec<[WordOccurrenceId; 2]>>::default();
+    word_index.reserve(word_occurrences.len());
+
+    let mut word_occurrence_offsets_by_command = vec![0usize; commands.len()];
+    for fact in word_occurrences.iter() {
+        word_occurrence_offsets_by_command[fact.command_id.index()] += 1;
+    }
+
+    let mut next_word_occurrence_offset = 0usize;
+    let word_occurrence_ids_by_command = word_occurrence_offsets_by_command
+        .iter_mut()
+        .map(|count| {
+            let range = IdRange::from_start_len(next_word_occurrence_offset, *count);
+            *count = next_word_occurrence_offset;
+            next_word_occurrence_offset = range.end_index();
+            range
+        })
+        .collect::<Vec<_>>();
+
+    let mut word_occurrence_ids = vec![WordOccurrenceId::new(0); next_word_occurrence_offset];
+    for (index, fact) in word_occurrences.iter().enumerate() {
+        let id = WordOccurrenceId::new(index);
+        word_index
+            .entry(occurrence_key(word_nodes, fact))
+            .or_default()
+            .push(id);
+        let command_index = fact.command_id.index();
+        let offset = word_occurrence_offsets_by_command[command_index];
+        word_occurrence_ids[offset] = id;
+        word_occurrence_offsets_by_command[command_index] += 1;
+    }
+
+    let mut word_occurrence_id_store = ListArena::with_capacity(word_occurrence_ids.len());
+    let all_word_occurrence_ids = word_occurrence_id_store.push_many(word_occurrence_ids);
+    debug_assert_eq!(all_word_occurrence_ids.start_index(), 0);
+    debug_assert_eq!(
+        all_word_occurrence_ids.end_index(),
+        next_word_occurrence_offset
+    );
+    fact_store.word_occurrence_ids = word_occurrence_id_store;
+    fact_store.word_occurrence_ids_by_command = word_occurrence_ids_by_command;
+
+    word_index
 }
 
 fn build_c006_suppressing_reference_offsets_by_name(

--- a/crates/shuck-linter/src/facts/command_options.rs
+++ b/crates/shuck-linter/src/facts/command_options.rs
@@ -697,6 +697,7 @@ impl<'a> CommandOptionFacts<'a> {
         &self.file_operand_words
     }
 
+    #[cfg_attr(shuck_profiling, inline(never))]
     fn build(command: &'a Command, normalized: &NormalizedCommand<'a>, source: &str) -> Self {
         Self {
             rm: normalized

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -665,12 +665,13 @@ fn background_semicolon_span(
     Some(Span::from_positions(start, end))
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn populate_scope_fact_ranges<'a>(
     commands: &mut [CommandFact<'a>],
     fact_store: &mut FactStore<'a>,
     pipelines: &[PipelineFact<'a>],
     if_condition_command_ids: &FxHashSet<CommandId>,
-    source: &str,
+    source: &'a str,
 ) {
     let (pipeline_summaries, pipeline_summary_ids_by_writer) = {
         let command_facts = CommandFacts::new(commands, fact_store);
@@ -681,60 +682,93 @@ fn populate_scope_fact_ranges<'a>(
             source,
         )
     };
-    let mut source_words = Vec::new();
-    let mut name_reads = Vec::new();
-    let mut heredoc_name_reads = Vec::new();
-    let mut name_writes = Vec::new();
+    let inputs = ScopeFactInputs {
+        pipeline_summaries: &pipeline_summaries,
+        pipeline_summary_ids_by_writer: &pipeline_summary_ids_by_writer,
+        if_condition_command_ids,
+        source,
+    };
+    let mut scratch = ScopeFactScratch::default();
 
     for index in 0..commands.len() {
-        {
-            let command_facts = CommandFacts::new(commands, fact_store);
-            let command = command_facts
-                .get(index)
-                .expect("command index should resolve while populating scope facts");
-            collect_scope_read_source_words_for_command(
-                command_facts,
-                command,
-                &pipeline_summaries,
-                &pipeline_summary_ids_by_writer[index],
-                if_condition_command_ids,
-                source,
-                &mut source_words,
-            );
-            collect_scope_name_read_uses_for_command(
-                command_facts,
-                command,
-                &pipeline_summaries,
-                &pipeline_summary_ids_by_writer[index],
-                source,
-                &mut name_reads,
-            );
-            collect_scope_heredoc_name_read_uses_for_command(
-                command_facts,
-                command,
-                &pipeline_summaries,
-                &pipeline_summary_ids_by_writer[index],
-                source,
-                &mut heredoc_name_reads,
-            );
-            collect_scope_name_write_uses_for_command(
-                command_facts,
-                command,
-                source,
-                &mut name_writes,
-            );
-        }
-
-        commands[index].scope_read_source_words =
-            fact_store.scope_read_source_words.push_many(source_words.drain(..));
-        commands[index].scope_name_read_uses =
-            fact_store.scope_name_read_uses.push_many(name_reads.drain(..));
-        commands[index].scope_heredoc_name_read_uses = fact_store
-            .scope_heredoc_name_read_uses
-            .push_many(heredoc_name_reads.drain(..));
-        commands[index].scope_name_write_uses =
-            fact_store.scope_name_write_uses.push_many(name_writes.drain(..));
+        populate_scope_fact_ranges_for_command(index, commands, fact_store, inputs, &mut scratch);
     }
+}
+
+#[derive(Clone, Copy)]
+struct ScopeFactInputs<'facts, 'a> {
+    pipeline_summaries: &'facts [PipelineScopeSummary<'a>],
+    pipeline_summary_ids_by_writer: &'facts [SmallVec<[usize; 1]>],
+    if_condition_command_ids: &'facts FxHashSet<CommandId>,
+    source: &'a str,
+}
+
+#[derive(Default)]
+struct ScopeFactScratch<'a> {
+    source_words: Vec<PathWordFact<'a>>,
+    name_reads: Vec<ComparableNameUse>,
+    heredoc_name_reads: Vec<ComparableNameUse>,
+    name_writes: Vec<ComparableNameUse>,
+}
+
+#[cfg_attr(shuck_profiling, inline(never))]
+fn populate_scope_fact_ranges_for_command<'a>(
+    index: usize,
+    commands: &mut [CommandFact<'a>],
+    fact_store: &mut FactStore<'a>,
+    inputs: ScopeFactInputs<'_, 'a>,
+    scratch: &mut ScopeFactScratch<'a>,
+) {
+    {
+        let command_facts = CommandFacts::new(commands, fact_store);
+        let command = command_facts
+            .get(index)
+            .expect("command index should resolve while populating scope facts");
+        collect_scope_read_source_words_for_command(
+            command_facts,
+            command,
+            inputs.pipeline_summaries,
+            &inputs.pipeline_summary_ids_by_writer[index],
+            inputs.if_condition_command_ids,
+            inputs.source,
+            &mut scratch.source_words,
+        );
+        collect_scope_name_read_uses_for_command(
+            command_facts,
+            command,
+            inputs.pipeline_summaries,
+            &inputs.pipeline_summary_ids_by_writer[index],
+            inputs.source,
+            &mut scratch.name_reads,
+        );
+        collect_scope_heredoc_name_read_uses_for_command(
+            command_facts,
+            command,
+            inputs.pipeline_summaries,
+            &inputs.pipeline_summary_ids_by_writer[index],
+            inputs.source,
+            &mut scratch.heredoc_name_reads,
+        );
+        collect_scope_name_write_uses_for_command(
+            command_facts,
+            command,
+            inputs.source,
+            &mut scratch.name_writes,
+        );
+    }
+
+    commands[index].scope_read_source_words = fact_store
+        .scope_read_source_words
+        .push_many(scratch.source_words.drain(..));
+    commands[index].scope_name_read_uses = fact_store
+        .scope_name_read_uses
+        .push_many(scratch.name_reads.drain(..));
+    commands[index].scope_heredoc_name_read_uses = fact_store
+        .scope_heredoc_name_read_uses
+        .push_many(scratch.heredoc_name_reads.drain(..));
+    commands[index].scope_name_write_uses = fact_store
+        .scope_name_write_uses
+        .push_many(scratch.name_writes.drain(..));
 }
 
 struct PipelineScopeSummary<'a> {
@@ -743,6 +777,7 @@ struct PipelineScopeSummary<'a> {
     heredoc_name_reads: Vec<ComparableNameUse>,
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_pipeline_scope_summaries<'a>(
     commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
@@ -801,6 +836,7 @@ fn build_pipeline_scope_summaries<'a>(
     (summaries, summary_ids_by_writer)
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn collect_scope_read_source_words_for_command<'a>(
     commands: CommandFacts<'_, 'a>,
     command: CommandFactRef<'_, 'a>,
@@ -831,6 +867,7 @@ fn collect_scope_read_source_words_for_command<'a>(
     dedup_path_words(words);
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn collect_scope_name_read_uses_for_command(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
@@ -849,6 +886,7 @@ fn collect_scope_name_read_uses_for_command(
     dedup_name_uses(uses);
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn collect_scope_heredoc_name_read_uses_for_command(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
@@ -874,6 +912,7 @@ fn collect_scope_heredoc_name_read_uses_for_command(
     dedup_name_uses(uses);
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn collect_scope_name_write_uses_for_command(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
@@ -1396,6 +1435,7 @@ fn compare_command_parent_entries(
         .then_with(|| right_id.index().cmp(&left_id.index()))
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_command_dominance_barrier_flags(commands: &[CommandFact<'_>]) -> Vec<bool> {
     commands
         .iter()

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -13,6 +13,7 @@ struct ShebangHeaderFacts {
     enables_errexit: bool,
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
     let mut source_lines = source_lines_with_offsets(source).enumerate();
     let Some((_, first_line)) = source_lines.next() else {
@@ -302,6 +303,7 @@ fn line_span(line_number: usize, offset: usize, line: &str) -> Span {
     Span::from_positions(start, end)
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_commented_continuation_comment_spans(source: &str, indexer: &Indexer) -> Vec<Span> {
     let line_index = indexer.line_index();
     let comment_index = indexer.comment_index();

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -97,6 +97,7 @@ pub(super) struct ConditionalPortabilityInputs<'a> {
     pub nested_pattern_charclass_spans: &'a FxHashSet<FactSpan>,
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_conditional_portability_facts<'a>(
     commands: &[CommandFact<'a>],
     elif_condition_command_ids: &FxHashSet<CommandId>,

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -81,6 +81,7 @@ struct EscapeScanMatchContext {
     host_contains_single_quoted_fragment: bool,
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_escape_scan_matches(
     commands: &[CommandFact<'_>],
     nodes: &[WordNode<'_>],

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -124,6 +124,7 @@ impl FunctionCliDispatchFacts {
     }
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_function_header_facts<'a>(
     semantic: &SemanticModel,
     functions: &[&'a FunctionDef],
@@ -153,6 +154,7 @@ fn build_function_header_facts<'a>(
         .collect()
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_function_cli_dispatch_facts(
     semantic: &SemanticModel,
     function_headers: &[FunctionHeaderFact<'_>],

--- a/crates/shuck-linter/src/facts/heredocs.rs
+++ b/crates/shuck-linter/src/facts/heredocs.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_heredoc_fact_summary(
     commands: &[CommandFact<'_>],
     source: &str,
@@ -222,4 +223,3 @@ fn position_at_offset_opt(source: &str, target_offset: usize) -> Option<Position
     }
     Some(position)
 }
-

--- a/crates/shuck-linter/src/facts/lists.rs
+++ b/crates/shuck-linter/src/facts/lists.rs
@@ -105,6 +105,7 @@ impl<'a> ListFact<'a> {
     }
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_list_facts<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1183,6 +1183,7 @@ fn split_scope_compat_build_flag_family_name(name: &str) -> Option<(&str, &'stat
         })
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn populate_array_assignment_split_scalar_expansion_spans(
     shell: ShellDialect,
     commands: &[CommandFact<'_>],

--- a/crates/shuck-linter/src/facts/pipelines.rs
+++ b/crates/shuck-linter/src/facts/pipelines.rs
@@ -99,6 +99,7 @@ impl<'a> PipelineFact<'a> {
 }
 
 
+#[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_pipeline_facts<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,

--- a/crates/shuck-linter/src/facts/presence.rs
+++ b/crates/shuck-linter/src/facts/presence.rs
@@ -42,6 +42,7 @@ pub(super) struct PresenceTestedNames {
     pub(super) names_by_name: FxHashMap<Name, Vec<PresenceTestNameFact>>,
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_presence_tested_names(
     commands: &[CommandFact<'_>],
     source: &str,

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -682,6 +682,7 @@ pub(crate) fn analyze_redirect_target(
     })
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_redirect_facts<'a>(
     redirects: &'a [Redirect],
     semantic: Option<&SemanticModel>,

--- a/crates/shuck-linter/src/facts/statements.rs
+++ b/crates/shuck-linter/src/facts/statements.rs
@@ -19,6 +19,7 @@ impl StatementFact {
     }
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_statement_facts<'a>(
     commands: &[CommandFact<'a>],
     command_ids_by_span: &CommandLookupIndex,
@@ -249,4 +250,3 @@ fn collect_statement_sequence_facts_in_stmt<'a>(
         facts,
     );
 }
-

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -148,6 +148,7 @@ impl SubstitutionFact {
     }
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn populate_substitution_fact_ranges<'a>(
     commands: &mut [CommandFact<'a>],
     fact_store: &mut FactStore<'a>,

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -409,6 +409,7 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
+    #[cfg_attr(shuck_profiling, inline(never))]
     pub(super) fn finish(self) -> SurfaceFragmentFacts {
         self.facts
     }

--- a/crates/shuck-linter/src/facts/words.rs
+++ b/crates/shuck-linter/src/facts/words.rs
@@ -1743,6 +1743,7 @@ fn parameter_expansion_end_offset(source: &str, dollar_offset: usize) -> Option<
     (end > after_dollar).then_some(end)
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_brace_variable_before_bracket_spans<'a>(
     nodes: &[WordNode<'a>],
     occurrences: &[WordOccurrence],
@@ -1895,6 +1896,7 @@ fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source: &str) -> 
     spans
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_alias_definition_expansion_spans(
     commands: &[CommandFact<'_>],
     fact_store: &FactStore<'_>,
@@ -2288,6 +2290,7 @@ struct WordFactLookup<'facts, 'a> {
     source: &'a str,
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_echo_to_sed_substitution_spans<'a>(
     commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
@@ -3392,6 +3395,7 @@ fn build_unquoted_command_argument_use_offsets(
     offsets_by_name
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn build_word_facts_for_command<'a>(
     visit: CommandVisit<'a>,
     source: &'a str,


### PR DESCRIPTION
## Summary

- Add profiler-visible `#[inline(never)]` boundaries around major linter fact-building phases.
- Extract word occurrence index construction from the monolithic facts builder into a named helper.
- Split scope fact population into profiler-visible subframes for pipeline summaries, per-command population, source-word reads, name reads, heredoc reads, and writes.
- Preserve the existing fact-building data flow while making profiling output easier to attribute.

## Validation

- `cargo fmt --check`
- `make test`
- `cargo test -p shuck-linter`
- `cargo build --profile profiling -p shuck-cli`
- `cargo build --profile profiling -p shuck-benchmark --features large-corpus-hotspots --example large_corpus_profile`
- `scripts/profiling/profile_large_corpus.sh nvm-sh__nvm__nvm.sh .cache/profiles 2000 1 12`
- Confirmed profiling symbols with `nm target/profiling/shuck` and `nm target/profiling/examples/large_corpus_profile` for frames such as `build_word_occurrence_index`, `build_word_facts_for_command`, `build_presence_tested_names`, `build_escape_scan_matches`, `populate_scope_fact_ranges_for_command`, and `collect_scope_read_source_words_for_command`.
