### PR TITLE
docs(parser): document public API surface

### DIFF
--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -267,7 +267,11 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse the input and return the AST, recovery diagnostics, and syntax facts.
+    /// Parse the configured input.
+    ///
+    /// The returned [`ParseResult`] contains the best AST the parser could
+    /// produce, plus recovery diagnostics and syntax facts. Use
+    /// [`ParseResult::is_ok`] when a caller needs to reject recovered parses.
     pub fn parse(mut self) -> ParseResult {
         self.parse_impl()
     }

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -330,6 +330,10 @@ pub(crate) enum TokenPayload<'a> {
 }
 
 /// Token produced by the shell lexer.
+///
+/// Public consumers can inspect the token kind and source span. Word payloads,
+/// descriptor payloads, and lexer recovery details are currently parser-internal
+/// so the lexer can evolve without expanding the public API.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LexedToken<'a> {
     /// Token kind used by the parser.
@@ -707,7 +711,11 @@ impl<'a> PositionMap<'a> {
     }
 }
 
-/// Lexer for bash scripts.
+/// Source-backed lexer for shell scripts.
+///
+/// The public lexer surface is intended for lower-level tooling and
+/// benchmarks. It tokenizes using the default bash profile; use the parser
+/// constructors when dialect or zsh option state matters.
 #[derive(Clone)]
 pub struct Lexer<'a> {
     #[allow(dead_code)] // Stored for error reporting in future
