### PR TITLE
perf(linter): speed up facts builder hotspots

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -2291,7 +2291,7 @@ fn collect_dollar_question_after_command_spans_in_function_body(
 fn build_declaration_assignment_probes<'a>(
     command: &'a Command,
     normalized: &NormalizedCommand<'a>,
-    semantic: &SemanticModel,
+    declaration_index: &FxHashMap<usize, &Declaration>,
     source: &str,
     zsh_options: Option<&ZshOptionState>,
 ) -> Vec<DeclarationAssignmentProbe> {
@@ -2328,7 +2328,7 @@ fn build_declaration_assignment_probes<'a>(
         return Vec::new();
     }
 
-    let Some(declaration) = semantic_declaration_for_command(semantic, command) else {
+    let Some(declaration) = semantic_declaration_for_command(declaration_index, command) else {
         return Vec::new();
     };
     let kind = declaration_kind_from_semantic(declaration.builtin);
@@ -2361,15 +2361,28 @@ fn build_declaration_assignment_probes<'a>(
         .collect()
 }
 
+fn build_semantic_declaration_index(
+    semantic: &SemanticModel,
+) -> FxHashMap<usize, &Declaration> {
+    let declarations = semantic.declarations();
+    let mut index = FxHashMap::with_capacity_and_hasher(declarations.len(), Default::default());
+    for declaration in declarations {
+        index.insert(declaration.span.start.offset, declaration);
+    }
+    index
+}
+
 fn semantic_declaration_for_command<'a>(
-    semantic: &'a SemanticModel,
+    declaration_index: &FxHashMap<usize, &'a Declaration>,
     command: &Command,
 ) -> Option<&'a Declaration> {
     let span = command_span(command);
-    semantic.declarations().iter().find(|declaration| {
-        declaration.span.start.offset == span.start.offset
-            && declaration.span.end.offset == span.end.offset
-    })
+    let declaration = *declaration_index.get(&span.start.offset)?;
+    if declaration.span.end.offset == span.end.offset {
+        Some(declaration)
+    } else {
+        None
+    }
 }
 
 fn declaration_kind_from_semantic(builtin: DeclarationBuiltin) -> DeclarationKind {
@@ -2488,6 +2501,7 @@ fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
 fn collect_binding_values<'a>(
     command: &'a Command,
     semantic: &SemanticModel,
+    declaration_index: &FxHashMap<usize, &Declaration>,
     source: &str,
     binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
 ) {
@@ -2531,7 +2545,7 @@ fn collect_binding_values<'a>(
     }
 
     if matches!(command, Command::Simple(_))
