### PR TITLE
fix(parser): harden fuzz-discovered parser edge cases

### DIFF
--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -4238,7 +4238,7 @@ fn scan_command_subst_parameter_expansion_len(
     parameter_depth: usize,
 ) -> Option<usize> {
     if parameter_depth >= MAX_PARAMETER_EXPANSION_SCAN_DEPTH {
-        return None;
+        return scan_command_subst_parameter_expansion_len_balanced(input, subst_depth);
     }
 
     let mut index = 0usize;
@@ -4325,6 +4325,109 @@ fn scan_command_subst_parameter_expansion_len(
                 && !was_escaped =>
             {
                 return Some(next_index);
+            }
+            _ => {}
+        }
+
+        ansi_c_quote_pending = ch == '$'
+            && !in_single
+            && !in_ansi_c_single
+            && !in_double
+            && !in_backtick
+            && !was_escaped;
+        index = next_index;
+    }
+
+    None
+}
+
+fn scan_command_subst_parameter_expansion_len_balanced(
+    input: &str,
+    subst_depth: usize,
+) -> Option<usize> {
+    let mut index = 0usize;
+    let mut brace_depth = 1usize;
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_ansi_c_single = false;
+    let mut in_backtick = false;
+    let mut escaped = false;
+    let mut ansi_c_quote_pending = false;
+
+    while let Some((ch, next_index)) = next_char_boundary(input, index) {
+        let was_escaped = escaped;
+        if ch == '\\' && !in_single {
+            escaped = !escaped;
+            index = next_index;
+            ansi_c_quote_pending = false;
+            continue;
+        }
+        escaped = false;
+
+        if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped && ch == '$' {
+            if input[next_index..].starts_with('{') {
+                brace_depth = brace_depth.saturating_add(1);
+                index = next_index + '{'.len_utf8();
+                ansi_c_quote_pending = false;
+                continue;
+            }
+
+            if input[next_index..].starts_with('(')
+                && !input[next_index + '('.len_utf8()..].starts_with('(')
+                && let Some(consumed) = scan_command_substitution_body_len_inner(
+                    &input[next_index + '('.len_utf8()..],
+                    subst_depth + 1,
+                )
+            {
+                index = next_index + '('.len_utf8() + consumed;
+                ansi_c_quote_pending = false;
+                continue;
+            }
+        }
+
+        if !in_single
+            && !in_ansi_c_single
+            && !in_double
+            && !in_backtick
+            && !was_escaped
+            && matches!(ch, '<' | '>')
+            && input[next_index..].starts_with('(')
+            && let Some(consumed) = scan_command_substitution_body_len_inner(
+                &input[next_index + '('.len_utf8()..],
+                subst_depth + 1,
+            )
+        {
+            index = next_index + '('.len_utf8() + consumed;
+            ansi_c_quote_pending = false;
+            continue;
+        }
+
+        match ch {
+            '\'' if !in_double && !in_backtick && !was_escaped => {
+                if in_ansi_c_single {
+                    in_ansi_c_single = false;
+                } else if !in_single && ansi_c_quote_pending {
+                    in_ansi_c_single = true;
+                } else {
+                    in_single = !in_single;
+                }
+            }
+            '"' if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped => {
+                in_double = !in_double
+            }
+            '`' if !in_single && !in_ansi_c_single && !in_double && !was_escaped => {
+                in_backtick = !in_backtick
+            }
+            '}' if !in_single
+                && !in_ansi_c_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped =>
+            {
+                brace_depth = brace_depth.saturating_sub(1);
+                if brace_depth == 0 {
+                    return Some(next_index);
+                }
             }
             _ => {}
         }
@@ -4993,6 +5096,19 @@ mod tests {
         assert_eq!(
             token.word_text(),
             Some(r#"$(echo "$(echo "$(echo "$(echo "${name}")")")")"#)
+        );
+    }
+
+    #[test]
+    fn test_command_substitution_preserves_deep_parameter_operand_paren() {
+        let source = r#""$(echo "${a:-${b:-${c:-${d:-${e:-x})}}}}")""#;
+        let mut lexer = Lexer::new(source);
+
+        let token = lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::QuotedWord);
+        assert_eq!(
+            token.word_text(),
+            Some(r#"$(echo "${a:-${b:-${c:-${d:-${e:-x})}}}}")"#)
         );
     }
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -551,6 +551,7 @@ pub(crate) struct HeredocRead {
 /// Maximum nesting depth for command substitution in the lexer.
 /// Prevents stack overflow from deeply nested $() patterns.
 const DEFAULT_MAX_SUBST_DEPTH: usize = 50;
+const MAX_PARAMETER_EXPANSION_SCAN_DEPTH: usize = 4;
 
 #[derive(Clone, Debug)]
 struct Cursor<'a> {
@@ -4231,6 +4232,10 @@ fn scan_double_quoted_command_substitution_segment(
 }
 
 fn scan_command_subst_parameter_expansion_len(input: &str, subst_depth: usize) -> Option<usize> {
+    if subst_depth >= MAX_PARAMETER_EXPANSION_SCAN_DEPTH {
+        return None;
+    }
+
     let mut index = 0usize;
     let mut in_single = false;
     let mut in_double = false;
@@ -4253,7 +4258,7 @@ fn scan_command_subst_parameter_expansion_len(input: &str, subst_depth: usize) -
             if input[next_index..].starts_with('{')
                 && let Some(consumed) = scan_command_subst_parameter_expansion_len(
                     &input[next_index + '{'.len_utf8()..],
-                    subst_depth,
+                    subst_depth + 1,
                 )
             {
                 index = next_index + '{'.len_utf8() + consumed;
@@ -4463,7 +4468,10 @@ fn flush_scanned_command_subst_keyword(
     *word_started_at_command_start = false;
 }
 
-fn scan_command_substitution_body_len_inner(input: &str, subst_depth: usize) -> Option<usize> {
+pub(super) fn scan_command_substitution_body_len_inner(
+    input: &str,
+    subst_depth: usize,
+) -> Option<usize> {
     if subst_depth >= DEFAULT_MAX_SUBST_DEPTH {
         return None;
     }

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -4212,6 +4212,7 @@ fn scan_double_quoted_command_substitution_segment(
                 let consumed = scan_command_subst_parameter_expansion_len(
                     &input[next_index + '{'.len_utf8()..],
                     subst_depth,
+                    0,
                 )?;
                 index = next_index + '{'.len_utf8() + consumed;
             }
@@ -4231,8 +4232,12 @@ fn scan_double_quoted_command_substitution_segment(
     None
 }
 
-fn scan_command_subst_parameter_expansion_len(input: &str, subst_depth: usize) -> Option<usize> {
-    if subst_depth >= MAX_PARAMETER_EXPANSION_SCAN_DEPTH {
+fn scan_command_subst_parameter_expansion_len(
+    input: &str,
+    subst_depth: usize,
+    parameter_depth: usize,
+) -> Option<usize> {
+    if parameter_depth >= MAX_PARAMETER_EXPANSION_SCAN_DEPTH {
         return None;
     }
 
@@ -4258,7 +4263,8 @@ fn scan_command_subst_parameter_expansion_len(input: &str, subst_depth: usize) -
             if input[next_index..].starts_with('{')
                 && let Some(consumed) = scan_command_subst_parameter_expansion_len(
                     &input[next_index + '{'.len_utf8()..],
-                    subst_depth + 1,
+                    subst_depth,
+                    parameter_depth + 1,
                 )
             {
                 index = next_index + '{'.len_utf8() + consumed;
@@ -4751,6 +4757,7 @@ pub(super) fn scan_command_substitution_body_len_inner(
                 let consumed = scan_command_subst_parameter_expansion_len(
                     &input[next_index + '{'.len_utf8()..],
                     subst_depth,
+                    0,
                 )?;
                 index = next_index + '{'.len_utf8() + consumed;
                 if expecting_redirection_target {
@@ -4973,6 +4980,19 @@ mod tests {
         assert_eq!(
             token.word_text(),
             Some(r#"$(echo "${@}" | tr -d '[:space:]')"#)
+        );
+    }
+
+    #[test]
+    fn test_deep_command_substitution_preserves_simple_parameter_expansion() {
+        let source = r#""$(echo "$(echo "$(echo "$(echo "${name}")")")")""#;
+        let mut lexer = Lexer::new(source);
+
+        let token = lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::QuotedWord);
+        assert_eq!(
+            token.word_text(),
+            Some(r#"$(echo "$(echo "$(echo "$(echo "${name}")")")")"#)
         );
     }
 

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -714,7 +714,10 @@ impl<'a> Parser<'a> {
         let mut cursor = parts[0].span.start.offset;
         for part in parts {
             if part.span.start.offset > cursor
-                && self.input[cursor..part.span.start.offset].contains(['{', '}'])
+                && self
+                    .input
+                    .get(cursor..part.span.start.offset)
+                    .is_some_and(|raw| raw.contains(['{', '}']))
             {
                 return true;
             }
@@ -725,7 +728,10 @@ impl<'a> Parser<'a> {
                 }
                 WordPart::SingleQuoted { .. }
                 | WordPart::DoubleQuoted { .. }
-                | WordPart::ZshQualifiedGlob(_) => part.span.slice(self.input).contains(['{', '}']),
+                | WordPart::ZshQualifiedGlob(_) => self
+                    .input
+                    .get(part.span.start.offset..part.span.end.offset)
+                    .is_some_and(|raw| raw.contains(['{', '}'])),
                 WordPart::Variable(_)
                 | WordPart::CommandSubstitution { .. }
                 | WordPart::ArithmeticExpansion { .. }
@@ -767,7 +773,10 @@ impl<'a> Parser<'a> {
                     );
                 }
                 WordPart::SingleQuoted { .. } => {
-                    Self::push_brace_scan_text(part.span.slice(self.input), part.span.start, out);
+                    if let Some(raw) = self.input.get(part.span.start.offset..part.span.end.offset)
+                    {
+                        Self::push_brace_scan_text(raw, part.span.start, out);
+                    }
                 }
                 WordPart::DoubleQuoted { parts, .. } => {
                     self.collect_brace_scan_chars_from_double_quoted_part(part.span, parts, out);
@@ -819,7 +828,10 @@ impl<'a> Parser<'a> {
                     );
                 }
                 WordPart::SingleQuoted { .. } => {
-                    Self::push_brace_scan_text(part.span.slice(self.input), part.span.start, out);
+                    if let Some(raw) = self.input.get(part.span.start.offset..part.span.end.offset)
+                    {
+                        Self::push_brace_scan_text(raw, part.span.start, out);
+                    }
                 }
                 WordPart::DoubleQuoted { parts, .. } => {
                     self.collect_brace_scan_chars_from_double_quoted_part(part.span, parts, out);

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -81,6 +81,10 @@ const DEFAULT_MAX_AST_DEPTH: usize = 100;
 /// In release builds this could safely be higher, but we use one value for consistency.
 const HARD_MAX_AST_DEPTH: usize = 100;
 
+/// Auxiliary word reparsing happens while the main parser is already on the stack.
+/// Keep its synthetic parser shallower than the main AST limit.
+const SOURCE_TEXT_WORD_REPARSE_MAX_DEPTH: usize = 32;
+
 /// Default maximum parser operations (matches ExecutionLimits default)
 const DEFAULT_MAX_PARSER_OPERATIONS: usize = 100_000;
 
@@ -484,7 +488,25 @@ impl<'a> Parser<'a> {
     /// Parse a fragment against the original source span so part offsets stay
     /// aligned with the surrounding script.
     fn parse_word_fragment(source: &str, text: &str, span: Span) -> Word {
-        let mut parser = Parser::new(text);
+        Self::parse_word_fragment_with_limits(
+            source,
+            text,
+            span,
+            DEFAULT_MAX_AST_DEPTH,
+            DEFAULT_MAX_PARSER_OPERATIONS,
+            ShellProfile::native(ShellDialect::Bash),
+        )
+    }
+
+    fn parse_word_fragment_with_limits(
+        source: &str,
+        text: &str,
+        span: Span,
+        max_depth: usize,
+        max_fuel: usize,
+        shell_profile: ShellProfile,
+    ) -> Word {
+        let mut parser = Parser::with_limits_and_profile(text, max_depth, max_fuel, shell_profile);
         let source_backed = span.end.offset <= source.len() && span.slice(source) == text;
         let start = Position::new();
         let fragment_span = Span::from_positions(start, start.advanced_by(text));
@@ -5116,17 +5138,40 @@ impl<'a> Parser<'a> {
         }
 
         let span = text.span();
+        let remaining_depth = self.max_depth.saturating_sub(self.current_depth);
+        if remaining_depth == 0 {
+            return self.word_with_single_part(
+                self.literal_part_from_text(text.slice(self.input), span, text.is_source_backed()),
+                span,
+            );
+        }
+        let reparse_depth = (remaining_depth - 1).min(SOURCE_TEXT_WORD_REPARSE_MAX_DEPTH);
+
         if !text.is_source_backed()
             && span.start.offset <= span.end.offset
             && span.end.offset <= self.input.len()
         {
             let raw = span.slice(self.input);
             if raw.contains("\\\"") {
-                return Self::parse_word_fragment(self.input, raw, span);
+                return Self::parse_word_fragment_with_limits(
+                    self.input,
+                    raw,
+                    span,
+                    reparse_depth,
+                    self.fuel,
+                    self.shell_profile.clone(),
+                );
             }
         }
 
-        Self::parse_word_fragment(self.input, text.slice(self.input), text.span())
+        Self::parse_word_fragment_with_limits(
+            self.input,
+            text.slice(self.input),
+            text.span(),
+            reparse_depth,
+            self.fuel,
+            self.shell_profile.clone(),
+        )
     }
 
     fn simple_source_text_as_word(&self, text: &SourceText) -> Option<Word> {

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -85,6 +85,10 @@ const HARD_MAX_AST_DEPTH: usize = 100;
 /// Keep its synthetic parser shallower than the main AST limit.
 const SOURCE_TEXT_WORD_REPARSE_MAX_DEPTH: usize = 32;
 
+/// Pattern operands can themselves contain parameter expansions with pattern operands.
+/// Keep that source-text reparsing shallow and preserve deeper text literally.
+const SOURCE_TEXT_PATTERN_REPARSE_MAX_DEPTH: usize = 4;
+
 /// Default maximum parser operations (matches ExecutionLimits default)
 const DEFAULT_MAX_PARSER_OPERATIONS: usize = 100_000;
 
@@ -349,6 +353,7 @@ impl<'a> Parser<'a> {
             current_depth: 0,
             fuel: max_fuel,
             max_fuel,
+            source_text_pattern_depth: 0,
             comments,
             aliases: HashMap::new(),
             expand_aliases: false,
@@ -5254,6 +5259,7 @@ impl<'a> Parser<'a> {
             peeked_token: self.peeked_token.clone(),
             current_depth: self.current_depth,
             fuel: self.fuel,
+            source_text_pattern_depth: self.source_text_pattern_depth,
             comments: self.comments.clone(),
             expand_next_word: self.expand_next_word,
             brace_group_depth: self.brace_group_depth,
@@ -5277,6 +5283,7 @@ impl<'a> Parser<'a> {
         self.peeked_token = checkpoint.peeked_token;
         self.current_depth = checkpoint.current_depth;
         self.fuel = checkpoint.fuel;
+        self.source_text_pattern_depth = checkpoint.source_text_pattern_depth;
         self.comments = checkpoint.comments;
         self.expand_next_word = checkpoint.expand_next_word;
         self.brace_group_depth = checkpoint.brace_group_depth;

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -83,7 +83,7 @@ const HARD_MAX_AST_DEPTH: usize = 100;
 
 /// Auxiliary word reparsing happens while the main parser is already on the stack.
 /// Keep its synthetic parser shallower than the main AST limit.
-const SOURCE_TEXT_WORD_REPARSE_MAX_DEPTH: usize = 32;
+const SOURCE_TEXT_WORD_REPARSE_MAX_DEPTH: usize = 8;
 
 /// Pattern operands can themselves contain parameter expansions with pattern operands.
 /// Keep that source-text reparsing shallow and preserve deeper text literally.

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -492,6 +492,7 @@ impl<'a> Parser<'a> {
 
     /// Parse a fragment against the original source span so part offsets stay
     /// aligned with the surrounding script.
+    #[cfg(test)]
     fn parse_word_fragment(source: &str, text: &str, span: Span) -> Word {
         Self::parse_word_fragment_with_limits(
             source,

--- a/crates/shuck-parser/src/parser/parser_state.rs
+++ b/crates/shuck-parser/src/parser/parser_state.rs
@@ -122,6 +122,8 @@ pub struct Parser<'a> {
     pub(super) fuel: usize,
     /// Maximum fuel (for error reporting)
     pub(super) max_fuel: usize,
+    /// Depth of reparsing source-text operands as patterns.
+    pub(super) source_text_pattern_depth: usize,
     /// Comments collected during parsing.
     pub(super) comments: Vec<Comment>,
     /// Known aliases declared earlier in the current parse stream.
@@ -155,6 +157,7 @@ pub(super) struct ParserCheckpoint<'a> {
     pub(super) current_span: Span,
     pub(super) peeked_token: Option<LexedToken<'a>>,
     pub(super) current_depth: usize,
+    pub(super) source_text_pattern_depth: usize,
     pub(super) fuel: usize,
     pub(super) comments: Vec<Comment>,
     pub(super) expand_next_word: bool,

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -1986,6 +1986,33 @@ fn test_zsh_case_group_separator_after_parameter_segment() {
 }
 
 #[test]
+fn test_zsh_case_group_separator_after_long_literal_prefix() {
+    let long_prefix = "a".repeat(600);
+    let input = format!(
+        "case \"$mode\" in\n  ({}|literal)) print ok ;;\nesac\n",
+        long_prefix
+    );
+    let script = Parser::with_dialect(&input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Case(command) = compound else {
+        panic!("expected case command");
+    };
+
+    let pattern = &command.cases[0].patterns[0];
+    let PatternPart::Group { kind, patterns } = &pattern.parts[0].kind else {
+        panic!("expected long zsh case group");
+    };
+    assert_eq!(*kind, PatternGroupKind::ExactlyOne);
+    assert_eq!(patterns.len(), 2);
+    assert_eq!(patterns[0].render_syntax(&input), long_prefix);
+    assert_eq!(patterns[1].render_syntax(&input), "literal");
+}
+
+#[test]
 fn test_zsh_case_accepts_numeric_range_pattern() {
     let input = concat!("case \"$jobspec\" in\n", "  <->) print ok ;;\n", "esac\n",);
     let script = Parser::with_dialect(input, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -1955,6 +1955,37 @@ fn test_zsh_case_accepts_suffix_bare_group_pattern() {
 }
 
 #[test]
+fn test_zsh_case_group_separator_after_parameter_segment() {
+    let input = concat!(
+        "case \"$mode\" in\n",
+        "  (${kind}|literal)) print ok ;;\n",
+        "esac\n",
+    );
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Case(command) = compound else {
+        panic!("expected case command");
+    };
+
+    let pattern = &command.cases[0].patterns[0];
+    let PatternPart::Group { kind, patterns } = &pattern.parts[0].kind else {
+        panic!("expected zsh group with parameter branch");
+    };
+    assert_eq!(*kind, PatternGroupKind::ExactlyOne);
+    assert_eq!(
+        patterns
+            .iter()
+            .map(|pattern| pattern.render_syntax(input))
+            .collect::<Vec<_>>(),
+        vec!["${kind}", "literal"]
+    );
+}
+
+#[test]
 fn test_zsh_case_accepts_numeric_range_pattern() {
     let input = concat!("case \"$jobspec\" in\n", "  <->) print ok ;;\n", "esac\n",);
     let script = Parser::with_dialect(input, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -3983,7 +3983,7 @@ fn test_parse_pattern_preserves_dynamic_fragments_inside_extglob() {
 
 #[test]
 fn test_parse_pattern_preserves_delimiters_past_group_depth_limit() {
-    let mut nested = "@(a|b)".to_string();
+    let mut nested = "?(a|b)".to_string();
     for suffix in ["c", "d", "e", "f", "g", "h", "i", "j", "k"] {
         nested = format!("@({nested}|{suffix})");
     }
@@ -4016,7 +4016,7 @@ fn test_parse_pattern_preserves_delimiters_past_group_depth_limit() {
         assert_eq!(patterns[1].render(&input), suffix);
         pattern = &patterns[0];
     }
-    assert_eq!(pattern.render(&input), "@(@(a|b)|c)");
+    assert_eq!(pattern.render(&input), "@(?(a|b)|c)");
 }
 
 #[test]
@@ -7715,6 +7715,30 @@ fn test_parse_zsh_deep_parameter_array_comma_stays_nested() {
         value.span.slice(source),
         "${a:-${b:-${c:-${d:-${e:-x},y}}}}"
     );
+}
+
+#[test]
+fn test_parse_zsh_deep_arithmetic_array_comma_stays_nested() {
+    let mut nested = "$((a, b))".to_string();
+    for _ in 0..5 {
+        nested = format!("$(({nested}))");
+    }
+    let source = format!("values=({nested})\n");
+    let output = Parser::with_dialect(&source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let command = expect_simple(&output.file.body[0]);
+    assert_eq!(command.assignments.len(), 1);
+    let AssignmentValue::Compound(array) = &command.assignments[0].value else {
+        panic!("expected compound assignment value");
+    };
+    assert_eq!(array.elements.len(), 1);
+
+    let ArrayElem::Sequential(value) = &array.elements[0] else {
+        panic!("expected sequential array element");
+    };
+    assert_eq!(value.span.slice(&source), nested);
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -7657,6 +7657,29 @@ fn test_parse_zsh_git_extras_style_quoted_continuations_inside_assignment() {
 }
 
 #[test]
+fn test_parse_zsh_deep_parameter_array_comma_stays_nested() {
+    let source = "values=(${a:-${b:-${c:-${d:-${e:-x},y}}}})\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let command = expect_simple(&output.file.body[0]);
+    assert_eq!(command.assignments.len(), 1);
+    let AssignmentValue::Compound(array) = &command.assignments[0].value else {
+        panic!("expected compound assignment value");
+    };
+    assert_eq!(array.elements.len(), 1);
+
+    let ArrayElem::Sequential(value) = &array.elements[0] else {
+        panic!("expected sequential array element");
+    };
+    assert_eq!(
+        value.span.slice(source),
+        "${a:-${b:-${c:-${d:-${e:-x},y}}}}"
+    );
+}
+
+#[test]
 fn test_parse_zsh_parameter_default_with_prompt_escape_text() {
     let source = "color_green=${BATTERY_COLOR_GREEN:-%F{green}}\n";
     Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -7742,6 +7742,30 @@ fn test_parse_zsh_deep_arithmetic_array_comma_stays_nested() {
 }
 
 #[test]
+fn test_parse_zsh_deep_arithmetic_skips_nested_parameter_parens() {
+    let mut nested = "$(( ${name:-1),2} ))".to_string();
+    for _ in 0..5 {
+        nested = format!("$(({nested}))");
+    }
+    let source = format!("values=({nested})\n");
+    let output = Parser::with_dialect(&source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let command = expect_simple(&output.file.body[0]);
+    assert_eq!(command.assignments.len(), 1);
+    let AssignmentValue::Compound(array) = &command.assignments[0].value else {
+        panic!("expected compound assignment value");
+    };
+    assert_eq!(array.elements.len(), 1);
+
+    let ArrayElem::Sequential(value) = &array.elements[0] else {
+        panic!("expected sequential array element");
+    };
+    assert_eq!(value.span.slice(&source), nested);
+}
+
+#[test]
 fn test_parse_zsh_parameter_default_with_prompt_escape_text() {
     let source = "color_green=${BATTERY_COLOR_GREEN:-%F{green}}\n";
     Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -3982,6 +3982,44 @@ fn test_parse_pattern_preserves_dynamic_fragments_inside_extglob() {
 }
 
 #[test]
+fn test_parse_pattern_preserves_delimiters_past_group_depth_limit() {
+    let mut nested = "@(a|b)".to_string();
+    for suffix in ["c", "d", "e", "f", "g", "h", "i", "j", "k"] {
+        nested = format!("@({nested}|{suffix})");
+    }
+    let input = format!("[[ value == {nested} ]]\n");
+    let script = Parser::new(&input).parse().unwrap().file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(pattern) = binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    let mut pattern = pattern;
+
+    for suffix in ["k", "j", "i", "h", "g", "f", "e", "d"] {
+        let [
+            PatternPartNode {
+                kind: PatternPart::Group { patterns, .. },
+                ..
+            },
+        ] = pattern.parts.as_slice()
+        else {
+            panic!("expected nested group");
+        };
+        assert_eq!(patterns.len(), 2);
+        assert_eq!(patterns[1].render(&input), suffix);
+        pattern = &patterns[0];
+    }
+    assert_eq!(pattern.render(&input), "@(@(a|b)|c)");
+}
+
+#[test]
 fn test_parse_conditional_regex_rejects_unquoted_right_brace_operand() {
     let input = "[[ { =~ { ]]\n";
     assert!(Parser::new(input).parse().is_err());

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -61,6 +61,9 @@ impl Default for DecodeWordPartsOptions {
 }
 
 impl<'a> PatternParser<'a> {
+    const MAX_PATTERN_GROUP_DEPTH: usize = 32;
+    const MAX_ZSH_CASE_GROUP_PRESCAN_BYTES: usize = 512;
+
     fn new(input: &'a str, word: &'a Word) -> Self {
         Self::from_word_parts_with_mode(input, &word.parts, word.span, PatternParseMode::Standard)
     }
@@ -109,17 +112,23 @@ impl<'a> PatternParser<'a> {
                 .map(|segment| self.segment_start(segment))
                 .unwrap_or(self.full_span.start),
         };
-        let mut pattern = self.parse_until(&mut cursor, false);
+        let mut pattern = self.parse_until(&mut cursor, false, 0);
         pattern.span = self.full_span;
         pattern
     }
 
-    fn parse_until(&self, cursor: &mut PatternCursor, stop_at_group_delim: bool) -> Pattern {
+    fn parse_until(
+        &self,
+        cursor: &mut PatternCursor,
+        stop_at_group_delim: bool,
+        group_depth: usize,
+    ) -> Pattern {
         let start = cursor.position;
         let mut parts = Vec::new();
         let mut literal = String::new();
         let mut literal_start: Option<Position> = None;
         let mut literal_end = start;
+        let allow_groups = group_depth < Self::MAX_PATTERN_GROUP_DEPTH;
 
         while let Some(segment) = self.segments.get(cursor.segment_index) {
             if stop_at_group_delim && self.peek_group_delimiter(*cursor).is_some() {
@@ -145,7 +154,10 @@ impl<'a> PatternParser<'a> {
                         continue;
                     }
 
-                    if let Some((group, next_cursor)) = self.try_parse_group(*cursor) {
+                    if allow_groups
+                        && let Some((group, next_cursor)) =
+                            self.try_parse_group(*cursor, group_depth)
+                    {
                         self.flush_literal(
                             &mut parts,
                             &mut literal,
@@ -157,7 +169,10 @@ impl<'a> PatternParser<'a> {
                         continue;
                     }
 
-                    if let Some((group, next_cursor)) = self.try_parse_zsh_case_group(*cursor) {
+                    if allow_groups
+                        && let Some((group, next_cursor)) =
+                            self.try_parse_zsh_case_group(*cursor, group_depth)
+                    {
                         self.flush_literal(
                             &mut parts,
                             &mut literal,
@@ -220,6 +235,7 @@ impl<'a> PatternParser<'a> {
     fn try_parse_zsh_case_group(
         &self,
         cursor: PatternCursor,
+        group_depth: usize,
     ) -> Option<(PatternPartNode, PatternCursor)> {
         if !matches!(
             self.mode,
@@ -232,12 +248,15 @@ impl<'a> PatternParser<'a> {
         if self.is_escaped(cursor) || opener != '(' {
             return None;
         }
+        if !self.has_zsh_case_group_separator(cursor) {
+            return None;
+        }
 
         let start = cursor.position;
         let mut next_cursor = cursor;
         self.consume_literal_char(&mut next_cursor)?;
 
-        let mut patterns = vec![self.parse_until(&mut next_cursor, true)];
+        let mut patterns = vec![self.parse_until(&mut next_cursor, true, group_depth + 1)];
         if self.peek_group_delimiter(next_cursor) != Some('|') {
             return None;
         }
@@ -245,7 +264,7 @@ impl<'a> PatternParser<'a> {
         loop {
             if self.peek_group_delimiter(next_cursor) == Some('|') {
                 self.consume_literal_char(&mut next_cursor)?;
-                patterns.push(self.parse_until(&mut next_cursor, true));
+                patterns.push(self.parse_until(&mut next_cursor, true, group_depth + 1));
                 continue;
             }
 
@@ -265,6 +284,45 @@ impl<'a> PatternParser<'a> {
 
             return None;
         }
+    }
+
+    fn has_zsh_case_group_separator(&self, cursor: PatternCursor) -> bool {
+        let Some(PatternSegment::Literal { text, .. }) = self.segments.get(cursor.segment_index)
+        else {
+            return false;
+        };
+        let Some(rest) = text.get(cursor.literal_offset + '('.len_utf8()..) else {
+            return false;
+        };
+
+        let mut escaped = false;
+        let mut paren_depth = 0usize;
+        let mut scanned = 0usize;
+        for ch in rest.chars() {
+            scanned += ch.len_utf8();
+            if scanned > Self::MAX_ZSH_CASE_GROUP_PRESCAN_BYTES {
+                return false;
+            }
+
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+
+            match ch {
+                '(' => paren_depth = paren_depth.saturating_add(1),
+                ')' if paren_depth == 0 => return false,
+                ')' => paren_depth -= 1,
+                '|' if paren_depth == 0 => return true,
+                _ => {}
+            }
+        }
+
+        false
     }
 
     fn flush_literal(
@@ -336,7 +394,11 @@ impl<'a> PatternParser<'a> {
         ))
     }
 
-    fn try_parse_group(&self, cursor: PatternCursor) -> Option<(PatternPartNode, PatternCursor)> {
+    fn try_parse_group(
+        &self,
+        cursor: PatternCursor,
+        group_depth: usize,
+    ) -> Option<(PatternPartNode, PatternCursor)> {
         let PatternSegment::Literal { text, .. } = self.segments.get(cursor.segment_index)? else {
             return None;
         };
@@ -366,7 +428,7 @@ impl<'a> PatternParser<'a> {
 
         let mut patterns = Vec::new();
         loop {
-            patterns.push(self.parse_until(&mut next_cursor, true));
+            patterns.push(self.parse_until(&mut next_cursor, true, group_depth + 1));
             match self.peek_group_delimiter(next_cursor) {
                 Some('|') => {
                     self.consume_literal_char(&mut next_cursor)?;
@@ -1126,7 +1188,17 @@ impl<'a> Parser<'a> {
         false
     }
 
+    const MAX_ARRAY_NESTED_EXPANSION_SCAN_DEPTH: usize = 4;
+
     fn scan_array_arithmetic_expansion_len(text: &str) -> Option<usize> {
+        Self::scan_array_arithmetic_expansion_len_inner(text, 0)
+    }
+
+    fn scan_array_arithmetic_expansion_len_inner(text: &str, scan_depth: usize) -> Option<usize> {
+        if scan_depth >= Self::MAX_ARRAY_NESTED_EXPANSION_SCAN_DEPTH {
+            return None;
+        }
+
         let mut index = 0usize;
         let mut depth = 2usize;
         let mut in_single = false;
@@ -1146,8 +1218,10 @@ impl<'a> Parser<'a> {
 
             if !in_single && !was_escaped && ch == '$' {
                 if text[next_index..].starts_with("((")
-                    && let Some(consumed) =
-                        Self::scan_array_arithmetic_expansion_len(&text[next_index + 2..])
+                    && let Some(consumed) = Self::scan_array_arithmetic_expansion_len_inner(
+                        &text[next_index + 2..],
+                        scan_depth + 1,
+                    )
                 {
                     index = next_index + 2 + consumed;
                     continue;
@@ -1155,8 +1229,9 @@ impl<'a> Parser<'a> {
 
                 if text[next_index..].starts_with('(')
                     && !text[next_index + '('.len_utf8()..].starts_with('(')
-                    && let Some(consumed) = lexer::scan_command_substitution_body_len(
+                    && let Some(consumed) = lexer::scan_command_substitution_body_len_inner(
                         &text[next_index + '('.len_utf8()..],
+                        scan_depth + 1,
                     )
                 {
                     index = next_index + '('.len_utf8() + consumed;
@@ -1164,8 +1239,9 @@ impl<'a> Parser<'a> {
                 }
 
                 if text[next_index..].starts_with('{')
-                    && let Some(consumed) = Self::scan_array_parameter_expansion_len(
+                    && let Some(consumed) = Self::scan_array_parameter_expansion_len_inner(
                         &text[next_index + '{'.len_utf8()..],
+                        scan_depth + 1,
                     )
                 {
                     index = next_index + '{'.len_utf8() + consumed;
@@ -1195,6 +1271,14 @@ impl<'a> Parser<'a> {
     }
 
     fn scan_array_parameter_expansion_len(text: &str) -> Option<usize> {
+        Self::scan_array_parameter_expansion_len_inner(text, 0)
+    }
+
+    fn scan_array_parameter_expansion_len_inner(text: &str, depth: usize) -> Option<usize> {
+        if depth >= Self::MAX_ARRAY_NESTED_EXPANSION_SCAN_DEPTH {
+            return None;
+        }
+
         let mut index = 0usize;
         let mut in_single = false;
         let mut in_ansi_c_single = false;
@@ -1217,8 +1301,9 @@ impl<'a> Parser<'a> {
 
             if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped && ch == '$' {
                 if text[next_index..].starts_with('{')
-                    && let Some(consumed) = Self::scan_array_parameter_expansion_len(
+                    && let Some(consumed) = Self::scan_array_parameter_expansion_len_inner(
                         &text[next_index + '{'.len_utf8()..],
+                        depth + 1,
                     )
                 {
                     index = next_index + '{'.len_utf8() + consumed;
@@ -1227,8 +1312,10 @@ impl<'a> Parser<'a> {
                 }
 
                 if text[next_index..].starts_with("((")
-                    && let Some(consumed) =
-                        Self::scan_array_arithmetic_expansion_len(&text[next_index + 2..])
+                    && let Some(consumed) = Self::scan_array_arithmetic_expansion_len_inner(
+                        &text[next_index + 2..],
+                        depth + 1,
+                    )
                 {
                     index = next_index + 2 + consumed;
                     ansi_c_quote_pending = false;
@@ -1237,8 +1324,9 @@ impl<'a> Parser<'a> {
 
                 if text[next_index..].starts_with('(')
                     && !text[next_index + '('.len_utf8()..].starts_with('(')
-                    && let Some(consumed) = lexer::scan_command_substitution_body_len(
+                    && let Some(consumed) = lexer::scan_command_substitution_body_len_inner(
                         &text[next_index + '('.len_utf8()..],
+                        depth + 1,
                     )
                 {
                     index = next_index + '('.len_utf8() + consumed;
@@ -1254,8 +1342,10 @@ impl<'a> Parser<'a> {
                 && !was_escaped
                 && matches!(ch, '<' | '>')
                 && text[next_index..].starts_with('(')
-                && let Some(consumed) =
-                    lexer::scan_command_substitution_body_len(&text[next_index + '('.len_utf8()..])
+                && let Some(consumed) = lexer::scan_command_substitution_body_len_inner(
+                    &text[next_index + '('.len_utf8()..],
+                    depth + 1,
+                )
             {
                 index = next_index + '('.len_utf8() + consumed;
                 ansi_c_quote_pending = false;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1387,6 +1387,29 @@ impl<'a> Parser<'a> {
             }
             escaped = false;
 
+            if !in_single && !was_escaped && ch == '$' {
+                if text[next_index..].starts_with('{')
+                    && let Some(consumed) = Self::scan_array_parameter_expansion_len_inner(
+                        &text[next_index + '{'.len_utf8()..],
+                        0,
+                    )
+                {
+                    index = next_index + '{'.len_utf8() + consumed;
+                    continue;
+                }
+
+                if text[next_index..].starts_with('(')
+                    && !text[next_index + '('.len_utf8()..].starts_with('(')
+                    && let Some(consumed) = lexer::scan_command_substitution_body_len_inner(
+                        &text[next_index + '('.len_utf8()..],
+                        0,
+                    )
+                {
+                    index = next_index + '('.len_utf8() + consumed;
+                    continue;
+                }
+            }
+
             match ch {
                 '\'' if !in_double && !was_escaped => in_single = !in_single,
                 '"' if !in_single && !was_escaped => in_double = !in_double,

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -189,7 +189,14 @@ impl<'a> PatternParser<'a> {
                         continue;
                     }
 
-                    if let Some((char_class, next_cursor)) = self.try_parse_char_class(*cursor) {
+                    let starts_unparsed_group = !allow_groups
+                        && stop_at_group_delim
+                        && unparsed_group_depth == 0
+                        && self.starts_unparsed_pattern_group(*cursor);
+
+                    if !starts_unparsed_group
+                        && let Some((char_class, next_cursor)) = self.try_parse_char_class(*cursor)
+                    {
                         self.flush_literal(
                             &mut parts,
                             &mut literal,
@@ -201,7 +208,9 @@ impl<'a> PatternParser<'a> {
                         continue;
                     }
 
-                    if let Some((wildcard, next_cursor)) = self.try_parse_wildcard(*cursor) {
+                    if !starts_unparsed_group
+                        && let Some((wildcard, next_cursor)) = self.try_parse_wildcard(*cursor)
+                    {
                         self.flush_literal(
                             &mut parts,
                             &mut literal,
@@ -213,10 +222,6 @@ impl<'a> PatternParser<'a> {
                         continue;
                     }
 
-                    let starts_unparsed_group = !allow_groups
-                        && stop_at_group_delim
-                        && unparsed_group_depth == 0
-                        && self.starts_unparsed_pattern_group(*cursor);
                     let was_escaped = self.is_escaped(*cursor);
                     let Some((ch, span)) = self.consume_literal_char(cursor) else {
                         break;
@@ -1290,7 +1295,7 @@ impl<'a> Parser<'a> {
 
     fn scan_array_arithmetic_expansion_len_inner(text: &str, scan_depth: usize) -> Option<usize> {
         if scan_depth >= Self::MAX_ARRAY_NESTED_EXPANSION_SCAN_DEPTH {
-            return None;
+            return Self::scan_array_arithmetic_expansion_len_balanced(text);
         }
 
         let mut index = 0usize;
@@ -1349,6 +1354,45 @@ impl<'a> Parser<'a> {
                 '(' if !in_single && !in_double && !was_escaped => depth += 1,
                 ')' if !in_single && !in_double && !was_escaped => {
                     depth -= 1;
+                    index = next_index;
+                    if depth == 0 {
+                        return Some(index);
+                    }
+                    continue;
+                }
+                _ => {}
+            }
+
+            index = next_index;
+        }
+
+        None
+    }
+
+    fn scan_array_arithmetic_expansion_len_balanced(text: &str) -> Option<usize> {
+        let mut index = 0usize;
+        let mut depth = 2usize;
+        let mut in_single = false;
+        let mut in_double = false;
+        let mut escaped = false;
+
+        while index < text.len() {
+            let ch = text[index..].chars().next()?;
+            let next_index = index + ch.len_utf8();
+            let was_escaped = escaped;
+            if ch == '\\' && !in_single {
+                escaped = !escaped;
+                index = next_index;
+                continue;
+            }
+            escaped = false;
+
+            match ch {
+                '\'' if !in_double && !was_escaped => in_single = !in_single,
+                '"' if !in_single && !was_escaped => in_double = !in_double,
+                '(' if !in_single && !in_double && !was_escaped => depth = depth.saturating_add(1),
+                ')' if !in_single && !in_double && !was_escaped => {
+                    depth = depth.saturating_sub(1);
                     index = next_index;
                     if depth == 0 {
                         return Some(index);

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -61,7 +61,7 @@ impl Default for DecodeWordPartsOptions {
 }
 
 impl<'a> PatternParser<'a> {
-    const MAX_PATTERN_GROUP_DEPTH: usize = 32;
+    const MAX_PATTERN_GROUP_DEPTH: usize = 8;
     const MAX_ZSH_CASE_GROUP_PRESCAN_BYTES: usize = 512;
 
     fn new(input: &'a str, word: &'a Word) -> Self {
@@ -609,6 +609,21 @@ impl<'a> Parser<'a> {
 
     pub(super) fn pattern_from_source_text(&mut self, text: &SourceText) -> Pattern {
         let span = text.span();
+        if self.source_text_pattern_depth >= SOURCE_TEXT_PATTERN_REPARSE_MAX_DEPTH {
+            return Pattern {
+                parts: vec![PatternPartNode::new(
+                    PatternPart::Literal(if text.is_source_backed() {
+                        LiteralText::source()
+                    } else {
+                        LiteralText::owned(text.slice(self.input).to_string())
+                    }),
+                    span,
+                )],
+                span,
+            };
+        }
+
+        self.source_text_pattern_depth += 1;
         let mut parts = WordPartBuffer::new();
         self.decode_word_parts_into_with_quote_fragments(
             text.slice(self.input),
@@ -622,7 +637,9 @@ impl<'a> Parser<'a> {
             },
             &mut parts,
         );
-        PatternParser::from_word_parts(self.input, &parts, span).parse()
+        let pattern = PatternParser::from_word_parts(self.input, &parts, span).parse();
+        self.source_text_pattern_depth -= 1;
+        pattern
     }
 
     pub(super) fn single_literal_word_text<'b>(&'b self, word: &'b Word) -> Option<&'b str> {

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -305,7 +305,7 @@ impl<'a> PatternParser<'a> {
                     for ch in rest.chars() {
                         scanned += ch.len_utf8();
                         if scanned > Self::MAX_ZSH_CASE_GROUP_PRESCAN_BYTES {
-                            return false;
+                            return true;
                         }
 
                         if escaped {
@@ -329,7 +329,7 @@ impl<'a> PatternParser<'a> {
                 PatternSegment::Word(part) => {
                     scanned += part.span.end.offset.saturating_sub(part.span.start.offset);
                     if scanned > Self::MAX_ZSH_CASE_GROUP_PRESCAN_BYTES {
-                        return false;
+                        return true;
                     }
                     escaped = false;
                 }
@@ -1307,7 +1307,7 @@ impl<'a> Parser<'a> {
 
     fn scan_array_parameter_expansion_len_inner(text: &str, depth: usize) -> Option<usize> {
         if depth >= Self::MAX_ARRAY_NESTED_EXPANSION_SCAN_DEPTH {
-            return None;
+            return Self::scan_array_parameter_expansion_len_balanced(text);
         }
 
         let mut index = 0usize;
@@ -1406,6 +1406,117 @@ impl<'a> Parser<'a> {
                     && !was_escaped =>
                 {
                     return Some(next_index);
+                }
+                _ => {}
+            }
+
+            ansi_c_quote_pending = ch == '$'
+                && !in_single
+                && !in_ansi_c_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped;
+            index = next_index;
+        }
+
+        None
+    }
+
+    fn scan_array_parameter_expansion_len_balanced(text: &str) -> Option<usize> {
+        let mut index = 0usize;
+        let mut brace_depth = 1usize;
+        let mut in_single = false;
+        let mut in_ansi_c_single = false;
+        let mut in_double = false;
+        let mut in_backtick = false;
+        let mut escaped = false;
+        let mut ansi_c_quote_pending = false;
+
+        while index < text.len() {
+            let ch = text[index..].chars().next()?;
+            let next_index = index + ch.len_utf8();
+            let was_escaped = escaped;
+            if ch == '\\' && !in_single {
+                escaped = !escaped;
+                index = next_index;
+                ansi_c_quote_pending = false;
+                continue;
+            }
+            escaped = false;
+
+            if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped && ch == '$' {
+                if text[next_index..].starts_with("((")
+                    && let Some(consumed) =
+                        Self::scan_array_arithmetic_expansion_len_inner(&text[next_index + 2..], 0)
+                {
+                    index = next_index + 2 + consumed;
+                    ansi_c_quote_pending = false;
+                    continue;
+                }
+
+                if text[next_index..].starts_with('(')
+                    && !text[next_index + '('.len_utf8()..].starts_with('(')
+                    && let Some(consumed) = lexer::scan_command_substitution_body_len_inner(
+                        &text[next_index + '('.len_utf8()..],
+                        0,
+                    )
+                {
+                    index = next_index + '('.len_utf8() + consumed;
+                    ansi_c_quote_pending = false;
+                    continue;
+                }
+
+                if text[next_index..].starts_with('{') {
+                    brace_depth = brace_depth.saturating_add(1);
+                    index = next_index + '{'.len_utf8();
+                    ansi_c_quote_pending = false;
+                    continue;
+                }
+            }
+
+            if !in_single
+                && !in_ansi_c_single
+                && !in_double
+                && !in_backtick
+                && !was_escaped
+                && matches!(ch, '<' | '>')
+                && text[next_index..].starts_with('(')
+                && let Some(consumed) = lexer::scan_command_substitution_body_len_inner(
+                    &text[next_index + '('.len_utf8()..],
+                    0,
+                )
+            {
+                index = next_index + '('.len_utf8() + consumed;
+                ansi_c_quote_pending = false;
+                continue;
+            }
+
+            match ch {
+                '\'' if !in_double && !in_backtick && !was_escaped => {
+                    if in_ansi_c_single {
+                        in_ansi_c_single = false;
+                    } else if !in_single && ansi_c_quote_pending {
+                        in_ansi_c_single = true;
+                    } else {
+                        in_single = !in_single;
+                    }
+                }
+                '"' if !in_single && !in_ansi_c_single && !in_backtick && !was_escaped => {
+                    in_double = !in_double
+                }
+                '`' if !in_single && !in_ansi_c_single && !in_double && !was_escaped => {
+                    in_backtick = !in_backtick
+                }
+                '}' if !in_single
+                    && !in_ansi_c_single
+                    && !in_double
+                    && !in_backtick
+                    && !was_escaped =>
+                {
+                    brace_depth = brace_depth.saturating_sub(1);
+                    if brace_depth == 0 {
+                        return Some(next_index);
+                    }
                 }
                 _ => {}
             }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -129,9 +129,14 @@ impl<'a> PatternParser<'a> {
         let mut literal_start: Option<Position> = None;
         let mut literal_end = start;
         let allow_groups = group_depth < Self::MAX_PATTERN_GROUP_DEPTH;
+        let mut unparsed_group_depth = 0usize;
+        let mut pending_unparsed_group_open = false;
 
         while let Some(segment) = self.segments.get(cursor.segment_index) {
-            if stop_at_group_delim && self.peek_group_delimiter(*cursor).is_some() {
+            if stop_at_group_delim
+                && unparsed_group_depth == 0
+                && self.peek_group_delimiter(*cursor).is_some()
+            {
                 break;
             }
 
@@ -208,6 +213,11 @@ impl<'a> PatternParser<'a> {
                         continue;
                     }
 
+                    let starts_unparsed_group = !allow_groups
+                        && stop_at_group_delim
+                        && unparsed_group_depth == 0
+                        && self.starts_unparsed_pattern_group(*cursor);
+                    let was_escaped = self.is_escaped(*cursor);
                     let Some((ch, span)) = self.consume_literal_char(cursor) else {
                         break;
                     };
@@ -216,6 +226,28 @@ impl<'a> PatternParser<'a> {
                     }
                     literal_end = span.end;
                     literal.push(ch);
+                    if !allow_groups && stop_at_group_delim && !was_escaped {
+                        if pending_unparsed_group_open && ch == '(' {
+                            unparsed_group_depth = unparsed_group_depth.saturating_add(1);
+                            pending_unparsed_group_open = false;
+                        } else if unparsed_group_depth > 0 {
+                            match ch {
+                                '(' => {
+                                    unparsed_group_depth = unparsed_group_depth.saturating_add(1)
+                                }
+                                ')' => {
+                                    unparsed_group_depth = unparsed_group_depth.saturating_sub(1)
+                                }
+                                _ => {}
+                            }
+                        } else if starts_unparsed_group {
+                            if ch == '(' {
+                                unparsed_group_depth = unparsed_group_depth.saturating_add(1);
+                            } else {
+                                pending_unparsed_group_open = true;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -337,6 +369,37 @@ impl<'a> PatternParser<'a> {
         }
 
         false
+    }
+
+    fn starts_unparsed_pattern_group(&self, cursor: PatternCursor) -> bool {
+        if self.is_escaped(cursor) {
+            return false;
+        }
+
+        let Some(ch) = self.peek_literal_char(cursor) else {
+            return false;
+        };
+
+        if matches!(
+            self.mode,
+            PatternParseMode::ZshCase | PatternParseMode::ZshConditional
+        ) && ch == '('
+            && self.has_zsh_case_group_separator(cursor)
+        {
+            return true;
+        }
+
+        if !matches!(ch, '?' | '*' | '+' | '@' | '!') {
+            return false;
+        }
+
+        let Some(PatternSegment::Literal { text, .. }) = self.segments.get(cursor.segment_index)
+        else {
+            return false;
+        };
+        let next_offset = cursor.literal_offset + ch.len_utf8();
+        text.get(next_offset..)
+            .is_some_and(|rest| rest.starts_with('('))
     }
 
     fn flush_literal(

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -287,38 +287,52 @@ impl<'a> PatternParser<'a> {
     }
 
     fn has_zsh_case_group_separator(&self, cursor: PatternCursor) -> bool {
-        let Some(PatternSegment::Literal { text, .. }) = self.segments.get(cursor.segment_index)
-        else {
-            return false;
-        };
-        let Some(rest) = text.get(cursor.literal_offset + '('.len_utf8()..) else {
-            return false;
-        };
-
         let mut escaped = false;
         let mut paren_depth = 0usize;
         let mut scanned = 0usize;
-        for ch in rest.chars() {
-            scanned += ch.len_utf8();
-            if scanned > Self::MAX_ZSH_CASE_GROUP_PRESCAN_BYTES {
-                return false;
-            }
+        for (index, segment) in self.segments.iter().enumerate().skip(cursor.segment_index) {
+            match segment {
+                PatternSegment::Literal { text, .. } => {
+                    let offset = if index == cursor.segment_index {
+                        cursor.literal_offset + '('.len_utf8()
+                    } else {
+                        0
+                    };
+                    let Some(rest) = text.get(offset..) else {
+                        return false;
+                    };
 
-            if escaped {
-                escaped = false;
-                continue;
-            }
-            if ch == '\\' {
-                escaped = true;
-                continue;
-            }
+                    for ch in rest.chars() {
+                        scanned += ch.len_utf8();
+                        if scanned > Self::MAX_ZSH_CASE_GROUP_PRESCAN_BYTES {
+                            return false;
+                        }
 
-            match ch {
-                '(' => paren_depth = paren_depth.saturating_add(1),
-                ')' if paren_depth == 0 => return false,
-                ')' => paren_depth -= 1,
-                '|' if paren_depth == 0 => return true,
-                _ => {}
+                        if escaped {
+                            escaped = false;
+                            continue;
+                        }
+                        if ch == '\\' {
+                            escaped = true;
+                            continue;
+                        }
+
+                        match ch {
+                            '(' => paren_depth = paren_depth.saturating_add(1),
+                            ')' if paren_depth == 0 => return false,
+                            ')' => paren_depth -= 1,
+                            '|' if paren_depth == 0 => return true,
+                            _ => {}
+                        }
+                    }
+                }
+                PatternSegment::Word(part) => {
+                    scanned += part.span.end.offset.saturating_sub(part.span.start.offset);
+                    if scanned > Self::MAX_ZSH_CASE_GROUP_PRESCAN_BYTES {
+                        return false;
+                    }
+                    escaped = false;
+                }
             }
         }
 

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -769,6 +769,10 @@ fn mapfile_target(args: &[&Word], source: &str) -> Option<MapfileTarget> {
         index += 1;
     }
 
+    if index > args.len() {
+        return None;
+    }
+
     if let Some((name, span)) = args[index..]
         .iter()
         .find_map(|word| named_target_word(word, source))

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -3999,6 +3999,19 @@ mapfile
 }
 
 #[test]
+fn mapfile_missing_option_operand_does_not_panic() {
+    let source = "mapfile -u\n";
+    let model = model(source);
+
+    assert!(
+        !model
+            .bindings()
+            .iter()
+            .any(|binding| matches!(binding.kind, BindingKind::MapfileTarget))
+    );
+}
+
+#[test]
 fn read_header_bindings_consumed_in_loop_body_are_live() {
     let source = "\
 printf '%s\n' 'service safe ok yes' | while read UNIT EXPOSURE PREDICATE HAPPY; do


### PR DESCRIPTION
## Summary
- bound nested expansion, pattern, and source-text word reparsing paths found by fuzzing
- handle missing `mapfile` option operands without semantic-analysis panics
- make brace-syntax scans tolerate invalid UTF-8 byte offsets from recovered/fuzzed parses

## Validation
- fixed fuzz repros for parser timeout/slow-unit cases and arithmetic crash artifact
- `make test`
- `make test-large-corpus`
- fuzz loops 1-5 completed; loop 6 was in progress after the final fix when PR submission was requested

## Notes
Formatter fuzz targets were intentionally skipped because formatter fuzzing is currently out of scope.
