### PR TITLE
test(semantic): cover function binding scope lookup

### DIFF
--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -383,6 +383,33 @@ printf '%s\\n' \"$scoped\"
 }
 
 #[test]
+fn analysis_maps_function_binding_to_body_scope() {
+    let model = model(
+        "\
+x=1
+f() {
+  :
+}
+",
+    );
+    let function_binding = binding_for_name(&model, "f");
+    let assignment_binding = binding_for_name(&model, "x");
+    let analysis = model.analysis();
+
+    let function_scope = analysis
+        .function_scope_for_binding(function_binding.id)
+        .expect("expected function body scope for function binding");
+    let ScopeKind::Function(function_scope_kind) = model.scope_kind(function_scope) else {
+        panic!("expected function binding to map to a function scope");
+    };
+    assert!(function_scope_kind.contains_name_str("f"));
+    assert_eq!(
+        analysis.function_scope_for_binding(assignment_binding.id),
+        None
+    );
+}
+
+#[test]
 fn zsh_anonymous_functions_create_function_scoped_locals() {
     let source = "function { local scoped=1; echo \"$scoped\" \"$1\"; } arg\necho \"$scoped\"\n";
     let model = model_with_dialect(source, ShellDialect::Zsh);


### PR DESCRIPTION
## Summary

- add a focused semantic regression test for looking up a function body scope from its definition binding
- assert non-function bindings do not map to function scopes

## Validation

- cargo test -p shuck-semantic analysis_maps_function_binding_to_body_scope