-        && let Some(declaration) = semantic_declaration_for_command(semantic, command)
+        && let Some(declaration) = semantic_declaration_for_command(declaration_index, command)
     {
         for operand in &declaration.operands {
             let SemanticDeclarationOperand::Assignment {

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -118,6 +118,7 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut pattern_charclass_spans = Vec::new();
         let mut arithmetic_summary = ArithmeticFactSummary::default();
         let mut surface_fragments = SurfaceFragmentSink::new(self.source);
+        let semantic_declaration_index = build_semantic_declaration_index(self.semantic);
         let mut functions = Vec::with_capacity(capacity.functions);
         let mut function_body_without_braces_spans = Vec::with_capacity(capacity.functions);
         let redundant_return_status_spans = Vec::new();
@@ -170,6 +171,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 collect_binding_values(
                     visit.command,
                     self.semantic,
+                    &semantic_declaration_index,
                     self.source,
                     &mut binding_values,
                 );
@@ -287,7 +289,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 let declaration_assignment_probes = build_declaration_assignment_probes(
                     visit.command,
                     &normalized,
-                    self.semantic,
+                    &semantic_declaration_index,
                     self.source,
                     command_zsh_options.as_ref(),
                 );

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -269,6 +269,10 @@ impl StaticCasePatternMatcher {
             return false;
         }
 
+        if let Some(result) = subsumes_fixed_length_fast_path(self, other) {
+            return result;
+        }
+
         let symbols = merged_case_pattern_symbols(
             self.literal_symbols.as_ref(),
             other.literal_symbols.as_ref(),
@@ -304,6 +308,10 @@ impl StaticCasePatternMatcher {
     }
 
     fn intersects(&self, other: &Self) -> bool {
+        if let Some(result) = intersects_fixed_length_fast_path(self, other) {
+            return result;
+        }
+
         let symbols = merged_case_pattern_symbols(
             self.literal_symbols.as_ref(),
             other.literal_symbols.as_ref(),
@@ -400,6 +408,55 @@ impl StaticCasePatternMatcher {
     fn is_accepting(&self, states: &[usize]) -> bool {
         states.contains(&self.tokens.len())
     }
+}
+
+fn subsumes_fixed_length_fast_path(
+    left: &StaticCasePatternMatcher,
+    right: &StaticCasePatternMatcher,
+) -> Option<bool> {
+    if left.max_len.is_none() || right.max_len.is_none() {
+        return None;
+    }
+    if left.tokens.len() != right.tokens.len() {
+        return Some(false);
+    }
+    let result = left
+        .tokens
+        .iter()
+        .zip(right.tokens.iter())
+        .all(|(l, r)| match (l, r) {
+            (CasePatternToken::Literal(a), CasePatternToken::Literal(b)) => a == b,
+            (CasePatternToken::AnyChar, _) => true,
+            (CasePatternToken::Literal(_), CasePatternToken::AnyChar) => false,
+            (CasePatternToken::AnyString, _) | (_, CasePatternToken::AnyString) => {
+                unreachable!("AnyString tokens excluded by max_len check")
+            }
+        });
+    Some(result)
+}
+
+fn intersects_fixed_length_fast_path(
+    left: &StaticCasePatternMatcher,
+    right: &StaticCasePatternMatcher,
+) -> Option<bool> {
+    if left.max_len.is_none() || right.max_len.is_none() {
+        return None;
+    }
+    if left.tokens.len() != right.tokens.len() {
+        return Some(false);
+    }
+    let result = left
+        .tokens
+        .iter()
+        .zip(right.tokens.iter())
+        .all(|(l, r)| match (l, r) {
+            (CasePatternToken::Literal(a), CasePatternToken::Literal(b)) => a == b,
+            (CasePatternToken::AnyChar, _) | (_, CasePatternToken::AnyChar) => true,
+            (CasePatternToken::AnyString, _) | (_, CasePatternToken::AnyString) => {
+                unreachable!("AnyString tokens excluded by max_len check")
+            }
+        });
+    Some(result)
 }
 
 fn summarize_static_case_pattern_tokens(tokens: &[CasePatternToken]) -> StaticCasePatternSummary {

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -81,6 +81,29 @@ struct EscapeScanMatchContext {
     host_contains_single_quoted_fragment: bool,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(super) struct SingleQuotedFragmentBounds {
+    start: usize,
+    end: usize,
+}
+
+fn build_sorted_single_quoted_bounds(
+    fragments: &[SingleQuotedFragmentFact],
+) -> Vec<SingleQuotedFragmentBounds> {
+    let mut bounds: Vec<SingleQuotedFragmentBounds> = fragments
+        .iter()
+        .map(|fragment| {
+            let span = fragment.span();
+            SingleQuotedFragmentBounds {
+                start: span.start.offset,
+                end: span.end.offset,
+            }
+        })
+        .collect();
+    bounds.sort_unstable_by_key(|b| b.start);
+    bounds
+}
+
 #[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_escape_scan_matches(
     commands: &[CommandFact<'_>],
@@ -91,6 +114,7 @@ pub(super) fn build_escape_scan_matches(
 ) -> Vec<EscapeScanMatch> {
     let mut matches = Vec::new();
     let mut span_buffer = Vec::new();
+    let single_quoted_bounds = build_sorted_single_quoted_bounds(inputs.single_quoted_fragments);
 
     for fact in occurrences
         .iter()
@@ -109,7 +133,7 @@ pub(super) fn build_escape_scan_matches(
         let word = occurrence_word(nodes, fact);
         let host_contains_single_quoted_fragment = span_contains_single_quoted_fragment(
             occurrence_span(nodes, fact),
-            inputs.single_quoted_fragments,
+            &single_quoted_bounds,
         );
 
         span_buffer.clear();
@@ -129,7 +153,7 @@ pub(super) fn build_escape_scan_matches(
                     tr_operand_argument,
                     host_contains_single_quoted_fragment,
                 },
-                inputs.single_quoted_fragments,
+                &single_quoted_bounds,
             );
         }
     }
@@ -154,10 +178,10 @@ pub(super) fn build_escape_scan_matches(
                 tr_operand_argument: is_tr_operand_argument(commands, nodes, fact),
                 host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
                     occurrence_span(nodes, fact),
-                    inputs.single_quoted_fragments,
+                    &single_quoted_bounds,
                 ),
             },
-            inputs.single_quoted_fragments,
+            &single_quoted_bounds,
         );
     }
 
@@ -178,7 +202,7 @@ pub(super) fn build_escape_scan_matches(
 
         let host_contains_single_quoted_fragment = span_contains_single_quoted_fragment(
             occurrence_span(nodes, fact),
-            inputs.single_quoted_fragments,
+            &single_quoted_bounds,
         );
 
         span_buffer.clear();
@@ -198,7 +222,7 @@ pub(super) fn build_escape_scan_matches(
                     tr_operand_argument,
                     host_contains_single_quoted_fragment,
                 },
-                inputs.single_quoted_fragments,
+                &single_quoted_bounds,
             );
         }
     }
@@ -221,10 +245,10 @@ pub(super) fn build_escape_scan_matches(
                 tr_operand_argument: false,
                 host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
                     span,
-                    inputs.single_quoted_fragments,
+                    &single_quoted_bounds,
                 ),
             },
-            inputs.single_quoted_fragments,
+            &single_quoted_bounds,
         );
     }
 
