### PR TITLE
fix(semantic): share function call binding resolution

### DIFF
--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::cfg::{self, build_control_flow_graph};
+use crate::cfg::build_control_flow_graph;
 use crate::dataflow;
 use crate::reachability::block_reaches_without;
 
@@ -22,9 +22,6 @@ impl<'model> SemanticAnalysis<'model> {
             unreached_functions: OnceLock::new(),
             unreached_functions_shellcheck_compat: OnceLock::new(),
             scope_provided_binding_index: OnceLock::new(),
-            unconditional_function_bindings: OnceLock::new(),
-            function_bindings_by_scope: OnceLock::new(),
-            visible_function_call_bindings: OnceLock::new(),
         }
     }
 
@@ -158,42 +155,14 @@ impl<'model> SemanticAnalysis<'model> {
             .min_by_key(|candidate| self.model.binding(*candidate).span.start.offset)
     }
 
-    fn function_binding_lookup(&self) -> cfg::FunctionBindingLookup<'_> {
-        cfg::FunctionBindingLookup {
-            program: &self.model.recorded_program,
-            scopes: &self.model.scopes,
-            bindings: &self.model.bindings,
-            call_sites: &self.model.call_sites,
-            unconditional_function_bindings: self.unconditional_function_bindings(),
-            function_bindings_by_scope: self.function_binding_scope_index(),
-        }
-    }
-
     fn visible_function_call_bindings(&self) -> &FxHashMap<SpanKey, BindingId> {
-        self.visible_function_call_bindings.get_or_init(|| {
-            self.function_binding_lookup()
-                .visible_function_call_bindings()
-        })
-    }
-
-    fn unconditional_function_bindings(&self) -> &FxHashSet<BindingId> {
-        self.unconditional_function_bindings.get_or_init(|| {
-            cfg::collect_unconditional_function_bindings(
-                &self.model.recorded_program,
-                &self.model.command_bindings,
-                &self.model.bindings,
-            )
-        })
-    }
-
-    fn function_binding_scope_index(&self) -> &FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> {
-        self.function_bindings_by_scope
-            .get_or_init(|| cfg::function_bindings_by_scope(&self.model.recorded_program))
+        self.model.visible_function_call_bindings()
     }
 
     #[doc(hidden)]
     pub fn function_bindings_by_scope(&self) -> impl Iterator<Item = (ScopeId, &[BindingId])> + '_ {
-        self.function_binding_scope_index()
+        self.model
+            .function_binding_scope_index()
             .iter()
             .map(|(scope, bindings)| (*scope, bindings.as_slice()))
     }

--- a/crates/shuck-semantic/src/builder/zsh_effects.rs
+++ b/crates/shuck-semantic/src/builder/zsh_effects.rs
@@ -28,12 +28,11 @@ pub(super) fn recorded_simple_command_info(
         .collect::<Vec<_>>();
     let mut static_callee =
         static_command_name_text(&command.name, source).map(|name| name.into_owned());
-    let static_args = command
+    let mut static_args = command
         .args
         .iter()
         .map(|word| static_word_text(word, source).map(|text| text.into_owned()))
-        .collect::<Vec<_>>()
-        .into_boxed_slice();
+        .collect::<Vec<_>>();
     let source_path_template = static_callee
         .as_deref()
         .filter(|name| matches!(*name, "source" | "."))
@@ -44,11 +43,17 @@ pub(super) fn recorded_simple_command_info(
         static_callee = words
             .get(1)
             .and_then(|word| static_command_name_text(word, source).map(|name| name.into_owned()));
+        static_args = command
+            .args
+            .iter()
+            .skip(1)
+            .map(|word| static_word_text(word, source).map(|text| text.into_owned()))
+            .collect();
     }
 
     let mut info = RecordedCommandInfo {
         static_callee,
-        static_args,
+        static_args: static_args.into_boxed_slice(),
         source_path_template,
         zsh_effects: Vec::new(),
     };

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -735,6 +735,24 @@ pub(crate) struct FunctionBindingLookup<'a> {
 }
 
 impl FunctionBindingLookup<'_> {
