### PR TITLE
perf(linter): borrow pipeline segment names from source

### DIFF
--- a/crates/shuck-linter/src/facts/pipelines.rs
+++ b/crates/shuck-linter/src/facts/pipelines.rs
@@ -2,8 +2,8 @@
 pub struct PipelineSegmentFact<'a> {
     stmt: &'a Stmt,
     command_id: CommandId,
-    literal_name: Option<Box<str>>,
-    effective_name: Option<Box<str>>,
+    literal_name: Option<Cow<'a, str>>,
+    effective_name: Option<Cow<'a, str>>,
 }
 
 impl<'a> PipelineSegmentFact<'a> {
@@ -187,13 +187,7 @@ fn build_pipeline_segment_fact<'a>(
     PipelineSegmentFact {
         stmt: fact.stmt(),
         command_id: fact.id(),
-        literal_name: fact
-            .literal_name()
-            .map(str::to_owned)
-            .map(String::into_boxed_str),
-        effective_name: fact
-            .effective_name()
-            .map(str::to_owned)
-            .map(String::into_boxed_str),
+        literal_name: fact.normalized().literal_name.clone(),
+        effective_name: fact.normalized().effective_name.clone(),
     }
 }


### PR DESCRIPTION
## Summary
- `PipelineSegmentFact::{literal_name, effective_name}` allocated `Box<str>` per pipeline segment by cloning `&str` out of `NormalizedCommand`'s already-borrowed `Cow<'a, str>`.
- Switched both fields to `Option<Cow<'a, str>>` and `clone()` the `Cow` from `CommandFact::normalized()`. Borrowed names stay allocation-free; only alias-resolved (rare `Cow::Owned`) names still allocate.
- The public getters are unchanged (`Option<&str>` via `Cow::as_deref`).

## Profile
Fixture: `xwmx__nb__nb`, 12 iterations.

| | avg ms | total samples |
|---|---:|---:|
| before | 191.9 | 4702 |
| after | 180.9 | 4408 |

That is a **5.7%** wall-clock improvement, and `build_pipeline_facts` falls out of the top-12 hotspot list.

## Test plan
- [x] `cargo test -p shuck-linter --lib` (3141 passed)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `make test-large-corpus` (compatibility unchanged)