### PR TITLE
refactor(semantic): consolidate enclosing function scope lookup

### DIFF
--- a/crates/shuck-semantic/src/call_graph.rs
+++ b/crates/shuck-semantic/src/call_graph.rs
@@ -3,7 +3,7 @@ use shuck_ast::{Name, Span};
 use smallvec::SmallVec;
 
 use crate::binding::Binding;
-use crate::scope::ancestor_scopes;
+use crate::scope::{ancestor_scopes, enclosing_function_scope};
 use crate::{BindingId, Scope, ScopeId, ScopeKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,8 +108,7 @@ pub(crate) fn build_call_graph(
 }
 
 fn is_in_function_scope(scopes: &[Scope], scope: ScopeId) -> bool {
-    ancestor_scopes(scopes, scope)
-        .any(|scope| matches!(scopes[scope.index()].kind, ScopeKind::Function(_)))
+    enclosing_function_scope(scopes, scope).is_some()
 }
 
 fn is_in_named_function_scope(scopes: &[Scope], scope: ScopeId, name: &Name) -> bool {

--- a/crates/shuck-semantic/src/function_call_reachability.rs
+++ b/crates/shuck-semantic/src/function_call_reachability.rs
@@ -723,9 +723,7 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
     }
 
     fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
-        self.model()
-            .ancestor_scopes(scope)
-            .find(|scope_id| matches!(self.model().scope_kind(*scope_id), ScopeKind::Function(_)))
+        self.model().enclosing_function_scope(scope)
     }
 
     fn call_is_inside_scope(&self, scope: ScopeId, ancestor_scope: ScopeId) -> bool {

--- a/crates/shuck-semantic/src/function_resolution.rs
+++ b/crates/shuck-semantic/src/function_resolution.rs
@@ -3,7 +3,7 @@ use shuck_ast::{Name, Span};
 use smallvec::SmallVec;
 
 use crate::cfg::{CommandId, RecordedCommandKind, RecordedCommandRange, RecordedProgram};
-use crate::scope::ancestor_scopes;
+use crate::scope::{ancestor_scopes, enclosing_scope_matching};
 use crate::{Binding, BindingId, BindingKind, CallSite, Scope, ScopeId, SpanKey};
 
 pub(crate) struct FunctionBindingLookup<'a> {
@@ -332,8 +332,9 @@ impl FunctionCallResolver<'_> {
     }
 
     fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
