### PR TITLE
perf(linter): binary-search commands contained in pipeline span

### DIFF
--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -886,10 +886,7 @@ fn build_pipeline_scope_summaries<'a>(
         let mut source_words = Vec::new();
         let mut name_reads = Vec::new();
         let mut heredoc_name_reads = Vec::new();
-        for command in commands
-            .iter()
-            .filter(|command| contains_span(pipeline.span(), command.span()))
-        {
+        for command in commands.contained_in(pipeline.span()) {
             collect_own_scope_read_source_words(
                 command,
                 if_condition_command_ids,

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -304,6 +304,29 @@ impl<'facts, 'a> CommandFacts<'facts, 'a> {
         }
     }
 
+    /// Iterate commands whose span is fully contained in `outer`.
+    ///
+    /// Relies on `self.commands` being sorted by `span.start.offset` ascending,
+    /// which `LinterFactsBuilder::build` enforces. Uses a binary search to skip
+    /// commands that start before `outer`, then walks forward only as far as
+    /// the outer span reaches.
+    pub(crate) fn contained_in(
+        self,
+        outer: Span,
+    ) -> impl Iterator<Item = CommandFactRef<'facts, 'a>> {
+        let start_offset = outer.start.offset;
+        let end_offset = outer.end.offset;
+        let start = self
+            .commands
+            .partition_point(|fact| fact.span().start.offset < start_offset);
+        let store = self.store;
+        self.commands[start..]
+            .iter()
+            .take_while(move |fact| fact.span().start.offset <= end_offset)
+            .filter(move |fact| fact.span().end.offset <= end_offset)
+            .map(move |fact| CommandFactRef::new(fact, store))
+    }
+
     pub fn first(self) -> Option<CommandFactRef<'facts, 'a>> {
         self.get(0)
     }


### PR DESCRIPTION
## Summary
- `build_pipeline_scope_summaries` previously walked every `CommandFact` for each pipeline to filter the ones whose span sits inside the pipeline. With many pipelines in a script that O(P*N) scan dominated the function (~1% of total samples on `xwmx__nb__nb`).
- `LinterFactsBuilder::build` already sorts `CommandFact` entries by start offset, so we can `partition_point` to the first command at or after the pipeline start and stop walking once we pass its end.
- Adds a `CommandFacts::contained_in` helper and uses it from the pipeline scope loop. The function falls from 47 of 4553 samples (1.0%) on main to 1 of 4501 samples (0.02%) on the same fixture.

## Test plan
- [x] `cargo test -p shuck-linter` (3141 tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `make test-large-corpus` (identical shuck-only / shellcheck-only diagnostic set vs main)
- [x] samply profile on `xwmx__nb__nb` confirms ~98% reduction in `build_pipeline_scope_summaries` self+descendant samples