### PR TITLE
refactor(semantic): move command containment queries out of linter

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -439,13 +439,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     .is_some_and(Option::is_some)
             })
             .collect::<Vec<_>>();
-        let command_parent_ids =
-            build_linter_command_parent_ids(self.semantic, &command_fact_indices_by_id);
-        let command_child_ids_by_parent = build_linter_command_child_ids_by_parent(
-            self.semantic,
-            &command_parent_ids,
-            &command_fact_indices_by_id,
-        );
+        let command_child_ids_by_parent =
+            build_linter_command_child_ids_by_parent(self.semantic, &command_fact_indices_by_id);
         let command_child_index = CommandChildIndex::from_parent_lists(command_child_ids_by_parent);
 
         populate_linebreak_in_test_facts(&mut commands, self.source);
@@ -486,7 +481,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &function_headers,
             &function_cli_dispatch_facts,
             &commands,
-            &command_parent_ids,
         );
         collect_condition_status_capture_from_sequences(
             &self.file.body,
@@ -827,6 +821,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 &backtick_substitution_spans,
             );
         LinterFacts {
+            semantic: self.semantic,
             source,
             commands,
             command_fact_indices_by_id,
@@ -835,8 +830,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             command_ids_by_name_word_span,
             innermost_command_ids_by_offset,
             innermost_command_ids_by_binding_offset,
-            command_containing_offset_index: OnceLock::new(),
-            command_parent_ids,
             command_dominance_barrier_flags,
             if_condition_command_ids,
             elif_condition_command_ids,
@@ -971,47 +964,16 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
     }
 }
 
