### PR TITLE
fix(semantic): exclude synthetic ids from public commands iteration

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -986,17 +986,15 @@ fn build_linter_command_parent_ids(
     semantic: &SemanticModel,
     command_fact_indices_by_id: &[Option<usize>],
 ) -> Vec<Option<CommandId>> {
-    semantic
-        .commands()
-        .iter()
-        .copied()
-        .map(|id| {
-            if !command_fact_exists(command_fact_indices_by_id, id) {
-                return None;
-            }
-            nearest_fact_backed_semantic_parent(semantic, command_fact_indices_by_id, id)
-        })
-        .collect()
+    let mut parent_ids = vec![None; semantic.command_count()];
+    for id in semantic.commands().iter().copied() {
+        if !command_fact_exists(command_fact_indices_by_id, id) {
+            continue;
+        }
+        parent_ids[id.index()] =
+            nearest_fact_backed_semantic_parent(semantic, command_fact_indices_by_id, id);
+    }
+    parent_ids
 }
 
 fn nearest_fact_backed_semantic_parent(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -121,7 +121,7 @@ impl SpanKey {
 
 #[derive(Debug)]
 struct CommandTopology {
-    ids: Vec<CommandId>,
+    syntax_backed_ids: Vec<CommandId>,
     structural_ids: Vec<CommandId>,
     ids_by_syntax_span: FxHashMap<SpanKey, SmallVec<[CommandId; 1]>>,
     parent_ids: Vec<Option<CommandId>>,
@@ -1293,7 +1293,7 @@ impl SemanticModel {
     }
 
     pub fn commands(&self) -> &[CommandId] {
-        &self.command_topology().ids
+        &self.command_topology().syntax_backed_ids
     }
 
     pub fn structural_commands(&self) -> &[CommandId] {
@@ -1659,8 +1659,13 @@ fn build_command_topology(model: &SemanticModel) -> CommandTopology {
     offset_order
         .sort_unstable_by(|left, right| compare_command_ids_by_syntax_span(model, *left, *right));
 
+    let syntax_backed_ids = ids
+        .into_iter()
+        .filter(|id| program.command(*id).syntax_kind.is_some())
+        .collect::<Vec<_>>();
+
     CommandTopology {
-        ids,
+        syntax_backed_ids,
         structural_ids,
         ids_by_syntax_span,
         parent_ids,

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1125,6 +1125,16 @@ fn command_lookup_by_span_and_kind_skips_synthetic_commands() {
 }
 
 #[test]
+fn commands_iter_filters_synthetic_ids_so_command_kind_is_safe() {
+    let source = "case \"$x\" in $(echo a)) ;; esac\n";
+    let model = model(source);
+
+    for id in model.commands().iter().copied() {
+        let _ = model.command_kind(id);
+    }
+}
+
+#[test]
 fn command_topology_preserves_nested_region_immediate_parents() {
     let source = "echo >\"$(a | b)\"\n";
     let model = model(source);


### PR DESCRIPTION
## Summary

Addresses the unresolved P2 review on #687 about `SemanticModel::commands()` returning synthetic placeholder ids.

`commands()` previously returned every recorded command id, including synthetic placeholders inserted for cases like an empty `case` arm whose body has only pattern regions. Iterating those ids and then calling another public API like `command_kind` (which calls `expect` on the recorded `syntax_kind`) would panic on otherwise-valid scripts such as:

```bash
case "$x" in $(echo a)) ;; esac
```

This change filters `commands()` to syntax-backed ids by precomputing a `syntax_backed_ids` slice on `CommandTopology`. Two linter helpers that previously sized their output by `commands().len()` (`build_linter_command_parent_ids` and the index it feeds) now size by `semantic.command_count()` so they remain keyed by `CommandId.index()`.

## Test plan

- [x] `cargo test -p shuck-semantic --lib` — 333 pass, including new `commands_iter_filters_synthetic_ids_so_command_kind_is_safe`
- [x] `cargo test -p shuck-linter --lib` — 3141 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean