### PR TITLE
refactor(linter): share overwritten function analysis

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -669,6 +669,12 @@ impl<'a> LinterFactsBuilder<'a> {
         } = build_env_prefix_scope_spans(self.source, &commands);
         let unset_command_ids_by_target_name =
             build_unset_command_ids_by_target_name(&commands, &structural_command_ids, source);
+        let function_unset_command_ids_by_target_name =
+            build_function_unset_command_ids_by_target_name(
+                &commands,
+                &structural_command_ids,
+                source,
+            );
         let word_index = build_word_occurrence_index(
             &commands,
             &word_nodes,
@@ -791,6 +797,7 @@ impl<'a> LinterFactsBuilder<'a> {
             env_prefix_assignment_scope_spans,
             env_prefix_expansion_scope_spans,
             unset_command_ids_by_target_name,
+            function_unset_command_ids_by_target_name,
             presence_tested_names: presence_tested_names.global_names,
             nested_presence_test_spans: presence_tested_names.nested_command_spans_by_name,
             c006_presence_tested_names: presence_tested_names.c006_global_names,
@@ -1174,6 +1181,41 @@ fn build_unset_command_ids_by_target_name(
                     .or_default()
                     .push(command_id);
             }
+        }
+    }
+
+    command_ids_by_name
+}
+
+fn build_function_unset_command_ids_by_target_name(
+    commands: &[CommandFact<'_>],
+    structural_command_ids: &[CommandId],
+    source: &str,
+) -> FxHashMap<Name, Vec<CommandId>> {
+    let mut command_ids_by_name = FxHashMap::<Name, Vec<CommandId>>::default();
+
+    for command_id in structural_command_ids.iter().copied() {
+        let command = &commands[command_id.index()];
+        let Some(unset) = command.options().unset() else {
+            continue;
+        };
+        if !unset.function_mode || !unset.options_parseable() {
+            continue;
+        }
+
+        let mut targets = Vec::new();
+        for word in unset.operand_words() {
+            let Some(text) = static_word_text(word, source) else {
+                break;
+            };
+            let target = Name::from(text.as_ref());
+            if !targets.contains(&target) {
+                targets.push(target);
+            }
+        }
+
+        for target in targets {
+            command_ids_by_name.entry(target).or_default().push(command_id);
         }
     }
 

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -17,6 +17,7 @@ pub struct LinterFacts<'a> {
     env_prefix_assignment_scope_spans: Vec<Span>,
     env_prefix_expansion_scope_spans: Vec<Span>,
     unset_command_ids_by_target_name: FxHashMap<Name, Vec<CommandId>>,
+    function_unset_command_ids_by_target_name: FxHashMap<Name, Vec<CommandId>>,
     presence_tested_names: FxHashSet<Name>,
     nested_presence_test_spans: FxHashMap<Name, Vec<Span>>,
     c006_presence_tested_names: FxHashSet<Name>,
@@ -243,6 +244,18 @@ impl<'a> LinterFacts<'a> {
         name: &Name,
     ) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
         self.unset_command_ids_by_target_name
+            .get(name)
+            .into_iter()
+            .flatten()
+            .copied()
+            .map(|id| self.command(id))
+    }
+
+    pub(crate) fn function_unset_commands_for_name(
+        &self,
+        name: &Name,
+    ) -> impl Iterator<Item = CommandFactRef<'_, 'a>> + '_ {
+        self.function_unset_command_ids_by_target_name
             .get(name)
             .into_iter()
             .flatten()

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,6 +1,6 @@
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::static_word_text;
+use shuck_ast::Name;
 use shuck_semantic::{
     BindingKind, BindingOrigin, OverwrittenFunction as SemanticOverwrittenFunction, ScopeId,
     ScopeKind, UnreachedFunction as SemanticUnreachedFunction, UnreachedFunctionReason,
@@ -286,37 +286,6 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
                 });
         }
 
