### PR TITLE
refactor(linter): reuse command topology facts

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -849,6 +849,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             command_ids_by_name_word_span,
             innermost_command_ids_by_offset,
             innermost_command_ids_by_binding_offset,
+            command_containing_offset_index: OnceLock::new(),
             command_parent_ids,
             command_dominance_barrier_flags,
             if_condition_command_ids,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1017,22 +1017,63 @@ struct CommandContainingOffsetIndex {
 
 impl CommandContainingOffsetIndex {
     fn build(commands: &[CommandFact<'_>]) -> Self {
-        let mut entries = commands
+        let mut events = commands
             .iter()
-            .map(|command| {
+            .flat_map(|command| {
                 let span = command.span();
-                CommandContainingOffsetEntry {
-                    start_offset: span.start.offset,
-                    end_offset: span.end.offset,
-                    id: command.id(),
-                }
+                [
+                    CommandContainingOffsetEvent {
+                        offset: span.start.offset,
+                        end_offset: span.end.offset,
+                        id: command.id(),
+                        kind: CommandContainingOffsetEventKind::Start,
+                    },
+                    CommandContainingOffsetEvent {
+                        offset: span.end.offset.saturating_add(1),
+                        end_offset: span.end.offset,
+                        id: command.id(),
+                        kind: CommandContainingOffsetEventKind::End,
+                    },
+                ]
             })
             .collect::<Vec<_>>();
-        entries.sort_unstable_by(|left, right| {
-            left.start_offset
-                .cmp(&right.start_offset)
+        events.sort_unstable_by(|left, right| {
+            left.offset
+                .cmp(&right.offset)
+                .then_with(|| left.kind.cmp(&right.kind))
                 .then_with(|| right.end_offset.cmp(&left.end_offset))
+                .then_with(|| left.id.index().cmp(&right.id.index()))
         });
+
+        let mut entries = Vec::new();
+        let mut active = Vec::<CommandId>::new();
+        let mut index = 0;
+        while let Some(event) = events.get(index).copied() {
+            let offset = event.offset;
+            while events.get(index).is_some_and(|event| {
+                event.offset == offset && event.kind == CommandContainingOffsetEventKind::End
+            }) {
+                let id = events[index].id;
+                active.retain(|active_id| *active_id != id);
+                index += 1;
+            }
+            while events.get(index).is_some_and(|event| {
+                event.offset == offset && event.kind == CommandContainingOffsetEventKind::Start
+            }) {
+                active.push(events[index].id);
+                index += 1;
+            }
+
+            let Some(next_offset) = events.get(index).map(|event| event.offset) else {
+                break;
+            };
+            if offset < next_offset
+                && let Some(id) = active.last().copied()
+            {
+                push_command_containing_offset_entry(&mut entries, offset, next_offset - 1, id);
+            }
+        }
+
         Self { entries }
     }
 
@@ -1040,12 +1081,44 @@ impl CommandContainingOffsetIndex {
         let upper_bound = self
             .entries
             .partition_point(|entry| entry.start_offset <= offset);
-        self.entries[..upper_bound]
-            .iter()
-            .rev()
-            .find(|entry| offset <= entry.end_offset)
-            .map(|entry| entry.id)
+        let entry = self.entries.get(upper_bound.checked_sub(1)?)?;
+        (offset <= entry.end_offset).then_some(entry.id)
     }
+}
+
+fn push_command_containing_offset_entry(
+    entries: &mut Vec<CommandContainingOffsetEntry>,
+    start_offset: usize,
+    end_offset: usize,
+    id: CommandId,
+) {
+    if let Some(last) = entries.last_mut()
+        && last.id == id
+        && last.end_offset.saturating_add(1) == start_offset
+    {
+        last.end_offset = end_offset;
+        return;
+    }
+
+    entries.push(CommandContainingOffsetEntry {
+        start_offset,
+        end_offset,
+        id,
+    });
+}
+
+#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+enum CommandContainingOffsetEventKind {
+    End,
+    Start,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandContainingOffsetEvent {
+    offset: usize,
+    end_offset: usize,
+    id: CommandId,
+    kind: CommandContainingOffsetEventKind,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -324,6 +324,22 @@ impl<'a> LinterFacts<'a> {
         precomputed_command_id_for_offset(&self.innermost_command_ids_by_offset, offset)
     }
 
+    pub(crate) fn innermost_command_id_containing_offset(&self, offset: usize) -> Option<CommandId> {
+        self.commands
+            .iter()
+            .filter(|command| {
+                command.span().start.offset <= offset && offset <= command.span().end.offset
+            })
+            .max_by(|left, right| {
+                left.span()
+                    .start
+                    .offset
+                    .cmp(&right.span().start.offset)
+                    .then_with(|| right.span().end.offset.cmp(&left.span().end.offset))
+            })
+            .map(CommandFact::id)
+    }
+
     pub(crate) fn innermost_command_at_binding_offset(
         &self,
         offset: usize,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -8,6 +8,7 @@ pub struct LinterFacts<'a> {
     command_ids_by_name_word_span: FxHashMap<FactSpan, CommandId>,
     innermost_command_ids_by_offset: CommandOffsetLookup,
     innermost_command_ids_by_binding_offset: CommandOffsetLookup,
+    command_containing_offset_index: OnceLock<CommandContainingOffsetIndex>,
     command_parent_ids: Vec<Option<CommandId>>,
     command_dominance_barrier_flags: Vec<bool>,
     if_condition_command_ids: FxHashSet<CommandId>,
@@ -325,19 +326,9 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub(crate) fn innermost_command_id_containing_offset(&self, offset: usize) -> Option<CommandId> {
-        self.commands
-            .iter()
-            .filter(|command| {
-                command.span().start.offset <= offset && offset <= command.span().end.offset
-            })
-            .max_by(|left, right| {
-                left.span()
-                    .start
-                    .offset
-                    .cmp(&right.span().start.offset)
-                    .then_with(|| right.span().end.offset.cmp(&left.span().end.offset))
-            })
-            .map(CommandFact::id)
+        self.command_containing_offset_index
+            .get_or_init(|| CommandContainingOffsetIndex::build(&self.commands))
+            .innermost_command_id_containing_offset(offset)
     }
 
     pub(crate) fn innermost_command_at_binding_offset(
@@ -1017,6 +1008,51 @@ impl<'a> LinterFacts<'a> {
         self.possible_variable_misspelling_scope_compat_name_uses
             .get_or_init(|| build_possible_variable_misspelling_scope_compat_name_uses(self))
     }
+}
+
+#[derive(Debug, Default)]
+struct CommandContainingOffsetIndex {
+    entries: Vec<CommandContainingOffsetEntry>,
+}
+
+impl CommandContainingOffsetIndex {
+    fn build(commands: &[CommandFact<'_>]) -> Self {
+        let mut entries = commands
+            .iter()
+            .map(|command| {
+                let span = command.span();
+                CommandContainingOffsetEntry {
+                    start_offset: span.start.offset,
+                    end_offset: span.end.offset,
+                    id: command.id(),
+                }
+            })
+            .collect::<Vec<_>>();
+        entries.sort_unstable_by(|left, right| {
+            left.start_offset
+                .cmp(&right.start_offset)
+                .then_with(|| right.end_offset.cmp(&left.end_offset))
+        });
+        Self { entries }
+    }
+
+    fn innermost_command_id_containing_offset(&self, offset: usize) -> Option<CommandId> {
+        let upper_bound = self
+            .entries
+            .partition_point(|entry| entry.start_offset <= offset);
+        self.entries[..upper_bound]
+            .iter()
+            .rev()
+            .find(|entry| offset <= entry.end_offset)
+            .map(|entry| entry.id)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandContainingOffsetEntry {
+    start_offset: usize,
+    end_offset: usize,
+    id: CommandId,
 }
 
 fn build_possible_variable_misspelling_scope_compat_name_uses(

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1193,6 +1193,20 @@ time timed
                 .and_then(|fact| fact.effective_name()),
             Some("right")
         );
+        assert_eq!(
+            facts
+                .innermost_command_id_containing_offset(brace_offset + 2)
+                .map(|id| facts.command(id))
+                .and_then(|fact| fact.effective_name()),
+            Some("brace_inner")
+        );
+        assert_eq!(
+            facts
+                .innermost_command_id_containing_offset(right_offset + 2)
+                .map(|id| facts.command(id))
+                .and_then(|fact| fact.effective_name()),
+            Some("right")
+        );
     });
 }
 

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -32,8 +32,7 @@ pub fn quoted_bash_source(checker: &mut Checker) {
                 .filter(move |reference| reference.span == span)
         })
         .collect::<Vec<_>>();
-    let mut context =
-        QuotedBashSourceContext::new(checker.facts(), semantic, &candidate_references);
+    let mut context = QuotedBashSourceContext::new(checker.facts(), semantic);
     let spans = candidate_references
         .into_iter()
         .filter(|reference| context.reference_is_array_like(reference))
@@ -47,7 +46,6 @@ struct QuotedBashSourceContext<'a, 'src> {
     facts: &'a LinterFacts<'src>,
     semantic: &'a shuck_semantic::SemanticModel,
     local_declarations: LocalDeclarationIndex,
-    innermost_command_ids_by_offset: FxHashMap<usize, Option<CommandId>>,
     simple_command_ancestors_by_offset: FxHashMap<usize, Vec<SimpleCommandAncestor>>,
     same_command_writers_by_name: FxHashMap<Name, Vec<BindingId>>,
     presence_test_ends_by_name_binding: FxHashMap<Name, FxHashMap<Option<BindingId>, Vec<usize>>>,
@@ -59,38 +57,11 @@ struct QuotedBashSourceContext<'a, 'src> {
 }
 
 impl<'a, 'src> QuotedBashSourceContext<'a, 'src> {
-    fn new(
-        facts: &'a LinterFacts<'src>,
-        semantic: &'a shuck_semantic::SemanticModel,
-        candidate_references: &[&Reference],
-    ) -> Self {
-        let mut command_query_offsets = candidate_references
-            .iter()
-            .map(|reference| reference.span.start.offset)
-            .collect::<Vec<_>>();
-        command_query_offsets.extend(
-            semantic
-                .bindings()
-                .iter()
-                .filter(|binding| {
-                    matches!(
-                        binding.kind,
-                        BindingKind::ArrayAssignment
-                            | BindingKind::MapfileTarget
-                            | BindingKind::ReadTarget
-                    )
-                })
-                .map(|binding| binding.span.start.offset),
-        );
-
+    fn new(facts: &'a LinterFacts<'src>, semantic: &'a shuck_semantic::SemanticModel) -> Self {
         Self {
             facts,
             semantic,
             local_declarations: LocalDeclarationIndex::build(semantic),
-            innermost_command_ids_by_offset: build_innermost_command_ids_by_offset(
-                facts.commands(),
-                command_query_offsets,
-            ),
             simple_command_ancestors_by_offset: FxHashMap::default(),
             same_command_writers_by_name: FxHashMap::default(),
             presence_test_ends_by_name_binding: FxHashMap::default(),
@@ -317,11 +288,7 @@ impl<'a, 'src> QuotedBashSourceContext<'a, 'src> {
             .entry(offset)
             .or_insert_with(|| {
                 let mut ancestors = Vec::new();
-                let mut current = self
-                    .innermost_command_ids_by_offset
-                    .get(&offset)
-                    .copied()
-                    .flatten();
+                let mut current = self.facts.innermost_command_id_containing_offset(offset);
                 while let Some(command_id) = current {
                     let command = self.facts.command(command_id);
                     if matches!(command.command(), Command::Simple(_)) {
@@ -493,80 +460,6 @@ impl LocalDeclarationIndex {
             span.start.offset,
             span.end.offset,
         ))
-    }
-}
-
-#[derive(Clone, Copy)]
-struct OpenCommand {
-    end_offset: usize,
-    id: CommandId,
-}
-
-fn build_innermost_command_ids_by_offset(
-    commands: crate::facts::CommandFacts<'_, '_>,
-    mut offsets: Vec<usize>,
-) -> FxHashMap<usize, Option<CommandId>> {
-    if offsets.is_empty() {
-        return FxHashMap::default();
-    }
-
-    offsets.sort_unstable();
-    offsets.dedup();
-
-    let mut command_spans = commands
-        .iter()
-        .map(|command| (command.span(), command.id()))
-        .collect::<Vec<_>>();
-    if command_spans
-        .windows(2)
-        .any(|window| compare_command_offset_entries(window[0], window[1]).is_gt())
-    {
-        command_spans.sort_unstable_by(|left, right| compare_command_offset_entries(*left, *right));
-    }
-
-    let mut command_ids_by_offset = FxHashMap::default();
-    let mut active_commands = Vec::new();
-    let mut next_command = 0;
-    for offset in offsets {
-        pop_finished_commands(&mut active_commands, offset);
-
-        while let Some((span, id)) = command_spans.get(next_command).copied() {
-            if span.start.offset > offset {
-                break;
-            }
-
-            pop_finished_commands(&mut active_commands, span.start.offset);
-            active_commands.push(OpenCommand {
-                end_offset: span.end.offset,
-                id,
-            });
-            next_command += 1;
-        }
-
-        pop_finished_commands(&mut active_commands, offset);
-        command_ids_by_offset.insert(offset, active_commands.last().map(|command| command.id));
-    }
-
-    command_ids_by_offset
-}
-
-fn compare_command_offset_entries(
-    (left_span, _left_id): (Span, CommandId),
-    (right_span, _right_id): (Span, CommandId),
-) -> std::cmp::Ordering {
-    left_span
-        .start
-        .offset
-        .cmp(&right_span.start.offset)
-        .then_with(|| right_span.end.offset.cmp(&left_span.end.offset))
-}
-
-fn pop_finished_commands(active_commands: &mut Vec<OpenCommand>, offset: usize) {
-    while active_commands
-        .last()
-        .is_some_and(|command| command.end_offset < offset)
-    {
-        active_commands.pop();
     }
 }
 


### PR DESCRIPTION
## Summary

- Move the containing-offset command lookup onto `LinterFacts` as a crate-private helper.
- Remove the `quoted_bash_source` rule's local command-position index and reuse facts-owned command topology plus parent IDs.
- Keep the rule-local cache limited to simple-command ancestors derived from facts.

## Validation

- `cargo fmt`
- `cargo test -p shuck-linter`
- `cargo test -p shuck-linter rules::correctness::quoted_bash_source -- --nocapture`
- `git diff --check`