### PR TITLE
refactor(linter): reuse semantic statement sequences

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -547,8 +547,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 self.source,
             );
         annotate_conditional_assignment_value_paths(self.semantic, &lists, &mut binding_values);
-        let statement_facts =
-            build_statement_facts(&commands, &command_ids_by_span, &self.file.body);
+        let statement_facts = build_statement_facts(&commands, self.semantic);
         let background_semicolon_spans =
             build_background_semicolon_spans(&commands, &case_items, self.source);
         let single_test_subshell_spans =

--- a/crates/shuck-linter/src/facts/statements.rs
+++ b/crates/shuck-linter/src/facts/statements.rs
@@ -22,231 +22,36 @@ impl StatementFact {
 #[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_statement_facts<'a>(
     commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-    body: &StmtSeq,
+    semantic: &SemanticModel,
 ) -> Vec<StatementFact> {
-    let mut facts = Vec::new();
-    collect_statement_facts_in_stmt_seq(body, commands, command_ids_by_span, &mut facts);
-    facts
+    let command_ids_by_stmt_span = build_command_ids_by_stmt_span(commands);
+
+    semantic
+        .statement_sequence_commands()
+        .iter()
+        .filter_map(|statement| {
+            let command_id =
+                command_ids_by_stmt_span.get(&FactSpan::new(statement.stmt_span()))?;
+            Some(StatementFact {
+                body_span: statement.body_span(),
+                stmt_span: statement.stmt_span(),
+                command_id: *command_id,
+            })
+        })
+        .collect()
 }
 