-        ancestor_scopes(self.scopes, scope)
-            .find(|scope_id| self.function_bindings_by_scope.contains_key(scope_id))
+        enclosing_scope_matching(self.scopes, scope, |scope_id, _| {
+            self.function_bindings_by_scope.contains_key(&scope_id)
+        })
     }
 
     fn scope_has_ancestor(&self, scope: ScopeId, ancestor: ScopeId) -> bool {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -109,7 +109,7 @@ use crate::cfg::{
 use crate::dataflow::{DataflowContext, DataflowResult, ExactVariableDataflow};
 use crate::function_resolution::FunctionBindingLookup;
 use crate::runtime::RuntimePrelude;
-use crate::scope::ancestor_scopes;
+use crate::scope::{ancestor_scopes, enclosing_function_scope};
 use crate::source_closure::ImportedBindingContractSite;
 use crate::zsh_options::ZshOptionAnalysis;
 
@@ -1057,8 +1057,7 @@ impl SemanticModel {
     }
 
     pub fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
-        self.ancestor_scopes(scope)
-            .find(|scope| matches!(self.scope(*scope).kind, ScopeKind::Function(_)))
+        enclosing_function_scope(&self.scopes, scope)
     }
 
     fn previous_visible_binding_id_in_scope_chain(

--- a/crates/shuck-semantic/src/nonpersistent.rs
+++ b/crates/shuck-semantic/src/nonpersistent.rs
@@ -167,10 +167,7 @@ impl SemanticModel {
                 .or_insert(CandidateNonpersistentAssignment {
                     binding_id: binding.id,
                     effective_local: binding_effectively_targets_local(self, binding),
-                    enclosing_function_scope: enclosing_function_scope_for_scope(
-                        self,
-                        binding.scope,
-                    ),
+                    enclosing_function_scope: self.enclosing_function_scope(binding.scope),
                     assignment_span: binding.span,
                     subshell_start: nonpersistent_scope.span.start.offset,
                     subshell_end: nonpersistent_scope.span.end.offset,
@@ -280,8 +277,7 @@ impl SemanticModel {
             let event_command_index =
                 precomputed_command_index_for_offset(&command_offsets, reference.span.start.offset);
             let resolved = self.resolved_binding(reference.id);
-            let reference_function_scope =
-                enclosing_function_scope_for_scope(self, reference.scope);
+            let reference_function_scope = self.enclosing_function_scope(reference.scope);
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
                 reference.span.start.offset > candidate.subshell_end
                     && !has_intervening_persistent_reset(
@@ -331,8 +327,7 @@ impl SemanticModel {
                 .and_then(|index| context.commands.get(index))
                 .map(|command| command.span.end.offset)
                 .unwrap_or(synthetic_read.span().start.offset);
-            let synthetic_function_scope =
-                enclosing_function_scope_for_scope(self, synthetic_read.scope());
+            let synthetic_function_scope = self.enclosing_function_scope(synthetic_read.scope());
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
                 synthetic_read.span().start.offset > candidate.subshell_end
                     && !same_command_prefix_reset
@@ -364,7 +359,7 @@ impl SemanticModel {
                 .unwrap_or(&[]);
             let event_command_index =
                 precomputed_command_index_for_offset(&command_offsets, read.span.start.offset);
-            let read_function_scope = enclosing_function_scope_for_scope(self, read.scope);
+            let read_function_scope = self.enclosing_function_scope(read.scope);
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
                 read.span.start.offset > candidate.subshell_end
                     && candidate_allows_unresolved_later_use(candidate, read_function_scope)
@@ -400,7 +395,7 @@ impl SemanticModel {
                 .get(&binding.name)
                 .map(Vec::as_slice)
                 .unwrap_or(&[]);
-            let binding_function_scope = enclosing_function_scope_for_scope(self, binding.scope);
+            let binding_function_scope = self.enclosing_function_scope(binding.scope);
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
                 binding.span.start.offset > candidate.subshell_end
                     && candidate_allows_unresolved_later_use(candidate, binding_function_scope)
@@ -573,20 +568,13 @@ fn binding_effectively_targets_local(semantic: &SemanticModel, binding: &Binding
         return true;
     }
 
-    let binding_function_scope = enclosing_function_scope_for_scope(semantic, binding.scope);
+    let binding_function_scope = semantic.enclosing_function_scope(binding.scope);
     semantic
         .previous_visible_binding(&binding.name, binding.span, Some(binding.span))
         .is_some_and(|previous| {
             previous.attributes.contains(BindingAttributes::LOCAL)
-                && enclosing_function_scope_for_scope(semantic, previous.scope)
-                    == binding_function_scope
+                && semantic.enclosing_function_scope(previous.scope) == binding_function_scope
         })
-}
-
-fn enclosing_function_scope_for_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<ScopeId> {
-    semantic
-        .ancestor_scopes(scope)
-        .find(|scope| matches!(semantic.scope_kind(*scope), ScopeKind::Function(_)))
 }
 
 fn has_intervening_persistent_reset(

--- a/crates/shuck-semantic/src/scope.rs
+++ b/crates/shuck-semantic/src/scope.rs
@@ -19,6 +19,23 @@ pub(crate) fn ancestor_scopes(
     std::iter::successors(Some(start), move |scope| scopes[scope.index()].parent)
 }
 
+pub(crate) fn enclosing_scope_matching<F>(
+    scopes: &[Scope],
+    start: ScopeId,
+    mut matches_scope: F,
+) -> Option<ScopeId>
+where
+    F: FnMut(ScopeId, &Scope) -> bool,
+{
+    ancestor_scopes(scopes, start).find(|scope| matches_scope(*scope, &scopes[scope.index()]))
+}
+
+pub(crate) fn enclosing_function_scope(scopes: &[Scope], start: ScopeId) -> Option<ScopeId> {
+    enclosing_scope_matching(scopes, start, |_, scope| {
+        matches!(scope.kind, ScopeKind::Function(_))
+    })
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Scope {
     pub id: ScopeId,


### PR DESCRIPTION
## Summary

Consolidates repeated semantic-layer enclosing function scope lookup logic behind shared scope helpers.

- adds a reusable `enclosing_scope_matching` primitive and shared `enclosing_function_scope` helper in `shuck-semantic`
- makes `SemanticModel::enclosing_function_scope` delegate to the shared helper
- replaces duplicate ancestor-walk helpers in call graph, direct call reachability, and nonpersistent assignment analysis
- keeps function-resolution semantics intact by preserving its function-binding-index predicate through the shared matching primitive

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-semantic`
