### PR TITLE
refactor(linter): move safe-value flow helpers to semantic

### DIFF
--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -2673,7 +2673,7 @@ impl<'a> SafeValueIndex<'a> {
                     *binding_block,
                     reference_block,
                     &candidates,
-                    &unreachable,
+                    unreachable,
                 )
             })
             .map(|(binding_id, _)| binding_id)

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -2645,8 +2645,7 @@ impl<'a> SafeValueIndex<'a> {
             return Vec::new();
         };
 
-        let cfg = self.analysis.cfg();
-        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let unreachable = self.analysis.unreachable_blocks();
         let candidates = self
             .semantic
             .bindings_for(name)
@@ -2757,7 +2756,7 @@ impl<'a> SafeValueIndex<'a> {
         let mut stack = vec![binding_block];
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
-            if self.analysis.cfg().unreachable().contains(&block_id) || !seen.insert(block_id) {
+            if self.analysis.block_is_unreachable(block_id) || !seen.insert(block_id) {
                 continue;
             }
             for (successor, _) in cfg.successors(block_id) {

--- a/crates/shuck-linter/src/rules/common/safe_value.rs
+++ b/crates/shuck-linter/src/rules/common/safe_value.rs
@@ -11,7 +11,7 @@ use shuck_semantic::{
     AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, LoopValueOrigin, ScopeId,
     ScopeKind, SemanticAnalysis, SemanticModel, UninitializedCertainty,
 };
-use shuck_semantic::{BindingId, BlockId, ReferenceId, ReferenceKind};
+use shuck_semantic::{BindingId, BlockId, ReferenceId};
 
 use crate::facts::analyze_literal_runtime;
 use crate::{ExpansionContext, FactSpan, LinterFacts};
@@ -99,10 +99,6 @@ pub struct SafeValueIndex<'a> {
     maybe_uninitialized_refs: FxHashSet<FactSpan>,
     function_commands_by_span: FxHashMap<FactSpan, crate::facts::CommandId>,
     commands_by_name_word_span: FxHashMap<FactSpan, crate::facts::CommandId>,
-    reference_ids_by_name_span: FxHashMap<(Name, FactSpan), ReferenceId>,
-    block_by_reference: FxHashMap<ReferenceId, BlockId>,
-    block_by_binding: FxHashMap<BindingId, BlockId>,
-    unreachable_blocks: FxHashSet<BlockId>,
     command_cover_memo: RefCell<FxHashMap<(crate::facts::CommandId, Name, FactSpan), bool>>,
     memo: FxHashMap<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>), bool>,
     visiting: FxHashSet<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>)>,
@@ -143,34 +139,6 @@ impl<'a> SafeValueIndex<'a> {
                 commands_by_name_word_span.insert(FactSpan::new(name_word.span), command.id());
             }
         }
