### PR TITLE
perf(linter): simple-glob fast path for case-pattern matcher

### DIFF
--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -273,6 +273,10 @@ impl StaticCasePatternMatcher {
             return result;
         }
 
+        if both_have_simple_glob_form(self, other) {
+            return true;
+        }
+
         let symbols = merged_case_pattern_symbols(
             self.literal_symbols.as_ref(),
             other.literal_symbols.as_ref(),
@@ -309,6 +313,10 @@ impl StaticCasePatternMatcher {
 
     fn intersects(&self, other: &Self) -> bool {
         if let Some(result) = intersects_fixed_length_fast_path(self, other) {
+            return result;
+        }
+
+        if let Some(result) = intersects_simple_glob_fast_path(self, other) {
             return result;
         }
 
@@ -433,6 +441,50 @@ fn subsumes_fixed_length_fast_path(
             }
         });
     Some(result)
+}
+
+fn glob_simple_form(matcher: &StaticCasePatternMatcher) -> Option<bool> {
+    let mut star_count = 0u32;
+    for token in &matcher.tokens {
+        match token {
+            CasePatternToken::Literal(_) => {}
+            CasePatternToken::AnyChar => return None,
+            CasePatternToken::AnyString => {
+                star_count += 1;
+                if star_count > 1 {
+                    return None;
+                }
+            }
+        }
+    }
+    Some(star_count == 1)
+}
+
+fn both_have_simple_glob_form(
+    left: &StaticCasePatternMatcher,
+    right: &StaticCasePatternMatcher,
+) -> bool {
+    glob_simple_form(left).is_some() && glob_simple_form(right).is_some()
+}
+
+fn intersects_simple_glob_fast_path(
+    left: &StaticCasePatternMatcher,
+    right: &StaticCasePatternMatcher,
+) -> Option<bool> {
+    let lh = glob_simple_form(left)?;
+    let rh = glob_simple_form(right)?;
+    let lp: &str = left.literal_prefix.as_ref();
+    let ls: &str = left.literal_suffix.as_ref();
+    let rp: &str = right.literal_prefix.as_ref();
+    let rs: &str = right.literal_suffix.as_ref();
+    Some(match (lh, rh) {
+        (false, false) => lp == rp,
+        (false, true) => lp.len() >= rp.len() + rs.len() && lp.starts_with(rp) && lp.ends_with(rs),
+        (true, false) => rp.len() >= lp.len() + ls.len() && rp.starts_with(lp) && rp.ends_with(ls),
+        (true, true) => {
+            (lp.starts_with(rp) || rp.starts_with(lp)) && (ls.ends_with(rs) || rs.ends_with(ls))
+        }
+    })
 }
 
 fn intersects_fixed_length_fast_path(


### PR DESCRIPTION
Stacked on top of #659. Once that lands, this PR's diff collapses to a single commit.

## Summary
- Add a second fast path to `StaticCasePatternMatcher::{subsumes,intersects}` for patterns whose tokens are literals plus at most one `AnyString` and no `AnyChar` — i.e. the common shell shapes `*`, `prefix*`, `*suffix`, `prefix*suffix`, and plain literals.
- For this shape, `subsumes` always returns true once `could_subsume` has passed, and `intersects` decomposes into a small case analysis over whether each side has the `*`. The NFA worklist (with its per-call `FxHashSet`/Vec/SmallVec allocations) is skipped.
- Patterns with multiple `*` or any `?` continue to use the existing NFA path.

## Profile delta
On `xwmx__nb__nb` (12 iterations, warm), attributed-exclusive cost of `StaticCasePatternMatcher::advance` drops from **3.9% → 3.3%** of total samples (~15% relative). The broader `LinterFactsBuilder::build` rollup is unchanged within noise — past 31% will need attacks on several remaining 1% sub-frames (`presence::sorted_presence_reference_indices`, `build_command_offset_order`, etc.).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo test -p shuck-linter` (3111 passed / 0 failed)
- [x] Reprofiled with `scripts/profiling/profile_large_corpus.sh xwmx__nb__nb`