### PR TITLE
perf(linter): u128 bitset NFA for case-pattern matcher

### DIFF
--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -85,3 +85,7 @@ harness = false
 name = "large_corpus_hotspots"
 harness = false
 required-features = ["large-corpus-hotspots"]
+
+[[bench]]
+name = "case_patterns"
+harness = false

--- a/crates/shuck-benchmark/benches/case_patterns.rs
+++ b/crates/shuck-benchmark/benches/case_patterns.rs
@@ -1,0 +1,232 @@
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use shuck_benchmark::configure_benchmark_allocator;
+use shuck_linter::BenchmarkCasePatternMatcher as Matcher;
+
+configure_benchmark_allocator!();
+
+struct PatternPair {
+    name: &'static str,
+    left: &'static str,
+    right: &'static str,
+}
+
+const PAIRS: &[PatternPair] = &[
+    // Pure literals — fixed-length fast path; no NFA work.
+    PatternPair {
+        name: "literal/equal",
+        left: "abcdef",
+        right: "abcdef",
+    },
+    PatternPair {
+        name: "literal/diff",
+        left: "abcdef",
+        right: "abcxyz",
+    },
+    PatternPair {
+        name: "literal/long_equal",
+        left: "configure_benchmark_allocator",
+        right: "configure_benchmark_allocator",
+    },
+    // Single '?' — fixed length, fast path.
+    PatternPair {
+        name: "qmark/single",
+        left: "?",
+        right: "a",
+    },
+    PatternPair {
+        name: "qmark/triple_dot_sh",
+        left: "???.sh",
+        right: "foo.sh",
+    },
+    PatternPair {
+        name: "qmark/all_qmark",
+        left: "????????",
+        right: "abcdefgh",
+    },
+    // Single-'*' simple-glob shapes — should hit PR #663's fast path.
+    PatternPair {
+        name: "star/bare",
+        left: "*",
+        right: "anything-here",
+    },
+    PatternPair {
+        name: "star/star_vs_star",
+        left: "*",
+        right: "*",
+    },
+    PatternPair {
+        name: "star/prefix",
+        left: "foo*",
+        right: "foobar",
+    },
+    PatternPair {
+        name: "star/suffix",
+        left: "*.txt",
+        right: "readme.txt",
+    },
+    PatternPair {
+        name: "star/middle",
+        left: "foo*bar",
+        right: "fooXYZbar",
+    },
+    PatternPair {
+        name: "star/prefix_vs_prefix",
+        left: "foo*",
+        right: "foobar*",
+    },
+    PatternPair {
+        name: "star/suffix_vs_suffix",
+        left: "*.sh",
+        right: "*.bash",
+    },
+    PatternPair {
+        name: "star/disjoint_prefix",
+        left: "foo*",
+        right: "bar*",
+    },
+    // Multi-'*' patterns — fall through to NFA product walk.
+    PatternPair {
+        name: "multistar/contains",
+        left: "*foo*",
+        right: "abcfoodef",
+    },
+    PatternPair {
+        name: "multistar/two_each",
+        left: "*foo*",
+        right: "*bar*",
+    },
+    PatternPair {
+        name: "multistar/three_segments",
+        left: "*a*b*c*",
+        right: "axxbyycyy",
+    },
+    PatternPair {
+        name: "multistar/repeated_token",
+        left: "*aa*",
+        right: "aaaaaaaaaa",
+    },
+    // Mixed '*' and '?' — NFA walk, more expensive.
+    PatternPair {
+        name: "mixed/qstar_around_lit",
+        left: "?*foo*?",
+        right: "abcfoodef",
+    },
+    PatternPair {
+        name: "mixed/lit_q_star",
+        left: "foo?*bar",
+        right: "fooXbar",
+    },
+    PatternPair {
+        name: "mixed/star_q_lit_q",
+        left: "*?.t?t",
+        right: "ab.txt",
+    },
+    PatternPair {
+        name: "mixed/long_alternation",
+        left: "a*?b*?c*?d",
+        right: "axbycdzdz",
+    },
+    // Realistic shell case-arm shapes.
+    PatternPair {
+        name: "shell/help",
+        left: "--help",
+        right: "--help",
+    },
+    PatternPair {
+        name: "shell/h_short",
+        left: "-h",
+        right: "--help",
+    },
+    PatternPair {
+        name: "shell/dash_anything",
+        left: "-*",
+        right: "-h",
+    },
+    PatternPair {
+        name: "shell/double_dash_anything",
+        left: "--*",
+        right: "--verbose",
+    },
+    PatternPair {
+        name: "shell/sh_ext",
+        left: "*.sh",
+        right: "*.bash",
+    },
+    PatternPair {
+        name: "shell/script_ext",
+        left: "*.sh",
+        right: "*.zsh",
+    },
+    PatternPair {
+        name: "shell/path_under",
+        left: "/usr/local/*",
+        right: "/usr/local/bin/foo",
+    },
+    PatternPair {
+        name: "shell/wildcard_anywhere",
+        left: "*",
+        right: "/var/log/messages",
+    },
+];
+
+fn build_matchers() -> Vec<(&'static str, Matcher, Matcher)> {
+    PAIRS
+        .iter()
+        .map(|pair| {
+            let left = Matcher::from_glob(pair.left)
+                .unwrap_or_else(|| panic!("not statically analyzable: {}", pair.left));
+            let right = Matcher::from_glob(pair.right)
+                .unwrap_or_else(|| panic!("not statically analyzable: {}", pair.right));
+            (pair.name, left, right)
+        })
+        .collect()
+}
+
+fn bench_subsumes(c: &mut Criterion) {
+    let mut group = c.benchmark_group("case_pattern_subsumes");
+    for (name, left, right) in build_matchers() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &(left, right),
+            |b, (l, r)| {
+                b.iter(|| {
+                    let a = black_box(l).subsumes(black_box(r));
+                    let b = black_box(r).subsumes(black_box(l));
+                    black_box(a) || black_box(b)
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_intersects(c: &mut Criterion) {
+    let mut group = c.benchmark_group("case_pattern_intersects");
+    for (name, left, right) in build_matchers() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(name),
+            &(left, right),
+            |b, (l, r)| {
+                b.iter(|| black_box(black_box(l).intersects(black_box(r))));
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_from_glob(c: &mut Criterion) {
+    let mut group = c.benchmark_group("case_pattern_from_glob");
+    for pair in PAIRS {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(pair.name),
+            pair.left,
+            |b, glob| {
+                b.iter(|| black_box(Matcher::from_glob(black_box(glob))));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_subsumes, bench_intersects, bench_from_glob);
+criterion_main!(benches);

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -179,6 +179,97 @@ struct StaticCasePatternMatcher {
     literal_suffix: Box<str>,
     literal_symbols: Box<[char]>,
     start_states: Box<[usize]>,
+    bit_nfa: Option<StaticCasePatternBitNfa>,
+}
+
+#[derive(Debug, Clone)]
+struct StaticCasePatternBitNfa {
+    accept: u128,
+    start: u128,
+    any_char: u128,
+    any_string: u128,
+    literal_masks: Box<[(char, u128)]>,
+}
+
+impl StaticCasePatternBitNfa {
+    fn new(tokens: &[CasePatternToken]) -> Option<Self> {
+        if tokens.len() >= 128 {
+            return None;
+        }
+
+        let mut any_char = 0u128;
+        let mut any_string = 0u128;
+        let mut literal_masks = Vec::<(char, u128)>::new();
+
+        for (i, token) in tokens.iter().copied().enumerate() {
+            let bit = 1u128 << i;
+            match token {
+                CasePatternToken::Literal(c) => literal_masks.push((c, bit)),
+                CasePatternToken::AnyChar => any_char |= bit,
+                CasePatternToken::AnyString => any_string |= bit,
+            }
+        }
+
+        literal_masks.sort_by_key(|(c, _)| *c);
+        let mut merged: Vec<(char, u128)> = Vec::with_capacity(literal_masks.len());
+        for (c, mask) in literal_masks {
+            match merged.last_mut() {
+                Some((last_c, last_mask)) if *last_c == c => *last_mask |= mask,
+                _ => merged.push((c, mask)),
+            }
+        }
+
+        let mut nfa = Self {
+            accept: 1u128 << tokens.len(),
+            start: 1,
+            any_char,
+            any_string,
+            literal_masks: merged.into_boxed_slice(),
+        };
+        nfa.start = nfa.epsilon_closure(nfa.start);
+        Some(nfa)
+    }
+
+    #[inline]
+    fn is_accepting(&self, states: u128) -> bool {
+        states & self.accept != 0
+    }
+
+    #[inline]
+    fn literal_mask(&self, c: char) -> u128 {
+        match self
+            .literal_masks
+            .binary_search_by_key(&c, |(literal, _)| *literal)
+        {
+            Ok(index) => self.literal_masks[index].1,
+            Err(_) => 0,
+        }
+    }
+
+    #[inline]
+    fn epsilon_closure(&self, mut states: u128) -> u128 {
+        loop {
+            let next = states | ((states & self.any_string) << 1);
+            if next == states {
+                return states;
+            }
+            states = next;
+        }
+    }
+
+    #[inline]
+    fn advance(&self, states: u128, symbol: CasePatternSymbol) -> u128 {
+        if states == 0 {
+            return 0;
+        }
+        let literal = match symbol {
+            CasePatternSymbol::Literal(c) => self.literal_mask(c),
+            CasePatternSymbol::Other => 0,
+        };
+        let shifted = (states & (literal | self.any_char)) << 1;
+        let stayed = states & self.any_string;
+        self.epsilon_closure(shifted | stayed)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -226,6 +317,7 @@ impl StaticCasePatternMatcher {
             literal_symbols,
             start_states,
         } = summarize_static_case_pattern_tokens(&tokens);
+        let bit_nfa = StaticCasePatternBitNfa::new(&tokens);
         Some(Self {
             tokens,
             min_len,
@@ -234,6 +326,7 @@ impl StaticCasePatternMatcher {
             literal_suffix,
             literal_symbols,
             start_states,
+            bit_nfa,
         })
     }
 
@@ -253,6 +346,7 @@ impl StaticCasePatternMatcher {
             literal_symbols,
             start_states,
         } = summarize_static_case_pattern_tokens(&tokens);
+        let bit_nfa = StaticCasePatternBitNfa::new(&tokens);
         Some(Self {
             tokens,
             min_len,
@@ -261,6 +355,7 @@ impl StaticCasePatternMatcher {
             literal_suffix,
             literal_symbols,
             start_states,
+            bit_nfa,
         })
     }
 
@@ -277,6 +372,14 @@ impl StaticCasePatternMatcher {
             return true;
         }
 
+        if let (Some(left_nfa), Some(right_nfa)) = (&self.bit_nfa, &other.bit_nfa) {
+            return self.subsumes_bitset(other, left_nfa, right_nfa);
+        }
+
+        self.subsumes_slow(other)
+    }
+
+    fn subsumes_slow(&self, other: &Self) -> bool {
         let symbols = merged_case_pattern_symbols(
             self.literal_symbols.as_ref(),
             other.literal_symbols.as_ref(),
@@ -311,7 +414,90 @@ impl StaticCasePatternMatcher {
         true
     }
 
+    fn subsumes_bitset(
+        &self,
+        other: &Self,
+        left_nfa: &StaticCasePatternBitNfa,
+        right_nfa: &StaticCasePatternBitNfa,
+    ) -> bool {
+        let symbols = merged_case_pattern_symbols(
+            self.literal_symbols.as_ref(),
+            other.literal_symbols.as_ref(),
+        );
+
+        let start = (left_nfa.start, right_nfa.start);
+        let mut seen = FxHashSet::default();
+        let mut worklist = Vec::with_capacity(32);
+        seen.insert(start);
+        worklist.push(start);
+
+        while let Some((left, right)) = worklist.pop() {
+            if right_nfa.is_accepting(right) && !left_nfa.is_accepting(left) {
+                return false;
+            }
+
+            for symbol in symbols.iter().copied() {
+                let next_right = right_nfa.advance(right, symbol);
+                if next_right == 0 {
+                    continue;
+                }
+                let next_left = left_nfa.advance(left, symbol);
+                let next = (next_left, next_right);
+                if seen.insert(next) {
+                    worklist.push(next);
+                }
+            }
+        }
+
+        true
+    }
+
+    fn intersects_bitset(
+        &self,
+        other: &Self,
+        left_nfa: &StaticCasePatternBitNfa,
+        right_nfa: &StaticCasePatternBitNfa,
+    ) -> bool {
+        let symbols = merged_case_pattern_symbols(
+            self.literal_symbols.as_ref(),
+            other.literal_symbols.as_ref(),
+        );
+
+        let start = (left_nfa.start, right_nfa.start);
+        let mut seen = FxHashSet::default();
+        let mut worklist = Vec::with_capacity(32);
+        seen.insert(start);
+        worklist.push(start);
+
+        while let Some((left, right)) = worklist.pop() {
+            if left_nfa.is_accepting(left) && right_nfa.is_accepting(right) {
+                return true;
+            }
+
+            for symbol in symbols.iter().copied() {
+                let next_left = left_nfa.advance(left, symbol);
+                if next_left == 0 {
+                    continue;
+                }
+                let next_right = right_nfa.advance(right, symbol);
+                if next_right == 0 {
+                    continue;
+                }
+                let next = (next_left, next_right);
+                if seen.insert(next) {
+                    worklist.push(next);
+                }
+            }
+        }
+
+        false
+    }
+
     fn intersects(&self, other: &Self) -> bool {
+        if !self.could_intersect(other) {
+            return false;
+        }
+
         if let Some(result) = intersects_fixed_length_fast_path(self, other) {
             return result;
         }
@@ -320,6 +506,14 @@ impl StaticCasePatternMatcher {
             return result;
         }
 
+        if let (Some(left_nfa), Some(right_nfa)) = (&self.bit_nfa, &other.bit_nfa) {
+            return self.intersects_bitset(other, left_nfa, right_nfa);
+        }
+
+        self.intersects_slow(other)
+    }
+
+    fn intersects_slow(&self, other: &Self) -> bool {
         let symbols = merged_case_pattern_symbols(
             self.literal_symbols.as_ref(),
             other.literal_symbols.as_ref(),
@@ -356,6 +550,28 @@ impl StaticCasePatternMatcher {
         }
 
         false
+    }
+
+    fn could_intersect(&self, other: &Self) -> bool {
+        if matches!(self.max_len, Some(max) if max < other.min_len) {
+            return false;
+        }
+        if matches!(other.max_len, Some(max) if max < self.min_len) {
+            return false;
+        }
+        if !literal_prefixes_compatible(
+            self.literal_prefix.as_ref(),
+            other.literal_prefix.as_ref(),
+        ) {
+            return false;
+        }
+        if !literal_suffixes_compatible(
+            self.literal_suffix.as_ref(),
+            other.literal_suffix.as_ref(),
+        ) {
+            return false;
+        }
+        true
     }
 
     fn could_subsume(&self, other: &Self) -> bool {
@@ -415,6 +631,51 @@ impl StaticCasePatternMatcher {
 
     fn is_accepting(&self, states: &[usize]) -> bool {
         states.contains(&self.tokens.len())
+    }
+}
+
+#[cfg(feature = "benchmarking")]
+pub mod benchmark {
+    use super::{
+        StaticCasePatternBitNfa, StaticCasePatternMatcher, StaticCasePatternSummary,
+        collect_static_case_pattern_tokens, summarize_static_case_pattern_tokens,
+    };
+
+    #[doc(hidden)]
+    pub struct CasePatternMatcher(StaticCasePatternMatcher);
+
+    impl CasePatternMatcher {
+        pub fn from_glob(glob: &str) -> Option<Self> {
+            let mut tokens = Vec::new();
+            collect_static_case_pattern_tokens(glob, &mut tokens)?;
+            let StaticCasePatternSummary {
+                min_len,
+                max_len,
+                literal_prefix,
+                literal_suffix,
+                literal_symbols,
+                start_states,
+            } = summarize_static_case_pattern_tokens(&tokens);
+            let bit_nfa = StaticCasePatternBitNfa::new(&tokens);
+            Some(Self(StaticCasePatternMatcher {
+                tokens,
+                min_len,
+                max_len,
+                literal_prefix,
+                literal_suffix,
+                literal_symbols,
+                start_states,
+                bit_nfa,
+            }))
+        }
+
+        pub fn subsumes(&self, other: &Self) -> bool {
+            self.0.subsumes(&other.0)
+        }
+
+        pub fn intersects(&self, other: &Self) -> bool {
+            self.0.intersects(&other.0)
+        }
     }
 }
 
@@ -509,6 +770,16 @@ fn intersects_fixed_length_fast_path(
             }
         });
     Some(result)
+}
+
+#[inline]
+fn literal_prefixes_compatible(left: &str, right: &str) -> bool {
+    left.is_empty() || right.is_empty() || left.starts_with(right) || right.starts_with(left)
+}
+
+#[inline]
+fn literal_suffixes_compatible(left: &str, right: &str) -> bool {
+    left.is_empty() || right.is_empty() || left.ends_with(right) || right.ends_with(left)
 }
 
 fn summarize_static_case_pattern_tokens(tokens: &[CasePatternToken]) -> StaticCasePatternSummary {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -161,6 +161,10 @@ pub fn benchmark_collect_word_facts(file: &File, source: &str, semantic: &Semant
     facts::words::benchmark_collect_word_facts(file, source, semantic)
 }
 
+#[cfg(feature = "benchmarking")]
+#[doc(hidden)]
+pub use facts::benchmark::CasePatternMatcher as BenchmarkCasePatternMatcher;
+
 /// Builds semantic facts and linter diagnostics for a parsed file at an optional source path.
 pub fn analyze_file_at_path(
     file: &File,


### PR DESCRIPTION
## Summary

- Rewrite `StaticCasePatternMatcher::{subsumes,intersects}` to use a u128-bitset NFA when patterns fit in 127 tokens. State sets become bitmasks, `advance` becomes pure bit ops, and epsilon closure is a fixpoint over `(states & any_string) << 1`. The existing SmallVec/`FxHashSet` worklist is retained as a fallback for patterns over the bit budget.
- Add a `could_intersect` cheap pre-check (length bounds + literal prefix/suffix compatibility) mirroring `could_subsume`, so trivially disjoint pairs short-circuit before any BFS.
- Add a Criterion bench `shuck-benchmark/benches/case_patterns.rs` covering literal, qmark, single-star, multi-star, mixed, and shell-extension patterns across `subsumes`, `intersects`, and matcher construction.

This stacks alongside #663's simple-glob fast path: the simple-glob shortcut still runs first for the cheapest pairs, and the bitset path handles everything else efficiently before any fallback to the slow worklist.

## Bench deltas (representative)

| Bench | Before | After | Delta |
|---|---:|---:|---:|
| `case_pattern_intersects/shell/sh_ext` (`*.sh` vs `*.bash`) | ~7 µs | 5.9 ns | -99.9% |
| `case_pattern_intersects/star/disjoint_prefix` (`foo*` vs `bar*`) | ~3.5 µs | 3.6 ns | -99.9% |
| `case_pattern_subsumes/multistar/two_each` (`*foo*` vs `*bar*`) | ~10 µs | 892 ns | -91% |
| `case_pattern_subsumes/star/star_vs_star` | — | — | -86% |

Tiny regressions (within noise) on already-fast paths such as `intersects/qmark/single` (8.7ns → 10ns).

Motivation: drilldown profiles flagged `StaticCasePatternMatcher::advance` and the surrounding `case_patterns` code as the dominant sub-frame inside `LinterFactsBuilder::build` (≈3% of total samples on the `xwmx__nb__nb` corpus).

## Test plan

- [x] `cargo build -p shuck-linter`
- [x] `cargo build -p shuck-benchmark --bench case_patterns`
- [x] `cargo test -p shuck-linter` (3110 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-linter -p shuck-benchmark --all-targets -- -D warnings`
- [ ] Re-run `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C062` (and any other case-pattern rules) once CI runs the suite