### PR TITLE
refactor(semantic): move safe-value flow queries

### DIFF
--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -9,7 +9,8 @@ use shuck_ast::{
 };
 use shuck_semantic::{
     AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, CallSite,
-    LoopValueOrigin, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel, UninitializedCertainty,
+    LoopValueOrigin, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel, SemanticValueFlow,
+    UninitializedCertainty,
 };
 use shuck_semantic::{BindingId, BlockId, ReferenceId};
 
@@ -92,14 +93,13 @@ impl SafeValueQuery {
 pub struct SafeValueIndex<'a> {
     semantic: &'a SemanticModel,
     analysis: &'a SemanticAnalysis<'a>,
+    value_flow: RefCell<SemanticValueFlow<'a, 'a>>,
     facts: &'a LinterFacts<'a>,
     source: &'a str,
     command_cover_memo: RefCell<FxHashMap<(crate::facts::CommandId, Name, FactSpan), bool>>,
     memo: FxHashMap<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>), bool>,
     visiting: FxHashSet<(FactSpan, FactSpan, SafeValueQuery, Option<ScopeId>)>,
     binding_value_stack: Vec<BindingId>,
-    helper_binding_memo: FxHashMap<(Name, ScopeId, FactSpan), Box<[BindingId]>>,
-    helper_binding_visiting: FxHashSet<(Name, ScopeId, FactSpan)>,
     s001_unset_before_call_memo: FxHashMap<ScopeId, bool>,
     #[cfg(test)]
     uninitialized_reference_overrides: FxHashMap<FactSpan, UninitializedCertainty>,
