### PR TITLE
perf(ast): add ASCII fast path to Position::advanced_by

### DIFF
--- a/crates/shuck-ast/src/span.rs
+++ b/crates/shuck-ast/src/span.rs
@@ -37,6 +37,18 @@ impl Position {
 
     /// Return a new position advanced by every character in `text`.
     pub fn advanced_by(mut self, text: &str) -> Self {
+        if text.is_ascii() {
+            let len = text.len();
+            match text.rfind('\n') {
+                Some(last_newline) => {
+                    self.line += text.bytes().filter(|byte| *byte == b'\n').count();
+                    self.column = len - last_newline;
+                }
+                None => self.column += len,
+            }
+            self.offset += len;
+            return self;
+        }
         for ch in text.chars() {
             self.advance(ch);
         }


### PR DESCRIPTION
## Summary
- `Position::advanced_by` is on every hot path: lexer/parser, semantic builder, fact builder, and many rule helpers. The previous implementation called `chars()` and dispatched per character through `advance(ch)`, which UTF-8-decodes byte-by-byte even when the input is plain ASCII shell text.
- Add an ASCII fast path that uses `text.is_ascii()` (auto-vectorized) plus `str::rfind('\n')` (memchr-backed) so line/column/offset are computed in a small number of vectorized passes instead of one branch per code point. The non-ASCII path is unchanged.

## Impact
- On the `xwmx__nb__nb` large-corpus fixture, `Position::advanced_by` no longer appears in the top hotspots (was 1.2% of total samples).

## Test plan
- [x] `cargo test --all`
- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-ast --all-targets -- -D warnings`
- [x] `make test-large-corpus` (no diff vs. shellcheck oracle)