### PR TITLE
test(parser): add obscure zsh syntax fixtures

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1198,6 +1198,212 @@ helper_value=ready
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
+    fn obscure_zsh_linter_stress_source() -> &'static str {
+        r#"#!/bin/zsh
+() {
+  emulate -L zsh
+  setopt extendedglob
+  local -a matches=(src/**/*.zsh(.N:t:r))
+  print -r -- ${(j:,:)matches}
+} one two
+
+{
+  if [[ -n ${commands[zsh]} ]] {
+    print -r -- ok
+  } elif (( ${+commands[false]} )) {
+    print -r -- maybe
+  } else {
+    print -r -- missing
+  }
+} always {
+  print -r -- cleanup
+}
+
+repeat 2 print -r -- tick
+
+foreach item (alpha beta gamma) {
+  print -r -- ${item:u}
+}
+
+typeset -A colors=(
+  [normal]=black
+  [warning]=yellow
+  [error]=red
+)
+print -r -- ${colors[(i)warn*]} ${colors[(r)r*]}
+colors[(I)e*]=brightred
+
+local target=/tmp/archive.tar.gz
+print -r -- ${${target:t}:r} ${${:-$target}:h}
+print -r -- ${(Q)${:-one\ two}} ${(%)${:-%n@%m}}
+
+local -a words=(one two three)
+print -r -- ${(j:|:)words}
+print -r -- ${(qqq)${(F)words}}
+
+print -r -- **/*.zsh(.DN:t:r)
+print -r -- *(^@N) *(.om[1,3])
+
+diff =(print -r -- left) <(print -r -- right)
+cat > >(sed 's/^/[out] /') <<< ${:-payload}
+
+print -r -- message >out.log >audit.log
+print -r -- quiet &>/dev/null &|
+
+case $OSTYPE in
+  (darwin|freebsd)<->)
+    print -r -- bsd ;|
+  linux(|-gnu))
+    print -r -- linux ;&
+  *)
+    print -r -- other ;;
+esac
+
+if [[ $file == (#b)(*/)([^/]##).(zsh|plugin)(#e) ]]; then
+  print -r -- $match[1] $match[2]
+fi
+
+zparseopts -D -E -F -- \
+  h=help -help=help \
+  v+:=verbose -verbose+:=verbose \
+  o:=output -output:=output
+
+noglob command print -r -- **/*(N)
+whence -m 'z*' >/dev/null
+
+PS1=$'%F{green}%n%f:%~ %# '
+local rendered=${(%)PS1}
+print -r -- $rendered
+
+integer count=${#path}
+(( count += ${+commands[git]} ? path[(I)*bin*] : 0 ))
+print -r -- $count
+
+coproc {
+  print -r -- request
+  read -r reply
+  print -r -- $reply
+}
+"#
+    }
+
+    #[test]
+    fn default_linter_handles_obscure_zsh_syntax_without_parse_rule_diagnostics() {
+        let source = obscure_zsh_linter_stress_source();
+        let path = Path::new("stress.zsh");
+        let diagnostics =
+            crate::test::test_snippet_at_path(path, source, &LinterSettings::default());
+
+        let parse_rules = [
+            Rule::MissingFi,
+            Rule::IfMissingThen,
+            Rule::LoopWithoutEnd,
+            Rule::MissingDoneInForLoop,
+            Rule::DanglingElse,
+            Rule::UntilMissingDo,
+            Rule::IfBracketGlued,
+            Rule::CPrototypeFragment,
+        ];
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !parse_rules.contains(&diagnostic.rule)),
+            "unexpected parse-shaped diagnostics: {diagnostics:#?}"
+        );
+    }
+
+    #[test]
+    fn native_zsh_portability_rules_ignore_obscure_zsh_syntax() {
+        let source = obscure_zsh_linter_stress_source();
+        let path = Path::new("stress.zsh");
+        let settings = LinterSettings::for_rules([
+            Rule::ZshRedirPipe,
+            Rule::ZshBraceIf,
+            Rule::ZshAlwaysBlock,
+            Rule::ZshFlagExpansion,
+            Rule::NestedZshSubstitution,
+            Rule::ZshNestedExpansion,
+            Rule::ZshPromptBracket,
+            Rule::ZshAssignmentToZero,
+            Rule::ZshParameterFlag,
+            Rule::ZshArraySubscriptInCase,
+            Rule::ZshParameterIndexFlag,
+            Rule::MultiVarForLoop,
+            Rule::ProcessSubstitution,
+            Rule::HereString,
+            Rule::Coproc,
+            Rule::ArrayAssignment,
+            Rule::ArrayReference,
+        ])
+        .with_shell(ShellDialect::Zsh);
+        let diagnostics = crate::test::test_snippet_at_path(path, source, &settings);
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:#?}");
+    }
+
+    #[test]
+    fn sourced_zsh_helper_imports_bindings_after_obscure_native_syntax() {
+        let temp = tempdir().unwrap();
+        let main = temp.path().join("main.zsh");
+        let helper = temp.path().join("helper.zsh");
+        fs::write(
+            &main,
+            "\
+#!/bin/zsh
+. ./helper.zsh
+print -r -- \"$helper_value\"
+",
+        )
+        .unwrap();
+        fs::write(
+            &helper,
+            r#"#!/bin/zsh
+() {
+  emulate -L zsh
+  local -a matches=(src/**/*.zsh(.N:t:r))
+  print -r -- ${(j:,:)matches}
+}
+
+{
+  if [[ -n ${commands[zsh]} ]] {
+    print -r -- ok
+  } else {
+    print -r -- missing
+  }
+} always {
+  print -r -- cleanup
+}
+
+typeset -A colors=(
+  [normal]=black
+  [warning]=yellow
+  [error]=red
+)
+print -r -- ${colors[(i)warn*]} ${colors[(r)r*]}
+
+foreach item (alpha beta gamma) {
+  print -r -- ${item:u}
+}
+
+print -r -- **/*.zsh(.DN:t:r)
+print -r -- *(^@N) *(.om[1,3])
+print -r -- quiet &>/dev/null &|
+
+case $OSTYPE in
+  (darwin|freebsd)<->) print -r -- bsd ;|
+  linux(|-gnu)) print -r -- linux ;&
+  *) print -r -- other ;;
+esac
+
+helper_value=ready
+"#,
+        )
+        .unwrap();
+
+        let diagnostics = lint_path_for_rule(&main, Rule::UndefinedVariable);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
     #[test]
     fn sourced_env_split_bash_helper_prefers_shebang_over_sh_extension() {
         let temp = tempdir().unwrap();

--- a/crates/shuck-parser/tests/oils_parse.rs
+++ b/crates/shuck-parser/tests/oils_parse.rs
@@ -10,7 +10,11 @@ use shuck_parser::parser::{Parser, ShellDialect};
 
 const OILS_DIR: &str = "tests/testdata/oils";
 const EXPECTATIONS_PATH: &str = "tests/testdata/oils_expectations.json";
-const ZSH_FIXTURE_FILES: &[&str] = &["zsh-idioms.test.sh", "zsh-large-corpus-regressions.test.sh"];
+const ZSH_FIXTURE_FILES: &[&str] = &[
+    "zsh-idioms.test.sh",
+    "zsh-large-corpus-regressions.test.sh",
+    "zsh-obscure-syntax.test.sh",
+];
 const ZSH_DEFAULT_PARSE_ERR_FILES: &[&str] = &["oils/zsh-large-corpus-regressions.test.sh"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]

--- a/crates/shuck-parser/tests/oils_parse.rs
+++ b/crates/shuck-parser/tests/oils_parse.rs
@@ -15,6 +15,7 @@ const ZSH_FIXTURE_FILES: &[&str] = &[
     "zsh-large-corpus-regressions.test.sh",
     "zsh-obscure-syntax.test.sh",
 ];
+const DEFAULT_ONLY_SKIP_FILES: &[&str] = &["oils/zsh-obscure-syntax.test.sh"];
 const ZSH_DEFAULT_PARSE_ERR_FILES: &[&str] = &["oils/zsh-large-corpus-regressions.test.sh"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
@@ -143,6 +144,28 @@ fn zsh_fixture_cases_match_parser_expectations_in_zsh_mode() {
         skipped_cases,
         failures.join("\n")
     );
+}
+
+#[test]
+fn zsh_only_default_skips_do_not_disable_zsh_mode_cases() {
+    let expectations_path = manifest_dir().join(EXPECTATIONS_PATH);
+    let expectations = load_expectations(&expectations_path);
+    let path = manifest_dir()
+        .join(OILS_DIR)
+        .join("zsh-obscure-syntax.test.sh");
+    let source = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    let spec_file = parse_spec_file(&path, &source);
+
+    assert!(!spec_file.cases.is_empty());
+    for spec_case in &spec_file.cases {
+        assert_eq!(
+            zsh_expectation_for(&expectations, &spec_file.path, &spec_case.name),
+            Expectation::ParseOk,
+            "{} should stay active in zsh-mode parser tests",
+            spec_case.name
+        );
+    }
 }
 
 fn load_selected_spec_files(oils_dir: &Path, filenames: &[&str]) -> Vec<SpecFile> {
@@ -360,6 +383,10 @@ fn expectation_for(
     file_path: &str,
     case_name: &str,
 ) -> Expectation {
+    if DEFAULT_ONLY_SKIP_FILES.contains(&file_path) {
+        return Expectation::Skip;
+    }
+
     if ZSH_DEFAULT_PARSE_ERR_FILES.contains(&file_path) {
         return expectations
             .get(file_path)

--- a/crates/shuck-parser/tests/testdata/oils/zsh-obscure-syntax.test.sh
+++ b/crates/shuck-parser/tests/testdata/oils/zsh-obscure-syntax.test.sh
@@ -1,0 +1,125 @@
+## compare_shells: zsh
+
+#### anonymous function with scoped options and argv
+
+() {
+  emulate -L zsh
+  setopt extendedglob
+  local -a matches=(src/**/*.zsh(.N:t:r))
+  print -r -- ${(j:,:)matches}
+} one two
+
+#### brace control flow with always cleanup
+
+{
+  if [[ -n ${commands[zsh]} ]] {
+    print -r -- ok
+  } elif (( ${+commands[false]} )) {
+    print -r -- maybe
+  } else {
+    print -r -- missing
+  }
+} always {
+  print -r -- cleanup
+}
+
+#### repeat and foreach short loop forms
+
+repeat 2 print -r -- tick
+
+foreach item (alpha beta gamma) {
+  print -r -- ${item:u}
+}
+
+for key value in ${(kv)parameters}; {
+  [[ $key == path ]] && print -r -- $value
+}
+
+#### typed associative array assignment and subscript flags
+
+typeset -A colors=(
+  [normal]=black
+  [warning]=yellow
+  [error]=red
+)
+print -r -- ${colors[(i)warn*]} ${colors[(r)r*]}
+colors[(I)e*]=brightred
+
+#### nested parameter substitutions with colon modifiers
+
+local target=/tmp/archive.tar.gz
+print -r -- ${${target:t}:r} ${${:-$target}:h}
+print -r -- ${(Q)${:-one\ two}} ${(%)${:-%n@%m}}
+
+#### parameter flags with delimiter arguments
+
+local -a words=(one two three)
+print -r -- ${(j:|:)words}
+print -r -- ${(ps:\0:)${:-one${(l:1::\0:):-}two}}
+print -r -- ${(qqq)${(F)words}}
+
+#### glob qualifiers and directory stack modifiers
+
+print -r -- **/*.zsh(.DN:t:r)
+print -r -- *(^@N) *(.om[1,3])
+
+#### equals and command process substitution words
+
+diff =(print -r -- left) <(print -r -- right)
+cat > >(sed 's/^/[out] /') <<< ${:-payload}
+
+#### zsh multios and pipe redirection
+
+print -r -- message >out.log >audit.log
+print -r -- quiet &>/dev/null &|
+
+#### case pattern operators and fallthrough terminators
+
+case $OSTYPE in
+  (darwin|freebsd)<->)
+    print -r -- bsd ;|
+  linux(|-gnu))
+    print -r -- linux ;&
+  *)
+    print -r -- other ;;
+esac
+
+#### extended glob patterns in conditionals
+
+if [[ $file == (#b)(*/)([^/]##).(zsh|plugin)(#e) ]]; then
+  print -r -- $match[1] $match[2]
+fi
+
+if [[ $name == (#i)readme.(md|txt) && $path == (#s)*/docs/*(#e) ]]; then
+  print -r -- docs
+fi
+
+#### zparseopts style option specs and command modifiers
+
+zparseopts -D -E -F -- \
+  h=help -help=help \
+  v+:=verbose -verbose+:=verbose \
+  o:=output -output:=output
+
+noglob command print -r -- **/*(N)
+whence -m 'z*' >/dev/null
+
+#### prompt escapes and ${(%)...} inside assignment
+
+PS1=$'%F{green}%n%f:%~ %# '
+local rendered=${(%)PS1}
+print -r -- $rendered
+
+#### arithmetic with zsh subscript expressions
+
+integer count=${#path}
+(( count += ${+commands[git]} ? path[(I)*bin*] : 0 ))
+print -r -- $count
+
+#### coproc block with zsh-style body
+
+coproc {
+  print -r -- request
+  read -r reply
+  print -r -- $reply
+}

--- a/crates/shuck-parser/tests/testdata/oils_expectations.json
+++ b/crates/shuck-parser/tests/testdata/oils_expectations.json
@@ -1,4 +1,8 @@
 {
+  "oils/zsh-obscure-syntax.test.sh": {
+    "expectation": "skip",
+    "reason": "fixture is intentionally zsh-only and is covered by the zsh-mode parser harness"
+  },
   "oils/array-sparse.test.sh::crash dump": {
     "expectation": "skip",
     "reason": "case uses YSH/OILS-only syntax or option modes outside the current Bash parser"

--- a/crates/shuck-parser/tests/testdata/oils_expectations.json
+++ b/crates/shuck-parser/tests/testdata/oils_expectations.json
@@ -1,8 +1,4 @@
 {
-  "oils/zsh-obscure-syntax.test.sh": {
-    "expectation": "skip",
-    "reason": "fixture is intentionally zsh-only and is covered by the zsh-mode parser harness"
-  },
   "oils/array-sparse.test.sh::crash dump": {
     "expectation": "skip",
     "reason": "case uses YSH/OILS-only syntax or option modes outside the current Bash parser"


### PR DESCRIPTION
## Summary

- add a zsh-only Oils parser fixture covering obscure syntax surfaces such as anonymous functions, `always`, short loops, multi-target `for`, associative subscripts, nested parameter modifiers, glob qualifiers, multios, extendedglob conditionals, and `coproc`
- include the fixture in the zsh-mode parser harness
- skip the fixture in the default parser expectation sweep because it is intentionally zsh-only

## Validation

- `zsh -n crates/shuck-parser/tests/testdata/oils/zsh-obscure-syntax.test.sh`
- `cargo test -p shuck-parser --test oils_parse zsh_fixture_cases_match_parser_expectations_in_zsh_mode -- --exact --nocapture`
- `cargo test -p shuck-parser --test oils_parse oils_corpus_matches_parser_expectations -- --exact --nocapture`
- `cargo test -p shuck-parser`
- `cargo fmt --check`
- `git diff --check`