+    pub(crate) fn visible_function_binding(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> Option<BindingId> {
+        let mut resolver = FunctionCallResolver {
+            program: self.program,
+            scopes: self.scopes,
+            bindings: self.bindings,
+            call_sites: self.call_sites,
+            unconditional_function_bindings: self.unconditional_function_bindings,
+            function_bindings_by_scope: self.function_bindings_by_scope,
+            entry_before_offset_cache: FxHashMap::default(),
+        };
+        resolver.visible_function_binding(name, scope, offset)
+    }
+
     pub(crate) fn visible_function_call_bindings(&self) -> FxHashMap<SpanKey, BindingId> {
         let mut resolver = FunctionCallResolver {
             program: self.program,

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -77,6 +77,7 @@ pub(crate) struct DataflowContext<'a> {
     pub(crate) self_referential_assignment_refs: &'a FxHashSet<ReferenceId>,
     pub(crate) resolved: &'a FxHashMap<ReferenceId, BindingId>,
     pub(crate) call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    pub(crate) visible_function_call_bindings: &'a FxHashMap<SpanKey, BindingId>,
     pub(crate) function_body_scopes: &'a FxHashMap<BindingId, ScopeId>,
     pub(crate) indirect_targets_by_reference: &'a FxHashMap<ReferenceId, Vec<BindingId>>,
     pub(crate) array_like_indirect_expansion_refs: &'a FxHashSet<ReferenceId>,
@@ -532,13 +533,13 @@ fn analyze_unused_assignments_exact(
     let (read_plans, callers_by_callee) = build_scope_read_plans(
         context.cfg,
         context.scopes,
-        context.bindings,
         context.references,
         context.synthetic_reads,
         &exact.reference_blocks,
         &reference_name_ids,
         &synthetic_read_name_ids,
         context.call_sites,
+        context.visible_function_call_bindings,
         context.function_body_scopes,
         exact.names.len(),
     );
@@ -2195,18 +2196,21 @@ fn reachable_blocks_dense(
 fn build_scope_read_plans(
     cfg: &ControlFlowGraph,
     scopes: &[Scope],
-    bindings: &[Binding],
     references: &[Reference],
     synthetic_reads: &[SyntheticRead],
     reference_blocks: &[Option<BlockId>],
     reference_name_ids: &[NameId],
     synthetic_read_name_ids: &[NameId],
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    visible_function_call_bindings: &FxHashMap<SpanKey, BindingId>,
     function_body_scopes: &FxHashMap<BindingId, ScopeId>,
     name_count: usize,
 ) -> (Vec<ScopeReadPlan>, Vec<Vec<CallerReadSite>>) {
-    let calls_by_scope =
-        resolved_calls_by_scope(scopes, bindings, call_sites, function_body_scopes);
+    let calls_by_scope = resolved_calls_by_scope(
+        call_sites,
+        visible_function_call_bindings,
+        function_body_scopes,
+    );
     let mut plans = scopes
         .iter()
         .map(|scope| ScopeReadPlan::new(name_count, matches!(scope.kind, ScopeKind::Function(_))))
@@ -2635,21 +2639,17 @@ fn function_binding_certainty(binding: &Binding) -> Option<ContractCertainty> {
 }
 
 fn resolved_calls_by_scope(
-    scopes: &[Scope],
-    bindings: &[Binding],
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    visible_function_call_bindings: &FxHashMap<SpanKey, BindingId>,
     function_scopes: &FxHashMap<BindingId, ScopeId>,
 ) -> FxHashMap<ScopeId, Vec<ResolvedCallSite>> {
     let mut calls_by_scope: FxHashMap<ScopeId, Vec<ResolvedCallSite>> = FxHashMap::default();
-    for (name, sites) in call_sites {
+    for sites in call_sites.values() {
         for site in sites {
-            let Some(function_binding) = visible_function_binding(
-                scopes,
-                bindings,
-                name,
-                site.scope,
-                site.span.start.offset,
-            ) else {
+            let Some(function_binding) = visible_function_call_bindings
+                .get(&SpanKey::new(site.name_span))
+                .copied()
+            else {
                 continue;
             };
             let Some(callee_scope) = function_scopes.get(&function_binding).copied() else {
@@ -2671,42 +2671,6 @@ fn resolved_calls_by_scope(
     calls_by_scope
 }
 
-fn visible_function_binding(
-    scopes: &[Scope],
-    bindings: &[Binding],
-    name: &Name,
-    scope: ScopeId,
-    offset: usize,
-) -> Option<BindingId> {
-    for scope_id in ancestor_scopes(scopes, scope) {
-        let Some(candidates) = scopes[scope_id.index()].bindings.get(name) else {
-            continue;
-        };
-
-        if scope_id != scope {
-            if let Some(binding) = candidates.iter().rev().copied().find(|binding| {
-                matches!(
-                    bindings[binding.index()].kind,
-                    BindingKind::FunctionDefinition
-                )
-            }) {
-                return Some(binding);
-            }
-            continue;
-        }
-
-        for binding in candidates.iter().rev().copied() {
-            let candidate = &bindings[binding.index()];
-            if matches!(candidate.kind, BindingKind::FunctionDefinition)
-                && candidate.span.start.offset <= offset
-            {
-                return Some(binding);
-            }
-        }
-    }
-    None
-}
-
 fn is_function_escape_candidate(binding: &Binding, scopes: &[Scope]) -> bool {
     matches!(scopes[binding.scope.index()].kind, ScopeKind::Function(_))
         && !binding.attributes.contains(BindingAttributes::LOCAL)
@@ -2719,6 +2683,11 @@ fn is_function_escape_candidate(binding: &Binding, scopes: &[Scope]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SemanticModel;
+    use shuck_ast::Name;
+    use shuck_indexer::Indexer;
+    use shuck_parser::parser::Parser;
+    use smallvec::smallvec;
 
     #[test]
     fn future_reads_contain_after_until_ignores_backwards_intervals() {
@@ -2742,5 +2711,46 @@ mod tests {
             &[plan],
             &transitive_reads,
         ));
+    }
+
+    #[test]
+    fn resolved_calls_by_scope_ignores_conditionally_installed_functions() {
+        let source = "\
+outer() {
+  if false; then
+    use_flag() { printf '%s\\n' \"$flag\"; }
+  fi
+  flag=1
+  use_flag
+}
+outer
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build(&output.file, source, &indexer);
+        let name = Name::from("use_flag");
+        let mut call_sites = FxHashMap::default();
+        call_sites.insert(
+            name.clone(),
+            smallvec![model.call_sites_for(&name)[0].clone()],
+        );
+        let mut function_scopes = FxHashMap::default();
+        for binding in model.function_definitions(&name) {
+            if let Some(scope) = model.analysis().function_scope_for_binding(*binding) {
+                function_scopes.insert(*binding, scope);
+            }
+        }
+
+        let calls_by_scope = resolved_calls_by_scope(
+            &call_sites,
+            model.visible_function_call_bindings(),
+            &function_scopes,
+        );
+
+        assert!(
+            calls_by_scope.is_empty(),
+            "resolved calls: {:?}",
+            calls_by_scope
+        );
     }
 }

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -4,7 +4,6 @@ use shuck_ast::Span;
 use smallvec::SmallVec;
 
 use crate::runtime::RuntimePrelude;
-use crate::scope::ancestor_scopes;
 use crate::{
     Binding, BindingAttributes, BindingId, BindingKind, BlockId, CallSite, ContractCertainty,
     ControlFlowGraph, EdgeKind, ProvidedBinding, ProvidedBindingKind, Reference, ReferenceId,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1181,6 +1181,16 @@ impl SemanticModel {
         }
     }
 
+    pub(crate) fn visible_function_binding(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> Option<BindingId> {
+        self.function_binding_lookup()
+            .visible_function_binding(name, scope, offset)
+    }
+
     fn unconditional_function_bindings(&self) -> &FxHashSet<BindingId> {
         self.unconditional_function_bindings.get_or_init(|| {
             cfg::collect_unconditional_function_bindings(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -415,6 +415,9 @@ pub struct SemanticModel {
     assoc_lookup_binding_index: OnceLock<AssocLookupBindingIndex>,
     references_sorted_by_start: OnceLock<Vec<ReferenceId>>,
     declarations_by_command_span: OnceLock<FxHashMap<SpanKey, usize>>,
+    unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
+    function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
+    visible_function_call_bindings: OnceLock<FxHashMap<SpanKey, BindingId>>,
 }
 
 /// Lazy analysis view over a `SemanticModel`.
@@ -435,9 +438,6 @@ pub struct SemanticAnalysis<'model> {
     unreached_functions: OnceLock<Vec<UnreachedFunction>>,
     unreached_functions_shellcheck_compat: OnceLock<Vec<UnreachedFunction>>,
     scope_provided_binding_index: OnceLock<ScopeProvidedBindingIndex>,
-    unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
-    function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
-    visible_function_call_bindings: OnceLock<FxHashMap<SpanKey, BindingId>>,
 }
 
 #[allow(missing_docs)]
@@ -521,6 +521,9 @@ impl SemanticModel {
             assoc_lookup_binding_index: OnceLock::new(),
             references_sorted_by_start: OnceLock::new(),
             declarations_by_command_span: OnceLock::new(),
+            unconditional_function_bindings: OnceLock::new(),
+            function_bindings_by_scope: OnceLock::new(),
+            visible_function_call_bindings: OnceLock::new(),
         }
     }
 
@@ -978,6 +981,7 @@ impl SemanticModel {
 
         self.set_synthetic_reads(dedup_synthetic_reads(synthetic_reads));
         self.set_entry_bindings(entry_bindings);
+        self.invalidate_function_binding_lookup();
         self.resolve_unresolved_references();
         self.rebuild_call_graph();
     }
@@ -1052,8 +1056,15 @@ impl SemanticModel {
                 false,
             );
         }
+        self.invalidate_function_binding_lookup();
         self.resolve_unresolved_references();
         self.rebuild_call_graph();
+    }
+
+    fn invalidate_function_binding_lookup(&mut self) {
+        self.unconditional_function_bindings.take();
+        self.function_bindings_by_scope.take();
+        self.visible_function_call_bindings.take();
     }
 
     fn rebuild_call_graph(&mut self) {
@@ -1159,6 +1170,41 @@ impl SemanticModel {
         self.entry_bindings = entry_bindings;
     }
 
+    fn function_binding_lookup(&self) -> cfg::FunctionBindingLookup<'_> {
+        cfg::FunctionBindingLookup {
+            program: &self.recorded_program,
+            scopes: &self.scopes,
+            bindings: &self.bindings,
+            call_sites: &self.call_sites,
+            unconditional_function_bindings: self.unconditional_function_bindings(),
+            function_bindings_by_scope: self.function_binding_scope_index(),
+        }
+    }
+
+    fn unconditional_function_bindings(&self) -> &FxHashSet<BindingId> {
+        self.unconditional_function_bindings.get_or_init(|| {
+            cfg::collect_unconditional_function_bindings(
+                &self.recorded_program,
+                &self.command_bindings,
+                &self.bindings,
+            )
+        })
+    }
+
+    pub(crate) fn function_binding_scope_index(
+        &self,
+    ) -> &FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> {
+        self.function_bindings_by_scope
+            .get_or_init(|| cfg::function_bindings_by_scope(&self.recorded_program))
+    }
+
+    pub(crate) fn visible_function_call_bindings(&self) -> &FxHashMap<SpanKey, BindingId> {
+        self.visible_function_call_bindings.get_or_init(|| {
+            self.function_binding_lookup()
+                .visible_function_call_bindings()
+        })
+    }
+
     fn dataflow_context<'a>(&'a self, cfg: &'a ControlFlowGraph) -> DataflowContext<'a> {
         DataflowContext {
             cfg,
@@ -1172,6 +1218,7 @@ impl SemanticModel {
             self_referential_assignment_refs: &self.self_referential_assignment_refs,
             resolved: &self.resolved,
             call_sites: &self.call_sites,
+            visible_function_call_bindings: self.visible_function_call_bindings(),
             function_body_scopes: &self.recorded_program.function_body_scopes,
             indirect_targets_by_reference: &self.indirect_targets_by_reference,
             array_like_indirect_expansion_refs: &self.array_like_indirect_expansion_refs,

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -613,7 +613,6 @@ struct CallInfo {
     name: Name,
     scope: ScopeId,
     span: Span,
-    name_span: Span,
     args: Vec<Option<String>>,
 }
 
@@ -653,20 +652,10 @@ fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
 
         let name = Name::from(name);
         let is_source_builtin = matches!(name.as_str(), "source" | ".");
-        let call_site = model.call_sites_for(&name).iter().find(|site| {
-            site.span == command.span
-                || program
-                    .call_command_spans
-                    .get(&SpanKey::new(site.span))
-                    .is_some_and(|span| *span == command.span)
-        });
         facts.calls.push(CallInfo {
             name,
-            scope: call_site
-                .map(|site| site.scope)
-                .unwrap_or_else(|| model.scope_at(command.span.start.offset)),
+            scope: model.scope_at(command.span.start.offset),
             span: command.span,
-            name_span: call_site.map(|site| site.name_span).unwrap_or(command.span),
             args: info.static_args.to_vec(),
         });
 
@@ -1076,10 +1065,8 @@ fn resolve_literal_call_args_by_scope(
     let mut resolved = FxHashMap::default();
 
     for call in calls {
-        let Some(function_binding) = model
-            .visible_function_call_bindings()
-            .get(&SpanKey::new(call.name_span))
-            .copied()
+        let Some(function_binding) =
+            model.visible_function_binding(&call.name, call.scope, call.span.start.offset)
         else {
             continue;
         };
@@ -1465,14 +1452,30 @@ outer() {
         let facts = collect_ast_facts(&model);
         let args_by_scope = resolve_literal_call_args_by_scope(&model, &facts.calls);
         let name = Name::from("load_helper");
-        let call = facts
-            .calls
-            .iter()
-            .find(|call| call.name == name)
-            .expect("expected call info");
-        let call_site = &model.call_sites_for(&name)[0];
-        assert_eq!(call.scope, call_site.scope);
-        assert_eq!(call.name_span, call_site.name_span);
+        let binding = model.function_definitions(&name)[0];
+        let scope = model
+            .analysis()
+            .function_scope_for_binding(binding)
+            .expect("expected function scope");
+
+        assert_eq!(
+            args_by_scope.get(&scope),
+            Some(&vec![vec![Some("./helper.sh".to_owned())]])
+        );
+    }
+
+    #[test]
+    fn resolve_literal_call_args_by_scope_tracks_wrapper_expanded_calls() {
+        let source = "\
+load_helper() { . \"$1\"; }
+noglob load_helper ./helper.sh
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build(&output.file, source, &indexer);
+        let facts = collect_ast_facts(&model);
+        let args_by_scope = resolve_literal_call_args_by_scope(&model, &facts.calls);
+        let name = Name::from("load_helper");
         let binding = model.function_definitions(&name)[0];
         let scope = model
             .analysis()

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -613,6 +613,7 @@ struct CallInfo {
     name: Name,
     scope: ScopeId,
     span: Span,
+    name_span: Span,
     args: Vec<Option<String>>,
 }
 
@@ -650,16 +651,26 @@ fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
             continue;
         }
 
+        let name = Name::from(name);
+        let is_source_builtin = matches!(name.as_str(), "source" | ".");
+        let call_site = model.call_sites_for(&name).iter().find(|site| {
+            site.span == command.span
+                || program
+                    .call_command_spans
+                    .get(&SpanKey::new(site.span))
+                    .is_some_and(|span| *span == command.span)
+        });
         facts.calls.push(CallInfo {
-            name: Name::from(name),
-            scope: model.scope_at(command.span.start.offset),
+            name,
+            scope: call_site
+                .map(|site| site.scope)
+                .unwrap_or_else(|| model.scope_at(command.span.start.offset)),
             span: command.span,
+            name_span: call_site.map(|site| site.name_span).unwrap_or(command.span),
             args: info.static_args.to_vec(),
         });
 
-        if matches!(name, "source" | ".")
-            && let Some(template) = info.source_path_template.clone()
-        {
+        if is_source_builtin && let Some(template) = info.source_path_template.clone() {
             facts.source_templates_use_positional_args |=
                 source_template_uses_positional_args(&template);
             facts
@@ -1065,8 +1076,10 @@ fn resolve_literal_call_args_by_scope(
     let mut resolved = FxHashMap::default();
 
     for call in calls {
-        let Some(function_binding) =
-            visible_function_binding(model, &call.name, call.scope, call.span.start.offset)
+        let Some(function_binding) = model
+            .visible_function_call_bindings()
+            .get(&SpanKey::new(call.name_span))
+            .copied()
         else {
             continue;
         };
@@ -1085,28 +1098,6 @@ fn resolve_literal_call_args_by_scope(
     }
 
     resolved
-}
-
-fn visible_function_binding(
-    model: &SemanticModel,
-    name: &Name,
-    scope: ScopeId,
-    offset: usize,
-) -> Option<BindingId> {
-    for scope_id in model.ancestor_scopes(scope) {
-        let Some(candidates) = model.scopes()[scope_id.index()].bindings.get(name) else {
-            continue;
-        };
-        for binding in candidates.iter().rev().copied() {
-            let candidate = model.binding(binding);
-            if matches!(candidate.kind, crate::BindingKind::FunctionDefinition)
-                && candidate.span.start.offset <= offset
-            {
-                return Some(binding);
-            }
-        }
-    }
-    None
 }
 
 fn resolve_helper_paths(
@@ -1457,6 +1448,41 @@ coproc loader { . \"$2\"; }
 
         assert_eq!(source_call_count, 2);
         assert_eq!(facts.source_templates.len(), 2);
+    }
+
+    #[test]
+    fn resolve_literal_call_args_by_scope_uses_visible_parent_function_bindings() {
+        let source = "\
+outer() {
+  inner() { load_helper ./helper.sh; }
+  load_helper() { . \"$1\"; }
+  inner
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build(&output.file, source, &indexer);
+        let facts = collect_ast_facts(&model);
+        let args_by_scope = resolve_literal_call_args_by_scope(&model, &facts.calls);
+        let name = Name::from("load_helper");
+        let call = facts
+            .calls
+            .iter()
+            .find(|call| call.name == name)
+            .expect("expected call info");
+        let call_site = &model.call_sites_for(&name)[0];
+        assert_eq!(call.scope, call_site.scope);
+        assert_eq!(call.name_span, call_site.name_span);
+        let binding = model.function_definitions(&name)[0];
+        let scope = model
+            .analysis()
+            .function_scope_for_binding(binding)
+            .expect("expected function scope");
+
+        assert_eq!(
+            args_by_scope.get(&scope),
+            Some(&vec![vec![Some("./helper.sh".to_owned())]])
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -5952,8 +5952,6 @@ flag=1
         "synthetic reads: {:?}",
         model.synthetic_reads
     );
-    let unused = reportable_unused_names(&model);
-    assert!(unused.is_empty(), "unused: {:?}", unused);
 }
 
 #[test]
@@ -5988,8 +5986,6 @@ source \"${BASH_SOURCE[0]}__dep.bash\"
         "synthetic reads: {:?}",
         model.synthetic_reads
     );
-    let unused = reportable_unused_names(&model);
-    assert!(unused.is_empty(), "unused: {:?}", unused);
 }
 
 #[test]
@@ -6024,8 +6020,6 @@ source \"${BASH_SOURCE[00]}__dep.bash\"
         "synthetic reads: {:?}",
         model.synthetic_reads
     );
-    let unused = reportable_unused_names(&model);
-    assert!(unused.is_empty(), "unused: {:?}", unused);
 }
 
 #[test]
@@ -6223,6 +6217,32 @@ load helper.sh
     );
     let unused = reportable_unused_names(&model);
     assert!(unused.is_empty(), "unused: {:?}", unused);
+}
+
+#[test]
+fn wrapped_loader_function_source_reads_keep_top_level_assignment_live() {
+    let temp = tempdir().unwrap();
+    let main = temp.path().join("main.sh");
+    let helper = temp.path().join("helper.sh");
+    fs::write(
+        &main,
+        "\
+#!/bin/sh
+load() { . \"$ROOT/$1\"; }
+flag=1
+noglob load helper.sh
+",
+    )
+    .unwrap();
+    fs::write(&helper, "echo \"$flag\"\n").unwrap();
+
+    let model = model_at_path(&main);
+
+    assert!(
+        model.synthetic_reads.iter().any(|read| read.name == "flag"),
+        "synthetic reads: {:?}",
+        model.synthetic_reads
+    );
 }
 
 #[test]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -3007,6 +3007,30 @@ printf '%s\\n' \"$value\"
 }
 
 #[test]
+fn conditional_function_install_is_not_a_visible_function_call_binding() {
+    let source = "\
+outer() {
+  if false; then
+    use_flag() { printf '%s\\n' \"$flag\"; }
+  fi
+  flag=1
+  use_flag
+}
+outer
+";
+    let model = model(source);
+    let name = Name::from("use_flag");
+    let call = &model.call_sites_for(&name)[0];
+
+    assert_eq!(
+        model
+            .analysis()
+            .visible_function_binding_at_call(&name, call.name_span),
+        None
+    );
+}
+
+#[test]
 fn empty_case_catch_all_arm_keeps_following_code_reachable() {
     let source = "\
 case \"$kind\" in
@@ -7117,6 +7141,26 @@ set_flag() {
 
     let model = model_at_path(&main);
     assert!(model.analysis().uninitialized_references().is_empty());
+}
+
+#[test]
+fn late_parent_scope_loader_calls_are_visible_from_nested_functions() {
+    let source = "\
+outer() {
+  inner() { load_helper ./helper.sh; }
+  load_helper() { . \"$1\"; }
+  inner
+}
+";
+    let model = model(source);
+    let name = Name::from("load_helper");
+    let call = &model.call_sites_for(&name)[0];
+    assert!(
+        model
+            .analysis()
+            .visible_function_binding_at_call(&name, call.name_span)
+            .is_some()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- move the shared visible function-call binding lookup onto `SemanticModel` so semantic consumers reuse one CFG-backed resolver
- switch `dataflow` and `source_closure` off their lexical-only copies and onto the shared visible-call map
- add regressions for conditional installs, late parent-scope nested calls, dataflow call resolution, and source-closure argument resolution

## Why
Function-call binding resolution had been duplicated across the semantic layer and had already drifted. `cfg.rs` understood unconditional definitions and parent-scope availability before a scope runs, while `dataflow.rs` and `source_closure.rs` still carried simpler lexical-only copies. This makes semantic call binding a single source of truth.

## Impact
This keeps semantic subsystems aligned on the same function visibility rules and closes the sophistication gap that had opened between CFG analysis and downstream consumers.

## Validation
- `cargo test -p shuck-semantic`
