### PR TITLE
perf(semantic): cache function-definition bindings index

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -301,12 +301,7 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
     }
 
     let mut seen_function_unset_targets = FxHashSet::<Name>::default();
-    for binding in checker
-        .semantic()
-        .bindings()
-        .iter()
-        .filter(|binding| matches!(binding.kind, BindingKind::FunctionDefinition))
-    {
+    for binding in checker.semantic().function_definition_bindings() {
         if !seen_function_unset_targets.insert(binding.name.clone()) {
             continue;
         }
@@ -706,10 +701,7 @@ fn report_compat_cutoff_function_definitions(checker: &mut Checker<'_>) {
     };
     let candidates = checker
         .semantic()
-        .bindings()
-        .iter()
-        .filter(|binding| matches!(binding.kind, BindingKind::FunctionDefinition))
-        .filter(|binding| !matches!(binding.kind, BindingKind::Imported))
+        .function_definition_bindings()
         .filter_map(|binding| {
             let cutoff = first_compat_cutoff_after_binding(
                 checker,
@@ -737,9 +729,7 @@ fn report_compat_cutoff_function_definitions(checker: &mut Checker<'_>) {
 fn report_transient_shadowed_file_scope_definitions(checker: &mut Checker<'_>) {
     let candidates = checker
         .semantic()
-        .bindings()
-        .iter()
-        .filter(|binding| matches!(binding.kind, BindingKind::FunctionDefinition))
+        .function_definition_bindings()
         .filter(|binding| scope_is_file_scope(checker, binding.scope))
         .filter_map(|binding| {
             let first_shadow_offset = checker

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -420,6 +420,7 @@ pub struct SemanticModel {
     unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
     function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
     visible_function_call_bindings: OnceLock<FxHashMap<SpanKey, BindingId>>,
+    function_definition_binding_ids: OnceLock<Vec<BindingId>>,
 }
 
 /// Lazy analysis view over a `SemanticModel`.
@@ -598,6 +599,7 @@ impl SemanticModel {
             unconditional_function_bindings: OnceLock::new(),
             function_bindings_by_scope: OnceLock::new(),
             visible_function_call_bindings: OnceLock::new(),
+            function_definition_binding_ids: OnceLock::new(),
         }
     }
 
@@ -625,6 +627,21 @@ impl SemanticModel {
 
     pub fn bindings(&self) -> &[Binding] {
         &self.bindings
+    }
+
+    /// Yield every binding with `BindingKind::FunctionDefinition`.
+    ///
+    /// Backed by a lazily-built index so repeat calls avoid rescanning the
+    /// full `bindings()` slice.
+    pub fn function_definition_bindings(&self) -> impl ExactSizeIterator<Item = &Binding> + '_ {
+        let ids = self.function_definition_binding_ids.get_or_init(|| {
+            self.bindings
+                .iter()
+                .filter(|binding| matches!(binding.kind, BindingKind::FunctionDefinition))
+                .map(|binding| binding.id)
+                .collect()
+        });
+        ids.iter().map(|id| &self.bindings[id.index()])
     }
 
     pub fn references(&self) -> &[Reference] {
@@ -1139,6 +1156,7 @@ impl SemanticModel {
         self.unconditional_function_bindings.take();
         self.function_bindings_by_scope.take();
         self.visible_function_call_bindings.take();
+        self.function_definition_binding_ids.take();
     }
 
     fn rebuild_call_graph(&mut self) {


### PR DESCRIPTION
## Summary
- Replace three repeated `bindings().iter().filter(... FunctionDefinition)` scans in `overwritten_function.rs` with a new `SemanticModel::function_definition_bindings()` accessor.
- The accessor is backed by a `OnceLock<Vec<BindingId>>` so the filter is paid once per file rather than on every C063 entry point.
- Also drops a dead `BindingKind::Imported` filter from one call site (mutually exclusive with `FunctionDefinition`).

This is a follow-up to the bindings-by-start-offset PR (#684). C063 / overwritten-function ranked at ~3.2% of attributed-exclusive samples on the `xwmx__nb__nb` profile, with the three filter scans showing up under the rule entry points. The new accessor turns those scans into pointer-chasing iteration over a precomputed `Vec<BindingId>`.

## Test plan
- [x] `cargo test -p shuck-linter -p shuck-semantic`
- [x] `cargo clippy -p shuck-linter -p shuck-semantic --all-targets -- -D warnings`
- [x] `cargo fmt --check`