### PR TITLE
refactor(semantic): reuse command normalization for zsh effects

### DIFF
--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -8,10 +8,9 @@ use shuck_ast::{
     CompoundCommand, ConditionalBinaryOp, ConditionalExpr, ConditionalUnaryOp, DeclOperand, File,
     FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, LiteralText, Name,
     NormalizedCommand, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
-    PatternGroupKind, PatternPart, PatternPartNode, Position, SourceText, Span,
-    StaticCommandWrapperTarget, Stmt, StmtSeq, Subscript, SubscriptInterpretation, VarRef, Word,
-    WordPart, WordPartNode, WrapperKind, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
-    normalize_command_words, static_command_name_text, static_command_wrapper_target_index,
+    PatternGroupKind, PatternPart, PatternPartNode, Position, SourceText, Span, Stmt, StmtSeq,
+    Subscript, SubscriptInterpretation, VarRef, Word, WordPart, WordPartNode, WrapperKind,
+    ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment, normalize_command_words,
     static_word_text, try_static_word_parts_text,
 };
 use shuck_indexer::Indexer;

--- a/crates/shuck-semantic/src/builder/zsh_effects.rs
+++ b/crates/shuck-semantic/src/builder/zsh_effects.rs
@@ -43,13 +43,13 @@ pub(super) fn recorded_simple_command_info(
         source_path_template,
         zsh_effects: Vec::new(),
     };
