### PR TITLE
refactor(semantic): expose visible candidate bindings

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -132,7 +132,10 @@ impl<'a, 'src> QuotedBashSourceContext<'a, 'src> {
         {
             binding_ids.push(binding.id);
         }
-        for binding_id in candidate_binding_ids_for_reference(self.semantic, reference) {
+        for binding_id in self
+            .semantic
+            .visible_candidate_bindings_for_reference(reference)
+        {
             if seen.insert(binding_id) {
                 binding_ids.push(binding_id);
             }
@@ -249,8 +252,10 @@ impl<'a, 'src> QuotedBashSourceContext<'a, 'src> {
             }
 
             for test in self.facts.presence_test_names(name) {
-                let binding_id =
-                    resolve_binding_visible_at(self.semantic, name, test.tested_span());
+                let binding_id = self
+                    .semantic
+                    .visible_binding(name, test.tested_span())
+                    .map(|binding| binding.id);
                 by_binding
                     .entry(binding_id)
                     .or_default()
@@ -645,56 +650,6 @@ fn binding_suppresses_same_command_array_read(binding: &Binding, assignment_only
         || (matches!(binding.kind, BindingKind::ReadTarget)
             && binding.attributes.contains(BindingAttributes::ARRAY))
         || (matches!(binding.kind, BindingKind::ArrayAssignment) && assignment_only)
-}
-
-fn resolve_binding_visible_at(
-    semantic: &shuck_semantic::SemanticModel,
-    name: &shuck_ast::Name,
-    tested_span: Span,
-) -> Option<BindingId> {
-    semantic
-        .bindings_for(name)
-        .iter()
-        .copied()
-        .rev()
-        .find(|binding_id| semantic.binding_visible_at(*binding_id, tested_span))
-}
-
-fn candidate_binding_ids_for_reference(
-    semantic: &shuck_semantic::SemanticModel,
-    reference: &Reference,
-) -> Vec<BindingId> {
-    let all_bindings = semantic.bindings_for(&reference.name);
-    let binding_ids = semantic
-        .ancestor_scopes(reference.scope)
-        .filter_map(|scope| {
-            all_bindings.iter().copied().rev().find(|binding_id| {
-                let binding = semantic.binding(*binding_id);
-                binding.scope == scope && semantic.binding_visible_at(*binding_id, reference.span)
-            })
-        })
-        .collect::<Vec<_>>();
-    if !binding_ids.is_empty() {
-        return binding_ids;
-    }
-
-    semantic
-        .ancestor_scopes(reference.scope)
-        .skip(1)
-        .filter_map(|scope| {
-            all_bindings.iter().copied().rev().find(|binding_id| {
-                let binding = semantic.binding(*binding_id);
-                binding.scope == scope && semantic.binding_visible_at(*binding_id, reference.span)
-            })
-        })
-        .chain(all_bindings.iter().copied().filter(|binding_id| {
-            let binding = semantic.binding(*binding_id);
-            binding.scope != reference.scope
-                && binding.span.start.offset < reference.span.start.offset
-        }))
-        .collect::<FxHashSet<_>>()
-        .into_iter()
-        .collect::<Vec<_>>()
 }
 
 fn is_bash_runtime_array_name(name: &str) -> bool {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -760,6 +760,44 @@ impl SemanticModel {
         self.previous_visible_binding(name, at, None)
     }
 
+    /// Return binding candidates for a reference using lexical visibility first,
+    /// then prior same-name bindings outside the reference scope.
+    pub fn visible_candidate_bindings_for_reference(
+        &self,
+        reference: &Reference,
+    ) -> Vec<BindingId> {
+        let all_bindings = self.bindings_for(&reference.name);
+        let binding_ids = self
+            .ancestor_scopes(reference.scope)
+            .filter_map(|scope| {
+                all_bindings.iter().copied().rev().find(|binding_id| {
+                    let binding = self.binding(*binding_id);
+                    binding.scope == scope && self.binding_visible_at(*binding_id, reference.span)
+                })
+            })
+            .collect::<Vec<_>>();
+        if !binding_ids.is_empty() {
+            return binding_ids;
+        }
+
+        self.ancestor_scopes(reference.scope)
+            .skip(1)
+            .filter_map(|scope| {
+                all_bindings.iter().copied().rev().find(|binding_id| {
+                    let binding = self.binding(*binding_id);
+                    binding.scope == scope && self.binding_visible_at(*binding_id, reference.span)
+                })
+            })
+            .chain(all_bindings.iter().copied().filter(|binding_id| {
+                let binding = self.binding(*binding_id);
+                binding.scope != reference.scope
+                    && binding.span.start.offset < reference.span.start.offset
+            }))
+            .collect::<FxHashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>()
+    }
+
     #[doc(hidden)]
     pub fn binding_visible_at(&self, binding_id: BindingId, at: Span) -> bool {
         let binding = self.binding(binding_id);

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -2489,6 +2489,50 @@ f() {
 }
 
 #[test]
+fn visible_candidate_bindings_for_reference_returns_visible_scope_chain() {
+    let source = "\
+#!/bin/bash
+value=outer
+f() {
+  local value=inner
+  printf '%s\\n' \"$value\"
+}
+";
+    let model = model(source);
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "value")
+        .unwrap();
+    let candidates = model.visible_candidate_bindings_for_reference(reference);
+    let value_bindings = model.bindings_for(&Name::from("value"));
+
+    assert_eq!(candidates, vec![value_bindings[1], value_bindings[0]]);
+}
+
+#[test]
+fn visible_candidate_bindings_for_reference_falls_back_to_prior_outer_scope_bindings() {
+    let source = "\
+#!/bin/bash
+first() {
+  target=(one two)
+}
+second() {
+  printf '%s\\n' \"$target\"
+}
+";
+    let model = model(source);
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.kind == ReferenceKind::Expansion && reference.name == "target")
+        .unwrap();
+    let candidates = model.visible_candidate_bindings_for_reference(reference);
+
+    assert_eq!(candidates, model.bindings_for(&Name::from("target")));
+}
+
+#[test]
 fn assoc_lookup_binding_prefers_visible_assoc_declarations_and_respects_local_shadowing() {
     let model = model(
         "\


### PR DESCRIPTION
## Summary
- add a semantic-owned visible candidate binding query for references
- update quoted_bash_source to consume semantic visibility primitives instead of rebuilding scope lookup locally
- cover the visible scope-chain and prior outer-scope fallback behavior in semantic tests

## Validation
- cargo fmt
- cargo test -p shuck-semantic visible_candidate_bindings_for_reference
- cargo test -p shuck-linter quoted_bash_source
- git diff --check