### PR TITLE
perf(linter): index suppression command spans once per file

### DIFF
--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -28,8 +28,18 @@ impl SuppressionIndex {
             )
         });
 
+        let mut sorted_command_spans: Option<Vec<Span>> = None;
         let mut by_rule = FxHashMap::default();
         for directive in ordered {
+            let directive_range = (matches!(directive.action, SuppressionAction::Disable)
+                && directive.line >= first_stmt_line)
+                .then(|| {
+                    let spans =
+                        sorted_command_spans.get_or_insert_with(|| collect_command_spans(file));
+                    next_command_range_after(spans, directive.range.end())
+                })
+                .flatten();
+
             for &rule in &directive.codes {
                 let index = by_rule
                     .entry(rule)
@@ -40,8 +50,7 @@ impl SuppressionIndex {
                     SuppressionAction::Disable => {
                         if directive.line < first_stmt_line {
                             index.whole_file = true;
-                        } else if let Some(range) = next_command_range(file, directive.range.end())
-                        {
+                        } else if let Some(range) = directive_range {
                             index.ranges.push(range);
                         }
                     }
@@ -134,33 +143,23 @@ fn merge_overlapping_ranges(ranges: &mut Vec<LineRange>) {
     *ranges = merged;
 }
 
-fn next_command_range(file: &File, offset: TextSize) -> Option<LineRange> {
-    let mut next = None;
+fn collect_command_spans(file: &File) -> Vec<Span> {
+    let mut spans = Vec::new();
     for command in file.body.iter() {
         walk_command(command, &mut |span| {
-            consider_command(span, offset, &mut next)
+            if span.start.line != 0 && span.end.line != 0 {
+                spans.push(span);
+            }
         });
     }
-
-    next.and_then(line_range)
+    spans.sort_unstable_by_key(|span| span.start.offset);
+    spans
 }
 
-fn consider_command(span: Span, offset: TextSize, next: &mut Option<Span>) {
-    if span.start.line == 0 || span.end.line == 0 {
-        return;
-    }
-
-    let start = TextSize::new(span.start.offset as u32);
-    if start <= offset {
-        return;
-    }
-
-    if next
-        .as_ref()
-        .is_none_or(|current| span.start.offset < current.start.offset)
-    {
-        *next = Some(span);
-    }
+fn next_command_range_after(spans: &[Span], offset: TextSize) -> Option<LineRange> {
+    let offset = offset.to_u32() as usize;
+    let idx = spans.partition_point(|span| span.start.offset <= offset);
+    spans.get(idx).copied().and_then(line_range)
 }
 
 fn line_range(span: Span) -> Option<LineRange> {

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -152,7 +152,11 @@ fn collect_command_spans(file: &File) -> Vec<Span> {
             }
         });
     }
-    spans.sort_unstable_by_key(|span| span.start.offset);
+    // Stable sort preserves walk order so a parent statement keeps priority over
+    // its children when both share the same start offset (e.g. a binary command
+    // and its left operand). The lookup picks the first span at each start
+    // offset, matching the previous behavior of `consider_command`.
+    spans.sort_by_key(|span| span.start.offset);
     spans
 }
 
@@ -855,6 +859,22 @@ echo $foo
 
         assert!(index.is_suppressed(Rule::UnquotedExpansion, 4));
         assert!(!index.is_suppressed(Rule::UnquotedExpansion, 6));
+    }
+
+    #[test]
+    fn scopes_shellcheck_disable_to_the_full_multiline_binary_statement() {
+        let source = "\
+foo='a b'
+# shellcheck disable=SC2086
+echo $foo &&
+  echo $bar
+echo $baz
+";
+        let index = suppression_index(source);
+
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 3));
+        assert!(index.is_suppressed(Rule::UnquotedExpansion, 4));
+        assert!(!index.is_suppressed(Rule::UnquotedExpansion, 5));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- \`SuppressionIndex::new\` was calling \`next_command_range\` once per \`Disable\` directive **and** once per rule code on each directive. Each call did a full O(file-size) AST walk through every word, redirect, pattern, and arithmetic/conditional expression to find the closest Stmt starting after the directive offset.
- The recursion through words, word parts, redirects, patterns, etc. never produced a candidate span on its own \xe2\x80\x94 it only existed to descend into command/process substitutions and find embedded Stmts. The single \`visit(span)\` call lives at the top of \`walk_command\`, where it visits each Stmt's \`statement_suppression_span\`.
- Walk once at the top of \`new\`, sort the candidate spans by \`start.offset\`, and binary-search per directive. Also lift the per-directive lookup out of the inner \`directive.codes\` loop — a directive disabling N codes now does one search instead of N.
- Behavior is preserved: same suppression-style span policy (selective heredoc-with-expansion extension), same line-range computation, same merge step.

## Measured impact (\`xwmx__nb__nb\`, 12 iter)
- \`walk_word_parts\` (was rank 6, 2.5%) — off the top 15
- \`walk_command\` (was rank 12, 1.7%) — off the top 15
- Wall-clock avg: 286.6ms → 243.9ms (-14.9%)

## Test plan
- [x] \`cargo test -p shuck-linter\` (3116 + suppression tests pass)
- [x] \`cargo clippy -p shuck-linter --all-targets -- -D warnings\`
- [x] \`cargo fmt --check\`