### PR TITLE
perf(linter): speed up local-cross-reference rule

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
+++ b/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
@@ -1,6 +1,7 @@
 use rustc_hash::FxHashMap;
 use shuck_ast::{ArrayElem, Assignment, AssignmentValue, Span};
 use shuck_semantic::ReferenceKind;
+use smallvec::SmallVec;
 
 use crate::{Checker, Rule, Violation};
 
@@ -27,60 +28,58 @@ pub fn local_cross_reference(checker: &mut Checker) {
     checker.report_all_dedup(spans, || LocalCrossReference);
 }
 
-fn declaration_cross_reference_spans(
-    checker: &Checker<'_>,
-    fact: crate::CommandFactRef<'_, '_>,
+fn declaration_cross_reference_spans<'a>(
+    checker: &Checker<'a>,
+    fact: crate::CommandFactRef<'_, 'a>,
 ) -> Vec<Span> {
     let Some(declaration) = fact.declaration() else {
         return Vec::new();
     };
 
-    let mut seen_targets = FxHashMap::default();
+    let semantic = checker.semantic();
+    let mut seen_targets: FxHashMap<&'a str, Span> = FxHashMap::default();
     let mut spans = Vec::new();
+    let mut value_spans: SmallVec<[Span; 4]> = SmallVec::new();
 
     for assignment in declaration.assignment_operands.iter().copied() {
-        for value_span in assignment_value_spans(assignment) {
-            for reference in checker.semantic().references().iter().filter(|reference| {
-                reference.kind != ReferenceKind::DeclarationName
-                    && contains_span(value_span, reference.span)
-            }) {
+        value_spans.clear();
+        push_assignment_value_spans(assignment, &mut value_spans);
+        for value_span in &value_spans {
+            for reference in semantic.references_in_span(*value_span) {
+                if reference.kind == ReferenceKind::DeclarationName {
+                    continue;
+                }
                 if let Some(previous_span) = seen_targets.get(reference.name.as_str()) {
                     spans.push(*previous_span);
                 }
             }
         }
 
-        seen_targets.insert(
-            assignment.target.name.as_str().to_owned(),
-            assignment.target.name_span,
-        );
+        seen_targets.insert(assignment.target.name.as_str(), assignment.target.name_span);
     }
 
     spans
 }
 
-fn assignment_value_spans(assignment: &Assignment) -> Vec<Span> {
+fn push_assignment_value_spans(assignment: &Assignment, spans: &mut SmallVec<[Span; 4]>) {
     match &assignment.value {
-        AssignmentValue::Scalar(word) => vec![word.span],
-        AssignmentValue::Compound(array) => array
-            .elements
-            .iter()
-            .flat_map(array_element_spans)
-            .collect(),
-    }
-}
-
-fn array_element_spans(element: &ArrayElem) -> Vec<Span> {
-    match element {
-        ArrayElem::Sequential(word) => vec![word.span],
-        ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
-            vec![key.span(), value.span]
+        AssignmentValue::Scalar(word) => spans.push(word.span),
+        AssignmentValue::Compound(array) => {
+            for element in &array.elements {
+                push_array_element_spans(element, spans);
+            }
         }
     }
 }
 
-fn contains_span(outer: Span, inner: Span) -> bool {
-    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
+fn push_array_element_spans(element: &ArrayElem, spans: &mut SmallVec<[Span; 4]>) {
+    match element {
+        ArrayElem::Sequential(word) => spans.push(word.span),
+        ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
+            spans.push(key.span());
+            spans.push(value.span);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -477,6 +477,7 @@ pub struct SemanticModel {
     heuristic_unused_assignments: Vec<BindingId>,
     zsh_option_analysis: Option<ZshOptionAnalysis>,
     assoc_lookup_binding_index: OnceLock<AssocLookupBindingIndex>,
+    references_sorted_by_start: OnceLock<Vec<ReferenceId>>,
 }
 
 /// Lazy analysis view over a `SemanticModel`.
@@ -579,6 +580,7 @@ impl SemanticModel {
             heuristic_unused_assignments: built.heuristic_unused_assignments,
             zsh_option_analysis,
             assoc_lookup_binding_index: OnceLock::new(),
+            references_sorted_by_start: OnceLock::new(),
         }
     }
 
@@ -610,6 +612,25 @@ impl SemanticModel {
 
     pub fn references(&self) -> &[Reference] {
         &self.references
+    }
+
+    /// Yield every reference whose span is fully contained within `outer`.
+    ///
+    /// Backed by a lazily-built index sorted by reference start offset, so a
+    /// per-span query costs `O(log n + matches)` rather than scanning every
+    /// reference in the file.
+    pub fn references_in_span(&self, outer: Span) -> ReferencesInSpan<'_> {
+        let sorted = self
+            .references_sorted_by_start
+            .get_or_init(|| build_references_sorted_by_start(&self.references));
+        let lower = sorted.partition_point(|id| {
+            self.references[id.index()].span.start.offset < outer.start.offset
+        });
+        ReferencesInSpan {
+            references: &self.references,
+            ids: sorted[lower..].iter(),
+            end: outer.end.offset,
+        }
     }
 
     pub fn binding(&self, id: BindingId) -> &Binding {
@@ -1463,6 +1484,40 @@ fn infer_bash_from_shebang(source: &str) -> Option<bool> {
 
 fn contains_offset(span: Span, offset: usize) -> bool {
     span.start.offset <= offset && offset <= span.end.offset
+}
+
+fn build_references_sorted_by_start(references: &[Reference]) -> Vec<ReferenceId> {
+    let mut ids: Vec<ReferenceId> = (0..references.len() as u32).map(ReferenceId).collect();
+    ids.sort_by_key(|id| references[id.index()].span.start.offset);
+    ids
+}
+
+/// Iterator returned by [`SemanticModel::references_in_span`].
+///
+/// Walks the references sorted index forward from the first candidate and
+/// stops as soon as a reference starts past the outer span's end.
+#[derive(Debug, Clone)]
+pub struct ReferencesInSpan<'a> {
+    references: &'a [Reference],
+    ids: std::slice::Iter<'a, ReferenceId>,
+    end: usize,
+}
+
+impl<'a> Iterator for ReferencesInSpan<'a> {
+    type Item = &'a Reference;
+
+    fn next(&mut self) -> Option<&'a Reference> {
+        loop {
+            let id = self.ids.next()?;
+            let reference = &self.references[id.index()];
+            if reference.span.start.offset > self.end {
+                return None;
+            }
+            if reference.span.end.offset <= self.end {
+                return Some(reference);
+            }
+        }
+    }
 }
 
 fn scope_span_width(span: Span) -> usize {


### PR DESCRIPTION
## Summary

- Hot path for `rules::local_cross_reference` (C136) rescanned every reference in the file for each assignment value span in a declaration command — `O(commands × value_spans × all_refs)`. Replaced with a cached, span-keyed lookup.
- Added `OnceLock<Vec<ReferenceId>>` sorted by start offset on `SemanticModel`, plus a public `references_in_span(outer)` iterator that `partition_point`s into the sorted list, walks forward, and stops as soon as a reference starts past `outer.end`.
- Rule now does `O(log n + matches)` per value span, drops the per-assignment `String::to_owned()` for `seen_targets` by borrowing the AST name, and reuses a single `SmallVec` for value spans across operands.

## Perf

Profile of `xwmx__nb__nb` (12 iterations, samply at 2 kHz):

| | Before | After |
|---|---:|---:|
| Wall clock (avg) | 267.8 ms | 247.4 ms (-7.6%) |
| `local_cross_reference` attributed exclusive | 5.0% | falls below top-20 (≤0.5%) |

## Test plan

- [x] `cargo test -p shuck-linter local_cross_reference` (4/4 pass)
- [x] `cargo test -p shuck-semantic --lib` (311/311 pass)
- [x] `cargo clippy -p shuck-semantic -p shuck-linter --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C136` over 34593 fixtures: `blocking=0 warnings=0 implementation_diffs=0`