### PR TITLE
refactor(semantic): own function call reachability

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -2,7 +2,9 @@ use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::Name;
 use shuck_semantic::{
-    BindingKind, BindingOrigin, OverwrittenFunction as SemanticOverwrittenFunction, ScopeId,
+    BindingId, BindingKind, BindingOrigin, DirectFunctionCallReachability,
+    DirectFunctionCallWindow, FunctionCallCandidate, FunctionCallPersistence,
+    OverwrittenFunction as SemanticOverwrittenFunction, ScopeId,
     UnreachedFunction as SemanticUnreachedFunction, UnreachedFunctionReason,
 };
 
@@ -143,12 +145,6 @@ struct FunctionCutoff {
 }
 
 #[derive(Clone, Copy)]
-struct CompatCallFact {
-    scope: ScopeId,
-    span: shuck_ast::Span,
-}
-
-#[derive(Clone, Copy)]
 struct CompatUnsetCommandFact {
     scope: ScopeId,
     offset: usize,
@@ -168,7 +164,6 @@ struct CompatTopLevelControlFacts {
 }
 
 struct CompatStructuralFacts {
-    call_facts_by_name: CompatCallFactsByName,
     unset_commands_by_target: CompatUnsetCommandsByTarget,
     scopes_by_offset: FxHashMap<usize, ScopeId>,
     function_definition_offsets: FxHashSet<usize>,
@@ -182,18 +177,7 @@ struct CompatLoopCandidate {
     body_span: shuck_ast::Span,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct CompatCallResolutionKey {
-    binding: shuck_semantic::BindingId,
-    call_scope: ScopeId,
-    visibility_start: usize,
-    visibility_end: usize,
-    cfg_start: usize,
-    cfg_end: usize,
-}
-
-type CompatCallFactsByName = FxHashMap<String, Vec<CompatCallFact>>;
-type CompatFunctionBindingsByScope = FxHashMap<ScopeId, Vec<shuck_semantic::BindingId>>;
+type CompatFunctionBindingsByScope = FxHashMap<ScopeId, Vec<BindingId>>;
 type CompatUnsetCommandsByTarget = FxHashMap<String, Vec<CompatUnsetCommandFact>>;
 type CompatUnsetterFunctionsByTarget = FxHashMap<String, Vec<shuck_ast::Name>>;
 
@@ -202,51 +186,7 @@ struct CompatUnsetFacts {
     functions_by_target: CompatUnsetterFunctionsByTarget,
 }
 
-struct CompatReachState<'a> {
-    scope_run_cache: &'a mut FxHashMap<(ScopeId, usize), bool>,
-    scope_between_cache: &'a mut FxHashMap<(ScopeId, usize, usize), bool>,
-    call_resolution_cache: &'a mut FxHashMap<CompatCallResolutionKey, bool>,
-    call_facts_by_name: &'a CompatCallFactsByName,
-    function_bindings_by_scope: &'a CompatFunctionBindingsByScope,
-    activation_index: Option<&'a CompatActivationIndex>,
-}
-
-#[derive(Clone, Copy)]
-struct BoundaryCallWindow {
-    after_offset: usize,
-    before_offset: usize,
-    boundary_scope: ScopeId,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct CompatScopeActivation {
-    activation_offset: usize,
-    required_before_offset: usize,
-    persistent: bool,
-}
-
-struct CompatActivationIndex {
-    activations_by_scope: FxHashMap<ScopeId, Vec<CompatScopeActivation>>,
-}
-
-#[derive(Clone, Copy)]
-struct CompatActivationEdge {
-    target_scope: ScopeId,
-    target_binding_offset: usize,
-    call_offset: usize,
-    persistent: bool,
-}
-
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct CompatActivationEdgeKey {
-    target_binding: shuck_semantic::BindingId,
-    target_scope: ScopeId,
-    call_scope: ScopeId,
-    call_offset: usize,
-}
-
 fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts {
-    let mut calls = CompatCallFactsByName::default();
     let mut unset_commands_by_target = CompatUnsetCommandsByTarget::default();
     let mut scopes_by_offset = FxHashMap::<usize, ScopeId>::default();
     let mut function_definition_offsets = FxHashSet::<usize>::default();
@@ -273,17 +213,6 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
         let is_return = fact.effective_name_is("return");
         if is_return {
             return_offsets.insert(offset);
-        }
-
-        if !is_function && let Some(name) = fact.effective_name() {
-            let scope = fact.scope();
-            calls
-                .entry(name.to_owned())
-                .or_default()
-                .push(CompatCallFact {
-                    scope,
-                    span: fact.body_span(),
-                });
         }
 
         let apparent_loop_body_span = apparent_infinite_loop_body_span(checker, fact.command());
@@ -337,7 +266,6 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
         .collect();
 
     CompatStructuralFacts {
-        call_facts_by_name: calls,
         unset_commands_by_target,
         scopes_by_offset,
         function_definition_offsets,
@@ -349,244 +277,39 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
     }
 }
 
+fn build_supplemental_function_call_candidates(
+    checker: &Checker<'_>,
+) -> Vec<FunctionCallCandidate> {
+    checker
+        .facts()
+        .structural_commands()
+        .filter(|fact| !matches!(fact.command(), shuck_ast::Command::Function(_)))
+        .filter_map(|fact| {
+            let callee = fact.effective_name()?;
+            Some(FunctionCallCandidate {
+                callee: Name::from(callee),
+                scope: fact.scope(),
+                name_span: fact.body_span(),
+                command_span: fact.body_span(),
+            })
+        })
+        .collect()
+}
+
+fn build_direct_function_call_reachability<'checker, 'model>(
+    checker: &'checker Checker<'model>,
+) -> DirectFunctionCallReachability<'checker, 'model> {
+    checker
+        .semantic_analysis()
+        .direct_function_call_reachability(build_supplemental_function_call_candidates(checker))
+}
+
 fn build_compat_function_bindings_by_scope(checker: &Checker<'_>) -> CompatFunctionBindingsByScope {
     checker
         .semantic_analysis()
         .function_bindings_by_scope()
         .map(|(scope, bindings)| (scope, bindings.to_vec()))
         .collect()
-}
-
-fn build_compat_activation_index(
-    checker: &Checker<'_>,
-    call_facts_by_name: &CompatCallFactsByName,
-    function_bindings_by_scope: &CompatFunctionBindingsByScope,
-    call_resolution_cache: &mut FxHashMap<CompatCallResolutionKey, bool>,
-) -> CompatActivationIndex {
-    let edges_by_caller = build_compat_activation_edges_by_caller(
-        checker,
-        call_facts_by_name,
-        function_bindings_by_scope,
-        call_resolution_cache,
-    );
-    let mut index = CompatActivationIndex {
-        activations_by_scope: FxHashMap::default(),
-    };
-    let mut pending = Vec::new();
-
-    for edge in edges_by_caller
-        .get(&None)
-        .into_iter()
-        .flat_map(|edges| edges.iter())
-    {
-        if edge.call_offset <= edge.target_binding_offset {
-            continue;
-        }
-        let activation = CompatScopeActivation {
-            activation_offset: edge.call_offset,
-            required_before_offset: edge.call_offset,
-            persistent: edge.persistent,
-        };
-        if index.insert(edge.target_scope, activation) {
-            pending.push((edge.target_scope, activation));
-        }
-    }
-
-    while let Some((scope, activation)) = pending.pop() {
-        if !index.contains(scope, activation) {
-            continue;
-        }
-        for edge in edges_by_caller
-            .get(&Some(scope))
-            .into_iter()
-            .flat_map(|edges| edges.iter())
-        {
-            if activation.activation_offset <= edge.target_binding_offset {
-                continue;
-            }
-            let next = CompatScopeActivation {
-                activation_offset: activation.activation_offset,
-                required_before_offset: activation.required_before_offset.max(edge.call_offset),
-                persistent: activation.persistent && edge.persistent,
-            };
-            if index.insert(edge.target_scope, next) {
-                pending.push((edge.target_scope, next));
-            }
-        }
-    }
-
-    index
-}
-
-fn build_compat_activation_edges_by_caller(
-    checker: &Checker<'_>,
-    call_facts_by_name: &CompatCallFactsByName,
-    function_bindings_by_scope: &CompatFunctionBindingsByScope,
-    call_resolution_cache: &mut FxHashMap<CompatCallResolutionKey, bool>,
-) -> FxHashMap<Option<ScopeId>, Vec<CompatActivationEdge>> {
-    let mut edges_by_caller = FxHashMap::<Option<ScopeId>, Vec<CompatActivationEdge>>::default();
-    let mut seen_edges = FxHashSet::<CompatActivationEdgeKey>::default();
-
-    for (target_scope, binding_ids) in function_bindings_by_scope {
-        for target_binding in binding_ids {
-            let binding = checker.semantic().binding(*target_binding);
-            for fact in call_facts_by_name
-                .get(binding.name.as_str())
-                .into_iter()
-                .flat_map(|facts| facts.iter())
-            {
-                add_compat_activation_edge(
-                    checker,
-                    *target_binding,
-                    *target_scope,
-                    binding.span.start.offset,
-                    fact.scope,
-                    fact.span.start.offset,
-                    fact.span,
-                    fact.span,
-                    call_resolution_cache,
-                    &mut seen_edges,
-                    &mut edges_by_caller,
-                );
-            }
-            for site in checker.semantic().call_sites_for(&binding.name) {
-                add_compat_activation_edge(
-                    checker,
-                    *target_binding,
-                    *target_scope,
-                    binding.span.start.offset,
-                    site.scope,
-                    site.name_span.start.offset,
-                    site.name_span,
-                    site.span,
-                    call_resolution_cache,
-                    &mut seen_edges,
-                    &mut edges_by_caller,
-                );
-            }
-        }
-    }
-
-    edges_by_caller
-}
-
-#[expect(
-    clippy::too_many_arguments,
-    reason = "keeps activation edge construction local"
-)]
-fn add_compat_activation_edge(
-    checker: &Checker<'_>,
-    target_binding: shuck_semantic::BindingId,
-    target_scope: ScopeId,
-    target_binding_offset: usize,
-    call_scope: ScopeId,
-    call_offset: usize,
-    visibility_span: shuck_ast::Span,
-    cfg_span: shuck_ast::Span,
-    call_resolution_cache: &mut FxHashMap<CompatCallResolutionKey, bool>,
-    seen_edges: &mut FxHashSet<CompatActivationEdgeKey>,
-    edges_by_caller: &mut FxHashMap<Option<ScopeId>, Vec<CompatActivationEdge>>,
-) {
-    if !call_may_resolve_to_binding_cached_in(
-        call_resolution_cache,
-        checker,
-        target_binding,
-        call_scope,
-        visibility_span,
-        cfg_span,
-    ) {
-        return;
-    }
-
-    let key = CompatActivationEdgeKey {
-        target_binding,
-        target_scope,
-        call_scope,
-        call_offset,
-    };
-    if !seen_edges.insert(key) {
-        return;
-    }
-
-    let edge = CompatActivationEdge {
-        target_scope,
-        target_binding_offset,
-        call_offset,
-        persistent: !scope_has_transient_ancestor(checker, call_scope),
-    };
-    edges_by_caller
-        .entry(checker.semantic().enclosing_function_scope(call_scope))
-        .or_default()
-        .push(edge);
-}
-
-impl CompatActivationIndex {
-    fn insert(&mut self, scope: ScopeId, activation: CompatScopeActivation) -> bool {
-        let activations = self.activations_by_scope.entry(scope).or_default();
-        if activations
-            .iter()
-            .any(|existing| activation_dominates(*existing, activation))
-        {
-            return false;
-        }
-        activations.retain(|existing| !activation_dominates(activation, *existing));
-        activations.push(activation);
-        true
-    }
-
-    fn contains(&self, scope: ScopeId, activation: CompatScopeActivation) -> bool {
-        self.activations_by_scope
-            .get(&scope)
-            .is_some_and(|activations| activations.contains(&activation))
-    }
-
-    fn scope_can_run_before_offset(
-        &self,
-        checker: &Checker<'_>,
-        scope: ScopeId,
-        before_offset: usize,
-        persistent: bool,
-    ) -> bool {
-        let Some(function_scope) = checker.semantic().enclosing_function_scope(scope) else {
-            return true;
-        };
-        self.activations_by_scope
-            .get(&function_scope)
-            .is_some_and(|activations| {
-                activations.iter().any(|activation| {
-                    activation.required_before_offset <= before_offset
-                        && (!persistent || activation.persistent)
-                })
-            })
-    }
-
-    fn scope_can_run_between_offsets(
-        &self,
-        checker: &Checker<'_>,
-        scope: ScopeId,
-        after_offset: usize,
-        before_offset: usize,
-        persistent: bool,
-    ) -> bool {
-        let Some(function_scope) = checker.semantic().enclosing_function_scope(scope) else {
-            return true;
-        };
-        self.activations_by_scope
-            .get(&function_scope)
-            .is_some_and(|activations| {
-                activations.iter().any(|activation| {
-                    activation.activation_offset > after_offset
-                        && activation.required_before_offset <= before_offset
-                        && (!persistent || activation.persistent)
-                })
-            })
-    }
-}
-
-fn activation_dominates(left: CompatScopeActivation, right: CompatScopeActivation) -> bool {
-    left.activation_offset >= right.activation_offset
-        && left.required_before_offset <= right.required_before_offset
-        && (left.persistent || !right.persistent)
 }
 
 fn build_compat_script_terminator_facts(
@@ -676,9 +399,6 @@ fn build_compat_unset_facts(
 }
 
 fn report_compat_cutoff_function_definitions(checker: &mut Checker<'_>) {
-    let mut scope_run_cache = FxHashMap::default();
-    let mut scope_between_cache = FxHashMap::default();
-    let mut call_resolution_cache = FxHashMap::default();
     let structural_facts = build_compat_structural_facts(checker);
     let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
     let unset_facts = build_compat_unset_facts(
@@ -687,20 +407,8 @@ fn report_compat_cutoff_function_definitions(checker: &mut Checker<'_>) {
         &structural_facts.unset_commands_by_target,
     );
     let script_terminators = build_compat_script_terminator_facts(checker, &structural_facts);
-    let activation_index = build_compat_activation_index(
-        checker,
-        &structural_facts.call_facts_by_name,
-        &function_bindings_by_scope,
-        &mut call_resolution_cache,
-    );
-    let mut reach = CompatReachState {
-        scope_run_cache: &mut scope_run_cache,
-        scope_between_cache: &mut scope_between_cache,
-        call_resolution_cache: &mut call_resolution_cache,
-        call_facts_by_name: &structural_facts.call_facts_by_name,
-        function_bindings_by_scope: &function_bindings_by_scope,
-        activation_index: Some(&activation_index),
-    };
+    let mut reach = build_direct_function_call_reachability(checker);
+    reach.enable_activation_index();
     let candidates = checker
         .semantic()
         .function_definition_bindings()
@@ -713,13 +421,8 @@ fn report_compat_cutoff_function_definitions(checker: &mut Checker<'_>) {
                 &script_terminators,
                 &structural_facts.top_level_control,
             )?;
-            (!has_direct_call_to_binding_before_offset_cached(
-                checker,
-                binding.id,
-                cutoff.offset,
-                &mut reach,
-            ))
-            .then(|| (binding.id, binding.name.to_string(), cutoff.reason))
+            (!binding_has_direct_call_before_offset(&mut reach, binding.id, cutoff.offset))
+                .then(|| (binding.id, binding.name.to_string(), cutoff.reason))
         })
         .collect::<Vec<_>>();
 
@@ -782,8 +485,8 @@ fn report_transient_shadowed_file_scope_definitions(checker: &mut Checker<'_>) {
 
 fn first_compat_cutoff_after_binding(
     checker: &Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
-    reach: &mut CompatReachState<'_>,
+    binding_id: BindingId,
+    reach: &mut DirectFunctionCallReachability<'_, '_>,
     unset_facts: &CompatUnsetFacts,
     script_terminators: &[CompatScriptTerminatorFact],
     top_level_control: &CompatTopLevelControlFacts,
@@ -839,7 +542,7 @@ fn unset_function_cutoff_offsets(
     checker: &Checker<'_>,
     name: &str,
     after_offset: usize,
-    reach: &mut CompatReachState<'_>,
+    reach: &mut DirectFunctionCallReachability<'_, '_>,
     unset_facts: &CompatUnsetFacts,
 ) -> Vec<usize> {
     let mut offsets = unset_facts
@@ -850,12 +553,10 @@ fn unset_function_cutoff_offsets(
         .filter(|fact| {
             fact.offset > after_offset
                 && !command_offset_is_under_dominance_barrier(checker, fact.offset)
-                && command_scope_can_run_persistently_before_offset(
-                    checker,
+                && reach.scope_can_run_before_offset(
                     fact.scope,
                     fact.offset,
-                    reach,
-                    &mut FxHashSet::default(),
+                    FunctionCallPersistence::PersistentOnly,
                 )
         })
         .map(|fact| fact.offset)
@@ -877,12 +578,10 @@ fn unset_function_cutoff_offsets(
                     !command_offset_is_under_dominance_barrier(checker, site.name_span.start.offset)
                 })
                 .filter(|site| {
-                    command_scope_can_run_persistently_before_offset(
-                        checker,
+                    reach.scope_can_run_before_offset(
                         site.scope,
                         site.name_span.start.offset,
-                        reach,
-                        &mut FxHashSet::default(),
+                        FunctionCallPersistence::PersistentOnly,
                     )
                 })
                 .map(|site| site.name_span.start.offset),
@@ -920,9 +619,9 @@ fn command_offset_is_unreachable(checker: &Checker<'_>, offset: usize) -> bool {
 
 fn compat_script_terminator_offsets(
     checker: &Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
+    binding_id: BindingId,
     after_offset: usize,
-    reach: &mut CompatReachState<'_>,
+    reach: &mut DirectFunctionCallReachability<'_, '_>,
     script_terminators: &[CompatScriptTerminatorFact],
 ) -> Vec<usize> {
     let binding = checker.semantic().binding(binding_id);
@@ -955,24 +654,20 @@ fn terminator_scope_can_cut_off_binding(
     binding_is_file_scope: bool,
     terminator_scope: ScopeId,
     terminator_offset: usize,
-    reach: &mut CompatReachState<'_>,
+    reach: &mut DirectFunctionCallReachability<'_, '_>,
 ) -> bool {
     if binding_is_file_scope && !checker.semantic_analysis().cfg().script_always_terminates() {
         return false;
     }
 
-    command_scope_can_run_before_offset(
-        checker,
+    reach.scope_can_run_before_offset(
         binding_scope,
         terminator_offset,
-        reach,
-        &mut FxHashSet::default(),
-    ) && command_scope_can_run_before_offset(
-        checker,
+        FunctionCallPersistence::Any,
+    ) && reach.scope_can_run_before_offset(
         terminator_scope,
         terminator_offset,
-        reach,
-        &mut FxHashSet::default(),
+        FunctionCallPersistence::Any,
     )
 }
 
@@ -988,751 +683,41 @@ fn scope_has_transient_ancestor(checker: &Checker<'_>, scope: ScopeId) -> bool {
 
 fn has_direct_call_to_binding_before_offset(
     checker: &Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
+    binding_id: BindingId,
     before_offset: usize,
 ) -> bool {
-    let mut scope_run_cache = FxHashMap::default();
-    let mut scope_between_cache = FxHashMap::default();
-    let mut call_resolution_cache = FxHashMap::default();
-    let structural_facts = build_compat_structural_facts(checker);
-    let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
-    let mut reach = CompatReachState {
-        scope_run_cache: &mut scope_run_cache,
-        scope_between_cache: &mut scope_between_cache,
-        call_resolution_cache: &mut call_resolution_cache,
-        call_facts_by_name: &structural_facts.call_facts_by_name,
-        function_bindings_by_scope: &function_bindings_by_scope,
-        activation_index: None,
-    };
-    has_direct_call_to_binding_before_offset_cached(checker, binding_id, before_offset, &mut reach)
+    let mut reach = build_direct_function_call_reachability(checker);
+    binding_has_direct_call_before_offset(&mut reach, binding_id, before_offset)
 }
 
-fn has_direct_call_to_binding_before_offset_cached(
-    checker: &Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
+fn binding_has_direct_call_before_offset(
+    reach: &mut DirectFunctionCallReachability<'_, '_>,
+    binding_id: BindingId,
     before_offset: usize,
-    reach: &mut CompatReachState<'_>,
 ) -> bool {
-    let binding = checker.semantic().binding(binding_id);
-    let mut visiting = FxHashSet::default();
-    reach
-        .call_facts_by_name
-        .get(binding.name.as_str())
-        .into_iter()
-        .flat_map(|facts| facts.iter())
-        .any(|fact| {
-            call_may_resolve_to_binding_cached(
-                checker, reach, binding_id, fact.scope, fact.span, fact.span,
-            ) && call_can_reach_binding_before_offset(
-                checker,
-                fact.scope,
-                fact.span.start.offset,
-                binding.span.start.offset,
-                before_offset,
-                reach,
-                &mut visiting,
-            )
-        })
-        || checker
-            .semantic()
-            .call_sites_for(&binding.name)
-            .iter()
-            .any(|site| {
-                call_may_resolve_to_binding_cached(
-                    checker,
-                    reach,
-                    binding_id,
-                    site.scope,
-                    site.name_span,
-                    site.span,
-                ) && call_can_reach_binding_before_offset(
-                    checker,
-                    site.scope,
-                    site.name_span.start.offset,
-                    binding.span.start.offset,
-                    before_offset,
-                    reach,
-                    &mut visiting,
-                )
-            })
+    reach.binding_has_reachable_direct_call(
+        binding_id,
+        DirectFunctionCallWindow::before_offset(before_offset),
+    )
 }
 
 fn has_non_transient_direct_call_to_binding_between_offsets(
     checker: &Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
+    binding_id: BindingId,
     after_offset: usize,
     before_offset: usize,
 ) -> bool {
-    let mut scope_run_cache = FxHashMap::default();
-    let mut scope_between_cache = FxHashMap::default();
-    let mut call_resolution_cache = FxHashMap::default();
-    let structural_facts = build_compat_structural_facts(checker);
-    let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
-    let mut reach = CompatReachState {
-        scope_run_cache: &mut scope_run_cache,
-        scope_between_cache: &mut scope_between_cache,
-        call_resolution_cache: &mut call_resolution_cache,
-        call_facts_by_name: &structural_facts.call_facts_by_name,
-        function_bindings_by_scope: &function_bindings_by_scope,
-        activation_index: None,
-    };
-    let mut visiting = FxHashSet::default();
-    let binding = checker.semantic().binding(binding_id);
-
-    reach
-        .call_facts_by_name
-        .get(binding.name.as_str())
-        .into_iter()
-        .flat_map(|facts| facts.iter())
-        .any(|fact| {
-            let call_offset = fact.span.start.offset;
-            call_offset <= before_offset
-                && !scope_has_transient_ancestor(checker, fact.scope)
-                && call_may_resolve_to_binding_cached(
-                    checker, &mut reach, binding_id, fact.scope, fact.span, fact.span,
-                )
-                && call_scope_can_execute_after_offset_before_offset(
-                    checker,
-                    fact.scope,
-                    call_offset,
-                    after_offset,
-                    before_offset,
-                    &mut reach,
-                    &mut visiting,
-                )
-        })
-        || checker
-            .semantic()
-            .call_sites_for(&binding.name)
-            .iter()
-            .any(|site| {
-                let call_offset = site.name_span.start.offset;
-                call_offset <= before_offset
-                    && !scope_has_transient_ancestor(checker, site.scope)
-                    && call_may_resolve_to_binding_cached(
-                        checker,
-                        &mut reach,
-                        binding_id,
-                        site.scope,
-                        site.name_span,
-                        site.span,
-                    )
-                    && call_scope_can_execute_after_offset_before_offset(
-                        checker,
-                        site.scope,
-                        call_offset,
-                        after_offset,
-                        before_offset,
-                        &mut reach,
-                        &mut visiting,
-                    )
-            })
-}
-
-fn call_can_reach_binding_before_offset(
-    checker: &Checker<'_>,
-    call_scope: ScopeId,
-    call_offset: usize,
-    binding_offset: usize,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    if call_offset > before_offset {
-        return false;
-    }
-
-    call_scope_can_execute_after_offset_before_offset(
-        checker,
-        call_scope,
-        call_offset,
-        binding_offset,
-        before_offset,
-        reach,
-        visiting,
-    )
-}
-
-fn command_scope_can_run_between_offsets(
-    checker: &Checker<'_>,
-    scope: ScopeId,
-    after_offset: usize,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    if let Some(activation_index) = reach.activation_index {
-        return activation_index.scope_can_run_between_offsets(
-            checker,
-            scope,
-            after_offset,
-            before_offset,
-            false,
-        );
-    }
-
-    let Some(function_scope) = checker.semantic().enclosing_function_scope(scope) else {
-        return true;
-    };
-    if !visiting.contains(&function_scope)
-        && let Some(cached) =
-            reach
-                .scope_between_cache
-                .get(&(function_scope, after_offset, before_offset))
-    {
-        return *cached;
-    }
-    if !visiting.insert(function_scope) {
-        return false;
-    }
-
-    let can_run = reach
-        .function_bindings_by_scope
-        .get(&function_scope)
-        .into_iter()
-        .flat_map(|bindings| bindings.iter())
-        .any(|function_binding| {
-            has_call_to_function_binding_between_offsets(
-                checker,
-                *function_binding,
-                after_offset,
-                before_offset,
-                reach,
-                visiting,
-            )
-        });
-
-    visiting.remove(&function_scope);
-    reach
-        .scope_between_cache
-        .insert((function_scope, after_offset, before_offset), can_run);
-    can_run
-}
-
-fn has_call_to_function_binding_between_offsets(
-    checker: &Checker<'_>,
-    function_binding: shuck_semantic::BindingId,
-    after_offset: usize,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    let binding = checker.semantic().binding(function_binding);
-    let required_after = after_offset.max(binding.span.start.offset);
-    reach
-        .call_facts_by_name
-        .get(binding.name.as_str())
-        .into_iter()
-        .flat_map(|facts| facts.iter())
-        .any(|fact| {
-            let call_offset = fact.span.start.offset;
-            call_offset <= before_offset
-                && call_may_resolve_to_binding_cached(
-                    checker,
-                    reach,
-                    function_binding,
-                    fact.scope,
-                    fact.span,
-                    fact.span,
-                )
-                && call_scope_can_execute_after_offset_before_offset(
-                    checker,
-                    fact.scope,
-                    call_offset,
-                    required_after,
-                    before_offset,
-                    reach,
-                    visiting,
-                )
-        })
-        || checker
-            .semantic()
-            .call_sites_for(&binding.name)
-            .iter()
-            .any(|site| {
-                let call_offset = site.name_span.start.offset;
-                call_offset <= before_offset
-                    && call_may_resolve_to_binding_cached(
-                        checker,
-                        reach,
-                        function_binding,
-                        site.scope,
-                        site.name_span,
-                        site.span,
-                    )
-                    && call_scope_can_execute_after_offset_before_offset(
-                        checker,
-                        site.scope,
-                        call_offset,
-                        required_after,
-                        before_offset,
-                        reach,
-                        visiting,
-                    )
-            })
-}
-
-fn command_scope_can_run_before_offset(
-    checker: &Checker<'_>,
-    scope: ScopeId,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    if let Some(activation_index) = reach.activation_index {
-        return activation_index.scope_can_run_before_offset(checker, scope, before_offset, false);
-    }
-
-    let Some(function_scope) = checker.semantic().enclosing_function_scope(scope) else {
-        return true;
-    };
-    if !visiting.contains(&function_scope)
-        && let Some(cached) = reach.scope_run_cache.get(&(function_scope, before_offset))
-    {
-        return *cached;
-    }
-    if !visiting.insert(function_scope) {
-        return false;
-    }
-
-    let can_run = reach
-        .function_bindings_by_scope
-        .get(&function_scope)
-        .into_iter()
-        .flat_map(|bindings| bindings.iter())
-        .any(|function_binding| {
-            has_call_to_function_binding_before_offset(
-                checker,
-                *function_binding,
-                before_offset,
-                reach,
-                visiting,
-            )
-        });
-
-    visiting.remove(&function_scope);
-    reach
-        .scope_run_cache
-        .insert((function_scope, before_offset), can_run);
-    can_run
-}
-
-fn command_scope_can_run_persistently_before_offset(
-    checker: &Checker<'_>,
-    scope: ScopeId,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    if scope_has_transient_ancestor(checker, scope) {
-        return false;
-    }
-    if let Some(activation_index) = reach.activation_index {
-        return activation_index.scope_can_run_before_offset(checker, scope, before_offset, true);
-    }
-
-    let Some(function_scope) = checker.semantic().enclosing_function_scope(scope) else {
-        return true;
-    };
-    if !visiting.insert(function_scope) {
-        return false;
-    }
-
-    let can_run = reach
-        .function_bindings_by_scope
-        .get(&function_scope)
-        .into_iter()
-        .flat_map(|bindings| bindings.iter())
-        .any(|function_binding| {
-            has_persistent_call_to_function_binding_before_offset(
-                checker,
-                *function_binding,
-                before_offset,
-                reach,
-                visiting,
-            )
-        });
-
-    visiting.remove(&function_scope);
-    can_run
-}
-
-fn has_persistent_call_to_function_binding_before_offset(
-    checker: &Checker<'_>,
-    function_binding: shuck_semantic::BindingId,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    let binding = checker.semantic().binding(function_binding);
-    reach
-        .call_facts_by_name
-        .get(binding.name.as_str())
-        .into_iter()
-        .flat_map(|facts| facts.iter())
-        .any(|fact| {
-            fact.span.start.offset <= before_offset
-                && call_may_resolve_to_binding_cached(
-                    checker,
-                    reach,
-                    function_binding,
-                    fact.scope,
-                    fact.span,
-                    fact.span,
-                )
-                && call_scope_can_execute_persistently_after_offset_before_offset(
-                    checker,
-                    fact.scope,
-                    fact.span.start.offset,
-                    binding.span.start.offset,
-                    before_offset,
-                    reach,
-                    visiting,
-                )
-        })
-        || checker
-            .semantic()
-            .call_sites_for(&binding.name)
-            .iter()
-            .any(|site| {
-                site.name_span.start.offset <= before_offset
-                    && call_may_resolve_to_binding_cached(
-                        checker,
-                        reach,
-                        function_binding,
-                        site.scope,
-                        site.name_span,
-                        site.span,
-                    )
-                    && call_scope_can_execute_persistently_after_offset_before_offset(
-                        checker,
-                        site.scope,
-                        site.name_span.start.offset,
-                        binding.span.start.offset,
-                        before_offset,
-                        reach,
-                        visiting,
-                    )
-            })
-}
-
-fn command_scope_can_run_persistently_between_offsets(
-    checker: &Checker<'_>,
-    scope: ScopeId,
-    after_offset: usize,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    if scope_has_transient_ancestor(checker, scope) {
-        return false;
-    }
-    if let Some(activation_index) = reach.activation_index {
-        return activation_index.scope_can_run_between_offsets(
-            checker,
-            scope,
-            after_offset,
-            before_offset,
-            true,
-        );
-    }
-
-    let Some(function_scope) = checker.semantic().enclosing_function_scope(scope) else {
-        return true;
-    };
-    if !visiting.insert(function_scope) {
-        return false;
-    }
-
-    let can_run = reach
-        .function_bindings_by_scope
-        .get(&function_scope)
-        .into_iter()
-        .flat_map(|bindings| bindings.iter())
-        .any(|function_binding| {
-            has_persistent_call_to_function_binding_between_offsets(
-                checker,
-                *function_binding,
-                after_offset,
-                before_offset,
-                reach,
-                visiting,
-            )
-        });
-
-    visiting.remove(&function_scope);
-    can_run
-}
-
-fn has_persistent_call_to_function_binding_between_offsets(
-    checker: &Checker<'_>,
-    function_binding: shuck_semantic::BindingId,
-    after_offset: usize,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    let binding = checker.semantic().binding(function_binding);
-    let required_after = after_offset.max(binding.span.start.offset);
-    reach
-        .call_facts_by_name
-        .get(binding.name.as_str())
-        .into_iter()
-        .flat_map(|facts| facts.iter())
-        .any(|fact| {
-            let call_offset = fact.span.start.offset;
-            call_offset <= before_offset
-                && call_may_resolve_to_binding_cached(
-                    checker,
-                    reach,
-                    function_binding,
-                    fact.scope,
-                    fact.span,
-                    fact.span,
-                )
-                && call_scope_can_execute_persistently_after_offset_before_offset(
-                    checker,
-                    fact.scope,
-                    call_offset,
-                    required_after,
-                    before_offset,
-                    reach,
-                    visiting,
-                )
-        })
-        || checker
-            .semantic()
-            .call_sites_for(&binding.name)
-            .iter()
-            .any(|site| {
-                let call_offset = site.name_span.start.offset;
-                call_offset <= before_offset
-                    && call_may_resolve_to_binding_cached(
-                        checker,
-                        reach,
-                        function_binding,
-                        site.scope,
-                        site.name_span,
-                        site.span,
-                    )
-                    && call_scope_can_execute_persistently_after_offset_before_offset(
-                        checker,
-                        site.scope,
-                        call_offset,
-                        required_after,
-                        before_offset,
-                        reach,
-                        visiting,
-                    )
-            })
-}
-
-fn call_scope_can_execute_persistently_after_offset_before_offset(
-    checker: &Checker<'_>,
-    call_scope: ScopeId,
-    call_offset: usize,
-    after_offset: usize,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    if call_offset > before_offset || scope_has_transient_ancestor(checker, call_scope) {
-        return false;
-    }
-
-    if checker
-        .semantic()
-        .enclosing_function_scope(call_scope)
-        .is_none()
-    {
-        return call_offset > after_offset;
-    }
-
-    command_scope_can_run_persistently_between_offsets(
-        checker,
-        call_scope,
-        after_offset,
-        before_offset,
-        reach,
-        visiting,
-    )
-}
-
-fn has_call_to_function_binding_before_offset(
-    checker: &Checker<'_>,
-    function_binding: shuck_semantic::BindingId,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    let binding = checker.semantic().binding(function_binding);
-    reach
-        .call_facts_by_name
-        .get(binding.name.as_str())
-        .into_iter()
-        .flat_map(|facts| facts.iter())
-        .any(|fact| {
-            fact.span.start.offset <= before_offset
-                && call_may_resolve_to_binding_cached(
-                    checker,
-                    reach,
-                    function_binding,
-                    fact.scope,
-                    fact.span,
-                    fact.span,
-                )
-                && call_scope_can_execute_after_offset_before_offset(
-                    checker,
-                    fact.scope,
-                    fact.span.start.offset,
-                    binding.span.start.offset,
-                    before_offset,
-                    reach,
-                    visiting,
-                )
-        })
-        || checker
-            .semantic()
-            .call_sites_for(&binding.name)
-            .iter()
-            .any(|site| {
-                site.name_span.start.offset <= before_offset
-                    && call_may_resolve_to_binding_cached(
-                        checker,
-                        reach,
-                        function_binding,
-                        site.scope,
-                        site.name_span,
-                        site.span,
-                    )
-                    && call_scope_can_execute_after_offset_before_offset(
-                        checker,
-                        site.scope,
-                        site.name_span.start.offset,
-                        binding.span.start.offset,
-                        before_offset,
-                        reach,
-                        visiting,
-                    )
-            })
-}
-
-fn call_may_resolve_to_binding_cached(
-    checker: &Checker<'_>,
-    reach: &mut CompatReachState<'_>,
-    binding_id: shuck_semantic::BindingId,
-    call_scope: ScopeId,
-    visibility_span: shuck_ast::Span,
-    cfg_span: shuck_ast::Span,
-) -> bool {
-    call_may_resolve_to_binding_cached_in(
-        reach.call_resolution_cache,
-        checker,
+    let mut reach = build_direct_function_call_reachability(checker);
+    reach.binding_has_reachable_direct_call(
         binding_id,
-        call_scope,
-        visibility_span,
-        cfg_span,
-    )
-}
-
-fn call_may_resolve_to_binding_cached_in(
-    call_resolution_cache: &mut FxHashMap<CompatCallResolutionKey, bool>,
-    checker: &Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
-    call_scope: ScopeId,
-    visibility_span: shuck_ast::Span,
-    cfg_span: shuck_ast::Span,
-) -> bool {
-    let key = CompatCallResolutionKey {
-        binding: binding_id,
-        call_scope,
-        visibility_start: visibility_span.start.offset,
-        visibility_end: visibility_span.end.offset,
-        cfg_start: cfg_span.start.offset,
-        cfg_end: cfg_span.end.offset,
-    };
-    if let Some(cached) = call_resolution_cache.get(&key) {
-        return *cached;
-    }
-
-    let resolved =
-        call_may_resolve_to_binding(checker, binding_id, call_scope, visibility_span, cfg_span);
-    call_resolution_cache.insert(key, resolved);
-    resolved
-}
-
-fn call_may_resolve_to_binding(
-    checker: &Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
-    call_scope: ScopeId,
-    visibility_span: shuck_ast::Span,
-    cfg_span: shuck_ast::Span,
-) -> bool {
-    let binding = checker.semantic().binding(binding_id);
-    let has_prior_shadowing_function_definition =
-        checker.facts().function_headers().iter().any(|header| {
-            let Some((name, name_span)) = header.static_name_entry() else {
-                return false;
-            };
-            if name != &binding.name || name_span.start.offset >= visibility_span.start.offset {
-                return false;
-            }
-            if header.binding_id() == Some(binding_id) {
-                return false;
-            }
-            header.function_scope().is_some_and(|scope| {
-                checker
-                    .semantic()
-                    .ancestor_scopes(call_scope)
-                    .any(|ancestor| ancestor == scope)
-            })
-        });
-
-    checker
-        .semantic_analysis()
-        .function_call_may_resolve_to_binding(
-            binding_id,
-            call_scope,
-            visibility_span,
-            cfg_span,
-            has_prior_shadowing_function_definition,
-        )
-}
-
-fn call_scope_can_execute_after_offset_before_offset(
-    checker: &Checker<'_>,
-    call_scope: ScopeId,
-    call_offset: usize,
-    after_offset: usize,
-    before_offset: usize,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    if call_offset > before_offset {
-        return false;
-    }
-
-    if checker
-        .semantic()
-        .enclosing_function_scope(call_scope)
-        .is_none()
-    {
-        return call_offset > after_offset;
-    }
-
-    command_scope_can_run_between_offsets(
-        checker,
-        call_scope,
-        after_offset,
-        before_offset,
-        reach,
-        visiting,
+        DirectFunctionCallWindow::between_offsets(after_offset, before_offset)
+            .require_non_transient_call(),
     )
 }
 
 fn report_function_definition(
     checker: &mut Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
+    binding_id: BindingId,
     name: String,
     reason: FunctionNotReachedReason,
 ) {
@@ -1866,239 +851,22 @@ fn enclosing_function_scope_can_run_persistently(checker: &Checker<'_>, scope: S
         return false;
     }
 
-    let mut scope_run_cache = FxHashMap::default();
-    let mut scope_between_cache = FxHashMap::default();
-    let mut call_resolution_cache = FxHashMap::default();
-    let structural_facts = build_compat_structural_facts(checker);
-    let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
-    let mut reach = CompatReachState {
-        scope_run_cache: &mut scope_run_cache,
-        scope_between_cache: &mut scope_between_cache,
-        call_resolution_cache: &mut call_resolution_cache,
-        call_facts_by_name: &structural_facts.call_facts_by_name,
-        function_bindings_by_scope: &function_bindings_by_scope,
-        activation_index: None,
-    };
-
-    command_scope_can_run_persistently_before_offset(
-        checker,
-        scope,
-        usize::MAX,
-        &mut reach,
-        &mut FxHashSet::default(),
-    )
+    let mut reach = build_direct_function_call_reachability(checker);
+    reach.scope_can_run_before_offset(scope, usize::MAX, FunctionCallPersistence::PersistentOnly)
 }
 
-fn has_direct_call_inside_enclosing_function(
-    checker: &Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
-) -> bool {
+fn has_direct_call_inside_enclosing_function(checker: &Checker<'_>, binding_id: BindingId) -> bool {
     let binding = checker.semantic().binding(binding_id);
     let Some(enclosing_scope) = checker.semantic().enclosing_function_scope(binding.scope) else {
         return false;
     };
 
-    let mut scope_run_cache = FxHashMap::default();
-    let mut scope_between_cache = FxHashMap::default();
-    let mut call_resolution_cache = FxHashMap::default();
-    let structural_facts = build_compat_structural_facts(checker);
-    let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
-    let mut reach = CompatReachState {
-        scope_run_cache: &mut scope_run_cache,
-        scope_between_cache: &mut scope_between_cache,
-        call_resolution_cache: &mut call_resolution_cache,
-        call_facts_by_name: &structural_facts.call_facts_by_name,
-        function_bindings_by_scope: &function_bindings_by_scope,
-        activation_index: None,
-    };
-    let mut visiting = FxHashSet::default();
-    let window = BoundaryCallWindow {
-        after_offset: binding.span.start.offset,
-        before_offset: usize::MAX,
-        boundary_scope: enclosing_scope,
-    };
-
-    reach
-        .call_facts_by_name
-        .get(binding.name.as_str())
-        .into_iter()
-        .flat_map(|facts| facts.iter())
-        .any(|fact| {
-            checker
-                .semantic()
-                .scope_is_in_scope_or_descendant(fact.scope, enclosing_scope)
-                && call_may_resolve_to_binding_cached(
-                    checker, &mut reach, binding_id, fact.scope, fact.span, fact.span,
-                )
-                && call_scope_can_execute_inside_boundary_after_offset_before_offset(
-                    checker,
-                    fact.scope,
-                    fact.span.start.offset,
-                    window,
-                    &mut reach,
-                    &mut visiting,
-                )
-        })
-        || checker
-            .semantic()
-            .call_sites_for(&binding.name)
-            .iter()
-            .any(|site| {
-                checker
-                    .semantic()
-                    .scope_is_in_scope_or_descendant(site.scope, enclosing_scope)
-                    && call_may_resolve_to_binding_cached(
-                        checker,
-                        &mut reach,
-                        binding_id,
-                        site.scope,
-                        site.name_span,
-                        site.span,
-                    )
-                    && call_scope_can_execute_inside_boundary_after_offset_before_offset(
-                        checker,
-                        site.scope,
-                        site.name_span.start.offset,
-                        window,
-                        &mut reach,
-                        &mut visiting,
-                    )
-            })
-}
-
-fn call_scope_can_execute_inside_boundary_after_offset_before_offset(
-    checker: &Checker<'_>,
-    call_scope: ScopeId,
-    call_offset: usize,
-    window: BoundaryCallWindow,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    if call_offset > window.before_offset {
-        return false;
-    }
-
-    let Some(function_scope) = checker.semantic().enclosing_function_scope(call_scope) else {
-        return call_offset > window.after_offset;
-    };
-    if function_scope == window.boundary_scope {
-        return call_offset > window.after_offset;
-    }
-
-    command_scope_can_run_inside_boundary_between_offsets(
-        checker, call_scope, window, reach, visiting,
+    let mut reach = build_direct_function_call_reachability(checker);
+    reach.binding_has_reachable_direct_call(
+        binding_id,
+        DirectFunctionCallWindow::between_offsets(binding.span.start.offset, usize::MAX)
+            .within_scope(enclosing_scope),
     )
-}
-
-fn command_scope_can_run_inside_boundary_between_offsets(
-    checker: &Checker<'_>,
-    scope: ScopeId,
-    window: BoundaryCallWindow,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    let Some(function_scope) = checker.semantic().enclosing_function_scope(scope) else {
-        return true;
-    };
-    if function_scope == window.boundary_scope {
-        return true;
-    }
-    if !checker
-        .semantic()
-        .scope_is_in_scope_or_descendant(function_scope, window.boundary_scope)
-    {
-        return false;
-    }
-    if !visiting.insert(function_scope) {
-        return false;
-    }
-
-    let can_run = reach
-        .function_bindings_by_scope
-        .get(&function_scope)
-        .into_iter()
-        .flat_map(|bindings| bindings.iter())
-        .any(|function_binding| {
-            has_call_to_function_binding_inside_boundary_between_offsets(
-                checker,
-                *function_binding,
-                window,
-                reach,
-                visiting,
-            )
-        });
-
-    visiting.remove(&function_scope);
-    can_run
-}
-
-fn has_call_to_function_binding_inside_boundary_between_offsets(
-    checker: &Checker<'_>,
-    function_binding: shuck_semantic::BindingId,
-    window: BoundaryCallWindow,
-    reach: &mut CompatReachState<'_>,
-    visiting: &mut FxHashSet<ScopeId>,
-) -> bool {
-    let binding = checker.semantic().binding(function_binding);
-    let nested_window = BoundaryCallWindow {
-        after_offset: window.after_offset.max(binding.span.start.offset),
-        ..window
-    };
-    reach
-        .call_facts_by_name
-        .get(binding.name.as_str())
-        .into_iter()
-        .flat_map(|facts| facts.iter())
-        .any(|fact| {
-            let call_offset = fact.span.start.offset;
-            call_offset <= window.before_offset
-                && checker
-                    .semantic()
-                    .scope_is_in_scope_or_descendant(fact.scope, window.boundary_scope)
-                && call_may_resolve_to_binding_cached(
-                    checker,
-                    reach,
-                    function_binding,
-                    fact.scope,
-                    fact.span,
-                    fact.span,
-                )
-                && call_scope_can_execute_inside_boundary_after_offset_before_offset(
-                    checker,
-                    fact.scope,
-                    call_offset,
-                    nested_window,
-                    reach,
-                    visiting,
-                )
-        })
-        || checker
-            .semantic()
-            .call_sites_for(&binding.name)
-            .iter()
-            .any(|site| {
-                let call_offset = site.name_span.start.offset;
-                call_offset <= window.before_offset
-                    && checker
-                        .semantic()
-                        .scope_is_in_scope_or_descendant(site.scope, window.boundary_scope)
-                    && call_may_resolve_to_binding_cached(
-                        checker,
-                        reach,
-                        function_binding,
-                        site.scope,
-                        site.name_span,
-                        site.span,
-                    )
-                    && call_scope_can_execute_inside_boundary_after_offset_before_offset(
-                        checker,
-                        site.scope,
-                        call_offset,
-                        nested_window,
-                        reach,
-                        visiting,
-                    )
-            })
 }
 
 fn has_apparent_infinite_loop_after(checker: &Checker<'_>, offset: usize) -> bool {
@@ -2191,13 +959,7 @@ fn enclosing_function_has_reportable_c063_diagnostic(
     has_unreached_diagnostic || has_overwrite_diagnostic || has_compat_cutoff_diagnostic
 }
 
-fn compat_cutoff_would_report_binding(
-    checker: &Checker<'_>,
-    binding_id: shuck_semantic::BindingId,
-) -> bool {
-    let mut scope_run_cache = FxHashMap::default();
-    let mut scope_between_cache = FxHashMap::default();
-    let mut call_resolution_cache = FxHashMap::default();
+fn compat_cutoff_would_report_binding(checker: &Checker<'_>, binding_id: BindingId) -> bool {
     let structural_facts = build_compat_structural_facts(checker);
     let function_bindings_by_scope = build_compat_function_bindings_by_scope(checker);
     let unset_facts = build_compat_unset_facts(
@@ -2206,14 +968,7 @@ fn compat_cutoff_would_report_binding(
         &structural_facts.unset_commands_by_target,
     );
     let script_terminators = build_compat_script_terminator_facts(checker, &structural_facts);
-    let mut reach = CompatReachState {
-        scope_run_cache: &mut scope_run_cache,
-        scope_between_cache: &mut scope_between_cache,
-        call_resolution_cache: &mut call_resolution_cache,
-        call_facts_by_name: &structural_facts.call_facts_by_name,
-        function_bindings_by_scope: &function_bindings_by_scope,
-        activation_index: None,
-    };
+    let mut reach = build_direct_function_call_reachability(checker);
     let Some(cutoff) = first_compat_cutoff_after_binding(
         checker,
         binding_id,
@@ -2225,7 +980,7 @@ fn compat_cutoff_would_report_binding(
         return false;
     };
 
-    !has_direct_call_to_binding_before_offset_cached(checker, binding_id, cutoff.offset, &mut reach)
+    !binding_has_direct_call_before_offset(&mut reach, binding_id, cutoff.offset)
 }
 
 #[cfg(test)]

--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -179,6 +179,13 @@ impl<'model> SemanticAnalysis<'model> {
             .map(|(scope, bindings)| (*scope, bindings.as_slice()))
     }
 
+    pub fn direct_function_call_reachability<'analysis>(
+        &'analysis self,
+        supplemental_calls: impl IntoIterator<Item = FunctionCallCandidate>,
+    ) -> DirectFunctionCallReachability<'analysis, 'model> {
+        DirectFunctionCallReachability::new(self, supplemental_calls)
+    }
+
     #[doc(hidden)]
     pub fn block_ids_for_span(&self, span: Span) -> &[BlockId] {
         self.cfg().block_ids_for_span(span)

--- a/crates/shuck-semantic/src/function_call_reachability.rs
+++ b/crates/shuck-semantic/src/function_call_reachability.rs
@@ -1,0 +1,815 @@
+use super::*;
+
+/// Direct function-call candidate supplied by higher-level analyses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FunctionCallCandidate {
+    pub callee: Name,
+    pub scope: ScopeId,
+    pub name_span: Span,
+    pub command_span: Span,
+}
+
+/// Controls whether transient execution contexts are accepted for a direct-call query.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum FunctionCallPersistence {
+    #[default]
+    Any,
+    PersistentOnly,
+}
+
+/// Offset and scope constraints for a direct function-call reachability query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DirectFunctionCallWindow {
+    pub after_offset: usize,
+    pub before_offset: usize,
+    pub persistence: FunctionCallPersistence,
+    pub scope_boundary: Option<ScopeId>,
+    pub require_non_transient_call: bool,
+}
+
+impl DirectFunctionCallWindow {
+    pub fn before_offset(before_offset: usize) -> Self {
+        Self {
+            after_offset: 0,
+            before_offset,
+            persistence: FunctionCallPersistence::Any,
+            scope_boundary: None,
+            require_non_transient_call: false,
+        }
+    }
+
+    pub fn between_offsets(after_offset: usize, before_offset: usize) -> Self {
+        Self {
+            after_offset,
+            before_offset,
+            persistence: FunctionCallPersistence::Any,
+            scope_boundary: None,
+            require_non_transient_call: false,
+        }
+    }
+
+    pub fn persistent(mut self) -> Self {
+        self.persistence = FunctionCallPersistence::PersistentOnly;
+        self
+    }
+
+    pub fn require_non_transient_call(mut self) -> Self {
+        self.require_non_transient_call = true;
+        self
+    }
+
+    pub fn within_scope(mut self, scope: ScopeId) -> Self {
+        self.scope_boundary = Some(scope);
+        self
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct FunctionCallResolutionKey {
+    binding: BindingId,
+    call_scope: ScopeId,
+    visibility_start: usize,
+    visibility_end: usize,
+    cfg_start: usize,
+    cfg_end: usize,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct FunctionScopeActivation {
+    activation_offset: usize,
+    required_before_offset: usize,
+    persistent: bool,
+}
+
+struct FunctionActivationIndex {
+    activations_by_scope: FxHashMap<ScopeId, Vec<FunctionScopeActivation>>,
+}
+
+#[derive(Clone, Copy)]
+struct FunctionActivationEdge {
+    target_scope: ScopeId,
+    target_binding_offset: usize,
+    call_offset: usize,
+    persistent: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct FunctionActivationEdgeKey {
+    target_binding: BindingId,
+    target_scope: ScopeId,
+    call_scope: ScopeId,
+    call_offset: usize,
+}
+
+#[derive(Clone, Copy)]
+struct BoundaryCallWindow {
+    after_offset: usize,
+    before_offset: usize,
+    boundary_scope: ScopeId,
+    persistence: FunctionCallPersistence,
+    require_non_transient_call: bool,
+}
+
+/// Reachability engine for direct calls to function bindings.
+pub struct DirectFunctionCallReachability<'analysis, 'model> {
+    analysis: &'analysis SemanticAnalysis<'model>,
+    supplemental_calls_by_name: FxHashMap<Name, Vec<FunctionCallCandidate>>,
+    scope_run_cache: FxHashMap<(ScopeId, usize), bool>,
+    scope_between_cache: FxHashMap<(ScopeId, usize, usize), bool>,
+    call_resolution_cache: FxHashMap<FunctionCallResolutionKey, bool>,
+    activation_index: Option<FunctionActivationIndex>,
+}
+
+impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
+    pub(crate) fn new(
+        analysis: &'analysis SemanticAnalysis<'model>,
+        supplemental_calls: impl IntoIterator<Item = FunctionCallCandidate>,
+    ) -> Self {
+        let mut supplemental_calls_by_name =
+            FxHashMap::<Name, Vec<FunctionCallCandidate>>::default();
+        for call in supplemental_calls {
+            supplemental_calls_by_name
+                .entry(call.callee.clone())
+                .or_default()
+                .push(call);
+        }
+
+        Self {
+            analysis,
+            supplemental_calls_by_name,
+            scope_run_cache: FxHashMap::default(),
+            scope_between_cache: FxHashMap::default(),
+            call_resolution_cache: FxHashMap::default(),
+            activation_index: None,
+        }
+    }
+
+    pub fn enable_activation_index(&mut self) {
+        if self.activation_index.is_none() {
+            self.activation_index = Some(self.build_activation_index());
+        }
+    }
+
+    pub fn binding_has_reachable_direct_call(
+        &mut self,
+        binding_id: BindingId,
+        window: DirectFunctionCallWindow,
+    ) -> bool {
+        let binding = self.analysis.model.binding(binding_id);
+        let after_offset = window.after_offset.max(binding.span.start.offset);
+        if let Some(boundary_scope) = window.scope_boundary {
+            let window = BoundaryCallWindow {
+                after_offset,
+                before_offset: window.before_offset,
+                boundary_scope,
+                persistence: window.persistence,
+                require_non_transient_call: window.require_non_transient_call,
+            };
+            return self.has_call_to_function_binding_inside_boundary(binding_id, window);
+        }
+
+        self.has_call_to_function_binding_between_offsets(
+            binding_id,
+            after_offset,
+            window.before_offset,
+            window.persistence,
+            window.require_non_transient_call,
+            &mut FxHashSet::default(),
+        )
+    }
+
+    pub fn scope_can_run_before_offset(
+        &mut self,
+        scope: ScopeId,
+        before_offset: usize,
+        persistence: FunctionCallPersistence,
+    ) -> bool {
+        match persistence {
+            FunctionCallPersistence::Any => self.command_scope_can_run_before_offset(
+                scope,
+                before_offset,
+                &mut FxHashSet::default(),
+            ),
+            FunctionCallPersistence::PersistentOnly => self
+                .command_scope_can_run_persistently_before_offset(
+                    scope,
+                    before_offset,
+                    &mut FxHashSet::default(),
+                ),
+        }
+    }
+
+    pub fn scope_can_run_between_offsets(
+        &mut self,
+        scope: ScopeId,
+        after_offset: usize,
+        before_offset: usize,
+        persistence: FunctionCallPersistence,
+    ) -> bool {
+        match persistence {
+            FunctionCallPersistence::Any => self.command_scope_can_run_between_offsets(
+                scope,
+                after_offset,
+                before_offset,
+                &mut FxHashSet::default(),
+            ),
+            FunctionCallPersistence::PersistentOnly => self
+                .command_scope_can_run_persistently_between_offsets(
+                    scope,
+                    after_offset,
+                    before_offset,
+                    &mut FxHashSet::default(),
+                ),
+        }
+    }
+
+    fn model(&self) -> &'model SemanticModel {
+        self.analysis.model
+    }
+
+    fn call_candidates_for(&self, name: &Name) -> Vec<FunctionCallCandidate> {
+        let mut candidates = self
+            .supplemental_calls_by_name
+            .get(name)
+            .cloned()
+            .unwrap_or_default();
+        candidates.extend(self.model().call_sites_for(name).iter().map(|site| {
+            FunctionCallCandidate {
+                callee: site.callee.clone(),
+                scope: site.scope,
+                name_span: site.name_span,
+                command_span: site.span,
+            }
+        }));
+        candidates
+    }
+
+    fn build_activation_index(&mut self) -> FunctionActivationIndex {
+        let edges_by_caller = self.build_activation_edges_by_caller();
+        let mut index = FunctionActivationIndex {
+            activations_by_scope: FxHashMap::default(),
+        };
+        let mut pending = Vec::new();
+
+        for edge in edges_by_caller
+            .get(&None)
+            .into_iter()
+            .flat_map(|edges| edges.iter())
+        {
+            if edge.call_offset <= edge.target_binding_offset {
+                continue;
+            }
+            let activation = FunctionScopeActivation {
+                activation_offset: edge.call_offset,
+                required_before_offset: edge.call_offset,
+                persistent: edge.persistent,
+            };
+            if index.insert(edge.target_scope, activation) {
+                pending.push((edge.target_scope, activation));
+            }
+        }
+
+        while let Some((scope, activation)) = pending.pop() {
+            if !index.contains(scope, activation) {
+                continue;
+            }
+            for edge in edges_by_caller
+                .get(&Some(scope))
+                .into_iter()
+                .flat_map(|edges| edges.iter())
+            {
+                if activation.activation_offset <= edge.target_binding_offset {
+                    continue;
+                }
+                let next = FunctionScopeActivation {
+                    activation_offset: activation.activation_offset,
+                    required_before_offset: activation.required_before_offset.max(edge.call_offset),
+                    persistent: activation.persistent && edge.persistent,
+                };
+                if index.insert(edge.target_scope, next) {
+                    pending.push((edge.target_scope, next));
+                }
+            }
+        }
+
+        index
+    }
+
+    fn build_activation_edges_by_caller(
+        &mut self,
+    ) -> FxHashMap<Option<ScopeId>, Vec<FunctionActivationEdge>> {
+        let mut edges_by_caller =
+            FxHashMap::<Option<ScopeId>, Vec<FunctionActivationEdge>>::default();
+        let mut seen_edges = FxHashSet::<FunctionActivationEdgeKey>::default();
+        let scope_bindings = self
+            .model()
+            .function_binding_scope_index()
+            .iter()
+            .map(|(scope, bindings)| (*scope, bindings.to_vec()))
+            .collect::<Vec<_>>();
+
+        for (target_scope, binding_ids) in scope_bindings {
+            for target_binding in binding_ids {
+                let binding = self.model().binding(target_binding);
+                for call in self.call_candidates_for(&binding.name) {
+                    self.add_activation_edge(
+                        target_binding,
+                        target_scope,
+                        binding.span.start.offset,
+                        &call,
+                        &mut seen_edges,
+                        &mut edges_by_caller,
+                    );
+                }
+            }
+        }
+
+        edges_by_caller
+    }
+
+    fn add_activation_edge(
+        &mut self,
+        target_binding: BindingId,
+        target_scope: ScopeId,
+        target_binding_offset: usize,
+        call: &FunctionCallCandidate,
+        seen_edges: &mut FxHashSet<FunctionActivationEdgeKey>,
+        edges_by_caller: &mut FxHashMap<Option<ScopeId>, Vec<FunctionActivationEdge>>,
+    ) {
+        if !self.call_may_resolve_to_binding_cached(target_binding, call) {
+            return;
+        }
+
+        let key = FunctionActivationEdgeKey {
+            target_binding,
+            target_scope,
+            call_scope: call.scope,
+            call_offset: call.name_span.start.offset,
+        };
+        if !seen_edges.insert(key) {
+            return;
+        }
+
+        let edge = FunctionActivationEdge {
+            target_scope,
+            target_binding_offset,
+            call_offset: call.name_span.start.offset,
+            persistent: !self.analysis.scope_runs_in_transient_context(call.scope),
+        };
+        edges_by_caller
+            .entry(self.enclosing_function_scope(call.scope))
+            .or_default()
+            .push(edge);
+    }
+
+    fn command_scope_can_run_between_offsets(
+        &mut self,
+        scope: ScopeId,
+        after_offset: usize,
+        before_offset: usize,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        if let Some(activation_index) = &self.activation_index {
+            return activation_index.scope_can_run_between_offsets(
+                self,
+                scope,
+                after_offset,
+                before_offset,
+                false,
+            );
+        }
+
+        let Some(function_scope) = self.enclosing_function_scope(scope) else {
+            return true;
+        };
+        if !visiting.contains(&function_scope)
+            && let Some(cached) =
+                self.scope_between_cache
+                    .get(&(function_scope, after_offset, before_offset))
+        {
+            return *cached;
+        }
+        if !visiting.insert(function_scope) {
+            return false;
+        }
+
+        let binding_ids = self.function_bindings_for_scope(function_scope);
+        let can_run = binding_ids.into_iter().any(|function_binding| {
+            self.has_call_to_function_binding_between_offsets(
+                function_binding,
+                after_offset,
+                before_offset,
+                FunctionCallPersistence::Any,
+                false,
+                visiting,
+            )
+        });
+
+        visiting.remove(&function_scope);
+        self.scope_between_cache
+            .insert((function_scope, after_offset, before_offset), can_run);
+        can_run
+    }
+
+    fn command_scope_can_run_before_offset(
+        &mut self,
+        scope: ScopeId,
+        before_offset: usize,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        if let Some(activation_index) = &self.activation_index {
+            return activation_index.scope_can_run_before_offset(self, scope, before_offset, false);
+        }
+
+        let Some(function_scope) = self.enclosing_function_scope(scope) else {
+            return true;
+        };
+        if !visiting.contains(&function_scope)
+            && let Some(cached) = self.scope_run_cache.get(&(function_scope, before_offset))
+        {
+            return *cached;
+        }
+        if !visiting.insert(function_scope) {
+            return false;
+        }
+
+        let binding_ids = self.function_bindings_for_scope(function_scope);
+        let can_run = binding_ids.into_iter().any(|function_binding| {
+            self.has_call_to_function_binding_between_offsets(
+                function_binding,
+                0,
+                before_offset,
+                FunctionCallPersistence::Any,
+                false,
+                visiting,
+            )
+        });
+
+        visiting.remove(&function_scope);
+        self.scope_run_cache
+            .insert((function_scope, before_offset), can_run);
+        can_run
+    }
+
+    fn command_scope_can_run_persistently_before_offset(
+        &mut self,
+        scope: ScopeId,
+        before_offset: usize,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        if self.analysis.scope_runs_in_transient_context(scope) {
+            return false;
+        }
+        if let Some(activation_index) = &self.activation_index {
+            return activation_index.scope_can_run_before_offset(self, scope, before_offset, true);
+        }
+
+        let Some(function_scope) = self.enclosing_function_scope(scope) else {
+            return true;
+        };
+        if !visiting.insert(function_scope) {
+            return false;
+        }
+
+        let binding_ids = self.function_bindings_for_scope(function_scope);
+        let can_run = binding_ids.into_iter().any(|function_binding| {
+            self.has_call_to_function_binding_between_offsets(
+                function_binding,
+                0,
+                before_offset,
+                FunctionCallPersistence::PersistentOnly,
+                false,
+                visiting,
+            )
+        });
+
+        visiting.remove(&function_scope);
+        can_run
+    }
+
+    fn command_scope_can_run_persistently_between_offsets(
+        &mut self,
+        scope: ScopeId,
+        after_offset: usize,
+        before_offset: usize,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        if self.analysis.scope_runs_in_transient_context(scope) {
+            return false;
+        }
+        if let Some(activation_index) = &self.activation_index {
+            return activation_index.scope_can_run_between_offsets(
+                self,
+                scope,
+                after_offset,
+                before_offset,
+                true,
+            );
+        }
+
+        let Some(function_scope) = self.enclosing_function_scope(scope) else {
+            return true;
+        };
+        if !visiting.insert(function_scope) {
+            return false;
+        }
+
+        let binding_ids = self.function_bindings_for_scope(function_scope);
+        let can_run = binding_ids.into_iter().any(|function_binding| {
+            self.has_call_to_function_binding_between_offsets(
+                function_binding,
+                after_offset,
+                before_offset,
+                FunctionCallPersistence::PersistentOnly,
+                false,
+                visiting,
+            )
+        });
+
+        visiting.remove(&function_scope);
+        can_run
+    }
+
+    fn has_call_to_function_binding_between_offsets(
+        &mut self,
+        function_binding: BindingId,
+        after_offset: usize,
+        before_offset: usize,
+        persistence: FunctionCallPersistence,
+        require_non_transient_call: bool,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let binding = self.model().binding(function_binding);
+        let required_after = after_offset.max(binding.span.start.offset);
+        self.call_candidates_for(&binding.name)
+            .into_iter()
+            .any(|call| {
+                let call_offset = call.name_span.start.offset;
+                call_offset <= before_offset
+                    && (!require_non_transient_call
+                        || !self.analysis.scope_runs_in_transient_context(call.scope))
+                    && self.call_may_resolve_to_binding_cached(function_binding, &call)
+                    && self.call_scope_can_execute_after_offset_before_offset(
+                        call.scope,
+                        call_offset,
+                        required_after,
+                        before_offset,
+                        persistence,
+                        visiting,
+                    )
+            })
+    }
+
+    fn call_scope_can_execute_after_offset_before_offset(
+        &mut self,
+        call_scope: ScopeId,
+        call_offset: usize,
+        after_offset: usize,
+        before_offset: usize,
+        persistence: FunctionCallPersistence,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        if call_offset > before_offset {
+            return false;
+        }
+        if matches!(persistence, FunctionCallPersistence::PersistentOnly)
+            && self.analysis.scope_runs_in_transient_context(call_scope)
+        {
+            return false;
+        }
+
+        if self.enclosing_function_scope(call_scope).is_none() {
+            return call_offset > after_offset;
+        }
+
+        match persistence {
+            FunctionCallPersistence::Any => self.command_scope_can_run_between_offsets(
+                call_scope,
+                after_offset,
+                before_offset,
+                visiting,
+            ),
+            FunctionCallPersistence::PersistentOnly => self
+                .command_scope_can_run_persistently_between_offsets(
+                    call_scope,
+                    after_offset,
+                    before_offset,
+                    visiting,
+                ),
+        }
+    }
+
+    fn has_call_to_function_binding_inside_boundary(
+        &mut self,
+        function_binding: BindingId,
+        window: BoundaryCallWindow,
+    ) -> bool {
+        self.has_call_to_function_binding_inside_boundary_with_visiting(
+            function_binding,
+            window,
+            &mut FxHashSet::default(),
+        )
+    }
+
+    fn has_call_to_function_binding_inside_boundary_with_visiting(
+        &mut self,
+        function_binding: BindingId,
+        window: BoundaryCallWindow,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let binding = self.model().binding(function_binding);
+        let nested_window = BoundaryCallWindow {
+            after_offset: window.after_offset.max(binding.span.start.offset),
+            ..window
+        };
+        self.call_candidates_for(&binding.name)
+            .into_iter()
+            .any(|call| {
+                let call_offset = call.name_span.start.offset;
+                call_offset <= window.before_offset
+                    && self.call_is_inside_scope(call.scope, window.boundary_scope)
+                    && (!window.require_non_transient_call
+                        || !self.analysis.scope_runs_in_transient_context(call.scope))
+                    && (!matches!(window.persistence, FunctionCallPersistence::PersistentOnly)
+                        || !self.analysis.scope_runs_in_transient_context(call.scope))
+                    && self.call_may_resolve_to_binding_cached(function_binding, &call)
+                    && self.call_scope_can_execute_inside_boundary_after_offset_before_offset(
+                        call.scope,
+                        call_offset,
+                        nested_window,
+                        visiting,
+                    )
+            })
+    }
+
+    fn call_scope_can_execute_inside_boundary_after_offset_before_offset(
+        &mut self,
+        call_scope: ScopeId,
+        call_offset: usize,
+        window: BoundaryCallWindow,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        if call_offset > window.before_offset {
+            return false;
+        }
+
+        let Some(function_scope) = self.enclosing_function_scope(call_scope) else {
+            return call_offset > window.after_offset;
+        };
+        if function_scope == window.boundary_scope {
+            return call_offset > window.after_offset;
+        }
+
+        self.command_scope_can_run_inside_boundary_between_offsets(call_scope, window, visiting)
+    }
+
+    fn command_scope_can_run_inside_boundary_between_offsets(
+        &mut self,
+        scope: ScopeId,
+        window: BoundaryCallWindow,
+        visiting: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        let Some(function_scope) = self.enclosing_function_scope(scope) else {
+            return true;
+        };
+        if function_scope == window.boundary_scope {
+            return true;
+        }
+        if !self.call_is_inside_scope(function_scope, window.boundary_scope) {
+            return false;
+        }
+        if !visiting.insert(function_scope) {
+            return false;
+        }
+
+        let binding_ids = self.function_bindings_for_scope(function_scope);
+        let can_run = binding_ids.into_iter().any(|function_binding| {
+            self.has_call_to_function_binding_inside_boundary_with_visiting(
+                function_binding,
+                window,
+                visiting,
+            )
+        });
+
+        visiting.remove(&function_scope);
+        can_run
+    }
+
+    fn call_may_resolve_to_binding_cached(
+        &mut self,
+        binding_id: BindingId,
+        call: &FunctionCallCandidate,
+    ) -> bool {
+        let key = FunctionCallResolutionKey {
+            binding: binding_id,
+            call_scope: call.scope,
+            visibility_start: call.name_span.start.offset,
+            visibility_end: call.name_span.end.offset,
+            cfg_start: call.command_span.start.offset,
+            cfg_end: call.command_span.end.offset,
+        };
+        if let Some(cached) = self.call_resolution_cache.get(&key) {
+            return *cached;
+        }
+
+        let resolved = self.analysis.function_call_may_resolve_to_binding(
+            binding_id,
+            call.scope,
+            call.name_span,
+            call.command_span,
+        );
+        self.call_resolution_cache.insert(key, resolved);
+        resolved
+    }
+
+    fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
+        self.model()
+            .ancestor_scopes(scope)
+            .find(|scope_id| matches!(self.model().scope_kind(*scope_id), ScopeKind::Function(_)))
+    }
+
+    fn call_is_inside_scope(&self, scope: ScopeId, ancestor_scope: ScopeId) -> bool {
+        scope == ancestor_scope
+            || self
+                .model()
+                .ancestor_scopes(scope)
+                .any(|scope| scope == ancestor_scope)
+    }
+
+    fn function_bindings_for_scope(&self, scope: ScopeId) -> Vec<BindingId> {
+        self.model()
+            .function_binding_scope_index()
+            .get(&scope)
+            .map(|bindings| bindings.iter().copied().collect())
+            .unwrap_or_default()
+    }
+}
+
+impl FunctionActivationIndex {
+    fn insert(&mut self, scope: ScopeId, activation: FunctionScopeActivation) -> bool {
+        let activations = self.activations_by_scope.entry(scope).or_default();
+        if activations
+            .iter()
+            .any(|existing| activation_dominates(*existing, activation))
+        {
+            return false;
+        }
+        activations.retain(|existing| !activation_dominates(activation, *existing));
+        activations.push(activation);
+        true
+    }
+
+    fn contains(&self, scope: ScopeId, activation: FunctionScopeActivation) -> bool {
+        self.activations_by_scope
+            .get(&scope)
+            .is_some_and(|activations| activations.contains(&activation))
+    }
+
+    fn scope_can_run_before_offset(
+        &self,
+        reachability: &DirectFunctionCallReachability<'_, '_>,
+        scope: ScopeId,
+        before_offset: usize,
+        persistent: bool,
+    ) -> bool {
+        let Some(function_scope) = reachability.enclosing_function_scope(scope) else {
+            return true;
+        };
+        self.activations_by_scope
+            .get(&function_scope)
+            .is_some_and(|activations| {
+                activations.iter().any(|activation| {
+                    activation.required_before_offset <= before_offset
+                        && (!persistent || activation.persistent)
+                })
+            })
+    }
+
+    fn scope_can_run_between_offsets(
+        &self,
+        reachability: &DirectFunctionCallReachability<'_, '_>,
+        scope: ScopeId,
+        after_offset: usize,
+        before_offset: usize,
+        persistent: bool,
+    ) -> bool {
+        let Some(function_scope) = reachability.enclosing_function_scope(scope) else {
+            return true;
+        };
+        self.activations_by_scope
+            .get(&function_scope)
+            .is_some_and(|activations| {
+                activations.iter().any(|activation| {
+                    activation.activation_offset > after_offset
+                        && activation.required_before_offset <= before_offset
+                        && (!persistent || activation.persistent)
+                })
+            })
+    }
+}
+
+fn activation_dominates(left: FunctionScopeActivation, right: FunctionScopeActivation) -> bool {
+    left.activation_offset >= right.activation_offset
+        && left.required_before_offset <= right.required_before_offset
+        && (left.persistent || !right.persistent)
+}

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -24,6 +24,8 @@ mod declaration;
 #[allow(missing_docs)]
 mod dense_bit_set;
 #[allow(missing_docs)]
+mod function_call_reachability;
+#[allow(missing_docs)]
 mod function_resolution;
 #[allow(missing_docs)]
 mod nonpersistent;
@@ -72,6 +74,11 @@ pub use dataflow::{
 };
 /// Declaration records discovered while building the semantic model.
 pub use declaration::{Declaration, DeclarationBuiltin, DeclarationOperand};
+/// Direct function-call reachability query types.
+pub use function_call_reachability::{
+    DirectFunctionCallReachability, DirectFunctionCallWindow, FunctionCallCandidate,
+    FunctionCallPersistence,
+};
 /// Nonpersistent assignment effects, such as assignments made in subshells and read later outside.
 pub use nonpersistent::{
     NonpersistentAssignmentAnalysis, NonpersistentAssignmentAnalysisContext,

--- a/crates/shuck-semantic/src/reachability.rs
+++ b/crates/shuck-semantic/src/reachability.rs
@@ -113,7 +113,6 @@ impl<'model> SemanticAnalysis<'model> {
         call_scope: ScopeId,
         visibility_span: Span,
         cfg_span: Span,
-        has_prior_shadowing_function_definition: bool,
     ) -> bool {
         let binding = self.model.binding(binding_id);
         if let Some(visible) = self.model.visible_binding(&binding.name, visibility_span)
@@ -156,8 +155,7 @@ impl<'model> SemanticAnalysis<'model> {
                             .model
                             .ancestor_scopes(call_scope)
                             .any(|scope| scope == other_binding.scope)
-                })
-            || has_prior_shadowing_function_definition;
+                });
         if !has_visible_shadow {
             return true;
         }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::cfg::build_control_flow_graph;
-use shuck_ast::{Command, CompoundCommand};
+use shuck_ast::{Command, CompoundCommand, Position, Span};
 use shuck_indexer::Indexer;
 use shuck_parser::parser::{Parser, ShellDialect};
 use std::fs;
@@ -31,6 +31,20 @@ fn model_with_profile(source: &str, profile: ShellProfile) -> SemanticModel {
             ..SemanticBuildOptions::default()
         },
     )
+}
+
+fn span_for_nth(source: &str, needle: &str, index: usize) -> Span {
+    let start_offset = source
+        .match_indices(needle)
+        .nth(index)
+        .map(|(offset, _)| offset)
+        .unwrap();
+    let start = Position::new().advanced_by(&source[..start_offset]);
+    Span::from_positions(start, start.advanced_by(needle))
+}
+
+fn function_binding_id(model: &SemanticModel, name: &str, index: usize) -> BindingId {
+    model.function_definitions(&Name::from(name))[index]
 }
 
 fn command_id_starting_with(
@@ -1800,6 +1814,146 @@ printf '%s\\n' \"$(
     let site = &model.call_sites_for(&Name::from("target"))[0];
 
     assert!(analysis.call_site_runs_in_transient_context(site.scope));
+}
+
+#[test]
+fn function_call_reachability_finds_direct_call_before_cutoff() {
+    let source = "\
+target() { :; }
+target
+exit
+";
+    let model = model(source);
+    let binding = function_binding_id(&model, "target", 0);
+    let cutoff = span_for_nth(source, "exit", 0).start.offset;
+    let analysis = model.analysis();
+    let mut reachability = analysis.direct_function_call_reachability(Vec::new());
+
+    assert!(reachability.binding_has_reachable_direct_call(
+        binding,
+        DirectFunctionCallWindow::before_offset(cutoff)
+    ));
+}
+
+#[test]
+fn function_call_reachability_respects_between_offsets() {
+    let source = "\
+target() { :; }
+echo before
+target
+exit
+";
+    let model = model(source);
+    let binding = function_binding_id(&model, "target", 0);
+    let after = span_for_nth(source, "echo", 0).start.offset;
+    let before = span_for_nth(source, "exit", 0).start.offset;
+    let early_before = span_for_nth(source, "target", 1).start.offset - 1;
+    let analysis = model.analysis();
+    let mut reachability = analysis.direct_function_call_reachability(Vec::new());
+
+    assert!(reachability.binding_has_reachable_direct_call(
+        binding,
+        DirectFunctionCallWindow::between_offsets(after, before)
+    ));
+    assert!(!reachability.binding_has_reachable_direct_call(
+        binding,
+        DirectFunctionCallWindow::between_offsets(after, early_before)
+    ));
+}
+
+#[test]
+fn function_call_reachability_persistent_query_excludes_transient_calls() {
+    let source = "\
+target() { :; }
+value=$(target)
+";
+    let model = model(source);
+    let binding = function_binding_id(&model, "target", 0);
+    let analysis = model.analysis();
+    let mut reachability = analysis.direct_function_call_reachability(Vec::new());
+
+    assert!(reachability.binding_has_reachable_direct_call(
+        binding,
+        DirectFunctionCallWindow::before_offset(source.len())
+    ));
+    assert!(!reachability.binding_has_reachable_direct_call(
+        binding,
+        DirectFunctionCallWindow::before_offset(source.len()).persistent()
+    ));
+}
+
+#[test]
+fn function_call_reachability_follows_nested_function_activation() {
+    let source = "\
+target() { :; }
+wrapper() {
+  target
+}
+wrapper
+";
+    let model = model(source);
+    let binding = function_binding_id(&model, "target", 0);
+    let analysis = model.analysis();
+    let mut reachability = analysis.direct_function_call_reachability(Vec::new());
+
+    assert!(reachability.binding_has_reachable_direct_call(
+        binding,
+        DirectFunctionCallWindow::before_offset(source.len())
+    ));
+}
+
+#[test]
+fn function_call_reachability_blocks_prior_shadowed_binding() {
+    let source = "\
+target() { : old; }
+target() { : new; }
+target
+";
+    let model = model(source);
+    let first = function_binding_id(&model, "target", 0);
+    let second = function_binding_id(&model, "target", 1);
+    let analysis = model.analysis();
+    let mut reachability = analysis.direct_function_call_reachability(Vec::new());
+
+    assert!(!reachability.binding_has_reachable_direct_call(
+        first,
+        DirectFunctionCallWindow::before_offset(source.len())
+    ));
+    assert!(reachability.binding_has_reachable_direct_call(
+        second,
+        DirectFunctionCallWindow::before_offset(source.len())
+    ));
+}
+
+#[test]
+fn function_call_reachability_uses_supplemental_call_candidates() {
+    let source = "\
+target() { :; }
+command target
+";
+    let model = model(source);
+    let binding = function_binding_id(&model, "target", 0);
+    let target_span = span_for_nth(source, "target", 1);
+    let command_span = span_for_nth(source, "command target", 0);
+    let supplemental = vec![FunctionCallCandidate {
+        callee: Name::from("target"),
+        scope: model.scope_at(target_span.start.offset),
+        name_span: target_span,
+        command_span,
+    }];
+
+    let analysis = model.analysis();
+    let mut without_supplemental = analysis.direct_function_call_reachability(Vec::new());
+    assert!(!without_supplemental.binding_has_reachable_direct_call(
+        binding,
+        DirectFunctionCallWindow::before_offset(source.len())
+    ));
+
+    let mut with_supplemental = analysis.direct_function_call_reachability(supplemental);
+    assert!(with_supplemental.binding_has_reachable_direct_call(
+        binding,
+        DirectFunctionCallWindow::before_offset(source.len())
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- move C063 direct function-call reachability into a new semantic-owned query object
- keep C063 cutoff/reporting policy in the linter while passing supplemental normalized call candidates into semantic
- add semantic coverage for cutoff windows, between-offset queries, persistent/transient calls, nested activation, shadowing, and supplemental calls

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-semantic function_call_reachability`
- `cargo test -p shuck-linter overwritten_function`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C063`