### PR TITLE
refactor(semantic): expose function binding lookup

### DIFF
--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -160,7 +160,8 @@ fn build_function_header_facts<'a>(
         .iter()
         .copied()
         .map(|input| {
-            let binding_id = function_header_binding_id(semantic, input.function);
+            let binding_id = semantic
+                .function_definition_binding_for_command_span(semantic.command_span(input.command_id));
             let scope_id =
                 binding_id.and_then(|binding_id| semantic_analysis.function_scope_for_binding(binding_id));
             let call_arity = binding_id
@@ -623,18 +624,6 @@ fn function_call_diagnostic_span(
     }
 
     trim_trailing_whitespace_span(command.stmt().span, source)
-}
-
-fn function_header_binding_id(
-    semantic: &SemanticModel,
-    function: &FunctionDef,
-) -> Option<BindingId> {
-    let (name, name_span) = function.static_name_entries().next()?;
-    semantic
-        .function_definitions(name)
-        .iter()
-        .copied()
-        .find(|binding_id| semantic.binding(*binding_id).span == name_span)
 }
 
 fn first_positional_dispatch_in_commands(commands: &StmtSeq) -> Option<Span> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1269,6 +1269,19 @@ impl SemanticModel {
             .map(|declaration_index| &self.declarations[*declaration_index])
     }
 
+    pub fn function_definition_binding_for_command_span(&self, span: Span) -> Option<BindingId> {
+        self.command_bindings
+            .get(&SpanKey::new(span))
+            .and_then(|bindings| {
+                bindings.iter().copied().find(|binding_id| {
+                    matches!(
+                        self.bindings[binding_id.index()].kind,
+                        BindingKind::FunctionDefinition
+                    )
+                })
+            })
+    }
+
     pub fn source_refs(&self) -> &[SourceRef] {
         &self.source_refs
     }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -509,6 +509,33 @@ fn zsh_multi_name_functions_bind_each_static_alias() {
 }
 
 #[test]
+fn function_definition_binding_lookup_uses_the_command_span() {
+    let source = "build() { :; }\nbuild() { echo later; }\n";
+    let model = model(source);
+    let name = Name::from("build");
+    let definitions = model.function_definitions(&name);
+    assert_eq!(definitions.len(), 2);
+
+    let function_commands = model
+        .commands()
+        .iter()
+        .copied()
+        .filter(|command| model.command_kind(*command) == CommandKind::Function)
+        .collect::<Vec<_>>();
+    assert_eq!(function_commands.len(), 2);
+
+    for (command, definition) in function_commands
+        .into_iter()
+        .zip(definitions.iter().copied())
+    {
+        assert_eq!(
+            model.function_definition_binding_for_command_span(model.command_span(command)),
+            Some(definition)
+        );
+    }
+}
+
+#[test]
 fn zsh_multi_name_function_lookup_works_through_any_alias() {
     let source = "flag=1\nfunction music itunes() { echo \"$flag\"; }\nitunes\n";
     let model = model_with_dialect(source, ShellDialect::Zsh);


### PR DESCRIPTION
## Summary
- add a semantic-owned lookup for function definition bindings by command span
- update function facts to use the semantic query instead of rematching bindings by name and span
- cover repeated same-name definitions with a semantic regression test

## Validation
- cargo fmt
- cargo test -p shuck-semantic function_definition_binding_lookup_uses_the_command_span
- cargo test -p shuck-linter --lib function
- cargo test -p shuck-linter --lib facts::tests::functions::function_header_fact_tracks_binding_scope_and_call_arity