### PR TITLE
perf(linter): reuse semantic analysis for facts

### DIFF
--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -121,10 +121,11 @@ impl<'a> Checker<'a> {
     }
 
     fn build_facts(&self) -> LinterFacts<'a> {
-        LinterFacts::build_with_shell_and_ambient_shell_options(
+        LinterFacts::build_with_semantic_analysis_shell_and_ambient_shell_options(
             self.file,
             self.source,
             self.semantic,
+            &self.semantic_analysis,
             self.indexer,
             self.shell,
             self.ambient_shell_options,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -470,7 +470,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             build_presence_tested_names(&commands, self.source, self.semantic);
         let function_headers = build_function_header_facts(
             self.semantic,
-            &semantic_analysis,
+            semantic_analysis,
             &functions,
             &commands,
             self.source,
@@ -478,7 +478,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         );
         let function_cli_dispatch_facts = build_function_cli_dispatch_facts(
             self.semantic,
-            &semantic_analysis,
+            semantic_analysis,
             &function_headers,
             self.file,
             self.source,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -1,7 +1,8 @@
-struct LinterFactsBuilder<'a> {
+struct LinterFactsBuilder<'a, 'analysis> {
     file: &'a File,
     source: &'a str,
     semantic: &'a SemanticModel,
+    semantic_analysis: &'analysis SemanticAnalysis<'a>,
     _indexer: &'a Indexer,
     shell: ShellDialect,
     ambient_shell_options: AmbientShellOptions,
@@ -54,11 +55,12 @@ fn estimate_fact_build_capacity(file: &File) -> FactBuildCapacity {
     capacity
 }
 
-impl<'a> LinterFactsBuilder<'a> {
+impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
     fn new(
         file: &'a File,
         source: &'a str,
         semantic: &'a SemanticModel,
+        semantic_analysis: &'analysis SemanticAnalysis<'a>,
         indexer: &'a Indexer,
         shell: ShellDialect,
         ambient_shell_options: AmbientShellOptions,
@@ -67,6 +69,7 @@ impl<'a> LinterFactsBuilder<'a> {
             file,
             source,
             semantic,
+            semantic_analysis,
             _indexer: indexer,
             shell,
             ambient_shell_options,
@@ -75,7 +78,7 @@ impl<'a> LinterFactsBuilder<'a> {
 
     fn build(self) -> LinterFacts<'a> {
         let source = self.source;
-        let semantic_analysis = self.semantic.analysis();
+        let semantic_analysis = self.semantic_analysis;
         let capacity = estimate_fact_build_capacity(self.file);
         let estimated_word_nodes = capacity.commands.saturating_mul(2);
         let estimated_word_occurrences = capacity.commands.saturating_mul(3);

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -175,7 +175,36 @@ impl<'a> LinterFacts<'a> {
         shell: ShellDialect,
         ambient_shell_options: AmbientShellOptions,
     ) -> Self {
-        LinterFactsBuilder::new(file, source, semantic, indexer, shell, ambient_shell_options)
+        let semantic_analysis = semantic.analysis();
+        Self::build_with_semantic_analysis_shell_and_ambient_shell_options(
+            file,
+            source,
+            semantic,
+            &semantic_analysis,
+            indexer,
+            shell,
+            ambient_shell_options,
+        )
+    }
+
+    pub(crate) fn build_with_semantic_analysis_shell_and_ambient_shell_options(
+        file: &'a File,
+        source: &'a str,
+        semantic: &'a SemanticModel,
+        semantic_analysis: &SemanticAnalysis<'a>,
+        indexer: &'a Indexer,
+        shell: ShellDialect,
+        ambient_shell_options: AmbientShellOptions,
+    ) -> Self {
+        LinterFactsBuilder::new(
+            file,
+            source,
+            semantic,
+            semantic_analysis,
+            indexer,
+            shell,
+            ambient_shell_options,
+        )
         .build()
     }
 


### PR DESCRIPTION
## Summary

- Thread Checker's existing SemanticAnalysis into LinterFacts construction.
- Add an internal facts constructor that accepts a borrowed SemanticAnalysis while keeping the existing convenience constructors for standalone callers.
- Avoid rebuilding the lazy SemanticAnalysis cache set when facts and rules both need semantic-derived work.

## Validation

- `cargo fmt`
- `cargo check -p shuck-linter`
- `cargo test -p shuck-linter`
- `git diff --check`