### PR TITLE
fix(semantic): resolve alias function flow

### DIFF
--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -4898,6 +4898,43 @@ use
 }
 
 #[test]
+fn value_flow_resolves_multi_name_function_alias_fallbacks() {
+    let source = "\
+#!/bin/zsh
+use() {
+  itunes
+  print $foo
+}
+function music itunes() {
+  foo=1
+}
+use
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let binding = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .expect("expected foo binding");
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let mut value_flow = analysis.value_flow();
+
+    assert_eq!(
+        value_flow.nonlocal_value_bindings_from_called_functions_before(
+            &reference.name,
+            reference.scope,
+            reference.span,
+        ),
+        vec![binding.id]
+    );
+}
+
+#[test]
 fn value_flow_uses_path_covering_alternate_function_definitions() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/value_flow.rs
+++ b/crates/shuck-semantic/src/value_flow.rs
@@ -524,8 +524,16 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             return self.analysis.function_scope_for_binding(binding_id) == Some(callee_scope);
         }
 
-        self.function_binding_for_scope(callee_scope)
-            .is_some_and(|binding_id| {
+        let Some(function_kind) = self.named_function_kind(callee_scope) else {
+            return false;
+        };
+        if !function_kind.contains_name(function_name) {
+            return false;
+        }
+
+        self.function_bindings_for_scope(callee_scope)
+            .into_iter()
+            .any(|binding_id| {
                 self.function_binding_may_resolve_at_call(binding_id, function_name, site)
             })
     }
@@ -556,19 +564,26 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
     }
 
     fn function_definition_command_for_binding(&self, binding_id: BindingId) -> Option<CommandId> {
+        let binding_scope = self.analysis.function_scope_for_binding(binding_id)?;
+        let binding_span = self.model().binding(binding_id).span;
         self.model().commands().iter().copied().find(|command_id| {
-            self.model().function_definition_binding_for_command_span(
-                self.model().command_span(*command_id),
-            ) == Some(binding_id)
+            let command_span = self.model().command_span(*command_id);
+            span_contains(command_span, binding_span)
+                && self
+                    .model()
+                    .function_definition_binding_for_command_span(command_span)
+                    .and_then(|candidate| self.analysis.function_scope_for_binding(candidate))
+                    == Some(binding_scope)
         })
     }
 
-    fn function_binding_for_scope(&self, scope: ScopeId) -> Option<BindingId> {
+    fn function_bindings_for_scope(&self, scope: ScopeId) -> Vec<BindingId> {
         self.model()
             .recorded_program
             .function_body_scopes
             .iter()
-            .find_map(|(binding_id, body_scope)| (*body_scope == scope).then_some(*binding_id))
+            .filter_map(|(binding_id, body_scope)| (*body_scope == scope).then_some(*binding_id))
+            .collect()
     }
 
     fn possible_function_bindings_cover_call(
@@ -743,4 +758,8 @@ fn binding_is_name_only_declaration(binding: &Binding) -> bool {
         && !binding
             .attributes
             .contains(BindingAttributes::DECLARATION_INITIALIZED)
+}
+
+fn span_contains(outer: Span, inner: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }


### PR DESCRIPTION
## Summary
- fix semantic value-flow fallback lookup for multi-name function aliases on a shared definition command
- match function definition commands by function scope instead of only the first binding on the command span
- add a Zsh multi-name alias regression for nonlocal value-flow propagation

## Validation
- cargo fmt --check
- cargo test -p shuck-semantic value_flow
- cargo test -p shuck-linter safe_value
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001