### PR TITLE
perf(linter): collapse safe_value into S001

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -85,6 +85,8 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut structural_command_ids = Vec::with_capacity(capacity.structural_commands);
         let mut command_ids_by_span =
             CommandLookupIndex::with_capacity_and_hasher(capacity.commands, Default::default());
+        let mut command_ids_by_name_word_span =
+            FxHashMap::with_capacity_and_hasher(capacity.commands, Default::default());
         let mut command_parent_ids = Vec::with_capacity(capacity.commands);
         let mut command_child_ids_by_parent = Vec::<Vec<CommandId>>::with_capacity(capacity.commands);
         let mut active_parent_commands = Vec::<OpenParentCommand>::new();
@@ -199,6 +201,9 @@ impl<'a> LinterFactsBuilder<'a> {
                     command_start_offset,
                     &normalized,
                 );
+                if let Some(name_word) = normalized.body_name_word() {
+                    command_ids_by_name_word_span.insert(FactSpan::new(name_word.span), id);
+                }
                 let nested_word_command = context.nested_word_command;
                 if !nested_word_command {
                     structural_command_ids.push(id);
@@ -319,7 +324,10 @@ impl<'a> LinterFactsBuilder<'a> {
                 });
 
                 if let Command::Function(function) = visit.command {
-                    functions.push(function);
+                    functions.push(FunctionFactInput {
+                        command_id: id,
+                        function,
+                    });
                     if let Some(span) = function_body_without_braces_span(function) {
                         function_body_without_braces_spans.push(span);
                     }
@@ -466,6 +474,17 @@ impl<'a> LinterFactsBuilder<'a> {
             &function_headers,
             self.file,
             self.source,
+        );
+        let function_definition_command_ids_by_scope = function_headers
+            .iter()
+            .filter_map(|header| header.function_scope().map(|scope| (scope, header.command_id())))
+            .collect::<FxHashMap<_, _>>();
+        let case_cli_reachable_function_scopes = build_case_cli_reachable_function_scopes(
+            self.semantic,
+            &function_headers,
+            &function_cli_dispatch_facts,
+            &commands,
+            &command_parent_ids,
         );
         collect_condition_status_capture_from_sequences(
             &self.file.body,
@@ -778,6 +797,7 @@ impl<'a> LinterFactsBuilder<'a> {
             commands,
             structural_command_ids,
             command_ids_by_span,
+            command_ids_by_name_word_span,
             innermost_command_ids_by_offset,
             innermost_command_ids_by_binding_offset,
             command_parent_ids,
@@ -814,6 +834,8 @@ impl<'a> LinterFactsBuilder<'a> {
             brace_variable_before_bracket_spans,
             completion_registered_function_command_flags,
             function_headers,
+            function_definition_command_ids_by_scope,
+            case_cli_reachable_function_scopes,
             function_in_alias_spans,
             alias_definition_expansion_spans,
             function_body_without_braces_spans,

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -1,5 +1,6 @@
 #[derive(Debug, Clone)]
 pub struct FunctionHeaderFact<'a> {
+    command_id: CommandId,
     function: &'a FunctionDef,
     binding_id: Option<BindingId>,
     scope_id: Option<ScopeId>,
@@ -7,6 +8,10 @@ pub struct FunctionHeaderFact<'a> {
 }
 
 impl<'a> FunctionHeaderFact<'a> {
+    pub fn command_id(&self) -> CommandId {
+        self.command_id
+    }
+
     pub fn function(&self) -> &'a FunctionDef {
         self.function
     }
@@ -124,29 +129,46 @@ impl FunctionCliDispatchFacts {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FunctionFactInput<'a> {
+    command_id: CommandId,
+    function: &'a FunctionDef,
+}
+
 #[cfg_attr(shuck_profiling, inline(never))]
 fn build_function_header_facts<'a>(
     semantic: &SemanticModel,
-    functions: &[&'a FunctionDef],
+    functions: &[FunctionFactInput<'a>],
     commands: &[CommandFact<'a>],
     source: &str,
     command_offset_order: &CommandOffsetOrder,
 ) -> Vec<FunctionHeaderFact<'a>> {
-    let call_arity_by_binding =
-        build_function_call_arity_facts(semantic, functions, commands, source, command_offset_order);
+    let call_arity_by_binding = build_function_call_arity_facts(
+        semantic,
+        &functions
+            .iter()
+            .map(|input| input.function)
+            .collect::<Vec<_>>(),
+        commands,
+        source,
+        command_offset_order,
+    );
     functions
         .iter()
         .copied()
-        .map(|function| {
-            let binding_id = function_header_binding_id(semantic, function);
+        .map(|input| {
+            let binding_id = function_header_binding_id(semantic, input.function);
             let scope_id = binding_id
-                .and_then(|binding_id| function_header_scope_id(semantic, function, binding_id));
+                .and_then(|binding_id| {
+                    function_header_scope_id(semantic, input.function, binding_id)
+                });
             let call_arity = binding_id
                 .and_then(|binding_id| call_arity_by_binding.get(&binding_id).cloned())
                 .unwrap_or_default();
 
             FunctionHeaderFact {
-                function,
+                command_id: input.command_id,
+                function: input.function,
                 binding_id,
                 scope_id,
                 call_arity,
@@ -219,6 +241,64 @@ fn build_function_cli_dispatch_facts(
     facts
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
+fn build_case_cli_reachable_function_scopes(
+    semantic: &SemanticModel,
+    function_headers: &[FunctionHeaderFact<'_>],
+    function_cli_dispatch_facts: &FxHashMap<ScopeId, FunctionCliDispatchFacts>,
+    commands: &[CommandFact<'_>],
+    command_parent_ids: &[Option<CommandId>],
+) -> FxHashSet<ScopeId> {
+    let dispatcher_offset = function_headers
+        .iter()
+        .filter_map(|header| {
+            let scope = header.function_scope()?;
+            function_cli_dispatch_facts
+                .get(&scope)
+                .copied()
+                .unwrap_or_default()
+                .dispatcher_span()
+                .map(|span| span.start.offset)
+        })
+        .min();
+    let top_level_exit_offset = commands
+        .iter()
+        .filter(|command| {
+            command_parent_ids
+                .get(command.id().index())
+                .copied()
+                .flatten()
+                .is_none()
+                && semantic
+                    .ancestor_scopes(command.scope())
+                    .all(|scope| {
+                        !matches!(semantic.scope(scope).kind, shuck_semantic::ScopeKind::Function(_))
+                    })
+                && command_fact_is_standalone_exit(command)
+        })
+        .map(|command| command.span().start.offset)
+        .min();
+
+    function_headers
+        .iter()
+        .filter_map(|header| {
+            let scope = header.function_scope()?;
+            let nested = semantic
+                .ancestor_scopes(scope)
+                .skip(1)
+                .any(|ancestor| {
+                    matches!(semantic.scope(ancestor).kind, shuck_semantic::ScopeKind::Function(_))
+                });
+            (nested
+                || dispatcher_offset
+                    .is_some_and(|offset| header.function().span.start.offset < offset)
+                || top_level_exit_offset
+                    .is_some_and(|offset| header.function().span.start.offset < offset))
+            .then_some(scope)
+        })
+        .collect()
+}
+
 fn stmt_is_top_level_exit(stmt: &Stmt) -> bool {
     if stmt.negated || matches!(stmt.terminator, Some(StmtTerminator::Background(_))) {
         return false;
@@ -235,6 +315,22 @@ fn stmt_is_top_level_exit(stmt: &Stmt) -> bool {
     }
 
     true
+}
+
+fn command_fact_is_standalone_exit(command: &CommandFact<'_>) -> bool {
+    if command.stmt().negated
+        || matches!(
+            command.stmt().terminator,
+            Some(StmtTerminator::Background(_))
+        )
+    {
+        return false;
+    }
+
+    let Command::Builtin(BuiltinCommand::Exit(exit)) = command.command() else {
+        return false;
+    };
+    exit.extra_args.is_empty() && exit.assignments.is_empty() && command.stmt().redirects.is_empty()
 }
 
 fn build_function_parameter_fallback_spans(

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -4,6 +4,7 @@ pub struct LinterFacts<'a> {
     structural_command_ids: Vec<CommandId>,
     #[cfg_attr(not(test), allow(dead_code))]
     command_ids_by_span: CommandLookupIndex,
+    command_ids_by_name_word_span: FxHashMap<FactSpan, CommandId>,
     innermost_command_ids_by_offset: CommandOffsetLookup,
     innermost_command_ids_by_binding_offset: CommandOffsetLookup,
     command_parent_ids: Vec<Option<CommandId>>,
@@ -39,6 +40,8 @@ pub struct LinterFacts<'a> {
     brace_variable_before_bracket_spans: Vec<Span>,
     completion_registered_function_command_flags: Vec<bool>,
     function_headers: Vec<FunctionHeaderFact<'a>>,
+    function_definition_command_ids_by_scope: FxHashMap<ScopeId, CommandId>,
+    case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
     function_in_alias_spans: Vec<Span>,
     alias_definition_expansion_spans: Vec<Span>,
     function_body_without_braces_spans: Vec<Span>,
@@ -254,6 +257,14 @@ impl<'a> LinterFacts<'a> {
         CommandFactRef::new(&self.commands[id.index()], &self.fact_store)
     }
 
+    pub fn command_for_name_word_span(&self, span: Span) -> Option<CommandFactRef<'_, 'a>> {
+        self.command_ids_by_name_word_span
+            .get(&FactSpan::new(span))
+            .copied()
+            .or_else(|| self.command_id_for_exact_span(span))
+            .map(|id| self.command(id))
+    }
+
     pub fn innermost_command_at(&self, offset: usize) -> Option<CommandFactRef<'_, 'a>> {
         self.innermost_command_id_at(offset)
             .map(|id| self.command(id))
@@ -280,6 +291,17 @@ impl<'a> LinterFacts<'a> {
             .map(|parent_id| self.command(parent_id))
     }
 
+    pub fn function_definition_command(&self, scope: ScopeId) -> Option<CommandFactRef<'_, 'a>> {
+        self.function_definition_command_ids_by_scope
+            .get(&scope)
+            .copied()
+            .map(|id| self.command(id))
+    }
+
+    pub fn is_case_cli_reachable_function_scope(&self, scope: ScopeId) -> bool {
+        self.case_cli_reachable_function_scopes.contains(&scope)
+    }
+
     pub fn command_is_dominance_barrier(&self, id: CommandId) -> bool {
         self.command_dominance_barrier_flags
             .get(id.index())
@@ -295,6 +317,16 @@ impl<'a> LinterFacts<'a> {
     #[cfg_attr(not(test), allow(dead_code))]
     fn command_id_for_command(&self, command: &Command) -> Option<CommandId> {
         command_id_for_command(command, &self.command_ids_by_span)
+    }
+
+    fn command_id_for_exact_span(&self, span: Span) -> Option<CommandId> {
+        let mut current = self.innermost_command_id_at(span.start.offset)?;
+        loop {
+            if self.command(current).span() == span {
+                return Some(current);
+            }
+            current = self.command_parent_id(current)?;
+        }
     }
 
     pub fn binding_value(&self, binding_id: BindingId) -> Option<&BindingValueFact<'a>> {

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -1,4 +1,5 @@
 use super::*;
+use shuck_ast::Command;
 
 #[test]
 fn function_header_fact_span_in_source_stops_at_header() {
@@ -41,6 +42,64 @@ fn function_header_fact_tracks_binding_scope_and_call_arity() {
         assert_eq!(
             header.call_arity().zero_arg_call_spans()[0].slice(source),
             "greet"
+        );
+    });
+}
+
+#[test]
+fn function_definition_command_lookup_returns_header_command() {
+    let source = "#!/bin/sh\ngreet() { echo hi; }\n";
+
+    with_facts(source, None, |_, facts| {
+        let header = facts
+            .function_headers()
+            .iter()
+            .find(|header| {
+                header
+                    .static_name_entry()
+                    .is_some_and(|(name, _)| name == "greet")
+            })
+            .expect("expected greet header fact");
+        let scope = header
+            .function_scope()
+            .expect("expected greet function scope");
+        let definition_command = facts
+            .function_definition_command(scope)
+            .expect("expected definition command");
+
+        assert_eq!(definition_command.id(), header.command_id());
+        assert!(matches!(definition_command.command(), Command::Function(_)));
+    });
+}
+
+#[test]
+fn command_for_name_word_span_resolves_definition_and_call_commands() {
+    let source = "#!/bin/sh\ngreet() { echo hi; }\ngreet\n";
+
+    with_facts(source, None, |_, facts| {
+        let header = facts
+            .function_headers()
+            .iter()
+            .find(|header| {
+                header
+                    .static_name_entry()
+                    .is_some_and(|(name, _)| name == "greet")
+            })
+            .expect("expected greet header fact");
+        let definition_command = facts.command(header.command_id());
+        let call_name_span = header.call_arity().zero_arg_call_spans()[0];
+
+        assert_eq!(
+            facts
+                .command_for_name_word_span(definition_command.span())
+                .map(|command| command.id()),
+            Some(header.command_id())
+        );
+        assert_eq!(
+            facts
+                .command_for_name_word_span(call_name_span)
+                .and_then(|command| command.body_name_word().map(|word| word.span.slice(source))),
+            Some("greet")
         );
     });
 }
@@ -238,6 +297,47 @@ exit $?
                 if name == "start" { "$1" } else { "\"$1\"" }
             );
         }
+    });
+}
+
+#[test]
+fn case_cli_reachable_function_scopes_track_dispatchable_functions() {
+    let source = "\
+#!/bin/sh
+start() { echo hi; }
+case \"$1\" in
+  start) \"$1\" ;;
+esac
+exit $?
+late() { echo later; }
+";
+
+    with_facts(source, None, |_, facts| {
+        let start = facts
+            .function_headers()
+            .iter()
+            .find(|header| {
+                header
+                    .static_name_entry()
+                    .is_some_and(|(name, _)| name == "start")
+            })
+            .expect("expected start header fact");
+        let late = facts
+            .function_headers()
+            .iter()
+            .find(|header| {
+                header
+                    .static_name_entry()
+                    .is_some_and(|(name, _)| name == "late")
+            })
+            .expect("expected late header fact");
+
+        assert!(facts.is_case_cli_reachable_function_scope(
+            start.function_scope().expect("expected start scope")
+        ));
+        assert!(!facts.is_case_cli_reachable_function_scope(
+            late.function_scope().expect("expected late scope")
+        ));
     });
 }
 

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -88,8 +88,6 @@ pub use rule_selector::{RuleSelector, SelectorParseError};
 /// Sets of enabled or disabled rules.
 pub use rule_set::RuleSet;
 #[allow(unused_imports)]
-pub(crate) use rules::common::safe_value::{S001QuoteExposure, SafeValueIndex, SafeValueQuery};
-#[allow(unused_imports)]
 pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 /// Linter configuration and per-file ignore types.
 pub use settings::{

--- a/crates/shuck-linter/src/rules/common/mod.rs
+++ b/crates/shuck-linter/src/rules/common/mod.rs
@@ -1,2 +1,1 @@
-pub mod safe_value;
 pub mod word;

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -1,9 +1,11 @@
+mod safe_value;
+
 use rustc_hash::FxHashSet;
 use shuck_ast::Span;
 
+use self::safe_value::{S001QuoteExposure, SafeValueIndex, SafeValueQuery};
 use crate::{
-    Checker, ExpansionContext, FactSpan, Rule, S001QuoteExposure, SafeValueIndex, SafeValueQuery,
-    ShellDialect, Violation, WordOccurrenceRef,
+    Checker, ExpansionContext, FactSpan, Rule, ShellDialect, Violation, WordOccurrenceRef,
 };
 
 pub struct UnquotedExpansion;

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -94,11 +94,6 @@ pub struct SafeValueIndex<'a> {
     analysis: &'a SemanticAnalysis<'a>,
     facts: &'a LinterFacts<'a>,
     source: &'a str,
-    case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
-    definite_uninitialized_refs: FxHashSet<FactSpan>,
-    maybe_uninitialized_refs: FxHashSet<FactSpan>,
-    function_commands_by_span: FxHashMap<FactSpan, crate::facts::CommandId>,
-    commands_by_name_word_span: FxHashMap<FactSpan, crate::facts::CommandId>,
     command_cover_memo: RefCell<FxHashMap<(crate::facts::CommandId, Name, FactSpan), bool>>,
     memo: FxHashMap<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>), bool>,
     visiting: FxHashSet<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>)>,
@@ -106,6 +101,8 @@ pub struct SafeValueIndex<'a> {
     helper_binding_memo: FxHashMap<(Name, ScopeId, FactSpan), Box<[BindingId]>>,
     helper_binding_visiting: FxHashSet<(Name, ScopeId, FactSpan)>,
     s001_unset_before_call_memo: FxHashMap<ScopeId, bool>,
+    #[cfg(test)]
+    uninitialized_reference_overrides: FxHashMap<FactSpan, UninitializedCertainty>,
 }
 
 impl<'a> SafeValueIndex<'a> {
@@ -115,40 +112,11 @@ impl<'a> SafeValueIndex<'a> {
         facts: &'a LinterFacts<'a>,
         source: &'a str,
     ) -> Self {
-        let definite_uninitialized_refs = analysis
-            .uninitialized_references()
-            .iter()
-            .filter(|uninitialized| uninitialized.certainty == UninitializedCertainty::Definite)
-            .map(|uninitialized| FactSpan::new(semantic.reference(uninitialized.reference).span))
-            .collect();
-        let maybe_uninitialized_refs = analysis
-            .uninitialized_references()
-            .iter()
-            .filter(|uninitialized| uninitialized.certainty == UninitializedCertainty::Possible)
-            .map(|uninitialized| FactSpan::new(semantic.reference(uninitialized.reference).span))
-            .collect();
-        let case_cli_reachable_function_scopes =
-            build_case_cli_reachable_function_scopes(semantic, facts);
-        let mut function_commands_by_span = FxHashMap::default();
-        let mut commands_by_name_word_span = FxHashMap::default();
-        for command in facts.commands() {
-            if let Command::Function(function) = command.command() {
-                function_commands_by_span.insert(FactSpan::new(function.span), command.id());
-            }
-            if let Some(name_word) = command.body_name_word() {
-                commands_by_name_word_span.insert(FactSpan::new(name_word.span), command.id());
-            }
-        }
         Self {
             semantic,
             analysis,
             facts,
             source,
-            case_cli_reachable_function_scopes,
-            definite_uninitialized_refs,
-            maybe_uninitialized_refs,
-            function_commands_by_span,
-            commands_by_name_word_span,
             command_cover_memo: RefCell::new(FxHashMap::default()),
             memo: FxHashMap::default(),
             visiting: FxHashSet::default(),
@@ -156,6 +124,8 @@ impl<'a> SafeValueIndex<'a> {
             helper_binding_memo: FxHashMap::default(),
             helper_binding_visiting: FxHashSet::default(),
             s001_unset_before_call_memo: FxHashMap::default(),
+            #[cfg(test)]
+            uninitialized_reference_overrides: FxHashMap::default(),
         }
     }
 
@@ -245,6 +215,30 @@ impl<'a> SafeValueIndex<'a> {
             .all(|(part, span)| self.part_is_safe(part, span, query))
     }
 
+    fn uninitialized_reference_certainty_at(&self, span: Span) -> Option<UninitializedCertainty> {
+        #[cfg(test)]
+        if let Some(certainty) = self
+            .uninitialized_reference_overrides
+            .get(&FactSpan::new(span))
+            .copied()
+        {
+            return Some(certainty);
+        }
+
+        self.analysis.uninitialized_reference_certainty_at(span)
+    }
+
+    #[cfg(test)]
+    fn override_uninitialized_reference_certainty(
+        &mut self,
+        span: Span,
+        certainty: UninitializedCertainty,
+    ) {
+        self.uninitialized_reference_overrides
+            .insert(FactSpan::new(span), certainty);
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn word_occurrence_is_safe(
         &mut self,
         fact: crate::WordOccurrenceRef<'_, 'a>,
@@ -549,17 +543,6 @@ impl<'a> SafeValueIndex<'a> {
         false
     }
 
-    fn span_is_inside_command_substitution_scope(&self, span: Span) -> bool {
-        self.semantic
-            .ancestor_scopes(self.semantic.scope_at(span.start.offset))
-            .any(|scope| {
-                matches!(
-                    self.semantic.scope(scope).kind,
-                    ScopeKind::CommandSubstitution
-                )
-            })
-    }
-
     fn literal_part_is_safe(&self, part: &WordPart, span: Span, query: SafeValueQuery) -> bool {
         let word = Word {
             parts: vec![WordPartNode::new(part.clone(), span)],
@@ -788,31 +771,32 @@ impl<'a> SafeValueIndex<'a> {
         if !outer_bindings_cover_callers && !direct_bindings_cover_all_paths {
             return false;
         }
-        if self
-            .definite_uninitialized_refs
-            .contains(&FactSpan::new(at))
-        {
-            if bindings.iter().copied().any(|binding_id| {
-                !helper_bindings.contains(&binding_id)
-                    && self.binding_is_guarded_before_reference(binding_id, at)
-            }) {
-                return false;
+        match self.uninitialized_reference_certainty_at(at) {
+            Some(UninitializedCertainty::Definite) => {
+                if bindings.iter().copied().any(|binding_id| {
+                    !helper_bindings.contains(&binding_id)
+                        && self.binding_is_guarded_before_reference(binding_id, at)
+                }) {
+                    return false;
+                }
             }
-        } else if self.maybe_uninitialized_refs.contains(&FactSpan::new(at)) {
-            let has_dominating_binding = bindings
-                .iter()
-                .copied()
-                .any(|binding_id| self.binding_dominates_reference(binding_id, name, at));
-            if !has_dominating_binding
-                && !bindings_cover_all_paths
-                && !unset_covers_reference
-                && !bindings
+            Some(UninitializedCertainty::Possible) => {
+                let has_dominating_binding = bindings
                     .iter()
                     .copied()
-                    .all(|binding_id| helper_bindings.contains(&binding_id))
-            {
-                return false;
+                    .any(|binding_id| self.binding_dominates_reference(binding_id, name, at));
+                if !has_dominating_binding
+                    && !bindings_cover_all_paths
+                    && !unset_covers_reference
+                    && !bindings
+                        .iter()
+                        .copied()
+                        .all(|binding_id| helper_bindings.contains(&binding_id))
+                {
+                    return false;
+                }
             }
+            None => {}
         }
 
         bindings
@@ -885,14 +869,10 @@ impl<'a> SafeValueIndex<'a> {
             })
     }
 
-    pub fn in_case_cli_dispatch_entrypoint(&self, offset: usize) -> bool {
-        self.case_cli_dispatch_scope_at(offset).is_some()
-    }
-
     fn case_cli_reachable_function_scope_at(&self, offset: usize) -> Option<ScopeId> {
-        let scope = self.enclosing_function_scope_at(offset)?;
-        self.case_cli_reachable_function_scopes
-            .contains(&scope)
+        let scope = self.analysis.enclosing_function_scope_at(offset)?;
+        self.facts
+            .is_case_cli_reachable_function_scope(scope)
             .then_some(scope)
     }
 
@@ -1015,11 +995,6 @@ impl<'a> SafeValueIndex<'a> {
     ) -> bool {
         let binding = self.semantic.binding(binding_id);
         self.facts.function_headers().iter().any(|header| {
-            let Some(function_definition_command) =
-                self.function_definition_command(header.function())
-            else {
-                return false;
-            };
             function_has_terminal_exit(header.function())
                 && header
                     .call_arity()
@@ -1033,7 +1008,7 @@ impl<'a> SafeValueIndex<'a> {
                             && {
                                 let call_span = command.span_in_source(self.source);
                                 self.definition_command_resolves_at_call(
-                                    function_definition_command.id(),
+                                    header.command_id(),
                                     call_span,
                                 ) && call_span.end.offset <= at.start.offset
                                     && (call_span.start.offset >= binding.span.end.offset
@@ -1053,16 +1028,6 @@ impl<'a> SafeValueIndex<'a> {
                     Command::Builtin(BuiltinCommand::Exit(_) | BuiltinCommand::Return(_))
                 )
         })
-    }
-
-    fn function_definition_command(
-        &self,
-        function: &FunctionDef,
-    ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
-        self.function_commands_by_span
-            .get(&FactSpan::new(function.span))
-            .copied()
-            .map(|id| self.facts.command(id))
     }
 
     fn definition_command_is_visible_at_call(
@@ -1114,21 +1079,14 @@ impl<'a> SafeValueIndex<'a> {
         &self,
         span: Span,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
-        self.commands_by_name_word_span
-            .get(&FactSpan::new(span))
-            .copied()
-            .map(|id| self.facts.command(id))
+        self.facts.command_for_name_word_span(span)
     }
 
     fn function_definition_command_for_scope(
         &self,
         scope: ScopeId,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
-        self.facts
-            .function_headers()
-            .iter()
-            .find(|header| header.function_scope() == Some(scope))
-            .and_then(|header| self.function_definition_command(header.function()))
+        self.facts.function_definition_command(scope)
     }
 
     fn s001_reference_function_unset_before_first_call(&mut self, at: Span) -> bool {
@@ -2419,8 +2377,8 @@ impl<'a> SafeValueIndex<'a> {
             return Vec::new();
         };
         if self
-            .case_cli_reachable_function_scopes
-            .contains(&helper_scope)
+            .facts
+            .is_case_cli_reachable_function_scope(helper_scope)
             || !self.named_function_call_sites(helper_scope).is_empty()
         {
             return Vec::new();
@@ -3247,7 +3205,7 @@ impl<'a> SafeValueIndex<'a> {
             let Some(function_kind) = self.named_function_kind(callee_scope) else {
                 continue;
             };
-            let Some(definition_command) = self.function_definition_command(header.function())
+            let Some(definition_command) = self.facts.function_definition_command(callee_scope)
             else {
                 continue;
             };
@@ -4125,15 +4083,6 @@ fn span_contains(container: Span, inner: Span) -> bool {
     container.start.offset <= inner.start.offset && inner.end.offset <= container.end.offset
 }
 
-fn shell_name_is_plain_scalar(text: &str) -> bool {
-    let mut chars = text.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    (first == '_' || first.is_ascii_alphabetic())
-        && chars.all(|character| character == '_' || character.is_ascii_alphanumeric())
-}
-
 fn shell_name_is_uppercase_setup_value(text: &str) -> bool {
     let mut saw_uppercase = false;
     for character in text.chars() {
@@ -4155,69 +4104,6 @@ fn literal_is_setup_atom(text: &str) -> bool {
         && text
             .bytes()
             .all(|byte| byte == b'_' || byte.is_ascii_uppercase() || byte.is_ascii_digit())
-}
-
-fn build_case_cli_reachable_function_scopes(
-    semantic: &SemanticModel,
-    facts: &LinterFacts<'_>,
-) -> FxHashSet<ScopeId> {
-    let dispatcher_offset = facts
-        .function_headers()
-        .iter()
-        .filter_map(|header| {
-            let scope = header.function_scope()?;
-            facts
-                .function_cli_dispatch_facts(scope)
-                .dispatcher_span()
-                .map(|span| span.start.offset)
-        })
-        .min();
-    let top_level_exit_offset = facts
-        .commands()
-        .iter()
-        .filter(|command| {
-            facts.command_parent_id(command.id()).is_none()
-                && semantic
-                    .ancestor_scopes(semantic.scope_at(command.span().start.offset))
-                    .all(|scope| !matches!(semantic.scope(scope).kind, ScopeKind::Function(_)))
-                && command_fact_is_standalone_exit(*command)
-        })
-        .map(|command| command.span().start.offset)
-        .min();
-
-    facts
-        .function_headers()
-        .iter()
-        .filter_map(|header| {
-            let scope = header.function_scope()?;
-            let nested = semantic
-                .ancestor_scopes(scope)
-                .skip(1)
-                .any(|ancestor| matches!(semantic.scope(ancestor).kind, ScopeKind::Function(_)));
-            (nested
-                || dispatcher_offset
-                    .is_some_and(|offset| header.function().span.start.offset < offset)
-                || top_level_exit_offset
-                    .is_some_and(|offset| header.function().span.start.offset < offset))
-            .then_some(scope)
-        })
-        .collect()
-}
-
-fn command_fact_is_standalone_exit(command: crate::facts::CommandFactRef<'_, '_>) -> bool {
-    if command.stmt().negated
-        || matches!(
-            command.stmt().terminator,
-            Some(StmtTerminator::Background(_))
-        )
-    {
-        return false;
-    }
-
-    let Command::Builtin(BuiltinCommand::Exit(exit)) = command.command() else {
-        return false;
-    };
-    exit.extra_args.is_empty() && exit.assignments.is_empty() && command.stmt().redirects.is_empty()
 }
 
 fn safe_special_parameter(name: &Name) -> bool {
@@ -4474,12 +4360,6 @@ fn alternative_terminal_flow_kind(
     TerminalFlowKind::None
 }
 
-fn span_strictly_contains(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset
-        && outer.end.offset >= inner.end.offset
-        && outer != inner
-}
-
 #[cfg(test)]
 mod tests {
     use shuck_ast::{Command, Name, RedirectKind};
@@ -4487,7 +4367,7 @@ mod tests {
     use shuck_parser::parser::Parser;
     use shuck_semantic::{
         BindingOrigin, ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind,
-        SemanticBuildOptions, SemanticModel,
+        SemanticBuildOptions, SemanticModel, UninitializedCertainty,
     };
 
     use super::{SafeValueIndex, SafeValueQuery, function_has_terminal_exit};
@@ -6504,9 +6384,10 @@ fi
             "expected exhaustive branch ladder to cover all paths"
         );
 
-        safe_values
-            .maybe_uninitialized_refs
-            .insert(crate::FactSpan::new(part_span));
+        safe_values.override_uninitialized_reference_certainty(
+            part_span,
+            UninitializedCertainty::Possible,
+        );
 
         assert!(safe_values.part_is_safe(part, part_span, SafeValueQuery::Argv));
     }

--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -14,6 +14,7 @@ impl<'model> SemanticAnalysis<'model> {
             unused_assignments: OnceLock::new(),
             unused_assignments_shellcheck_compat: OnceLock::new(),
             uninitialized_references: OnceLock::new(),
+            uninitialized_reference_certainties: OnceLock::new(),
             dead_code: OnceLock::new(),
             unreachable_blocks: OnceLock::new(),
             overwritten_functions: OnceLock::new(),

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -489,6 +489,7 @@ pub struct SemanticAnalysis<'model> {
     unused_assignments: OnceLock<Vec<BindingId>>,
     unused_assignments_shellcheck_compat: OnceLock<Vec<BindingId>>,
     uninitialized_references: OnceLock<Vec<UninitializedReference>>,
+    uninitialized_reference_certainties: OnceLock<FxHashMap<SpanKey, UninitializedCertainty>>,
     dead_code: OnceLock<Vec<DeadCode>>,
     unreachable_blocks: OnceLock<FxHashSet<BlockId>>,
     overwritten_functions: OnceLock<Vec<OverwrittenFunction>>,

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -7841,6 +7841,38 @@ load_value
 }
 
 #[test]
+fn uninitialized_reference_certainty_lookup_matches_analysis_results() {
+    let source = "\
+#!/bin/bash
+echo \"$definite\"
+case \"$1\" in
+  yes)
+    possible=1
+    ;;
+esac
+echo \"$possible\"
+";
+    let model = model(source);
+    let analysis = model.analysis();
+    let references = analysis.uninitialized_references().to_vec();
+
+    assert!(
+        !references.is_empty(),
+        "expected representative uninitialized references"
+    );
+
+    for uninitialized in references {
+        let reference = model.reference(uninitialized.reference);
+        assert_eq!(
+            analysis.uninitialized_reference_certainty_at(reference.span),
+            Some(uninitialized.certainty),
+            "certainty lookup should match analysis results for {}",
+            reference.name
+        );
+    }
+}
+
+#[test]
 fn recorded_program_and_cfg_capture_non_arithmetic_var_ref_nested_regions() {
     let source = "\
 [[ -v assoc[\"$(printf inner)\"] ]]

--- a/crates/shuck-semantic/src/uninitialized.rs
+++ b/crates/shuck-semantic/src/uninitialized.rs
@@ -14,6 +14,31 @@ impl<'model> SemanticAnalysis<'model> {
             .as_slice()
     }
 
+    /// Returns the cached uninitialized-reference certainty for the reference at `span`.
+    #[doc(hidden)]
+    pub fn uninitialized_reference_certainty_at(
+        &self,
+        span: Span,
+    ) -> Option<UninitializedCertainty> {
+        self.uninitialized_reference_certainties()
+            .get(&SpanKey::new(span))
+            .copied()
+    }
+
+    fn uninitialized_reference_certainties(&self) -> &FxHashMap<SpanKey, UninitializedCertainty> {
+        self.uninitialized_reference_certainties.get_or_init(|| {
+            self.uninitialized_references()
+                .iter()
+                .map(|uninitialized| {
+                    (
+                        SpanKey::new(self.model.reference(uninitialized.reference).span),
+                        uninitialized.certainty,
+                    )
+                })
+                .collect()
+        })
+    }
+
     pub(crate) fn reference_for_name_at(&self, name: &Name, at: Span) -> Option<&Reference> {
         let references = self.model.reference_index.get(name)?;
         let first_candidate = references.partition_point(|reference_id| {


### PR DESCRIPTION
## Summary
- collapse `safe_value` into the S001 `unquoted_expansion` rule and remove the shared `rules/common` layer
- move command/function/case-dispatch structural lookups into linter facts and move cached uninitialized-reference certainty lookup into semantic
- keep S001 behavior stable while removing the extra `SafeValueIndex` build-time traversal

## Why
`safe_value` was rebuilding indexes over commands and uninitialized references while constructing the S001 evaluator. This change pushes shared analysis down into facts and semantic, keeps rule-specific policy in S001, and avoids the extra traversal on the hot path.

## Validation
- `cargo test -p shuck-linter unquoted_expansion`
- `cargo test -p shuck-semantic`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001`

## Notes
- large corpus finished with `implementation_diffs=0` and `mapping_issues=0`
- the existing `reviewed_divergences=23` residuals were unchanged
