### PR TITLE
perf(semantic): use line-start index in source_line

### DIFF
--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -2325,25 +2325,19 @@ fn braced_parameter_end_offset(
     None
 }
 
-fn source_line(source: &str, target_line: usize) -> Option<(usize, &str)> {
-    if target_line == 0 {
-        return None;
-    }
-
-    let mut line_start = 0;
-    for (index, line) in source.split_inclusive('\n').enumerate() {
-        let line_number = index + 1;
-        if line_number == target_line {
-            let line = line.strip_suffix('\n').unwrap_or(line);
-            let line = line.strip_suffix('\r').unwrap_or(line);
-            return Some((line_start, line));
-        }
-        line_start += line.len();
-    }
-
-    if target_line == source.split_inclusive('\n').count() + 1 && line_start == source.len() {
-        return Some((line_start, ""));
-    }
-
-    None
+fn source_line<'a>(
+    source: &'a str,
+    line_start_offsets: &[usize],
+    target_line: usize,
+) -> Option<(usize, &'a str)> {
+    let line_index = target_line.checked_sub(1)?;
+    let line_start = *line_start_offsets.get(line_index)?;
+    let line_end = line_start_offsets
+        .get(line_index + 1)
+        .copied()
+        .unwrap_or(source.len());
+    let line = source.get(line_start..line_end)?;
+    let line = line.strip_suffix('\n').unwrap_or(line);
+    let line = line.strip_suffix('\r').unwrap_or(line);
+    Some((line_start, line))
 }

--- a/crates/shuck-semantic/src/builder/references.rs
+++ b/crates/shuck-semantic/src/builder/references.rs
@@ -143,7 +143,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             return None;
         }
 
-        let (line_start_offset, line) = source_line(self.source, span.start.line)?;
+        let (line_start_offset, line) =
+            source_line(self.source, &self.line_start_offsets, span.start.line)?;
         let name = name.as_str();
         let mut best = None::<(usize, usize, usize)>;
         for (start, _) in line.match_indices('$') {
@@ -173,7 +174,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         needle: &str,
         span: Span,
     ) -> Option<Span> {
-        let (line_start_offset, line) = source_line(self.source, span.start.line)?;
+        let (line_start_offset, line) =
+            source_line(self.source, &self.line_start_offsets, span.start.line)?;
         let mut best = None::<(usize, usize, usize)>;
         let name = needle.strip_prefix("${").unwrap_or(needle);
         for (start, _) in line.match_indices(needle) {


### PR DESCRIPTION
## Summary
- `source_line` (in `crates/shuck-semantic/src/builder/mod.rs`) was rescanning the entire source via `split_inclusive('\n')` on every call — an O(n) memchr loop per reference-span recovery. Profiles showed the leaf at ~5.5% of total samples on `xwmx__nb__nb`.
- `SemanticModelBuilder` already builds and stores `line_start_offsets` once at construction (already consumed by `source_position_at_offset`). Plumb that slice through `source_line` so the lookup becomes O(1): index into the precomputed starts, slice between consecutive entries (or `source.len()` for the last line), and strip trailing `\n` / `\r`.
- The trailing-newline special case (target line one past the last newline returning an empty string) is preserved by the final entry of `line_start_offsets` for sources ending in `\n`.

## Profile
On `xwmx__nb__nb` (12 iters, warm), `Semantic source-line lookup` (previously rank 4 at 5.5%) drops out of the top-12 hotspots. Wall-clock is in the same ~190–197 ms band as before.

## Test plan
- [x] `cargo test -p shuck-semantic` (315 passed)
- [x] `cargo test -p shuck-linter --lib` (3113 passed)
- [x] `cargo clippy -p shuck-semantic --all-targets -- -D warnings`
- [x] Re-profiled with `scripts/profiling/profile_large_corpus.sh xwmx__nb__nb` — confirmed `source_line` no longer in top-12