-fn collect_statement_facts_in_stmt_seq<'a>(
-    body: &StmtSeq,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-    facts: &mut Vec<StatementFact>,
-) {
-    for stmt in &body.stmts {
-        if let Some(id) = command_fact_for_stmt(stmt, commands, command_ids_by_span) {
-            facts.push(StatementFact {
-                body_span: body.span,
-                stmt_span: stmt.span,
-                command_id: id.id(),
-            });
-        }
+fn build_command_ids_by_stmt_span(commands: &[CommandFact<'_>]) -> FxHashMap<FactSpan, CommandId> {
+    let mut command_ids_by_stmt_span = FxHashMap::default();
 
-        collect_statement_sequence_facts_in_command(
-            &stmt.command,
-            commands,
-            command_ids_by_span,
-            facts,
-        );
+    for command in commands {
+        if command.is_nested_word_command() {
+            continue;
+        }
+        command_ids_by_stmt_span
+            .entry(FactSpan::new(command.stmt().span))
+            .or_insert_with(|| command.id());
     }
-}
 
-fn collect_statement_sequence_facts_in_command<'a>(
-    command: &Command,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-    facts: &mut Vec<StatementFact>,
-) {
-    match command {
-        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => {}
-        Command::Binary(binary) => {
-            collect_statement_sequence_facts_in_stmt(
-                &binary.left,
-                commands,
-                command_ids_by_span,
-                facts,
-            );
-            collect_statement_sequence_facts_in_stmt(
-                &binary.right,
-                commands,
-                command_ids_by_span,
-                facts,
-            );
-        }
-        Command::Compound(command) => match command {
-            CompoundCommand::If(command) => {
-                collect_statement_facts_in_stmt_seq(
-                    &command.condition,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-                collect_statement_facts_in_stmt_seq(
-                    &command.then_branch,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-                for (condition, body) in &command.elif_branches {
-                    collect_statement_facts_in_stmt_seq(
-                        condition,
-                        commands,
-                        command_ids_by_span,
-                        facts,
-                    );
-                    collect_statement_facts_in_stmt_seq(body, commands, command_ids_by_span, facts);
-                }
-                if let Some(body) = &command.else_branch {
-                    collect_statement_facts_in_stmt_seq(body, commands, command_ids_by_span, facts);
-                }
-            }
-            CompoundCommand::For(command) => {
-                collect_statement_facts_in_stmt_seq(
-                    &command.body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-            }
-            CompoundCommand::Repeat(command) => {
-                collect_statement_facts_in_stmt_seq(
-                    &command.body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-            }
-            CompoundCommand::Foreach(command) => {
-                collect_statement_facts_in_stmt_seq(
-                    &command.body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-            }
-            CompoundCommand::ArithmeticFor(command) => {
-                collect_statement_facts_in_stmt_seq(
-                    &command.body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-            }
-            CompoundCommand::While(command) => {
-                collect_statement_facts_in_stmt_seq(
-                    &command.condition,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-                collect_statement_facts_in_stmt_seq(
-                    &command.body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-            }
-            CompoundCommand::Until(command) => {
-                collect_statement_facts_in_stmt_seq(
-                    &command.condition,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-                collect_statement_facts_in_stmt_seq(
-                    &command.body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-            }
-            CompoundCommand::Case(command) => {
-                for case in &command.cases {
-                    collect_statement_facts_in_stmt_seq(
-                        &case.body,
-                        commands,
-                        command_ids_by_span,
-                        facts,
-                    );
-                }
-            }
-            CompoundCommand::Select(command) => {
-                collect_statement_facts_in_stmt_seq(
-                    &command.body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-            }
-            CompoundCommand::Subshell(body) | CompoundCommand::BraceGroup(body) => {
-                collect_statement_facts_in_stmt_seq(body, commands, command_ids_by_span, facts);
-            }
-            CompoundCommand::Arithmetic(_) | CompoundCommand::Conditional(_) => {}
-            CompoundCommand::Time(command) => {
-                if let Some(inner) = &command.command {
-                    collect_statement_sequence_facts_in_stmt(
-                        inner,
-                        commands,
-                        command_ids_by_span,
-                        facts,
-                    );
-                }
-            }
-            CompoundCommand::Coproc(command) => {
-                collect_statement_sequence_facts_in_stmt(
-                    &command.body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-            }
-            CompoundCommand::Always(command) => {
-                collect_statement_facts_in_stmt_seq(
-                    &command.body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-                collect_statement_facts_in_stmt_seq(
-                    &command.always_body,
-                    commands,
-                    command_ids_by_span,
-                    facts,
-                );
-            }
-        },
-        Command::Function(function) => {
-            collect_statement_sequence_facts_in_stmt(
-                &function.body,
-                commands,
-                command_ids_by_span,
-                facts,
-            );
-        }
-        Command::AnonymousFunction(function) => {
-            collect_statement_sequence_facts_in_stmt(
-                &function.body,
-                commands,
-                command_ids_by_span,
-                facts,
-            );
-        }
-    }
-}
-
-fn collect_statement_sequence_facts_in_stmt<'a>(
-    stmt: &Stmt,
-    commands: &[CommandFact<'a>],
-    command_ids_by_span: &CommandLookupIndex,
-    facts: &mut Vec<StatementFact>,
-) {
-    collect_statement_sequence_facts_in_command(
-        &stmt.command,
-        commands,
-        command_ids_by_span,
-        facts,
-    );
+    command_ids_by_stmt_span
 }

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -60,7 +60,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     ) {
         recorded.reserve(commands.len());
         for stmt in commands.iter() {
-            recorded.push(self.visit_stmt(stmt, flow));
+            let command = self.visit_stmt(stmt, flow);
+            self.recorded_program
+                .push_statement_sequence_command(commands.span, stmt.span);
+            recorded.push(command);
         }
     }
 

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -166,6 +166,7 @@ pub(crate) struct RecordedProgram {
     function_bodies: FxHashMap<ScopeId, RecordedCommandRange>,
     commands: Vec<RecordedCommand>,
     command_sequence_items: Vec<RecordedCommandId>,
+    statement_sequence_commands: Vec<StatementSequenceCommand>,
     isolated_regions: Vec<IsolatedRegion>,
     case_arms: Vec<RecordedCaseArm>,
     pipeline_segments: Vec<RecordedPipelineSegment>,
@@ -174,6 +175,22 @@ pub(crate) struct RecordedProgram {
     pub(crate) command_infos: FxHashMap<SpanKey, RecordedCommandInfo>,
     pub(crate) function_body_scopes: FxHashMap<BindingId, ScopeId>,
     pub(crate) call_command_spans: FxHashMap<SpanKey, Span>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StatementSequenceCommand {
+    body_span: Span,
+    stmt_span: Span,
+}
+
+impl StatementSequenceCommand {
+    pub fn body_span(&self) -> Span {
+        self.body_span
+    }
+
+    pub fn stmt_span(&self) -> Span {
+        self.stmt_span
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -401,6 +418,18 @@ impl RecordedProgram {
 
     pub(crate) fn commands_in(&self, range: RecordedCommandRange) -> &[RecordedCommandId] {
         range.slice(&self.command_sequence_items)
+    }
+
+    pub fn statement_sequence_commands(&self) -> &[StatementSequenceCommand] {
+        &self.statement_sequence_commands
+    }
+
+    pub(crate) fn push_statement_sequence_command(&mut self, body_span: Span, stmt_span: Span) {
+        self.statement_sequence_commands
+            .push(StatementSequenceCommand {
+                body_span,
+                stmt_span,
+            });
     }
 
     pub(crate) fn nested_regions(&self, range: RecordedRegionRange) -> &[IsolatedRegion] {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -52,7 +52,10 @@ pub use call_graph::{
     CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,
 };
 /// Control-flow graph types and flow-context annotations.
-pub use cfg::{BasicBlock, BlockId, ControlFlowGraph, EdgeKind, FlowContext, UnreachableCauseKind};
+pub use cfg::{
+    BasicBlock, BlockId, ControlFlowGraph, EdgeKind, FlowContext, StatementSequenceCommand,
+    UnreachableCauseKind,
+};
 /// Contract and build-option types used when constructing semantic models.
 pub use contract::{
     ContractCertainty, FileContract, FileEntryBindingInitialization, FileEntryContractCollector,
@@ -1137,6 +1140,10 @@ impl SemanticModel {
             .get(&id)
             .map(Vec::as_slice)
             .unwrap_or(&[])
+    }
+
+    pub fn statement_sequence_commands(&self) -> &[StatementSequenceCommand] {
+        self.recorded_program.statement_sequence_commands()
     }
 
     pub(crate) fn recorded_program(&self) -> &RecordedProgram {


### PR DESCRIPTION
## Summary

- record statement-sequence membership during semantic traversal
- expose semantic statement sequence records through `SemanticModel`
- build linter `StatementFact`s from semantic membership instead of re-walking compound AST structure

## Validation

- `cargo test -p shuck-linter combine_appends --lib`
- `make test`