### PR TITLE
perf(linter): index bindings by start offset for span queries

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
+++ b/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
@@ -1,4 +1,3 @@
-use shuck_ast::Span;
 use shuck_semantic::{Binding, BindingAttributes, BindingKind, DeclarationBuiltin, ScopeKind};
 
 use crate::{Checker, Rule, ShellDialect, Violation};
@@ -34,9 +33,8 @@ pub fn local_top_level(checker: &mut Checker) {
         })
         .filter_map(|declaration| {
             let binding_scopes = semantic
-                .bindings()
-                .iter()
-                .filter(|binding| local_binding_belongs_to_declaration(binding, declaration.span))
+                .bindings_in_span(declaration.span)
+                .filter(|binding| local_binding_belongs_to_declaration_kind(binding))
                 .map(|binding| binding.scope)
                 .collect::<Vec<_>>();
 
@@ -63,13 +61,7 @@ pub fn local_top_level(checker: &mut Checker) {
     checker.report_all_dedup(spans, || LocalTopLevel);
 }
 
-fn local_binding_belongs_to_declaration(binding: &Binding, declaration_span: Span) -> bool {
-    if binding.span.start.offset < declaration_span.start.offset
-        || binding.span.end.offset > declaration_span.end.offset
-    {
-        return false;
-    }
-
+fn local_binding_belongs_to_declaration_kind(binding: &Binding) -> bool {
     matches!(
         binding.kind,
         BindingKind::Declaration(DeclarationBuiltin::Local)

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -416,6 +416,7 @@ pub struct SemanticModel {
     zsh_option_analysis: Option<ZshOptionAnalysis>,
     assoc_lookup_binding_index: OnceLock<AssocLookupBindingIndex>,
     references_sorted_by_start: OnceLock<Vec<ReferenceId>>,
+    bindings_sorted_by_start: OnceLock<Vec<BindingId>>,
     declarations_by_command_span: OnceLock<FxHashMap<SpanKey, usize>>,
     unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
     function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
@@ -594,6 +595,7 @@ impl SemanticModel {
             zsh_option_analysis,
             assoc_lookup_binding_index: OnceLock::new(),
             references_sorted_by_start: OnceLock::new(),
+            bindings_sorted_by_start: OnceLock::new(),
             declarations_by_command_span: OnceLock::new(),
             unconditional_function_bindings: OnceLock::new(),
             function_bindings_by_scope: OnceLock::new(),
@@ -645,6 +647,24 @@ impl SemanticModel {
         });
         ReferencesInSpan {
             references: &self.references,
+            ids: sorted[lower..].iter(),
+            end: outer.end.offset,
+        }
+    }
+
+    /// Yield every binding whose span is fully contained within `outer`.
+    ///
+    /// Backed by a lazily-built index sorted by binding start offset, so a
+    /// per-span query costs `O(log n + matches)` rather than scanning every
+    /// binding in the file.
+    pub fn bindings_in_span(&self, outer: Span) -> BindingsInSpan<'_> {
+        let sorted = self
+            .bindings_sorted_by_start
+            .get_or_init(|| build_bindings_sorted_by_start(&self.bindings));
+        let lower = sorted
+            .partition_point(|id| self.bindings[id.index()].span.start.offset < outer.start.offset);
+        BindingsInSpan {
+            bindings: &self.bindings,
             ids: sorted[lower..].iter(),
             end: outer.end.offset,
         }
@@ -1652,6 +1672,12 @@ fn build_references_sorted_by_start(references: &[Reference]) -> Vec<ReferenceId
     ids
 }
 
+fn build_bindings_sorted_by_start(bindings: &[Binding]) -> Vec<BindingId> {
+    let mut ids: Vec<BindingId> = (0..bindings.len() as u32).map(BindingId).collect();
+    ids.sort_by_key(|id| bindings[id.index()].span.start.offset);
+    ids
+}
+
 fn build_declarations_by_command_span(declarations: &[Declaration]) -> FxHashMap<SpanKey, usize> {
     let mut index = FxHashMap::with_capacity_and_hasher(declarations.len(), Default::default());
     for (declaration_index, declaration) in declarations.iter().enumerate() {
@@ -1683,6 +1709,34 @@ impl<'a> Iterator for ReferencesInSpan<'a> {
             }
             if reference.span.end.offset <= self.end {
                 return Some(reference);
+            }
+        }
+    }
+}
+
+/// Iterator returned by [`SemanticModel::bindings_in_span`].
+///
+/// Walks the bindings sorted index forward from the first candidate and
+/// stops as soon as a binding starts past the outer span's end.
+#[derive(Debug, Clone)]
+pub struct BindingsInSpan<'a> {
+    bindings: &'a [Binding],
+    ids: std::slice::Iter<'a, BindingId>,
+    end: usize,
+}
+
+impl<'a> Iterator for BindingsInSpan<'a> {
+    type Item = &'a Binding;
+
+    fn next(&mut self) -> Option<&'a Binding> {
+        loop {
+            let id = self.ids.next()?;
+            let binding = &self.bindings[id.index()];
+            if binding.span.start.offset > self.end {
+                return None;
+            }
+            if binding.span.end.offset <= self.end {
+                return Some(binding);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Adds `SemanticModel::bindings_in_span(outer)` mirroring `references_in_span`. Backed by a `OnceLock<Vec<BindingId>>` sorted by start offset; the iterator walks forward from the binary-searched lower bound and stops once a binding starts past `outer.end`. Per-span cost: `O(log n + matches)`.
- Switches `script_scope_local::local_top_level` from a per-declaration linear scan over `semantic.bindings()` to `bindings_in_span(declaration.span)`. The kind/attribute filter stays in the rule. The span-containment branch in `local_binding_belongs_to_declaration` is no longer needed (the iterator enforces it), so the helper collapses to a kind filter.

This was the only rule with the outer/inner-loop shape over bindings; the other `bindings()` callers are single-pass scans that wouldn't benefit from an index.

## Profile (xwmx__nb__nb, 12 iters @ 2 kHz)

| Metric | main | this PR | delta |
|---|---:|---:|---:|
| avg wall clock | 202.9 ms | 184.4 ms | **-9.1%** |
| `rules::script_scope_local::local_top_level` | 2.6% (rank 5) | off top 15 | gone |

(Main here already includes #683's RPO worklist.)

## Test plan

- [x] `cargo build -p shuck-linter -p shuck-semantic`
- [x] `cargo test -p shuck-linter -p shuck-semantic` (3116 + 324 passed)
- [x] `cargo test -p shuck-cli` (all suites passed)
- [x] `cargo clippy -p shuck-linter -p shuck-semantic --all-targets -- -D warnings`
- [x] `cargo fmt`
- [x] before/after `scripts/profiling/profile_large_corpus.sh xwmx__nb__nb`