### PR TITLE
refactor(semantic): index declarations by command span

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1849,7 +1849,7 @@ fn collect_dollar_question_after_command_spans_in_function_body(
 fn build_declaration_assignment_probes<'a>(
     command: &'a Command,
     normalized: &NormalizedCommand<'a>,
-    declaration_index: &FxHashMap<usize, &Declaration>,
+    semantic: &SemanticModel,
     source: &str,
     zsh_options: Option<&ZshOptionState>,
 ) -> Vec<DeclarationAssignmentProbe> {
@@ -1886,7 +1886,7 @@ fn build_declaration_assignment_probes<'a>(
         return Vec::new();
     }
 
-    let Some(declaration) = semantic_declaration_for_command(declaration_index, command) else {
+    let Some(declaration) = semantic.declaration_for_command_span(command_span(command)) else {
         return Vec::new();
     };
     let kind = declaration_kind_from_semantic(declaration.builtin);
@@ -1917,30 +1917,6 @@ fn build_declaration_assignment_probes<'a>(
             })
         })
         .collect()
-}
-
-fn build_semantic_declaration_index(
-    semantic: &SemanticModel,
-) -> FxHashMap<usize, &Declaration> {
-    let declarations = semantic.declarations();
-    let mut index = FxHashMap::with_capacity_and_hasher(declarations.len(), Default::default());
-    for declaration in declarations {
-        index.insert(declaration.span.start.offset, declaration);
-    }
-    index
-}
-
-fn semantic_declaration_for_command<'a>(
-    declaration_index: &FxHashMap<usize, &'a Declaration>,
-    command: &Command,
-) -> Option<&'a Declaration> {
-    let span = command_span(command);
-    let declaration = *declaration_index.get(&span.start.offset)?;
-    if declaration.span.end.offset == span.end.offset {
-        Some(declaration)
-    } else {
-        None
-    }
 }
 
 fn declaration_kind_from_semantic(builtin: DeclarationBuiltin) -> DeclarationKind {
@@ -2059,7 +2035,6 @@ fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
 fn collect_binding_values<'a>(
     command: &'a Command,
     semantic: &SemanticModel,
-    declaration_index: &FxHashMap<usize, &Declaration>,
     source: &str,
     binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
 ) {
@@ -2103,7 +2078,7 @@ fn collect_binding_values<'a>(
     }
 
     if matches!(command, Command::Simple(_))
-        && let Some(declaration) = semantic_declaration_for_command(declaration_index, command)
+        && let Some(declaration) = semantic.declaration_for_command_span(command_span(command))
     {
         for operand in &declaration.operands {
             let SemanticDeclarationOperand::Assignment {

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -119,7 +119,6 @@ impl<'a> LinterFactsBuilder<'a> {
         let mut pattern_charclass_spans = Vec::new();
         let mut arithmetic_summary = ArithmeticFactSummary::default();
         let mut surface_fragments = SurfaceFragmentSink::new(self.source);
-        let semantic_declaration_index = build_semantic_declaration_index(self.semantic);
         let mut functions = Vec::with_capacity(capacity.functions);
         let mut function_body_without_braces_spans = Vec::with_capacity(capacity.functions);
         let redundant_return_status_spans = Vec::new();
@@ -172,7 +171,6 @@ impl<'a> LinterFactsBuilder<'a> {
                 collect_binding_values(
                     visit.command,
                     self.semantic,
-                    &semantic_declaration_index,
                     self.source,
                     &mut binding_values,
                 );
@@ -290,7 +288,7 @@ impl<'a> LinterFactsBuilder<'a> {
                 let declaration_assignment_probes = build_declaration_assignment_probes(
                     visit.command,
                     &normalized,
-                    &semantic_declaration_index,
+                    self.semantic,
                     self.source,
                     command_zsh_options.as_ref(),
                 );

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -410,6 +410,7 @@ pub struct SemanticModel {
     zsh_option_analysis: Option<ZshOptionAnalysis>,
     assoc_lookup_binding_index: OnceLock<AssocLookupBindingIndex>,
     references_sorted_by_start: OnceLock<Vec<ReferenceId>>,
+    declarations_by_command_span: OnceLock<FxHashMap<SpanKey, usize>>,
 }
 
 /// Lazy analysis view over a `SemanticModel`.
@@ -515,6 +516,7 @@ impl SemanticModel {
             zsh_option_analysis,
             assoc_lookup_binding_index: OnceLock::new(),
             references_sorted_by_start: OnceLock::new(),
+            declarations_by_command_span: OnceLock::new(),
         }
     }
 
@@ -1113,6 +1115,15 @@ impl SemanticModel {
         &self.declarations
     }
 
+    pub fn declaration_for_command_span(&self, span: Span) -> Option<&Declaration> {
+        let index = self
+            .declarations_by_command_span
+            .get_or_init(|| build_declarations_by_command_span(&self.declarations));
+        index
+            .get(&SpanKey::new(span))
+            .map(|declaration_index| &self.declarations[*declaration_index])
+    }
+
     pub fn source_refs(&self) -> &[SourceRef] {
         &self.source_refs
     }
@@ -1424,6 +1435,14 @@ fn build_references_sorted_by_start(references: &[Reference]) -> Vec<ReferenceId
     let mut ids: Vec<ReferenceId> = (0..references.len() as u32).map(ReferenceId).collect();
     ids.sort_by_key(|id| references[id.index()].span.start.offset);
     ids
+}
+
+fn build_declarations_by_command_span(declarations: &[Declaration]) -> FxHashMap<SpanKey, usize> {
+    let mut index = FxHashMap::with_capacity_and_hasher(declarations.len(), Default::default());
+    for (declaration_index, declaration) in declarations.iter().enumerate() {
+        index.insert(SpanKey::new(declaration.span), declaration_index);
+    }
+    index
 }
 
 /// Iterator returned by [`SemanticModel::references_in_span`].


### PR DESCRIPTION
## Summary

- Add a lazy semantic-model index for declaration lookup by command span.
- Replace the linter fact builder's per-build declaration offset map with `SemanticModel::declaration_for_command_span`.
- Keep declaration assignment and binding-value facts using semantic-owned declaration data directly.

## Validation

- `cargo test -p shuck-linter facts::tests::assignments`
- `cargo test -p shuck-semantic declaration`
- `make test`