### PR TITLE
refactor(linter): reuse semantic function scope checks

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -566,6 +566,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let completion_registered_function_command_flags =
             build_completion_registered_function_command_flags(
                 self.semantic,
+                semantic_analysis,
                 &commands,
                 &command_fact_indices_by_id,
                 &lists,
@@ -663,6 +664,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         } = surface_fragments.finish();
         let function_positional_parameter_facts = build_function_positional_parameter_facts(
             self.semantic,
+            semantic_analysis,
             &commands,
             &positional_parameters,
         );

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -366,6 +366,7 @@ fn build_function_parameter_fallback_spans(
 
 fn build_completion_registered_function_command_flags(
     semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
     lists: &[ListFact<'_>],
@@ -381,7 +382,8 @@ fn build_completion_registered_function_command_flags(
 
     let mut flags = vec![false; function_command_slot_count(commands)];
     for command in commands {
-        flags[command.id().index()] = enclosing_function_scope(semantic, command.scope())
+        flags[command.id().index()] = semantic_analysis
+            .enclosing_function_scope_at(command.span().start.offset)
             .is_some_and(|scope| registered_scopes.contains(&scope));
     }
     flags
@@ -822,6 +824,7 @@ fn is_plausible_shell_function_name(name: &str) -> bool {
 
 fn build_function_positional_parameter_facts(
     semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
     positional_parameter_fragments: &[PositionalParameterFragmentFact],
 ) -> FxHashMap<ScopeId, FunctionPositionalParameterFacts> {
@@ -868,7 +871,9 @@ fn build_function_positional_parameter_facts(
                 continue;
             }
 
-            let Some(scope) = enclosing_function_scope(semantic, reference.scope) else {
+            let Some(scope) =
+                semantic_analysis.enclosing_function_scope_at(reference.span.start.offset)
+            else {
                 continue;
             };
 
@@ -884,7 +889,8 @@ fn build_function_positional_parameter_facts(
             continue;
         }
 
-        let Some(scope) = enclosing_function_scope(semantic, reference.scope) else {
+        let Some(scope) = semantic_analysis.enclosing_function_scope_at(reference.span.start.offset)
+        else {
             continue;
         };
 
@@ -898,17 +904,18 @@ fn build_function_positional_parameter_facts(
             continue;
         }
 
-        let fragment_scope = semantic.scope_at(fragment.span().start.offset);
+        let fragment_offset = fragment.span().start.offset;
+        let fragment_scope = semantic.scope_at(fragment_offset);
         if reference_has_local_positional_reset(
             semantic,
             fragment_scope,
-            fragment.span().start.offset,
+            fragment_offset,
             &local_reset_offsets_by_scope,
         ) {
             continue;
         }
 
-        let Some(scope) = enclosing_function_scope(semantic, fragment_scope) else {
+        let Some(scope) = semantic_analysis.enclosing_function_scope_at(fragment_offset) else {
             continue;
         };
 
@@ -935,15 +942,6 @@ fn build_function_positional_parameter_facts(
     }
 
     facts
-}
-
-fn enclosing_function_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<ScopeId> {
-    semantic.ancestor_scopes(scope).find(|scope| {
-        matches!(
-            semantic.scope_kind(*scope),
-            shuck_semantic::ScopeKind::Function(_)
-        )
-    })
 }
 
 fn enclosing_function_scope_for_positional_reset(

--- a/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
@@ -1,5 +1,4 @@
 use shuck_ast::{BuiltinCommand, Command, Span};
-use shuck_semantic::ScopeKind;
 
 use crate::{Checker, Rule, Violation};
 
@@ -46,13 +45,10 @@ pub(crate) fn loop_control_violations(
             _ => None,
         })
         .filter(|(command_span, _, keyword)| {
-            let scope = checker.semantic().scope_at(command_span.start.offset);
-            let inside_function = checker.semantic().ancestor_scopes(scope).any(|ancestor| {
-                matches!(
-                    checker.semantic().scope_kind(ancestor),
-                    ScopeKind::Function(_)
-                )
-            });
+            let inside_function = checker
+                .semantic_analysis()
+                .enclosing_function_scope_at(command_span.start.offset)
+                .is_some();
             let in_subshell = checker
                 .semantic()
                 .flow_context_at(command_span)

--- a/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
+++ b/crates/shuck-linter/src/rules/correctness/script_scope_local.rs
@@ -1,4 +1,4 @@
-use shuck_semantic::{Binding, BindingAttributes, BindingKind, DeclarationBuiltin, ScopeKind};
+use shuck_semantic::{Binding, BindingAttributes, BindingKind, DeclarationBuiltin};
 
 use crate::{Checker, Rule, ShellDialect, Violation};
 
@@ -20,6 +20,7 @@ pub fn local_top_level(checker: &mut Checker) {
     }
 
     let semantic = checker.semantic();
+    let semantic_analysis = checker.semantic_analysis();
     let spans = semantic
         .declarations()
         .iter()
@@ -32,27 +33,27 @@ pub fn local_top_level(checker: &mut Checker) {
             })
         })
         .filter_map(|declaration| {
-            let binding_scopes = semantic
+            let binding_offsets = semantic
                 .bindings_in_span(declaration.span)
                 .filter(|binding| local_binding_belongs_to_declaration_kind(binding))
-                .map(|binding| binding.scope)
+                .map(|binding| binding.span.start.offset)
                 .collect::<Vec<_>>();
 
-            if binding_scopes
-                .iter()
-                .any(|scope| matches!(semantic.scope_kind(*scope), ScopeKind::Function(_)))
-            {
+            if binding_offsets.iter().any(|offset| {
+                semantic_analysis
+                    .enclosing_function_scope_at(*offset)
+                    .is_some()
+            }) {
                 return None;
             }
 
-            if !binding_scopes.is_empty() {
+            if !binding_offsets.is_empty() {
                 return Some(declaration.span);
             }
 
-            let scope = semantic.scope_at(declaration.span.start.offset);
-            let inside_function = semantic
-                .ancestor_scopes(scope)
-                .any(|scope| matches!(semantic.scope_kind(scope), ScopeKind::Function(_)));
+            let inside_function = semantic_analysis
+                .enclosing_function_scope_at(declaration.span.start.offset)
+                .is_some();
 
             (!inside_function).then_some(declaration.span)
         })

--- a/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
@@ -1,5 +1,5 @@
 use shuck_ast::Span;
-use shuck_semantic::{ScopeKind, SourceRef, SourceRefKind};
+use shuck_semantic::{SourceRef, SourceRefKind};
 
 use crate::{Checker, CommandFactRef, Rule, ShellDialect, Violation};
 
@@ -55,9 +55,8 @@ fn same_start(left: Span, right: Span) -> bool {
 }
 
 fn inside_function(checker: &Checker<'_>, span: Span) -> bool {
-    let scope = checker.semantic().scope_at(span.start.offset);
     checker
-        .semantic()
-        .ancestor_scopes(scope)
-        .any(|scope| matches!(checker.semantic().scope_kind(scope), ScopeKind::Function(_)))
+        .semantic_analysis()
+        .enclosing_function_scope_at(span.start.offset)
+        .is_some()
 }

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -1,5 +1,3 @@
-use shuck_semantic::ScopeKind;
-
 use crate::{Checker, DeclarationKind, Rule, Violation};
 
 pub struct ExportCommandSubstitution {
@@ -69,11 +67,10 @@ fn should_report_s010_declaration(
         return true;
     }
 
-    let scope = checker.semantic().scope_at(span.start.offset);
     let inside_function = checker
-        .semantic()
-        .ancestor_scopes(scope)
-        .any(|scope| matches!(checker.semantic().scope_kind(scope), ScopeKind::Function(_)));
+        .semantic_analysis()
+        .enclosing_function_scope_at(span.start.offset)
+        .is_some();
 
     !inside_function
 }


### PR DESCRIPTION
## Summary

- Replace repeated linter-side `scope_at`/`ancestor_scopes`/`ScopeKind::Function` checks with `SemanticAnalysis::enclosing_function_scope_at`.
- Thread `SemanticAnalysis` into function fact builders that need enclosing function scope lookup.
- Remove the duplicate fact-local enclosing function scope helper.

## Why

The semantic layer already exposes the enclosing-function query, so rules and facts should consume that API instead of rebuilding the same scope traversal locally.

## Validation

- `cargo fmt --check`
- `cargo check -p shuck-linter`
- `cargo test -p shuck-linter`