### PR TITLE
refactor(semantic): share ancestor scope traversal

### DIFF
--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -32,6 +32,7 @@ use crate::cfg::{
 use crate::declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 use crate::reference::{Reference, ReferenceKind};
 use crate::runtime::RuntimePrelude;
+use crate::scope::ancestor_scopes;
 use crate::source_closure::source_path_template;
 use crate::source_ref::{
     SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution,
@@ -2140,10 +2141,6 @@ fn pattern_group_can_match_empty(kind: PatternGroupKind, patterns: &[Pattern]) -
         }
         PatternGroupKind::NoneOf => false,
     }
-}
-
-fn ancestor_scopes(scopes: &[Scope], start: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
-    std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
 }
 
 fn function_scope_kind(function: &FunctionDef) -> FunctionScopeKind {

--- a/crates/shuck-semantic/src/call_graph.rs
+++ b/crates/shuck-semantic/src/call_graph.rs
@@ -3,6 +3,7 @@ use shuck_ast::{Name, Span};
 use smallvec::SmallVec;
 
 use crate::binding::Binding;
+use crate::scope::ancestor_scopes;
 use crate::{BindingId, Scope, ScopeId, ScopeKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -104,10 +105,6 @@ pub(crate) fn build_call_graph(
         uncalled,
         overwritten,
     }
-}
-
-fn ancestor_scopes(scopes: &[Scope], start: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
-    std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
 }
 
 fn is_in_function_scope(scopes: &[Scope], scope: ScopeId) -> bool {

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -4,6 +4,7 @@ use shuck_parser::ZshEmulationMode;
 use smallvec::{SmallVec, smallvec};
 use std::marker::PhantomData;
 
+use crate::scope::ancestor_scopes;
 use crate::source_closure::SourcePathTemplate;
 use crate::{Binding, BindingId, BindingKind, CallSite, ReferenceId, Scope, ScopeId, SpanKey};
 
@@ -1305,10 +1306,6 @@ impl FunctionCallResolver<'_> {
                     && candidate.span.start.offset <= offset
             })
     }
-}
-
-fn ancestor_scopes(scopes: &[Scope], start: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
-    std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
 }
 
 struct SequenceResult {

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -4,6 +4,7 @@ use shuck_ast::Span;
 use smallvec::SmallVec;
 
 use crate::runtime::RuntimePrelude;
+use crate::scope::ancestor_scopes;
 use crate::{
     Binding, BindingAttributes, BindingId, BindingKind, BlockId, CallSite, ContractCertainty,
     ControlFlowGraph, EdgeKind, ProvidedBinding, ProvidedBindingKind, Reference, ReferenceId,
@@ -2713,10 +2714,6 @@ fn is_function_escape_candidate(binding: &Binding, scopes: &[Scope]) -> bool {
             binding.kind,
             BindingKind::FunctionDefinition | BindingKind::Imported | BindingKind::Nameref
         )
-}
-
-fn ancestor_scopes(scopes: &[Scope], start: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
-    std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
 }
 
 #[cfg(test)]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -92,6 +92,7 @@ use crate::call_graph::build_call_graph;
 use crate::cfg::RecordedProgram;
 use crate::dataflow::{DataflowContext, DataflowResult, ExactVariableDataflow};
 use crate::runtime::RuntimePrelude;
+use crate::scope::ancestor_scopes;
 use crate::source_closure::ImportedBindingContractSite;
 use crate::zsh_options::ZshOptionAnalysis;
 
@@ -749,7 +750,7 @@ impl SemanticModel {
     }
 
     pub fn ancestor_scopes(&self, scope: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
-        std::iter::successors(Some(scope), move |scope| self.scopes[scope.index()].parent)
+        ancestor_scopes(&self.scopes, scope)
     }
 
     fn previous_visible_binding_id_in_scope_chain(

--- a/crates/shuck-semantic/src/scope.rs
+++ b/crates/shuck-semantic/src/scope.rs
@@ -12,6 +12,13 @@ impl ScopeId {
     }
 }
 
+pub(crate) fn ancestor_scopes(
+    scopes: &[Scope],
+    start: ScopeId,
+) -> impl Iterator<Item = ScopeId> + '_ {
+    std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Scope {
     pub id: ScopeId,


### PR DESCRIPTION
## Summary

- Move raw semantic scope-chain traversal into `scope.rs`
- Have `SemanticModel::ancestor_scopes` delegate to the shared helper
- Replace the duplicated helpers in builder, CFG, dataflow, and call graph code

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-semantic`