-fn build_linter_command_parent_ids(
-    semantic: &SemanticModel,
-    command_fact_indices_by_id: &[Option<usize>],
-) -> Vec<Option<CommandId>> {
-    let mut parent_ids = vec![None; semantic.command_count()];
-    for id in semantic.commands().iter().copied() {
-        if !command_fact_exists(command_fact_indices_by_id, id) {
-            continue;
-        }
-        parent_ids[id.index()] =
-            nearest_fact_backed_semantic_parent(semantic, command_fact_indices_by_id, id);
-    }
-    parent_ids
-}
-
-fn nearest_fact_backed_semantic_parent(
-    semantic: &SemanticModel,
-    command_fact_indices_by_id: &[Option<usize>],
-    id: CommandId,
-) -> Option<CommandId> {
-    let mut current = semantic.command_parent_id(id);
-    while let Some(parent) = current {
-        if command_fact_exists(command_fact_indices_by_id, parent) {
-            return Some(parent);
-        }
-        current = semantic.command_parent_id(parent);
-    }
-    None
-}
-
 fn build_linter_command_child_ids_by_parent(
     semantic: &SemanticModel,
-    command_parent_ids: &[Option<CommandId>],
     command_fact_indices_by_id: &[Option<usize>],
 ) -> Vec<Vec<CommandId>> {
-    let mut children_by_parent = vec![Vec::new(); command_parent_ids.len()];
+    let mut children_by_parent = vec![Vec::new(); semantic.command_count()];
     for child in semantic.commands().iter().copied() {
         if !command_fact_exists(command_fact_indices_by_id, child) {
             continue;
         }
-        if let Some(parent) = command_parent_ids[child.index()] {
+        if let Some(parent) = semantic.syntax_backed_command_parent_id(child) {
             children_by_parent[parent.index()].push(child);
         }
     }

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -242,7 +242,6 @@ fn build_case_cli_reachable_function_scopes(
     function_headers: &[FunctionHeaderFact<'_>],
     function_cli_dispatch_facts: &FxHashMap<ScopeId, FunctionCliDispatchFacts>,
     commands: &[CommandFact<'_>],
-    command_parent_ids: &[Option<CommandId>],
 ) -> FxHashSet<ScopeId> {
     let dispatcher_offset = function_headers
         .iter()
@@ -259,11 +258,7 @@ fn build_case_cli_reachable_function_scopes(
     let top_level_exit_offset = commands
         .iter()
         .filter(|command| {
-            command_parent_ids
-                .get(command.id().index())
-                .copied()
-                .flatten()
-                .is_none()
+            semantic.syntax_backed_command_parent_id(command.id()).is_none()
                 && semantic.enclosing_function_scope(command.scope()).is_none()
                 && command_fact_is_standalone_exit(command)
         })

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1,4 +1,5 @@
 pub struct LinterFacts<'a> {
+    semantic: &'a SemanticModel,
     source: &'a str,
     commands: Vec<CommandFact<'a>>,
     command_fact_indices_by_id: Vec<Option<usize>>,
@@ -8,8 +9,6 @@ pub struct LinterFacts<'a> {
     command_ids_by_name_word_span: FxHashMap<FactSpan, CommandId>,
     innermost_command_ids_by_offset: CommandOffsetLookup,
     innermost_command_ids_by_binding_offset: CommandOffsetLookup,
-    command_containing_offset_index: OnceLock<CommandContainingOffsetIndex>,
-    command_parent_ids: Vec<Option<CommandId>>,
     command_dominance_barrier_flags: Vec<bool>,
     if_condition_command_ids: FxHashSet<CommandId>,
     elif_condition_command_ids: FxHashSet<CommandId>,
@@ -326,9 +325,13 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub(crate) fn innermost_command_id_containing_offset(&self, offset: usize) -> Option<CommandId> {
-        self.command_containing_offset_index
-            .get_or_init(|| CommandContainingOffsetIndex::build(&self.commands))
+        self.semantic
             .innermost_command_id_containing_offset(offset)
+            .filter(|id| {
+                self.command_fact_indices_by_id
+                    .get(id.index())
+                    .is_some_and(Option::is_some)
+            })
     }
 
     pub(crate) fn innermost_command_at_binding_offset(
@@ -340,7 +343,11 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn command_parent_id(&self, id: CommandId) -> Option<CommandId> {
-        self.command_parent_ids.get(id.index()).copied().flatten()
+        self.semantic.syntax_backed_command_parent_id(id).filter(|parent_id| {
+            self.command_fact_indices_by_id
+                .get(parent_id.index())
+                .is_some_and(Option::is_some)
+        })
     }
 
     pub fn command_parent(&self, id: CommandId) -> Option<CommandFactRef<'_, 'a>> {
@@ -1008,124 +1015,6 @@ impl<'a> LinterFacts<'a> {
         self.possible_variable_misspelling_scope_compat_name_uses
             .get_or_init(|| build_possible_variable_misspelling_scope_compat_name_uses(self))
     }
-}
-
-#[derive(Debug, Default)]
-struct CommandContainingOffsetIndex {
-    entries: Vec<CommandContainingOffsetEntry>,
-}
-
-impl CommandContainingOffsetIndex {
-    fn build(commands: &[CommandFact<'_>]) -> Self {
-        let mut events = commands
-            .iter()
-            .flat_map(|command| {
-                let span = command.span();
-                [
-                    CommandContainingOffsetEvent {
-                        offset: span.start.offset,
-                        end_offset: span.end.offset,
-                        id: command.id(),
-                        kind: CommandContainingOffsetEventKind::Start,
-                    },
-                    CommandContainingOffsetEvent {
-                        offset: span.end.offset.saturating_add(1),
-                        end_offset: span.end.offset,
-                        id: command.id(),
-                        kind: CommandContainingOffsetEventKind::End,
-                    },
-                ]
-            })
-            .collect::<Vec<_>>();
-        events.sort_unstable_by(|left, right| {
-            left.offset
-                .cmp(&right.offset)
-                .then_with(|| left.kind.cmp(&right.kind))
-                .then_with(|| right.end_offset.cmp(&left.end_offset))
-                .then_with(|| left.id.index().cmp(&right.id.index()))
-        });
-
-        let mut entries = Vec::new();
-        let mut active = Vec::<CommandId>::new();
-        let mut index = 0;
-        while let Some(event) = events.get(index).copied() {
-            let offset = event.offset;
-            while events.get(index).is_some_and(|event| {
-                event.offset == offset && event.kind == CommandContainingOffsetEventKind::End
-            }) {
-                let id = events[index].id;
-                active.retain(|active_id| *active_id != id);
-                index += 1;
-            }
-            while events.get(index).is_some_and(|event| {
-                event.offset == offset && event.kind == CommandContainingOffsetEventKind::Start
-            }) {
-                active.push(events[index].id);
-                index += 1;
-            }
-
-            let Some(next_offset) = events.get(index).map(|event| event.offset) else {
-                break;
-            };
-            if offset < next_offset
-                && let Some(id) = active.last().copied()
-            {
-                push_command_containing_offset_entry(&mut entries, offset, next_offset - 1, id);
-            }
-        }
-
-        Self { entries }
-    }
-
-    fn innermost_command_id_containing_offset(&self, offset: usize) -> Option<CommandId> {
-        let upper_bound = self
-            .entries
-            .partition_point(|entry| entry.start_offset <= offset);
-        let entry = self.entries.get(upper_bound.checked_sub(1)?)?;
-        (offset <= entry.end_offset).then_some(entry.id)
-    }
-}
-
-fn push_command_containing_offset_entry(
-    entries: &mut Vec<CommandContainingOffsetEntry>,
-    start_offset: usize,
-    end_offset: usize,
-    id: CommandId,
-) {
-    if let Some(last) = entries.last_mut()
-        && last.id == id
-        && last.end_offset.saturating_add(1) == start_offset
-    {
-        last.end_offset = end_offset;
-        return;
-    }
-
-    entries.push(CommandContainingOffsetEntry {
-        start_offset,
-        end_offset,
-        id,
-    });
-}
-
-#[derive(Debug, Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
-enum CommandContainingOffsetEventKind {
-    End,
-    Start,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct CommandContainingOffsetEvent {
-    offset: usize,
-    end_offset: usize,
-    id: CommandId,
-    kind: CommandContainingOffsetEventKind,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct CommandContainingOffsetEntry {
-    start_offset: usize,
-    end_offset: usize,
-    id: CommandId,
 }
 
 fn build_possible_variable_misspelling_scope_compat_name_uses(

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -498,7 +498,10 @@ impl<'a> SafeValueIndex<'a> {
         let mut current = self
             .facts
             .innermost_command_id_at(span.start.offset)
-            .or_else(|| self.innermost_command_id_containing_offset(span.start.offset));
+            .or_else(|| {
+                self.facts
+                    .innermost_command_id_containing_offset(span.start.offset)
+            });
         while let Some(command_id) = current {
             if matches!(
                 self.facts.command(command_id).command(),
@@ -524,7 +527,10 @@ impl<'a> SafeValueIndex<'a> {
         let mut current = self
             .facts
             .innermost_command_id_at(span.start.offset)
-            .or_else(|| self.innermost_command_id_containing_offset(span.start.offset));
+            .or_else(|| {
+                self.facts
+                    .innermost_command_id_containing_offset(span.start.offset)
+            });
         while let Some(command_id) = current {
             if let Command::Compound(CompoundCommand::If(command)) =
                 self.facts.command(command_id).command()
@@ -980,7 +986,10 @@ impl<'a> SafeValueIndex<'a> {
     fn span_is_exit_or_return_argument(&self, at: Span) -> bool {
         self.facts
             .innermost_command_id_at(at.start.offset)
-            .or_else(|| self.innermost_command_id_containing_offset(at.start.offset))
+            .or_else(|| {
+                self.facts
+                    .innermost_command_id_containing_offset(at.start.offset)
+            })
             .is_some_and(|command_id| {
                 let command = self.facts.command(command_id);
                 match command.command() {
@@ -1012,7 +1021,10 @@ impl<'a> SafeValueIndex<'a> {
     fn span_is_return_argument(&self, at: Span) -> bool {
         self.facts
             .innermost_command_id_at(at.start.offset)
-            .or_else(|| self.innermost_command_id_containing_offset(at.start.offset))
+            .or_else(|| {
+                self.facts
+                    .innermost_command_id_containing_offset(at.start.offset)
+            })
             .is_some_and(|command_id| {
                 let command = self.facts.command(command_id);
                 match command.command() {
@@ -3680,31 +3692,14 @@ impl<'a> SafeValueIndex<'a> {
         let command_id = self
             .facts
             .innermost_command_id_at(at.start.offset)
-            .or_else(|| self.innermost_command_id_containing_offset(at.start.offset))?;
+            .or_else(|| {
+                self.facts
+                    .innermost_command_id_containing_offset(at.start.offset)
+            })?;
         self.analysis
             .block_ids_for_span(self.facts.command(command_id).span())
             .first()
             .copied()
-    }
-
-    fn innermost_command_id_containing_offset(
-        &self,
-        offset: usize,
-    ) -> Option<crate::facts::CommandId> {
-        self.facts
-            .commands()
-            .iter()
-            .filter(|command| {
-                command.span().start.offset <= offset && offset <= command.span().end.offset
-            })
-            .max_by(|left, right| {
-                left.span()
-                    .start
-                    .offset
-                    .cmp(&right.span().start.offset)
-                    .then_with(|| right.span().end.offset.cmp(&left.span().end.offset))
-            })
-            .map(|command| command.id())
     }
 
     fn block_for_binding(&self, binding_id: BindingId) -> Option<BlockId> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -180,7 +180,31 @@ struct CommandTopology {
     ids_by_syntax_span: FxHashMap<SpanKey, SmallVec<[CommandId; 1]>>,
     parent_ids: Vec<Option<CommandId>>,
     child_ids: Vec<Vec<CommandId>>,
+    syntax_backed_parent_ids: Vec<Option<CommandId>>,
+    syntax_backed_child_ids: Vec<Vec<CommandId>>,
     offset_order: Vec<CommandId>,
+    containing_offset_entries: Vec<CommandContainingOffsetEntry>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandContainingOffsetEntry {
+    start_offset: usize,
+    end_offset: usize,
+    id: CommandId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum CommandContainingOffsetEventKind {
+    End,
+    Start,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CommandContainingOffsetEvent {
+    offset: usize,
+    end_offset: usize,
+    id: CommandId,
+    kind: CommandContainingOffsetEventKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1570,6 +1594,14 @@ impl SemanticModel {
         &self.command_topology().child_ids[id.index()]
     }
 
+    pub fn syntax_backed_command_parent_id(&self, id: CommandId) -> Option<CommandId> {
+        self.command_topology().syntax_backed_parent_ids[id.index()]
+    }
+
+    pub fn syntax_backed_command_children(&self, id: CommandId) -> &[CommandId] {
+        &self.command_topology().syntax_backed_child_ids[id.index()]
+    }
+
     pub fn innermost_command_id_at(&self, offset: usize) -> Option<CommandId> {
         let topology = self.command_topology();
         let mut innermost = None;
@@ -1583,6 +1615,17 @@ impl SemanticModel {
             }
         }
         innermost
+    }
+
+    pub fn innermost_command_id_containing_offset(&self, offset: usize) -> Option<CommandId> {
+        let topology = self.command_topology();
+        let upper_bound = topology
+            .containing_offset_entries
+            .partition_point(|entry| entry.start_offset <= offset);
+        let entry = topology
+            .containing_offset_entries
+            .get(upper_bound.checked_sub(1)?)?;
+        (offset <= entry.end_offset).then_some(entry.id)
     }
 
     /// Returns logical list commands flattened by the semantic traversal.
@@ -1880,6 +1923,12 @@ fn build_command_topology(model: &SemanticModel) -> CommandTopology {
         .into_iter()
         .filter(|id| program.command(*id).syntax_kind.is_some())
         .collect::<Vec<_>>();
+    let syntax_backed_parent_ids =
+        build_syntax_backed_command_parent_ids(model, &syntax_backed_ids, &parent_ids);
+    let syntax_backed_child_ids =
+        build_command_child_ids(command_count, &syntax_backed_ids, &syntax_backed_parent_ids);
+    let containing_offset_entries =
+        build_command_containing_offset_entries(model, &syntax_backed_ids);
 
     CommandTopology {
         syntax_backed_ids,
@@ -1887,8 +1936,130 @@ fn build_command_topology(model: &SemanticModel) -> CommandTopology {
         ids_by_syntax_span,
         parent_ids,
         child_ids,
+        syntax_backed_parent_ids,
+        syntax_backed_child_ids,
         offset_order,
+        containing_offset_entries,
     }
+}
+
+fn build_syntax_backed_command_parent_ids(
+    model: &SemanticModel,
+    syntax_backed_ids: &[CommandId],
+    parent_ids: &[Option<CommandId>],
+) -> Vec<Option<CommandId>> {
+    let mut syntax_backed_parent_ids = vec![None; parent_ids.len()];
+    for id in syntax_backed_ids.iter().copied() {
+        let mut current = parent_ids[id.index()];
+        while let Some(parent) = current {
+            if model.command_syntax_kind(parent).is_some() {
+                syntax_backed_parent_ids[id.index()] = Some(parent);
+                break;
+            }
+            current = parent_ids[parent.index()];
+        }
+    }
+    syntax_backed_parent_ids
+}
+
+fn build_command_child_ids(
+    command_count: usize,
+    command_ids: &[CommandId],
+    parent_ids: &[Option<CommandId>],
+) -> Vec<Vec<CommandId>> {
+    let mut child_ids = vec![Vec::new(); command_count];
+    for child in command_ids.iter().copied() {
+        if let Some(parent) = parent_ids[child.index()] {
+            child_ids[parent.index()].push(child);
+        }
+    }
+    child_ids
+}
+
+fn build_command_containing_offset_entries(
+    model: &SemanticModel,
+    syntax_backed_ids: &[CommandId],
+) -> Vec<CommandContainingOffsetEntry> {
+    let mut events = syntax_backed_ids
+        .iter()
+        .copied()
+        .flat_map(|id| {
+            let span = model.command_span(id);
+            [
+                CommandContainingOffsetEvent {
+                    offset: span.start.offset,
+                    end_offset: span.end.offset,
+                    id,
+                    kind: CommandContainingOffsetEventKind::Start,
+                },
+                CommandContainingOffsetEvent {
+                    offset: span.end.offset.saturating_add(1),
+                    end_offset: span.end.offset,
+                    id,
+                    kind: CommandContainingOffsetEventKind::End,
+                },
+            ]
+        })
+        .collect::<Vec<_>>();
+    events.sort_unstable_by(|left, right| {
+        left.offset
+            .cmp(&right.offset)
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| right.end_offset.cmp(&left.end_offset))
+            .then_with(|| left.id.index().cmp(&right.id.index()))
+    });
+
+    let mut entries = Vec::new();
+    let mut active = Vec::<CommandId>::new();
+    let mut index = 0;
+    while let Some(event) = events.get(index).copied() {
+        let offset = event.offset;
+        while events.get(index).is_some_and(|event| {
+            event.offset == offset && event.kind == CommandContainingOffsetEventKind::End
+        }) {
+            let id = events[index].id;
+            active.retain(|active_id| *active_id != id);
+            index += 1;
+        }
+        while events.get(index).is_some_and(|event| {
+            event.offset == offset && event.kind == CommandContainingOffsetEventKind::Start
+        }) {
+            active.push(events[index].id);
+            index += 1;
+        }
+
+        let Some(next_offset) = events.get(index).map(|event| event.offset) else {
+            break;
+        };
+        if offset < next_offset
+            && let Some(id) = active.last().copied()
+        {
+            push_command_containing_offset_entry(&mut entries, offset, next_offset - 1, id);
+        }
+    }
+
+    entries
+}
+
+fn push_command_containing_offset_entry(
+    entries: &mut Vec<CommandContainingOffsetEntry>,
+    start_offset: usize,
+    end_offset: usize,
+    id: CommandId,
+) {
+    if let Some(last) = entries.last_mut()
+        && last.id == id
+        && last.end_offset.saturating_add(1) == start_offset
+    {
+        last.end_offset = end_offset;
+        return;
+    }
+
+    entries.push(CommandContainingOffsetEntry {
+        start_offset,
+        end_offset,
+        id,
+    });
 }
 
 fn attach_containing_command_parents(

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1139,6 +1139,25 @@ fn command_topology_excludes_nested_substitutions_from_structural_commands() {
 }
 
 #[test]
+fn command_topology_skips_synthetic_parents_for_syntax_backed_queries() {
+    let source = "case \"$x\" in $(echo \"$v\")) ;; esac\n";
+    let model = model(source);
+
+    let case_id = command_id_starting_with(&model, source, "case").unwrap();
+    let echo_id = command_id_starting_with(&model, source, "echo").unwrap();
+
+    assert_eq!(
+        model.syntax_backed_command_parent_id(echo_id),
+        Some(case_id)
+    );
+    assert!(
+        model
+            .syntax_backed_command_children(case_id)
+            .contains(&echo_id)
+    );
+}
+
+#[test]
 fn command_lookup_by_span_and_kind_skips_synthetic_commands() {
     let source = "case \"$x\" in $(echo a)) ;; esac\n";
     let model = model(source);
@@ -1212,6 +1231,29 @@ fn command_topology_finds_innermost_command_at_offsets() {
     );
     assert_eq!(
         model.innermost_command_id_at(source.find("bar").unwrap()),
+        Some(bar_id)
+    );
+}
+
+#[test]
+fn command_topology_finds_innermost_command_containing_arbitrary_offsets() {
+    let source = "if foo; then bar; fi\n";
+    let model = model(source);
+
+    let if_id = command_id_starting_with(&model, source, "if foo").unwrap();
+    let foo_id = command_id_starting_with(&model, source, "foo").unwrap();
+    let bar_id = command_id_starting_with(&model, source, "bar").unwrap();
+
+    assert_eq!(
+        model.innermost_command_id_containing_offset(source.find("if").unwrap() + 1),
+        Some(if_id)
+    );
+    assert_eq!(
+        model.innermost_command_id_containing_offset(source.find("foo").unwrap() + 1),
+        Some(foo_id)
+    );
+    assert_eq!(
+        model.innermost_command_id_containing_offset(source.find("bar").unwrap() + 1),
         Some(bar_id)
     );
 }


### PR DESCRIPTION
## Summary
- move syntax-backed command containment and parent/child lookups into shuck-semantic
- switch linter facts and safe-value callers onto the semantic-owned containment queries
- remove linter-local command containment indexing that duplicated semantic topology work

## Testing
- cargo test -p shuck-semantic command_topology_
- cargo test -p shuck-linter precomputes_command_containment_and_barrier_flags_for_nested_commands
- cargo test -p shuck-linter safe_value
- cargo test -p shuck-linter quoted_bash_source
- make test-large-corpus