-    if !normalized_command_can_have_zsh_effects(&normalized) {
-        return info;
-    }
-    let Some(effect_callee) = normalized.effective_name.as_deref() else {
+    let Some(effect_command) = normalized_zsh_effect_command(&normalized, source) else {
         return info;
     };
-    let args = normalized.body_args();
+    let Some(effect_callee) = effect_command.effective_name.as_deref() else {
+        return info;
+    };
+    let args = effect_command.body_args();
 
     match effect_callee {
         "emulate" => info.zsh_effects = parse_emulate_effects(args, source),
@@ -107,6 +107,25 @@ fn recorded_static_args(
         .into_boxed_slice()
 }
 
+fn normalized_zsh_effect_command<'a>(
+    command: &NormalizedCommand<'a>,
+    source: &'a str,
+) -> Option<NormalizedCommand<'a>> {
+    if !normalized_command_can_have_zsh_effects(command) {
+        return None;
+    }
+
+    let effect_start = command
+        .body_words
+        .iter()
+        .position(|word| {
+            static_word_text(word, source).is_none_or(|text| !is_recorded_assignment_word(&text))
+        })
+        .unwrap_or(command.body_words.len());
+    let effect_command = normalize_command_words(&command.body_words[effect_start..], source)?;
+    normalized_command_can_have_zsh_effects(&effect_command).then_some(effect_command)
+}
+
 fn normalized_command_can_have_zsh_effects(command: &NormalizedCommand<'_>) -> bool {
     command.wrappers.iter().all(|wrapper| {
         matches!(
@@ -114,6 +133,17 @@ fn normalized_command_can_have_zsh_effects(command: &NormalizedCommand<'_>) -> b
             WrapperKind::Command | WrapperKind::Builtin | WrapperKind::Noglob | WrapperKind::Exec
         )
     })
+}
+
+fn is_recorded_assignment_word(word: &str) -> bool {
+    let Some((name, _value)) = word.split_once('=') else {
+        return false;
+    };
+    !name.is_empty()
+        && !name.starts_with('-')
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 pub(super) fn parse_emulate_effects(args: &[&Word], source: &str) -> Vec<RecordedZshCommandEffect> {

--- a/crates/shuck-semantic/src/builder/zsh_effects.rs
+++ b/crates/shuck-semantic/src/builder/zsh_effects.rs
@@ -26,44 +26,32 @@ pub(super) fn recorded_simple_command_info(
     let words = std::iter::once(&command.name)
         .chain(command.args.iter())
         .collect::<Vec<_>>();
-    let mut static_callee =
-        static_command_name_text(&command.name, source).map(|name| name.into_owned());
-    let mut static_args = command
-        .args
-        .iter()
-        .map(|word| static_word_text(word, source).map(|text| text.into_owned()))
-        .collect::<Vec<_>>();
-    let source_path_template = static_callee
+    let normalized = normalize_command_words(&words, source)
+        .expect("recorded simple commands always include a command name");
+    let static_callee = recorded_static_callee(&normalized).map(ToOwned::to_owned);
+    let static_args = recorded_static_args(command, &normalized, source);
+    let source_path_template = normalized
+        .literal_name
         .as_deref()
         .filter(|name| matches!(*name, "source" | "."))
         .and_then(|_| command.args.first())
         .and_then(|word| source_path_template(word, source, bash_runtime_vars_enabled));
 
-    if static_callee.as_deref() == Some("noglob") {
-        static_callee = words
-            .get(1)
-            .and_then(|word| static_command_name_text(word, source).map(|name| name.into_owned()));
-        static_args = command
-            .args
-            .iter()
-            .skip(1)
-            .map(|word| static_word_text(word, source).map(|text| text.into_owned()))
-            .collect();
-    }
-
     let mut info = RecordedCommandInfo {
         static_callee,
-        static_args: static_args.into_boxed_slice(),
+        static_args,
         source_path_template,
         zsh_effects: Vec::new(),
     };
-    let Some((effect_callee, effect_index)) = normalize_recorded_zsh_effect_command(&words, source)
-    else {
+    if !normalized_command_can_have_zsh_effects(&normalized) {
+        return info;
+    }
+    let Some(effect_callee) = normalized.effective_name.as_deref() else {
         return info;
     };
-    let args = words.get(effect_index + 1..).unwrap_or(&[]);
+    let args = normalized.body_args();
 
-    match effect_callee.as_str() {
+    match effect_callee {
         "emulate" => info.zsh_effects = parse_emulate_effects(args, source),
         "setopt" => {
             info.zsh_effects = vec![RecordedZshCommandEffect::SetOptions {
@@ -91,45 +79,41 @@ pub(super) fn recorded_simple_command_info(
     info
 }
 
-pub(super) fn normalize_recorded_zsh_effect_command(
-    words: &[&Word],
-    source: &str,
-) -> Option<(String, usize)> {
-    let mut index = 0usize;
-
-    while let Some(word) = words.get(index) {
-        let text = static_word_text(word, source)?;
-        if is_recorded_assignment_word(&text) {
-            index += 1;
-            continue;
-        }
-
-        match static_command_wrapper_target_index(words.len(), index, text.as_ref(), |word_index| {
-            static_word_text(words[word_index], source)
-        }) {
-            StaticCommandWrapperTarget::NotWrapper => return Some((text.into_owned(), index)),
-            StaticCommandWrapperTarget::Wrapper {
-                target_index: Some(target_index),
-            } => {
-                index = target_index;
-                continue;
-            }
-            StaticCommandWrapperTarget::Wrapper { target_index: None } => return None,
-        }
+fn recorded_static_callee<'a>(normalized: &'a NormalizedCommand<'a>) -> Option<&'a str> {
+    if normalized.wrappers == [WrapperKind::Noglob] {
+        return normalized.effective_name.as_deref();
     }
-
-    None
+    normalized.literal_name.as_deref()
 }
 
-pub(super) fn is_recorded_assignment_word(word: &str) -> bool {
-    let Some((name, _value)) = word.split_once('=') else {
-        return false;
-    };
-    !name.is_empty()
-        && !name.starts_with('-')
-        && name
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+fn recorded_static_args(
+    command: &shuck_ast::SimpleCommand,
+    normalized: &NormalizedCommand<'_>,
+    source: &str,
+) -> Box<[Option<String>]> {
+    if normalized.wrappers == [WrapperKind::Noglob] {
+        return normalized
+            .body_args()
+            .iter()
+            .map(|word| static_word_text(word, source).map(|text| text.into_owned()))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+    }
+    command
+        .args
+        .iter()
+        .map(|word| static_word_text(word, source).map(|text| text.into_owned()))
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+fn normalized_command_can_have_zsh_effects(command: &NormalizedCommand<'_>) -> bool {
+    command.wrappers.iter().all(|wrapper| {
+        matches!(
+            wrapper,
+            WrapperKind::Command | WrapperKind::Builtin | WrapperKind::Noglob | WrapperKind::Exec
+        )
+    })
 }
 
 pub(super) fn parse_emulate_effects(args: &[&Word], source: &str) -> Vec<RecordedZshCommandEffect> {

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -1489,6 +1489,24 @@ noglob load_helper ./helper.sh
     }
 
     #[test]
+    fn shell_precommand_wrappers_do_not_create_source_template_facts() {
+        let source = "\
+#!/bin/bash
+command . \"$1\"
+builtin source \"$2\"
+noglob source \"$3\"
+";
+        let output = Parser::with_dialect(source, ShellDialect::Bash)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build(&output.file, source, &indexer);
+        let facts = collect_ast_facts(&model);
+
+        assert!(facts.source_templates.is_empty());
+    }
+
+    #[test]
     fn summarize_helper_reuses_request_profile_cache_hit_before_reading() {
         let temp = tempdir().unwrap();
         let helper = temp.path().join("helper");

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -8257,6 +8257,27 @@ print *
 }
 
 #[test]
+fn zsh_option_analysis_skips_assignment_prefixes_after_wrappers() {
+    for source in [
+        "\
+command FOO=1 setopt no_glob
+print *
+",
+        "\
+noglob FOO=1 setopt no_glob
+print *
+",
+    ] {
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected wrapped zsh option effects");
+
+        assert_eq!(options.glob, OptionValue::Off, "{source}");
+    }
+}
+
+#[test]
 fn zsh_option_analysis_tracks_command_repeated_p_wrapper() {
     let source = "\
 command -pp setopt no_glob
@@ -8304,6 +8325,14 @@ print *
 ",
         "\
 find . -exec setopt no_glob \\;
+print *
+",
+        "\
+command FOO=1 sudo setopt no_glob
+print *
+",
+        "\
+command FOO=1 find . -exec setopt no_glob \\;
 print *
 ",
     ] {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -8296,6 +8296,27 @@ print *
 }
 
 #[test]
+fn zsh_option_analysis_ignores_external_command_wrappers() {
+    for source in [
+        "\
+sudo setopt no_glob
+print *
+",
+        "\
+find . -exec setopt no_glob \\;
+print *
+",
+    ] {
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let options = model
+            .zsh_options_at(source.find("print").unwrap())
+            .expect("expected wrapped zsh options");
+
+        assert_eq!(options.glob, OptionValue::On, "{source}");
+    }
+}
+
+#[test]
 fn zsh_option_analysis_ignores_command_lookup_modes() {
     for source in [
         "\


### PR DESCRIPTION
## Summary
- derive semantic recorded command info from the shared AST command normalizer
- remove the parallel zsh-effect wrapper peeling path
- add coverage that external wrappers do not affect zsh option state

## Validation
- cargo check -p shuck-semantic
- cargo test -p shuck-semantic
- git diff --check