### PR TITLE
docs(indexer): document public API contracts

### DIFF
--- a/crates/shuck-indexer/src/comment_index.rs
+++ b/crates/shuck-indexer/src/comment_index.rs
@@ -10,17 +10,29 @@ use shuck_ast::{
 use crate::LineIndex;
 
 /// A source comment with resolved positional metadata.
+///
+/// Comments are discovered from parser output rather than by rescanning the
+/// source text. This keeps nested comments from command substitutions and other
+/// parsed shell constructs aligned with the AST that downstream analysis sees.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IndexedComment {
-    /// Byte range of the comment in source (including the `#`).
+    /// Byte range of the comment in source, including the `#` marker.
     pub range: TextRange,
-    /// The 1-based line number this comment appears on.
+    /// The 1-based physical line number this comment appears on.
     pub line: usize,
-    /// Whether this comment is the only non-whitespace content on its line.
+    /// Whether this comment is the only non-horizontal-whitespace content on its line.
+    ///
+    /// Spaces, tabs, and carriage returns before or after the comment are
+    /// ignored for this classification.
     pub is_own_line: bool,
 }
 
-/// Comment ranges and position metadata.
+/// Comment ranges and line-oriented lookup metadata.
+///
+/// The index stores comments in source order and keeps a compact per-line range
+/// table so callers can ask for comments on a line without scanning the full
+/// comment list. It includes shebang-style comments when the parser represents
+/// them as comments.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CommentIndex {
     comments: Vec<IndexedComment>,
