### PR TITLE
refactor(linter): share binding visibility helpers

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
@@ -33,7 +33,11 @@ pub fn append_to_array_as_string(checker: &mut Checker) {
                 return None;
             }
 
-            let prior_binding = previous_visible_binding(semantic, binding)?;
+            let prior_binding = semantic.previous_visible_binding(
+                &binding.name,
+                binding.span,
+                Some(binding.span),
+            )?;
             if !binding_is_array_like(prior_binding) {
                 return None;
             }
@@ -46,33 +50,6 @@ pub fn append_to_array_as_string(checker: &mut Checker) {
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || AppendToArrayAsString);
-}
-
-fn previous_visible_binding<'a>(
-    semantic: &'a shuck_semantic::SemanticModel,
-    binding: &Binding,
-) -> Option<&'a Binding> {
-    for scope_id in semantic.ancestor_scopes(binding.scope) {
-        let Some(scope) = semantic.scopes().iter().find(|scope| scope.id == scope_id) else {
-            continue;
-        };
-        let Some(candidates) = scope.bindings.get(&binding.name) else {
-            continue;
-        };
-
-        for candidate_id in candidates.iter().rev() {
-            let candidate = semantic.binding(*candidate_id);
-
-            if candidate.id == binding.id {
-                continue;
-            }
-            if candidate.span.start.offset <= binding.span.start.offset {
-                return Some(candidate);
-            }
-        }
-    }
-
-    None
 }
 
 fn binding_is_array_like(binding: &Binding) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -7,6 +7,8 @@ use shuck_semantic::{
 
 use crate::{Checker, ComparableNameUseKind, Rule, ShellDialect, Violation, WrapperKind};
 
+use super::variable_reference_common::has_visible_function_name_binding;
+
 pub struct ArrayToStringConversion;
 
 impl Violation for ArrayToStringConversion {
@@ -448,30 +450,8 @@ fn command_name_has_visible_function_binding(
     name: &str,
     at: shuck_ast::Span,
 ) -> bool {
-    let semantic = checker.semantic();
     let name = Name::from(name);
-
-    if semantic
-        .function_definitions(&name)
-        .iter()
-        .copied()
-        .any(|binding_id| semantic.binding_visible_at(binding_id, at))
-    {
-        return true;
-    }
-
-    semantic
-        .bindings_for(&name)
-        .iter()
-        .rev()
-        .copied()
-        .any(|binding_id| {
-            let binding = semantic.binding(binding_id);
-            binding
-                .attributes
-                .contains(BindingAttributes::IMPORTED_FUNCTION)
-                && semantic.binding_visible_at(binding_id, at)
-        })
+    has_visible_function_name_binding(checker, &name, at)
 }
 
 fn command_forces_builtin_resolution(

--- a/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
@@ -1,8 +1,9 @@
 use shuck_ast::{ConditionalBinaryOp, Name, Span, is_shell_variable_name, static_word_text};
 use shuck_parser::text_is_self_contained_arithmetic_expression;
-use shuck_semantic::{BindingAttributes, BindingKind};
 
 use crate::{Checker, ConditionalNodeFact, ConditionalOperandFact, Rule, Violation, WordQuote};
+
+use super::variable_reference_common::binding_defines_variable_name_at;
 
 pub struct StringComparedWithEq;
 
@@ -125,23 +126,8 @@ fn looks_like_defined_variable_name(checker: &Checker<'_>, text: &str, span: Spa
         .copied()
         .any(|binding_id| {
             let binding = checker.semantic().binding(binding_id);
-            if binding
-                .attributes
-                .contains(BindingAttributes::IMPORTED_FUNCTION)
-                || matches!(binding.kind, BindingKind::FunctionDefinition)
-            {
-                return false;
-            }
-
-            if binding.span.start.offset == span.start.offset {
-                return false;
-            }
-
-            let imported_binding = binding.attributes.intersects(
-                BindingAttributes::IMPORTED_POSSIBLE | BindingAttributes::IMPORTED_FILE_ENTRY,
-            ) || matches!(binding.kind, BindingKind::Imported);
-
-            !imported_binding || checker.semantic().binding_visible_at(binding_id, span)
+            binding.span.start.offset != span.start.offset
+                && binding_defines_variable_name_at(checker, binding, span)
         })
 }
 

--- a/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
+++ b/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
@@ -1,5 +1,6 @@
 use shuck_ast::Name;
-use shuck_semantic::{BindingKind, Reference, ReferenceKind};
+use shuck_ast::Span;
+use shuck_semantic::{Binding, BindingAttributes, BindingKind, Reference, ReferenceKind};
 
 use crate::Checker;
 
@@ -75,6 +76,58 @@ pub(super) fn has_same_name_defining_bindings(checker: &Checker<'_>, name: &Name
         .iter()
         .copied()
         .any(|binding_id| is_sc2154_defining_binding(checker.semantic().binding(binding_id).kind))
+}
+
+pub(super) fn has_visible_function_name_binding(
+    checker: &Checker<'_>,
+    name: &Name,
+    at: Span,
+) -> bool {
+    let semantic = checker.semantic();
+    let scope = semantic.scope_at(at.start.offset);
+    if checker
+        .semantic_analysis()
+        .visible_function_binding_defined_before(name, scope, at.start.offset)
+        .is_some()
+    {
+        return true;
+    }
+
+    semantic
+        .bindings_for(name)
+        .iter()
+        .copied()
+        .any(|binding_id| {
+            let binding = semantic.binding(binding_id);
+            binding
+                .attributes
+                .contains(BindingAttributes::IMPORTED_FUNCTION)
+                && semantic.binding_visible_at(binding_id, at)
+        })
+}
+
+pub(super) fn binding_defines_variable_name_at(
+    checker: &Checker<'_>,
+    binding: &Binding,
+    at: Span,
+) -> bool {
+    if binding_is_function_name(binding) {
+        return false;
+    }
+
+    let imported_binding = binding
+        .attributes
+        .intersects(BindingAttributes::IMPORTED_POSSIBLE | BindingAttributes::IMPORTED_FILE_ENTRY)
+        || matches!(binding.kind, BindingKind::Imported);
+
+    !imported_binding || checker.semantic().binding_visible_at(binding.id, at)
+}
+
+fn binding_is_function_name(binding: &Binding) -> bool {
+    binding
+        .attributes
+        .contains(BindingAttributes::IMPORTED_FUNCTION)
+        || matches!(binding.kind, BindingKind::FunctionDefinition)
 }
 
 fn is_shell_special_parameter(name: &str) -> bool {


### PR DESCRIPTION
## Summary

- Replace the rule-local previous-visible-binding walk in `append_to_array_as_string` with `SemanticModel::previous_visible_binding`.
- Add shared correctness-rule helpers for visible function-name bindings and variable-name defining bindings.
- Route `array_to_string_conversion` and `string_compared_with_eq` through the shared helpers instead of open-coded scans.

## Validation

- `cargo fmt`
- `cargo test -p shuck-linter append_to_array_as_string`
- `cargo test -p shuck-linter array_to_string_conversion`
- `cargo test -p shuck-linter string_compared_with_eq`
- `cargo test -p shuck-linter undefined_variable`
- `cargo test -p shuck-linter possible_variable_misspelling`
- `make test`