### PR TITLE
refactor(semantic): share call graph construction

### DIFF
--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -22,7 +22,7 @@ use crate::binding::{
     AssignmentValueOrigin, Binding, BindingAttributes, BindingKind, BindingOrigin,
     BuiltinBindingTargetKind, LoopValueOrigin,
 };
-use crate::call_graph::{CallGraph, CallSite, OverwrittenFunction};
+use crate::call_graph::{CallGraph, CallSite, build_call_graph};
 use crate::cfg::{
     FlowContext, IsolatedRegion, RecordedCaseArm, RecordedCommand, RecordedCommandId,
     RecordedCommandInfo, RecordedCommandKind, RecordedCommandRange, RecordedElifBranch,
@@ -237,7 +237,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         builder.mark_scope_completed(ScopeId(0));
         builder.drain_deferred_functions();
 
-        let call_graph = builder.build_call_graph();
+        let call_graph = build_call_graph(
+            &builder.scopes,
+            &builder.bindings,
+            &builder.functions,
+            &builder.call_sites,
+        );
         let heuristic_unused_assignments = builder.compute_heuristic_unused_assignments();
 
         BuildOutput {
@@ -2139,21 +2144,6 @@ fn pattern_group_can_match_empty(kind: PatternGroupKind, patterns: &[Pattern]) -
 
 fn ancestor_scopes(scopes: &[Scope], start: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
     std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
-}
-
-fn is_in_function_scope(scopes: &[Scope], scope: ScopeId) -> bool {
-    ancestor_scopes(scopes, scope)
-        .skip(1)
-        .any(|scope| matches!(scopes[scope.index()].kind, ScopeKind::Function(_)))
-}
-
-fn is_in_named_function_scope(scopes: &[Scope], scope: ScopeId, name: &Name) -> bool {
-    ancestor_scopes(scopes, scope).any(|scope| {
-        matches!(
-            &scopes[scope.index()].kind,
-            ScopeKind::Function(function) if function.contains_name(name)
-        )
-    })
 }
 
 fn function_scope_kind(function: &FunctionDef) -> FunctionScopeKind {

--- a/crates/shuck-semantic/src/builder/references.rs
+++ b/crates/shuck-semantic/src/builder/references.rs
@@ -301,66 +301,6 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         None
     }
 
-    pub(super) fn build_call_graph(&self) -> CallGraph {
-        let mut reachable = FxHashSet::default();
-        let mut worklist = self
-            .call_sites
-            .values()
-            .flat_map(|sites| sites.iter())
-            .filter(|site| !is_in_function_scope(&self.scopes, site.scope))
-            .map(|site| site.callee.clone())
-            .collect::<Vec<_>>();
-
-        while let Some(name) = worklist.pop() {
-            if reachable.contains(name.as_str()) {
-                continue;
-            }
-            for sites in self.call_sites.values() {
-                for site in sites {
-                    if is_in_named_function_scope(&self.scopes, site.scope, &name) {
-                        worklist.push(site.callee.clone());
-                    }
-                }
-            }
-            reachable.insert(name);
-        }
-
-        let uncalled = self
-            .functions
-            .iter()
-            .filter(|(name, _)| !reachable.contains(*name))
-            .flat_map(|(_, bindings)| bindings.iter().copied())
-            .collect();
-
-        let overwritten = self
-            .functions
-            .iter()
-            .flat_map(|(name, bindings)| {
-                bindings.windows(2).map(move |pair| OverwrittenFunction {
-                    name: name.clone(),
-                    first: pair[0],
-                    second: pair[1],
-                    first_called: self
-                        .call_sites
-                        .get(name)
-                        .into_iter()
-                        .flat_map(|sites| sites.iter())
-                        .any(|site| {
-                            let first = self.bindings[pair[0].index()].span.start.offset;
-                            let second = self.bindings[pair[1].index()].span.start.offset;
-                            site.span.start.offset > first && site.span.start.offset < second
-                        }),
-                })
-            })
-            .collect();
-
-        CallGraph {
-            reachable,
-            uncalled,
-            overwritten,
-        }
-    }
-
     pub(super) fn compute_heuristic_unused_assignments(&self) -> Vec<BindingId> {
         self.bindings
             .iter()

--- a/crates/shuck-semantic/src/call_graph.rs
+++ b/crates/shuck-semantic/src/call_graph.rs
@@ -1,7 +1,9 @@
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Name, Span};
+use smallvec::SmallVec;
 
-use crate::{BindingId, ScopeId};
+use crate::binding::Binding;
+use crate::{BindingId, Scope, ScopeId, ScopeKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallSite {
@@ -39,4 +41,85 @@ pub struct UnreachedFunction {
     pub name: Name,
     pub binding: BindingId,
     pub reason: UnreachedFunctionReason,
+}
+
+pub(crate) fn build_call_graph(
+    scopes: &[Scope],
+    bindings: &[Binding],
+    functions: &FxHashMap<Name, SmallVec<[BindingId; 2]>>,
+    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+) -> CallGraph {
+    let mut reachable = FxHashSet::default();
+    let mut worklist = call_sites
+        .values()
+        .flat_map(|sites| sites.iter())
+        .filter(|site| !is_in_function_scope(scopes, site.scope))
+        .map(|site| site.callee.clone())
+        .collect::<Vec<_>>();
+
+    while let Some(name) = worklist.pop() {
+        if reachable.contains(name.as_str()) {
+            continue;
+        }
+        for sites in call_sites.values() {
+            for site in sites {
+                if is_in_named_function_scope(scopes, site.scope, &name) {
+                    worklist.push(site.callee.clone());
+                }
+            }
+        }
+        reachable.insert(name);
+    }
+
+    let uncalled = functions
+        .iter()
+        .filter(|(name, _)| !reachable.contains(*name))
+        .flat_map(|(_, bindings)| bindings.iter().copied())
+        .collect();
+
+    let overwritten = functions
+        .iter()
+        .flat_map(|(name, function_bindings)| {
+            function_bindings
+                .windows(2)
+                .map(move |pair| OverwrittenFunction {
+                    name: name.clone(),
+                    first: pair[0],
+                    second: pair[1],
+                    first_called: call_sites
+                        .get(name)
+                        .into_iter()
+                        .flat_map(|sites| sites.iter())
+                        .any(|site| {
+                            let first = bindings[pair[0].index()].span.start.offset;
+                            let second = bindings[pair[1].index()].span.start.offset;
+                            site.span.start.offset > first && site.span.start.offset < second
+                        }),
+                })
+        })
+        .collect();
+
+    CallGraph {
+        reachable,
+        uncalled,
+        overwritten,
+    }
+}
+
+fn ancestor_scopes(scopes: &[Scope], start: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
+    std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
+}
+
+fn is_in_function_scope(scopes: &[Scope], scope: ScopeId) -> bool {
+    ancestor_scopes(scopes, scope)
+        .any(|scope| matches!(scopes[scope.index()].kind, ScopeKind::Function(_)))
+}
+
+fn is_in_named_function_scope(scopes: &[Scope], scope: ScopeId, name: &Name) -> bool {
+    ancestor_scopes(scopes, scope).any(|scope| {
+        matches!(
+            &scopes[scope.index()].kind,
+            ScopeKind::Function(function) if function.contains_name(name)
+        )
+    })
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -80,6 +80,7 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 
 use crate::builder::SemanticModelBuilder;
+use crate::call_graph::build_call_graph;
 use crate::cfg::RecordedProgram;
 use crate::dataflow::{DataflowContext, DataflowResult, ExactVariableDataflow};
 use crate::runtime::RuntimePrelude;
@@ -205,83 +206,6 @@ fn dedup_synthetic_reads(reads: Vec<SyntheticRead>) -> Vec<SyntheticRead> {
         }
     }
     deduped
-}
-
-fn build_call_graph(
-    scopes: &[Scope],
-    all_bindings: &[Binding],
-    functions: &FxHashMap<Name, SmallVec<[BindingId; 2]>>,
-    call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
-) -> CallGraph {
-    let mut reachable = FxHashSet::default();
-    let mut worklist = call_sites
-        .values()
-        .flat_map(|sites| sites.iter())
-        .filter(|site| !is_in_function_scope(scopes, site.scope))
-        .map(|site| site.callee.clone())
-        .collect::<Vec<_>>();
-
-    while let Some(name) = worklist.pop() {
-        if reachable.contains(name.as_str()) {
-            continue;
-        }
-        for sites in call_sites.values() {
-            for site in sites {
-                if is_in_named_function_scope(scopes, site.scope, &name) {
-                    worklist.push(site.callee.clone());
-                }
-            }
-        }
-        reachable.insert(name);
-    }
-
-    let uncalled = functions
-        .iter()
-        .filter(|(name, _)| !reachable.contains(*name))
-        .flat_map(|(_, bindings)| bindings.iter().copied())
-        .collect();
-
-    let overwritten = functions
-        .iter()
-        .flat_map(|(name, function_bindings)| {
-            function_bindings
-                .windows(2)
-                .map(move |pair| OverwrittenFunction {
-                    name: name.clone(),
-                    first: pair[0],
-                    second: pair[1],
-                    first_called: call_sites
-                        .get(name)
-                        .into_iter()
-                        .flat_map(|sites| sites.iter())
-                        .any(|site| {
-                            let first = all_bindings[pair[0].index()].span.start.offset;
-                            let second = all_bindings[pair[1].index()].span.start.offset;
-                            site.span.start.offset > first && site.span.start.offset < second
-                        }),
-                })
-        })
-        .collect();
-
-    CallGraph {
-        reachable,
-        uncalled,
-        overwritten,
-    }
-}
-
-fn is_in_function_scope(scopes: &[Scope], scope: ScopeId) -> bool {
-    ancestor_scopes(scopes, scope)
-        .any(|scope| matches!(scopes[scope.index()].kind, ScopeKind::Function(_)))
-}
-
-fn is_in_named_function_scope(scopes: &[Scope], scope: ScopeId, name: &Name) -> bool {
-    ancestor_scopes(scopes, scope).any(|scope| {
-        matches!(
-            &scopes[scope.index()].kind,
-            ScopeKind::Function(function) if function.contains_name(name)
-        )
-    })
 }
 
 fn assignment_like_binding(kind: BindingKind) -> bool {
@@ -1040,12 +964,7 @@ impl SemanticModel {
         self.set_synthetic_reads(dedup_synthetic_reads(synthetic_reads));
         self.set_entry_bindings(entry_bindings);
         self.resolve_unresolved_references();
-        self.call_graph = build_call_graph(
-            &self.scopes,
-            &self.bindings,
-            &self.functions,
-            &self.call_sites,
-        );
+        self.rebuild_call_graph();
     }
 
     fn mark_file_entry_consumed_bindings(&mut self) {
@@ -1119,6 +1038,10 @@ impl SemanticModel {
             );
         }
         self.resolve_unresolved_references();
+        self.rebuild_call_graph();
+    }
+
+    fn rebuild_call_graph(&mut self) {
         self.call_graph = build_call_graph(
             &self.scopes,
             &self.bindings,
@@ -1527,10 +1450,6 @@ fn scope_span_width(span: Span) -> usize {
 
 fn contains_span(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
-}
-
-fn ancestor_scopes(scopes: &[Scope], scope: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
-    std::iter::successors(Some(scope), move |scope| scopes[scope.index()].parent)
 }
 
 #[cfg(test)]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1255,6 +1255,18 @@ f() { echo again; }
 }
 
 #[test]
+fn call_graph_does_not_root_calls_inside_uncalled_functions() {
+    let source = "\
+f() { g; }
+g() { echo hi; }
+";
+    let model = model(source);
+
+    assert!(!model.call_graph().reachable.contains("f"));
+    assert!(!model.call_graph().reachable.contains("g"));
+}
+
+#[test]
 fn precise_overwritten_functions_track_real_overwrites() {
     let source = "\
 f() { echo hi; }


### PR DESCRIPTION
## Summary

- Move semantic call graph construction into a single shared helper in `call_graph.rs`.
- Route both initial semantic builds and post-contract rebuilds through the shared helper.
- Add a regression test so calls inside uncalled functions are not treated as root reachable calls.

## Validation

- `cargo test -p shuck-semantic`
- `make test`
- `make test-large-corpus`