### PR TITLE
perf(linter): drop redundant command-fact source-order scan

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1464,9 +1464,7 @@ fn escaped_braced_parameter_names(text: &str) -> Vec<String> {
 #[cfg_attr(shuck_profiling, inline(never))]
 fn build_innermost_command_ids_by_offset(
     commands: &[CommandFact<'_>],
-    command_fact_indices_by_id: &[Option<usize>],
     mut offsets: Vec<usize>,
-    command_order: &CommandOffsetOrder,
 ) -> CommandOffsetLookup {
     if offsets.is_empty() {
         return CommandOffsetLookup::default();
@@ -1481,9 +1479,8 @@ fn build_innermost_command_ids_by_offset(
     for offset in offsets {
         pop_finished_commands(&mut active_commands, offset);
 
-        while let Some((span, id)) =
-            command_order.entry(commands, command_fact_indices_by_id, next_command)
-        {
+        while let Some(command) = commands.get(next_command) {
+            let span = command.span();
             if span.start.offset > offset {
                 break;
             }
@@ -1491,7 +1488,7 @@ fn build_innermost_command_ids_by_offset(
             pop_finished_commands(&mut active_commands, span.start.offset);
             active_commands.push(OpenCommand {
                 end_offset: span.end.offset,
-                id,
+                id: command.id(),
             });
             next_command += 1;
         }
@@ -1508,51 +1505,6 @@ fn build_innermost_command_ids_by_offset(
     CommandOffsetLookup { entries }
 }
 
-pub(crate) enum CommandOffsetOrder {
-    SourceOrdered,
-    Sorted(Vec<CommandId>),
-}
-
-impl CommandOffsetOrder {
-    pub(super) fn entry(
-        &self,
-        commands: &[CommandFact<'_>],
-        command_fact_indices_by_id: &[Option<usize>],
-        index: usize,
-    ) -> Option<(Span, CommandId)> {
-        match self {
-            Self::SourceOrdered => {
-                let command = commands.get(index)?;
-                Some((command.span(), command.id()))
-            }
-            Self::Sorted(order) => {
-                let id = order.get(index).copied()?;
-                Some(command_offset_entry(commands, command_fact_indices_by_id, id))
-            }
-        }
-    }
-}
-
-#[cfg_attr(shuck_profiling, inline(never))]
-fn build_command_offset_order(
-    commands: &[CommandFact<'_>],
-    command_fact_indices_by_id: &[Option<usize>],
-    require_source_order: bool,
-) -> CommandOffsetOrder {
-    if !require_source_order {
-        return CommandOffsetOrder::SourceOrdered;
-    }
-
-    let mut command_order = commands.iter().map(CommandFact::id).collect::<Vec<_>>();
-    command_order.sort_unstable_by(|left, right| {
-        compare_command_offset_entries(
-            command_offset_entry(commands, command_fact_indices_by_id, *left),
-            command_offset_entry(commands, command_fact_indices_by_id, *right),
-        )
-    });
-    CommandOffsetOrder::Sorted(command_order)
-}
-
 #[derive(Debug, Default, Clone)]
 struct CommandOffsetLookup {
     entries: Vec<CommandOffsetLookupEntry>,
@@ -1562,29 +1514,6 @@ struct CommandOffsetLookup {
 struct CommandOffsetLookupEntry {
     offset: usize,
     id: CommandId,
-}
-
-fn compare_command_offset_entries(
-    (left_span, left_id): (Span, CommandId),
-    (right_span, right_id): (Span, CommandId),
-) -> std::cmp::Ordering {
-    left_span
-        .start
-        .offset
-        .cmp(&right_span.start.offset)
-        .then_with(|| right_span.end.offset.cmp(&left_span.end.offset))
-        .then_with(|| right_id.index().cmp(&left_id.index()))
-}
-
-fn command_offset_entry(
-    commands: &[CommandFact<'_>],
-    command_fact_indices_by_id: &[Option<usize>],
-    id: CommandId,
-) -> (Span, CommandId) {
-    (
-        command_fact(commands, command_fact_indices_by_id, id).span(),
-        id,
-    )
 }
 
 fn precomputed_command_id_for_offset(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -428,12 +428,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             .collect::<Vec<_>>();
         commands.sort_unstable_by(compare_command_facts_by_offset);
         let command_fact_indices_by_id = build_command_fact_indices_by_id(&commands);
-        let command_facts_require_source_order = !command_facts_are_source_ordered(&commands);
-        let command_offset_order = build_command_offset_order(
-            &commands,
-            &command_fact_indices_by_id,
-            command_facts_require_source_order,
-        );
         let structural_command_ids = self
             .semantic
             .structural_commands()
@@ -466,8 +460,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
 
         let presence_tested_names = build_presence_tested_names(
             &commands,
-            &command_fact_indices_by_id,
-            &command_offset_order,
             self.source,
             self.semantic,
         );
@@ -478,7 +470,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &commands,
             &command_fact_indices_by_id,
             self.source,
-            &command_offset_order,
         );
         let function_cli_dispatch_facts = build_function_cli_dispatch_facts(
             self.semantic,
@@ -786,22 +777,18 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         );
         let innermost_command_ids_by_offset = build_innermost_command_ids_by_offset(
             &commands,
-            &command_fact_indices_by_id,
             commands
                 .iter()
                 .map(|command| command.span().start.offset)
                 .collect(),
-            &command_offset_order,
         );
         let innermost_command_ids_by_binding_offset = build_innermost_command_ids_by_offset(
             &commands,
-            &command_fact_indices_by_id,
             self.semantic
                 .bindings()
                 .iter()
                 .map(|binding| binding.span.start.offset)
                 .collect(),
-            &command_offset_order,
         );
         let command_dominance_barrier_flags = build_command_dominance_barrier_flags(&commands);
         let c006_suppressing_reference_offsets_by_name =

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1514,12 +1514,6 @@ impl<'facts, 'a> CommandRelationshipContext<'facts, 'a> {
 
 }
 
-fn command_facts_are_source_ordered(commands: &[CommandFact<'_>]) -> bool {
-    commands
-        .windows(2)
-        .all(|window| compare_command_facts_by_offset(&window[0], &window[1]).is_le())
-}
-
 fn build_command_fact_indices_by_id(commands: &[CommandFact<'_>]) -> Vec<Option<usize>> {
     let len = commands
         .iter()

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -143,7 +143,6 @@ fn build_function_header_facts<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     source: &str,
-    command_offset_order: &CommandOffsetOrder,
 ) -> Vec<FunctionHeaderFact<'a>> {
     let call_arity_by_binding = build_function_call_arity_facts(
         semantic_analysis,
@@ -154,7 +153,6 @@ fn build_function_header_facts<'a>(
         commands,
         command_fact_indices_by_id,
         source,
-        command_offset_order,
     );
     functions
         .iter()
@@ -552,7 +550,6 @@ fn build_function_call_arity_facts<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     source: &str,
-    command_offset_order: &CommandOffsetOrder,
 ) -> FxHashMap<BindingId, FunctionCallArityFacts> {
     let mut facts = FxHashMap::<BindingId, FunctionCallArityFacts>::default();
     let mut seen_names = FxHashSet::default();
@@ -579,12 +576,7 @@ fn build_function_call_arity_facts<'a>(
         return facts;
     }
 
-    let command_ids_by_offset = build_innermost_command_ids_by_offset(
-        commands,
-        command_fact_indices_by_id,
-        offsets,
-        command_offset_order,
-    );
+    let command_ids_by_offset = build_innermost_command_ids_by_offset(commands, offsets);
 
     for name in unique_function_names {
         for (site, binding_id) in semantic_analysis.function_call_arity_sites(name) {

--- a/crates/shuck-linter/src/facts/presence.rs
+++ b/crates/shuck-linter/src/facts/presence.rs
@@ -45,8 +45,6 @@ pub(super) struct PresenceTestedNames {
 #[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_presence_tested_names(
     commands: &[CommandFact<'_>],
-    command_fact_indices_by_id: &[Option<usize>],
-    command_offset_order: &CommandOffsetOrder,
     source: &str,
     semantic: &SemanticModel,
 ) -> PresenceTestedNames {
@@ -56,11 +54,7 @@ pub(super) fn build_presence_tested_names(
     let mut c006_nested_command_spans_by_name = FxHashMap::<Name, Vec<Span>>::default();
     let mut references_by_name = FxHashMap::<Name, Vec<PresenceTestReferenceFact>>::default();
     let mut names_by_name = FxHashMap::<Name, Vec<PresenceTestNameFact>>::default();
-    let outermost_nested_scopes = build_outermost_nested_presence_scopes(
-        commands,
-        command_fact_indices_by_id,
-        command_offset_order,
-    );
+    let outermost_nested_scopes = build_outermost_nested_presence_scopes(commands);
     let mut command_names = FxHashSet::default();
     let mut c006_command_names = FxHashSet::default();
     let mut command_reference_ids = FxHashSet::default();
@@ -184,18 +178,12 @@ pub(super) fn build_presence_tested_names(
     }
 }
 
-fn build_outermost_nested_presence_scopes(
-    commands: &[CommandFact<'_>],
-    command_fact_indices_by_id: &[Option<usize>],
-    command_offset_order: &CommandOffsetOrder,
-) -> Vec<Option<Span>> {
+fn build_outermost_nested_presence_scopes(commands: &[CommandFact<'_>]) -> Vec<Option<Span>> {
     let mut outermost_scopes = vec![None; command_slot_count(commands)];
     let mut active_nested_scopes = Vec::<Span>::new();
-    for index in 0..commands.len() {
-        let (span, id) = command_offset_order
-            .entry(commands, command_fact_indices_by_id, index)
-            .expect("command_offset_order index in range");
-        let command = command_fact(commands, command_fact_indices_by_id, id);
+    for command in commands {
+        let span = command.span();
+        let id = command.id();
         let is_nested = command.is_nested_word_command();
         pop_finished_nested_presence_scopes(&mut active_nested_scopes, span.start.offset);
         outermost_scopes[id.index()] = active_nested_scopes

--- a/crates/shuck-linter/src/facts/tests/flow.rs
+++ b/crates/shuck-linter/src/facts/tests/flow.rs
@@ -216,13 +216,11 @@ fn precomputes_innermost_command_ids_for_nested_offsets() {
 
     let command_ids_by_offset = super::build_innermost_command_ids_by_offset(
         facts.commands().raw(),
-        &facts.command_fact_indices_by_id,
         vec![
             source.find("echo").expect("expected echo offset"),
             source.find("printf").expect("expected printf offset"),
             source.find("uname").expect("expected uname offset"),
         ],
-        &super::CommandOffsetOrder::SourceOrdered,
     );
 
     assert_eq!(

--- a/crates/shuck-linter/src/facts/tests/mod.rs
+++ b/crates/shuck-linter/src/facts/tests/mod.rs
@@ -8,10 +8,10 @@ use std::path::Path;
 
 #[allow(unused_imports)]
 use super::{
-    CommandId, CommandOffsetOrder, ConditionalNodeFact, ConditionalOperatorFamily,
-    ExpansionContext, ExprStringHelperKind, GrepPatternSourceKind, ListFact, ListSegmentKind,
-    MixedShortCircuitKind, SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax,
-    SubstitutionHostKind, SubstitutionOutputIntent, SudoFamilyInvoker, WordFactHostKind,
+    CommandId, ConditionalNodeFact, ConditionalOperatorFamily, ExpansionContext,
+    ExprStringHelperKind, GrepPatternSourceKind, ListFact, ListSegmentKind, MixedShortCircuitKind,
+    SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax, SubstitutionHostKind,
+    SubstitutionOutputIntent, SudoFamilyInvoker, WordFactHostKind,
     build_innermost_command_ids_by_offset, precomputed_command_id_for_offset,
 };
 use crate::WrapperKind;


### PR DESCRIPTION
## Summary
- The fact builder sorted commands with `compare_command_facts_by_offset` and then re-ran the same comparator pairwise to verify the result was source-ordered. The verification was always true, so the code path it gated (the `Sorted` arm of `CommandOffsetOrder` plus its helpers) was unreachable.
- Drop the verification scan, the now-unreachable enum variant, and the helpers that fed it. Callers that took an order argument no longer need it; `build_outermost_nested_presence_scopes` now iterates `commands` directly.
- Removes ~120 lines of dead infrastructure and the per-file O(n) verification scan that previously showed up as a small but real fact-builder sub-frame.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test -p shuck-linter --lib` (3141 passed)
- [x] Re-profiled `xwmx__nb__nb`: warm avg in line with main (~187ms vs ~186ms; the verification frame disappears from the drilldown)