@@ -731,7 +739,7 @@ pub struct Lexer<'a> {
 }
 
 impl<'a> Lexer<'a> {
-    /// Create a new lexer for the given input.
+    /// Create a new bash-profile lexer for the given input.
     pub fn new(input: &'a str) -> Self {
         Self::with_max_subst_depth_and_profile(
             input,
@@ -824,8 +832,11 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    /// Get the next token kind from the input without decoding or materializing
-    /// any payload text.
+    /// Get the next token kind from the input.
+    ///
+    /// This skips whitespace and line comments, matching
+    /// [`Lexer::next_lexed_token`]. It is useful for callers that only need the
+    /// token stream shape.
     pub fn next_token_kind(&mut self) -> Option<TokenKind> {
         self.next_lexed_token().map(|token| token.kind)
     }
@@ -1064,6 +1075,10 @@ impl<'a> Lexer<'a> {
     }
 
     /// Get the next source-backed token from the input, skipping line comments.
+    ///
+    /// Returned tokens expose their [`TokenKind`] and source [`Span`]. Comments
+    /// are omitted from this public stream; the parser uses an internal variant
+    /// when it needs to preserve them for AST attachment.
     pub fn next_lexed_token(&mut self) -> Option<LexedToken<'a>> {
         self.skip_whitespace();
         let start = self.current_position();

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -93,6 +93,10 @@ const SOURCE_TEXT_PATTERN_REPARSE_MAX_DEPTH: usize = 4;
 const DEFAULT_MAX_PARSER_OPERATIONS: usize = 100_000;
 
 /// Returns whether `text` parses as a nontrivial arithmetic expression.
+///
+/// Plain numbers and plain variable names are considered trivial. The helper
+/// returns `false` for empty text and for text that cannot be parsed inside a
+/// shell arithmetic command.
 pub fn text_looks_like_nontrivial_arithmetic_expression(text: &str) -> bool {
     let text = text.trim();
     if text.is_empty() {
@@ -122,7 +126,10 @@ pub fn text_looks_like_nontrivial_arithmetic_expression(text: &str) -> bool {
 }
 
 /// Returns whether `text` parses as an arithmetic expression without variable
-/// references or assignments.
+/// references, subscripts, shell words, or assignments.
+///
+/// This is useful when a caller needs a purely self-contained arithmetic value.
+/// Invalid or empty text returns `false`.
 pub fn text_is_self_contained_arithmetic_expression(text: &str) -> bool {
     let text = text.trim();
     if text.is_empty() {
@@ -221,11 +228,17 @@ impl<'a> Parser<'a> {
     }
 
     /// Create a new parser for the given input and shell dialect.
+    ///
+    /// This uses [`ShellProfile::native`] for the selected dialect. Use
+    /// [`Parser::with_profile`] when zsh option state is known.
     pub fn with_dialect(input: &'a str, dialect: ShellDialect) -> Self {
         Self::with_profile(input, ShellProfile::native(dialect))
     }
 
     /// Create a new parser for the given input and full shell profile.
+    ///
+    /// Profiles allow callers to provide parser-visible zsh option state in
+    /// addition to the broad shell dialect.
     pub fn with_profile(input: &'a str, shell_profile: ShellProfile) -> Self {
         Self::with_limits_and_profile(
             input,
@@ -235,7 +248,10 @@ impl<'a> Parser<'a> {
         )
     }
 
-    /// Create a new parser with a custom maximum AST depth.
+    /// Create a new bash parser with a custom maximum AST depth.
+    ///
+    /// The requested depth is clamped to the parser's hard safety cap. Hitting
+    /// the limit produces a non-clean [`ParseResult`] rather than panicking.
     pub fn with_max_depth(input: &'a str, max_depth: usize) -> Self {
         Self::with_limits_and_profile(
             input,
@@ -245,7 +261,10 @@ impl<'a> Parser<'a> {
         )
     }
 
-    /// Create a new parser with a custom fuel limit.
+    /// Create a new bash parser with a custom fuel limit.
+    ///
+    /// Fuel bounds the number of parser operations. Exhaustion produces a
+    /// terminal parse error in the returned [`ParseResult`].
     pub fn with_fuel(input: &'a str, max_fuel: usize) -> Self {
         Self::with_limits_and_profile(
             input,
@@ -255,11 +274,11 @@ impl<'a> Parser<'a> {
         )
     }
 
-    /// Create a new parser with custom depth and fuel limits.
+    /// Create a new bash parser with custom depth and fuel limits.
     ///
-    /// `max_depth` is clamped to `HARD_MAX_AST_DEPTH` (500)
-    /// to prevent stack overflow from misconfiguration. Even if the caller passes
-    /// `max_depth = 1_000_000`, the parser will cap it at 500.
+    /// `max_depth` is clamped to the parser's hard safety cap to prevent stack
+    /// overflow from misconfiguration. `max_fuel` bounds parser operations.
+    /// Either limit can produce a non-clean [`ParseResult`].
     pub fn with_limits(input: &'a str, max_depth: usize, max_fuel: usize) -> Self {
         Self::with_limits_and_profile(
             input,
@@ -270,6 +289,10 @@ impl<'a> Parser<'a> {
     }
 
     /// Create a new parser with custom depth, fuel, and dialect settings.
+    ///
+    /// This uses [`ShellProfile::native`] for `dialect`; use
+    /// [`Parser::with_limits_and_profile`] when explicit zsh option state is
+    /// available.
     pub fn with_limits_and_dialect(
         input: &'a str,
         max_depth: usize,
@@ -280,6 +303,9 @@ impl<'a> Parser<'a> {
     }
 
     /// Create a new parser with custom depth, fuel, and shell-profile settings.
+    ///
+    /// This is the most explicit constructor for embedders that need both
+    /// resource limits and parser-visible shell option state.
     pub fn with_limits_and_profile(
         input: &'a str,
         max_depth: usize,
@@ -436,8 +462,11 @@ impl<'a> Parser<'a> {
         self.current_span
     }
 
-    /// Parse a string as a word (handling $var, $((expr)), ${...}, etc.).
-    /// Used by the interpreter to expand operands in parameter expansions lazily.
+    /// Parse a standalone shell word string.
+    ///
+    /// This handles shell word constructs such as parameter expansion, command
+    /// substitution, arithmetic expansion, and quoting. The returned word is
+    /// positioned as if `input` started at the beginning of a file.
     pub fn parse_word_string(input: &str) -> Word {
         let mut parser = Parser::new(input);
         let start = Position::new();

--- a/crates/shuck-parser/src/parser/parser_state.rs
+++ b/crates/shuck-parser/src/parser/parser_state.rs
@@ -99,7 +99,12 @@ pub(super) enum Command {
     AnonymousFunction(AnonymousFunctionCommand, SmallVec<[Redirect; 1]>),
 }
 
-/// Parser for bash scripts.
+/// Stateful parser for shell scripts.
+///
+/// Construct a parser with one of the `Parser::with_*` constructors and then
+/// call `parse` to obtain a [`super::ParseResult`]. The parser is single-use:
+/// `parse` consumes the value so internal recovery state cannot leak between
+/// parses.
 #[derive(Clone)]
 pub struct Parser<'a> {
     pub(super) input: &'a str,

--- a/crates/shuck-parser/src/parser/profile.rs
+++ b/crates/shuck-parser/src/parser/profile.rs
@@ -1,6 +1,10 @@
 use super::ZshOptionState;
 
-/// Supported shell dialects for parsing.
+/// Supported shell dialects for parser syntax decisions.
+///
+/// Dialects select which grammar extensions the parser accepts. They do not
+/// try to model every runtime behavior of a shell; use [`ShellProfile`] when
+/// zsh option state also matters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ShellDialect {
     /// POSIX-style parsing used for `sh`, `dash`, and generic portable shell input.
@@ -32,7 +36,11 @@ pub(super) struct DialectFeatures {
 }
 
 impl ShellDialect {
-    /// Infer a shell dialect from a command or shebang name.
+    /// Infer a parser dialect from a command name, shebang interpreter name,
+    /// or user-facing shell selector.
+    ///
+    /// Unknown names fall back to [`ShellDialect::Bash`], matching Shuck's
+    /// default parsing mode.
     pub fn from_name(name: &str) -> Self {
         match name.trim().to_ascii_lowercase().as_str() {
             "sh" | "dash" | "ksh" | "posix" => Self::Posix,
@@ -108,17 +116,25 @@ impl ShellDialect {
     }
 }
 
-/// Dialect plus optional zsh option state used to configure the lexer and parser.
+/// Complete shell parsing profile.
+///
+/// A profile combines the broad syntax dialect with any option state that
+/// changes tokenization or grammar. Today only zsh carries parser-visible
+/// options; non-zsh profiles ignore the [`ShellProfile::options`] field.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ShellProfile {
     /// Shell dialect to parse.
     pub dialect: ShellDialect,
-    /// Optional zsh option state, used only for zsh parsing.
+    /// Optional zsh option state, used only when [`ShellProfile::dialect`] is
+    /// [`ShellDialect::Zsh`].
     pub options: Option<ZshOptionState>,
 }
 
 impl ShellProfile {
-    /// Build a native profile for `dialect`.
+    /// Build the parser's native profile for `dialect`.
+    ///
+    /// Native zsh profiles include [`ZshOptionState::zsh_default`]. Other
+    /// dialects carry no option state.
     pub fn native(dialect: ShellDialect) -> Self {
         Self {
             dialect,
@@ -127,6 +143,10 @@ impl ShellProfile {
     }
 
     /// Build a profile with explicit zsh option state.
+    ///
+    /// The provided options are retained only for [`ShellDialect::Zsh`]. For
+    /// other dialects, this returns a profile with `options: None` because
+    /// their parser behavior is not currently option-sensitive.
     pub fn with_zsh_options(dialect: ShellDialect, options: ZshOptionState) -> Self {
         Self {
             dialect,
@@ -135,6 +155,9 @@ impl ShellProfile {
     }
 
     /// Borrow the zsh option state, if this profile carries one.
+    ///
+    /// Callers should treat `None` as "no parser-visible zsh option state",
+    /// not as "all options are unknown".
     pub fn zsh_options(&self) -> Option<&ZshOptionState> {
         self.options.as_ref()
     }

--- a/crates/shuck-parser/src/parser/result.rs
+++ b/crates/shuck-parser/src/parser/result.rs
@@ -3,17 +3,24 @@ use shuck_ast::{File, Span};
 use crate::error::Error;
 
 /// Overall outcome of a parse attempt.
+///
+/// A parse can produce an AST even when recovery diagnostics were needed.
+/// Check [`ParseResult::is_ok`] when a caller requires a fully clean parse.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParseStatus {
     /// The parse completed without recovery diagnostics.
     Clean,
     /// The parse completed, but required recovery diagnostics.
     Recovered,
-    /// The parse failed with a terminal error.
+    /// The parse stopped after a terminal error.
     Fatal,
 }
 
 /// One branch separator recognized inside a zsh `case` pattern group.
+///
+/// These separators are exposed as syntax facts because they describe source
+/// surface that downstream tools may need even when the AST normalizes the
+/// surrounding pattern structure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ZshCaseGroupPart {
     /// Index of the owning pattern part within the parsed pattern.
@@ -23,6 +30,10 @@ pub struct ZshCaseGroupPart {
 }
 
 /// Additional parser-owned facts that are useful to downstream consumers.
+///
+/// These facts preserve parser discoveries that are awkward to represent
+/// directly in the shared AST but are still relevant to linting, formatting, or
+/// source remapping.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SyntaxFacts {
     /// Spans of zsh brace-style `if` bodies.
@@ -34,6 +45,8 @@ pub struct SyntaxFacts {
 }
 
 /// A parser diagnostic emitted while recovering from invalid input.
+///
+/// Diagnostics use Shuck-authored wording and source spans in the parsed input.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseDiagnostic {
     /// Human-readable diagnostic message.
@@ -42,8 +55,11 @@ pub struct ParseDiagnostic {
     pub span: Span,
 }
 
-/// The result of parsing a script, including any recovery diagnostics and
-/// syntax facts collected along the way.
+/// The result of parsing a script.
+///
+/// `ParseResult` always carries the best AST the parser produced. Inspect
+/// [`ParseResult::status`] or [`ParseResult::is_ok`] before assuming it was a
+/// clean parse.
 #[derive(Debug, Clone)]
 pub struct ParseResult {
     /// Parsed syntax tree for the file.

--- a/crates/shuck-parser/src/parser/zsh_options.rs
+++ b/crates/shuck-parser/src/parser/zsh_options.rs
@@ -1,4 +1,9 @@
-/// Tri-state option value used when modeling zsh option state.
+/// Tri-state value for a parser-visible zsh option.
+///
+/// `Unknown` is used when the parser cannot prove a single value, for example
+/// after merging control-flow paths that set an option differently. Consumers
+/// should only branch on [`OptionValue::On`] or [`OptionValue::Off`] when the
+/// corresponding `is_definitely_*` helper returns `true`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum OptionValue {
     /// The option is enabled.
@@ -22,6 +27,10 @@ impl OptionValue {
     }
 
     /// Merge two option values, preserving certainty only when they agree.
+    ///
+    /// This is intended for conservative flow joins: `On + On` remains `On`,
+    /// `Off + Off` remains `Off`, and every mixed or unknown combination
+    /// becomes [`OptionValue::Unknown`].
     pub const fn merge(self, other: Self) -> Self {
         match (self, other) {
             (Self::On, Self::On) => Self::On,
@@ -32,6 +41,9 @@ impl OptionValue {
 }
 
 /// Target emulation mode for zsh's `emulate` behavior.
+///
+/// The parser uses this to derive the option snapshot implied by commands such
+/// as `emulate sh` or `emulate ksh`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ZshEmulationMode {
     /// Native zsh behavior.
@@ -44,62 +56,71 @@ pub enum ZshEmulationMode {
     Csh,
 }
 
-/// Snapshot of zsh option state used by the parser and lexer.
+/// Snapshot of parser-visible zsh option state.
+///
+/// The fields here intentionally cover options that can change syntax,
+/// tokenization, or word interpretation. They are not a full zsh runtime option
+/// table. Use [`ZshOptionState::zsh_default`] for native zsh parsing, then
+/// apply `setopt`, `unsetopt`, or `emulate` effects when a caller has already
+/// discovered them.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ZshOptionState {
-    /// State of the `sh_word_split` option.
+    /// Whether unquoted parameter expansion is treated as eligible for
+    /// shell-style word splitting.
     pub sh_word_split: OptionValue,
-    /// State of the `glob_subst` option.
+    /// Whether parameter expansion results are treated as glob patterns.
     pub glob_subst: OptionValue,
-    /// State of the `rc_expand_param` option.
+    /// Whether array parameters can participate in brace-like expansion.
     pub rc_expand_param: OptionValue,
-    /// State of the `glob` option.
+    /// Whether ordinary filename generation is enabled.
     pub glob: OptionValue,
-    /// State of the `nomatch` option.
+    /// Whether unmatched filename-generation patterns are treated as errors.
     pub nomatch: OptionValue,
-    /// State of the `null_glob` option.
+    /// Whether unmatched filename-generation patterns can expand to nothing.
     pub null_glob: OptionValue,
-    /// State of the `csh_null_glob` option.
+    /// Whether csh-style null glob handling is enabled.
     pub csh_null_glob: OptionValue,
-    /// State of the `extended_glob` option.
+    /// Whether zsh extended glob operators are enabled.
     pub extended_glob: OptionValue,
-    /// State of the `ksh_glob` option.
+    /// Whether ksh-style glob operators are enabled.
     pub ksh_glob: OptionValue,
-    /// State of the `sh_glob` option.
+    /// Whether sh-compatible glob parsing is enabled.
     pub sh_glob: OptionValue,
-    /// State of the `bare_glob_qual` option.
+    /// Whether unparenthesized zsh glob qualifiers are enabled.
     pub bare_glob_qual: OptionValue,
-    /// State of the `glob_dots` option.
+    /// Whether glob patterns match dotfiles without an explicit dot.
     pub glob_dots: OptionValue,
-    /// State of the `equals` option.
+    /// Whether leading `=` words are eligible for command-path expansion.
     pub equals: OptionValue,
-    /// State of the `magic_equal_subst` option.
+    /// Whether assignment-like words can apply `=` expansion after the first
+    /// equals sign.
     pub magic_equal_subst: OptionValue,
-    /// State of the `sh_file_expansion` option.
+    /// Whether file expansion follows sh-compatible ordering.
     pub sh_file_expansion: OptionValue,
-    /// State of the `glob_assign` option.
+    /// Whether assignment values can be parsed as glob assignments.
     pub glob_assign: OptionValue,
-    /// State of the `ignore_braces` option.
+    /// Whether brace characters should be treated literally instead of as zsh
+    /// brace syntax.
     pub ignore_braces: OptionValue,
-    /// State of the `ignore_close_braces` option.
+    /// Whether unmatched closing braces should be treated literally.
     pub ignore_close_braces: OptionValue,
-    /// State of the `brace_ccl` option.
+    /// Whether character-class brace expansion syntax is enabled.
     pub brace_ccl: OptionValue,
-    /// State of the `ksh_arrays` option.
+    /// Whether array indexing follows ksh-style zero-based behavior.
     pub ksh_arrays: OptionValue,
-    /// State of the `ksh_zero_subscript` option.
+    /// Whether subscript zero is accepted with ksh-style array semantics.
     pub ksh_zero_subscript: OptionValue,
-    /// State of the `short_loops` option.
+    /// Whether zsh short loop forms are accepted.
     pub short_loops: OptionValue,
-    /// State of the `short_repeat` option.
+    /// Whether zsh short `repeat` forms are accepted.
     pub short_repeat: OptionValue,
-    /// State of the `rc_quotes` option.
+    /// Whether doubled single quotes are decoded inside single-quoted strings.
     pub rc_quotes: OptionValue,
-    /// State of the `interactive_comments` option.
+    /// Whether `#` starts comments in interactive-style zsh parsing contexts.
     pub interactive_comments: OptionValue,
-    /// State of the `c_bases` option.
+    /// Whether C-style numeric base prefixes are accepted in arithmetic text.
     pub c_bases: OptionValue,
-    /// State of the `octal_zeroes` option.
+    /// Whether leading zeroes are interpreted as octal arithmetic literals.
     pub octal_zeroes: OptionValue,
 }
 
@@ -136,6 +157,9 @@ enum ZshOptionField {
 
 impl ZshOptionState {
     /// Default zsh option state used for native zsh parsing.
+    ///
+    /// This is the parser's baseline before source-level commands such as
+    /// `emulate`, `setopt`, and `unsetopt` are considered.
     pub const fn zsh_default() -> Self {
         Self {
             sh_word_split: OptionValue::Off,
@@ -168,7 +192,11 @@ impl ZshOptionState {
         }
     }
 
-    /// Option state implied by `emulate <mode>`.
+    /// Return the option state implied by `emulate <mode>`.
+    ///
+    /// This models the subset of emulation effects that the parser currently
+    /// needs. Callers can further refine the returned state with
+    /// [`ZshOptionState::apply_setopt`] and [`ZshOptionState::apply_unsetopt`].
     pub fn for_emulate(mode: ZshEmulationMode) -> Self {
         let mut state = Self::zsh_default();
         match mode {
@@ -198,16 +226,20 @@ impl ZshOptionState {
         state
     }
 
-    /// Apply a zsh `setopt`-style option name.
+    /// Apply a zsh `setopt`-style option name to this snapshot.
     ///
-    /// Returns `true` when the option name was recognized.
+    /// Names are matched with zsh-style aliases, underscores, and `no_`
+    /// prefixes where supported by this parser. Returns `true` when the option
+    /// name was recognized and this snapshot was updated.
     pub fn apply_setopt(&mut self, name: &str) -> bool {
         self.apply_named_option(name, true)
     }
 
-    /// Apply a zsh `unsetopt`-style option name.
+    /// Apply a zsh `unsetopt`-style option name to this snapshot.
     ///
-    /// Returns `true` when the option name was recognized.
+    /// Names are matched with zsh-style aliases, underscores, and `no_`
+    /// prefixes where supported by this parser. Returns `true` when the option
+    /// name was recognized and this snapshot was updated.
     pub fn apply_unsetopt(&mut self, name: &str) -> bool {
         self.apply_named_option(name, false)
     }
@@ -277,6 +309,9 @@ impl ZshOptionState {
     }
 
     /// Merge two option snapshots field by field.
+    ///
+    /// Each field preserves a definite value only when both inputs agree. This
+    /// is useful for conservative joins across control-flow paths.
     pub fn merge(&self, other: &Self) -> Self {
         let mut merged = Self::zsh_default();
         for field in ZshOptionField::ALL {


### PR DESCRIPTION
## Summary

- expand `shuck-parser` public API docs for parser constructors, parse results, syntax facts, lexer tokens, shell profiles, and zsh option state
- clarify parser limit and fuel semantics, including the hard depth cap behavior
- make zsh option field docs describe parser-visible behavior instead of repeating option names

## Validation

- `cargo fmt --check`
- `cargo check -p shuck-parser`
- `cargo doc -p shuck-parser --no-deps`