-        if fact.effective_name_is("unset")
-            && let Some(unset) = fact.options().unset()
-            && unset.function_mode
-            && unset.options_parseable()
-        {
-            let mut targets = Vec::new();
-            for word in unset.operand_words() {
-                let Some(text) = static_word_text(word, checker.source()) else {
-                    break;
-                };
-                let target = text.into_owned();
-                if !targets.contains(&target) {
-                    targets.push(target);
-                }
-            }
-
-            if !targets.is_empty()
-                && !command_offset_is_under_dominance_barrier(checker, offset)
-                && !command_offset_is_unreachable(checker, offset)
-            {
-                let scope = fact.scope();
-                let command_fact = CompatUnsetCommandFact { scope, offset };
-                for target in targets {
-                    unset_commands_by_target
-                        .entry(target)
-                        .or_default()
-                        .push(command_fact);
-                }
-            }
-        }
-
         let apparent_loop_body_span = apparent_infinite_loop_body_span(checker, fact.command());
         if is_return || apparent_loop_body_span.is_some() {
             let scope = fact.scope();
@@ -327,6 +296,36 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
                 if let Some(body_span) = apparent_loop_body_span {
                     top_level_loop_candidates.push(CompatLoopCandidate { offset, body_span });
                 }
+            }
+        }
+    }
+
+    let mut seen_function_unset_targets = FxHashSet::<Name>::default();
+    for binding in checker
+        .semantic()
+        .bindings()
+        .iter()
+        .filter(|binding| matches!(binding.kind, BindingKind::FunctionDefinition))
+    {
+        if !seen_function_unset_targets.insert(binding.name.clone()) {
+            continue;
+        }
+
+        for fact in checker
+            .facts()
+            .function_unset_commands_for_name(&binding.name)
+        {
+            let offset = fact.body_span().start.offset;
+            if !command_offset_is_under_dominance_barrier(checker, offset)
+                && !command_offset_is_unreachable(checker, offset)
+            {
+                unset_commands_by_target
+                    .entry(binding.name.to_string())
+                    .or_default()
+                    .push(CompatUnsetCommandFact {
+                        scope: fact.scope(),
+                        offset,
+                    });
             }
         }
     }