-        let reference_ids_by_name_span = semantic
-            .references()
-            .iter()
-            .filter(|reference| {
-                !matches!(
-                    reference.kind,
-                    ReferenceKind::DeclarationName | ReferenceKind::ImplicitRead
-                )
-            })
-            .map(|reference| {
-                (
-                    (reference.name.clone(), FactSpan::new(reference.span)),
-                    reference.id,
-                )
-            })
-            .collect();
-        let mut block_by_reference = FxHashMap::default();
-        let mut block_by_binding = FxHashMap::default();
-        for block in analysis.cfg().blocks() {
-            for reference_id in &block.references {
-                block_by_reference.insert(*reference_id, block.id);
-            }
-            for binding_id in &block.bindings {
-                block_by_binding.insert(*binding_id, block.id);
-            }
-        }
-        let unreachable_blocks = analysis.cfg().unreachable().iter().copied().collect();
-
         Self {
             semantic,
             analysis,
@@ -181,10 +149,6 @@ impl<'a> SafeValueIndex<'a> {
             maybe_uninitialized_refs,
             function_commands_by_span,
             commands_by_name_word_span,
-            reference_ids_by_name_span,
-            block_by_reference,
-            block_by_binding,
-            unreachable_blocks,
             command_cover_memo: RefCell::new(FxHashMap::default()),
             memo: FxHashMap::default(),
             visiting: FxHashSet::default(),
@@ -991,9 +955,8 @@ impl<'a> SafeValueIndex<'a> {
         binding_id: BindingId,
         ancestor_scope: ScopeId,
     ) -> bool {
-        self.semantic
-            .ancestor_scopes(self.semantic.binding(binding_id).scope)
-            .any(|scope| scope == ancestor_scope)
+        self.analysis
+            .binding_is_in_scope_or_descendant(binding_id, ancestor_scope)
     }
 
     fn is_argument_of_dynamic_command(&self, at: Span) -> bool {
@@ -1366,9 +1329,7 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn enclosing_function_scope_at(&self, offset: usize) -> Option<ScopeId> {
-        self.semantic
-            .ancestor_scopes(self.semantic.scope_at(offset))
-            .find(|scope| matches!(self.semantic.scope(*scope).kind, ScopeKind::Function(_)))
+        self.analysis.enclosing_function_scope_at(offset)
     }
 
     fn binding_is_quoted_static_literal(&self, binding_id: BindingId) -> bool {
@@ -2189,29 +2150,13 @@ impl<'a> SafeValueIndex<'a> {
             return true;
         }
 
-        let cfg = self.analysis.cfg();
         let entry = self
             .enclosing_function_scope_at(at.start.offset)
-            .and_then(|scope| cfg.scope_entry(scope))
-            .unwrap_or_else(|| cfg.entry());
-        let mut stack = vec![entry];
-        let mut seen = FxHashSet::default();
-        while let Some(block_id) = stack.pop() {
-            if cover_blocks.contains(&block_id)
-                || self.unreachable_blocks.contains(&block_id)
-                || !seen.insert(block_id)
-            {
-                continue;
-            }
-            if block_id == reference_block {
-                return false;
-            }
-            for (successor, _) in cfg.successors(block_id) {
-                stack.push(*successor);
-            }
-        }
-
-        true
+            .and_then(|scope| self.analysis.cfg().scope_entry(scope))
+            .unwrap_or_else(|| self.analysis.cfg().entry());
+        let cover_blocks = cover_blocks.iter().copied().collect::<FxHashSet<_>>();
+        self.analysis
+            .blocks_cover_all_paths_to_block(entry, reference_block, &cover_blocks)
     }
 
     fn unset_command_covers_reference(&self, name: &Name, at: Span) -> bool {
@@ -2700,7 +2645,8 @@ impl<'a> SafeValueIndex<'a> {
             return Vec::new();
         };
 
-        let unreachable = &self.unreachable_blocks;
+        let cfg = self.analysis.cfg();
+        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
         let candidates = self
             .semantic
             .bindings_for(name)
@@ -2728,7 +2674,7 @@ impl<'a> SafeValueIndex<'a> {
                     *binding_block,
                     reference_block,
                     &candidates,
-                    unreachable,
+                    &unreachable,
                 )
             })
             .map(|(binding_id, _)| binding_id)
@@ -2811,7 +2757,7 @@ impl<'a> SafeValueIndex<'a> {
         let mut stack = vec![binding_block];
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {
-            if self.unreachable_blocks.contains(&block_id) || !seen.insert(block_id) {
+            if self.analysis.cfg().unreachable().contains(&block_id) || !seen.insert(block_id) {
                 continue;
             }
             for (successor, _) in cfg.successors(block_id) {
@@ -3475,41 +3421,12 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn binding_dominates_reference(&self, binding_id: BindingId, name: &Name, at: Span) -> bool {
-        let Some(reference_id) = self.reference_id_for_name_at(name, at) else {
-            return false;
-        };
-        let Some(reference_block) = self.block_for_reference(reference_id) else {
-            return false;
-        };
-        let Some(binding_block) = self.block_for_binding(binding_id) else {
-            return false;
-        };
-        if binding_block == reference_block {
-            return !self.binding_is_guarded_before_reference(binding_id, at);
-        }
-
-        let cfg = self.analysis.cfg();
-        let mut stack = vec![self.flow_entry_block_for_binding_scopes(
-            &[self.semantic.binding(binding_id).scope],
-            at.start.offset,
-        )];
-        let mut seen = FxHashSet::default();
-        while let Some(block_id) = stack.pop() {
-            if block_id == binding_block
-                || self.unreachable_blocks.contains(&block_id)
-                || !seen.insert(block_id)
-            {
-                continue;
-            }
-            if block_id == reference_block {
-                return false;
-            }
-            for (successor, _) in cfg.successors(block_id) {
-                stack.push(*successor);
-            }
-        }
-
-        true
+        self.analysis.binding_dominates_reference_from_flow_entry(
+            binding_id,
+            name,
+            at,
+            !self.binding_is_guarded_before_reference(binding_id, at),
+        )
     }
 
     fn bindings_cover_all_paths_to_reference(
@@ -3567,31 +3484,16 @@ impl<'a> SafeValueIndex<'a> {
             return true;
         }
 
-        let cfg = self.analysis.cfg();
         let binding_scopes = bindings
             .iter()
             .copied()
             .map(|binding_id| self.semantic.binding(binding_id).scope)
             .collect::<Vec<_>>();
-        let mut stack =
-            vec![self.flow_entry_block_for_binding_scopes(&binding_scopes, at.start.offset)];
-        let mut seen = FxHashSet::default();
-        while let Some(block_id) = stack.pop() {
-            if cover_blocks.contains(&block_id)
-                || self.unreachable_blocks.contains(&block_id)
-                || !seen.insert(block_id)
-            {
-                continue;
-            }
-            if block_id == reference_block {
-                return false;
-            }
-            for (successor, _) in cfg.successors(block_id) {
-                stack.push(*successor);
-            }
-        }
-
-        true
+        let entry = self
+            .analysis
+            .flow_entry_block_for_binding_scopes(&binding_scopes, at.start.offset);
+        self.analysis
+            .blocks_cover_all_paths_to_block(entry, reference_block, &cover_blocks)
     }
 
     fn unset_value_blocks_for_name_before_reference(
@@ -3671,60 +3573,17 @@ impl<'a> SafeValueIndex<'a> {
             .copied()
             .map(|binding_id| self.semantic.binding(binding_id).scope)
             .collect::<Vec<_>>();
-        let mut stack =
-            vec![self.flow_entry_block_for_binding_scopes(&binding_scopes, call_span.start.offset)];
-        let mut seen = FxHashSet::default();
-        while let Some(block_id) = stack.pop() {
-            if cover_blocks.contains(&block_id)
-                || self.unreachable_blocks.contains(&block_id)
-                || !seen.insert(block_id)
-            {
-                continue;
-            }
-            if call_blocks.contains(&block_id) {
-                return false;
-            }
-            for (successor, _) in cfg.successors(block_id) {
-                stack.push(*successor);
-            }
-        }
-
-        true
-    }
-
-    fn flow_entry_block_for_binding_scopes(
-        &self,
-        binding_scopes: &[ScopeId],
-        reference_offset: usize,
-    ) -> BlockId {
-        let cfg = self.analysis.cfg();
-        self.semantic
-            .ancestor_scopes(self.semantic.scope_at(reference_offset))
-            .find_map(|scope| {
-                if !matches!(
-                    self.semantic.scope(scope).kind,
-                    ScopeKind::Function(_) | ScopeKind::File
-                ) {
-                    return None;
-                }
-                binding_scopes
-                    .iter()
-                    .copied()
-                    .all(|binding_scope| {
-                        self.semantic
-                            .ancestor_scopes(binding_scope)
-                            .any(|ancestor| ancestor == scope)
-                    })
-                    .then(|| cfg.scope_entry(scope))
-                    .flatten()
-            })
-            .unwrap_or_else(|| cfg.entry())
+        let entry = self
+            .analysis
+            .flow_entry_block_for_binding_scopes(&binding_scopes, call_span.start.offset);
+        call_blocks.iter().copied().all(|call_block| {
+            self.analysis
+                .blocks_cover_all_paths_to_block(entry, call_block, &cover_blocks)
+        })
     }
 
     fn reference_id_for_name_at(&self, name: &Name, at: Span) -> Option<ReferenceId> {
-        self.reference_ids_by_name_span
-            .get(&(name.clone(), FactSpan::new(at)))
-            .copied()
+        self.analysis.reference_id_for_name_at(name, at)
     }
 
     fn block_for_name_reference_or_virtual_offset(&self, name: &Name, at: Span) -> Option<BlockId> {
@@ -3763,11 +3622,11 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn block_for_binding(&self, binding_id: BindingId) -> Option<BlockId> {
-        self.block_by_binding.get(&binding_id).copied()
+        self.analysis.block_for_binding(binding_id)
     }
 
     fn block_for_reference(&self, reference_id: ReferenceId) -> Option<BlockId> {
-        self.block_by_reference.get(&reference_id).copied()
+        self.analysis.block_for_reference_id(reference_id)
     }
 
     fn transformation_is_safe(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -482,6 +482,7 @@ pub struct SemanticAnalysis<'model> {
     unused_assignments_shellcheck_compat: OnceLock<Vec<BindingId>>,
     uninitialized_references: OnceLock<Vec<UninitializedReference>>,
     dead_code: OnceLock<Vec<DeadCode>>,
+    unreachable_blocks: OnceLock<FxHashSet<BlockId>>,
     overwritten_functions: OnceLock<Vec<OverwrittenFunction>>,
     unreached_functions: OnceLock<Vec<UnreachedFunction>>,
     unreached_functions_shellcheck_compat: OnceLock<Vec<UnreachedFunction>>,
@@ -1290,6 +1291,7 @@ impl<'model> SemanticAnalysis<'model> {
             unused_assignments_shellcheck_compat: OnceLock::new(),
             uninitialized_references: OnceLock::new(),
             dead_code: OnceLock::new(),
+            unreachable_blocks: OnceLock::new(),
             overwritten_functions: OnceLock::new(),
             unreached_functions: OnceLock::new(),
             unreached_functions_shellcheck_compat: OnceLock::new(),
@@ -1311,6 +1313,19 @@ impl<'model> SemanticAnalysis<'model> {
                 &self.model.call_sites,
             )
         })
+    }
+
+    /// Returns the CFG's unreachable blocks as an indexed set.
+    #[doc(hidden)]
+    pub fn unreachable_blocks(&self) -> &FxHashSet<BlockId> {
+        self.unreachable_blocks
+            .get_or_init(|| self.cfg().unreachable().iter().copied().collect())
+    }
+
+    /// Returns whether a CFG block is unreachable.
+    #[doc(hidden)]
+    pub fn block_is_unreachable(&self, block_id: BlockId) -> bool {
+        self.unreachable_blocks().contains(&block_id)
     }
 
     pub fn visible_function_binding_at_call(
@@ -1566,7 +1581,7 @@ impl<'model> SemanticAnalysis<'model> {
         }
 
         let cfg = self.cfg();
-        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let unreachable = self.unreachable_blocks();
         let mut stack = vec![entry];
         let mut seen = FxHashSet::default();
         while let Some(block_id) = stack.pop() {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1482,6 +1482,144 @@ impl<'model> SemanticAnalysis<'model> {
             })
     }
 
+    /// Returns the semantic reference for a named expansion contained by `at`.
+    #[doc(hidden)]
+    pub fn reference_id_for_name_at(&self, name: &Name, at: Span) -> Option<ReferenceId> {
+        self.reference_for_name_at(name, at)
+            .map(|reference| reference.id)
+    }
+
+    /// Returns the CFG block containing `reference_id`, if it was recorded in the CFG.
+    #[doc(hidden)]
+    pub fn block_for_reference_id(&self, reference_id: ReferenceId) -> Option<BlockId> {
+        let exact = self.exact_variable_dataflow();
+        exact.reference_block(&self.model.references[reference_id.index()])
+    }
+
+    /// Returns the CFG block containing `binding_id`, if it was recorded in the CFG.
+    #[doc(hidden)]
+    pub fn block_for_binding(&self, binding_id: BindingId) -> Option<BlockId> {
+        self.exact_variable_dataflow().binding_block(binding_id)
+    }
+
+    /// Returns the innermost function scope containing `offset`.
+    #[doc(hidden)]
+    pub fn enclosing_function_scope_at(&self, offset: usize) -> Option<ScopeId> {
+        self.model
+            .ancestor_scopes(self.model.scope_at(offset))
+            .find(|scope| matches!(self.model.scope(*scope).kind, ScopeKind::Function(_)))
+    }
+
+    /// Returns whether a binding's scope is `ancestor_scope` or nested below it.
+    #[doc(hidden)]
+    pub fn binding_is_in_scope_or_descendant(
+        &self,
+        binding_id: BindingId,
+        ancestor_scope: ScopeId,
+    ) -> bool {
+        self.model
+            .ancestor_scopes(self.model.binding(binding_id).scope)
+            .any(|scope| scope == ancestor_scope)
+    }
+
+    /// Returns the entry block that covers the common runtime scope of `binding_scopes`.
+    #[doc(hidden)]
+    pub fn flow_entry_block_for_binding_scopes(
+        &self,
+        binding_scopes: &[ScopeId],
+        reference_offset: usize,
+    ) -> BlockId {
+        let cfg = self.cfg();
+        self.model
+            .ancestor_scopes(self.model.scope_at(reference_offset))
+            .find_map(|scope| {
+                if !matches!(
+                    self.model.scope(scope).kind,
+                    ScopeKind::Function(_) | ScopeKind::File
+                ) {
+                    return None;
+                }
+                binding_scopes
+                    .iter()
+                    .copied()
+                    .all(|binding_scope| {
+                        self.model
+                            .ancestor_scopes(binding_scope)
+                            .any(|ancestor| ancestor == scope)
+                    })
+                    .then(|| cfg.scope_entry(scope))
+                    .flatten()
+            })
+            .unwrap_or_else(|| cfg.entry())
+    }
+
+    /// Returns true when every path from `entry` to `target` crosses one of `cover_blocks`.
+    #[doc(hidden)]
+    pub fn blocks_cover_all_paths_to_block(
+        &self,
+        entry: BlockId,
+        target: BlockId,
+        cover_blocks: &FxHashSet<BlockId>,
+    ) -> bool {
+        if cover_blocks.contains(&target) {
+            return true;
+        }
+
+        let cfg = self.cfg();
+        let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+        let mut stack = vec![entry];
+        let mut seen = FxHashSet::default();
+        while let Some(block_id) = stack.pop() {
+            if cover_blocks.contains(&block_id)
+                || unreachable.contains(&block_id)
+                || !seen.insert(block_id)
+            {
+                continue;
+            }
+            if block_id == target {
+                return false;
+            }
+            for (successor, _) in cfg.successors(block_id) {
+                stack.push(*successor);
+            }
+        }
+
+        true
+    }
+
+    /// Returns true when a binding's CFG block dominates a named reference from the relevant
+    /// runtime entry block. Same-block ordering remains caller policy because it often depends on
+    /// rule-local structural facts.
+    #[doc(hidden)]
+    pub fn binding_dominates_reference_from_flow_entry(
+        &self,
+        binding_id: BindingId,
+        name: &Name,
+        at: Span,
+        same_block_dominates: bool,
+    ) -> bool {
+        let Some(reference_id) = self.reference_id_for_name_at(name, at) else {
+            return false;
+        };
+        let Some(reference_block) = self.block_for_reference_id(reference_id) else {
+            return false;
+        };
+        let Some(binding_block) = self.block_for_binding(binding_id) else {
+            return false;
+        };
+        if binding_block == reference_block {
+            return same_block_dominates;
+        }
+
+        let binding_scope = self.model.binding(binding_id).scope;
+        let entry = self.flow_entry_block_for_binding_scopes(&[binding_scope], at.start.offset);
+        self.blocks_cover_all_paths_to_block(
+            entry,
+            reference_block,
+            &FxHashSet::from_iter([binding_block]),
+        )
+    }
+
     pub fn reaching_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
         let cfg = self.cfg();
         let context = self.model.dataflow_context(cfg);
@@ -7580,6 +7718,84 @@ printf '%s\\n' \"$foo\"
             .reaching_bindings_for_name(&target_reference.name, target_reference.span);
 
         assert_eq!(reaching, vec![foo_bindings[1]]);
+    }
+
+    #[test]
+    fn semantic_analysis_exposes_binding_and_reference_flow_blocks() {
+        let source = "\
+#!/bin/bash
+foo=1
+printf '%s\\n' \"$foo\"
+";
+        let model = model(source);
+        let binding = model
+            .bindings()
+            .iter()
+            .find(|binding| {
+                binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment)
+            })
+            .expect("expected foo binding");
+        let reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.name == "foo")
+            .expect("expected foo reference");
+        let analysis = model.analysis();
+
+        assert_eq!(
+            analysis.reference_id_for_name_at(&reference.name, reference.span),
+            Some(reference.id)
+        );
+        assert!(analysis.block_for_binding(binding.id).is_some());
+        assert!(analysis.block_for_reference_id(reference.id).is_some());
+        assert!(analysis.binding_dominates_reference_from_flow_entry(
+            binding.id,
+            &reference.name,
+            reference.span,
+            true
+        ));
+    }
+
+    #[test]
+    fn semantic_block_coverage_detects_uncovered_branch_paths() {
+        let source = "\
+#!/bin/bash
+if cond; then
+  foo=1
+fi
+printf '%s\\n' \"$foo\"
+";
+        let model = model(source);
+        let binding = model
+            .bindings()
+            .iter()
+            .find(|binding| {
+                binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment)
+            })
+            .expect("expected foo binding");
+        let reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.name == "foo")
+            .expect("expected foo reference");
+        let analysis = model.analysis();
+        let binding_block = analysis
+            .block_for_binding(binding.id)
+            .expect("expected binding block");
+        let reference_block = analysis
+            .block_for_reference_id(reference.id)
+            .expect("expected reference block");
+        let entry = analysis
+            .flow_entry_block_for_binding_scopes(&[binding.scope], reference.span.start.offset);
+        let cover_blocks = FxHashSet::from_iter([binding_block]);
+
+        assert!(!analysis.blocks_cover_all_paths_to_block(entry, reference_block, &cover_blocks));
+        assert!(!analysis.binding_dominates_reference_from_flow_entry(
+            binding.id,
+            &reference.name,
+            reference.span,
+            true
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Move reusable reference/block lookup and path-coverage helpers into `SemanticAnalysis`
- Replace `SafeValueIndex`'s local CFG/reference/block indexes with semantic-layer queries
- Cache unreachable CFG blocks in `SemanticAnalysis` so safe-value reachability walks keep O(1) membership checks
- Add semantic tests for straight-line dominance and uncovered branch path coverage

## Validation

- `cargo check -p shuck-linter`
- `cargo test -p shuck-semantic semantic_ -- --nocapture`
- `cargo test -p shuck-linter safe_value -- --nocapture`
- `git diff --check`

Prior validation on the original refactor before the unreachable-block cache follow-up:

- `cargo test -p shuck-linter unquoted_expansion -- --nocapture`
- `make test-large-corpus`

Prior large corpus summary: `blocking=0 warnings=23 fixtures=34593 unsupported_shells=887 implementation_diffs=0 mapping_issues=0 reviewed_divergences=23 harness_warnings=0 harness_failures=0`