### PR TITLE
refactor(semantic): move reference summary queries out of linter

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -654,7 +654,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         } = surface_fragments.finish();
         let function_positional_parameter_facts = build_function_positional_parameter_facts(
             self.semantic,
-            semantic_analysis,
             &commands,
             &positional_parameters,
         );
@@ -796,7 +795,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 &commands,
                 &command_fact_indices_by_id,
                 &innermost_command_ids_by_offset,
-                &subscript_later_suppression_reference_spans,
+                &subscript_later_suppression_spans,
             );
 
         let mut backtick_substitution_spans = word_spans::backtick_substitution_spans(source);
@@ -1103,23 +1102,27 @@ fn build_c006_suppressing_reference_offsets_by_name(
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
     innermost_command_ids_by_offset: &CommandOffsetLookup,
-    subscript_later_suppression_reference_spans: &FxHashSet<FactSpan>,
+    subscript_later_suppression_spans: &[Span],
 ) -> FxHashMap<Name, Vec<usize>> {
-    let mut offsets_by_name = FxHashMap::<Name, Vec<usize>>::default();
+    let mut offsets_by_name = semantic
+        .guarded_or_defaulting_reference_offsets_by_name()
+        .iter()
+        .map(|(name, offsets)| (name.clone(), offsets.to_vec()))
+        .collect::<FxHashMap<_, _>>();
 
-    for reference in semantic.references() {
-        if c006_reference_suppresses_later_references(
-            semantic,
-            commands,
-            command_fact_indices_by_id,
-            innermost_command_ids_by_offset,
-            subscript_later_suppression_reference_spans,
-            reference,
-        ) {
-            offsets_by_name
-                .entry(reference.name.clone())
-                .or_default()
-                .push(reference.span.start.offset);
+    for span in subscript_later_suppression_spans {
+        for reference in semantic.references_in_span(*span) {
+            if c006_subscript_reference_suppresses_later_references(
+                commands,
+                command_fact_indices_by_id,
+                innermost_command_ids_by_offset,
+                reference,
+            ) {
+                offsets_by_name
+                    .entry(reference.name.clone())
+                    .or_default()
+                    .push(reference.span.start.offset);
+            }
         }
     }
 
@@ -1131,36 +1134,12 @@ fn build_c006_suppressing_reference_offsets_by_name(
     offsets_by_name
 }
 
-fn c006_reference_suppresses_later_references(
-    semantic: &SemanticModel,
-    commands: &[CommandFact<'_>],
-    command_fact_indices_by_id: &[Option<usize>],
-    innermost_command_ids_by_offset: &CommandOffsetLookup,
-    subscript_later_suppression_reference_spans: &FxHashSet<FactSpan>,
-    reference: &Reference,
-) -> bool {
-    semantic.is_guarded_parameter_reference(reference.id)
-        || semantic.is_defaulting_parameter_operand_reference(reference.id)
-        || c006_subscript_reference_suppresses_later_references(
-            commands,
-            command_fact_indices_by_id,
-            innermost_command_ids_by_offset,
-            subscript_later_suppression_reference_spans,
-            reference,
-        )
-}
-
 fn c006_subscript_reference_suppresses_later_references(
     commands: &[CommandFact<'_>],
     command_fact_indices_by_id: &[Option<usize>],
     innermost_command_ids_by_offset: &CommandOffsetLookup,
-    subscript_later_suppression_reference_spans: &FxHashSet<FactSpan>,
     reference: &Reference,
 ) -> bool {
-    if !subscript_later_suppression_reference_spans.contains(&FactSpan::new(reference.span)) {
-        return false;
-    }
-
     precomputed_command_id_for_offset(
         innermost_command_ids_by_offset,
         reference.span.start.offset,

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -806,11 +806,9 @@ fn is_plausible_shell_function_name(name: &str) -> bool {
 
 fn build_function_positional_parameter_facts(
     semantic: &SemanticModel,
-    semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
     positional_parameter_fragments: &[PositionalParameterFragmentFact],
 ) -> FxHashMap<ScopeId, FunctionPositionalParameterFacts> {
-    let mut facts: FxHashMap<ScopeId, FunctionPositionalParameterFacts> = FxHashMap::default();
     let mut local_reset_offsets_by_scope: FxHashMap<ScopeId, Vec<usize>> = FxHashMap::default();
 
     for command in commands {
@@ -831,54 +829,21 @@ fn build_function_positional_parameter_facts(
         }
     }
 
-    for reference in semantic.references() {
-        if reference_has_local_positional_reset(
-            semantic,
-            reference.scope,
-            reference.span.start.offset,
-            &local_reset_offsets_by_scope,
-        ) {
-            continue;
-        }
-
-        let Some(index) = positional_parameter_index(reference.name.as_str()) else {
-            let Some(uses_positional_parameters) =
-                special_positional_parameter_name(reference.name.as_str())
-            else {
-                continue;
-            };
-
-            if semantic.is_guarded_parameter_reference(reference.id) {
-                continue;
-            }
-
-            let Some(scope) =
-                semantic_analysis.enclosing_function_scope_at(reference.span.start.offset)
-            else {
-                continue;
-            };
-
-            if uses_positional_parameters {
-                facts
-                    .entry(scope)
-                    .or_default()
-                    .uses_unprotected_positional_parameters = true;
-            }
-            continue;
-        };
-        if semantic.is_guarded_parameter_reference(reference.id) {
-            continue;
-        }
-
-        let Some(scope) = semantic_analysis.enclosing_function_scope_at(reference.span.start.offset)
-        else {
-            continue;
-        };
-
-        let entry = facts.entry(scope).or_default();
-        entry.required_arg_count = entry.required_arg_count.max(index);
-        entry.uses_unprotected_positional_parameters = true;
-    }
+    let mut facts = semantic
+        .function_positional_reference_summary(&local_reset_offsets_by_scope)
+        .into_iter()
+        .map(|(scope, summary)| {
+            (
+                scope,
+                FunctionPositionalParameterFacts {
+                    required_arg_count: summary.required_arg_count(),
+                    uses_unprotected_positional_parameters: summary
+                        .uses_unprotected_positional_parameters(),
+                    resets_positional_parameters: false,
+                },
+            )
+        })
+        .collect::<FxHashMap<_, _>>();
 
     for fragment in positional_parameter_fragments {
         if fragment.is_guarded() {
@@ -896,7 +861,7 @@ fn build_function_positional_parameter_facts(
             continue;
         }
 
-        let Some(scope) = semantic_analysis.enclosing_function_scope_at(fragment_offset) else {
+        let Some(scope) = semantic.enclosing_function_scope(fragment_scope) else {
             continue;
         };
 
@@ -937,22 +902,4 @@ fn reference_has_local_positional_reset(
                 .get(&transient_scope)
                 .is_some_and(|offsets| offsets.iter().any(|reset_offset| *reset_offset < offset))
         })
-}
-
-fn positional_parameter_index(name: &str) -> Option<usize> {
-    if name == "0" || matches!(name, "@" | "*" | "#") {
-        return None;
-    }
-    if name.chars().all(|ch| ch.is_ascii_digit()) {
-        name.parse::<usize>().ok()
-    } else {
-        None
-    }
-}
-
-fn special_positional_parameter_name(name: &str) -> Option<bool> {
-    match name {
-        "@" | "*" | "#" => Some(true),
-        _ => None,
-    }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -210,6 +210,33 @@ pub struct SyntheticRead {
     pub(crate) name: Name,
 }
 
+/// Summary of positional-parameter reads reachable from a function scope.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FunctionPositionalReferenceSummary {
+    required_arg_count: usize,
+    uses_unprotected_positional_parameters: bool,
+}
+
+#[allow(missing_docs)]
+impl FunctionPositionalReferenceSummary {
+    pub fn required_arg_count(self) -> usize {
+        self.required_arg_count
+    }
+
+    pub fn uses_unprotected_positional_parameters(self) -> bool {
+        self.uses_unprotected_positional_parameters
+    }
+
+    fn record_required_arg_count(&mut self, index: usize) {
+        self.required_arg_count = self.required_arg_count.max(index);
+        self.uses_unprotected_positional_parameters = true;
+    }
+
+    fn record_use(&mut self) {
+        self.uses_unprotected_positional_parameters = true;
+    }
+}
+
 /// Behavior flags for unused-assignment analysis.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct UnusedAssignmentAnalysisOptions {
@@ -482,6 +509,7 @@ pub struct SemanticModel {
     command_topology: OnceLock<CommandTopology>,
     references_sorted_by_start: OnceLock<Vec<ReferenceId>>,
     bindings_sorted_by_start: OnceLock<Vec<BindingId>>,
+    guarded_or_defaulting_reference_offsets_by_name: OnceLock<FxHashMap<Name, Box<[usize]>>>,
     declarations_by_command_span: OnceLock<FxHashMap<SpanKey, usize>>,
     unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
     function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
@@ -669,6 +697,7 @@ impl SemanticModel {
             command_topology: OnceLock::new(),
             references_sorted_by_start: OnceLock::new(),
             bindings_sorted_by_start: OnceLock::new(),
+            guarded_or_defaulting_reference_offsets_by_name: OnceLock::new(),
             declarations_by_command_span: OnceLock::new(),
             unconditional_function_bindings: OnceLock::new(),
             function_bindings_by_scope: OnceLock::new(),
@@ -720,6 +749,68 @@ impl SemanticModel {
 
     pub fn references(&self) -> &[Reference] {
         &self.references
+    }
+
+    /// Returns guarded or defaulting reference offsets grouped by variable name.
+    ///
+    /// Backed by a lazily-built summary so repeated undefined-variable suppression
+    /// checks can reuse the same grouped offsets instead of rescanning `references()`.
+    pub fn guarded_or_defaulting_reference_offsets_by_name(
+        &self,
+    ) -> &FxHashMap<Name, Box<[usize]>> {
+        self.guarded_or_defaulting_reference_offsets_by_name
+            .get_or_init(|| {
+                build_guarded_or_defaulting_reference_offsets_by_name(
+                    &self.references,
+                    &self.guarded_parameter_refs,
+                    &self.defaulting_parameter_operand_refs,
+                )
+            })
+    }
+
+    /// Summarize unguarded positional-parameter reads by enclosing function scope.
+    ///
+    /// Callers can pass transient-scope `set --` offsets to exclude reads that are
+    /// masked by a nested local positional reset.
+    pub fn function_positional_reference_summary(
+        &self,
+        local_reset_offsets_by_scope: &FxHashMap<ScopeId, Vec<usize>>,
+    ) -> FxHashMap<ScopeId, FunctionPositionalReferenceSummary> {
+        let mut summaries = FxHashMap::<ScopeId, FunctionPositionalReferenceSummary>::default();
+
+        for (name, reference_ids) in &self.reference_index {
+            let Some(kind) = positional_parameter_reference_kind(name.as_str()) else {
+                continue;
+            };
+
+            for reference_id in reference_ids {
+                let reference = &self.references[reference_id.index()];
+                if self.is_guarded_parameter_reference(reference.id)
+                    || reference_has_local_positional_reset(
+                        self,
+                        reference.scope,
+                        reference.span.start.offset,
+                        local_reset_offsets_by_scope,
+                    )
+                {
+                    continue;
+                }
+
+                let Some(function_scope) = self.enclosing_function_scope(reference.scope) else {
+                    continue;
+                };
+
+                let entry = summaries.entry(function_scope).or_default();
+                match kind {
+                    PositionalParameterReferenceKind::Indexed(index) => {
+                        entry.record_required_arg_count(index);
+                    }
+                    PositionalParameterReferenceKind::Special => entry.record_use(),
+                }
+            }
+        }
+
+        summaries
     }
 
     /// Yield every reference whose span is fully contained within `outer`.
@@ -2398,10 +2489,71 @@ fn build_references_sorted_by_start(references: &[Reference]) -> Vec<ReferenceId
     ids
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PositionalParameterReferenceKind {
+    Indexed(usize),
+    Special,
+}
+
+fn positional_parameter_reference_kind(name: &str) -> Option<PositionalParameterReferenceKind> {
+    match name {
+        "@" | "*" | "#" => Some(PositionalParameterReferenceKind::Special),
+        "0" => None,
+        _ if name.chars().all(|ch| ch.is_ascii_digit()) => name
+            .parse::<usize>()
+            .ok()
+            .map(PositionalParameterReferenceKind::Indexed),
+        _ => None,
+    }
+}
+
+fn reference_has_local_positional_reset(
+    semantic: &SemanticModel,
+    scope: ScopeId,
+    offset: usize,
+    local_reset_offsets_by_scope: &FxHashMap<ScopeId, Vec<usize>>,
+) -> bool {
+    semantic
+        .transient_ancestor_scopes_within_function(scope)
+        .any(|transient_scope| {
+            local_reset_offsets_by_scope
+                .get(&transient_scope)
+                .is_some_and(|offsets| offsets.iter().any(|reset_offset| *reset_offset < offset))
+        })
+}
+
 fn build_bindings_sorted_by_start(bindings: &[Binding]) -> Vec<BindingId> {
     let mut ids: Vec<BindingId> = (0..bindings.len() as u32).map(BindingId).collect();
     ids.sort_by_key(|id| bindings[id.index()].span.start.offset);
     ids
+}
+
+fn build_guarded_or_defaulting_reference_offsets_by_name(
+    references: &[Reference],
+    guarded_parameter_refs: &FxHashSet<ReferenceId>,
+    defaulting_parameter_operand_refs: &FxHashSet<ReferenceId>,
+) -> FxHashMap<Name, Box<[usize]>> {
+    let mut offsets_by_name = FxHashMap::<Name, Vec<usize>>::default();
+
+    for reference in references {
+        if guarded_parameter_refs.contains(&reference.id)
+            || defaulting_parameter_operand_refs.contains(&reference.id)
+        {
+            offsets_by_name
+                .entry(reference.name.clone())
+                .or_default()
+                .push(reference.span.start.offset);
+        }
+    }
+
+    offsets_by_name
+        .into_iter()
+        .map(|(name, mut offsets)| {
+            offsets.sort_unstable();
+            offsets.dedup();
+            (name, offsets.into_boxed_slice())
+        })
+        .collect()
 }
 
 fn build_declarations_by_command_span(declarations: &[Declaration]) -> FxHashMap<SpanKey, usize> {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -5790,7 +5790,7 @@ relay() {
     local_resets.insert(transient_scope, vec![reset_offset]);
 
     let with_resets = model.function_positional_reference_summary(&local_resets);
-    assert!(with_resets.get(&greet_scope).is_none());
+    assert!(!with_resets.contains_key(&greet_scope));
     assert_eq!(
         with_resets
             .get(&relay_scope)

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -5685,6 +5685,130 @@ printf '%s\\n' \
 }
 
 #[test]
+fn guarded_or_defaulting_reference_offsets_are_grouped_by_name() {
+    let source = "\
+printf '%s\\n' \
+  \"${missing_default:-$fallback_name}\" \
+  \"${missing_assign:=$seed_name}\" \
+  \"${missing_replace:+$seed_name}\" \
+  \"${missing_error:?$hint_name}\" \
+  \"${missing_error:?$hint_name}\"
+";
+    let model = model(source);
+    let mut expected = FxHashMap::<String, Vec<usize>>::default();
+
+    for reference in model.references() {
+        if model.is_guarded_parameter_reference(reference.id)
+            || model.is_defaulting_parameter_operand_reference(reference.id)
+        {
+            expected
+                .entry(reference.name.as_str().to_owned())
+                .or_default()
+                .push(reference.span.start.offset);
+        }
+    }
+
+    for offsets in expected.values_mut() {
+        offsets.sort_unstable();
+        offsets.dedup();
+    }
+
+    let actual = model
+        .guarded_or_defaulting_reference_offsets_by_name()
+        .iter()
+        .map(|(name, offsets)| (name.as_str().to_owned(), offsets.to_vec()))
+        .collect::<FxHashMap<_, _>>();
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn function_positional_reference_summary_respects_local_transient_resets() {
+    let source = "\
+greet() {
+  (
+    set -- inner
+    printf '%s\\n' \"$1\"
+  )
+}
+relay() {
+  printf '%s\\n' \"$@\"
+}
+";
+    let model = model(source);
+
+    let greet_use_offset = span_for_nth(source, "printf '%s\\n' \"$1\"", 0)
+        .start
+        .offset;
+    let relay_use_offset = span_for_nth(source, "printf '%s\\n' \"$@\"", 0)
+        .start
+        .offset;
+    let greet_scope = model
+        .enclosing_function_scope(model.scope_at(greet_use_offset))
+        .unwrap();
+    let relay_scope = model
+        .enclosing_function_scope(model.scope_at(relay_use_offset))
+        .unwrap();
+
+    let without_resets = model.function_positional_reference_summary(&FxHashMap::default());
+    assert_eq!(
+        without_resets
+            .get(&greet_scope)
+            .copied()
+            .unwrap()
+            .required_arg_count(),
+        1
+    );
+    assert!(
+        without_resets
+            .get(&greet_scope)
+            .copied()
+            .unwrap()
+            .uses_unprotected_positional_parameters()
+    );
+    assert_eq!(
+        without_resets
+            .get(&relay_scope)
+            .copied()
+            .unwrap()
+            .required_arg_count(),
+        0
+    );
+    assert!(
+        without_resets
+            .get(&relay_scope)
+            .copied()
+            .unwrap()
+            .uses_unprotected_positional_parameters()
+    );
+
+    let transient_scope = model
+        .innermost_transient_scope_within_function(model.scope_at(greet_use_offset))
+        .unwrap();
+    let reset_offset = span_for_nth(source, "set -- inner", 0).start.offset;
+    let mut local_resets = FxHashMap::default();
+    local_resets.insert(transient_scope, vec![reset_offset]);
+
+    let with_resets = model.function_positional_reference_summary(&local_resets);
+    assert!(with_resets.get(&greet_scope).is_none());
+    assert_eq!(
+        with_resets
+            .get(&relay_scope)
+            .copied()
+            .unwrap()
+            .required_arg_count(),
+        0
+    );
+    assert!(
+        with_resets
+            .get(&relay_scope)
+            .copied()
+            .unwrap()
+            .uses_unprotected_positional_parameters()
+    );
+}
+
+#[test]
 fn branch_initialized_names_stay_initialized_inside_command_substitutions() {
     let source = "\
 if [ \"$1\" = h ]; then


### PR DESCRIPTION
## Summary
- move guarded/defaulting reference offset grouping into shuck-semantic
- add a semantic positional-parameter reference summary API for function-scope consumers
- switch linter fact builders to the semantic-owned summaries instead of rescanning all references

## Testing
- cargo test -p shuck-semantic guarded_or_defaulting_reference_offsets
- cargo test -p shuck-semantic function_positional_reference_summary_respects_local_transient_resets
- cargo test -p shuck-linter function_called_without_args
- cargo test -p shuck-linter function_references_unset_param
- cargo test -p shuck-linter c006
- make test-large-corpus