@@ -1674,50 +1673,8 @@ fn call_may_resolve_to_binding(
     cfg_span: shuck_ast::Span,
 ) -> bool {
     let binding = checker.semantic().binding(binding_id);
-    if let Some(visible) = checker
-        .semantic()
-        .visible_binding(&binding.name, visibility_span)
-        && visible.id != binding_id
-        && visible.scope != binding.scope
-        && matches!(visible.kind, BindingKind::FunctionDefinition)
-        && visible.span.start.offset < visibility_span.start.offset
-        && checker
-            .semantic()
-            .ancestor_scopes(call_scope)
-            .any(|scope| scope == visible.scope)
-    {
-        return false;
-    }
-
-    let has_visible_shadow = checker
-        .semantic()
-        .visible_binding(&binding.name, visibility_span)
-        .is_some_and(|visible| {
-            visible.id != binding_id
-                && matches!(visible.kind, BindingKind::FunctionDefinition)
-                && visible.span.start.offset < visibility_span.start.offset
-                && checker
-                    .semantic()
-                    .ancestor_scopes(call_scope)
-                    .any(|scope| scope == visible.scope)
-        })
-        || checker
-            .semantic()
-            .function_definitions(&binding.name)
-            .iter()
-            .copied()
-            .any(|other| {
-                if other == binding_id {
-                    return false;
-                }
-                let other_binding = checker.semantic().binding(other);
-                other_binding.span.start.offset < visibility_span.start.offset
-                    && checker
-                        .semantic()
-                        .ancestor_scopes(call_scope)
-                        .any(|scope| scope == other_binding.scope)
-            })
-        || checker.facts().function_headers().iter().any(|header| {
+    let has_prior_shadowing_function_definition =
+        checker.facts().function_headers().iter().any(|header| {
             let Some((name, name_span)) = header.static_name_entry() else {
                 return false;
             };
@@ -1734,33 +1691,16 @@ fn call_may_resolve_to_binding(
                     .any(|ancestor| ancestor == scope)
             })
         });
-    if !has_visible_shadow {
-        return true;
-    }
-    if enclosing_function_scope(checker, call_scope).is_some() {
-        return true;
-    }
 
-    let analysis = checker.semantic_analysis();
-    let mut avoid = analysis.shadow_function_blocks_for_binding(binding_id);
-    avoid.extend(analysis.cfg().script_terminators().iter().copied());
-    let binding_blocks = analysis
-        .reachable_blocks_for_binding(binding_id)
-        .into_iter()
-        .filter(|block| !avoid.contains(block))
-        .collect::<Vec<_>>();
-    let call_blocks = analysis
-        .block_ids_for_span(cfg_span)
-        .iter()
-        .copied()
-        .filter(|block| !analysis.block_is_unreachable(*block))
-        .filter(|block| !avoid.contains(block))
-        .collect::<Vec<_>>();
-    if binding_blocks.is_empty() || call_blocks.is_empty() {
-        return false;
-    }
-
-    analysis.blocks_have_path_avoiding(&binding_blocks, &call_blocks, &avoid)
+    checker
+        .semantic_analysis()
+        .function_call_may_resolve_to_binding(
+            binding_id,
+            call_scope,
+            visibility_span,
+            cfg_span,
+            has_prior_shadowing_function_definition,
+        )
 }
 
 fn call_scope_can_execute_after_offset_before_offset(

--- a/crates/shuck-semantic/src/reachability.rs
+++ b/crates/shuck-semantic/src/reachability.rs
@@ -89,6 +89,89 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    pub fn function_call_may_resolve_to_binding(
+        &self,
+        binding_id: BindingId,
+        call_scope: ScopeId,
+        visibility_span: Span,
+        cfg_span: Span,
+        has_prior_shadowing_function_definition: bool,
+    ) -> bool {
+        let binding = self.model.binding(binding_id);
+        if let Some(visible) = self.model.visible_binding(&binding.name, visibility_span)
+            && visible.id != binding_id
+            && visible.scope != binding.scope
+            && matches!(visible.kind, BindingKind::FunctionDefinition)
+            && visible.span.start.offset < visibility_span.start.offset
+            && self
+                .model
+                .ancestor_scopes(call_scope)
+                .any(|scope| scope == visible.scope)
+        {
+            return false;
+        }
+
+        let has_visible_shadow = self
+            .model
+            .visible_binding(&binding.name, visibility_span)
+            .is_some_and(|visible| {
+                visible.id != binding_id
+                    && matches!(visible.kind, BindingKind::FunctionDefinition)
+                    && visible.span.start.offset < visibility_span.start.offset
+                    && self
+                        .model
+                        .ancestor_scopes(call_scope)
+                        .any(|scope| scope == visible.scope)
+            })
+            || self
+                .model
+                .function_definitions(&binding.name)
+                .iter()
+                .copied()
+                .any(|other| {
+                    if other == binding_id {
+                        return false;
+                    }
+                    let other_binding = self.model.binding(other);
+                    other_binding.span.start.offset < visibility_span.start.offset
+                        && self
+                            .model
+                            .ancestor_scopes(call_scope)
+                            .any(|scope| scope == other_binding.scope)
+                })
+            || has_prior_shadowing_function_definition;
+        if !has_visible_shadow {
+            return true;
+        }
+        if self
+            .model
+            .ancestor_scopes(call_scope)
+            .any(|scope| matches!(self.model.scope_kind(scope), ScopeKind::Function(_)))
+        {
+            return true;
+        }
+
+        let mut avoid = self.shadow_function_blocks_for_binding(binding_id);
+        avoid.extend(self.cfg().script_terminators().iter().copied());
+        let binding_blocks = self
+            .reachable_blocks_for_binding(binding_id)
+            .into_iter()
+            .filter(|block| !avoid.contains(block))
+            .collect::<Vec<_>>();
+        let call_blocks = self
+            .block_ids_for_span(cfg_span)
+            .iter()
+            .copied()
+            .filter(|block| !self.block_is_unreachable(*block))
+            .filter(|block| !avoid.contains(block))
+            .collect::<Vec<_>>();
+        if binding_blocks.is_empty() || call_blocks.is_empty() {
+            return false;
+        }
+
+        self.blocks_have_path_avoiding(&binding_blocks, &call_blocks, &avoid)
+    }
+
     fn overwrite_call_site_resolves_to_binding(
         &self,
         name: &Name,


### PR DESCRIPTION
## Summary

- expose semantic call-reachability logic for overwritten-function checks
- add fact-layer indexing for function-mode `unset -f` targets
- refactor `overwritten_function` to consume semantic/fact APIs instead of rebuilding those structures locally

## Validation

- `cargo test -q -p shuck-semantic`
- `cargo test -q -p shuck-linter overwritten_function -- --nocapture`
- `cargo test -q -p shuck-linter c063_option_ -- --nocapture`
- `cargo test -q -p shuck-linter`
- `cargo fmt --check && git diff --check`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C063`
