### PR TITLE
refactor(linter): reuse semantic list and pipeline shapes

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -529,7 +529,12 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let case_pattern_shadows = build_case_pattern_shadow_facts(&commands, self.source);
         let case_pattern_impossible_spans =
             build_case_pattern_impossible_spans(&commands, self.source);
-        let pipelines = build_pipeline_facts(&commands, &command_ids_by_span, &command_child_index);
+        let pipelines = build_pipeline_facts(
+            &commands,
+            self.semantic,
+            &command_ids_by_span,
+            &command_child_index,
+        );
         populate_scope_fact_ranges(
             &mut commands,
             &mut fact_store,

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1316,8 +1316,48 @@ fn command_id_for_command(
         })
 }
 
-fn command_fact<'a>(commands: &'a [CommandFact<'a>], id: CommandId) -> &'a CommandFact<'a> {
+fn command_fact<'facts, 'a>(
+    commands: &'facts [CommandFact<'a>],
+    id: CommandId,
+) -> &'facts CommandFact<'a> {
     &commands[id.index()]
+}
+
+fn command_fact_for_semantic_span_matching<'facts, 'a>(
+    commands: &'facts [CommandFact<'a>],
+    command_ids_by_span: &CommandLookupIndex,
+    span: Span,
+    predicate: impl Fn(&CommandFact<'a>) -> bool,
+) -> Option<&'facts CommandFact<'a>> {
+    command_ids_by_span
+        .get(&FactSpan::new(span))
+        .and_then(|entries| {
+            entries
+                .iter()
+                .map(|entry| command_fact(commands, entry.id))
+                .find(|command| predicate(command))
+        })
+        .or_else(|| {
+            commands
+                .iter()
+                .find(|command| {
+                    predicate(command) && FactSpan::new(command.stmt().span) == FactSpan::new(span)
+                })
+        })
+        .or_else(|| {
+            commands
+                .iter()
+                .filter(|command| {
+                    let command_span = command.span();
+                    predicate(command)
+                        && span.start.offset <= command_span.start.offset
+                        && command_span.end.offset <= span.end.offset
+                })
+                .max_by_key(|command| {
+                    let span = command.span();
+                    (span.end.offset, std::cmp::Reverse(span.start.offset))
+                })
+        })
 }
 
 fn command_fact_ref<'facts, 'a>(

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -68,7 +68,7 @@ use shuck_semantic::{
     DeclarationOperand as SemanticDeclarationOperand, NonpersistentAssignmentAnalysisContext,
     NonpersistentAssignmentAnalysisOptions, NonpersistentAssignmentCommandContext,
     NonpersistentAssignmentExtraRead, OptionValue, Reference, ReferenceId, ReferenceKind, ScopeId,
-    SemanticAnalysis, SemanticModel, ZshOptionState,
+    SemanticAnalysis, SemanticModel, SemanticPipelineOperatorKind, ZshOptionState,
 };
 use smallvec::SmallVec;
 use std::{borrow::Cow, ops::ControlFlow, sync::OnceLock};

--- a/crates/shuck-linter/src/facts/pipelines.rs
+++ b/crates/shuck-linter/src/facts/pipelines.rs
@@ -102,148 +102,83 @@ impl<'a> PipelineFact<'a> {
 #[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_pipeline_facts<'a>(
     commands: &[CommandFact<'a>],
+    semantic: &SemanticModel,
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
 ) -> Vec<PipelineFact<'a>> {
     let command_relationships =
         CommandRelationshipContext::new(commands, command_ids_by_span, command_child_index);
-    let mut nested_pipeline_commands = FxHashSet::default();
 
-    for fact in commands {
-        let Command::Binary(command) = fact.command() else {
-            continue;
-        };
-        if !matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) {
-            continue;
-        }
-
-        record_nested_pipeline_command(
-            &command.left,
-            fact.id(),
-            command_relationships,
-            &mut nested_pipeline_commands,
-        );
-        record_nested_pipeline_command(
-            &command.right,
-            fact.id(),
-            command_relationships,
-            &mut nested_pipeline_commands,
-        );
-    }
-
-    commands
-        .iter()
-        .filter_map(|fact| {
+    semantic
+        .pipeline_commands()
+        .into_iter()
+        .filter_map(|pipeline| {
+            let fact = command_fact_for_semantic_span_matching(
+                commands,
+                command_ids_by_span,
+                pipeline.span,
+                |command| matches!(command.command(), Command::Binary(_)),
+            )?;
             let Command::Binary(command) = fact.command() else {
                 return None;
             };
-            if !matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll)
-                || nested_pipeline_commands.contains(&fact.id())
-            {
+            if !matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) {
                 return None;
             }
 
-            let segments = pipeline_segments(fact.command())?;
             Some(PipelineFact {
                 key: fact.key(),
                 command,
-                segments: segments
-                    .into_iter()
-                    .map(|stmt| {
-                        build_pipeline_segment_fact(
-                            stmt,
-                            command_relationships,
-                            fact.id(),
-                        )
+                segments: pipeline
+                    .segments
+                    .iter()
+                    .map(|segment| {
+                        build_pipeline_segment_fact(segment.command_span, command_relationships)
                     })
                     .collect::<Vec<_>>()
                     .into_boxed_slice(),
-                operators: pipeline_operator_facts(command),
+                operators: pipeline
+                    .segments
+                    .into_iter()
+                    .filter_map(|segment| segment.operator_before)
+                    .map(|operator| {
+                        let op = match operator.kind {
+                            SemanticPipelineOperatorKind::Pipe => BinaryOp::Pipe,
+                            SemanticPipelineOperatorKind::PipeAll => BinaryOp::PipeAll,
+                        };
+                        PipelineOperatorFact {
+                            op,
+                            span: operator.span,
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice(),
             })
         })
         .collect()
 }
 
-fn record_nested_pipeline_command(
-    stmt: &Stmt,
-    parent_id: CommandId,
-    command_relationships: CommandRelationshipContext<'_, '_>,
-    nested_pipeline_commands: &mut FxHashSet<CommandId>,
-) {
-    if matches!(
-        &stmt.command,
-        Command::Binary(child) if matches!(child.op, BinaryOp::Pipe | BinaryOp::PipeAll)
-    ) && let Some(child) = command_relationships.child_or_lookup_fact(parent_id, stmt)
-    {
-        nested_pipeline_commands.insert(child.id());
-    }
-}
-
-fn pipeline_segments(command: &Command) -> Option<Vec<&Stmt>> {
-    let Command::Binary(command) = command else {
-        return None;
-    };
-    if !matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) {
-        return None;
-    }
-
-    let mut segments = Vec::new();
-    collect_pipeline_segments(command, &mut segments);
-    Some(segments)
-}
-
-fn collect_pipeline_segments<'a>(command: &'a BinaryCommand, segments: &mut Vec<&'a Stmt>) {
-    match &command.left.command {
-        Command::Binary(left) if matches!(left.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            collect_pipeline_segments(left, segments);
-        }
-        _ => segments.push(&command.left),
-    }
-
-    match &command.right.command {
-        Command::Binary(right) if matches!(right.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            collect_pipeline_segments(right, segments);
-        }
-        _ => segments.push(&command.right),
-    }
-}
-
-fn pipeline_operator_facts(command: &BinaryCommand) -> Box<[PipelineOperatorFact]> {
-    let mut operators = Vec::new();
-    collect_pipeline_operator_facts(command, &mut operators);
-    operators.into_boxed_slice()
-}
-
-fn collect_pipeline_operator_facts(command: &BinaryCommand, out: &mut Vec<PipelineOperatorFact>) {
-    if let Command::Binary(left) = &command.left.command
-        && matches!(left.op, BinaryOp::Pipe | BinaryOp::PipeAll)
-    {
-        collect_pipeline_operator_facts(left, out);
-    }
-
-    out.push(PipelineOperatorFact {
-        op: command.op,
-        span: command.op_span,
-    });
-
-    if let Command::Binary(right) = &command.right.command
-        && matches!(right.op, BinaryOp::Pipe | BinaryOp::PipeAll)
-    {
-        collect_pipeline_operator_facts(right, out);
-    }
-}
-
 fn build_pipeline_segment_fact<'a>(
-    stmt: &'a Stmt,
+    command_span: Span,
     command_relationships: CommandRelationshipContext<'_, 'a>,
-    parent_id: CommandId,
 ) -> PipelineSegmentFact<'a> {
-    let Some(fact) = command_relationships.child_or_lookup_fact(parent_id, stmt) else {
+    let Some(fact) = command_fact_for_semantic_span_matching(
+        command_relationships.commands,
+        command_relationships.command_ids_by_span,
+        command_span,
+        |command| {
+            !matches!(
+                command.command(),
+                Command::Binary(binary)
+                    if matches!(binary.op, BinaryOp::Pipe | BinaryOp::PipeAll)
+            )
+        },
+    ) else {
         unreachable!("pipeline segment should have a corresponding command fact");
     };
 
     PipelineSegmentFact {
-        stmt,
+        stmt: fact.stmt(),
         command_id: fact.id(),
         literal_name: fact
             .literal_name()
@@ -253,42 +188,5 @@ fn build_pipeline_segment_fact<'a>(
             .effective_name()
             .map(str::to_owned)
             .map(String::into_boxed_str),
-    }
-}
-
-#[cfg(test)]
-mod pipeline_tests {
-    use shuck_ast::{Command, StmtSeq, Word};
-    use shuck_parser::parser::Parser;
-
-    use super::pipeline_segments;
-
-    fn parse_commands(source: &str) -> StmtSeq {
-        let output = Parser::new(source).parse().unwrap();
-        output.file.body
-    }
-
-    fn static_word_owned_text(word: &Word, source: &str) -> Option<String> {
-        word.try_static_text(source).map(|text| text.into_owned())
-    }
-
-    #[test]
-    fn pipeline_segments_flattens_pipe_chains() {
-        let source = "printf '%s\\n' a | command kill 0 | tee out.txt\n";
-        let commands = parse_commands(source);
-        let Command::Binary(command) = &commands[0].command else {
-            panic!("expected binary command");
-        };
-
-        let segments = pipeline_segments(&Command::Binary(command.clone()))
-            .expect("expected pipeline segments")
-            .into_iter()
-            .map(|stmt| match &stmt.command {
-                Command::Simple(command) => static_word_owned_text(&command.name, source).unwrap(),
-                _ => "<non-simple>".to_owned(),
-            })
-            .collect::<Vec<_>>();
-
-        assert_eq!(segments, vec!["printf", "command", "tee"]);
     }
 }

--- a/crates/shuck-linter/src/facts/tests/conditions.rs
+++ b/crates/shuck-linter/src/facts/tests/conditions.rs
@@ -1182,6 +1182,7 @@ for file in $(printf '%s\\n' one two) \"$(command find . -type f)\" literal; do 
 select choice in $(printf '%s\\n' a b) \"$(find . -type f)\" literal; do :; done
 printf '%s\\n' 123 |& command kill -9 | tee out.txt
 summary=$(printf '%s\\n' 456 | kill -TERM)
+! printf '%s\\n' neg | cat
 echo \"$(for nested in $(printf nested); do :; done)\"
 true && false || printf '%s\\n' fallback
 ";
@@ -1227,6 +1228,7 @@ true && false || printf '%s\\n' fallback
             vec![
                 vec!["printf".to_owned(), "kill".to_owned(), "tee".to_owned()],
                 vec!["printf".to_owned(), "kill".to_owned()],
+                vec!["printf".to_owned(), "cat".to_owned()],
             ]
         );
 

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -26,8 +26,8 @@ use crate::call_graph::{CallGraph, CallSite, build_call_graph};
 use crate::cfg::{
     FlowContext, IsolatedRegion, RecordedCaseArm, RecordedCommand, RecordedCommandId,
     RecordedCommandInfo, RecordedCommandKind, RecordedCommandRange, RecordedElifBranch,
-    RecordedListItem, RecordedListOperator, RecordedPipelineSegment, RecordedProgram,
-    RecordedZshCommandEffect, RecordedZshOptionUpdate,
+    RecordedListItem, RecordedListOperator, RecordedPipelineOperator, RecordedPipelineOperatorKind,
+    RecordedPipelineSegment, RecordedProgram, RecordedZshCommandEffect, RecordedZshOptionUpdate,
 };
 use crate::declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
 use crate::reference::{Reference, ReferenceKind};
@@ -2183,25 +2183,54 @@ fn command_span_from_compound(command: &CompoundCommand) -> Span {
     }
 }
 
-fn collect_pipeline_segments<'a>(stmt: &'a Stmt, out: &mut SmallVec<[&'a Stmt; 4]>) {
+struct PipelineSegmentInput<'a> {
+    operator_before: Option<RecordedPipelineOperator>,
+    stmt: &'a Stmt,
+}
+
+fn collect_pipeline_segments<'a>(
+    stmt: &'a Stmt,
+    operator_before: Option<RecordedPipelineOperator>,
+    out: &mut SmallVec<[PipelineSegmentInput<'a>; 4]>,
+) {
     match &stmt.command {
         Command::Binary(command) if matches!(command.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            collect_pipeline_segments(&command.left, out);
-            collect_pipeline_segments(&command.right, out);
+            collect_pipeline_segments(&command.left, operator_before, out);
+            collect_pipeline_segments(
+                &command.right,
+                Some(RecordedPipelineOperator {
+                    operator: recorded_pipeline_operator(command.op),
+                    span: command.op_span,
+                }),
+                out,
+            );
         }
-        _ => out.push(stmt),
+        _ => out.push(PipelineSegmentInput {
+            operator_before,
+            stmt,
+        }),
+    }
+}
+
+fn recorded_pipeline_operator(op: BinaryOp) -> RecordedPipelineOperatorKind {
+    match op {
+        BinaryOp::Pipe => RecordedPipelineOperatorKind::Pipe,
+        BinaryOp::PipeAll => RecordedPipelineOperatorKind::PipeAll,
+        BinaryOp::And | BinaryOp::Or => {
+            unreachable!("logical operators are not valid in pipelines")
+        }
     }
 }
 
 fn collect_logical_segments<'a>(
     stmt: &'a Stmt,
     commands: &mut SmallVec<[&'a Stmt; 4]>,
-    operators: &mut SmallVec<[RecordedListOperator; 4]>,
+    operators: &mut SmallVec<[(RecordedListOperator, Span); 4]>,
 ) {
     match &stmt.command {
         Command::Binary(command) if matches!(command.op, BinaryOp::And | BinaryOp::Or) => {
             collect_logical_segments(&command.left, commands, operators);
-            operators.push(recorded_list_operator(command.op));
+            operators.push((recorded_list_operator(command.op), command.op_span));
             collect_logical_segments(&command.right, commands, operators);
         }
         _ => commands.push(stmt),

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -361,17 +361,26 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         mut flow: FlowState,
     ) -> RecordedCommandId {
         flow.in_subshell = true;
-        let mut commands = SmallVec::<[&Stmt; 4]>::new();
-        collect_pipeline_segments(&command.left, &mut commands);
-        collect_pipeline_segments(&command.right, &mut commands);
+        let mut commands = SmallVec::<[PipelineSegmentInput<'a>; 4]>::new();
+        collect_pipeline_segments(&command.left, None, &mut commands);
+        collect_pipeline_segments(
+            &command.right,
+            Some(RecordedPipelineOperator {
+                operator: recorded_pipeline_operator(command.op),
+                span: command.op_span,
+            }),
+            &mut commands,
+        );
 
         let mut segments = Vec::with_capacity(commands.len());
-        for stmt in commands {
+        for segment in commands {
+            let stmt = segment.stmt;
             let scope = self.push_scope(ScopeKind::Pipeline, self.current_scope(), stmt.span);
             let recorded = self.visit_stmt(stmt, flow);
             self.pop_scope(scope);
             self.mark_scope_completed(scope);
             segments.push(RecordedPipelineSegment {
+                operator_before: segment.operator_before,
                 scope,
                 command: recorded,
             });
@@ -390,10 +399,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         command: &'a BinaryCommand,
         flow: FlowState,
     ) -> RecordedCommandId {
-        let mut operators = SmallVec::<[RecordedListOperator; 4]>::new();
+        let mut operators = SmallVec::<[(RecordedListOperator, Span); 4]>::new();
         let mut commands = SmallVec::<[&Stmt; 4]>::new();
         collect_logical_segments(&command.left, &mut commands, &mut operators);
-        operators.push(recorded_list_operator(command.op));
+        operators.push((recorded_list_operator(command.op), command.op_span));
         collect_logical_segments(&command.right, &mut commands, &mut operators);
 
         let mut recorded = SmallVec::<[RecordedCommandId; 4]>::with_capacity(commands.len());
@@ -414,7 +423,11 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             operators
                 .into_iter()
                 .zip(recorded)
-                .map(|(operator, command)| RecordedListItem { operator, command })
+                .map(|((operator, operator_span), command)| RecordedListItem {
+                    operator,
+                    operator_span,
+                    command,
+                })
                 .collect(),
         );
 

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -334,6 +334,7 @@ pub(crate) struct RecordedCaseArm {
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RecordedPipelineSegment {
+    pub(crate) operator_before: Option<RecordedPipelineOperator>,
     pub(crate) scope: ScopeId,
     pub(crate) command: RecordedCommandId,
 }
@@ -341,7 +342,20 @@ pub(crate) struct RecordedPipelineSegment {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RecordedListItem {
     pub(crate) operator: RecordedListOperator,
+    pub(crate) operator_span: Span,
     pub(crate) command: RecordedCommandId,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RecordedPipelineOperator {
+    pub(crate) operator: RecordedPipelineOperatorKind,
+    pub(crate) span: Span,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecordedPipelineOperatorKind {
+    Pipe,
+    PipeAll,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -92,7 +92,9 @@ use std::sync::OnceLock;
 
 use crate::builder::SemanticModelBuilder;
 use crate::call_graph::build_call_graph;
-use crate::cfg::RecordedProgram;
+use crate::cfg::{
+    RecordedCommandKind, RecordedListOperator, RecordedPipelineOperatorKind, RecordedProgram,
+};
 use crate::dataflow::{DataflowContext, DataflowResult, ExactVariableDataflow};
 use crate::runtime::RuntimePrelude;
 use crate::scope::ancestor_scopes;
@@ -438,6 +440,78 @@ pub struct SemanticAnalysis<'model> {
     unreached_functions: OnceLock<Vec<UnreachedFunction>>,
     unreached_functions_shellcheck_compat: OnceLock<Vec<UnreachedFunction>>,
     scope_provided_binding_index: OnceLock<ScopeProvidedBindingIndex>,
+}
+
+/// A flattened logical list command recorded by semantic analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticListCommand {
+    /// Span of the complete logical list command.
+    pub span: Span,
+    /// Commands in execution order, including the first command and each following list item.
+    pub segments: Box<[SemanticListSegment]>,
+}
+
+/// A flattened logical list segment recorded by semantic analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemanticListSegment {
+    /// Span of the segment command.
+    pub command_span: Span,
+    /// Operator that precedes this segment, or `None` for the first segment.
+    pub operator_before: Option<SemanticListOperator>,
+}
+
+/// A logical list operator recorded by semantic analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemanticListOperator {
+    /// Logical operator kind.
+    pub kind: SemanticListOperatorKind,
+    /// Span of the operator token.
+    pub span: Span,
+}
+
+/// Logical list operator kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SemanticListOperatorKind {
+    /// `&&`
+    And,
+    /// `||`
+    Or,
+}
+
+/// A flattened pipeline command recorded by semantic analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticPipelineCommand {
+    /// Span of the complete pipeline command.
+    pub span: Span,
+    /// Commands in execution order, including the first command and each following pipeline segment.
+    pub segments: Box<[SemanticPipelineSegment]>,
+}
+
+/// A flattened pipeline segment recorded by semantic analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemanticPipelineSegment {
+    /// Span of the segment command.
+    pub command_span: Span,
+    /// Operator that precedes this segment, or `None` for the first segment.
+    pub operator_before: Option<SemanticPipelineOperator>,
+}
+
+/// A pipeline operator recorded by semantic analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemanticPipelineOperator {
+    /// Pipeline operator kind.
+    pub kind: SemanticPipelineOperatorKind,
+    /// Span of the operator token.
+    pub span: Span,
+}
+
+/// Pipeline operator kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SemanticPipelineOperatorKind {
+    /// `|`
+    Pipe,
+    /// `|&`
+    PipeAll,
 }
 
 #[allow(missing_docs)]
@@ -1156,6 +1230,82 @@ impl SemanticModel {
 
     pub fn statement_sequence_commands(&self) -> &[StatementSequenceCommand] {
         self.recorded_program.statement_sequence_commands()
+    }
+
+    /// Returns logical list commands flattened by the semantic traversal.
+    pub fn list_commands(&self) -> Vec<SemanticListCommand> {
+        self.recorded_program
+            .commands()
+            .iter()
+            .filter_map(|command| {
+                let RecordedCommandKind::List { first, rest } = command.kind else {
+                    return None;
+                };
+
+                let rest = self.recorded_program.list_items(rest);
+                let mut segments = Vec::with_capacity(rest.len() + 1);
+                segments.push(SemanticListSegment {
+                    command_span: self.recorded_program.command(first).span,
+                    operator_before: None,
+                });
+                segments.extend(rest.iter().map(|item| SemanticListSegment {
+                    command_span: self.recorded_program.command(item.command).span,
+                    operator_before: Some(SemanticListOperator {
+                        kind: match item.operator {
+                            RecordedListOperator::And => SemanticListOperatorKind::And,
+                            RecordedListOperator::Or => SemanticListOperatorKind::Or,
+                        },
+                        span: item.operator_span,
+                    }),
+                }));
+
+                Some(SemanticListCommand {
+                    span: command.span,
+                    segments: segments.into_boxed_slice(),
+                })
+            })
+            .collect()
+    }
+
+    /// Returns pipeline commands flattened by the semantic traversal.
+    pub fn pipeline_commands(&self) -> Vec<SemanticPipelineCommand> {
+        self.recorded_program
+            .commands()
+            .iter()
+            .filter_map(|command| {
+                let RecordedCommandKind::Pipeline { segments } = command.kind else {
+                    return None;
+                };
+
+                let segments = self
+                    .recorded_program
+                    .pipeline_segments(segments)
+                    .iter()
+                    .map(|segment| SemanticPipelineSegment {
+                        command_span: self.recorded_program.command(segment.command).span,
+                        operator_before: segment.operator_before.map(|operator| {
+                            SemanticPipelineOperator {
+                                kind: match operator.operator {
+                                    RecordedPipelineOperatorKind::Pipe => {
+                                        SemanticPipelineOperatorKind::Pipe
+                                    }
+                                    RecordedPipelineOperatorKind::PipeAll => {
+                                        SemanticPipelineOperatorKind::PipeAll
+                                    }
+                                },
+                                span: operator.span,
+                            }
+                        }),
+                    })
+                    .collect::<Vec<_>>()
+                    .into_boxed_slice();
+
+                Some(SemanticPipelineCommand {
+                    span: command.span,
+                    segments,
+                })
+            })
+            .collect()
     }
 
     pub(crate) fn recorded_program(&self) -> &RecordedProgram {


### PR DESCRIPTION
## Summary
- expose semantic-owned flattened list and pipeline command summaries with operator metadata
- update linter facts to consume those semantic shapes while keeping rule-specific adornments in facts
- remove duplicated list/pipeline flattening helpers from linter facts

## Validation
- cargo test -p shuck-linter
- cargo test -p shuck-semantic
- git diff --check