### PR TITLE
fix(linter): add autofix for redundant echo spaces

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -837,6 +837,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             possible_variable_misspelling_use_scan: OnceLock::new(),
             possible_variable_misspelling_index: OnceLock::new(),
             possible_variable_misspelling_scope_compat_name_uses: OnceLock::new(),
+            redundant_echo_space_facts: OnceLock::new(),
             suppressed_subscript_reference_spans,
             subscript_later_suppression_reference_spans,
             compound_assignment_value_word_spans,

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -23,6 +23,22 @@ pub struct CommandFact<'a> {
     conditional: Option<ConditionalFact<'a>>,
 }
 
+#[derive(Debug, Clone)]
+pub struct RedundantEchoSpaceFact {
+    diagnostic_span: Span,
+    space_spans: Vec<Span>,
+}
+
+impl RedundantEchoSpaceFact {
+    pub fn diagnostic_span(&self) -> Span {
+        self.diagnostic_span
+    }
+
+    pub fn space_spans(&self) -> &[Span] {
+        &self.space_spans
+    }
+}
+
 impl<'a> CommandFact<'a> {
     pub fn id(&self) -> CommandId {
         self.id
@@ -663,6 +679,62 @@ fn background_semicolon_span(
     let start = position_at_offset(source, semicolon_offset)?;
     let end = position_at_offset(source, semicolon_offset + 1)?;
     Some(Span::from_positions(start, end))
+}
+
+fn build_redundant_echo_space_facts(facts: &LinterFacts<'_>) -> Vec<RedundantEchoSpaceFact> {
+    facts
+        .structural_commands()
+        .filter_map(|command| redundant_echo_space_fact(command, facts.source))
+        .collect()
+}
+
+fn redundant_echo_space_fact(
+    command: CommandFactRef<'_, '_>,
+    source: &str,
+) -> Option<RedundantEchoSpaceFact> {
+    if !command.effective_name_is("echo") || !command.wrappers().is_empty() {
+        return None;
+    }
+
+    let args = command.body_args();
+    let space_spans = args
+        .windows(2)
+        .filter_map(|pair| repeated_echo_argument_space_span(pair[0].span, pair[1].span, source))
+        .collect::<Vec<_>>();
+    if space_spans.is_empty() {
+        return None;
+    }
+
+    let name = command.body_name_word()?;
+    let last = args.last()?;
+    Some(RedundantEchoSpaceFact {
+        diagnostic_span: Span::from_positions(name.span.start, last.span.end),
+        space_spans,
+    })
+}
+
+fn repeated_echo_argument_space_span(left: Span, right: Span, source: &str) -> Option<Span> {
+    if left.end.line != right.start.line {
+        return None;
+    }
+
+    // Some spans can collapse a backslash-newline continuation onto one logical
+    // line. S037 only cares about repeated spaces on the same physical line.
+    let context_start = source[..left.end.offset]
+        .char_indices()
+        .next_back()
+        .map_or(left.end.offset, |(idx, _)| idx);
+    let context = source.get(context_start..right.start.offset)?;
+    if context.chars().any(|ch| matches!(ch, '\n' | '\r')) {
+        return None;
+    }
+
+    let gap = source.get(left.end.offset..right.start.offset)?;
+    if gap.len() < 4 || !gap.chars().all(|ch| ch == ' ') {
+        return None;
+    }
+
+    Some(Span::from_positions(left.end, right.start))
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -29,6 +29,7 @@ pub struct LinterFacts<'a> {
     possible_variable_misspelling_use_scan: OnceLock<bool>,
     possible_variable_misspelling_index: OnceLock<PossibleVariableMisspellingIndex>,
     possible_variable_misspelling_scope_compat_name_uses: OnceLock<Vec<ComparableNameUse>>,
+    redundant_echo_space_facts: OnceLock<Vec<RedundantEchoSpaceFact>>,
     suppressed_subscript_reference_spans: FxHashSet<FactSpan>,
     subscript_later_suppression_reference_spans: FxHashSet<FactSpan>,
     compound_assignment_value_word_spans: FxHashSet<FactSpan>,
@@ -331,6 +332,11 @@ impl<'a> LinterFacts<'a> {
     pub fn command_parent(&self, id: CommandId) -> Option<CommandFactRef<'_, 'a>> {
         self.command_parent_id(id)
             .map(|parent_id| self.command(parent_id))
+    }
+
+    pub fn redundant_echo_space_facts(&self) -> &[RedundantEchoSpaceFact] {
+        self.redundant_echo_space_facts
+            .get_or_init(|| build_redundant_echo_space_facts(self))
     }
 
     pub fn function_definition_command(&self, scope: ScopeId) -> Option<CommandFactRef<'_, 'a>> {

--- a/crates/shuck-linter/src/facts/tests/flow.rs
+++ b/crates/shuck-linter/src/facts/tests/flow.rs
@@ -67,6 +67,24 @@ esac
 }
 
 #[test]
+fn redundant_echo_space_facts_capture_diagnostic_and_edit_spans() {
+    let source = "#!/bin/bash\necho foo    bar    baz\necho foo  bar\n";
+
+    with_facts(source, None, |_, facts| {
+        let facts = facts.redundant_echo_space_facts();
+
+        assert_eq!(facts.len(), 1);
+        assert_eq!(
+            facts[0].diagnostic_span().slice(source),
+            "echo foo    bar    baz"
+        );
+        assert_eq!(facts[0].space_spans().len(), 2);
+        assert_eq!(facts[0].space_spans()[0].slice(source), "    ");
+        assert_eq!(facts[0].space_spans()[1].slice(source), "    ");
+    });
+}
+
+#[test]
 fn commented_continuation_facts_ignore_plain_comment_only_lines() {
     let source = "#!/bin/sh\necho hello \\\n  #world\n  foo\n";
 

--- a/crates/shuck-linter/src/rules/style/redundant_spaces_in_echo.rs
+++ b/crates/shuck-linter/src/rules/style/redundant_spaces_in_echo.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct RedundantSpacesInEcho;
 
 impl Violation for RedundantSpacesInEcho {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::RedundantSpacesInEcho
     }
@@ -10,71 +12,40 @@ impl Violation for RedundantSpacesInEcho {
     fn message(&self) -> String {
         "quote repeated spaces to avoid them collapsing into one".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("collapse repeated spaces between echo arguments".to_owned())
+    }
 }
 
 pub fn redundant_spaces_in_echo(checker: &mut Checker) {
-    let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
-        .structural_commands()
-        .filter(|fact| fact.effective_name_is("echo"))
-        .filter(|fact| fact.wrappers().is_empty())
-        .filter_map(|fact| {
-            if has_repeated_argument_spaces(fact.body_args(), source) {
-                fact.body_name_word()
-                    .and_then(|name| command_span(name, fact.body_args()))
-            } else {
-                None
-            }
+        .redundant_echo_space_facts()
+        .iter()
+        .map(|fact| {
+            crate::Diagnostic::new(RedundantSpacesInEcho, fact.diagnostic_span()).with_fix(
+                Fix::safe_edits(
+                    fact.space_spans()
+                        .iter()
+                        .copied()
+                        .map(|span| Edit::replacement(" ", span)),
+                ),
+            )
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || RedundantSpacesInEcho);
-}
-
-fn has_repeated_argument_spaces(words: &[&shuck_ast::Word], source: &str) -> bool {
-    words
-        .windows(2)
-        .any(|pair| repeated_space_gap(pair[0].span, pair[1].span, source))
-}
-
-fn repeated_space_gap(left: shuck_ast::Span, right: shuck_ast::Span, source: &str) -> bool {
-    if left.end.line != right.start.line {
-        return false;
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
     }
-
-    // Some spans can collapse a backslash-newline continuation onto one logical
-    // line. S037 only cares about repeated spaces on the same physical line.
-    let context_start = source[..left.end.offset]
-        .char_indices()
-        .next_back()
-        .map_or(left.end.offset, |(idx, _)| idx);
-    let Some(context) = source.get(context_start..right.start.offset) else {
-        return false;
-    };
-    if context.chars().any(|ch| matches!(ch, '\n' | '\r')) {
-        return false;
-    }
-
-    let Some(gap) = source.get(left.end.offset..right.start.offset) else {
-        return false;
-    };
-
-    gap.len() >= 4 && gap.chars().all(|ch| ch == ' ')
-}
-
-fn command_span(name: &shuck_ast::Word, args: &[&shuck_ast::Word]) -> Option<shuck_ast::Span> {
-    let last = args.last()?;
-    Some(shuck_ast::Span::from_positions(
-        name.span.start,
-        last.span.end,
-    ))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn reports_repeated_spaces_between_echo_arguments() {
@@ -188,5 +159,64 @@ echo café    bar
                 .collect::<Vec<_>>(),
             vec!["echo café    bar"]
         );
+    }
+
+    #[test]
+    fn applies_safe_fix_to_repeated_echo_spaces() {
+        let source = "\
+#!/bin/bash
+echo foo    bar
+echo -n    \"foo\"
+echo a    b    c
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::RedundantSpacesInEcho),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+echo foo bar
+echo -n \"foo\"
+echo a b c
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_non_redundant_echo_spacing_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+echo foo  bar
+echo    foo
+command echo foo    bar
+builtin echo foo    bar
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::RedundantSpacesInEcho).with_shell(ShellDialect::Sh),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("style").join("S037.sh").as_path(),
+            &LinterSettings::for_rule(Rule::RedundantSpacesInEcho),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("S037_fix_S037.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__redundant_spaces_in_echo__tests__S037_fix_S037.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__redundant_spaces_in_echo__tests__S037_fix_S037.sh.snap
@@ -1,0 +1,70 @@
+---
+source: crates/shuck-linter/src/rules/style/redundant_spaces_in_echo.rs
+assertion_line: 229
+---
+Diagnostics:
+S037 quote repeated spaces to avoid them collapsing into one
+ --> <source>:4:1
+  |
+4 | echo foo    bar
+  |
+
+S037 quote repeated spaces to avoid them collapsing into one
+ --> <source>:5:1
+  |
+5 | echo -n    "foo"
+  |
+
+S037 quote repeated spaces to avoid them collapsing into one
+ --> <source>:6:1
+  |
+6 | echo "foo"    bar
+  |
+
+S037 quote repeated spaces to avoid them collapsing into one
+ --> <source>:7:1
+  |
+7 | echo foo    "bar"
+  |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/bash
+ 
+ # Should trigger: repeated spacing between echoed arguments collapses.
+-echo foo    bar
+-echo -n    "foo"
+-echo "foo"    bar
+-echo foo    "bar"
++echo foo bar
++echo -n "foo"
++echo "foo" bar
++echo foo "bar"
+ 
+ # Should not trigger: single gaps and single-argument layout are fine.
+ echo foo  bar
+
+Fixed source:
+#!/bin/bash
+
+# Should trigger: repeated spacing between echoed arguments collapses.
+echo foo bar
+echo -n "foo"
+echo "foo" bar
+echo foo "bar"
+
+# Should not trigger: single gaps and single-argument layout are fine.
+echo foo  bar
+echo    foo
+
+# Should not trigger: wrapped echoes are intentionally skipped.
+command echo foo    bar
+builtin echo foo    bar
+
+Remaining diagnostics:
+<none>


### PR DESCRIPTION
## Summary

- Adds a safe autofix for S037 (`RedundantSpacesInEcho`) that collapses repeated spaces between `echo` arguments to a single separator space.
- Moves the exact repeated-space gap detection into `CommandFact` so the rule consumes precomputed facts and attaches span-anchored edits.
- Adds focused fix tests, a fact-layer test, and a snapshot for the S037 fixture fix output.

## Validation

- `cargo test -p shuck-linter redundant_spaces_in_echo`
- `cargo test -p shuck-linter command_facts_capture_redundant_echo_space_spans`
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S037` (`implementation_diffs=0`)
- `cargo test --workspace`