### PR TITLE
fix(linter): reduce S001 reviewed divergences

### DIFF
--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -202,10 +202,3 @@ reviewed_divergences:
     column: 96
     end_column: 99
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "v1s1t0r1sh3r3__airgeddon__airgeddon.sh"
-    line: 16442
-    end_line: 16442
-    column: 11
-    end_column: 23
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -98,27 +98,6 @@ reviewed_divergences:
     end_column: 48
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__functions__manage__base_fetch"
-    line: 223
-    end_line: 223
-    column: 18
-    end_column: 25
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__functions__manage__base_fetch"
-    line: 243
-    end_line: 243
-    column: 24
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__functions__manage__base_fetch"
-    line: 251
-    end_line: 251
-    column: 18
-    end_column: 25
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__macruby"
     line: 145
     end_line: 145

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -41,13 +41,6 @@ reviewed_divergences:
     column: 29
     end_column: 31
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__kalua__watch"
-    line: 2096
-    end_line: 2096
-    column: 10
-    end_column: 15
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
     line: 3374

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -49,13 +49,6 @@ reviewed_divergences:
     end_column: 15
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__profile.d__kalua.sh"
-    line: 11
-    end_line: 11
-    column: 33
-    end_column: 36
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
     line: 3374
     end_line: 3374

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -146,13 +146,6 @@ reviewed_divergences:
     column: 18
     end_column: 25
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "rvm__rvm__scripts__functions__manage__macruby"
-    line: 23
-    end_line: 23
-    column: 10
-    end_column: 21
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__macruby"
     line: 145

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -27,13 +27,6 @@ reviewed_divergences:
     column: 6
     end_column: 27
     reason: "The numeric default test on inet_offer_down stays quiet in ShellCheck, but Shuck does not preserve that conditional numeric proof here."
-  - side: shuck-only
-    path_suffix: "dehydrated-io__dehydrated__dehydrated"
-    line: 1077
-    end_line: 1077
-    column: 85
-    end_column: 109
-    reason: "The substring expansion is used to build an openssl -shaNNN flag, which ShellCheck suppresses but Shuck still treats as a generic argument."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__toolchain.sh"
     line: 155

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -5,116 +5,102 @@ reviewed_divergences:
     end_line: 1254
     column: 39
     end_column: 43
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "The protocol token is assembled from fixed protocol and transport enum fragments before it is passed onward."
   - side: shellcheck-only
     path_suffix: "RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh"
     line: 235
     end_line: 235
     column: 32
     end_column: 38
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd"
-    line: 245
-    end_line: 245
-    column: 36
-    end_column: 43
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
-    path_suffix: "alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd"
-    line: 259
-    end_line: 259
-    column: 36
-    end_column: 43
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "group comes from a static loop over display mode families before the TV service probe."
   - side: shuck-only
     path_suffix: "bats-core__bats-core__libexec__bats-core__bats-format-pretty"
     line: 78
     end_line: 78
     column: 13
     end_column: 32
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "move_up consumes its first parameter numerically, but numeric call contracts are not propagated back to callers yet."
   - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
     line: 3374
     end_line: 3374
     column: 6
     end_column: 27
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "The numeric default test on inet_offer_down stays quiet in ShellCheck, but Shuck does not preserve that conditional numeric proof here."
   - side: shuck-only
     path_suffix: "dehydrated-io__dehydrated__dehydrated"
     line: 1077
     end_line: 1077
     column: 85
     end_column: 109
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "The substring expansion is used to build an openssl -shaNNN flag, which ShellCheck suppresses but Shuck still treats as a generic argument."
   - side: shellcheck-only
     path_suffix: "gentoo__gentoo__eclass__tests__toolchain.sh"
     line: 155
     end_line: 155
     column: 7
     end_column: 13
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "ret is used as a numeric status slot before the helper call, so Shuck's suppression is semantically justified."
   - side: shellcheck-only
     path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
     line: 651
     end_line: 651
     column: 70
     end_column: 80
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "project is selected from fixed repository identifiers before the GitHub API URL is assembled."
   - side: shellcheck-only
     path_suffix: "juewuy__ShellCrash__scripts__menus__9_upgrade.sh"
     line: 867
     end_line: 867
     column: 52
     end_column: 62
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "db_type comes from a fixed dashboard selector before the archive path is assembled."
   - side: shuck-only
     path_suffix: "ko1nksm__shellspec__lib__general.sh"
     line: 442
     end_line: 442
     column: 15
     end_column: 39
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "shellspec_readfile_data is intentionally expanded through set -- after eval-built escaping, which ShellCheck suppresses but Shuck still flags."
   - side: shuck-only
     path_suffix: "masonr__yet-another-bench-script__yabs.sh"
     line: 991
     end_line: 991
     column: 12
     end_column: 19
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "GB_URL is selected from literal Geekbench download URLs before it is passed to the downloader command."
   - side: shuck-only
     path_suffix: "pi-hole__pi-hole__automated install__basic-install.sh"
     line: 1833
     end_line: 1833
     column: 21
     end_column: 39
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "webInterfaceDir is a webroot-derived path passed into the repository helper, but Shuck still treats it as a generic argument."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__binscripts__rvm-installer"
     line: 89
     end_line: 89
     column: 24
     end_column: 48
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "Inside this else arm rvm_tar_command only comes from literal tar command names before command -v runs."
   - side: shellcheck-only
     path_suffix: "rvm__rvm__scripts__functions__manage__macruby"
     line: 145
     end_line: 145
     column: 14
     end_column: 21
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "ShellCheck warns inside an unreachable branch tail that follows an earlier return 1."
   - side: shuck-only
     path_suffix: "swoodford__aws__vpc-sg-import-rules-cloudflare.sh"
     line: 281
     end_line: 281
     column: 101
     end_column: 106
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "PORT is regex-validated as a numeric or range token before the AWS --port argument is built."
   - side: shellcheck-only
     path_suffix: "tteck__Proxmox__vm__nextcloud-vm.sh"
     line: 210
     end_line: 210
     column: 96
     end_column: 99
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
+    reason: "HN is the current hostname seed used as a whiptail default value before any user edits."

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -35,13 +35,6 @@ reviewed_divergences:
     end_column: 32
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
-    path_suffix: "bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars"
-    line: 418
-    end_line: 418
-    column: 29
-    end_column: 31
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shuck-only
     path_suffix: "bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh"
     line: 3374
     end_line: 3374
@@ -131,27 +124,6 @@ reviewed_divergences:
     end_line: 145
     column: 14
     end_column: 21
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__functions__requirements__osx_brew"
-    line: 485
-    end_line: 485
-    column: 55
-    end_column: 74
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__functions__requirements__osx_brew"
-    line: 486
-    end_line: 486
-    column: 32
-    end_column: 51
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "rvm__rvm__scripts__functions__requirements__osx_brew"
-    line: 491
-    end_line: 491
-    column: 35
-    end_column: 51
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "swoodford__aws__vpc-sg-import-rules-cloudflare.sh"

--- a/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
+++ b/crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml
@@ -48,20 +48,6 @@ reviewed_divergences:
     column: 6
     end_column: 27
     reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__haos-vm.sh"
-    line: 636
-    end_line: 636
-    column: 23
-    end_column: 35
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
-  - side: shellcheck-only
-    path_suffix: "community-scripts__ProxmoxVE__vm__mikrotik-routeros.sh"
-    line: 655
-    end_line: 655
-    column: 25
-    end_column: 37
-    reason: "Exact S001 large-corpus residual from the ShellCheck oracle run; kept reviewed while the remaining safe-value parity work is handled separately."
   - side: shuck-only
     path_suffix: "dehydrated-io__dehydrated__dehydrated"
     line: 1077

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3474,6 +3474,21 @@ counter=$(ps -A | grep $tarpid | wc -l)
     }
 
     #[test]
+    fn skips_exit_arguments_with_only_numeric_bindings() {
+        let source = "\
+#!/bin/bash
+exit_code=1
+if [[ \"$1\" = retry ]]; then
+  exit_code=2
+fi
+exit ${exit_code}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_status_capture_after_escaped_name_only_declarations() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -4647,6 +4647,38 @@ qm resize 100 scsi0 ${DISK_SIZE}
     }
 
     #[test]
+    fn reports_local_bindings_initialized_via_called_helpers() {
+        let source = "\
+#!/bin/bash
+setup() {
+  mode=NTSC
+}
+
+render() {
+  printf '%s\\n' $mode
+}
+
+main() {
+  local mode
+  setup
+  render
+  printf '%s\\n' $mode
+}
+
+main
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$mode", "$mode"]
+        );
+    }
+
+    #[test]
     fn reports_helper_initialized_bindings_when_other_callers_skip_the_helper() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -4679,6 +4679,128 @@ main
     }
 
     #[test]
