### PR TITLE
refactor(semantic): centralize transient scope boundaries

### DIFF
--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -833,8 +833,7 @@ fn build_function_positional_parameter_facts(
         }
 
         let offset = command.span().start.offset;
-        if let Some(scope) = innermost_nonpersistent_scope_within_function(semantic, command.scope())
-        {
+        if let Some(scope) = semantic.innermost_transient_scope_within_function(command.scope()) {
             local_reset_offsets_by_scope
                 .entry(scope)
                 .or_default()
@@ -918,8 +917,7 @@ fn build_function_positional_parameter_facts(
     }
 
     for command in commands {
-        let Some(scope) =
-            enclosing_function_scope_for_positional_reset(semantic, command.scope())
+        let Some(scope) = semantic.enclosing_function_scope_without_transient_boundary(command.scope())
         else {
             continue;
         };
@@ -936,66 +934,19 @@ fn build_function_positional_parameter_facts(
     facts
 }
 
-fn enclosing_function_scope_for_positional_reset(
-    semantic: &SemanticModel,
-    scope: ScopeId,
-) -> Option<ScopeId> {
-    for scope in semantic.ancestor_scopes(scope) {
-        match semantic.scope_kind(scope) {
-            shuck_semantic::ScopeKind::Function(_) => return Some(scope),
-            shuck_semantic::ScopeKind::Subshell
-            | shuck_semantic::ScopeKind::CommandSubstitution
-            | shuck_semantic::ScopeKind::Pipeline => return None,
-            shuck_semantic::ScopeKind::File => {}
-        }
-    }
-
-    None
-}
-
-fn innermost_nonpersistent_scope_within_function(
-    semantic: &SemanticModel,
-    scope: ScopeId,
-) -> Option<ScopeId> {
-    for scope in semantic.ancestor_scopes(scope) {
-        match semantic.scope_kind(scope) {
-            shuck_semantic::ScopeKind::Subshell
-            | shuck_semantic::ScopeKind::CommandSubstitution
-            | shuck_semantic::ScopeKind::Pipeline => return Some(scope),
-            shuck_semantic::ScopeKind::Function(_) => return None,
-            shuck_semantic::ScopeKind::File => {}
-        }
-    }
-
-    None
-}
-
 fn reference_has_local_positional_reset(
     semantic: &SemanticModel,
     scope: ScopeId,
     offset: usize,
     local_reset_offsets_by_scope: &FxHashMap<ScopeId, Vec<usize>>,
 ) -> bool {
-    for scope in semantic.ancestor_scopes(scope) {
-        match semantic.scope_kind(scope) {
-            shuck_semantic::ScopeKind::Subshell
-            | shuck_semantic::ScopeKind::CommandSubstitution
-            | shuck_semantic::ScopeKind::Pipeline => {
-                if local_reset_offsets_by_scope
-                    .get(&scope)
-                    .is_some_and(|offsets| {
-                        offsets.iter().any(|reset_offset| *reset_offset < offset)
-                    })
-                {
-                    return true;
-                }
-            }
-            shuck_semantic::ScopeKind::Function(_) => return false,
-            shuck_semantic::ScopeKind::File => {}
-        }
-    }
-
-    false
+    semantic
+        .transient_ancestor_scopes_within_function(scope)
+        .any(|transient_scope| {
+            local_reset_offsets_by_scope
+                .get(&transient_scope)
+                .is_some_and(|offsets| offsets.iter().any(|reset_offset| *reset_offset < offset))
+        })
 }
 
 fn positional_parameter_index(name: &str) -> Option<usize> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1043,6 +1043,13 @@ impl SemanticModel {
         &self.scopes[scope.index()].kind
     }
 
+    fn scope_is_transient(&self, scope: ScopeId) -> bool {
+        matches!(
+            self.scope_kind(scope),
+            ScopeKind::Subshell | ScopeKind::CommandSubstitution | ScopeKind::Pipeline
+        )
+    }
+
     pub fn ancestor_scopes(&self, scope: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
         ancestor_scopes(&self.scopes, scope)
     }
@@ -1059,6 +1066,37 @@ impl SemanticModel {
     pub fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
         self.ancestor_scopes(scope)
             .find(|scope| matches!(self.scope(*scope).kind, ScopeKind::Function(_)))
+    }
+
+    #[doc(hidden)]
+    pub fn transient_ancestor_scopes_within_function(
+        &self,
+        scope: ScopeId,
+    ) -> impl Iterator<Item = ScopeId> + '_ {
+        self.ancestor_scopes(scope)
+            .take_while(|scope_id| !matches!(self.scope_kind(*scope_id), ScopeKind::Function(_)))
+            .filter(|scope_id| self.scope_is_transient(*scope_id))
+    }
+
+    #[doc(hidden)]
+    pub fn innermost_transient_scope_within_function(&self, scope: ScopeId) -> Option<ScopeId> {
+        self.transient_ancestor_scopes_within_function(scope).next()
+    }
+
+    #[doc(hidden)]
+    pub fn enclosing_function_scope_without_transient_boundary(
+        &self,
+        scope: ScopeId,
+    ) -> Option<ScopeId> {
+        if self
+            .transient_ancestor_scopes_within_function(scope)
+            .next()
+            .is_some()
+        {
+            None
+        } else {
+            self.enclosing_function_scope(scope)
+        }
     }
 
     fn previous_visible_binding_id_in_scope_chain(

--- a/crates/shuck-semantic/src/nonpersistent.rs
+++ b/crates/shuck-semantic/src/nonpersistent.rs
@@ -167,10 +167,7 @@ impl SemanticModel {
                 .or_insert(CandidateNonpersistentAssignment {
                     binding_id: binding.id,
                     effective_local: binding_effectively_targets_local(self, binding),
-                    enclosing_function_scope: enclosing_function_scope_for_scope(
-                        self,
-                        binding.scope,
-                    ),
+                    enclosing_function_scope: self.enclosing_function_scope(binding.scope),
                     assignment_span: binding.span,
                     subshell_start: nonpersistent_scope.span.start.offset,
                     subshell_end: nonpersistent_scope.span.end.offset,
@@ -280,8 +277,7 @@ impl SemanticModel {
             let event_command_index =
                 precomputed_command_index_for_offset(&command_offsets, reference.span.start.offset);
             let resolved = self.resolved_binding(reference.id);
-            let reference_function_scope =
-                enclosing_function_scope_for_scope(self, reference.scope);
+            let reference_function_scope = self.enclosing_function_scope(reference.scope);
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
                 reference.span.start.offset > candidate.subshell_end
                     && !has_intervening_persistent_reset(
@@ -331,8 +327,7 @@ impl SemanticModel {
                 .and_then(|index| context.commands.get(index))
                 .map(|command| command.span.end.offset)
                 .unwrap_or(synthetic_read.span().start.offset);
-            let synthetic_function_scope =
-                enclosing_function_scope_for_scope(self, synthetic_read.scope());
+            let synthetic_function_scope = self.enclosing_function_scope(synthetic_read.scope());
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
                 synthetic_read.span().start.offset > candidate.subshell_end
                     && !same_command_prefix_reset
@@ -364,7 +359,7 @@ impl SemanticModel {
                 .unwrap_or(&[]);
             let event_command_index =
                 precomputed_command_index_for_offset(&command_offsets, read.span.start.offset);
-            let read_function_scope = enclosing_function_scope_for_scope(self, read.scope);
+            let read_function_scope = self.enclosing_function_scope(read.scope);
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
                 read.span.start.offset > candidate.subshell_end
                     && candidate_allows_unresolved_later_use(candidate, read_function_scope)
@@ -400,7 +395,7 @@ impl SemanticModel {
                 .get(&binding.name)
                 .map(Vec::as_slice)
                 .unwrap_or(&[]);
-            let binding_function_scope = enclosing_function_scope_for_scope(self, binding.scope);
+            let binding_function_scope = self.enclosing_function_scope(binding.scope);
             if let Some(candidate) = candidates.iter().rev().find(|candidate| {
                 binding.span.start.offset > candidate.subshell_end
                     && candidate_allows_unresolved_later_use(candidate, binding_function_scope)
@@ -573,20 +568,13 @@ fn binding_effectively_targets_local(semantic: &SemanticModel, binding: &Binding
         return true;
     }
 
-    let binding_function_scope = enclosing_function_scope_for_scope(semantic, binding.scope);
+    let binding_function_scope = semantic.enclosing_function_scope(binding.scope);
     semantic
         .previous_visible_binding(&binding.name, binding.span, Some(binding.span))
         .is_some_and(|previous| {
             previous.attributes.contains(BindingAttributes::LOCAL)
-                && enclosing_function_scope_for_scope(semantic, previous.scope)
-                    == binding_function_scope
+                && semantic.enclosing_function_scope(previous.scope) == binding_function_scope
         })
-}
-
-fn enclosing_function_scope_for_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<ScopeId> {
-    semantic
-        .ancestor_scopes(scope)
-        .find(|scope| matches!(semantic.scope_kind(*scope), ScopeKind::Function(_)))
 }
 
 fn has_intervening_persistent_reset(

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1817,6 +1817,74 @@ printf '%s\\n' \"$(
 }
 
 #[test]
+fn function_scope_boundary_helpers_ignore_outer_transient_ancestors() {
+    let source = "\
+printf '%s\\n' \"$(
+  caller() {
+    printf '%s\\n' \"$1\"
+  }
+  caller
+)\"
+";
+    let model = model(source);
+    let scope = model.scope_at(
+        span_for_nth(source, "printf '%s\\n' \"$1\"", 0)
+            .start
+            .offset,
+    );
+
+    assert!(
+        model
+            .transient_ancestor_scopes_within_function(scope)
+            .next()
+            .is_none()
+    );
+    assert!(
+        model
+            .innermost_transient_scope_within_function(scope)
+            .is_none()
+    );
+    assert_eq!(
+        model.enclosing_function_scope_without_transient_boundary(scope),
+        model.enclosing_function_scope(scope)
+    );
+}
+
+#[test]
+fn function_scope_boundary_helpers_stop_at_in_function_transient_scopes() {
+    let source = "\
+caller() {
+  value=\"$(
+    printf '%s\\n' \"$1\"
+  )\"
+}
+";
+    let model = model(source);
+    let scope = model.scope_at(
+        span_for_nth(source, "printf '%s\\n' \"$1\"", 0)
+            .start
+            .offset,
+    );
+    let transients = model
+        .transient_ancestor_scopes_within_function(scope)
+        .collect::<Vec<_>>();
+
+    assert_eq!(transients.len(), 1);
+    assert!(matches!(
+        model.scope_kind(transients[0]),
+        ScopeKind::CommandSubstitution
+    ));
+    assert_eq!(
+        model.innermost_transient_scope_within_function(scope),
+        Some(transients[0])
+    );
+    assert_eq!(
+        model.enclosing_function_scope_without_transient_boundary(scope),
+        None
+    );
+}
+
+#[test]
 fn function_call_reachability_finds_direct_call_before_cutoff() {
     let source = "\
 target() { :; }


### PR DESCRIPTION
## Summary
- move transient scope boundary traversal helpers into `SemanticModel`
- reuse those helpers in linter positional-parameter facts and semantic nonpersistent analysis
- add semantic tests covering outer transient ancestors versus in-function transient boundaries

## Why
`crates/shuck-linter/src/facts/functions.rs` had duplicated ancestor walks that encoded semantic function/transient-boundary behavior. Centralizing that contract in `shuck-semantic` reduces drift between the semantic layer and linter facts.

## Impact
- keeps the offset-based positional-reset bookkeeping rule-local in linter facts
- makes the function/nonpersistent boundary contract reusable from semantic-owned APIs
- preserves the current behavior for the `C097` and `C123` compatibility paths

## Validation
- `cargo test -p shuck-semantic function_scope_boundary_helpers`
- `cargo test -p shuck-linter function_called_without_args`
- `cargo test -p shuck-linter function_references_unset_param`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C097,C123`