@@ -239,10 +263,10 @@ pub(super) fn build_escape_scan_matches(
                 tr_operand_argument: false,
                 host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
                     *span,
-                    inputs.single_quoted_fragments,
+                    &single_quoted_bounds,
                 ),
             },
-            inputs.single_quoted_fragments,
+            &single_quoted_bounds,
         );
     }
 
@@ -262,10 +286,10 @@ pub(super) fn build_escape_scan_matches(
                 tr_operand_argument: false,
                 host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
                     *span,
-                    inputs.single_quoted_fragments,
+                    &single_quoted_bounds,
                 ),
             },
-            inputs.single_quoted_fragments,
+            &single_quoted_bounds,
         );
     }
 
@@ -280,10 +304,10 @@ pub(super) fn build_escape_scan_matches(
                 tr_operand_argument: false,
                 host_contains_single_quoted_fragment: span_contains_single_quoted_fragment(
                     fragment.span(),
-                    inputs.single_quoted_fragments,
+                    &single_quoted_bounds,
                 ),
             },
-            inputs.single_quoted_fragments,
+            &single_quoted_bounds,
         );
     }
 
@@ -295,7 +319,7 @@ fn append_escape_scan_matches(
     scan_span: Span,
     source: &str,
     match_context: EscapeScanMatchContext,
-    single_quoted_fragments: &[SingleQuotedFragmentFact],
+    single_quoted_bounds: &[SingleQuotedFragmentBounds],
 ) {
     let text = scan_span.slice(source);
     let bytes = text.as_bytes();
@@ -369,7 +393,7 @@ fn append_escape_scan_matches(
                 .host_contains_single_quoted_fragment,
             inside_single_quoted_fragment: span_within_single_quoted_fragment(
                 report_span,
-                single_quoted_fragments,
+                single_quoted_bounds,
             ),
         });
     }
@@ -414,23 +438,24 @@ fn is_regex_like_context(context: Option<ExpansionContext>) -> bool {
     )
 }
 
-fn span_contains_single_quoted_fragment(
-    span: Span,
-    fragments: &[SingleQuotedFragmentFact],
-) -> bool {
-    fragments.iter().any(|fragment| {
-        let fragment_span = fragment.span();
-        fragment_span.start.offset >= span.start.offset
-            && fragment_span.end.offset <= span.end.offset
-    })
+fn span_contains_single_quoted_fragment(span: Span, bounds: &[SingleQuotedFragmentBounds]) -> bool {
+    let span_start = span.start.offset;
+    let span_end = span.end.offset;
+    let index = bounds.partition_point(|b| b.start < span_start);
+    bounds
+        .get(index)
+        .is_some_and(|b| b.start <= span_end && b.end <= span_end)
 }
 
-fn span_within_single_quoted_fragment(span: Span, fragments: &[SingleQuotedFragmentFact]) -> bool {
-    fragments.iter().any(|fragment| {
-        let fragment_span = fragment.span();
-        span.start.offset >= fragment_span.start.offset
-            && span.end.offset < fragment_span.end.offset
-    })
+fn span_within_single_quoted_fragment(span: Span, bounds: &[SingleQuotedFragmentBounds]) -> bool {
+    let span_start = span.start.offset;
+    let span_end = span.end.offset;
+    let index = bounds.partition_point(|b| b.start <= span_start);
+    if index == 0 {
+        return false;
+    }
+    let candidate = bounds[index - 1];
+    candidate.start <= span_start && span_end < candidate.end
 }
 
 fn span_within_any(span: Span, hosts: &[Span]) -> bool {


### PR DESCRIPTION
## Summary
- Replace per-command linear scan over `semantic.declarations()` with a `FxHashMap<usize, &Declaration>` keyed by command start offset, built once per file.
- Add a fixed-length fast path to `StaticCasePatternMatcher::{subsumes,intersects}` that bypasses the NFA worklist (and its `FxHashSet`/Vec/SmallVec allocations) when neither matcher contains an `AnyString`.
- Build a sorted `Vec<SingleQuotedFragmentBounds>` once per file and use `partition_point` for `span_contains_single_quoted_fragment` / `span_within_single_quoted_fragment`, replacing the per-occurrence / per-match linear scans in `escape_scan`.

## Profile delta
On the `xwmx__nb__nb` large-corpus fixture (12 iterations, warm), the linter facts builder bucket drops from **35.3% -> 31.2%** attributed exclusive. The three previously-called-out sub-frames (`semantic_declaration_for_command`, `StaticCasePatternMatcher::advance`, `escape_scan` linear scans) all drop out of the top 30 hotspots.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo test -p shuck-linter` (3111 passed / 0 failed)
- [x] Reprofiled with `scripts/profiling/profile_large_corpus.sh xwmx__nb__nb`