@@ -115,14 +115,13 @@ impl<'a> SafeValueIndex<'a> {
         Self {
             semantic,
             analysis,
+            value_flow: RefCell::new(analysis.value_flow()),
             facts,
             source,
             command_cover_memo: RefCell::new(FxHashMap::default()),
             memo: FxHashMap::default(),
             visiting: FxHashSet::default(),
             binding_value_stack: Vec::new(),
-            helper_binding_memo: FxHashMap::default(),
-            helper_binding_visiting: FxHashSet::default(),
             s001_unset_before_call_memo: FxHashMap::default(),
             #[cfg(test)]
             uninitialized_reference_overrides: FxHashMap::default(),
@@ -2701,25 +2700,26 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn visible_bindings_for_name_without_helpers(&self, name: &Name, at: Span) -> Vec<BindingId> {
-        let mut bindings = self.analysis.reaching_bindings_for_name(name, at);
-        self.retain_value_bindings(&mut bindings);
-        if self.reference_id_for_name_at(name, at).is_none() {
-            let virtual_bindings = self.virtual_reaching_bindings_for_name(name, at);
-            if !virtual_bindings.is_empty() {
-                bindings = virtual_bindings;
-            }
-        }
-        if bindings.is_empty()
-            && let Some(binding_id) = self.latest_visible_value_binding_for_name(name, at)
-        {
-            bindings.push(binding_id);
-        }
+        let synthetic_use_block = self
+            .reference_id_for_name_at(name, at)
+            .is_none()
+            .then(|| self.block_for_name_reference_or_virtual_offset(name, at))
+            .flatten();
+        let mut bindings = self
+            .value_flow
+            .borrow()
+            .reaching_value_bindings_for_name_with_synthetic_use_block(
+                name,
+                at,
+                synthetic_use_block,
+            );
         if let Some(current_binding) = self.current_binding_value_for_name(name) {
             if bindings.contains(&current_binding) {
-                bindings = self
-                    .analysis
-                    .visible_bindings_bypassing(name, current_binding, at);
-                self.retain_value_bindings(&mut bindings);
+                bindings = self.value_flow.borrow().reaching_value_bindings_bypassing(
+                    name,
+                    current_binding,
+                    at,
+                );
                 if bindings.is_empty()
                     && let Some(previous) = self.semantic.previous_visible_binding(
                         name,
@@ -2736,10 +2736,10 @@ impl<'a> SafeValueIndex<'a> {
             return bindings;
         }
         if bindings.len() == 1 {
-            let mut expanded = self
-                .analysis
-                .visible_bindings_bypassing(name, bindings[0], at);
-            self.retain_value_bindings(&mut expanded);
+            let mut expanded =
+                self.value_flow
+                    .borrow()
+                    .reaching_value_bindings_bypassing(name, bindings[0], at);
             if !expanded.is_empty() {
                 expanded.push(bindings[0]);
                 expanded
@@ -2757,123 +2757,9 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn binding_can_supply_parameter_value(&self, binding_id: BindingId) -> bool {
-        let binding = self.semantic.binding(binding_id);
-        match binding.origin {
-            BindingOrigin::FunctionDefinition { .. } => false,
-            BindingOrigin::Declaration { .. } => {
-                self.binding_is_name_only_declaration(binding_id)
-                    || binding.attributes.intersects(
-                        BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
-                    )
-            }
-            _ => true,
-        }
-    }
-
-    fn latest_visible_value_binding_for_name(&self, name: &Name, at: Span) -> Option<BindingId> {
-        self.semantic
-            .bindings_for(name)
-            .iter()
-            .copied()
-            .filter(|binding_id| self.binding_can_supply_parameter_value(*binding_id))
-            .filter(|binding_id| self.semantic.binding_visible_at(*binding_id, at))
-            .max_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset)
-    }
-
-    fn virtual_reaching_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
-        let Some(reference_block) = self.block_for_name_reference_or_virtual_offset(name, at)
-        else {
-            return Vec::new();
-        };
-
-        let unreachable = self.analysis.unreachable_blocks();
-        let candidates = self
-            .semantic
-            .bindings_for(name)
-            .iter()
-            .copied()
-            .filter(|binding_id| self.binding_can_supply_parameter_value(*binding_id))
-            .filter(|binding_id| self.semantic.binding_visible_at(*binding_id, at))
-            .filter_map(|binding_id| {
-                let block_id = self.block_for_binding(binding_id)?;
-                (!unreachable.contains(&block_id)).then_some((binding_id, block_id))
-            })
-            .collect::<Vec<_>>();
-
-        let mut bindings = candidates
-            .iter()
-            .copied()
-            .filter(|(binding_id, binding_block)| {
-                !self.binding_is_shadowed_before_virtual_reference(
-                    *binding_id,
-                    *binding_block,
-                    at,
-                    &candidates,
-                ) && self.binding_block_reaches_virtual_reference(
-                    *binding_id,
-                    *binding_block,
-                    reference_block,
-                    &candidates,
-                    unreachable,
-                )
-            })
-            .map(|(binding_id, _)| binding_id)
-            .collect::<Vec<_>>();
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
-        bindings.dedup();
-        bindings
-    }
-
-    fn binding_is_shadowed_before_virtual_reference(
-        &self,
-        binding_id: BindingId,
-        binding_block: BlockId,
-        at: Span,
-        candidates: &[(BindingId, BlockId)],
-    ) -> bool {
-        let binding = self.semantic.binding(binding_id);
-        candidates.iter().any(|(other_id, other_block)| {
-            *other_id != binding_id && *other_block == binding_block && {
-                let other = self.semantic.binding(*other_id);
-                other.span.start.offset > binding.span.start.offset
-                    && other.span.start.offset < at.start.offset
-            }
-        })
-    }
-
-    fn binding_block_reaches_virtual_reference(
-        &self,
-        binding_id: BindingId,
-        binding_block: BlockId,
-        reference_block: BlockId,
-        candidates: &[(BindingId, BlockId)],
-        unreachable: &FxHashSet<BlockId>,
-    ) -> bool {
-        let blocked_blocks = candidates
-            .iter()
-            .copied()
-            .filter(|(other_id, _)| *other_id != binding_id)
-            .map(|(_, block_id)| block_id)
-            .collect::<FxHashSet<_>>();
-        let cfg = self.analysis.cfg();
-        let mut stack = vec![binding_block];
-        let mut seen = FxHashSet::default();
-        while let Some(block_id) = stack.pop() {
-            if block_id != binding_block && blocked_blocks.contains(&block_id) {
-                continue;
-            }
-            if block_id == reference_block {
-                return true;
-            }
-            if unreachable.contains(&block_id) || !seen.insert(block_id) {
-                continue;
-            }
-            for (successor, _) in cfg.successors(block_id) {
-                stack.push(*successor);
-            }
-        }
-
-        false
+        self.value_flow
+            .borrow()
+            .binding_can_supply_parameter_value(binding_id)
     }
 
     fn future_binding_can_reach_reference(
@@ -3120,71 +3006,9 @@ impl<'a> SafeValueIndex<'a> {
         scope: ScopeId,
         at: Span,
     ) -> Vec<BindingId> {
-        let caller_has_visible_local = self.scope_has_visible_local_binding_before(name, scope, at);
-
-        let key = (name.clone(), scope, FactSpan::new(at));
-        if let Some(cached) = self.helper_binding_memo.get(&key) {
-            return cached.to_vec();
-        }
-        if !self.helper_binding_visiting.insert(key.clone()) {
-            return Vec::new();
-        }
-
-        let mut bindings = self
-            .helper_bindings_called_in_scope_before(name, scope, at)
-            .into_iter()
-            .collect::<FxHashSet<_>>();
-
-        if !caller_has_visible_local
-            && let Some(caller_bindings) = self.helper_bindings_reaching_all_callers(name, scope)
-        {
-            bindings.extend(caller_bindings);
-        }
-
-        self.helper_binding_visiting.remove(&key);
-        let mut bindings = bindings.into_iter().collect::<Vec<_>>();
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
-        bindings.dedup();
-        self.helper_binding_memo
-            .insert(key, bindings.clone().into_boxed_slice());
-        bindings
-    }
-
-    fn helper_bindings_reaching_all_callers(
-        &mut self,
-        name: &Name,
-        scope: ScopeId,
-    ) -> Option<FxHashSet<BindingId>> {
-        let function_kind = self.named_function_kind(scope)?;
-        let mut caller_sites = Vec::new();
-        let mut seen_sites = FxHashSet::default();
-
-        for function_name in function_kind.static_names() {
-            for site in self.semantic.call_sites_for(function_name) {
-                if site.scope == scope {
-                    continue;
-                }
-                if seen_sites.insert((site.scope, site.span.start.offset, site.span.end.offset)) {
-                    caller_sites.push(site.clone());
-                }
-            }
-        }
-
-        let mut saw_caller = false;
-        let mut union = FxHashSet::default();
-        for site in caller_sites {
-            saw_caller = true;
-            let branch = self
-                .caller_branch_bindings_before(name, site.scope, site.span)
-                .into_iter()
-                .collect::<FxHashSet<_>>();
-            if branch.is_empty() {
-                return Some(FxHashSet::default());
-            }
-            union.extend(branch);
-        }
-
-        saw_caller.then_some(union)
+        self.value_flow
+            .borrow_mut()
+            .nonlocal_value_bindings_from_called_functions_before(name, scope, at)
     }
 
     fn helper_outer_bindings_cover_all_caller_paths(
@@ -3276,7 +3100,11 @@ impl<'a> SafeValueIndex<'a> {
         at: Span,
     ) -> Vec<BindingId> {
         let mut branch = self.visible_bindings_for_name_without_helpers(name, at);
-        branch.extend(self.caller_visible_bindings_before(name, scope, at));
+        branch.extend(
+            self.value_flow
+                .borrow()
+                .ancestor_value_bindings_before(name, scope, at),
+        );
         branch.extend(self.called_helper_bindings_before(name, scope, at));
         if matches!(self.semantic.scope(scope).kind, ScopeKind::File)
             && self.callsite_is_within_guarded_branch(at)
@@ -3294,32 +3122,6 @@ impl<'a> SafeValueIndex<'a> {
         branch.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
         branch.dedup();
         branch
-    }
-
-    fn caller_visible_bindings_before(
-        &self,
-        name: &Name,
-        scope: ScopeId,
-        at: Span,
-    ) -> Vec<BindingId> {
-        let visible_scopes = self
-            .semantic
-            .ancestor_scopes(scope)
-            .collect::<FxHashSet<_>>();
-        let mut bindings = self
-            .semantic
-            .bindings_for(name)
-            .iter()
-            .copied()
-            .filter(|binding_id| {
-                let binding = self.semantic.binding(*binding_id);
-                visible_scopes.contains(&binding.scope)
-                    && binding.span.end.offset <= at.start.offset
-            })
-            .collect::<Vec<_>>();
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
-        bindings.dedup();
-        bindings
     }
 
     fn callsite_is_within_guarded_branch(&self, at: Span) -> bool {
@@ -3492,49 +3294,6 @@ impl<'a> SafeValueIndex<'a> {
         })
     }
 
-    fn helper_bindings_called_in_scope_before(
-        &self,
-        name: &Name,
-        scope: ScopeId,
-        at: Span,
-    ) -> Vec<BindingId> {
-        let mut bindings = Vec::new();
-
-        for callee_scope in self.helper_scopes_providing_name(name) {
-            let Some(function_kind) = self.named_function_kind(callee_scope) else {
-                continue;
-            };
-
-            let called_before = function_kind.static_names().iter().any(|function_name| {
-                self.semantic
-                    .call_sites_for(function_name)
-                    .iter()
-                    .any(|site| {
-                        site.scope == scope
-                            && self.function_scope_resolves_at_call_site(
-                                callee_scope,
-                                function_name,
-                                site,
-                            )
-                            && self.call_site_dominates_use(site.span, name, at)
-                    })
-            });
-            if !called_before {
-                continue;
-            }
-
-            bindings.extend(self.semantic.bindings_for(name).iter().copied().filter(
-                |binding_id| {
-                    let binding = self.semantic.binding(*binding_id);
-                    binding.scope == callee_scope
-                        && !binding.attributes.contains(BindingAttributes::LOCAL)
-                },
-            ));
-        }
-
-        bindings
-    }
-
     fn collect_transitive_helper_bindings_before(
         &self,
         name: &Name,
@@ -3621,40 +3380,9 @@ impl<'a> SafeValueIndex<'a> {
         scope: ScopeId,
         limit_offset: usize,
     ) -> Vec<ScopeId> {
-        let mut scopes = Vec::new();
-        let mut seen_scopes = FxHashSet::default();
-
-        for header in self.facts.function_headers() {
-            let Some(callee_scope) = header.function_scope() else {
-                continue;
-            };
-            let Some(function_kind) = self.named_function_kind(callee_scope) else {
-                continue;
-            };
-            let Some(definition_command) = self.facts.function_definition_command(callee_scope)
-            else {
-                continue;
-            };
-
-            let called_before = function_kind.static_names().iter().any(|function_name| {
-                self.semantic
-                    .call_sites_for(function_name)
-                    .iter()
-                    .any(|site| {
-                        site.scope == scope
-                            && self.call_site_dominates_offset(site.span, limit_offset)
-                            && self.definition_command_resolves_at_call(
-                                definition_command.id(),
-                                site.span,
-                            )
-                    })
-            });
-            if called_before && seen_scopes.insert(callee_scope) {
-                scopes.push(callee_scope);
-            }
-        }
-
-        scopes
+        self.value_flow
+            .borrow()
+            .called_function_scopes_before(scope, limit_offset)
     }
 
     fn function_scope_end_offset(&self, scope: ScopeId) -> Option<usize> {
@@ -3921,48 +3649,29 @@ impl<'a> SafeValueIndex<'a> {
         bindings: &[BindingId],
         call_span: Span,
     ) -> bool {
-        let cfg = self.analysis.cfg();
-        let call_blocks = cfg
+        let call_blocks = self
+            .analysis
+            .cfg()
             .blocks()
             .iter()
             .filter(|block| block.commands.contains(&call_span))
             .map(|block| block.id)
             .collect::<FxHashSet<_>>();
-        if call_blocks.is_empty() {
-            return true;
-        }
-
-        let cover_blocks = bindings
+        let cover_bindings = bindings
             .iter()
             .copied()
-            .filter_map(|binding_id| {
-                let binding_block = self.block_for_binding(binding_id)?;
-                if (call_blocks.contains(&binding_block)
-                    && self.binding_is_guarded_before_reference(binding_id, call_span))
-                    || self.binding_is_one_sided_short_circuit_assignment(binding_id)
-                {
-                    None
-                } else {
-                    Some(binding_block)
-                }
+            .filter(|binding_id| {
+                let Some(binding_block) = self.block_for_binding(*binding_id) else {
+                    return false;
+                };
+                !((call_blocks.contains(&binding_block)
+                    && self.binding_is_guarded_before_reference(*binding_id, call_span))
+                    || self.binding_is_one_sided_short_circuit_assignment(*binding_id))
             })
-            .collect::<FxHashSet<_>>();
-        if !cover_blocks.is_disjoint(&call_blocks) {
-            return true;
-        }
-
-        let binding_scopes = bindings
-            .iter()
-            .copied()
-            .map(|binding_id| self.semantic.binding(binding_id).scope)
             .collect::<Vec<_>>();
-        let entry = self
-            .analysis
-            .flow_entry_block_for_binding_scopes(&binding_scopes, call_span.start.offset);
-        call_blocks.iter().copied().all(|call_block| {
-            self.analysis
-                .blocks_cover_all_paths_to_block(entry, call_block, &cover_blocks)
-        })
+        self.value_flow
+            .borrow()
+            .value_bindings_cover_all_paths_to_span(&cover_bindings, call_span)
     }
 
     fn reference_id_for_name_at(&self, name: &Name, at: Span) -> Option<ReferenceId> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -42,6 +42,8 @@ mod uninitialized;
 #[allow(missing_docs)]
 mod unused;
 #[allow(missing_docs)]
+mod value_flow;
+#[allow(missing_docs)]
 mod zsh_options;
 
 /// Binding types and provenance metadata discovered during semantic analysis.
@@ -84,6 +86,8 @@ pub use scope::{FunctionScopeKind, Scope, ScopeId, ScopeKind};
 pub use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionState};
 /// Source-reference records and resolution state.
 pub use source_ref::{SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution};
+/// Value-flow query object built over semantic bindings, call sites, CFG, and dataflow.
+pub use value_flow::SemanticValueFlow;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Command, File, Name, Span};

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -4629,6 +4629,120 @@ use() {
 }
 
 #[test]
+fn value_flow_ignores_conditionally_installed_called_functions() {
+    let source = "\
+#!/bin/bash
+if cond; then
+  setfoo() {
+    foo=1
+  }
+fi
+use() {
+  setfoo
+  printf '%s\\n' \"$foo\"
+}
+";
+    let model = model(source);
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let mut value_flow = analysis.value_flow();
+
+    assert!(
+        value_flow
+            .nonlocal_value_bindings_from_called_functions_before(
+                &reference.name,
+                reference.scope,
+                reference.span,
+            )
+            .is_empty()
+    );
+}
+
+#[test]
+fn value_flow_uses_visible_top_level_functions_from_function_bodies() {
+    let source = "\
+#!/bin/bash
+use() {
+  setfoo
+  printf '%s\\n' \"$foo\"
+}
+setfoo() {
+  foo=1
+}
+use
+";
+    let model = model(source);
+    let binding = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .expect("expected foo binding");
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let mut value_flow = analysis.value_flow();
+
+    assert_eq!(
+        value_flow.nonlocal_value_bindings_from_called_functions_before(
+            &reference.name,
+            reference.scope,
+            reference.span,
+        ),
+        vec![binding.id]
+    );
+}
+
+#[test]
+fn value_flow_uses_path_covering_alternate_function_definitions() {
+    let source = "\
+#!/bin/bash
+if cond; then
+  setfoo() {
+    foo=1
+  }
+else
+  setfoo() {
+    foo=2
+  }
+fi
+use() {
+  setfoo
+  printf '%s\\n' \"$foo\"
+}
+";
+    let model = model(source);
+    let bindings = model
+        .bindings()
+        .iter()
+        .filter(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .map(|binding| binding.id)
+        .collect::<Vec<_>>();
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let mut value_flow = analysis.value_flow();
+
+    assert_eq!(
+        value_flow.nonlocal_value_bindings_from_called_functions_before(
+            &reference.name,
+            reference.scope,
+            reference.span,
+        ),
+        bindings
+    );
+}
+
+#[test]
 fn value_flow_detects_binding_paths_do_not_cover_span() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -4477,6 +4477,183 @@ printf '%s\\n' \"$foo\"
 }
 
 #[test]
+fn value_flow_returns_real_reference_reaching_value_bindings() {
+    let source = "\
+#!/bin/bash
+foo=1
+foo=2
+printf '%s\\n' \"$foo\"
+";
+    let model = model(source);
+    let bindings = model
+        .bindings()
+        .iter()
+        .filter(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .map(|binding| binding.id)
+        .collect::<Vec<_>>();
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+
+    assert_eq!(
+        value_flow.reaching_value_bindings_for_name(&reference.name, reference.span),
+        vec![bindings[1]]
+    );
+}
+
+#[test]
+fn value_flow_returns_synthetic_use_site_value_bindings() {
+    let source = "\
+#!/bin/bash
+foo=1
+if cond; then
+  foo=2
+fi
+printf done
+";
+    let model = model(source);
+    let printf = command_id_starting_with(&model, source, "printf").expect("expected printf");
+    let bindings = model
+        .bindings()
+        .iter()
+        .filter(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .map(|binding| binding.id)
+        .collect::<Vec<_>>();
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+
+    assert_eq!(
+        value_flow.reaching_value_bindings_for_name(&Name::from("foo"), model.command_span(printf)),
+        bindings
+    );
+}
+
+#[test]
+fn value_flow_can_bypass_one_reaching_binding() {
+    let source = "\
+#!/bin/bash
+foo=1
+if cond; then
+  foo=2
+fi
+printf '%s\\n' \"$foo\"
+";
+    let model = model(source);
+    let bindings = model
+        .bindings()
+        .iter()
+        .filter(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .map(|binding| binding.id)
+        .collect::<Vec<_>>();
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+
+    assert_eq!(
+        value_flow.reaching_value_bindings_bypassing(&reference.name, bindings[1], reference.span),
+        vec![bindings[0]]
+    );
+}
+
+#[test]
+fn value_flow_returns_ancestor_bindings_before_scope_site() {
+    let source = "\
+#!/bin/bash
+foo=1
+use() {
+  printf '%s\\n' \"$foo\"
+}
+";
+    let model = model(source);
+    let binding = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .expect("expected foo binding");
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+
+    assert_eq!(
+        value_flow.ancestor_value_bindings_before(&reference.name, reference.scope, reference.span),
+        vec![binding.id]
+    );
+}
+
+#[test]
+fn value_flow_returns_nonlocal_bindings_from_called_functions() {
+    let source = "\
+#!/bin/bash
+setfoo() {
+  foo=1
+}
+use() {
+  setfoo
+  printf '%s\\n' \"$foo\"
+}
+";
+    let model = model(source);
+    let binding = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .expect("expected foo binding");
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let mut value_flow = analysis.value_flow();
+
+    assert_eq!(
+        value_flow.nonlocal_value_bindings_from_called_functions_before(
+            &reference.name,
+            reference.scope,
+            reference.span,
+        ),
+        vec![binding.id]
+    );
+}
+
+#[test]
+fn value_flow_detects_binding_paths_do_not_cover_span() {
+    let source = "\
+#!/bin/bash
+if cond; then
+  foo=1
+fi
+printf '%s\\n' \"$foo\"
+";
+    let model = model(source);
+    let binding = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .expect("expected foo binding");
+    let printf = command_id_starting_with(&model, source, "printf").expect("expected printf");
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+
+    assert!(
+        !value_flow
+            .value_bindings_cover_all_paths_to_span(&[binding.id], model.command_span(printf))
+    );
+}
+
+#[test]
 fn ifs_assignments_are_treated_as_implicitly_used() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/value_flow.rs
+++ b/crates/shuck-semantic/src/value_flow.rs
@@ -1,0 +1,634 @@
+use super::*;
+
+#[derive(Debug)]
+pub struct SemanticValueFlow<'analysis, 'model> {
+    analysis: &'analysis SemanticAnalysis<'model>,
+    nonlocal_binding_memo: FxHashMap<(Name, ScopeId, SpanKey), Box<[BindingId]>>,
+    nonlocal_binding_visiting: FxHashSet<(Name, ScopeId, SpanKey)>,
+}
+
+impl<'model> SemanticAnalysis<'model> {
+    pub fn value_flow(&self) -> SemanticValueFlow<'_, 'model> {
+        SemanticValueFlow::new(self)
+    }
+}
+
+impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
+    fn new(analysis: &'analysis SemanticAnalysis<'model>) -> Self {
+        Self {
+            analysis,
+            nonlocal_binding_memo: FxHashMap::default(),
+            nonlocal_binding_visiting: FxHashSet::default(),
+        }
+    }
+
+    pub fn reaching_value_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
+        self.reaching_value_bindings_for_name_inner(name, at, None)
+    }
+
+    pub fn reaching_value_bindings_for_name_with_synthetic_use_block(
+        &self,
+        name: &Name,
+        at: Span,
+        synthetic_use_block: Option<BlockId>,
+    ) -> Vec<BindingId> {
+        self.reaching_value_bindings_for_name_inner(name, at, synthetic_use_block)
+    }
+
+    fn reaching_value_bindings_for_name_inner(
+        &self,
+        name: &Name,
+        at: Span,
+        synthetic_use_block: Option<BlockId>,
+    ) -> Vec<BindingId> {
+        let mut bindings = self.analysis.reaching_bindings_for_name(name, at);
+        self.retain_value_bindings(&mut bindings);
+        if self.analysis.reference_id_for_name_at(name, at).is_none() {
+            let synthetic_bindings =
+                self.synthetic_reaching_value_bindings_for_name(name, at, synthetic_use_block);
+            if !synthetic_bindings.is_empty() {
+                bindings = synthetic_bindings;
+            }
+        }
+        if bindings.is_empty()
+            && let Some(binding_id) = self.latest_visible_value_binding_for_name(name, at)
+        {
+            bindings.push(binding_id);
+        }
+        self.sort_and_dedup_bindings(&mut bindings);
+        bindings
+    }
+
+    pub fn reaching_value_bindings_bypassing(
+        &self,
+        name: &Name,
+        bypass_binding: BindingId,
+        at: Span,
+    ) -> Vec<BindingId> {
+        let mut bindings = self
+            .analysis
+            .visible_bindings_bypassing(name, bypass_binding, at);
+        self.retain_value_bindings(&mut bindings);
+        self.sort_and_dedup_bindings(&mut bindings);
+        bindings
+    }
+
+    pub fn ancestor_value_bindings_before(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        at: Span,
+    ) -> Vec<BindingId> {
+        let visible_scopes = self
+            .model()
+            .ancestor_scopes(scope)
+            .collect::<FxHashSet<_>>();
+        let mut bindings = self
+            .model()
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .filter(|binding_id| {
+                let binding = self.model().binding(*binding_id);
+                visible_scopes.contains(&binding.scope)
+                    && binding.span.end.offset <= at.start.offset
+            })
+            .collect::<Vec<_>>();
+        self.retain_value_bindings(&mut bindings);
+        self.sort_and_dedup_bindings(&mut bindings);
+        bindings
+    }
+
+    pub fn nonlocal_value_bindings_from_called_functions_before(
+        &mut self,
+        name: &Name,
+        scope: ScopeId,
+        at: Span,
+    ) -> Vec<BindingId> {
+        let caller_has_visible_local = self.scope_has_visible_local_binding_before(name, scope, at);
+
+        let key = (name.clone(), scope, SpanKey::new(at));
+        if let Some(cached) = self.nonlocal_binding_memo.get(&key) {
+            return cached.to_vec();
+        }
+        if !self.nonlocal_binding_visiting.insert(key.clone()) {
+            return Vec::new();
+        }
+
+        let mut bindings = self
+            .nonlocal_bindings_from_functions_called_in_scope_before(name, scope, at)
+            .into_iter()
+            .collect::<FxHashSet<_>>();
+
+        if !caller_has_visible_local
+            && let Some(caller_bindings) = self.nonlocal_bindings_reaching_all_callers(name, scope)
+        {
+            bindings.extend(caller_bindings);
+        }
+
+        self.nonlocal_binding_visiting.remove(&key);
+        let mut bindings = bindings.into_iter().collect::<Vec<_>>();
+        self.retain_value_bindings(&mut bindings);
+        self.sort_and_dedup_bindings(&mut bindings);
+        self.nonlocal_binding_memo
+            .insert(key, bindings.clone().into_boxed_slice());
+        bindings
+    }
+
+    pub fn called_function_scopes_before(
+        &self,
+        scope: ScopeId,
+        limit_offset: usize,
+    ) -> Vec<ScopeId> {
+        let mut scopes = Vec::new();
+        let mut seen_scopes = FxHashSet::default();
+
+        for (&function_binding, &callee_scope) in
+            &self.model().recorded_program.function_body_scopes
+        {
+            let binding = self.model().binding(function_binding);
+            let called_before = self
+                .model()
+                .call_sites_for(&binding.name)
+                .iter()
+                .any(|site| {
+                    site.scope == scope
+                        && self.call_site_dominates_offset(site.span, limit_offset)
+                        && self.function_scope_resolves_at_call_site(
+                            callee_scope,
+                            &binding.name,
+                            site,
+                        )
+                });
+            if called_before && seen_scopes.insert(callee_scope) {
+                scopes.push(callee_scope);
+            }
+        }
+
+        scopes.sort_by_key(|scope| self.model().scope(*scope).span.start.offset);
+        scopes
+    }
+
+    pub fn value_bindings_cover_all_paths_to_span(
+        &self,
+        bindings: &[BindingId],
+        target_span: Span,
+    ) -> bool {
+        let target_blocks = self
+            .analysis
+            .cfg()
+            .blocks()
+            .iter()
+            .filter(|block| block.commands.contains(&target_span))
+            .map(|block| block.id)
+            .collect::<FxHashSet<_>>();
+        if target_blocks.is_empty() {
+            return true;
+        }
+
+        let cover_blocks = bindings
+            .iter()
+            .copied()
+            .filter_map(|binding_id| self.analysis.block_for_binding(binding_id))
+            .collect::<FxHashSet<_>>();
+        if !cover_blocks.is_disjoint(&target_blocks) {
+            return true;
+        }
+
+        let binding_scopes = bindings
+            .iter()
+            .copied()
+            .map(|binding_id| self.model().binding(binding_id).scope)
+            .collect::<Vec<_>>();
+        let entry = self
+            .analysis
+            .flow_entry_block_for_binding_scopes(&binding_scopes, target_span.start.offset);
+        target_blocks.iter().copied().all(|target_block| {
+            self.analysis
+                .blocks_cover_all_paths_to_block(entry, target_block, &cover_blocks)
+        })
+    }
+
+    pub fn binding_visible_at(&self, binding_id: BindingId, at: Span) -> bool {
+        self.model().binding_visible_at(binding_id, at)
+    }
+
+    pub fn binding_can_supply_parameter_value(&self, binding_id: BindingId) -> bool {
+        let binding = self.model().binding(binding_id);
+        match binding.origin {
+            BindingOrigin::FunctionDefinition { .. } => false,
+            BindingOrigin::Declaration { .. } => {
+                binding_is_name_only_declaration(binding)
+                    || binding.attributes.intersects(
+                        BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
+                    )
+            }
+            _ => true,
+        }
+    }
+
+    fn synthetic_reaching_value_bindings_for_name(
+        &self,
+        name: &Name,
+        at: Span,
+        synthetic_use_block: Option<BlockId>,
+    ) -> Vec<BindingId> {
+        let Some(reference_block) =
+            synthetic_use_block.or_else(|| self.block_for_name_use_site(name, at))
+        else {
+            return Vec::new();
+        };
+
+        let unreachable = self.analysis.unreachable_blocks();
+        let candidates = self
+            .model()
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .filter(|binding_id| self.binding_can_supply_parameter_value(*binding_id))
+            .filter(|binding_id| self.model().binding_visible_at(*binding_id, at))
+            .filter_map(|binding_id| {
+                let block_id = self.analysis.block_for_binding(binding_id)?;
+                (!unreachable.contains(&block_id)).then_some((binding_id, block_id))
+            })
+            .collect::<Vec<_>>();
+
+        let mut bindings = candidates
+            .iter()
+            .copied()
+            .filter(|(binding_id, binding_block)| {
+                !self.binding_is_shadowed_before_synthetic_use(
+                    *binding_id,
+                    *binding_block,
+                    at,
+                    &candidates,
+                ) && self.binding_block_reaches_synthetic_use(
+                    *binding_id,
+                    *binding_block,
+                    reference_block,
+                    &candidates,
+                    unreachable,
+                )
+            })
+            .map(|(binding_id, _)| binding_id)
+            .collect::<Vec<_>>();
+        self.sort_and_dedup_bindings(&mut bindings);
+        bindings
+    }
+
+    fn binding_is_shadowed_before_synthetic_use(
+        &self,
+        binding_id: BindingId,
+        binding_block: BlockId,
+        at: Span,
+        candidates: &[(BindingId, BlockId)],
+    ) -> bool {
+        let binding = self.model().binding(binding_id);
+        candidates.iter().any(|(other_id, other_block)| {
+            *other_id != binding_id && *other_block == binding_block && {
+                let other = self.model().binding(*other_id);
+                other.span.start.offset > binding.span.start.offset
+                    && other.span.start.offset < at.start.offset
+            }
+        })
+    }
+
+    fn binding_block_reaches_synthetic_use(
+        &self,
+        binding_id: BindingId,
+        binding_block: BlockId,
+        reference_block: BlockId,
+        candidates: &[(BindingId, BlockId)],
+        unreachable: &FxHashSet<BlockId>,
+    ) -> bool {
+        let blocked_blocks = candidates
+            .iter()
+            .copied()
+            .filter(|(other_id, _)| *other_id != binding_id)
+            .map(|(_, block_id)| block_id)
+            .collect::<FxHashSet<_>>();
+        let cfg = self.analysis.cfg();
+        let mut stack = vec![binding_block];
+        let mut seen = FxHashSet::default();
+        while let Some(block_id) = stack.pop() {
+            if block_id != binding_block && blocked_blocks.contains(&block_id) {
+                continue;
+            }
+            if block_id == reference_block {
+                return true;
+            }
+            if unreachable.contains(&block_id) || !seen.insert(block_id) {
+                continue;
+            }
+            for (successor, _) in cfg.successors(block_id) {
+                stack.push(*successor);
+            }
+        }
+
+        false
+    }
+
+    fn latest_visible_value_binding_for_name(&self, name: &Name, at: Span) -> Option<BindingId> {
+        self.model()
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .filter(|binding_id| self.binding_can_supply_parameter_value(*binding_id))
+            .filter(|binding_id| self.model().binding_visible_at(*binding_id, at))
+            .max_by_key(|binding_id| self.model().binding(*binding_id).span.start.offset)
+    }
+
+    fn block_for_name_use_site(&self, name: &Name, at: Span) -> Option<BlockId> {
+        if let Some(reference_id) = self.analysis.reference_id_for_name_at(name, at) {
+            return self.analysis.block_for_reference_id(reference_id);
+        }
+
+        let command_id = self
+            .model()
+            .innermost_command_id_at(at.start.offset)
+            .or_else(|| self.innermost_command_id_containing_offset(at.start.offset))?;
+        self.analysis
+            .block_ids_for_span(self.model().command_syntax_span(command_id))
+            .first()
+            .copied()
+    }
+
+    fn innermost_command_id_containing_offset(&self, offset: usize) -> Option<CommandId> {
+        self.model()
+            .commands()
+            .iter()
+            .copied()
+            .filter(|command_id| {
+                let span = self.model().command_syntax_span(*command_id);
+                span.start.offset <= offset && offset <= span.end.offset
+            })
+            .max_by(|left, right| {
+                let left_span = self.model().command_syntax_span(*left);
+                let right_span = self.model().command_syntax_span(*right);
+                left_span
+                    .start
+                    .offset
+                    .cmp(&right_span.start.offset)
+                    .then_with(|| right_span.end.offset.cmp(&left_span.end.offset))
+            })
+    }
+
+    fn nonlocal_bindings_from_functions_called_in_scope_before(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        at: Span,
+    ) -> Vec<BindingId> {
+        let mut bindings = Vec::new();
+
+        for callee_scope in self.called_function_scopes_providing_name(name) {
+            let Some(function_kind) = self.named_function_kind(callee_scope) else {
+                continue;
+            };
+
+            let called_before = function_kind.static_names().iter().any(|function_name| {
+                self.model()
+                    .call_sites_for(function_name)
+                    .iter()
+                    .any(|site| {
+                        site.scope == scope
+                            && self.function_scope_resolves_at_call_site(
+                                callee_scope,
+                                function_name,
+                                site,
+                            )
+                            && self.call_site_dominates_offset(site.span, at.start.offset)
+                    })
+            });
+            if !called_before {
+                continue;
+            }
+
+            bindings.extend(self.nonlocal_bindings_for_name_in_scope(name, callee_scope));
+        }
+
+        bindings
+    }
+
+    fn nonlocal_bindings_reaching_all_callers(
+        &mut self,
+        name: &Name,
+        scope: ScopeId,
+    ) -> Option<FxHashSet<BindingId>> {
+        let function_kind = self.named_function_kind(scope)?;
+        let mut caller_sites = Vec::new();
+        let mut seen_sites = FxHashSet::default();
+
+        for function_name in function_kind.static_names() {
+            for site in self.model().call_sites_for(function_name) {
+                if site.scope == scope {
+                    continue;
+                }
+                if !self.function_scope_resolves_at_call_site(scope, function_name, site) {
+                    continue;
+                }
+                if seen_sites.insert((site.scope, site.span.start.offset, site.span.end.offset)) {
+                    caller_sites.push(site.clone());
+                }
+            }
+        }
+
+        let mut saw_caller = false;
+        let mut union = FxHashSet::default();
+        for site in caller_sites {
+            saw_caller = true;
+            let branch = self
+                .caller_branch_value_bindings_before(name, site.scope, site.span)
+                .into_iter()
+                .collect::<FxHashSet<_>>();
+            if branch.is_empty() {
+                return Some(FxHashSet::default());
+            }
+            union.extend(branch);
+        }
+
+        saw_caller.then_some(union)
+    }
+
+    fn caller_branch_value_bindings_before(
+        &mut self,
+        name: &Name,
+        scope: ScopeId,
+        at: Span,
+    ) -> Vec<BindingId> {
+        let mut branch = self.reaching_value_bindings_for_name(name, at);
+        branch.extend(self.ancestor_value_bindings_before(name, scope, at));
+        branch.extend(self.nonlocal_value_bindings_from_called_functions_before(name, scope, at));
+        if self.scope_has_visible_local_binding_before(name, scope, at) {
+            branch.retain(|binding_id| self.model().binding(*binding_id).scope == scope);
+        }
+        self.sort_and_dedup_bindings(&mut branch);
+        branch
+    }
+
+    fn called_function_scopes_providing_name(&self, name: &Name) -> Vec<ScopeId> {
+        self.model()
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .filter_map(|binding_id| {
+                let binding = self.model().binding(binding_id);
+                (!binding.attributes.contains(BindingAttributes::LOCAL)
+                    && matches!(
+                        self.model().scope(binding.scope).kind,
+                        ScopeKind::Function(_)
+                    ))
+                .then_some(binding.scope)
+            })
+            .collect::<FxHashSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn nonlocal_bindings_for_name_in_scope(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+    ) -> impl Iterator<Item = BindingId> + '_ {
+        self.model()
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .filter(move |binding_id| {
+                let binding = self.model().binding(*binding_id);
+                binding.scope == scope && !binding.attributes.contains(BindingAttributes::LOCAL)
+            })
+    }
+
+    fn named_function_kind(&self, scope: ScopeId) -> Option<&FunctionScopeKind> {
+        match &self.model().scope(scope).kind {
+            ScopeKind::Function(function) if !function.static_names().is_empty() => Some(function),
+            ScopeKind::File
+            | ScopeKind::Function(_)
+            | ScopeKind::Subshell
+            | ScopeKind::CommandSubstitution
+            | ScopeKind::Pipeline => None,
+        }
+    }
+
+    fn function_scope_resolves_at_call_site(
+        &self,
+        callee_scope: ScopeId,
+        function_name: &Name,
+        site: &CallSite,
+    ) -> bool {
+        if let Some(binding_id) = self
+            .analysis
+            .visible_function_binding_at_call(function_name, site.name_span)
+        {
+            return self.analysis.function_scope_for_binding(binding_id) == Some(callee_scope);
+        }
+
+        self.function_binding_for_scope(callee_scope)
+            .is_some_and(|binding_id| {
+                let binding = self.model().binding(binding_id);
+                binding.name == *function_name && binding.span.end.offset <= site.span.start.offset
+            })
+    }
+
+    fn function_binding_for_scope(&self, scope: ScopeId) -> Option<BindingId> {
+        self.model()
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .find_map(|(binding_id, body_scope)| (*body_scope == scope).then_some(*binding_id))
+    }
+
+    fn call_site_dominates_offset(&self, call_span: Span, limit_offset: usize) -> bool {
+        if call_span.start.offset >= limit_offset {
+            return false;
+        }
+
+        let Some(mut command_id) = self
+            .model()
+            .innermost_command_id_at(call_span.start.offset)
+            .or_else(|| self.innermost_command_id_containing_offset(call_span.start.offset))
+        else {
+            return true;
+        };
+
+        while self.model().command_syntax_span(command_id) != call_span {
+            let Some(parent_id) = self.model().command_parent_id(command_id) else {
+                return true;
+            };
+            command_id = parent_id;
+        }
+
+        let mut current = self.model().command_parent_id(command_id);
+        while let Some(command_id) = current {
+            let command_span = self.model().command_syntax_span(command_id);
+            if command_span.end.offset > limit_offset {
+                break;
+            }
+            if command_span.start.offset < call_span.start.offset
+                && self.command_is_dominance_barrier(command_id)
+            {
+                return false;
+            }
+            current = self.model().command_parent_id(command_id);
+        }
+
+        true
+    }
+
+    fn command_is_dominance_barrier(&self, command_id: CommandId) -> bool {
+        match self.model().command_kind(command_id) {
+            CommandKind::Binary => true,
+            CommandKind::Compound(kind) => !matches!(
+                kind,
+                CompoundCommandKind::BraceGroup
+                    | CompoundCommandKind::Arithmetic
+                    | CompoundCommandKind::Time
+            ),
+            CommandKind::Simple
+            | CommandKind::Builtin(_)
+            | CommandKind::Decl
+            | CommandKind::Function
+            | CommandKind::AnonymousFunction => false,
+        }
+    }
+
+    fn scope_has_visible_local_binding_before(
+        &self,
+        name: &Name,
+        scope: ScopeId,
+        at: Span,
+    ) -> bool {
+        self.model()
+            .bindings_for(name)
+            .iter()
+            .copied()
+            .any(|binding_id| {
+                let binding = self.model().binding(binding_id);
+                binding.scope == scope
+                    && binding.span.end.offset <= at.start.offset
+                    && binding.attributes.contains(BindingAttributes::LOCAL)
+            })
+    }
+
+    fn retain_value_bindings(&self, bindings: &mut Vec<BindingId>) {
+        bindings.retain(|binding_id| self.binding_can_supply_parameter_value(*binding_id));
+    }
+
+    fn sort_and_dedup_bindings(&self, bindings: &mut Vec<BindingId>) {
+        bindings.sort_by_key(|binding_id| self.model().binding(*binding_id).span.start.offset);
+        bindings.dedup();
+    }
+
+    fn model(&self) -> &'model SemanticModel {
+        self.analysis.model
+    }
+}
+
+fn binding_is_name_only_declaration(binding: &Binding) -> bool {
+    matches!(binding.origin, BindingOrigin::Declaration { .. })
+        && binding.attributes.contains(BindingAttributes::LOCAL)
+        && !binding
+            .attributes
+            .contains(BindingAttributes::DECLARATION_INITIALIZED)
+}

--- a/crates/shuck-semantic/src/value_flow.rs
+++ b/crates/shuck-semantic/src/value_flow.rs
@@ -526,9 +526,41 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
 
         self.function_binding_for_scope(callee_scope)
             .is_some_and(|binding_id| {
-                let binding = self.model().binding(binding_id);
-                binding.name == *function_name && binding.span.end.offset <= site.span.start.offset
+                self.function_binding_may_resolve_at_call(binding_id, function_name, site)
             })
+    }
+
+    fn function_binding_may_resolve_at_call(
+        &self,
+        binding_id: BindingId,
+        function_name: &Name,
+        site: &CallSite,
+    ) -> bool {
+        let Some(scope) = self.analysis.function_scope_for_binding(binding_id) else {
+            return false;
+        };
+        let Some(function_kind) = self.named_function_kind(scope) else {
+            return false;
+        };
+        if !function_kind.contains_name(function_name) {
+            return false;
+        }
+
+        if let Some(definition_command) = self.function_definition_command_for_binding(binding_id)
+            && self.definition_command_resolves_at_call(definition_command, site.span)
+        {
+            return true;
+        }
+
+        self.possible_function_bindings_cover_call(function_name, binding_id, site)
+    }
+
+    fn function_definition_command_for_binding(&self, binding_id: BindingId) -> Option<CommandId> {
+        self.model().commands().iter().copied().find(|command_id| {
+            self.model().function_definition_binding_for_command_span(
+                self.model().command_span(*command_id),
+            ) == Some(binding_id)
+        })
     }
 
     fn function_binding_for_scope(&self, scope: ScopeId) -> Option<BindingId> {
@@ -537,6 +569,86 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             .function_body_scopes
             .iter()
             .find_map(|(binding_id, body_scope)| (*body_scope == scope).then_some(*binding_id))
+    }
+
+    fn possible_function_bindings_cover_call(
+        &self,
+        function_name: &Name,
+        binding_id: BindingId,
+        site: &CallSite,
+    ) -> bool {
+        let candidates = self
+            .model()
+            .function_definitions(function_name)
+            .iter()
+            .copied()
+            .filter(|candidate| {
+                self.function_definition_command_for_binding(*candidate)
+                    .is_some_and(|command_id| {
+                        self.definition_command_scope_can_reach_call(command_id, site.span)
+                            && self.model().command_span(command_id).end.offset
+                                <= site.span.start.offset
+                    })
+            })
+            .collect::<Vec<_>>();
+        candidates.len() > 1
+            && candidates.contains(&binding_id)
+            && self.value_bindings_cover_all_paths_to_span(&candidates, site.span)
+    }
+
+    fn definition_command_resolves_at_call(&self, command_id: CommandId, call_span: Span) -> bool {
+        if !self.definition_command_is_visible_at_call(command_id, call_span) {
+            return false;
+        }
+
+        let command_span = self.model().command_span(command_id);
+        let definition_scope = self
+            .analysis
+            .enclosing_function_scope_at(command_span.start.offset);
+        let call_scope = self
+            .analysis
+            .enclosing_function_scope_at(call_span.start.offset);
+
+        if definition_scope.is_none() && call_scope.is_some() {
+            return true;
+        }
+
+        command_span.end.offset <= call_span.start.offset
+    }
+
+    fn definition_command_scope_can_reach_call(
+        &self,
+        command_id: CommandId,
+        call_span: Span,
+    ) -> bool {
+        let command_span = self.model().command_span(command_id);
+        let command_scope = self
+            .analysis
+            .enclosing_function_scope_at(command_span.start.offset);
+        let call_scope = self
+            .analysis
+            .enclosing_function_scope_at(call_span.start.offset);
+        command_scope.is_none() || command_scope == call_scope
+    }
+
+    fn definition_command_is_visible_at_call(
+        &self,
+        command_id: CommandId,
+        call_span: Span,
+    ) -> bool {
+        if !self.definition_command_scope_can_reach_call(command_id, call_span) {
+            return false;
+        }
+
+        let mut parent_id = self.model().command_parent_id(command_id);
+        while let Some(id) = parent_id {
+            if self.command_is_dominance_barrier(id) {
+                return false;
+            }
+            parent_id = self.model().command_parent_id(id);
+        }
+
+        true
     }
 
     fn call_site_dominates_offset(&self, call_span: Span, limit_offset: usize) -> bool {


### PR DESCRIPTION
## Summary
- add SemanticValueFlow for reusable shell value-flow queries over semantic bindings, calls, CFG, and dataflow
- move safe_value reaching/bypass/ancestor/nonlocal/path-coverage composition onto SemanticValueFlow
- keep S001-specific safety policy in safe_value and add semantic value-flow regression coverage

## Validation
- cargo test -p shuck-semantic value_flow
- cargo test -p shuck-linter safe_value
- make test
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001
- make test-large-corpus