### PR TITLE
perf(semantic): index callees by enclosing function in call graph BFS

### DIFF
--- a/crates/shuck-semantic/src/call_graph.rs
+++ b/crates/shuck-semantic/src/call_graph.rs
@@ -3,7 +3,7 @@ use shuck_ast::{Name, Span};
 use smallvec::SmallVec;
 
 use crate::binding::Binding;
-use crate::scope::{ancestor_scopes, enclosing_function_scope};
+use crate::scope::ancestor_scopes;
 use crate::{BindingId, Scope, ScopeId, ScopeKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,26 +50,37 @@ pub(crate) fn build_call_graph(
     functions: &FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     call_sites: &FxHashMap<Name, SmallVec<[CallSite; 2]>>,
 ) -> CallGraph {
-    let mut reachable = FxHashSet::default();
-    let mut worklist = call_sites
-        .values()
-        .flat_map(|sites| sites.iter())
-        .filter(|site| !is_in_function_scope(scopes, site.scope))
-        .map(|site| site.callee.clone())
-        .collect::<Vec<_>>();
-
-    while let Some(name) = worklist.pop() {
-        if reachable.contains(name.as_str()) {
-            continue;
-        }
-        for sites in call_sites.values() {
-            for site in sites {
-                if is_in_named_function_scope(scopes, site.scope, &name) {
-                    worklist.push(site.callee.clone());
+    let mut callees_by_enclosing_function: FxHashMap<Name, Vec<Name>> = FxHashMap::default();
+    let mut top_level_callees: Vec<Name> = Vec::new();
+    for sites in call_sites.values() {
+        for site in sites {
+            let mut saw_function_ancestor = false;
+            for ancestor in ancestor_scopes(scopes, site.scope) {
+                if let ScopeKind::Function(function) = &scopes[ancestor.index()].kind {
+                    saw_function_ancestor = true;
+                    for fn_name in function.static_names() {
+                        callees_by_enclosing_function
+                            .entry(fn_name.clone())
+                            .or_default()
+                            .push(site.callee.clone());
+                    }
                 }
             }
+            if !saw_function_ancestor {
+                top_level_callees.push(site.callee.clone());
+            }
         }
-        reachable.insert(name);
+    }
+
+    let mut reachable = FxHashSet::default();
+    let mut worklist = top_level_callees;
+    while let Some(name) = worklist.pop() {
+        if !reachable.insert(name.clone()) {
+            continue;
+        }
+        if let Some(callees) = callees_by_enclosing_function.get(&name) {
+            worklist.extend(callees.iter().cloned());
+        }
     }
 
     let uncalled = functions
@@ -105,17 +116,4 @@ pub(crate) fn build_call_graph(
         uncalled,
         overwritten,
     }
-}
-
-fn is_in_function_scope(scopes: &[Scope], scope: ScopeId) -> bool {
-    enclosing_function_scope(scopes, scope).is_some()
-}
-
-fn is_in_named_function_scope(scopes: &[Scope], scope: ScopeId, name: &Name) -> bool {
-    ancestor_scopes(scopes, scope).any(|scope| {
-        matches!(
-            &scopes[scope.index()].kind,
-            ScopeKind::Function(function) if function.contains_name(name)
-        )
-    })
 }


### PR DESCRIPTION
## Summary

\`build_call_graph\` used to do, for every name popped off its worklist, a full rescan of every call site asking \"is this site inside a function named N\" via a per-site ancestor walk. The loop was \`O(unique_names × total_call_sites × scope_depth)\`.

Precompute a reverse index \`callees_by_enclosing_function: Name → Vec<Name>\` in one linear pass over the call sites. The worklist then becomes a plain BFS over that map.

Wall-clock on \`xwmx__nb__nb\` (large-corpus fixture, 12 iterations):

| | avg |
|---|---:|
| before | 185.4ms |
| after | 174.0ms |
| delta | **-6.2%** |

Drilldown: \`build_call_graph\` falls from 30.4% of \`build_semantic_model_base\` (5.4% of total samples) to 3.3% / 0.2%.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -p shuck-semantic -p shuck-linter --all-targets -- -D warnings\`
- [x] \`cargo test -p shuck-semantic\` (352 passed)
- [x] \`cargo test -p shuck-linter\` (3141 passed)
- [x] \`make test-large-corpus\` (2 passed, 0 failed)