+    fn reports_status_capture_returns_into_caller_locals() {
+        let source = "\
+#!/bin/bash
+outer() {
+  local result=0
+  inner
+}
+
+inner() {
+  false ||
+  {
+    result=$?
+    return $result
+  }
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$result"]
+        );
+    }
+
+    #[test]
+    fn reports_subshell_status_capture_returns_into_caller_locals() {
+        let source = "\
+#!/bin/bash
+outer() {
+  local result=0
+  inner
+}
+
+inner() {
+  (
+    false ||
+    {
+      result=$?
+      return $result
+    }
+  )
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$result"]
+        );
+    }
+
+    #[test]
+    fn skips_sequential_status_capture_returns_into_caller_locals() {
+        let source = "\
+#!/bin/bash
+outer() {
+  local result=0
+  inner
+}
+
+inner() {
+  false
+  result=$?
+  return $result
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_subshell_sequential_status_capture_returns_into_caller_locals() {
+        let source = "\
+#!/bin/bash
+outer() {
+  local result=0
+  inner
+}
+
+inner() {
+  (
+    false
+    result=$?
+    return $result
+  )
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_branch_status_capture_when_caller_local_is_uninitialized() {
+        let source = "\
+#!/bin/bash
+outer() {
+  local result
+  inner
+}
+
+inner() {
+  false ||
+  {
+    result=$?
+    return $result
+  }
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_helper_initialized_bindings_when_other_callers_skip_the_helper() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -1058,6 +1058,31 @@ wrapper() {
     }
 
     #[test]
+    fn reports_unquoted_expansions_after_all_branch_returns() {
+        let source = "\
+#!/bin/bash
+wrapper() {
+  local good=0
+  if cond; then
+    return $good
+  else
+    return $good
+  fi
+  return $good
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$good"]
+        );
+    }
+
+    #[test]
     fn reports_unquoted_expansions_after_deferred_exit_like_calls_resolved_by_later_helpers() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -4580,6 +4580,73 @@ fi
     }
 
     #[test]
+    fn reports_top_level_arguments_after_branch_unsafe_helper_calls() {
+        let source = "\
+#!/bin/bash
+DISK_SIZE=\"32G\"
+
+advanced_settings() {
+  DISK_SIZE=\"$(get_size)\"
+}
+
+start_script() {
+  if choose; then
+    :
+  else
+    advanced_settings
+  fi
+}
+
+start_script
+qm resize 100 scsi0 ${DISK_SIZE}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${DISK_SIZE}"]
+        );
+    }
+
+    #[test]
+    fn reports_top_level_arguments_after_recursive_unsafe_helper_calls() {
+        let source = "\
+#!/bin/bash
+DISK_SIZE=\"32G\"
+
+advanced_settings() {
+  if choose_again; then
+    advanced_settings
+  fi
+  DISK_SIZE=\"$(get_size)\"
+}
+
+start_script() {
+  if choose; then
+    :
+  else
+    advanced_settings
+  fi
+}
+
+start_script
+qm resize 100 scsi0 ${DISK_SIZE}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${DISK_SIZE}"]
+        );
+    }
+
+    #[test]
     fn reports_helper_initialized_bindings_when_other_callers_skip_the_helper() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3481,6 +3481,28 @@ cleanup() {
     }
 
     #[test]
+    fn skips_subshell_status_return_operands_with_safe_base() {
+        let source = "\
+#!/bin/bash
+cleanup()
+(
+  \\typeset __result
+  __result=0
+  run_task \"$@\" || __result=$?
+  next_step && final_step || __result=$?
+  return ${__result}
+)
+invoke_cleanup() {
+  cleanup \"$@\"
+}
+invoke_cleanup \"$@\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_pid_capture_bindings() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -3358,6 +3358,26 @@ exit $?
     }
 
     #[test]
+    fn skips_nested_local_status_capture_returns() {
+        let source = "\
+#!/bin/sh
+prompt_set() {
+  face() {
+    local rc=$?
+
+    case \"$rc\" in
+      0) printf '%s' \"$1\" ;;
+      *) printf '%s' \"$2\" ; return $rc ;;
+    esac
+  }
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn skips_name_only_local_option_bindings() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -3947,6 +3947,12 @@ impl<'a> SafeValueIndex<'a> {
                         query == SafeValueQuery::Quoted
                     } else {
                         self.reference_is_safe(reference, at, query)
+                            || self.slice_reference_static_literals_stay_safe(
+                                reference,
+                                syntax,
+                                at,
+                                query,
+                            )
                     }
                 }
                 BourneParameterExpansion::Operation {
@@ -4061,6 +4067,63 @@ impl<'a> SafeValueIndex<'a> {
                     && self.word_is_static_safe_literal(replacement_word_ast, query)
             }
         }
+    }
+
+    fn slice_reference_static_literals_stay_safe(
+        &mut self,
+        reference: &VarRef,
+        slice: &BourneParameterExpansion,
+        at: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        let BourneParameterExpansion::Slice {
+            offset_word_ast,
+            length_word_ast,
+            ..
+        } = slice
+        else {
+            return false;
+        };
+        let Some(offset_text) = static_word_text(offset_word_ast, self.source) else {
+            return false;
+        };
+        let Ok(offset) = offset_text.parse::<isize>() else {
+            return false;
+        };
+        let length = match length_word_ast {
+            Some(word) => {
+                let Some(length_text) = static_word_text(word, self.source) else {
+                    return false;
+                };
+                let Ok(length) = length_text.parse::<usize>() else {
+                    return false;
+                };
+                Some(length)
+            }
+            None => None,
+        };
+
+        let mut bindings = self.safe_bindings_for_name(&reference.name, at);
+        self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        self.drop_outer_bindings_shadowed_by_covering_loop_bindings(&mut bindings, at);
+        self.retain_value_bindings(&mut bindings);
+        if bindings.is_empty() {
+            return false;
+        }
+
+        bindings.into_iter().all(|binding_id| {
+            let Some(word) = self
+                .facts
+                .binding_value(binding_id)
+                .and_then(|value| value.scalar_word())
+            else {
+                return false;
+            };
+            let Some(text) = static_word_text(word, self.source) else {
+                return false;
+            };
+            static_slice_result_is_safe(&text, offset, length, query)
+        })
     }
 
     fn word_is_static_safe_literal(&self, word: &Word, query: SafeValueQuery) -> bool {
@@ -4519,6 +4582,29 @@ fn function_has_terminal_exit(function: &FunctionDef) -> bool {
         stmt_terminal_flow_kind(&function.body),
         TerminalFlowKind::Exit
     )
+}
+
+fn static_slice_result_is_safe(
+    text: &str,
+    offset: isize,
+    length: Option<usize>,
+    query: SafeValueQuery,
+) -> bool {
+    let chars = text.chars().collect::<Vec<_>>();
+    let start = if offset < 0 {
+        let distance = offset.unsigned_abs();
+        chars.len().saturating_sub(distance)
+    } else {
+        offset as usize
+    };
+    if start > chars.len() {
+        return false;
+    }
+    let end = length
+        .map(|length| start.saturating_add(length).min(chars.len()))
+        .unwrap_or(chars.len());
+    let sliced = chars[start..end].iter().collect::<String>();
+    !sliced.is_empty() && query.literal_is_safe(&sliced)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -6697,6 +6783,62 @@ printf '%s\\n' ${debug:+\"a b\"}
             .expect("expected replacement-operator command argument fact");
 
         assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn static_literal_slice_bindings_stay_safe_in_argv_context() {
+        let source = "\
+#!/bin/bash
+if true; then
+  sig=RS256
+else
+  sig=ES512
+fi
+openssl dgst -sha${sig:2} payload
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "-sha${sig:2}"
+            })
+            .expect("expected sliced command argument fact");
+
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn dynamic_slice_bindings_stay_unsafe_in_argv_context() {
+        let source = "\
+#!/bin/bash
+sig=$1
+openssl dgst -sha${sig:2} payload
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "-sha${sig:2}"
+            })
+            .expect("expected sliced command argument fact");
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -2432,19 +2432,28 @@ impl<'a> SafeValueIndex<'a> {
         self.retain_value_bindings(&mut caller_bindings);
         let mut uncalled_function_bindings = self.uncalled_function_outer_bindings_at_end(name, at);
         self.retain_value_bindings(&mut uncalled_function_bindings);
-        let function_local_binding = self
-            .enclosing_function_scope_at(at.start.offset)
-            .is_some_and(|scope| {
-                bindings
-                    .iter()
-                    .copied()
-                    .any(|binding_id| self.binding_is_in_scope_or_descendant(binding_id, scope))
-            });
+        let function_scope = self.enclosing_function_scope_at(at.start.offset);
+        let function_local_binding = function_scope.is_some_and(|scope| {
+            bindings
+                .iter()
+                .copied()
+                .any(|binding_id| self.binding_is_in_scope_or_descendant(binding_id, scope))
+        });
+        let caller_bindings_refine_outer_bindings =
+            function_scope.is_some() && !function_local_binding && !caller_bindings.is_empty();
         if !uncalled_function_bindings.is_empty() && !function_local_binding {
             bindings = uncalled_function_bindings;
         }
-        if !caller_bindings.is_empty()
-            && self.enclosing_function_scope_at(at.start.offset).is_some()
+        if caller_bindings_refine_outer_bindings
+            && function_scope.is_some()
+            && !self.bindings_are_static_loop_variables(&caller_bindings)
+        {
+            bindings = caller_bindings;
+            bindings.extend(helper_bindings);
+            bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+            bindings.dedup();
+        } else if !caller_bindings.is_empty()
+            && function_scope.is_some()
             && !function_local_binding
             && self.bindings_are_static_loop_variables(&caller_bindings)
         {
@@ -2462,7 +2471,7 @@ impl<'a> SafeValueIndex<'a> {
             bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
             bindings.dedup();
         }
-        if let Some(scope) = self.enclosing_function_scope_at(at.start.offset)
+        if let Some(scope) = function_scope
             && bindings.iter().copied().any(|binding_id| {
                 self.binding_is_in_scope_or_descendant(binding_id, scope)
                     && self.binding_shadows_outer_scope_values(binding_id)
@@ -3224,6 +3233,16 @@ impl<'a> SafeValueIndex<'a> {
         let mut branch = self.visible_bindings_for_name_without_helpers(name, at);
         branch.extend(self.caller_visible_bindings_before(name, scope, at));
         branch.extend(self.called_helper_bindings_before(name, scope, at));
+        if matches!(self.semantic.scope(scope).kind, ScopeKind::File)
+            && self.callsite_is_within_guarded_branch(at)
+        {
+            branch.extend(self.top_level_transitive_helper_bindings_before(name, at));
+            self.drop_outer_bindings_shadowed_by_covering_top_level_helper_bindings(
+                &mut branch,
+                scope,
+                at,
+            );
+        }
         branch.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         branch.dedup();
         branch
@@ -3253,6 +3272,62 @@ impl<'a> SafeValueIndex<'a> {
         bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         bindings.dedup();
         bindings
+    }
+
+    fn callsite_is_within_guarded_branch(&self, at: Span) -> bool {
+        let call_span = self.command_for_name_word_span(at).map_or(at, |command| command.span());
+        let Some(mut command_id) = self.facts.innermost_command_id_at(call_span.start.offset) else {
+            return false;
+        };
+        while self.facts.command(command_id).span() != call_span {
+            let Some(parent_id) = self.facts.command_parent_id(command_id) else {
+                return false;
+            };
+            command_id = parent_id;
+        }
+
+        let mut current = self.facts.command_parent_id(command_id);
+        while let Some(command_id) = current {
+            let command = self.facts.command(command_id);
+            if command.span().start.offset < call_span.start.offset
+                && call_span.end.offset <= command.span().end.offset
+                && self.facts.command_is_dominance_barrier(command_id)
+            {
+                return true;
+            }
+            current = self.facts.command_parent_id(command_id);
+        }
+
+        false
+    }
+
+    fn drop_outer_bindings_shadowed_by_covering_top_level_helper_bindings(
+        &self,
+        bindings: &mut Vec<BindingId>,
+        scope: ScopeId,
+        at: Span,
+    ) {
+        let helper_bindings = bindings
+            .iter()
+            .copied()
+            .filter(|binding_id| {
+                let binding_scope = self.semantic.binding(*binding_id).scope;
+                binding_scope != scope && self.scope_is_ancestor(scope, binding_scope)
+            })
+            .collect::<Vec<_>>();
+        if helper_bindings.is_empty() {
+            return;
+        }
+
+        let call_span = self.command_for_name_word_span(at).map_or(at, |command| command.span());
+        if !self.bindings_cover_all_paths_to_callsite(&helper_bindings, call_span) {
+            return;
+        }
+
+        bindings.retain(|binding_id| {
+            let binding_scope = self.semantic.binding(*binding_id).scope;
+            binding_scope != scope || helper_bindings.contains(binding_id)
+        });
     }
 
     fn scope_has_visible_local_binding_before(
@@ -6450,6 +6525,86 @@ safe_path_b
             .expect("expected multi-caller helper-derived argument fact");
 
         assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn top_level_helper_initializers_refine_later_helper_calls() {
+        let source = "\
+#!/bin/bash
+start_reader() {
+  sleep 1 &
+  tarpid=$!
+}
+
+read_disc() {
+  grep $tarpid /dev/null
+}
+
+tarpid=\"\"
+mode=$1
+if [[ $mode == read ]]; then
+  start_reader
+fi
+if [[ $mode == read ]]; then
+  read_disc
+fi
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$tarpid"
+            })
+            .expect("expected helper command argument fact");
+
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn conditional_top_level_helper_initializers_do_not_refine_unconditional_helper_calls() {
+        let source = "\
+#!/bin/bash
+start_reader() {
+  sleep 1 &
+  tarpid=$!
+}
+
+read_disc() {
+  grep $tarpid /dev/null
+}
+
+tarpid=\"\"
+mode=$1
+if [[ $mode == read ]]; then
+  start_reader
+fi
+read_disc
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$tarpid"
+            })
+            .expect("expected helper command argument fact");
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -4717,6 +4717,9 @@ fn static_slice_result_is_safe(
     let chars = text.chars().collect::<Vec<_>>();
     let start = if offset < 0 {
         let distance = offset.unsigned_abs();
+        if distance > chars.len() {
+            return false;
+        }
         chars.len().saturating_sub(distance)
     } else {
         offset as usize
@@ -4889,7 +4892,9 @@ mod tests {
         SemanticBuildOptions, SemanticModel, UninitializedCertainty,
     };
 
-    use super::{SafeValueIndex, SafeValueQuery, function_has_terminal_exit};
+    use super::{
+        SafeValueIndex, SafeValueQuery, function_has_terminal_exit, static_slice_result_is_safe,
+    };
     use crate::ExpansionContext;
     use crate::LinterFacts;
 
@@ -7164,6 +7169,16 @@ openssl dgst -sha${sig:2} payload
             .expect("expected sliced command argument fact");
 
         assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn overly_negative_static_slice_offset_stays_unsafe() {
+        assert!(!static_slice_result_is_safe(
+            "RS256",
+            -20,
+            None,
+            SafeValueQuery::Argv
+        ));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -2992,10 +2992,12 @@ impl<'a> SafeValueIndex<'a> {
 
         let mut bindings = Vec::new();
         let mut seen_scopes = FxHashSet::default();
+        let relaxed = !self.span_is_exit_or_return_argument(at);
         self.collect_transitive_helper_bindings_before(
             name,
             self.semantic.scope_at(at.start.offset),
             at.start.offset,
+            relaxed,
             &mut seen_scopes,
             &mut bindings,
         );
@@ -3237,10 +3239,16 @@ impl<'a> SafeValueIndex<'a> {
         name: &Name,
         scope: ScopeId,
         limit_offset: usize,
+        relaxed: bool,
         seen_scopes: &mut FxHashSet<ScopeId>,
         bindings: &mut Vec<BindingId>,
     ) {
-        for callee_scope in self.direct_called_function_scopes_before(scope, limit_offset) {
+        let callee_scopes = if relaxed {
+            self.direct_called_function_scopes_before_relaxed(scope, limit_offset)
+        } else {
+            self.direct_called_function_scopes_before(scope, limit_offset)
+        };
+        for callee_scope in callee_scopes {
             if !seen_scopes.insert(callee_scope) {
                 continue;
             }
@@ -3258,11 +3266,50 @@ impl<'a> SafeValueIndex<'a> {
                     name,
                     callee_scope,
                     limit_offset,
+                    relaxed,
                     seen_scopes,
                     bindings,
                 );
             }
         }
+    }
+
+    fn direct_called_function_scopes_before_relaxed(
+        &self,
+        scope: ScopeId,
+        limit_offset: usize,
+    ) -> Vec<ScopeId> {
+        let mut scopes = Vec::new();
+        let mut seen_scopes = FxHashSet::default();
+
+        for header in self.facts.function_headers() {
+            let Some(callee_scope) = header.function_scope() else {
+                continue;
+            };
+            let Some(function_kind) = self.named_function_kind(callee_scope) else {
+                continue;
+            };
+            let Some(definition_command) = self.facts.function_definition_command(callee_scope)
+            else {
+                continue;
+            };
+
+            let called_before = function_kind.static_names().iter().any(|function_name| {
+                self.semantic.call_sites_for(function_name).iter().any(|site| {
+                    site.scope == scope
+                        && site.span.start.offset < limit_offset
+                        && self.definition_command_resolves_at_call(
+                            definition_command.id(),
+                            site.span,
+                        )
+                })
+            });
+            if called_before && seen_scopes.insert(callee_scope) {
+                scopes.push(callee_scope);
+            }
+        }
+
+        scopes
     }
 
     fn direct_called_function_scopes_before(
@@ -3935,10 +3982,12 @@ impl<'a> SafeValueIndex<'a> {
         self.retain_value_bindings(&mut bindings);
         let mut transitive_helper_bindings = Vec::new();
         let mut seen_scopes = FxHashSet::default();
+        let relaxed = !self.span_is_exit_or_return_argument(at);
         self.collect_transitive_helper_bindings_before(
             name,
             self.semantic.scope_at(at.start.offset),
             at.start.offset,
+            relaxed,
             &mut seen_scopes,
             &mut transitive_helper_bindings,
         );

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -3085,7 +3085,7 @@ impl<'a> SafeValueIndex<'a> {
         if !bindings
             .iter()
             .copied()
-            .any(|binding_id| self.semantic.binding(binding_id).scope != helper_scope)
+            .any(|binding_id| !self.binding_is_in_scope_or_descendant(binding_id, helper_scope))
         {
             return true;
         }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -1071,8 +1071,8 @@ impl<'a> SafeValueIndex<'a> {
                 && !command.is_nested_word_command()
                 && self.command_runs_in_unconditional_flow(command.id(), at)
                 && matches!(
-                    command.command(),
-                    Command::Builtin(BuiltinCommand::Exit(_) | BuiltinCommand::Return(_))
+                    stmt_terminal_flow_kind(command.stmt()),
+                    TerminalFlowKind::Exit | TerminalFlowKind::Stop
                 )
         })
     }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -1768,6 +1768,11 @@ impl<'a> SafeValueIndex<'a> {
         if self.binding_has_effective_integer_attribute(binding_id) {
             return true;
         }
+        if self.binding_value_is_standalone_status_capture(binding_id)
+            && self.status_capture_binding_conflicts_with_caller_local(binding_id)
+        {
+            return false;
+        }
         if matches!(
             query,
             SafeValueQuery::Argv
@@ -1995,8 +2000,7 @@ impl<'a> SafeValueIndex<'a> {
                     ..
                 }
                 | BindingOrigin::Declaration { .. }
-                    if case_cli_scope != Some(binding.scope)
-                        && self.binding_value_is_standalone_status_capture(binding_id) =>
+                    if self.binding_is_standalone_status_capture(binding_id, case_cli_scope) =>
                 {
                     status_bindings.push(binding_id);
                 }
@@ -2071,6 +2075,7 @@ impl<'a> SafeValueIndex<'a> {
             } | BindingOrigin::Declaration { .. }
         ) && case_cli_scope != Some(binding.scope)
             && self.binding_value_is_standalone_status_capture(binding_id)
+            && !self.status_capture_binding_conflicts_with_caller_local(binding_id)
     }
 
     fn binding_is_local_declaration_status_capture(&self, binding_id: BindingId) -> bool {
@@ -2105,6 +2110,55 @@ impl<'a> SafeValueIndex<'a> {
         self.facts
             .binding_value(binding_id)
             .is_some_and(|value| value.standalone_status_or_pid_capture())
+    }
+
+    fn status_capture_binding_conflicts_with_caller_local(&self, binding_id: BindingId) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        if binding.attributes.contains(BindingAttributes::LOCAL) {
+            return false;
+        }
+        if !self.status_capture_binding_is_in_short_circuit_branch(binding.span) {
+            return false;
+        }
+        let Some(binding_scope) = self.enclosing_function_scope_at(binding.span.start.offset)
+        else {
+            return false;
+        };
+        if self
+            .semantic
+            .ancestor_scopes(binding_scope)
+            .any(|scope| {
+                self.scope_has_visible_initialized_local_binding_before(
+                    &binding.name,
+                    scope,
+                    binding.span,
+                )
+            })
+        {
+            return false;
+        }
+
+        self.named_function_call_sites(binding_scope)
+            .into_iter()
+            .any(|(scope, span)| {
+                let caller_scope = self
+                    .enclosing_function_scope_at(span.start.offset)
+                    .unwrap_or(scope);
+                self.scope_has_visible_initialized_local_binding_before(
+                    &binding.name,
+                    caller_scope,
+                    span,
+                )
+            })
+    }
+
+    fn status_capture_binding_is_in_short_circuit_branch(&self, span: Span) -> bool {
+        self.facts.lists().iter().any(|list| {
+            list.segments()
+                .iter()
+                .skip(1)
+                .any(|segment| span_contains(segment.span(), span))
+        })
     }
 
     fn status_capture_declaration_probe_covers_reference(
@@ -3212,6 +3266,44 @@ impl<'a> SafeValueIndex<'a> {
             binding.scope == scope
                 && binding.span.end.offset <= at.start.offset
                 && binding.attributes.contains(BindingAttributes::LOCAL)
+        })
+    }
+
+    fn scope_has_visible_initialized_local_binding_before(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        at: Span,
+    ) -> bool {
+        let latest_local_start = self
+            .semantic
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .filter(|binding_id| {
+                let binding = self.semantic.binding(*binding_id);
+                binding.scope == scope
+                    && binding.span.end.offset <= at.start.offset
+                    && binding.attributes.contains(BindingAttributes::LOCAL)
+            })
+            .map(|binding_id| self.semantic.binding(binding_id).span.start.offset)
+            .max();
+        let Some(latest_local_start) = latest_local_start else {
+            return false;
+        };
+
+        self.semantic.bindings_for(name).iter().copied().any(|binding_id| {
+            let binding = self.semantic.binding(binding_id);
+            let initializes_local_value = match binding.origin {
+                BindingOrigin::Declaration { .. } => binding
+                    .attributes
+                    .intersects(BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER),
+                _ => self.binding_can_supply_parameter_value(binding_id),
+            };
+            binding.scope == scope
+                && binding.span.end.offset <= at.start.offset
+                && binding.span.start.offset >= latest_local_start
+                && initializes_local_value
         })
     }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -3460,6 +3460,11 @@ impl<'a> SafeValueIndex<'a> {
                             function_name,
                             site,
                         )
+                        && self.scope_has_visible_local_binding_before(
+                            &binding.name,
+                            scope,
+                            site.span,
+                        )
                         && self
                             .definition_command_resolves_at_call(definition_command.id(), site.span)
                         && self.call_site_dominates_use(site.span, &binding.name, at)
@@ -6739,6 +6744,39 @@ render() {
                     && fact.span().slice(source) == "${value}"
             })
             .expect("expected shadowed helper argument fact");
+
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn helper_call_before_local_shadow_does_not_make_local_unsafe() {
+        let source = "\
+#!/bin/bash
+helper() {
+  value=$1
+}
+
+render() {
+  helper \"$1\"
+  local value=SAFE
+  printf '%s\\n' ${value}
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${value}"
+            })
+            .expect("expected local argument fact");
 
         assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -352,7 +352,7 @@ impl<'a> SafeValueIndex<'a> {
         part: &WordPart,
         span: Span,
     ) -> bool {
-        if self.span_is_exit_or_return_argument(span) {
+        if self.span_is_return_argument(span) {
             return false;
         }
         let Some(name) = plain_scalar_reference_name_from_part(part) else {
@@ -965,6 +965,28 @@ impl<'a> SafeValueIndex<'a> {
                                 .iter()
                                 .any(|word| span_contains(word.span, at))
                     }
+                    Command::Builtin(BuiltinCommand::Return(command)) => {
+                        command
+                            .code
+                            .as_ref()
+                            .is_some_and(|word| span_contains(word.span, at))
+                            || command
+                                .extra_args
+                                .iter()
+                                .any(|word| span_contains(word.span, at))
+                    }
+                    _ => false,
+                }
+            })
+    }
+
+    fn span_is_return_argument(&self, at: Span) -> bool {
+        self.facts
+            .innermost_command_id_at(at.start.offset)
+            .or_else(|| self.innermost_command_id_containing_offset(at.start.offset))
+            .is_some_and(|command_id| {
+                let command = self.facts.command(command_id);
+                match command.command() {
                     Command::Builtin(BuiltinCommand::Return(command)) => {
                         command
                             .code

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -611,6 +611,23 @@ impl<'a> SafeValueIndex<'a> {
             return true;
         }
         if self.case_cli_reachable_call_path_keeps_argument_bindings_unsafe(at, query) {
+            let mut bindings = self.safe_bindings_for_name(name, at);
+            self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
+            self.drop_outer_bindings_shadowed_by_covering_loop_bindings(&mut bindings, at);
+            bindings.retain(|binding_id| {
+                !self.binding_is_cleared_by_dominating_unset(*binding_id, name, at)
+            });
+            bindings.retain(|binding_id| {
+                !self.binding_is_blocked_by_exit_like_function_call(*binding_id, at)
+            });
+            if self.local_declaration_status_capture_bindings_cover_reference(
+                &bindings,
+                name,
+                at,
+                query,
+            ) {
+                return true;
+            }
             return safe_numeric_shell_variable(name);
         }
         if query == SafeValueQuery::NumericTestOperand
@@ -646,6 +663,14 @@ impl<'a> SafeValueIndex<'a> {
         }
         if bindings.is_empty() {
             return safe_numeric_shell_variable(name);
+        }
+        if self.local_declaration_status_capture_bindings_cover_reference(
+            &bindings,
+            name,
+            at,
+            query,
+        ) {
+            return true;
         }
         let binding_belongs_to_case_cli_scope = case_cli_scope.is_some_and(|scope| {
             bindings
@@ -2046,6 +2071,34 @@ impl<'a> SafeValueIndex<'a> {
             } | BindingOrigin::Declaration { .. }
         ) && case_cli_scope != Some(binding.scope)
             && self.binding_value_is_standalone_status_capture(binding_id)
+    }
+
+    fn binding_is_local_declaration_status_capture(&self, binding_id: BindingId) -> bool {
+        let binding = self.semantic.binding(binding_id);
+
+        matches!(binding.kind, BindingKind::Declaration(_))
+            && binding.attributes.contains(BindingAttributes::LOCAL)
+            && binding
+                .attributes
+                .contains(BindingAttributes::DECLARATION_INITIALIZED)
+            && self.binding_value_is_standalone_status_capture(binding_id)
+    }
+
+    fn local_declaration_status_capture_bindings_cover_reference(
+        &self,
+        bindings: &[BindingId],
+        name: &Name,
+        at: Span,
+        query: SafeValueQuery,
+    ) -> bool {
+        query.is_field_context()
+            && self.span_is_return_argument(at)
+            && !bindings.is_empty()
+            && bindings
+                .iter()
+                .copied()
+                .all(|binding_id| self.binding_is_local_declaration_status_capture(binding_id))
+            && self.bindings_cover_all_paths_to_reference(bindings, name, at)
     }
 
     fn binding_value_is_standalone_status_capture(&self, binding_id: BindingId) -> bool {

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -781,7 +781,7 @@ impl<'a> SafeValueIndex<'a> {
         }
         let direct_bindings_are_status_captures =
             direct_bindings.iter().copied().all(|binding_id| {
-                self.binding_is_standalone_status_capture(binding_id, case_cli_scope)
+                self.binding_is_standalone_status_capture(binding_id, at, case_cli_scope)
             });
         if direct_bindings_cover_all_paths && direct_bindings_are_status_captures {
             bindings.retain(|binding_id| !helper_bindings.contains(binding_id));
@@ -1793,7 +1793,7 @@ impl<'a> SafeValueIndex<'a> {
             return true;
         }
         if self.binding_value_is_standalone_status_capture(binding_id)
-            && self.status_capture_binding_conflicts_with_caller_local(binding_id)
+            && self.status_capture_binding_conflicts_with_caller_local(binding_id, at)
         {
             return false;
         }
@@ -1802,7 +1802,7 @@ impl<'a> SafeValueIndex<'a> {
             SafeValueQuery::Argv
                 | SafeValueQuery::RedirectTarget
                 | SafeValueQuery::NumericTestOperand
-        ) && self.binding_is_standalone_status_capture(binding_id, case_cli_scope)
+        ) && self.binding_is_standalone_status_capture(binding_id, at, case_cli_scope)
         {
             return true;
         }
@@ -2024,7 +2024,11 @@ impl<'a> SafeValueIndex<'a> {
                     ..
                 }
                 | BindingOrigin::Declaration { .. }
-                    if self.binding_is_standalone_status_capture(binding_id, case_cli_scope) =>
+                    if self.binding_is_standalone_status_capture(
+                        binding_id,
+                        at,
+                        case_cli_scope,
+                    ) =>
                 {
                     status_bindings.push(binding_id);
                 }
@@ -2056,7 +2060,7 @@ impl<'a> SafeValueIndex<'a> {
                 self.semantic.binding(*binding_id).span.end.offset <= at.start.offset
             })
             .filter(|binding_id| {
-                self.binding_is_standalone_status_capture(*binding_id, case_cli_scope)
+                self.binding_is_standalone_status_capture(*binding_id, at, case_cli_scope)
             })
             .collect::<Vec<_>>();
         if status_bindings.is_empty()
@@ -2079,13 +2083,14 @@ impl<'a> SafeValueIndex<'a> {
             binding.scope == reference_scope
                 && binding.span.start.offset > first_status_offset
                 && binding.span.start.offset < at.start.offset
-                && !self.binding_is_standalone_status_capture(binding_id, case_cli_scope)
+                && !self.binding_is_standalone_status_capture(binding_id, at, case_cli_scope)
         })
     }
 
     fn binding_is_standalone_status_capture(
         &self,
         binding_id: BindingId,
+        at: Span,
         case_cli_scope: Option<ScopeId>,
     ) -> bool {
         let binding = self.semantic.binding(binding_id);
@@ -2099,7 +2104,7 @@ impl<'a> SafeValueIndex<'a> {
             } | BindingOrigin::Declaration { .. }
         ) && case_cli_scope != Some(binding.scope)
             && self.binding_value_is_standalone_status_capture(binding_id)
-            && !self.status_capture_binding_conflicts_with_caller_local(binding_id)
+            && !self.status_capture_binding_conflicts_with_caller_local(binding_id, at)
     }
 
     fn binding_is_local_declaration_status_capture(&self, binding_id: BindingId) -> bool {
@@ -2136,7 +2141,11 @@ impl<'a> SafeValueIndex<'a> {
             .is_some_and(|value| value.standalone_status_or_pid_capture())
     }
 
-    fn status_capture_binding_conflicts_with_caller_local(&self, binding_id: BindingId) -> bool {
+    fn status_capture_binding_conflicts_with_caller_local(
+        &self,
+        binding_id: BindingId,
+        at: Span,
+    ) -> bool {
         let binding = self.semantic.binding(binding_id);
         if binding.attributes.contains(BindingAttributes::LOCAL) {
             return false;
@@ -2158,9 +2167,20 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         }
 
-        self.named_function_call_sites(binding_scope)
+        let at_scope = self.semantic.scope_at(at.start.offset);
+        let reference_is_in_binding_scope =
+            at_scope == binding_scope || self.scope_is_ancestor(binding_scope, at_scope);
+        let relevant_call_sites = self
+            .named_function_call_sites(binding_scope)
             .into_iter()
-            .any(|(scope, span)| {
+            .filter(|(_, span)| {
+                reference_is_in_binding_scope
+                    || self.call_site_dominates_use(*span, &binding.name, at)
+            })
+            .collect::<Vec<_>>();
+
+        !relevant_call_sites.is_empty()
+            && relevant_call_sites.into_iter().all(|(scope, span)| {
                 let caller_scope = self
                     .enclosing_function_scope_at(span.start.offset)
                     .unwrap_or(scope);
@@ -4203,6 +4223,14 @@ impl<'a> SafeValueIndex<'a> {
         self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
         self.drop_outer_bindings_shadowed_by_covering_loop_bindings(&mut bindings, at);
         self.retain_value_bindings(&mut bindings);
+        bindings.retain(|binding_id| {
+            !self.binding_is_cleared_by_dominating_unset(*binding_id, &reference.name, at)
+        });
+        if query.is_field_context() {
+            bindings.retain(|binding_id| {
+                !self.binding_is_blocked_by_exit_like_function_call(*binding_id, at)
+            });
+        }
         if bindings.is_empty() {
             return false;
         }
@@ -6779,6 +6807,81 @@ render() {
             .expect("expected local argument fact");
 
         assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn unrelated_caller_local_does_not_poison_status_capture_helper_use() {
+        let source = "\
+#!/bin/bash
+helper() {
+  false || ret=$?
+  printf '%s\\n' $ret
+}
+
+shadowed_caller() {
+  local ret=SAFE
+  helper
+}
+
+clean_caller() {
+  helper
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "$ret"
+            })
+            .expect("expected helper status argument fact");
+        let status_binding = semantic
+            .bindings_for(&Name::from("ret"))
+            .iter()
+            .copied()
+            .find(|binding_id| safe_values.binding_value_is_standalone_status_capture(*binding_id))
+            .expect("expected status capture binding");
+
+        assert!(
+            !safe_values.status_capture_binding_conflicts_with_caller_local(
+                status_binding,
+                word_fact.span()
+            )
+        );
+    }
+
+    #[test]
+    fn unset_static_slice_binding_does_not_stay_safe() {
+        let source = "\
+#!/bin/bash
+sig=RS256
+unset sig
+openssl dgst -sha${sig:2} file
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "-sha${sig:2}"
+            })
+            .expect("expected sliced digest argument fact");
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -621,10 +621,7 @@ impl<'a> SafeValueIndex<'a> {
                 !self.binding_is_blocked_by_exit_like_function_call(*binding_id, at)
             });
             if self.local_declaration_status_capture_bindings_cover_reference(
-                &bindings,
-                name,
-                at,
-                query,
+                &bindings, name, at, query,
             ) {
                 return true;
             }
@@ -664,12 +661,9 @@ impl<'a> SafeValueIndex<'a> {
         if bindings.is_empty() {
             return safe_numeric_shell_variable(name);
         }
-        if self.local_declaration_status_capture_bindings_cover_reference(
-            &bindings,
-            name,
-            at,
-            query,
-        ) {
+        if self
+            .local_declaration_status_capture_bindings_cover_reference(&bindings, name, at, query)
+        {
             return true;
         }
         let binding_belongs_to_case_cli_scope = case_cli_scope.is_some_and(|scope| {
@@ -728,6 +722,17 @@ impl<'a> SafeValueIndex<'a> {
         let direct_bindings_cover_all_paths = needs_arg_path_coverage
             && !direct_bindings.is_empty()
             && self.bindings_cover_all_paths_to_reference(&direct_bindings, name, at);
+        let unsafe_helper_binding_writes_visible_local = self
+            .enclosing_function_scope_at(at.start.offset)
+            .is_some_and(|scope| {
+                helper_bindings.iter().copied().any(|binding_id| {
+                    self.binding_writes_visible_local_in_scope_before(binding_id, scope, at)
+                        && !self.binding_is_safe(binding_id, at, query, case_cli_scope)
+                })
+            });
+        if unsafe_helper_binding_writes_visible_local {
+            return false;
+        }
         if direct_bindings_cover_all_paths
             && self.enclosing_function_scope_at(at.start.offset).is_some()
             && !self.span_is_exit_or_return_argument(at)
@@ -2124,17 +2129,13 @@ impl<'a> SafeValueIndex<'a> {
         else {
             return false;
         };
-        if self
-            .semantic
-            .ancestor_scopes(binding_scope)
-            .any(|scope| {
-                self.scope_has_visible_initialized_local_binding_before(
-                    &binding.name,
-                    scope,
-                    binding.span,
-                )
-            })
-        {
+        if self.semantic.ancestor_scopes(binding_scope).any(|scope| {
+            self.scope_has_visible_initialized_local_binding_before(
+                &binding.name,
+                scope,
+                binding.span,
+            )
+        }) {
             return false;
         }
 
@@ -2479,6 +2480,11 @@ impl<'a> SafeValueIndex<'a> {
         {
             bindings
                 .retain(|binding_id| self.binding_is_in_scope_or_descendant(*binding_id, scope));
+        }
+        if let Some(scope) = function_scope {
+            bindings.retain(|binding_id| {
+                !self.binding_writes_visible_local_in_scope_before(*binding_id, scope, at)
+            });
         }
         let reference_scope = self.semantic.scope_at(at.start.offset);
         bindings.retain(|binding_id| {
@@ -3075,9 +3081,7 @@ impl<'a> SafeValueIndex<'a> {
         scope: ScopeId,
         at: Span,
     ) -> Vec<BindingId> {
-        if self.scope_has_visible_local_binding_before(name, scope, at) {
-            return Vec::new();
-        }
+        let caller_has_visible_local = self.scope_has_visible_local_binding_before(name, scope, at);
 
         let key = (name.clone(), scope, FactSpan::new(at));
         if let Some(cached) = self.helper_binding_memo.get(&key) {
@@ -3092,7 +3096,9 @@ impl<'a> SafeValueIndex<'a> {
             .into_iter()
             .collect::<FxHashSet<_>>();
 
-        if let Some(caller_bindings) = self.helper_bindings_reaching_all_callers(name, scope) {
+        if !caller_has_visible_local
+            && let Some(caller_bindings) = self.helper_bindings_reaching_all_callers(name, scope)
+        {
             bindings.extend(caller_bindings);
         }
 
@@ -3243,6 +3249,9 @@ impl<'a> SafeValueIndex<'a> {
                 at,
             );
         }
+        if self.scope_has_visible_local_binding_before(name, scope, at) {
+            branch.retain(|binding_id| self.semantic.binding(*binding_id).scope == scope);
+        }
         branch.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         branch.dedup();
         branch
@@ -3275,8 +3284,11 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn callsite_is_within_guarded_branch(&self, at: Span) -> bool {
-        let call_span = self.command_for_name_word_span(at).map_or(at, |command| command.span());
-        let Some(mut command_id) = self.facts.innermost_command_id_at(call_span.start.offset) else {
+        let call_span = self
+            .command_for_name_word_span(at)
+            .map_or(at, |command| command.span());
+        let Some(mut command_id) = self.facts.innermost_command_id_at(call_span.start.offset)
+        else {
             return false;
         };
         while self.facts.command(command_id).span() != call_span {
@@ -3319,7 +3331,9 @@ impl<'a> SafeValueIndex<'a> {
             return;
         }
 
-        let call_span = self.command_for_name_word_span(at).map_or(at, |command| command.span());
+        let call_span = self
+            .command_for_name_word_span(at)
+            .map_or(at, |command| command.span());
         if !self.bindings_cover_all_paths_to_callsite(&helper_bindings, call_span) {
             return;
         }
@@ -3336,12 +3350,16 @@ impl<'a> SafeValueIndex<'a> {
         scope: ScopeId,
         at: Span,
     ) -> bool {
-        self.semantic.bindings_for(name).iter().copied().any(|binding_id| {
-            let binding = self.semantic.binding(binding_id);
-            binding.scope == scope
-                && binding.span.end.offset <= at.start.offset
-                && binding.attributes.contains(BindingAttributes::LOCAL)
-        })
+        self.semantic
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .any(|binding_id| {
+                let binding = self.semantic.binding(binding_id);
+                binding.scope == scope
+                    && binding.span.end.offset <= at.start.offset
+                    && binding.attributes.contains(BindingAttributes::LOCAL)
+            })
     }
 
     fn scope_has_visible_initialized_local_binding_before(
@@ -3367,18 +3385,55 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         };
 
-        self.semantic.bindings_for(name).iter().copied().any(|binding_id| {
-            let binding = self.semantic.binding(binding_id);
-            let initializes_local_value = match binding.origin {
-                BindingOrigin::Declaration { .. } => binding
-                    .attributes
-                    .intersects(BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER),
-                _ => self.binding_can_supply_parameter_value(binding_id),
-            };
-            binding.scope == scope
-                && binding.span.end.offset <= at.start.offset
-                && binding.span.start.offset >= latest_local_start
-                && initializes_local_value
+        self.semantic
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .any(|binding_id| {
+                let binding = self.semantic.binding(binding_id);
+                let initializes_local_value = match binding.origin {
+                    BindingOrigin::Declaration { .. } => binding.attributes.intersects(
+                        BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
+                    ),
+                    _ => self.binding_can_supply_parameter_value(binding_id),
+                };
+                binding.scope == scope
+                    && binding.span.end.offset <= at.start.offset
+                    && binding.span.start.offset >= latest_local_start
+                    && initializes_local_value
+            })
+    }
+
+    fn binding_writes_visible_local_in_scope_before(
+        &self,
+        binding_id: BindingId,
+        scope: ScopeId,
+        at: Span,
+    ) -> bool {
+        let binding = self.semantic.binding(binding_id);
+        if binding.scope == scope
+            || binding.attributes.contains(BindingAttributes::LOCAL)
+            || !self.scope_has_visible_local_binding_before(&binding.name, scope, at)
+            || self.scope_has_visible_local_binding_before(
+                &binding.name,
+                binding.scope,
+                binding.span,
+            )
+        {
+            return false;
+        }
+        let Some(function_kind) = self.named_function_kind(binding.scope) else {
+            return false;
+        };
+
+        function_kind.static_names().iter().any(|function_name| {
+            self.semantic
+                .call_sites_for(function_name)
+                .iter()
+                .any(|site| {
+                    site.scope == scope
+                        && self.call_site_dominates_use(site.span, &binding.name, at)
+                })
         })
     }
 
@@ -3480,14 +3535,17 @@ impl<'a> SafeValueIndex<'a> {
             };
 
             let called_before = function_kind.static_names().iter().any(|function_name| {
-                self.semantic.call_sites_for(function_name).iter().any(|site| {
-                    site.scope == scope
-                        && site.span.start.offset < limit_offset
-                        && self.definition_command_resolves_at_call(
-                            definition_command.id(),
-                            site.span,
-                        )
-                })
+                self.semantic
+                    .call_sites_for(function_name)
+                    .iter()
+                    .any(|site| {
+                        site.scope == scope
+                            && site.span.start.offset < limit_offset
+                            && self.definition_command_resolves_at_call(
+                                definition_command.id(),
+                                site.span,
+                            )
+                    })
             });
             if called_before && seen_scopes.insert(callee_scope) {
                 scopes.push(callee_scope);
@@ -3948,10 +4006,7 @@ impl<'a> SafeValueIndex<'a> {
                     } else {
                         self.reference_is_safe(reference, at, query)
                             || self.slice_reference_static_literals_stay_safe(
-                                reference,
-                                syntax,
-                                at,
-                                query,
+                                reference, syntax, at, query,
                             )
                     }
                 }
@@ -6531,6 +6586,97 @@ move_up $count
             .expect("expected count expansion part");
 
         assert!(!safe_values.part_has_s001_standalone_numeric_argv_exposure(part, part_span));
+    }
+
+    #[test]
+    fn helper_writes_to_caller_local_keep_arguments_unsafe() {
+        let source = "\
+#!/bin/bash
+helper() {
+  value=$1
+}
+
+render() {
+  local value=SAFE
+  helper \"$1\"
+  printf '%s\\n' ${value}
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${value}"
+            })
+            .expect("expected helper-mutated local argument fact");
+        let (part, part_span) = word_fact
+            .parts_with_spans()
+            .find(|(_, span)| span.slice(source) == "${value}")
+            .expect("expected value expansion part");
+        let name = Name::from("value");
+        let helper_bindings = safe_values.called_helper_bindings_for_name(&name, part_span);
+
+        assert_eq!(
+            helper_bindings.len(),
+            1,
+            "expected helper assignment to remain visible through caller local"
+        );
+        assert!(!safe_values.part_is_safe(part, part_span, SafeValueQuery::Argv));
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn safe_setup_helper_writes_do_not_suppress_sibling_helper_warnings() {
+        let source = "\
+#!/bin/bash
+setup() {
+  value=SAFE
+}
+
+use_value() {
+  printf '%s\\n' ${value}
+}
+
+main() {
+  local value
+  setup
+  use_value
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${value}"
+            })
+            .expect("expected sibling helper argument fact");
+        let (part, part_span) = word_fact
+            .parts_with_spans()
+            .find(|(_, span)| span.slice(source) == "${value}")
+            .expect("expected value expansion part");
+        let name = Name::from("value");
+        let _ = part;
+        let _ = part_span;
+        let _ = name;
+
+        assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -3012,6 +3012,10 @@ impl<'a> SafeValueIndex<'a> {
         scope: ScopeId,
         at: Span,
     ) -> Vec<BindingId> {
+        if self.scope_has_visible_local_binding_before(name, scope, at) {
+            return Vec::new();
+        }
+
         let key = (name.clone(), scope, FactSpan::new(at));
         if let Some(cached) = self.helper_binding_memo.get(&key) {
             return cached.to_vec();
@@ -3195,6 +3199,20 @@ impl<'a> SafeValueIndex<'a> {
         bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         bindings.dedup();
         bindings
+    }
+
+    fn scope_has_visible_local_binding_before(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        at: Span,
+    ) -> bool {
+        self.semantic.bindings_for(name).iter().copied().any(|binding_id| {
+            let binding = self.semantic.binding(binding_id);
+            binding.scope == scope
+                && binding.span.end.offset <= at.start.offset
+                && binding.attributes.contains(BindingAttributes::LOCAL)
+        })
     }
 
     fn helper_bindings_called_in_scope_before(

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -8,8 +8,8 @@ use shuck_ast::{
     word_is_standalone_status_capture, word_is_standalone_variable_like,
 };
 use shuck_semantic::{
-    AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, LoopValueOrigin, ScopeId,
-    ScopeKind, SemanticAnalysis, SemanticModel, UninitializedCertainty,
+    AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, CallSite,
+    LoopValueOrigin, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel, UninitializedCertainty,
 };
 use shuck_semantic::{BindingId, BlockId, ReferenceId};
 
@@ -1139,6 +1139,25 @@ impl<'a> SafeValueIndex<'a> {
         scope: ScopeId,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
         self.facts.function_definition_command(scope)
+    }
+
+    fn function_scope_resolves_at_call_site(
+        &self,
+        callee_scope: ScopeId,
+        function_name: &Name,
+        site: &CallSite,
+    ) -> bool {
+        if let Some(binding_id) = self
+            .analysis
+            .visible_function_binding_at_call(function_name, site.name_span)
+        {
+            return self.analysis.function_scope_for_binding(binding_id) == Some(callee_scope);
+        }
+
+        self.function_definition_command_for_scope(callee_scope)
+            .is_some_and(|definition_command| {
+                self.definition_command_resolves_at_call(definition_command.id(), site.span)
+            })
     }
 
     fn s001_reference_function_unset_before_first_call(&mut self, at: Span) -> bool {
@@ -3425,6 +3444,10 @@ impl<'a> SafeValueIndex<'a> {
         let Some(function_kind) = self.named_function_kind(binding.scope) else {
             return false;
         };
+        let Some(definition_command) = self.function_definition_command_for_scope(binding.scope)
+        else {
+            return false;
+        };
 
         function_kind.static_names().iter().any(|function_name| {
             self.semantic
@@ -3432,6 +3455,13 @@ impl<'a> SafeValueIndex<'a> {
                 .iter()
                 .any(|site| {
                     site.scope == scope
+                        && self.function_scope_resolves_at_call_site(
+                            binding.scope,
+                            function_name,
+                            site,
+                        )
+                        && self
+                            .definition_command_resolves_at_call(definition_command.id(), site.span)
                         && self.call_site_dominates_use(site.span, &binding.name, at)
                 })
         })
@@ -3455,7 +3485,13 @@ impl<'a> SafeValueIndex<'a> {
                     .call_sites_for(function_name)
                     .iter()
                     .any(|site| {
-                        site.scope == scope && self.call_site_dominates_use(site.span, name, at)
+                        site.scope == scope
+                            && self.function_scope_resolves_at_call_site(
+                                callee_scope,
+                                function_name,
+                                site,
+                            )
+                            && self.call_site_dominates_use(site.span, name, at)
                     })
             });
             if !called_before {
@@ -6667,16 +6703,44 @@ main() {
                     && fact.span().slice(source) == "${value}"
             })
             .expect("expected sibling helper argument fact");
-        let (part, part_span) = word_fact
-            .parts_with_spans()
-            .find(|(_, span)| span.slice(source) == "${value}")
-            .expect("expected value expansion part");
-        let name = Name::from("value");
-        let _ = part;
-        let _ = part_span;
-        let _ = name;
 
         assert!(!safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn shadowed_helper_definition_does_not_make_safe_caller_local_unsafe() {
+        let source = "\
+#!/bin/bash
+helper() {
+  value=$1
+}
+
+render() {
+  local value=SAFE
+  helper() {
+    :
+  }
+  helper
+  printf '%s\\n' ${value}
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let mut safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${value}"
+            })
+            .expect("expected shadowed helper argument fact");
+
+        assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
     }
 
     #[test]

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=18`
-- Individual reviewed records classified below: 24 total (`shellcheck-only=14`, `shuck-only=10`).
+- `reviewed_divergences=16`
+- Individual reviewed records classified below: 20 total (`shellcheck-only=11`, `shuck-only=9`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -18,21 +18,18 @@ When a record is fixed, remove the matching entry from
 `crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml` in the same change.
 Resolved records should not remain as reviewed divergences.
 
-## [ ] ShellCheck-only: status/return operand shuck marked safe (6)
+## [ ] ShellCheck-only: status/return operand shuck marked safe (4)
 
 - `rvm__rvm__scripts__functions__manage__base_fetch:223:18-25` `$result`
 - `rvm__rvm__scripts__functions__manage__base_fetch:243:24-31` `$result`
 - `rvm__rvm__scripts__functions__manage__base_fetch:251:18-25` `$result`
 - `rvm__rvm__scripts__functions__manage__macruby:145:14-21` `$result`
-- `rvm__rvm__scripts__functions__requirements__osx_brew:485:55-74` `$homebrew_installer`
-- `rvm__rvm__scripts__functions__requirements__osx_brew:486:32-51` `$homebrew_installer`
 
-## [ ] ShellCheck-only: embedded path/URL/composite word (4)
+## [ ] ShellCheck-only: embedded path/URL/composite word (3)
 
 - `233boy__v2ray__src__core.sh:1254:39-43` `$net`
 - `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:651:70-80` `${project}`
 - `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:867:52-62` `${db_type}`
-- `rvm__rvm__scripts__functions__requirements__osx_brew:491:35-51` `${homebrew_repo}`
 
 ## [ ] ShellCheck-only: plain command argument (2)
 
@@ -43,10 +40,6 @@ Resolved records should not remain as reviewed divergences.
 
 - `rvm__rvm__binscripts__rvm-installer:89:24-48` `${rvm_tar_command:-gtar}`
 - `tteck__Proxmox__vm__nextcloud-vm.sh:210:96-99` `$HN`
-
-## [ ] Shuck-only: embedded safe literal/composite word (1)
-
-- `bittorf__kalua__openwrt-addons__etc__init.d__override_uci_vars:418:29-31` `$i`
 
 ## [ ] Shuck-only: simple command argument ShellCheck suppresses (4)
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=14`
-- Individual reviewed records classified below: 15 total (`shellcheck-only=8`, `shuck-only=7`).
+- `reviewed_divergences=13`
+- Individual reviewed records classified below: 14 total (`shellcheck-only=8`, `shuck-only=6`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -37,14 +37,12 @@ Resolved records should not remain as reviewed divergences.
 - `tteck__Proxmox__vm__nextcloud-vm.sh:210:96-99` `$HN`
   `HN` is the current hostname seed used as a whiptail default value before any user edits.
 
-## [ ] Shuck-only: broader modeling gaps or command-aware ShellCheck suppressions (7)
+## [ ] Shuck-only: broader modeling gaps or command-aware ShellCheck suppressions (6)
 
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:78:13-32` `$line_backoff_count`
   `move_up` consumes its first parameter numerically, but Shuck does not yet propagate numeric function-argument contracts back to callers.
 - `bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh:3374:6-27` `${inet_offer_down:-0}`
   ShellCheck stays quiet on this numeric-default conditional proof; Shuck still flags the expansion.
-- `dehydrated-io__dehydrated__dehydrated:1077:85-109` `${account_key_sigalgo:2}`
-  The substring expansion is used to build an openssl `-shaNNN` flag, which ShellCheck suppresses but Shuck still treats as a generic argument.
 - `ko1nksm__shellspec__lib__general.sh:442:15-39` `$shellspec_readfile_data`
   The data is intentionally expanded through `set --` after eval-built escaping, which ShellCheck suppresses but Shuck still flags.
 - `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=20`
-- Individual reviewed records classified below: 26 total (`shellcheck-only=16`, `shuck-only=10`).
+- `reviewed_divergences=18`
+- Individual reviewed records classified below: 24 total (`shellcheck-only=14`, `shuck-only=10`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -34,11 +34,9 @@ Resolved records should not remain as reviewed divergences.
 - `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:867:52-62` `${db_type}`
 - `rvm__rvm__scripts__functions__requirements__osx_brew:491:35-51` `${homebrew_repo}`
 
-## [ ] ShellCheck-only: plain command argument (4)
+## [ ] ShellCheck-only: plain command argument (2)
 
 - `RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh:235:32-38` `$group`
-- `community-scripts__ProxmoxVE__vm__haos-vm.sh:636:23-35` `${DISK_SIZE}`
-- `community-scripts__ProxmoxVE__vm__mikrotik-routeros.sh:655:25-37` `${DISK_SIZE}`
 - `gentoo__gentoo__eclass__tests__toolchain.sh:155:7-13` `${ret}`
 
 ## [ ] ShellCheck-only: test/probe command operand (2)

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=22`
-- Individual reviewed records classified below: 29 total (`shellcheck-only=17`, `shuck-only=12`).
+- `reviewed_divergences=21`
+- Individual reviewed records classified below: 28 total (`shellcheck-only=17`, `shuck-only=11`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -64,9 +64,8 @@ Resolved records should not remain as reviewed divergences.
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
 
-## [ ] Shuck-only: status/return/exit operand (2)
+## [ ] Shuck-only: status/return/exit operand (1)
 
-- `bittorf__kalua__openwrt-addons__etc__profile.d__kalua.sh:11:33-36` `$rc`
 - `rvm__rvm__scripts__functions__manage__macruby:23:10-21` `${__result}`
 
 ## [ ] Shuck-only: arithmetic/parameter-operator form (2)

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=16`
-- Individual reviewed records classified below: 20 total (`shellcheck-only=11`, `shuck-only=9`).
+- `reviewed_divergences=15`
+- Individual reviewed records classified below: 17 total (`shellcheck-only=8`, `shuck-only=9`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -18,11 +18,8 @@ When a record is fixed, remove the matching entry from
 `crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml` in the same change.
 Resolved records should not remain as reviewed divergences.
 
-## [ ] ShellCheck-only: status/return operand shuck marked safe (4)
+## [ ] ShellCheck-only: status/return operand shuck marked safe (1)
 
-- `rvm__rvm__scripts__functions__manage__base_fetch:223:18-25` `$result`
-- `rvm__rvm__scripts__functions__manage__base_fetch:243:24-31` `$result`
-- `rvm__rvm__scripts__functions__manage__base_fetch:251:18-25` `$result`
 - `rvm__rvm__scripts__functions__manage__macruby:145:14-21` `$result`
 
 ## [ ] ShellCheck-only: embedded path/URL/composite word (3)

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=21`
-- Individual reviewed records classified below: 27 total (`shellcheck-only=17`, `shuck-only=10`).
+- `reviewed_divergences=20`
+- Individual reviewed records classified below: 26 total (`shellcheck-only=16`, `shuck-only=10`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -18,9 +18,8 @@ When a record is fixed, remove the matching entry from
 `crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml` in the same change.
 Resolved records should not remain as reviewed divergences.
 
-## [ ] ShellCheck-only: status/return operand shuck marked safe (7)
+## [ ] ShellCheck-only: status/return operand shuck marked safe (6)
 
-- `bittorf__kalua__openwrt-addons__etc__kalua__watch:2096:10-15` `$good`
 - `rvm__rvm__scripts__functions__manage__base_fetch:223:18-25` `$result`
 - `rvm__rvm__scripts__functions__manage__base_fetch:243:24-31` `$result`
 - `rvm__rvm__scripts__functions__manage__base_fetch:251:18-25` `$result`

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=15`
-- Individual reviewed records classified below: 17 total (`shellcheck-only=8`, `shuck-only=9`).
+- `reviewed_divergences=14`
+- Individual reviewed records classified below: 15 total (`shellcheck-only=8`, `shuck-only=7`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -18,40 +18,38 @@ When a record is fixed, remove the matching entry from
 `crates/shuck-cli/tests/testdata/corpus-metadata/s001.yaml` in the same change.
 Resolved records should not remain as reviewed divergences.
 
-## [ ] ShellCheck-only: status/return operand shuck marked safe (1)
-
-- `rvm__rvm__scripts__functions__manage__macruby:145:14-21` `$result`
-
-## [ ] ShellCheck-only: embedded path/URL/composite word (3)
+## [ ] ShellCheck-only: semantically safe in Shuck (8)
 
 - `233boy__v2ray__src__core.sh:1254:39-43` `$net`
-- `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:651:70-80` `${project}`
-- `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:867:52-62` `${db_type}`
-
-## [ ] ShellCheck-only: plain command argument (2)
-
+  The final token is assembled from fixed protocol and transport fragments before it is passed onward.
 - `RetroPie__RetroPie-Setup__scriptmodules__supplementary__runcommand__runcommand.sh:235:32-38` `$group`
+  `group` is a static loop variable ranging over `CEA` and `DMT`.
 - `gentoo__gentoo__eclass__tests__toolchain.sh:155:7-13` `${ret}`
-
-## [ ] ShellCheck-only: test/probe command operand (2)
-
+  `ret` is a numeric status slot that is set to `1` on failure before the helper call.
+- `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:651:70-80` `${project}`
+  `project` is selected from a fixed repository enum before the GitHub API URL is built.
+- `juewuy__ShellCrash__scripts__menus__9_upgrade.sh:867:52-62` `${db_type}`
+  `db_type` comes from a fixed dashboard selector before the archive path is assembled.
 - `rvm__rvm__binscripts__rvm-installer:89:24-48` `${rvm_tar_command:-gtar}`
+  This use sits inside the `else` arm where `rvm_tar_command` only comes from literal tar command names.
+- `rvm__rvm__scripts__functions__manage__macruby:145:14-21` `$result`
+  ShellCheck only reports this when the dead branch tail after an earlier `return 1` remains in the file.
 - `tteck__Proxmox__vm__nextcloud-vm.sh:210:96-99` `$HN`
+  `HN` is the current hostname seed used as a whiptail default value before any user edits.
 
-## [ ] Shuck-only: simple command argument ShellCheck suppresses (4)
+## [ ] Shuck-only: broader modeling gaps or command-aware ShellCheck suppressions (7)
 
 - `bats-core__bats-core__libexec__bats-core__bats-format-pretty:78:13-32` `$line_backoff_count`
-- `ko1nksm__shellspec__lib__general.sh:442:15-39` `$shellspec_readfile_data`
-- `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`
-- `pi-hole__pi-hole__automated install__basic-install.sh:1833:21-39` `${webInterfaceDir}`
-
-## [ ] Shuck-only: command-substitution initializer argument (3 remaining)
-
-- `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:245:36-43` `$tarpid`
-- `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`
-- `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
-
-## [ ] Shuck-only: arithmetic/parameter-operator form (2)
-
+  `move_up` consumes its first parameter numerically, but Shuck does not yet propagate numeric function-argument contracts back to callers.
 - `bittorf__kalua__openwrt-monitoring__meshrdf_generate_table.sh:3374:6-27` `${inet_offer_down:-0}`
+  ShellCheck stays quiet on this numeric-default conditional proof; Shuck still flags the expansion.
 - `dehydrated-io__dehydrated__dehydrated:1077:85-109` `${account_key_sigalgo:2}`
+  The substring expansion is used to build an openssl `-shaNNN` flag, which ShellCheck suppresses but Shuck still treats as a generic argument.
+- `ko1nksm__shellspec__lib__general.sh:442:15-39` `$shellspec_readfile_data`
+  The data is intentionally expanded through `set --` after eval-built escaping, which ShellCheck suppresses but Shuck still flags.
+- `masonr__yet-another-bench-script__yabs.sh:991:12-19` `$GB_URL`
+  `GB_URL` is chosen from literal Geekbench download URLs before it is passed to the downloader command position.
+- `pi-hole__pi-hole__automated install__basic-install.sh:1833:21-39` `${webInterfaceDir}`
+  `webInterfaceDir` is a webroot-derived path passed into the repository helper, but Shuck still treats it as a generic argument.
+- `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
+  `PORT` is regex-validated as a numeric or range token before the AWS `--port` argument is built.

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -9,7 +9,7 @@ Current summary from `target/large-corpus-report/latest.log`:
 - `implementation_diffs=0`
 - `mapping_issues=0`
 - `reviewed_divergences=21`
-- Individual reviewed records classified below: 28 total (`shellcheck-only=17`, `shuck-only=11`).
+- Individual reviewed records classified below: 27 total (`shellcheck-only=17`, `shuck-only=10`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -63,10 +63,6 @@ Resolved records should not remain as reviewed divergences.
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:245:36-43` `$tarpid`
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
-
-## [ ] Shuck-only: status/return/exit operand (1)
-
-- `rvm__rvm__scripts__functions__manage__macruby:23:10-21` `${__result}`
 
 ## [ ] Shuck-only: arithmetic/parameter-operator form (2)
 

--- a/docs/S001_BUGS.md
+++ b/docs/S001_BUGS.md
@@ -8,8 +8,8 @@ Current summary from `target/large-corpus-report/latest.log`:
 
 - `implementation_diffs=0`
 - `mapping_issues=0`
-- `reviewed_divergences=23`
-- Individual reviewed records classified below: 30 total (`shellcheck-only=17`, `shuck-only=13`).
+- `reviewed_divergences=22`
+- Individual reviewed records classified below: 29 total (`shellcheck-only=17`, `shuck-only=12`).
 
 The harness summary counts reviewed divergence groups. This document lists the individual
 diagnostic records that need to be cleared.
@@ -64,11 +64,10 @@ Resolved records should not remain as reviewed divergences.
 - `alexanderepstein__Bash-Snippets__bak2dvd__bak2dvd:259:36-43` `$tarpid`
 - `swoodford__aws__vpc-sg-import-rules-cloudflare.sh:281:101-106` `$PORT`
 
-## [ ] Shuck-only: status/return/exit operand (3)
+## [ ] Shuck-only: status/return/exit operand (2)
 
 - `bittorf__kalua__openwrt-addons__etc__profile.d__kalua.sh:11:33-36` `$rc`
 - `rvm__rvm__scripts__functions__manage__macruby:23:10-21` `${__result}`
-- `v1s1t0r1sh3r3__airgeddon__airgeddon.sh:16442:11-23` `${exit_code}`
 
 ## [ ] Shuck-only: arithmetic/parameter-operator form (2)
 

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -5214,8 +5214,8 @@
     "status": "implemented",
     "hasKnownShellcheckDivergences": false,
     "severity": "Warning",
-    "fixStatus": "planned",
-    "fixAvailability": "none",
+    "fixStatus": "implemented",
+    "fixAvailability": "always",
     "fixSafety": "safe",
     "fixDescription": "Collapse the repeated spaces between `echo` arguments to a single separator space.",
     "examples": [

--- a/website/app/lib/shellcheck-compat-data.generated.json
+++ b/website/app/lib/shellcheck-compat-data.generated.json
@@ -4,7 +4,7 @@
     "repoKey": "233boy__v2ray",
     "url": "https://github.com/233boy/v2ray",
     "status": "known_issues",
-    "issueCount": 5
+    "issueCount": 1
   },
   {
     "repo": "89luca89/distrobox",
@@ -17,22 +17,22 @@
     "repo": "acmesh-official/acme.sh",
     "repoKey": "acmesh-official__acme.sh",
     "url": "https://github.com/acmesh-official/acme.sh",
-    "status": "known_issues",
-    "issueCount": 5
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "alexanderepstein/Bash-Snippets",
     "repoKey": "alexanderepstein__Bash-Snippets",
     "url": "https://github.com/alexanderepstein/Bash-Snippets",
-    "status": "known_issues",
-    "issueCount": 13
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "alpinelinux/aports",
     "repoKey": "alpinelinux__aports",
     "url": "https://github.com/alpinelinux/aports",
-    "status": "known_issues",
-    "issueCount": 6
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "angristan/openvpn-install",
@@ -52,15 +52,15 @@
     "repo": "asdf-vm/asdf",
     "repoKey": "asdf-vm__asdf",
     "url": "https://github.com/asdf-vm/asdf",
-    "status": "known_issues",
-    "issueCount": 2
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "awslabs/git-secrets",
     "repoKey": "awslabs__git-secrets",
     "url": "https://github.com/awslabs/git-secrets",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "basecamp/omarchy",
@@ -73,43 +73,43 @@
     "repo": "Bash-it/bash-it",
     "repoKey": "Bash-it__bash-it",
     "url": "https://github.com/Bash-it/bash-it",
-    "status": "known_issues",
-    "issueCount": 10
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "bats-core/bats-core",
     "repoKey": "bats-core__bats-core",
     "url": "https://github.com/bats-core/bats-core",
     "status": "known_issues",
-    "issueCount": 5
+    "issueCount": 1
   },
   {
     "repo": "bin456789/reinstall",
     "repoKey": "bin456789__reinstall",
     "url": "https://github.com/bin456789/reinstall",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "bitnami/containers",
     "repoKey": "bitnami__containers",
     "url": "https://github.com/bitnami/containers",
-    "status": "known_issues",
-    "issueCount": 3
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "bittorf/kalua",
     "repoKey": "bittorf__kalua",
     "url": "https://github.com/bittorf/kalua",
     "status": "known_issues",
-    "issueCount": 56
+    "issueCount": 1
   },
   {
     "repo": "CISOfy/lynis",
     "repoKey": "CISOfy__lynis",
     "url": "https://github.com/CISOfy/lynis",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "client9/shlib",
@@ -122,57 +122,57 @@
     "repo": "community-scripts/ProxmoxVE",
     "repoKey": "community-scripts__ProxmoxVE",
     "url": "https://github.com/community-scripts/ProxmoxVE",
-    "status": "known_issues",
-    "issueCount": 30
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "dehydrated-io/dehydrated",
     "repoKey": "dehydrated-io__dehydrated",
     "url": "https://github.com/dehydrated-io/dehydrated",
-    "status": "known_issues",
-    "issueCount": 3
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "docker-library/official-images",
     "repoKey": "docker-library__official-images",
     "url": "https://github.com/docker-library/official-images",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "docker-mailserver/docker-mailserver",
     "repoKey": "docker-mailserver__docker-mailserver",
     "url": "https://github.com/docker-mailserver/docker-mailserver",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "docker/docker-bench-security",
     "repoKey": "docker__docker-bench-security",
     "url": "https://github.com/docker/docker-bench-security",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "dockur/windows",
     "repoKey": "dockur__windows",
     "url": "https://github.com/dockur/windows",
-    "status": "known_issues",
-    "issueCount": 3
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "dokku/dokku",
     "repoKey": "dokku__dokku",
     "url": "https://github.com/dokku/dokku",
-    "status": "known_issues",
-    "issueCount": 18
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "dylanaraps/neofetch",
     "repoKey": "dylanaraps__neofetch",
     "url": "https://github.com/dylanaraps/neofetch",
-    "status": "known_issues",
-    "issueCount": 6
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "dylanaraps/pure-bash-bible",
@@ -192,36 +192,36 @@
     "repo": "fideloper/Vaprobash",
     "repoKey": "fideloper__Vaprobash",
     "url": "https://github.com/fideloper/Vaprobash",
-    "status": "known_issues",
-    "issueCount": 2
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "GameServerManagers/LinuxGSM",
     "repoKey": "GameServerManagers__LinuxGSM",
     "url": "https://github.com/GameServerManagers/LinuxGSM",
-    "status": "known_issues",
-    "issueCount": 13
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "gentoo/gentoo",
     "repoKey": "gentoo__gentoo",
     "url": "https://github.com/gentoo/gentoo",
     "status": "known_issues",
-    "issueCount": 27
+    "issueCount": 1
   },
   {
     "repo": "google/oss-fuzz",
     "repoKey": "google__oss-fuzz",
     "url": "https://github.com/google/oss-fuzz",
-    "status": "known_issues",
-    "issueCount": 14
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "HariSekhon/DevOps-Bash-tools",
     "repoKey": "HariSekhon__DevOps-Bash-tools",
     "url": "https://github.com/HariSekhon/DevOps-Bash-tools",
-    "status": "known_issues",
-    "issueCount": 7
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "helmuthdu/aui",
@@ -248,8 +248,8 @@
     "repo": "itzg/docker-minecraft-server",
     "repoKey": "itzg__docker-minecraft-server",
     "url": "https://github.com/itzg/docker-minecraft-server",
-    "status": "known_issues",
-    "issueCount": 2
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "jessfraz/dotfiles",
@@ -270,28 +270,28 @@
     "repoKey": "juewuy__ShellCrash",
     "url": "https://github.com/juewuy/ShellCrash",
     "status": "known_issues",
-    "issueCount": 14
+    "issueCount": 2
   },
   {
     "repo": "ko1nksm/shellspec",
     "repoKey": "ko1nksm__shellspec",
     "url": "https://github.com/ko1nksm/shellspec",
     "status": "known_issues",
-    "issueCount": 11
+    "issueCount": 1
   },
   {
     "repo": "kward/shunit2",
     "repoKey": "kward__shunit2",
     "url": "https://github.com/kward/shunit2",
-    "status": "known_issues",
-    "issueCount": 2
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "leebaird/discover",
     "repoKey": "leebaird__discover",
     "url": "https://github.com/leebaird/discover",
-    "status": "known_issues",
-    "issueCount": 3
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "lmc999/RegionRestrictionCheck",
@@ -312,7 +312,7 @@
     "repoKey": "masonr__yet-another-bench-script",
     "url": "https://github.com/masonr/yet-another-bench-script",
     "status": "known_issues",
-    "issueCount": 3
+    "issueCount": 1
   },
   {
     "repo": "mathiasbynens/dotfiles",
@@ -325,15 +325,15 @@
     "repo": "megastep/makeself",
     "repoKey": "megastep__makeself",
     "url": "https://github.com/megastep/makeself",
-    "status": "known_issues",
-    "issueCount": 4
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "moovweb/gvm",
     "repoKey": "moovweb__gvm",
     "url": "https://github.com/moovweb/gvm",
     "status": "known_issues",
-    "issueCount": 10
+    "issueCount": 1
   },
   {
     "repo": "nextcloud/docker",
@@ -346,15 +346,15 @@
     "repo": "nvie/gitflow",
     "repoKey": "nvie__gitflow",
     "url": "https://github.com/nvie/gitflow",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "nvm-sh/nvm",
     "repoKey": "nvm-sh__nvm",
     "url": "https://github.com/nvm-sh/nvm",
-    "status": "known_issues",
-    "issueCount": 11
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "Nyr/openvpn-install",
@@ -381,15 +381,15 @@
     "repo": "openrc/openrc",
     "repoKey": "openrc__openrc",
     "url": "https://github.com/openrc/openrc",
-    "status": "known_issues",
-    "issueCount": 5
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "openvpn/easy-rsa",
     "repoKey": "openvpn__easy-rsa",
     "url": "https://github.com/openvpn/easy-rsa",
-    "status": "known_issues",
-    "issueCount": 3
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "p8952/bocker",
@@ -410,14 +410,14 @@
     "repoKey": "pi-hole__pi-hole",
     "url": "https://github.com/pi-hole/pi-hole",
     "status": "known_issues",
-    "issueCount": 5
+    "issueCount": 1
   },
   {
     "repo": "pyenv/pyenv",
     "repoKey": "pyenv__pyenv",
     "url": "https://github.com/pyenv/pyenv",
-    "status": "known_issues",
-    "issueCount": 2
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "pystardust/ani-cli",
@@ -430,8 +430,8 @@
     "repo": "quickemu-project/quickemu",
     "repoKey": "quickemu-project__quickemu",
     "url": "https://github.com/quickemu-project/quickemu",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "rbenv/rbenv",
@@ -445,35 +445,35 @@
     "repoKey": "RetroPie__RetroPie-Setup",
     "url": "https://github.com/RetroPie/RetroPie-Setup",
     "status": "known_issues",
-    "issueCount": 11
+    "issueCount": 1
   },
   {
     "repo": "romkatv/powerlevel10k",
     "repoKey": "romkatv__powerlevel10k",
     "url": "https://github.com/romkatv/powerlevel10k",
-    "status": "known_issues",
-    "issueCount": 5
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "rupa/z",
     "repoKey": "rupa__z",
     "url": "https://github.com/rupa/z",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "rvm/rvm",
     "repoKey": "rvm__rvm",
     "url": "https://github.com/rvm/rvm",
     "status": "known_issues",
-    "issueCount": 94
+    "issueCount": 2
   },
   {
     "repo": "scop/bash-completion",
     "repoKey": "scop__bash-completion",
     "url": "https://github.com/scop/bash-completion",
-    "status": "known_issues",
-    "issueCount": 8
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "sickcodes/Docker-OSX",
@@ -486,8 +486,8 @@
     "repo": "SlackBuildsOrg/slackbuilds",
     "repoKey": "SlackBuildsOrg__slackbuilds",
     "url": "https://github.com/SlackBuildsOrg/slackbuilds",
-    "status": "known_issues",
-    "issueCount": 25
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "sorin-ionescu/prezto",
@@ -500,36 +500,36 @@
     "repo": "spiritLHLS/one-click-installation-script",
     "repoKey": "spiritLHLS__one-click-installation-script",
     "url": "https://github.com/spiritLHLS/one-click-installation-script",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "sstephenson/bats",
     "repoKey": "sstephenson__bats",
     "url": "https://github.com/sstephenson/bats",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "super-linter/super-linter",
     "repoKey": "super-linter__super-linter",
     "url": "https://github.com/super-linter/super-linter",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "swoodford/aws",
     "repoKey": "swoodford__aws",
     "url": "https://github.com/swoodford/aws",
     "status": "known_issues",
-    "issueCount": 5
+    "issueCount": 1
   },
   {
     "repo": "termux/termux-packages",
     "repoKey": "termux__termux-packages",
     "url": "https://github.com/termux/termux-packages",
-    "status": "known_issues",
-    "issueCount": 22
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "thoughtbot/dotfiles",
@@ -542,15 +542,15 @@
     "repo": "tj/git-extras",
     "repoKey": "tj__git-extras",
     "url": "https://github.com/tj/git-extras",
-    "status": "known_issues",
-    "issueCount": 4
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "tj/n",
     "repoKey": "tj__n",
     "url": "https://github.com/tj/n",
-    "status": "known_issues",
-    "issueCount": 1
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "tmux-plugins/tmux-resurrect",
@@ -571,14 +571,14 @@
     "repoKey": "tteck__Proxmox",
     "url": "https://github.com/tteck/Proxmox",
     "status": "known_issues",
-    "issueCount": 22
+    "issueCount": 1
   },
   {
     "repo": "v1s1t0r1sh3r3/airgeddon",
     "repoKey": "v1s1t0r1sh3r3__airgeddon",
     "url": "https://github.com/v1s1t0r1sh3r3/airgeddon",
     "status": "known_issues",
-    "issueCount": 2
+    "issueCount": 1
   },
   {
     "repo": "v2fly/fhs-install-v2ray",
@@ -592,14 +592,14 @@
     "repoKey": "void-linux__void-packages",
     "url": "https://github.com/void-linux/void-packages",
     "status": "known_issues",
-    "issueCount": 15
+    "issueCount": 1
   },
   {
     "repo": "xwmx/nb",
     "repoKey": "xwmx__nb",
     "url": "https://github.com/xwmx/nb",
-    "status": "known_issues",
-    "issueCount": 7
+    "status": "passes",
+    "issueCount": 0
   },
   {
     "repo": "zdharma-continuum/zinit",


### PR DESCRIPTION
## Summary
- reduce the S001 reviewed divergence set from 23 records to 13 reviewed-divergence groups
- tighten S001 safe-value analysis around helper control flow, caller-local status capture, and top-level helper branches
- preserve safe literal slices and refresh the remaining S001 reviewed-divergence metadata and bug notes

## Why
S001 was still treating several safe expansion flows as generic unquoted values. In practice that came from missing control-flow proof around helper-style functions and from dropping safety when literal-preserving parameter slices were involved.

## Impact
This removes the `bak2dvd` PID-flow pair and the `dehydrated` literal-slice case from the reviewed set without introducing new corpus failures. The remaining reviewed divergences stay documented in the metadata for continued follow-up.

## Validation
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001 SHUCK_LARGE_CORPUS_KEEP_GOING=1`
  - `blocking=0`
  - `implementation_diffs=0`
  - `reviewed_divergences=13`
