### PR TITLE
refactor(semantic): extract safe value flow queries

### DIFF
--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -8,8 +8,9 @@ use shuck_ast::{
     word_is_standalone_status_capture, word_is_standalone_variable_like,
 };
 use shuck_semantic::{
-    AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, LoopValueOrigin, ScopeId,
-    ScopeKind, SemanticAnalysis, SemanticModel, SemanticValueFlow, UninitializedCertainty,
+    AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, CallSite,
+    LoopValueOrigin, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel, SemanticValueFlow,
+    UninitializedCertainty,
 };
 use shuck_semantic::{BindingId, BlockId, ReferenceId};
 
@@ -1137,6 +1138,20 @@ impl<'a> SafeValueIndex<'a> {
         scope: ScopeId,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
         self.facts.function_definition_command(scope)
+    }
+
+    fn function_scope_resolves_at_call_site(&self, callee_scope: ScopeId, site: &CallSite) -> bool {
+        if let Some(binding_id) = self
+            .analysis
+            .visible_function_binding_at_call(&site.callee, site.name_span)
+        {
+            return self.analysis.function_scope_for_binding(binding_id) == Some(callee_scope);
+        }
+
+        self.function_definition_command_for_scope(callee_scope)
+            .is_some_and(|definition_command| {
+                self.definition_command_resolves_at_call(definition_command.id(), site.span)
+            })
     }
 
     fn s001_reference_function_unset_before_first_call(&mut self, at: Span) -> bool {
@@ -3216,13 +3231,16 @@ impl<'a> SafeValueIndex<'a> {
             return false;
         };
 
-        self.named_function_call_sites(binding.scope)
+        self.value_flow
+            .borrow()
+            .named_function_call_sites(binding.scope)
             .into_iter()
-            .any(|(caller_scope, span)| {
-                caller_scope == scope
-                    && self.scope_has_visible_local_binding_before(&binding.name, scope, span)
-                    && self.definition_command_resolves_at_call(definition_command.id(), span)
-                    && self.call_site_dominates_use(span, &binding.name, at)
+            .any(|site| {
+                site.scope == scope
+                    && self.function_scope_resolves_at_call_site(binding.scope, &site)
+                    && self.scope_has_visible_local_binding_before(&binding.name, scope, site.span)
+                    && self.definition_command_resolves_at_call(definition_command.id(), site.span)
+                    && self.call_site_dominates_use(site.span, &binding.name, at)
             })
     }
 
@@ -6353,6 +6371,58 @@ render() {
             .expect("expected shadowed helper argument fact");
 
         assert!(safe_values.word_occurrence_is_safe(word_fact, SafeValueQuery::Argv));
+    }
+
+    #[test]
+    fn shadowed_helper_call_site_does_not_count_as_outer_helper_write() {
+        let source = "\
+#!/bin/bash
+helper() {
+  value=$1
+}
+
+render() {
+  local value=SAFE
+  helper() {
+    :
+  }
+  helper
+  printf '%s\\n' ${value}
+}
+";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = SemanticModel::build(&output.file, source, &indexer);
+        let analysis = semantic.analysis();
+        let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+        let safe_values = SafeValueIndex::build(&semantic, &analysis, &facts, source);
+
+        let word_fact = facts
+            .word_facts()
+            .iter()
+            .find(|fact| {
+                fact.expansion_context() == Some(ExpansionContext::CommandArgument)
+                    && fact.span().slice(source) == "${value}"
+            })
+            .expect("expected local argument fact");
+        let render_scope = analysis
+            .enclosing_function_scope_at(word_fact.span().start.offset)
+            .expect("expected render scope");
+        let outer_helper_binding = semantic
+            .bindings()
+            .iter()
+            .find(|binding| {
+                binding.name == "value"
+                    && binding.scope != render_scope
+                    && matches!(binding.kind, shuck_semantic::BindingKind::Assignment)
+            })
+            .expect("expected outer helper binding");
+
+        assert!(!safe_values.binding_writes_visible_local_in_scope_before(
+            outer_helper_binding.id,
+            render_scope,
+            word_fact.span(),
+        ));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -8,9 +8,8 @@ use shuck_ast::{
     word_is_standalone_status_capture, word_is_standalone_variable_like,
 };
 use shuck_semantic::{
-    AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, CallSite,
-    LoopValueOrigin, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel, SemanticValueFlow,
-    UninitializedCertainty,
+    AssignmentValueOrigin, BindingAttributes, BindingKind, BindingOrigin, LoopValueOrigin, ScopeId,
+    ScopeKind, SemanticAnalysis, SemanticModel, SemanticValueFlow, UninitializedCertainty,
 };
 use shuck_semantic::{BindingId, BlockId, ReferenceId};
 
@@ -1138,25 +1137,6 @@ impl<'a> SafeValueIndex<'a> {
         scope: ScopeId,
     ) -> Option<crate::facts::CommandFactRef<'a, 'a>> {
         self.facts.function_definition_command(scope)
-    }
-
-    fn function_scope_resolves_at_call_site(
-        &self,
-        callee_scope: ScopeId,
-        function_name: &Name,
-        site: &CallSite,
-    ) -> bool {
-        if let Some(binding_id) = self
-            .analysis
-            .visible_function_binding_at_call(function_name, site.name_span)
-        {
-            return self.analysis.function_scope_for_binding(binding_id) == Some(callee_scope);
-        }
-
-        self.function_definition_command_for_scope(callee_scope)
-            .is_some_and(|definition_command| {
-                self.definition_command_resolves_at_call(definition_command.id(), site.span)
-            })
     }
 
     fn s001_reference_function_unset_before_first_call(&mut self, at: Span) -> bool {
@@ -2898,14 +2878,9 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn called_helper_bindings_for_name(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
-        let mut bindings = self
-            .semantic
-            .ancestor_scopes(self.semantic.scope_at(at.start.offset))
-            .flat_map(|scope| self.called_helper_bindings_before(name, scope, at))
-            .collect::<Vec<_>>();
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
-        bindings.dedup();
-        bindings
+        self.value_flow
+            .borrow_mut()
+            .helper_value_bindings_before(name, at)
     }
 
     fn s001_top_level_dispatch_helper_bindings_before(
@@ -2919,7 +2894,11 @@ impl<'a> SafeValueIndex<'a> {
 
         let mut bindings = Vec::new();
         let scope = self.semantic.scope_at(at.start.offset);
-        for dispatcher_scope in self.direct_called_function_scopes_before(scope, at.start.offset) {
+        let dispatcher_scopes = self
+            .value_flow
+            .borrow()
+            .called_function_scopes_before(scope, at.start.offset);
+        for dispatcher_scope in dispatcher_scopes {
             bindings.extend(self.s001_branch_helper_bindings_in_scope(name, dispatcher_scope));
         }
         bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
@@ -2978,20 +2957,7 @@ impl<'a> SafeValueIndex<'a> {
             return Vec::new();
         }
 
-        let mut bindings = Vec::new();
-        let mut seen_scopes = FxHashSet::default();
-        let relaxed = !self.span_is_exit_or_return_argument(at);
-        self.collect_transitive_helper_bindings_before(
-            name,
-            self.semantic.scope_at(at.start.offset),
-            at.start.offset,
-            relaxed,
-            &mut seen_scopes,
-            &mut bindings,
-        );
-        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
-        bindings.dedup();
-        bindings
+        self.transitive_helper_bindings_before(name, at, !self.span_is_exit_or_return_argument(at))
     }
 
     fn called_helper_bindings_before(
@@ -3067,24 +3033,12 @@ impl<'a> SafeValueIndex<'a> {
     }
 
     fn named_function_call_sites(&self, scope: ScopeId) -> Vec<(ScopeId, Span)> {
-        let Some(function_kind) = self.named_function_kind(scope) else {
-            return Vec::new();
-        };
-
-        let mut caller_sites = Vec::new();
-        let mut seen_sites = FxHashSet::default();
-        for function_name in function_kind.static_names() {
-            for site in self.semantic.call_sites_for(function_name) {
-                if site.scope == scope {
-                    continue;
-                }
-                if seen_sites.insert((site.scope, site.span.start.offset, site.span.end.offset)) {
-                    caller_sites.push((site.scope, site.span));
-                }
-            }
-        }
-
-        caller_sites
+        self.value_flow
+            .borrow()
+            .named_function_call_sites(scope)
+            .into_iter()
+            .map(|site| (site.scope, site.span))
+            .collect()
     }
 
     fn caller_branch_bindings_before(
@@ -3257,131 +3211,24 @@ impl<'a> SafeValueIndex<'a> {
         {
             return false;
         }
-        let Some(function_kind) = self.named_function_kind(binding.scope) else {
-            return false;
-        };
         let Some(definition_command) = self.function_definition_command_for_scope(binding.scope)
         else {
             return false;
         };
 
-        function_kind.static_names().iter().any(|function_name| {
-            self.semantic
-                .call_sites_for(function_name)
-                .iter()
-                .any(|site| {
-                    site.scope == scope
-                        && self.function_scope_resolves_at_call_site(
-                            binding.scope,
-                            function_name,
-                            site,
-                        )
-                        && self.scope_has_visible_local_binding_before(
-                            &binding.name,
-                            scope,
-                            site.span,
-                        )
-                        && self
-                            .definition_command_resolves_at_call(definition_command.id(), site.span)
-                        && self.call_site_dominates_use(site.span, &binding.name, at)
-                })
-        })
+        self.named_function_call_sites(binding.scope)
+            .into_iter()
+            .any(|(caller_scope, span)| {
+                caller_scope == scope
+                    && self.scope_has_visible_local_binding_before(&binding.name, scope, span)
+                    && self.definition_command_resolves_at_call(definition_command.id(), span)
+                    && self.call_site_dominates_use(span, &binding.name, at)
+            })
     }
 
-    fn collect_transitive_helper_bindings_before(
-        &self,
-        name: &Name,
-        scope: ScopeId,
-        limit_offset: usize,
-        relaxed: bool,
-        seen_scopes: &mut FxHashSet<ScopeId>,
-        bindings: &mut Vec<BindingId>,
-    ) {
-        let callee_scopes = if relaxed {
-            self.direct_called_function_scopes_before_relaxed(scope, limit_offset)
-        } else {
-            self.direct_called_function_scopes_before(scope, limit_offset)
-        };
-        for callee_scope in callee_scopes {
-            if !seen_scopes.insert(callee_scope) {
-                continue;
-            }
-
-            bindings.extend(self.semantic.bindings_for(name).iter().copied().filter(
-                |binding_id| {
-                    let binding = self.semantic.binding(*binding_id);
-                    binding.scope == callee_scope
-                        && !binding.attributes.contains(BindingAttributes::LOCAL)
-                },
-            ));
-
-            if let Some(limit_offset) = self.function_scope_end_offset(callee_scope) {
-                self.collect_transitive_helper_bindings_before(
-                    name,
-                    callee_scope,
-                    limit_offset,
-                    relaxed,
-                    seen_scopes,
-                    bindings,
-                );
-            }
-        }
-    }
-
-    fn direct_called_function_scopes_before_relaxed(
-        &self,
-        scope: ScopeId,
-        limit_offset: usize,
-    ) -> Vec<ScopeId> {
-        let mut scopes = Vec::new();
-        let mut seen_scopes = FxHashSet::default();
-
-        for header in self.facts.function_headers() {
-            let Some(callee_scope) = header.function_scope() else {
-                continue;
-            };
-            let Some(function_kind) = self.named_function_kind(callee_scope) else {
-                continue;
-            };
-            let Some(definition_command) = self.facts.function_definition_command(callee_scope)
-            else {
-                continue;
-            };
-
-            let called_before = function_kind.static_names().iter().any(|function_name| {
-                self.semantic
-                    .call_sites_for(function_name)
-                    .iter()
-                    .any(|site| {
-                        site.scope == scope
-                            && site.span.start.offset < limit_offset
-                            && self.definition_command_resolves_at_call(
-                                definition_command.id(),
-                                site.span,
-                            )
-                    })
-            });
-            if called_before && seen_scopes.insert(callee_scope) {
-                scopes.push(callee_scope);
-            }
-        }
-
-        scopes
-    }
-
-    fn direct_called_function_scopes_before(
-        &self,
-        scope: ScopeId,
-        limit_offset: usize,
-    ) -> Vec<ScopeId> {
-        self.value_flow
-            .borrow()
-            .called_function_scopes_before(scope, limit_offset)
-    }
-
-    fn function_scope_end_offset(&self, scope: ScopeId) -> Option<usize> {
-        self.function_scope_end_span(scope)
-            .map(|span| span.end.offset)
+    fn call_site_dominates_use(&self, call_span: Span, name: &Name, at: Span) -> bool {
+        let _ = name;
+        self.call_site_dominates_offset(call_span, at.start.offset)
     }
 
     fn function_scope_end_span(&self, scope: ScopeId) -> Option<Span> {
@@ -3392,9 +3239,39 @@ impl<'a> SafeValueIndex<'a> {
             .map(|header| Span::at(header.function().span.end))
     }
 
-    fn call_site_dominates_use(&self, call_span: Span, name: &Name, at: Span) -> bool {
-        let _ = name;
-        self.call_site_dominates_offset(call_span, at.start.offset)
+    fn transitive_helper_bindings_before(
+        &self,
+        name: &Name,
+        at: Span,
+        relaxed: bool,
+    ) -> Vec<BindingId> {
+        let scope = self.semantic.scope_at(at.start.offset);
+        let callee_scopes = if relaxed {
+            self.value_flow
+                .borrow()
+                .transitively_called_function_scopes_before_relaxed(scope, at.start.offset)
+        } else {
+            self.value_flow
+                .borrow()
+                .transitively_called_function_scopes_before(scope, at.start.offset)
+        };
+        let mut bindings = callee_scopes
+            .into_iter()
+            .flat_map(|callee_scope| {
+                self.semantic
+                    .bindings_for(name)
+                    .iter()
+                    .copied()
+                    .filter(move |binding_id| {
+                        let binding = self.semantic.binding(*binding_id);
+                        binding.scope == callee_scope
+                            && !binding.attributes.contains(BindingAttributes::LOCAL)
+                    })
+            })
+            .collect::<Vec<_>>();
+        bindings.sort_by_key(|binding_id| self.semantic.binding(*binding_id).span.start.offset);
+        bindings.dedup();
+        bindings
     }
 
     fn call_site_dominates_offset(&self, call_span: Span, limit_offset: usize) -> bool {
@@ -4055,16 +3932,10 @@ impl<'a> SafeValueIndex<'a> {
         self.drop_declarations_shadowed_by_covering_loop_bindings(&mut bindings, at);
         self.drop_outer_bindings_shadowed_by_covering_loop_bindings(&mut bindings, at);
         self.retain_value_bindings(&mut bindings);
-        let mut transitive_helper_bindings = Vec::new();
-        let mut seen_scopes = FxHashSet::default();
-        let relaxed = !self.span_is_exit_or_return_argument(at);
-        self.collect_transitive_helper_bindings_before(
+        let mut transitive_helper_bindings = self.transitive_helper_bindings_before(
             name,
-            self.semantic.scope_at(at.start.offset),
-            at.start.offset,
-            relaxed,
-            &mut seen_scopes,
-            &mut transitive_helper_bindings,
+            at,
+            !self.span_is_exit_or_return_argument(at),
         );
         self.retain_value_bindings(&mut transitive_helper_bindings);
         bindings.extend(transitive_helper_bindings.iter().copied());

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -5003,6 +5003,100 @@ use
 }
 
 #[test]
+fn value_flow_returns_helper_bindings_visible_at_reference() {
+    let source = "\
+#!/bin/bash
+setfoo() {
+  foo=1
+}
+use() {
+  setfoo
+  printf '%s\\n' \"$foo\"
+}
+";
+    let model = model(source);
+    let binding = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .expect("expected foo binding");
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let mut value_flow = analysis.value_flow();
+
+    assert_eq!(
+        value_flow.helper_value_bindings_before(&reference.name, reference.span),
+        vec![binding.id]
+    );
+}
+
+#[test]
+fn value_flow_named_function_call_sites_resolve_alias_fallbacks() {
+    let source = "\
+#!/bin/zsh
+use() {
+  itunes
+  print $foo
+}
+function music itunes() {
+  foo=1
+}
+use
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let helper_scope = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .map(|binding| binding.scope)
+        .expect("expected helper scope");
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+    let call_sites = value_flow.named_function_call_sites(helper_scope);
+
+    assert_eq!(call_sites.len(), 1);
+    assert_eq!(call_sites[0].callee.as_str(), "itunes");
+}
+
+#[test]
+fn value_flow_tracks_transitive_called_function_scopes_before() {
+    let source = "\
+#!/bin/bash
+first() {
+  second
+}
+second() {
+  foo=1
+}
+first
+printf '%s\\n' \"$foo\"
+";
+    let model = model(source);
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let helper_scope = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.name == "foo" && matches!(binding.kind, BindingKind::Assignment))
+        .map(|binding| binding.scope)
+        .expect("expected helper scope");
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+    let caller_scope = model.scope_at(reference.span.start.offset);
+    let callee_scopes = value_flow
+        .transitively_called_function_scopes_before(caller_scope, reference.span.start.offset);
+
+    assert!(callee_scopes.contains(&helper_scope));
+}
+
+#[test]
 fn value_flow_uses_path_covering_alternate_function_definitions() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/value_flow.rs
+++ b/crates/shuck-semantic/src/value_flow.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use super::*;
 
 #[derive(Debug)]
@@ -5,6 +7,9 @@ pub struct SemanticValueFlow<'analysis, 'model> {
     analysis: &'analysis SemanticAnalysis<'model>,
     nonlocal_binding_memo: FxHashMap<(Name, ScopeId, SpanKey), Box<[BindingId]>>,
     nonlocal_binding_visiting: FxHashSet<(Name, ScopeId, SpanKey)>,
+    named_function_call_sites_memo: RefCell<FxHashMap<ScopeId, Box<[CallSite]>>>,
+    resolved_named_function_call_sites_memo: RefCell<FxHashMap<ScopeId, Box<[CallSite]>>>,
+    function_definition_command_memo: RefCell<FxHashMap<ScopeId, Option<CommandId>>>,
 }
 
 impl<'model> SemanticAnalysis<'model> {
@@ -19,6 +24,9 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             analysis,
             nonlocal_binding_memo: FxHashMap::default(),
             nonlocal_binding_visiting: FxHashSet::default(),
+            named_function_call_sites_memo: RefCell::new(FxHashMap::default()),
+            resolved_named_function_call_sites_memo: RefCell::new(FxHashMap::default()),
+            function_definition_command_memo: RefCell::new(FxHashMap::default()),
         }
     }
 
@@ -99,6 +107,18 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         bindings
     }
 
+    pub fn helper_value_bindings_before(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
+        let mut bindings = self
+            .model()
+            .ancestor_scopes(self.model().scope_at(at.start.offset))
+            .flat_map(|scope| {
+                self.nonlocal_value_bindings_from_called_functions_before(name, scope, at)
+            })
+            .collect::<Vec<_>>();
+        self.sort_and_dedup_bindings(&mut bindings);
+        bindings
+    }
+
     pub fn nonlocal_value_bindings_from_called_functions_before(
         &mut self,
         name: &Name,
@@ -135,6 +155,34 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         bindings
     }
 
+    pub fn named_function_call_sites(&self, scope: ScopeId) -> Vec<CallSite> {
+        if let Some(cached) = self.named_function_call_sites_memo.borrow().get(&scope) {
+            return cached.to_vec();
+        }
+
+        let Some(function_kind) = self.named_function_kind(scope) else {
+            return Vec::new();
+        };
+
+        let mut caller_sites = Vec::new();
+        let mut seen_sites = FxHashSet::default();
+        for function_name in function_kind.static_names() {
+            for site in self.model().call_sites_for(function_name) {
+                if site.scope == scope {
+                    continue;
+                }
+                if seen_sites.insert((site.scope, site.span.start.offset, site.span.end.offset)) {
+                    caller_sites.push(site.clone());
+                }
+            }
+        }
+
+        self.named_function_call_sites_memo
+            .borrow_mut()
+            .insert(scope, caller_sites.clone().into_boxed_slice());
+        caller_sites
+    }
+
     pub fn called_function_scopes_before(
         &self,
         scope: ScopeId,
@@ -166,6 +214,79 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         }
 
         scopes.sort_by_key(|scope| self.model().scope(*scope).span.start.offset);
+        scopes
+    }
+
+    pub fn called_function_scopes_before_relaxed(
+        &self,
+        scope: ScopeId,
+        limit_offset: usize,
+    ) -> Vec<ScopeId> {
+        let mut scopes = Vec::new();
+        let mut seen_scopes = FxHashSet::default();
+
+        for (&_function_binding, &callee_scope) in
+            &self.model().recorded_program.function_body_scopes
+        {
+            let Some(function_kind) = self.named_function_kind(callee_scope) else {
+                continue;
+            };
+            let Some(definition_command) = self.function_definition_command_for_scope(callee_scope)
+            else {
+                continue;
+            };
+
+            let called_before = function_kind.static_names().iter().any(|function_name| {
+                self.model()
+                    .call_sites_for(function_name)
+                    .iter()
+                    .any(|site| {
+                        site.scope == scope
+                            && site.span.start.offset < limit_offset
+                            && self
+                                .definition_command_resolves_at_call(definition_command, site.span)
+                    })
+            });
+            if called_before && seen_scopes.insert(callee_scope) {
+                scopes.push(callee_scope);
+            }
+        }
+
+        scopes.sort_by_key(|callee_scope| self.model().scope(*callee_scope).span.start.offset);
+        scopes
+    }
+
+    pub fn transitively_called_function_scopes_before(
+        &self,
+        scope: ScopeId,
+        limit_offset: usize,
+    ) -> Vec<ScopeId> {
+        let mut seen_scopes = FxHashSet::default();
+        let mut scopes = Vec::new();
+        self.collect_transitively_called_function_scopes_before(
+            scope,
+            limit_offset,
+            false,
+            &mut seen_scopes,
+            &mut scopes,
+        );
+        scopes
+    }
+
+    pub fn transitively_called_function_scopes_before_relaxed(
+        &self,
+        scope: ScopeId,
+        limit_offset: usize,
+    ) -> Vec<ScopeId> {
+        let mut seen_scopes = FxHashSet::default();
+        let mut scopes = Vec::new();
+        self.collect_transitively_called_function_scopes_before(
+            scope,
+            limit_offset,
+            true,
+            &mut seen_scopes,
+            &mut scopes,
+        );
         scopes
     }
 
@@ -415,10 +536,40 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         name: &Name,
         scope: ScopeId,
     ) -> Option<FxHashSet<BindingId>> {
-        let function_kind = self.named_function_kind(scope)?;
+        let caller_sites = self.resolved_named_function_call_sites(scope);
+
+        let mut saw_caller = false;
+        let mut union = FxHashSet::default();
+        for site in caller_sites {
+            saw_caller = true;
+            let branch = self
+                .caller_value_bindings_before(name, site.scope, site.span)
+                .into_iter()
+                .collect::<FxHashSet<_>>();
+            if branch.is_empty() {
+                return Some(FxHashSet::default());
+            }
+            union.extend(branch);
+        }
+
+        saw_caller.then_some(union)
+    }
+
+    fn resolved_named_function_call_sites(&self, scope: ScopeId) -> Vec<CallSite> {
+        if let Some(cached) = self
+            .resolved_named_function_call_sites_memo
+            .borrow()
+            .get(&scope)
+        {
+            return cached.to_vec();
+        }
+
+        let Some(function_kind) = self.named_function_kind(scope) else {
+            return Vec::new();
+        };
+
         let mut caller_sites = Vec::new();
         let mut seen_sites = FxHashSet::default();
-
         for function_name in function_kind.static_names() {
             for site in self.model().call_sites_for(function_name) {
                 if site.scope == scope {
@@ -433,24 +584,13 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
             }
         }
 
-        let mut saw_caller = false;
-        let mut union = FxHashSet::default();
-        for site in caller_sites {
-            saw_caller = true;
-            let branch = self
-                .caller_branch_value_bindings_before(name, site.scope, site.span)
-                .into_iter()
-                .collect::<FxHashSet<_>>();
-            if branch.is_empty() {
-                return Some(FxHashSet::default());
-            }
-            union.extend(branch);
-        }
-
-        saw_caller.then_some(union)
+        self.resolved_named_function_call_sites_memo
+            .borrow_mut()
+            .insert(scope, caller_sites.clone().into_boxed_slice());
+        caller_sites
     }
 
-    fn caller_branch_value_bindings_before(
+    pub fn caller_value_bindings_before(
         &mut self,
         name: &Name,
         scope: ScopeId,
@@ -577,6 +717,22 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         })
     }
 
+    fn function_definition_command_for_scope(&self, scope: ScopeId) -> Option<CommandId> {
+        if let Some(cached) = self.function_definition_command_memo.borrow().get(&scope) {
+            return *cached;
+        }
+
+        let command_id = self
+            .function_bindings_for_scope(scope)
+            .into_iter()
+            .filter_map(|binding_id| self.function_definition_command_for_binding(binding_id))
+            .min_by_key(|command_id| self.model().command_span(*command_id).start.offset);
+        self.function_definition_command_memo
+            .borrow_mut()
+            .insert(scope, command_id);
+        command_id
+    }
+
     fn function_bindings_for_scope(&self, scope: ScopeId) -> Vec<BindingId> {
         self.model()
             .recorded_program
@@ -701,6 +857,40 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         }
 
         true
+    }
+
+    fn collect_transitively_called_function_scopes_before(
+        &self,
+        scope: ScopeId,
+        limit_offset: usize,
+        relaxed: bool,
+        seen_scopes: &mut FxHashSet<ScopeId>,
+        scopes: &mut Vec<ScopeId>,
+    ) {
+        let callee_scopes = if relaxed {
+            self.called_function_scopes_before_relaxed(scope, limit_offset)
+        } else {
+            self.called_function_scopes_before(scope, limit_offset)
+        };
+
+        for callee_scope in callee_scopes {
+            if !seen_scopes.insert(callee_scope) {
+                continue;
+            }
+            scopes.push(callee_scope);
+
+            let next_limit_offset = self
+                .function_definition_command_for_scope(callee_scope)
+                .map(|command_id| self.model().command_span(command_id).end.offset)
+                .unwrap_or_else(|| self.model().scope(callee_scope).span.end.offset);
+            self.collect_transitively_called_function_scopes_before(
+                callee_scope,
+                next_limit_offset,
+                relaxed,
+                seen_scopes,
+                scopes,
+            );
+        }
     }
 
     fn command_is_dominance_barrier(&self, command_id: CommandId) -> bool {


### PR DESCRIPTION
## Summary
- move reusable helper-binding and named call-site queries into semantic value_flow
- switch safe_value onto semantic-owned helper-flow and transitive call queries
- keep the rule focused on policy while reducing its local semantic-engine logic

## Testing
- cargo test -p shuck-semantic value_flow_
- cargo test -p shuck-linter safe_value
- cargo test -p shuck-linter quoted_bash_source
- cargo clippy --all-targets -- -D warnings
- make test-large-corpus