@@ -28,7 +40,12 @@ pub struct CommentIndex {
 }
 
 impl CommentIndex {
-    /// Build from AST-owned comments and source text.
+    /// Build a comment index from AST-owned comments and source text.
+    ///
+    /// `source`, `line_index`, and `file` must describe the same parsed source.
+    /// Comments with ranges outside `source` or on invalid UTF-8 boundaries are
+    /// skipped defensively, then the remaining comments are sorted by source
+    /// range before line lookup metadata is built.
     pub fn new(source: &str, line_index: &LineIndex, file: &File) -> Self {
         let mut comments = Vec::new();
         collect_file_comments(file, &mut comments);
@@ -93,12 +110,18 @@ impl CommentIndex {
         }
     }
 
-    /// All comments in source order.
+    /// Return all indexed comments in source order.
+    ///
+    /// The returned slice is stable for the lifetime of the index and does not
+    /// allocate.
     pub fn comments(&self) -> &[IndexedComment] {
         &self.comments
     }
 
-    /// Comments on a specific 1-based line.
+    /// Return comments on a specific 1-based line.
+    ///
+    /// Invalid line numbers return an empty slice. The returned comments retain
+    /// source order and borrow from the index.
     pub fn comments_on_line(&self, line: usize) -> &[IndexedComment] {
         let Some(range) = line
             .checked_sub(1)
@@ -110,7 +133,10 @@ impl CommentIndex {
         &self.comments[range.start..range.end]
     }
 
-    /// Whether the given byte offset falls inside a comment.
+    /// Return whether `offset` falls inside a comment range.
+    ///
+    /// Comment ranges are half-open: the start byte is included and the end byte
+    /// is excluded.
     pub fn is_comment(&self, offset: TextSize) -> bool {
         let index = self
             .comments

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -3,8 +3,21 @@
 
 //! Positional and structural indexes over parsed shell scripts.
 //!
-//! The indexer complements `shuck-parser` by building efficient lookup tables for line numbers,
-//! comments, syntactic regions, and continuation lines.
+//! The indexer complements `shuck-parser` by building compact lookup tables for
+//! source lines, comments, syntactic regions, heredoc bodies, and physical line
+//! continuations. It is intended to be built once from parser output and then
+//! shared by semantic analysis, lint rules, suppressions, formatters, and report
+//! rendering.
+//!
+//! All positions are byte offsets represented with `shuck_ast::TextSize` and
+//! `shuck_ast::TextRange`. The crate does not build a character index: callers
+//! that need display columns should combine these byte offsets with the original
+//! source text at the UI boundary.
+//!
+//! [`Indexer`] is the preferred construction path when parser output is
+//! available. The lower-level indexes are also exported for integrations that
+//! only need line mapping or that already have an AST-shaped source of comments
+//! or regions.
 mod comment_index;
 #[allow(missing_docs)]
 mod line_index;
@@ -22,6 +35,15 @@ use shuck_ast::TextSize;
 use shuck_parser::parser::ParseResult;
 
 /// Pre-computed positional and structural index over a parsed shell script.
+///
+/// `Indexer` owns the line, comment, and syntactic-region indexes for one source
+/// file. It also filters raw backslash-newline candidates into the continuation
+/// lines that matter to shell analysis: continuations in comments, quoted text,
+/// and heredoc bodies are excluded.
+///
+/// Build one `Indexer` for a parse result and pass references to downstream
+/// analysis code. Query methods borrow precomputed data and do not walk the AST,
+/// rescan the full source, or allocate.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Indexer {
     line_index: LineIndex,
@@ -31,7 +53,12 @@ pub struct Indexer {
 }
 
 impl Indexer {
-    /// Build an index from parser output and the original source text.
+    /// Build all indexes from parser output and the original source text.
+    ///
+    /// `source` must be the exact text used to produce `output`; ranges in the
+    /// parse result are interpreted as byte offsets into that string. Mismatched
+    /// source text can make line and region queries meaningless, even though the
+    /// constructor defensively avoids panicking on malformed comment ranges.
     pub fn new(source: &str, output: &ParseResult) -> Self {
         let line_index = LineIndex::new(source);
         let comment_index = CommentIndex::new(source, &line_index, &output.file);
@@ -47,27 +74,46 @@ impl Indexer {
         }
     }
 
-    /// The line index for the source text.
+    /// Return the line index for this source text.
+    ///
+    /// This is useful for converting diagnostic byte offsets to 1-based line
+    /// numbers or for extracting line-local snippets from the original source.
     pub fn line_index(&self) -> &LineIndex {
         &self.line_index
     }
 
-    /// The comment index extracted from the parsed file.
+    /// Return the comment index extracted from parser-owned comments.
+    ///
+    /// Comments are exposed in source order and include parser-recognized
+    /// comments inside nested shell constructs.
     pub fn comment_index(&self) -> &CommentIndex {
         &self.comment_index
     }
 
-    /// The syntactic region index for quoted, heredoc, and related spans.
+    /// Return the syntactic region index for quoted, heredoc, and related spans.
+    ///
+    /// Region lookups are intended for rules and formatters that need to avoid
+    /// interpreting bytes the same way in every syntactic context.
     pub fn region_index(&self) -> &RegionIndex {
         &self.region_index
     }
 
-    /// Byte offsets of the start of each continuation line.
+    /// Return byte offsets for the start of each semantic continuation line.
+    ///
+    /// Each offset points at the first byte of a physical line that continues
+    /// the previous one because that previous line ended with an active
+    /// backslash-newline. Continuations inside comments, quotes, and heredocs
+    /// are filtered out.
     pub fn continuation_line_starts(&self) -> &[TextSize] {
         &self.continuation_lines
     }
 
-    /// Whether the given byte offset is on a continuation line.
+    /// Return whether `offset` is on a semantic continuation line.
+    ///
+    /// The query first maps `offset` to its containing 1-based line, then checks
+    /// whether that line starts at one of [`Self::continuation_line_starts`].
+    /// Offsets past the final byte of the source are treated according to the
+    /// last indexed line.
     pub fn is_continuation(&self, offset: TextSize) -> bool {
         let line = self.line_index.line_number(offset);
         let Some(line_start) = self.line_index.line_start(line) else {

--- a/crates/shuck-indexer/src/line_index.rs
+++ b/crates/shuck-indexer/src/line_index.rs
@@ -1,6 +1,10 @@
 use shuck_ast::{TextRange, TextSize};
 
-/// Maps between byte offsets and source lines.
+/// Maps between byte offsets and 1-based source lines.
+///
+/// `LineIndex` stores the byte offset of each physical line start in the source
+/// text. It intentionally uses byte offsets, not character columns, so lookups
+/// stay cheap and match parser spans exactly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LineIndex {
     line_starts: Vec<TextSize>,
@@ -8,7 +12,15 @@ pub struct LineIndex {
 }
 
 impl LineIndex {
-    /// Build from source text.
+    /// Build a line index from source text.
+    ///
+    /// Empty source is treated as one empty line starting at byte offset `0`.
+    /// Every byte immediately after `\n` is recorded as the start of the next
+    /// line, including a trailing empty line when the source ends in a newline.
+    ///
+    /// This constructor also records raw backslash-newline candidates for
+    /// [`crate::Indexer`]. Those raw candidates are filtered later against
+    /// comments, quotes, and heredocs before becoming semantic continuations.
     pub fn new(source: &str) -> Self {
         let bytes = source.as_bytes();
         let mut line_starts = Vec::new();
@@ -32,17 +44,29 @@ impl LineIndex {
     }
 
     /// Return the 1-based line number containing `offset`.
+    ///
+    /// `offset` is a byte offset into the source. Offsets at a line start belong
+    /// to that new line, while offsets past the final indexed line map to the
+    /// last line. This method does not validate that `offset` is within the
+    /// original source length.
     pub fn line_number(&self, offset: TextSize) -> usize {
         self.line_starts.partition_point(|start| *start <= offset)
     }
 
-    /// Return the byte offset of the start of the given 1-based line.
+    /// Return the byte offset of the start of a 1-based line.
+    ///
+    /// Returns `None` for line `0` or for lines beyond the indexed source.
     pub fn line_start(&self, line: usize) -> Option<TextSize> {
         line.checked_sub(1)
             .and_then(|index| self.line_starts.get(index).copied())
     }
 
-    /// Return the byte range of the given 1-based line (excluding newline).
+    /// Return the byte range of a 1-based line, excluding its trailing newline.
+    ///
+    /// `source` must be the same text used to construct the index. The returned
+    /// range starts at [`Self::line_start`] and ends before a trailing `\n` when
+    /// present; a preceding `\r` is left in the range so callers can decide how
+    /// to handle CRLF display. Returns `None` for invalid line numbers.
     pub fn line_range(&self, line: usize, source: &str) -> Option<TextRange> {
         let start = self.line_start(line)?;
         let line_index = line.checked_sub(1)?;
@@ -62,7 +86,9 @@ impl LineIndex {
         Some(TextRange::new(start, end))
     }
 
-    /// Return the total number of lines.
+    /// Return the number of physical lines recorded for the source.
+    ///
+    /// The count is always at least `1`, even for empty source.
     pub fn line_count(&self) -> usize {
         self.line_starts.len()
     }

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -4,7 +4,12 @@ use shuck_ast::{
     HeredocBodyPartNode, Pattern, PatternPart, PatternPartNode, Redirect, RedirectKind, Stmt,
     StmtSeq, Subscript, TextRange, TextSize, VarRef, Word, WordPart, WordPartNode, ZshGlobSegment,
 };
-/// A syntactic region that affects lint rule behavior.
+/// A syntactic region that affects source interpretation.
+///
+/// Region kinds describe contexts where downstream tools should interpret bytes
+/// differently from ordinary shell source. For example, formatters and lint
+/// rules often need to suppress word-splitting assumptions inside quotes or
+/// avoid scanning heredoc bodies as command syntax.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegionKind {
     /// Text inside single quotes.
@@ -28,6 +33,16 @@ struct IndexedRegion {
 }
 
 /// Byte ranges of syntactic regions where special rules apply.
+///
+/// `RegionIndex` stores one sorted range list per commonly queried region type
+/// plus a combined list for queries that need the innermost containing region.
+/// Ranges are byte ranges in the original source and are half-open: the start
+/// byte is included and the end byte is excluded.
+///
+/// Region ranges generally include the syntactic delimiters represented by the
+/// parser span, such as quote characters or substitution delimiters. Callers
+/// that need only the interior text should trim delimiters using source-aware
+/// logic at the call site.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RegionIndex {
     single_quoted: Vec<TextRange>,
@@ -41,19 +56,32 @@ pub struct RegionIndex {
 }
 
 impl RegionIndex {
-    /// Build from source text and the parsed file.
+    /// Build a region index from source text and a parsed file.
+    ///
+    /// `source` is accepted for API symmetry with the other indexes and future
+    /// source-sensitive region collection, but current region construction is
+    /// driven by AST spans from `file`. `source` and `file` should describe the
+    /// same parsed text.
     pub fn new(source: &str, file: &File) -> Self {
         let mut collector = RegionCollector::new(source);
         collector.visit_file(file);
         collector.finish()
     }
 
-    /// Return the innermost region containing the given byte offset, if any.
+    /// Return the innermost region kind containing `offset`, if any.
+    ///
+    /// If multiple regions contain the same byte, the smallest containing range
+    /// wins. Ties prefer the region that starts later, matching the same
+    /// innermost rule used by [`Self::region_with_range_at`].
     pub fn region_at(&self, offset: TextSize) -> Option<RegionKind> {
         self.region_with_range_at(offset).map(|(kind, _)| kind)
     }
 
-    /// Return the innermost region kind and range containing the given byte offset, if any.
+    /// Return the innermost region kind and range containing `offset`, if any.
+    ///
+    /// The returned range is the original half-open byte range stored for that
+    /// region. This is useful when a caller needs both the classification and
+    /// the bounds of the syntactic context that produced it.
     pub fn region_with_range_at(&self, offset: TextSize) -> Option<(RegionKind, TextRange)> {
         let mut best: Option<IndexedRegion> = None;
         let end = self
@@ -75,34 +103,52 @@ impl RegionIndex {
         best.map(|region| (region.kind, region.range))
     }
 
-    /// Check if a byte offset falls inside any quoted region.
+    /// Return whether `offset` falls inside any quoted region.
+    ///
+    /// This includes single quotes, double quotes, and bodies of heredocs whose
+    /// delimiter was quoted.
     pub fn is_quoted(&self, offset: TextSize) -> bool {
         contains_any(&self.single_quoted, offset)
             || contains_any(&self.double_quoted, offset)
             || contains_any(&self.quoted_heredocs, offset)
     }
 
-    /// Check if a byte offset falls inside a heredoc body.
+    /// Return whether `offset` falls inside any heredoc body.
+    ///
+    /// Both quoted and unquoted heredoc bodies count as heredoc regions.
     pub fn is_heredoc(&self, offset: TextSize) -> bool {
         contains_any(&self.heredocs, offset)
     }
 
-    /// Check if a byte offset falls inside a quoted heredoc body.
+    /// Return whether `offset` falls inside a quoted heredoc body.
+    ///
+    /// A heredoc is considered quoted when its delimiter was quoted, which means
+    /// the shell treats the body more like literal text.
     pub fn is_quoted_heredoc(&self, offset: TextSize) -> bool {
         contains_any(&self.quoted_heredocs, offset)
     }
 
-    /// Check if a byte offset falls inside a command substitution.
+    /// Return whether `offset` falls inside a command substitution.
+    ///
+    /// This covers command substitutions represented by parser spans, including
+    /// nested substitutions inside words and heredoc bodies.
     pub fn is_command_substitution(&self, offset: TextSize) -> bool {
         contains_any(&self.command_substitutions, offset)
     }
 
-    /// Check if a byte offset falls inside an arithmetic context.
+    /// Return whether `offset` falls inside an arithmetic context.
+    ///
+    /// Arithmetic contexts include arithmetic commands, arithmetic `for`
+    /// headers, and arithmetic expansions represented by parser spans.
     pub fn is_arithmetic(&self, offset: TextSize) -> bool {
         contains_any(&self.arithmetic, offset)
     }
 
-    /// All heredoc body ranges.
+    /// Return all heredoc body ranges in source order.
+    ///
+    /// The ranges are half-open byte ranges and include both quoted and unquoted
+    /// heredoc bodies. The returned slice borrows from the index and does not
+    /// allocate.
     pub fn heredoc_ranges(&self) -> &[TextRange] {
         &self.heredocs
     }


### PR DESCRIPTION
## Summary

- expand shuck-indexer crate docs around byte-offset and range semantics
- document line, comment, region, and continuation query contracts
- keep the existing public surface intact for future formatter use

## Validation

- cargo fmt --check
- cargo rustdoc -p shuck-indexer --lib -- -D missing_docs
- cargo test -p shuck-indexer
