### PR TITLE
refactor(semantic): centralize function call resolution

### DIFF
--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -34,6 +34,7 @@ impl<'model> SemanticAnalysis<'model> {
                 &self.model.scopes,
                 &self.model.bindings,
                 &self.model.call_sites,
+                self.model.visible_function_call_bindings(),
             )
         })
     }
@@ -89,6 +90,17 @@ impl<'model> SemanticAnalysis<'model> {
                 .or_else(|| self.lexical_function_binding_for_call_offset(name, site))
                 .map(|binding| (site, binding))
         })
+    }
+
+    pub(crate) fn visible_function_binding_in_call_context(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> Option<BindingId> {
+        self.model
+            .function_binding_lookup()
+            .visible_function_binding(name, scope, offset)
     }
 
     pub fn function_scope_for_binding(&self, binding_id: BindingId) -> Option<ScopeId> {

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -4,9 +4,8 @@ use shuck_parser::ZshEmulationMode;
 use smallvec::{SmallVec, smallvec};
 use std::marker::PhantomData;
 
-use crate::scope::ancestor_scopes;
 use crate::source_closure::SourcePathTemplate;
-use crate::{Binding, BindingId, BindingKind, CallSite, ReferenceId, Scope, ScopeId, SpanKey};
+use crate::{Binding, BindingId, CallSite, ReferenceId, Scope, ScopeId, SpanKey};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BlockId(pub(crate) u32);
@@ -670,27 +669,14 @@ impl ExitEffect {
 
 fn compute_script_terminating_call_spans(
     program: &RecordedProgram,
-    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
-    scopes: &[Scope],
     bindings: &[Binding],
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    visible_function_call_bindings: &FxHashMap<SpanKey, BindingId>,
 ) -> FxHashSet<SpanKey> {
     if program.function_body_scopes.is_empty() || call_sites.is_empty() {
         return FxHashSet::default();
     }
 
-    let unconditional_function_bindings =
-        collect_unconditional_function_bindings(program, command_bindings, bindings);
-    let scope_function_bindings = function_bindings_by_scope(program);
-    let mut resolver = FunctionCallResolver {
-        program,
-        scopes,
-        bindings,
-        call_sites,
-        unconditional_function_bindings: &unconditional_function_bindings,
-        function_bindings_by_scope: &scope_function_bindings,
-        entry_before_offset_cache: FxHashMap::default(),
-    };
     let mut terminating_call_spans = FxHashSet::default();
     let mut always_exiting_scopes = FxHashSet::default();
 
@@ -707,8 +693,9 @@ fn compute_script_terminating_call_spans(
         }
         changed |= resolve_script_terminating_call_spans(
             program,
+            bindings,
             call_sites,
-            &mut resolver,
+            visible_function_call_bindings,
             &always_exiting_scopes,
             &mut terminating_call_spans,
         );
@@ -798,8 +785,9 @@ fn command_can_return_before(
 
 fn resolve_script_terminating_call_spans(
     program: &RecordedProgram,
+    bindings: &[Binding],
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
-    resolver: &mut FunctionCallResolver<'_>,
+    visible_function_call_bindings: &FxHashMap<SpanKey, BindingId>,
     always_exiting_scopes: &FxHashSet<ScopeId>,
     terminating_call_spans: &mut FxHashSet<SpanKey>,
 ) -> bool {
@@ -807,7 +795,7 @@ fn resolve_script_terminating_call_spans(
         .function_body_scopes
         .iter()
         .filter(|(_, scope)| always_exiting_scopes.contains(scope))
-        .map(|(binding, _)| resolver.bindings[binding.index()].name.clone())
+        .map(|(binding, _)| bindings[binding.index()].name.clone())
         .collect::<FxHashSet<_>>();
     let mut changed = false;
 
@@ -817,8 +805,9 @@ fn resolve_script_terminating_call_spans(
         };
 
         for site in sites {
-            let Some(binding) =
-                resolver.visible_function_binding(&name, site.scope, site.span.start.offset)
+            let Some(binding) = visible_function_call_bindings
+                .get(&SpanKey::new(site.name_span))
+                .copied()
             else {
                 continue;
             };
@@ -830,7 +819,7 @@ fn resolve_script_terminating_call_spans(
             }
             if file_entry_can_return_before_function_definition(
                 program,
-                resolver.bindings[binding.index()].span.start.offset,
+                bindings[binding.index()].span.start.offset,
             ) {
                 continue;
             }
@@ -842,82 +831,10 @@ fn resolve_script_terminating_call_spans(
     changed
 }
 
-pub(crate) struct FunctionBindingLookup<'a> {
-    pub(crate) program: &'a RecordedProgram,
-    pub(crate) scopes: &'a [Scope],
-    pub(crate) bindings: &'a [Binding],
-    pub(crate) call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
-    pub(crate) unconditional_function_bindings: &'a FxHashSet<BindingId>,
-    pub(crate) function_bindings_by_scope: &'a FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>,
-}
-
-impl FunctionBindingLookup<'_> {
-    pub(crate) fn visible_function_binding(
-        &self,
-        name: &Name,
-        scope: ScopeId,
-        offset: usize,
-    ) -> Option<BindingId> {
-        let mut resolver = FunctionCallResolver {
-            program: self.program,
-            scopes: self.scopes,
-            bindings: self.bindings,
-            call_sites: self.call_sites,
-            unconditional_function_bindings: self.unconditional_function_bindings,
-            function_bindings_by_scope: self.function_bindings_by_scope,
-            entry_before_offset_cache: FxHashMap::default(),
-        };
-        resolver.visible_function_binding(name, scope, offset)
-    }
-
-    pub(crate) fn visible_function_call_bindings(&self) -> FxHashMap<SpanKey, BindingId> {
-        let mut resolver = FunctionCallResolver {
-            program: self.program,
-            scopes: self.scopes,
-            bindings: self.bindings,
-            call_sites: self.call_sites,
-            unconditional_function_bindings: self.unconditional_function_bindings,
-            function_bindings_by_scope: self.function_bindings_by_scope,
-            entry_before_offset_cache: FxHashMap::default(),
-        };
-        let mut call_bindings = FxHashMap::default();
-
-        for (name, sites) in self.call_sites {
-            for site in sites {
-                let Some(binding) =
-                    resolver.visible_function_binding(name, site.scope, site.span.start.offset)
-                else {
-                    continue;
-                };
-                call_bindings.insert(SpanKey::new(site.name_span), binding);
-            }
-        }
-
-        call_bindings
-    }
-}
-
-pub(crate) fn function_bindings_by_scope(
+pub(crate) fn recorded_command_span_for_call_site(
     program: &RecordedProgram,
-) -> FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> {
-    let mut bindings_by_scope: FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> = FxHashMap::default();
-    for (&binding, &scope) in &program.function_body_scopes {
-        bindings_by_scope.entry(scope).or_default().push(binding);
-    }
-    bindings_by_scope
-}
-
-struct FunctionCallResolver<'a> {
-    program: &'a RecordedProgram,
-    scopes: &'a [Scope],
-    bindings: &'a [Binding],
-    call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
-    unconditional_function_bindings: &'a FxHashSet<BindingId>,
-    function_bindings_by_scope: &'a FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>,
-    entry_before_offset_cache: FxHashMap<(ScopeId, ScopeId, usize), bool>,
-}
-
-fn recorded_command_span_for_call_site(program: &RecordedProgram, site: &CallSite) -> Span {
+    site: &CallSite,
+) -> Span {
     if let Some(command_span) = program
         .call_command_spans
         .get(&SpanKey::new(site.span))
@@ -953,109 +870,6 @@ fn recorded_command_span_for_call_site(program: &RecordedProgram, site: &CallSit
         })
         .map(|command| command.span)
         .unwrap_or(site.span)
-}
-
-pub(crate) fn collect_unconditional_function_bindings(
-    program: &RecordedProgram,
-    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
-    bindings: &[Binding],
-) -> FxHashSet<BindingId> {
-    let mut unconditional = FxHashSet::default();
-    collect_sequence_function_bindings(
-        program,
-        program.file_commands(),
-        command_bindings,
-        bindings,
-        &mut unconditional,
-    );
-    for commands in program.function_bodies().values().copied() {
-        collect_sequence_function_bindings(
-            program,
-            commands,
-            command_bindings,
-            bindings,
-            &mut unconditional,
-        );
-    }
-    unconditional
-}
-
-fn collect_sequence_function_bindings(
-    program: &RecordedProgram,
-    commands: RecordedCommandRange,
-    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
-    bindings: &[Binding],
-    unconditional: &mut FxHashSet<BindingId>,
-) {
-    for &command_id in program.commands_in(commands) {
-        collect_command_function_bindings(
-            program,
-            command_id,
-            command_bindings,
-            bindings,
-            unconditional,
-        );
-    }
-}
-
-fn collect_command_function_bindings(
-    program: &RecordedProgram,
-    command_id: CommandId,
-    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
-    bindings: &[Binding],
-    unconditional: &mut FxHashSet<BindingId>,
-) {
-    let command = program.command(command_id);
-    collect_direct_function_bindings(command.span, command_bindings, bindings, unconditional);
-
-    match command.kind {
-        RecordedCommandKind::List { first, .. } => collect_command_function_bindings(
-            program,
-            first,
-            command_bindings,
-            bindings,
-            unconditional,
-        ),
-        RecordedCommandKind::BraceGroup { body } => collect_sequence_function_bindings(
-            program,
-            body,
-            command_bindings,
-            bindings,
-            unconditional,
-        ),
-        RecordedCommandKind::Linear
-        | RecordedCommandKind::Break { .. }
-        | RecordedCommandKind::Continue { .. }
-        | RecordedCommandKind::Return
-        | RecordedCommandKind::Exit
-        | RecordedCommandKind::If { .. }
-        | RecordedCommandKind::While { .. }
-        | RecordedCommandKind::Until { .. }
-        | RecordedCommandKind::For { .. }
-        | RecordedCommandKind::Select { .. }
-        | RecordedCommandKind::ArithmeticFor { .. }
-        | RecordedCommandKind::Case { .. }
-        | RecordedCommandKind::Subshell { .. }
-        | RecordedCommandKind::Pipeline { .. } => {}
-    }
-}
-
-fn collect_direct_function_bindings(
-    span: Span,
-    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
-    bindings: &[Binding],
-    unconditional: &mut FxHashSet<BindingId>,
-) {
-    let key = SpanKey::new(span);
-    let Some(command_bindings) = command_bindings.get(&key) else {
-        return;
-    };
-    unconditional.extend(command_bindings.iter().copied().filter(|binding| {
-        matches!(
-            bindings[binding.index()].kind,
-            BindingKind::FunctionDefinition
-        )
-    }));
 }
 
 fn function_scope_always_exits_script(
@@ -1296,182 +1110,6 @@ fn case_exit_effect(
     effect
 }
 
-impl FunctionCallResolver<'_> {
-    fn visible_function_binding(
-        &mut self,
-        name: &Name,
-        scope: ScopeId,
-        offset: usize,
-    ) -> Option<BindingId> {
-        for scope_id in ancestor_scopes(self.scopes, scope) {
-            let Some(candidates) = self.scopes[scope_id.index()].bindings.get(name) else {
-                continue;
-            };
-
-            for binding in candidates.iter().rev().copied() {
-                let candidate = &self.bindings[binding.index()];
-                if !matches!(candidate.kind, BindingKind::FunctionDefinition) {
-                    continue;
-                }
-
-                if scope_id == scope {
-                    if candidate.span.start.offset <= offset
-                        && self.unconditional_function_bindings.contains(&binding)
-                    {
-                        return Some(binding);
-                    }
-                    continue;
-                }
-
-                if !self.unconditional_function_bindings.contains(&binding) {
-                    return None;
-                }
-
-                return self
-                    .parent_scope_binding_available_before_scope_runs(candidate, scope)
-                    .then_some(binding);
-            }
-        }
-
-        None
-    }
-
-    fn parent_scope_binding_available_before_scope_runs(
-        &mut self,
-        candidate: &Binding,
-        scope: ScopeId,
-    ) -> bool {
-        if candidate.span.start.offset <= self.scopes[scope.index()].span.start.offset {
-            return true;
-        }
-
-        let mut visiting = FxHashSet::default();
-        !self.scope_has_known_entry_before_offset(
-            scope,
-            candidate.scope,
-            candidate.span.start.offset,
-            &mut visiting,
-        )
-    }
-
-    fn scope_has_known_entry_before_offset(
-        &mut self,
-        scope: ScopeId,
-        call_scope: ScopeId,
-        offset: usize,
-        visiting: &mut FxHashSet<ScopeId>,
-    ) -> bool {
-        let cache_key = (scope, call_scope, offset);
-        let cacheable = visiting.is_empty();
-        if cacheable && let Some(cached) = self.entry_before_offset_cache.get(&cache_key) {
-            return *cached;
-        }
-
-        if !visiting.insert(scope) {
-            return false;
-        }
-
-        let has_entry =
-            self.function_bindings_by_scope
-                .get(&scope)
-                .is_some_and(|function_bindings| {
-                    function_bindings.iter().copied().any(|binding| {
-                        let function = &self.bindings[binding.index()];
-                        let Some(sites) = self.call_sites.get(&function.name) else {
-                            return false;
-                        };
-                        sites.iter().any(|site| {
-                            self.call_site_may_reference_binding(site, binding, offset)
-                                && self.call_site_can_run_before_offset(
-                                    scope, site, call_scope, offset, visiting,
-                                )
-                        })
-                    })
-                });
-
-        visiting.remove(&scope);
-        if cacheable {
-            self.entry_before_offset_cache.insert(cache_key, has_entry);
-        }
-        has_entry
-    }
-
-    fn call_site_can_run_before_offset(
-        &mut self,
-        target_scope: ScopeId,
-        site: &CallSite,
-        call_scope: ScopeId,
-        offset: usize,
-        visiting: &mut FxHashSet<ScopeId>,
-    ) -> bool {
-        let command_start = recorded_command_span_for_call_site(self.program, site)
-            .start
-            .offset;
-        let Some(enclosing_function) = self.enclosing_function_scope(site.scope) else {
-            if self.scope_has_ancestor(site.scope, call_scope) {
-                return command_start < offset;
-            }
-            return self.scope_has_ancestor(call_scope, target_scope);
-        };
-
-        if enclosing_function == call_scope {
-            return command_start < offset;
-        }
-
-        self.scope_has_known_entry_before_offset(enclosing_function, call_scope, offset, visiting)
-    }
-
-    fn call_site_may_reference_binding(
-        &self,
-        site: &CallSite,
-        binding: BindingId,
-        offset: usize,
-    ) -> bool {
-        let target = &self.bindings[binding.index()];
-        if !self.scope_has_ancestor(site.scope, target.scope) {
-            return false;
-        }
-
-        if target.scope == site.scope {
-            return self.lexically_visible_function_binding_in_scope(
-                &target.name,
-                site.scope,
-                site.span.start.offset,
-            ) == Some(binding);
-        }
-
-        target.span.start.offset < offset
-    }
-
-    fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
-        ancestor_scopes(self.scopes, scope)
-            .find(|scope_id| self.function_bindings_by_scope.contains_key(scope_id))
-    }
-
-    fn scope_has_ancestor(&self, scope: ScopeId, ancestor: ScopeId) -> bool {
-        ancestor_scopes(self.scopes, scope).any(|scope_id| scope_id == ancestor)
-    }
-
-    fn lexically_visible_function_binding_in_scope(
-        &self,
-        name: &Name,
-        scope: ScopeId,
-        offset: usize,
-    ) -> Option<BindingId> {
-        self.scopes[scope.index()]
-            .bindings
-            .get(name)?
-            .iter()
-            .rev()
-            .copied()
-            .find(|binding| {
-                let candidate = &self.bindings[binding.index()];
-                matches!(candidate.kind, BindingKind::FunctionDefinition)
-                    && candidate.span.start.offset <= offset
-            })
-    }
-}
-
 struct SequenceResult {
     entry: Option<BlockId>,
     exits: SmallVec<[BlockId; 2]>,
@@ -1532,13 +1170,13 @@ pub(crate) fn build_control_flow_graph(
     scopes: &[Scope],
     bindings: &[Binding],
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    visible_function_call_bindings: &FxHashMap<SpanKey, BindingId>,
 ) -> ControlFlowGraph {
     let script_terminating_calls = compute_script_terminating_call_spans(
         program,
-        command_bindings,
-        scopes,
         bindings,
         call_sites,
+        visible_function_call_bindings,
     );
     let command_count = program.commands().len();
     let scope_count = scopes.len().max(1);

--- a/crates/shuck-semantic/src/function_resolution.rs
+++ b/crates/shuck-semantic/src/function_resolution.rs
@@ -1,0 +1,361 @@
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::{Name, Span};
+use smallvec::SmallVec;
+
+use crate::cfg::{CommandId, RecordedCommandKind, RecordedCommandRange, RecordedProgram};
+use crate::scope::ancestor_scopes;
+use crate::{Binding, BindingId, BindingKind, CallSite, Scope, ScopeId, SpanKey};
+
+pub(crate) struct FunctionBindingLookup<'a> {
+    pub(crate) program: &'a RecordedProgram,
+    pub(crate) scopes: &'a [Scope],
+    pub(crate) bindings: &'a [Binding],
+    pub(crate) call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    pub(crate) unconditional_function_bindings: &'a FxHashSet<BindingId>,
+    pub(crate) function_bindings_by_scope: &'a FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>,
+}
+
+impl FunctionBindingLookup<'_> {
+    pub(crate) fn visible_function_binding(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> Option<BindingId> {
+        let mut resolver = FunctionCallResolver {
+            program: self.program,
+            scopes: self.scopes,
+            bindings: self.bindings,
+            call_sites: self.call_sites,
+            unconditional_function_bindings: self.unconditional_function_bindings,
+            function_bindings_by_scope: self.function_bindings_by_scope,
+            entry_before_offset_cache: FxHashMap::default(),
+        };
+        resolver.visible_function_binding(name, scope, offset)
+    }
+
+    pub(crate) fn visible_function_call_bindings(&self) -> FxHashMap<SpanKey, BindingId> {
+        let mut resolver = FunctionCallResolver {
+            program: self.program,
+            scopes: self.scopes,
+            bindings: self.bindings,
+            call_sites: self.call_sites,
+            unconditional_function_bindings: self.unconditional_function_bindings,
+            function_bindings_by_scope: self.function_bindings_by_scope,
+            entry_before_offset_cache: FxHashMap::default(),
+        };
+        let mut call_bindings = FxHashMap::default();
+
+        for (name, sites) in self.call_sites {
+            for site in sites {
+                let Some(binding) =
+                    resolver.visible_function_binding(name, site.scope, site.span.start.offset)
+                else {
+                    continue;
+                };
+                call_bindings.insert(SpanKey::new(site.name_span), binding);
+            }
+        }
+
+        call_bindings
+    }
+}
+
+pub(crate) fn function_bindings_by_scope(
+    program: &RecordedProgram,
+) -> FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> {
+    let mut bindings_by_scope: FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> = FxHashMap::default();
+    for (&binding, &scope) in &program.function_body_scopes {
+        bindings_by_scope.entry(scope).or_default().push(binding);
+    }
+    bindings_by_scope
+}
+
+pub(crate) fn collect_unconditional_function_bindings(
+    program: &RecordedProgram,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    bindings: &[Binding],
+) -> FxHashSet<BindingId> {
+    let mut unconditional = FxHashSet::default();
+    collect_sequence_function_bindings(
+        program,
+        program.file_commands(),
+        command_bindings,
+        bindings,
+        &mut unconditional,
+    );
+    for commands in program.function_bodies().values().copied() {
+        collect_sequence_function_bindings(
+            program,
+            commands,
+            command_bindings,
+            bindings,
+            &mut unconditional,
+        );
+    }
+    unconditional
+}
+
+fn collect_sequence_function_bindings(
+    program: &RecordedProgram,
+    commands: RecordedCommandRange,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    bindings: &[Binding],
+    unconditional: &mut FxHashSet<BindingId>,
+) {
+    for &command_id in program.commands_in(commands) {
+        collect_command_function_bindings(
+            program,
+            command_id,
+            command_bindings,
+            bindings,
+            unconditional,
+        );
+    }
+}
+
+fn collect_command_function_bindings(
+    program: &RecordedProgram,
+    command_id: CommandId,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    bindings: &[Binding],
+    unconditional: &mut FxHashSet<BindingId>,
+) {
+    let command = program.command(command_id);
+    collect_direct_function_bindings(command.span, command_bindings, bindings, unconditional);
+
+    match command.kind {
+        RecordedCommandKind::List { first, .. } => collect_command_function_bindings(
+            program,
+            first,
+            command_bindings,
+            bindings,
+            unconditional,
+        ),
+        RecordedCommandKind::BraceGroup { body } => collect_sequence_function_bindings(
+            program,
+            body,
+            command_bindings,
+            bindings,
+            unconditional,
+        ),
+        RecordedCommandKind::Linear
+        | RecordedCommandKind::Break { .. }
+        | RecordedCommandKind::Continue { .. }
+        | RecordedCommandKind::Return
+        | RecordedCommandKind::Exit
+        | RecordedCommandKind::If { .. }
+        | RecordedCommandKind::While { .. }
+        | RecordedCommandKind::Until { .. }
+        | RecordedCommandKind::For { .. }
+        | RecordedCommandKind::Select { .. }
+        | RecordedCommandKind::ArithmeticFor { .. }
+        | RecordedCommandKind::Case { .. }
+        | RecordedCommandKind::Subshell { .. }
+        | RecordedCommandKind::Pipeline { .. } => {}
+    }
+}
+
+fn collect_direct_function_bindings(
+    span: Span,
+    command_bindings: &FxHashMap<SpanKey, SmallVec<[BindingId; 2]>>,
+    bindings: &[Binding],
+    unconditional: &mut FxHashSet<BindingId>,
+) {
+    let key = SpanKey::new(span);
+    let Some(command_bindings) = command_bindings.get(&key) else {
+        return;
+    };
+    unconditional.extend(command_bindings.iter().copied().filter(|binding| {
+        matches!(
+            bindings[binding.index()].kind,
+            BindingKind::FunctionDefinition
+        )
+    }));
+}
+
+struct FunctionCallResolver<'a> {
+    program: &'a RecordedProgram,
+    scopes: &'a [Scope],
+    bindings: &'a [Binding],
+    call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    unconditional_function_bindings: &'a FxHashSet<BindingId>,
+    function_bindings_by_scope: &'a FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>,
+    entry_before_offset_cache: FxHashMap<(ScopeId, ScopeId, usize), bool>,
+}
+
+impl FunctionCallResolver<'_> {
+    fn visible_function_binding(
+        &mut self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> Option<BindingId> {
+        for scope_id in ancestor_scopes(self.scopes, scope) {
+            let Some(candidates) = self.scopes[scope_id.index()].bindings.get(name) else {
+                continue;
+            };
+
+            for binding in candidates.iter().rev().copied() {
+                let candidate = &self.bindings[binding.index()];
+                if !matches!(candidate.kind, BindingKind::FunctionDefinition) {
+                    continue;
+                }
+
+                if scope_id == scope {
+                    if candidate.span.start.offset <= offset
+                        && self.unconditional_function_bindings.contains(&binding)
+                    {
+                        return Some(binding);
+                    }
+                    continue;
+                }
+
+                if !self.unconditional_function_bindings.contains(&binding) {
+                    return None;
+                }
+
+                return self
+                    .parent_scope_binding_available_before_scope_runs(candidate, scope)
+                    .then_some(binding);
+            }
+        }
+
+        None
+    }
+
+    fn parent_scope_binding_available_before_scope_runs(
+        &mut self,
+        candidate: &Binding,
+        scope: ScopeId,
+    ) -> bool {
+        if candidate.span.start.offset <= self.scopes[scope.index()].span.start.offset {
+            return true;
+        }
+
+        let mut visiting = FxHashSet::default();
+        !self.scope_has_known_entry_before_offset(
+            scope,
+            candidate.scope,
+            candidate.span.start.offset,
+            &mut visiting,
+        )
+    }
+
+    fn scope_has_known_entry_before_offset(
+        &mut self,
+        scope: ScopeId,
+        call_scope: ScopeId,
+        offset: usize,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let cache_key = (scope, call_scope, offset);
+        let cacheable = visiting.is_empty();
+        if cacheable && let Some(cached) = self.entry_before_offset_cache.get(&cache_key) {
+            return *cached;
+        }
+
+        if !visiting.insert(scope) {
+            return false;
+        }
+
+        let has_entry =
+            self.function_bindings_by_scope
+                .get(&scope)
+                .is_some_and(|function_bindings| {
+                    function_bindings.iter().copied().any(|binding| {
+                        let function = &self.bindings[binding.index()];
+                        let Some(sites) = self.call_sites.get(&function.name) else {
+                            return false;
+                        };
+                        sites.iter().any(|site| {
+                            self.call_site_may_reference_binding(site, binding, offset)
+                                && self.call_site_can_run_before_offset(
+                                    scope, site, call_scope, offset, visiting,
+                                )
+                        })
+                    })
+                });
+
+        visiting.remove(&scope);
+        if cacheable {
+            self.entry_before_offset_cache.insert(cache_key, has_entry);
+        }
+        has_entry
+    }
+
+    fn call_site_can_run_before_offset(
+        &mut self,
+        target_scope: ScopeId,
+        site: &CallSite,
+        call_scope: ScopeId,
+        offset: usize,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let command_start = crate::cfg::recorded_command_span_for_call_site(self.program, site)
+            .start
+            .offset;
+        let Some(enclosing_function) = self.enclosing_function_scope(site.scope) else {
+            if self.scope_has_ancestor(site.scope, call_scope) {
+                return command_start < offset;
+            }
+            return self.scope_has_ancestor(call_scope, target_scope);
+        };
+
+        if enclosing_function == call_scope {
+            return command_start < offset;
+        }
+
+        self.scope_has_known_entry_before_offset(enclosing_function, call_scope, offset, visiting)
+    }
+
+    fn call_site_may_reference_binding(
+        &self,
+        site: &CallSite,
+        binding: BindingId,
+        offset: usize,
+    ) -> bool {
+        let target = &self.bindings[binding.index()];
+        if !self.scope_has_ancestor(site.scope, target.scope) {
+            return false;
+        }
+
+        if target.scope == site.scope {
+            return self.lexically_visible_function_binding_in_scope(
+                &target.name,
+                site.scope,
+                site.span.start.offset,
+            ) == Some(binding);
+        }
+
+        target.span.start.offset < offset
+    }
+
+    fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
+        ancestor_scopes(self.scopes, scope)
+            .find(|scope_id| self.function_bindings_by_scope.contains_key(scope_id))
+    }
+
+    fn scope_has_ancestor(&self, scope: ScopeId, ancestor: ScopeId) -> bool {
+        ancestor_scopes(self.scopes, scope).any(|scope_id| scope_id == ancestor)
+    }
+
+    fn lexically_visible_function_binding_in_scope(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        offset: usize,
+    ) -> Option<BindingId> {
+        self.scopes[scope.index()]
+            .bindings
+            .get(name)?
+            .iter()
+            .rev()
+            .copied()
+            .find(|binding| {
+                let candidate = &self.bindings[binding.index()];
+                matches!(candidate.kind, BindingKind::FunctionDefinition)
+                    && candidate.span.start.offset <= offset
+            })
+    }
+}

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -24,6 +24,8 @@ mod declaration;
 #[allow(missing_docs)]
 mod dense_bit_set;
 #[allow(missing_docs)]
+mod function_resolution;
+#[allow(missing_docs)]
 mod nonpersistent;
 #[allow(missing_docs)]
 mod reachability;
@@ -98,6 +100,7 @@ use crate::cfg::{
     RecordedCommandKind, RecordedListOperator, RecordedPipelineOperatorKind, RecordedProgram,
 };
 use crate::dataflow::{DataflowContext, DataflowResult, ExactVariableDataflow};
+use crate::function_resolution::FunctionBindingLookup;
 use crate::runtime::RuntimePrelude;
 use crate::scope::ancestor_scopes;
 use crate::source_closure::ImportedBindingContractSite;
@@ -1653,8 +1656,8 @@ impl SemanticModel {
         self.entry_bindings = entry_bindings;
     }
 
-    fn function_binding_lookup(&self) -> cfg::FunctionBindingLookup<'_> {
-        cfg::FunctionBindingLookup {
+    fn function_binding_lookup(&self) -> FunctionBindingLookup<'_> {
+        FunctionBindingLookup {
             program: &self.recorded_program,
             scopes: &self.scopes,
             bindings: &self.bindings,
@@ -1664,19 +1667,9 @@ impl SemanticModel {
         }
     }
 
-    pub(crate) fn visible_function_binding(
-        &self,
-        name: &Name,
-        scope: ScopeId,
-        offset: usize,
-    ) -> Option<BindingId> {
-        self.function_binding_lookup()
-            .visible_function_binding(name, scope, offset)
-    }
-
     fn unconditional_function_bindings(&self) -> &FxHashSet<BindingId> {
         self.unconditional_function_bindings.get_or_init(|| {
-            cfg::collect_unconditional_function_bindings(
+            function_resolution::collect_unconditional_function_bindings(
                 &self.recorded_program,
                 &self.command_bindings,
                 &self.bindings,
@@ -1688,7 +1681,7 @@ impl SemanticModel {
         &self,
     ) -> &FxHashMap<ScopeId, SmallVec<[BindingId; 2]>> {
         self.function_bindings_by_scope
-            .get_or_init(|| cfg::function_bindings_by_scope(&self.recorded_program))
+            .get_or_init(|| function_resolution::function_bindings_by_scope(&self.recorded_program))
     }
 
     pub(crate) fn visible_function_call_bindings(&self) -> &FxHashMap<SpanKey, BindingId> {

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -613,7 +613,6 @@ struct CallInfo {
     name: Name,
     scope: ScopeId,
     span: Span,
-    call_site_span: Span,
     args: Vec<Option<String>>,
 }
 
@@ -653,19 +652,10 @@ fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
 
         let name = Name::from(name);
         let is_source_builtin = matches!(name.as_str(), "source" | ".");
-        let call_site_span = model
-            .call_sites_for(&name)
-            .iter()
-            .find(|site| {
-                crate::cfg::recorded_command_span_for_call_site(program, site) == command.span
-            })
-            .map(|site| site.span)
-            .unwrap_or(command.span);
         facts.calls.push(CallInfo {
             name,
             scope: model.scope_at(command.span.start.offset),
             span: command.span,
-            call_site_span,
             args: info.static_args.to_vec(),
         });
 
@@ -1076,18 +1066,11 @@ fn resolve_literal_call_args_by_scope(
     let analysis = model.analysis();
 
     for call in calls {
-        let function_binding = analysis
-            .function_call_arity_sites(&call.name)
-            .find(|(site, _)| site.span == call.call_site_span)
-            .map(|(_, binding)| binding)
-            .or_else(|| {
-                analysis.visible_function_binding_in_call_context(
-                    &call.name,
-                    call.scope,
-                    call.span.start.offset,
-                )
-            });
-        let Some(function_binding) = function_binding else {
+        let Some(function_binding) = analysis.visible_function_binding_in_call_context(
+            &call.name,
+            call.scope,
+            call.span.start.offset,
+        ) else {
             continue;
         };
         let Some(callee_scope) = analysis.function_scope_for_binding(function_binding) else {
@@ -1501,6 +1484,27 @@ noglob load_helper ./helper.sh
             args_by_scope.get(&scope),
             Some(&vec![vec![Some("./helper.sh".to_owned())]])
         );
+    }
+
+    #[test]
+    fn resolve_literal_call_args_by_scope_ignores_calls_before_function_definition() {
+        let source = "\
+load_helper ./helper.sh
+load_helper() { . \"$1\"; }
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let model = SemanticModel::build(&output.file, source, &indexer);
+        let facts = collect_ast_facts(&model);
+        let args_by_scope = resolve_literal_call_args_by_scope(&model, &facts.calls);
+        let name = Name::from("load_helper");
+        let binding = model.function_definitions(&name)[0];
+        let scope = model
+            .analysis()
+            .function_scope_for_binding(binding)
+            .expect("expected function scope");
+
+        assert_eq!(args_by_scope.get(&scope), None);
     }
 
     #[test]

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -613,6 +613,7 @@ struct CallInfo {
     name: Name,
     scope: ScopeId,
     span: Span,
+    call_site_span: Span,
     args: Vec<Option<String>>,
 }
 
@@ -652,10 +653,19 @@ fn collect_ast_facts(model: &SemanticModel) -> AstFacts {
 
         let name = Name::from(name);
         let is_source_builtin = matches!(name.as_str(), "source" | ".");
+        let call_site_span = model
+            .call_sites_for(&name)
+            .iter()
+            .find(|site| {
+                crate::cfg::recorded_command_span_for_call_site(program, site) == command.span
+            })
+            .map(|site| site.span)
+            .unwrap_or(command.span);
         facts.calls.push(CallInfo {
             name,
             scope: model.scope_at(command.span.start.offset),
             span: command.span,
+            call_site_span,
             args: info.static_args.to_vec(),
         });
 
@@ -1063,19 +1073,24 @@ fn resolve_literal_call_args_by_scope(
     calls: &[CallInfo],
 ) -> FxHashMap<ScopeId, Vec<Vec<Option<String>>>> {
     let mut resolved = FxHashMap::default();
+    let analysis = model.analysis();
 
     for call in calls {
-        let Some(function_binding) =
-            model.visible_function_binding(&call.name, call.scope, call.span.start.offset)
-        else {
+        let function_binding = analysis
+            .function_call_arity_sites(&call.name)
+            .find(|(site, _)| site.span == call.call_site_span)
+            .map(|(_, binding)| binding)
+            .or_else(|| {
+                analysis.visible_function_binding_in_call_context(
+                    &call.name,
+                    call.scope,
+                    call.span.start.offset,
+                )
+            });
+        let Some(function_binding) = function_binding else {
             continue;
         };
-        let Some(callee_scope) = model
-            .recorded_program()
-            .function_body_scopes
-            .get(&function_binding)
-            .copied()
-        else {
+        let Some(callee_scope) = analysis.function_scope_for_binding(function_binding) else {
             continue;
         };
         resolved

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -8208,6 +8208,7 @@ echo done
         &model.scopes,
         &model.bindings,
         &model.call_sites,
+        model.visible_function_call_bindings(),
     );
 
     assert!(!cfg.block_ids_for_span(conditional.span).is_empty());
@@ -8253,6 +8254,7 @@ echo done
         &model.scopes,
         &model.bindings,
         &model.call_sites,
+        model.visible_function_call_bindings(),
     );
 
     assert!(!cfg.block_ids_for_span(conditional.span).is_empty());


### PR DESCRIPTION
## Summary

- Move function call binding resolution out of CFG into a semantic-owned `function_resolution` module.
- Have CFG consume the cached `visible_function_call_bindings` map instead of resolving calls itself.
- Route source-closure call-to-scope resolution through `SemanticAnalysis`, including wrapper/effective-call cases.

## Why

Function call resolution was split between `analysis.rs`, `cfg.rs`, and `source_closure.rs`. This keeps the resolver and related lazy indexes owned by the semantic layer, while CFG and source closure consume semantic analysis helpers.

## Validation

- `cargo fmt --check`
- `cargo check -p shuck-semantic`
- `cargo test -p shuck-semantic`