### PR TITLE
perf(semantic): use dense visited bitset for cfg reachability DFS

### DIFF
--- a/crates/shuck-semantic/src/reachability.rs
+++ b/crates/shuck-semantic/src/reachability.rs
@@ -1488,14 +1488,14 @@ fn block_reaches_avoiding_many(
     first_avoid: &FxHashSet<BlockId>,
     second_avoid: &FxHashSet<BlockId>,
 ) -> bool {
-    let mut visited = vec![false; cfg.blocks().len()];
+    let mut visited = DenseBitSet::new(cfg.blocks().len());
     let mut stack = vec![start];
     while let Some(block) = stack.pop() {
         let idx = block.index();
-        if visited[idx] {
+        if visited.contains(idx) {
             continue;
         }
-        visited[idx] = true;
+        visited.insert(idx);
         if block == end {
             return true;
         }

--- a/crates/shuck-semantic/src/reachability.rs
+++ b/crates/shuck-semantic/src/reachability.rs
@@ -1488,12 +1488,14 @@ fn block_reaches_avoiding_many(
     first_avoid: &FxHashSet<BlockId>,
     second_avoid: &FxHashSet<BlockId>,
 ) -> bool {
-    let mut visited = FxHashSet::default();
+    let mut visited = vec![false; cfg.blocks().len()];
     let mut stack = vec![start];
     while let Some(block) = stack.pop() {
-        if !visited.insert(block) {
+        let idx = block.index();
+        if visited[idx] {
             continue;
         }
+        visited[idx] = true;
         if block == end {
             return true;
         }


### PR DESCRIPTION
## Summary

\`block_reaches_avoiding_many\` is a DFS that ran the visited set as an \`FxHashSet<BlockId>\` allocated per call. Since it's invoked across the \`starts × ends\` cross product from \`blocks_have_path_avoiding_many\`, hashbrown insert/lookup dominated the reachability hotspot in C063.

\`BlockId\` is a \`u32\` newtype with \`.index()\`, so a dense \`Vec<bool>\` sized to \`cfg.blocks().len()\` is a drop-in replacement: bounds-checked array store/load instead of FxHash + probe sequence.

Drilldown on \`xwmx__nb__nb\`:

| Frame | Before | After |
|---|---:|---:|
| \`block_reaches_avoiding_many\` (% of parent) | 15.4% | 8.5% |
| \`overwritten_function\` (% of total) | 3.4% | 2.8% |
| Hot leaf in this frame | \`hashbrown::HashMap::insert\` | itself |

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -p shuck-semantic --all-targets -- -D warnings\`
- [x] \`cargo test -p shuck-semantic\` (352 passed)
- [x] \`cargo test -p shuck-linter\` (3141 passed)
- [x] samply drilldown shows the hashbrown leaf is gone