### PR TITLE
perf(linter): skip array-split scan without command substitutions

### DIFF
--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1240,21 +1240,23 @@ fn collect_array_assignment_split_scalar_expansion_spans(
     let unquoted_command_substitution_spans =
         fact_store.word_spans(derived.unquoted_command_substitution_spans);
 
-    for command in commands {
-        if contains_span_strictly(fact_span, command.span())
-            && unquoted_command_substitution_spans
-                .iter()
-                .any(|span| contains_span_strictly(*span, command.span()))
-        {
-            for nested_id in fact_store.word_occurrence_ids_for_command(command.id()) {
-                let nested = &word_occurrences[nested_id.index()];
-                let nested_derived = word_node_derived(&word_nodes[nested.node_id.index()]);
-                split_sensitive_spans.extend(
-                    fact_store
-                        .word_spans(nested_derived.scalar_expansion_spans)
-                        .iter()
-                        .copied(),
-                );
+    if !unquoted_command_substitution_spans.is_empty() {
+        for command in commands {
+            if contains_span_strictly(fact_span, command.span())
+                && unquoted_command_substitution_spans
+                    .iter()
+                    .any(|span| contains_span_strictly(*span, command.span()))
+            {
+                for nested_id in fact_store.word_occurrence_ids_for_command(command.id()) {
+                    let nested = &word_occurrences[nested_id.index()];
+                    let nested_derived = word_node_derived(&word_nodes[nested.node_id.index()]);
+                    split_sensitive_spans.extend(
+                        fact_store
+                            .word_spans(nested_derived.scalar_expansion_spans)
+                            .iter()
+                            .copied(),
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- The per-command walk in `collect_array_assignment_split_scalar_expansion_spans` runs once per array-assignment word and iterates every command in the file. The inner condition gates everything on `unquoted_command_substitution_spans.iter().any(...)`, so words without unquoted command substitutions (the common shape `arr=("$x" "$y")`) walk the full command slice just to short-circuit on `.any()` returning `false`.
- Hoist the emptiness check above the loop so those words skip the scan entirely.

## Impact

On the `xwmx__nb__nb` large-corpus fixture (12 iterations, warm):

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Avg wall time | 463 ms | 403 ms | **−13.0%** |
| `populate_array_assignment_split_scalar_expansion_spans` share of all samples | 23.3% | 0.8% | **−96%** |
| Facts builder share of all samples | 60.5% | 49.7% | −10.8 pp |

This was the largest single sub-frame inside `LinterFactsBuilder::build` after PR #636 made the breakdown visible. It's now out of the top 10.

## Test plan

- [x] `cargo test -p shuck-linter --lib` (3108 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Profile with `scripts/profiling/profile_large_corpus.sh xwmx__nb__nb` (cold + warm)