### PR TITLE
perf(linter): index function call sites via semantic call graph

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1257,7 +1257,7 @@ fn build_nonpersistent_assignment_spans(
     commands: &[CommandFact<'_>],
     source: &str,
     suppress_bash_pipefail_pipeline_side_effects: bool,
-    require_source_ordered_command_lookup: bool,
+    command_offset_order: &CommandOffsetOrder,
 ) -> NonpersistentAssignmentSpans {
     let scope_spans_by_id = semantic
         .scopes()
@@ -1374,7 +1374,7 @@ fn build_nonpersistent_assignment_spans(
     let innermost_command_ids_by_offset = build_innermost_command_ids_by_offset(
         commands,
         command_id_query_offsets,
-        require_source_ordered_command_lookup,
+        command_offset_order,
     );
     let persistent_reset_offsets_by_name: FxHashMap<Name, Vec<PersistentReset>> =
         persistent_reset_offsets_by_name
@@ -1907,7 +1907,7 @@ fn escaped_braced_parameter_names(text: &str) -> Vec<String> {
 fn build_innermost_command_ids_by_offset(
     commands: &[CommandFact<'_>],
     mut offsets: Vec<usize>,
-    require_source_order: bool,
+    command_order: &CommandOffsetOrder,
 ) -> CommandOffsetLookup {
     if offsets.is_empty() {
         return CommandOffsetLookup::default();
@@ -1916,7 +1916,6 @@ fn build_innermost_command_ids_by_offset(
     offsets.sort_unstable();
     offsets.dedup();
 
-    let command_order = command_offset_order(commands, require_source_order);
     let mut entries = Vec::with_capacity(offsets.len());
     let mut active_commands = Vec::new();
     let mut next_command = 0;
@@ -1948,7 +1947,7 @@ fn build_innermost_command_ids_by_offset(
     CommandOffsetLookup { entries }
 }
 
-enum CommandOffsetOrder {
+pub(crate) enum CommandOffsetOrder {
     SourceOrdered,
     Sorted(Vec<CommandId>),
 }
@@ -1968,7 +1967,11 @@ impl CommandOffsetOrder {
     }
 }
 
-fn command_offset_order(commands: &[CommandFact<'_>], require_source_order: bool) -> CommandOffsetOrder {
+#[cfg_attr(shuck_profiling, inline(never))]
+fn build_command_offset_order(
+    commands: &[CommandFact<'_>],
+    require_source_order: bool,
+) -> CommandOffsetOrder {
     if !require_source_order {
         return CommandOffsetOrder::SourceOrdered;
     }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -421,6 +421,8 @@ impl<'a> LinterFactsBuilder<'a> {
         fact_store.word_spans = word_spans;
 
         let command_facts_require_source_order = !command_facts_are_source_ordered(&commands);
+        let command_offset_order =
+            build_command_offset_order(&commands, command_facts_require_source_order);
         let (command_parent_ids, command_child_index) = if !command_facts_require_source_order {
             (
                 command_parent_ids,
@@ -452,8 +454,13 @@ impl<'a> LinterFactsBuilder<'a> {
 
         let presence_tested_names =
             build_presence_tested_names(&commands, self.source, self.semantic);
-        let function_headers =
-            build_function_header_facts(self.semantic, &functions, &commands, self.source);
+        let function_headers = build_function_header_facts(
+            self.semantic,
+            &functions,
+            &commands,
+            self.source,
+            &command_offset_order,
+        );
         let function_cli_dispatch_facts = build_function_cli_dispatch_facts(
             self.semantic,
             &function_headers,
@@ -563,7 +570,7 @@ impl<'a> LinterFactsBuilder<'a> {
             &commands,
             self.source,
             matches!(self.shell, ShellDialect::Bash) && pipefail_enabled_anywhere,
-            command_facts_require_source_order,
+            &command_offset_order,
         );
         let heredoc_summary =
             build_heredoc_fact_summary(&commands, self.source, self.file.span.end.offset);
@@ -719,7 +726,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 .iter()
                 .map(|command| command.span().start.offset)
                 .collect(),
-            command_facts_require_source_order,
+            &command_offset_order,
         );
         let innermost_command_ids_by_binding_offset = build_innermost_command_ids_by_offset(
             &commands,
@@ -728,7 +735,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 .iter()
                 .map(|binding| binding.span.start.offset)
                 .collect(),
-            command_facts_require_source_order,
+            &command_offset_order,
         );
         let command_dominance_barrier_flags = build_command_dominance_barrier_flags(&commands);
         let c006_suppressing_reference_offsets_by_name =

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -130,9 +130,10 @@ fn build_function_header_facts<'a>(
     functions: &[&'a FunctionDef],
     commands: &[CommandFact<'a>],
     source: &str,
+    command_offset_order: &CommandOffsetOrder,
 ) -> Vec<FunctionHeaderFact<'a>> {
     let call_arity_by_binding =
-        build_function_call_arity_facts(semantic, functions, commands, source);
+        build_function_call_arity_facts(semantic, functions, commands, source, command_offset_order);
     functions
         .iter()
         .copied()
@@ -423,19 +424,44 @@ fn build_function_call_arity_facts<'a>(
     functions: &[&FunctionDef],
     commands: &[CommandFact<'a>],
     source: &str,
+    command_offset_order: &CommandOffsetOrder,
 ) -> FxHashMap<BindingId, FunctionCallArityFacts> {
     let mut facts = FxHashMap::<BindingId, FunctionCallArityFacts>::default();
     let mut seen_names = FxHashSet::default();
-
+    let mut unique_function_names: Vec<&Name> = Vec::with_capacity(functions.len());
     for function in functions {
         let Some((name, _)) = function.static_name_entries().next() else {
             continue;
         };
-        if !seen_names.insert(name.clone()) {
-            continue;
+        if seen_names.insert(name.clone()) {
+            unique_function_names.push(name);
         }
+    }
+    if unique_function_names.is_empty() {
+        return facts;
+    }
 
-        for command in commands {
+    let mut offsets = Vec::new();
+    for name in &unique_function_names {
+        for site in semantic.call_sites_for(name) {
+            offsets.push(site.name_span.start.offset);
+        }
+    }
+    if offsets.is_empty() {
+        return facts;
+    }
+
+    let command_ids_by_offset =
+        build_innermost_command_ids_by_offset(commands, offsets, command_offset_order);
+
+    for name in unique_function_names {
+        for site in semantic.call_sites_for(name) {
+            let Some(command_id) =
+                precomputed_command_id_for_offset(&command_ids_by_offset, site.name_span.start.offset)
+            else {
+                continue;
+            };
+            let command = command_fact(commands, command_id);
             if !command.wrappers().is_empty()
                 || command.effective_or_literal_name() != Some(name.as_str())
             {

--- a/crates/shuck-linter/src/facts/tests/flow.rs
+++ b/crates/shuck-linter/src/facts/tests/flow.rs
@@ -205,7 +205,7 @@ fn precomputes_innermost_command_ids_for_nested_offsets() {
             source.find("printf").expect("expected printf offset"),
             source.find("uname").expect("expected uname offset"),
         ],
-        false,
+        &super::CommandOffsetOrder::SourceOrdered,
     );
 
     assert_eq!(

--- a/crates/shuck-linter/src/facts/tests/mod.rs
+++ b/crates/shuck-linter/src/facts/tests/mod.rs
@@ -8,10 +8,10 @@ use std::path::Path;
 
 #[allow(unused_imports)]
 use super::{
-    CommandId, ConditionalNodeFact, ConditionalOperatorFamily, ExpansionContext,
-    ExprStringHelperKind, GrepPatternSourceKind, ListFact, ListSegmentKind, MixedShortCircuitKind,
-    SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax, SubstitutionHostKind,
-    SubstitutionOutputIntent, SudoFamilyInvoker, WordFactHostKind,
+    CommandId, CommandOffsetOrder, ConditionalNodeFact, ConditionalOperatorFamily,
+    ExpansionContext, ExprStringHelperKind, GrepPatternSourceKind, ListFact, ListSegmentKind,
+    MixedShortCircuitKind, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax,
+    SubstitutionHostKind, SubstitutionOutputIntent, SudoFamilyInvoker, WordFactHostKind,
     build_innermost_command_ids_by_offset, precomputed_command_id_for_offset,
 };
 use crate::WrapperKind;


### PR DESCRIPTION
## Summary

- Replaces the O(F × C) scan in `build_function_call_arity_facts` with a single `CommandOffsetLookup` keyed on the offsets that `semantic.call_sites_for` already exposes, so we visit each call site once instead of revisiting every command for every unique function name.
- Hoists the command-order sort out of `build_innermost_command_ids_by_offset` into `LinterFactsBuilder::build`. The three call sites (function call arity, command-offset index, binding-offset index, nonpersistent-assignment lookup) now share one sorted vector instead of independently re-sorting the same commands.

## Impact (xwmx/nb fixture, 12 iters, warm)

- Wall time: 259 ms → 234 ms (~9.6%)
- `build_function_header_facts` within facts builder: 5.1% → 0.7%
- `build_innermost_command_ids_by_offset` (lookup) + `build_command_offset_order` (hoisted sort) combined: 3.2% → 1.7%

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo test -p shuck-linter`
- [ ] Large-corpus comparison (`make test-large-corpus`)