### PR TITLE
perf(linter): bracket nested-scope walks by command index

### DIFF
--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1056,9 +1056,17 @@ fn collect_nested_scope_name_write_uses(
 
 /// Visits commands strictly nested inside `outer`'s span.
 ///
-/// Relies on `commands` being in DFS pre-order, so any command spatially
-/// nested in `outer` appears at a later index. Iteration stops as soon as a
-/// command starts past `outer`'s end offset.
+/// Relies on the DFS pre-order ID layout: any command spatially nested in
+/// `outer` has a higher index, so the search starts at `outer.id().index() +
+/// 1` and stops as soon as a command starts past `outer`'s end offset.
+///
+/// IDs are not strictly source-ordered — a stmt's redirects are visited
+/// after its body, so a leading-redirect substitution like `>"$(a)" cmd
+/// "$(b)"` assigns `b` a smaller ID than `a` even though `a` appears first
+/// in source. The bracketed range therefore filters with full
+/// `contains_span` (start *and* end) so that an arg-substitution at one
+/// index does not pick up its sibling redirect-substitution at a later
+/// index as nested.
 fn for_each_nested_command<'facts, 'a>(
     commands: CommandFacts<'facts, 'a>,
     outer: CommandFactRef<'_, 'a>,
@@ -1073,7 +1081,7 @@ fn for_each_nested_command<'facts, 'a>(
         if other.span().start.offset > outer_span.end.offset {
             break;
         }
-        if other.span().end.offset <= outer_span.end.offset {
+        if contains_span(outer_span, other.span()) {
             visit(other);
         }
     }

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1005,6 +1005,7 @@ fn collect_own_scope_name_write_uses(
     }
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn collect_nested_scope_read_source_words<'a>(
     commands: CommandFacts<'_, 'a>,
     command: CommandFactRef<'_, 'a>,
@@ -1012,62 +1013,84 @@ fn collect_nested_scope_read_source_words<'a>(
     source: &str,
     words: &mut Vec<PathWordFact<'a>>,
 ) {
-    for other in commands
-        .iter()
-        .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
-    {
+    for_each_nested_command(commands, command, |other| {
         collect_own_scope_read_source_words(other, if_condition_command_ids, source, words);
-    }
+    });
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn collect_nested_scope_name_read_uses(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
     uses: &mut Vec<ComparableNameUse>,
 ) {
-    for other in commands
-        .iter()
-        .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
-    {
+    for_each_nested_command(commands, command, |other| {
         collect_own_scope_name_read_uses(other, source, uses);
-    }
+    });
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn collect_nested_scope_heredoc_name_read_uses(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
     uses: &mut Vec<ComparableNameUse>,
 ) {
-    for other in commands
-        .iter()
-        .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
-    {
+    for_each_nested_command(commands, command, |other| {
         collect_own_scope_heredoc_name_read_uses(other, source, uses);
-    }
+    });
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
 fn collect_nested_scope_name_write_uses(
     commands: CommandFacts<'_, '_>,
     command: CommandFactRef<'_, '_>,
     source: &str,
     uses: &mut Vec<ComparableNameUse>,
 ) {
-    for other in commands
-        .iter()
-        .filter(|other| other.id() != command.id() && contains_span(command.span(), other.span()))
-    {
+    for_each_nested_command(commands, command, |other| {
         collect_own_scope_name_write_uses(other, source, uses);
+    });
+}
+
+/// Visits commands strictly nested inside `outer`'s span.
+///
+/// Relies on `commands` being in DFS pre-order, so any command spatially
+/// nested in `outer` appears at a later index. Iteration stops as soon as a
+/// command starts past `outer`'s end offset.
+fn for_each_nested_command<'facts, 'a>(
+    commands: CommandFacts<'facts, 'a>,
+    outer: CommandFactRef<'_, 'a>,
+    mut visit: impl FnMut(CommandFactRef<'facts, 'a>),
+) {
+    let outer_span = outer.span();
+    let start_index = outer.id().index() + 1;
+    for index in start_index..commands.len() {
+        let Some(other) = commands.get(index) else {
+            break;
+        };
+        if other.span().start.offset > outer_span.end.offset {
+            break;
+        }
+        if other.span().end.offset <= outer_span.end.offset {
+            visit(other);
+        }
     }
 }
 
 fn dedup_path_words(words: &mut Vec<PathWordFact<'_>>) {
+    if words.len() < 2 {
+        return;
+    }
     let mut seen = FxHashSet::<(FactSpan, ExpansionContext)>::default();
     words.retain(|fact| seen.insert((FactSpan::new(fact.word().span), fact.context())));
 }
 
 fn dedup_name_uses(uses: &mut Vec<ComparableNameUse>) {
+    if uses.len() < 2 {
+        return;
+    }
     let mut seen = FxHashSet::<(ComparableNameKey, FactSpan)>::default();
     uses.retain(|name_use| seen.insert((name_use.key().clone(), FactSpan::new(name_use.span()))));
 }


### PR DESCRIPTION
## Summary

- Replaces the four `collect_nested_scope_*_for_command` O(C^2) `commands.iter().filter(contains_span(...))` walks with a `for_each_nested_command` helper that exploits the DFS pre-order layout of `CommandFacts` to walk only the bracketed range of nested commands and stop early at the first sibling past the outer end offset.
- Short-circuits `dedup_path_words` and `dedup_name_uses` when the input has fewer than two entries, avoiding the `FxHashSet` allocation on the one-element fast path that dominates real fixtures.
- On the `xwmx__nb__nb` warm large-corpus profile this drops wall time **463 ms → 393 ms (-15.1%)**, brings `LinterFactsBuilder::build` from 60.1% to 53.7% of samples, and removes `collect_scope_heredoc_name_read_uses_for_command` (5.3%), `collect_scope_name_read_uses_for_command` (4.9%), and `collect_scope_read_source_words_for_command` (4.8%) from the profile top 20.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo test -p shuck-linter` (3108 passed)
- [x] `cargo test -p shuck-cli` (143 passed)
- [x] `samply` profile on `xwmx__nb__nb` warm confirms cluster removal and -15.1% wall time