### PR TITLE
refactor(linter): consolidate command substitution word traversal

### DIFF
--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1173,29 +1173,14 @@ fn collect_scope_compat_command_substitution_name_uses(
     allow_quoted_derived_words: bool,
     uses: &mut Vec<ComparableNameUse>,
 ) {
-    for visit in iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
-        visit_command_substitution_loop_header_words(visit.command, &mut |word| {
-            push_scope_compat_command_substitution_word_use(
-                word,
-                source,
-                allow_quoted_derived_words,
-                uses,
-            );
-        });
-        visit_command_argument_words_for_substitutions(visit.command, source, &mut |word| {
-            push_scope_compat_command_substitution_word_use(
-                word,
-                source,
-                allow_quoted_derived_words,
-                uses,
-            );
-        });
-    }
+    visit_command_substitution_candidate_words(body, source, &mut |word| {
+        push_scope_compat_command_substitution_word_use(
+            word,
+            source,
+            allow_quoted_derived_words,
+            uses,
+        );
+    });
 }
 
 fn push_scope_compat_command_substitution_word_use(

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -335,56 +335,16 @@ fn collect_command_substitution_comparable_name_uses(
     allow_quoted_derived_words: bool,
     uses: &mut Vec<ComparableNameUse>,
 ) {
-    for visit in iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
-        visit_command_substitution_loop_header_words(visit.command, &mut |word| {
-            if !allow_quoted_derived_words
-                && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
-            {
-                return;
-            }
-            if let Some(mut name_use) = standalone_comparable_name_use(word, source) {
-                name_use.mark_derived();
-                uses.push(name_use);
-            }
-        });
-        visit_command_argument_words_for_substitutions(visit.command, source, &mut |word| {
-            if !allow_quoted_derived_words
-                && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
-            {
-                return;
-            }
-            if let Some(mut name_use) = standalone_comparable_name_use(word, source) {
-                name_use.mark_derived();
-                uses.push(name_use);
-            }
-        });
-    }
-}
-
-fn visit_command_substitution_loop_header_words<'a>(
-    command: &'a Command,
-    visitor: &mut impl FnMut(&'a Word),
-) {
-    match command {
-        Command::Compound(CompoundCommand::For(command)) => {
-            if let Some(words) = &command.words {
-                for word in words {
-                    visitor(word);
-                }
-            }
+    visit_command_substitution_candidate_words(body, source, &mut |word| {
+        if !allow_quoted_derived_words && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
+        {
+            return;
         }
-        Command::Compound(CompoundCommand::Select(command)) => {
-            for word in &command.words {
-                visitor(word);
-            }
+        if let Some(mut name_use) = standalone_comparable_name_use(word, source) {
+            name_use.mark_derived();
+            uses.push(name_use);
         }
-        _ => {}
-    }
+    });
 }
 
 fn standalone_comparable_name_use(word: &Word, source: &str) -> Option<ComparableNameUse> {

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -1524,10 +1524,10 @@ fn is_bash_file_slurp_command(command: &Command, redirects: &[Redirect], source:
     )
 }
 
-fn visit_command_argument_words_for_substitutions(
-    command: &Command,
+fn visit_command_argument_words_for_substitutions<'a>(
+    command: &'a Command,
     source: &str,
-    visitor: &mut impl FnMut(&Word),
+    visitor: &mut impl FnMut(&'a Word),
 ) {
     match command {
         Command::Simple(command) => {
@@ -1763,7 +1763,7 @@ fn visit_decl_operand_words_for_substitutions(
     }
 }
 
-fn visit_words_for_substitutions(words: &[Word], visitor: &mut impl FnMut(&Word)) {
+fn visit_words_for_substitutions<'a>(words: &'a [Word], visitor: &mut impl FnMut(&'a Word)) {
     for word in words {
         visitor(word);
     }

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -56,6 +56,43 @@ fn iter_commands<'a>(
     visits.into_iter()
 }
 
+fn visit_command_substitution_candidate_words<'a>(
+    body: &'a StmtSeq,
+    source: &str,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    for visit in iter_commands(
+        body,
+        CommandWalkOptions {
+            descend_nested_word_commands: true,
+        },
+    ) {
+        visit_command_substitution_loop_header_words(visit.command, visitor);
+        visit_command_argument_words_for_substitutions(visit.command, source, visitor);
+    }
+}
+
+fn visit_command_substitution_loop_header_words<'a>(
+    command: &'a Command,
+    visitor: &mut impl FnMut(&'a Word),
+) {
+    match command {
+        Command::Compound(CompoundCommand::For(command)) => {
+            if let Some(words) = &command.words {
+                for word in words {
+                    visitor(word);
+                }
+            }
+        }
+        Command::Compound(CompoundCommand::Select(command)) => {
+            for word in &command.words {
+                visitor(word);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn zsh_glob_patterns(glob: &shuck_ast::ZshQualifiedGlob) -> impl Iterator<Item = &Pattern> + '_ {
     glob.segments.iter().filter_map(|segment| match segment {
         ZshGlobSegment::Pattern(pattern) => Some(pattern),


### PR DESCRIPTION
## Summary
- add a shared fact-layer visitor for command-substitution candidate words
- route redirects and model command-substitution name-use collection through the shared traversal
- make substitution word visitor lifetimes explicit so borrowed words pass through the shared helper

## Validation
- cargo test -p shuck-linter