### PR TITLE
refactor(semantic): index bindings by definition span

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1762,11 +1762,9 @@ fn collect_binding_values<'a>(
         let AssignmentValue::Scalar(word) = &assignment.value else {
             continue;
         };
-        if let Some(binding_id) = binding_value_definition_id_for_name(
-            semantic,
-            &assignment.target.name,
-            assignment.target.name_span,
-        ) {
+        if let Some(binding_id) =
+            binding_value_definition_id_for_span(semantic, assignment.target.name_span)
+        {
             binding_values.insert(binding_id, BindingValueFact::scalar(word));
         }
     }
@@ -1778,11 +1776,9 @@ fn collect_binding_values<'a>(
         let AssignmentValue::Scalar(word) = &assignment.value else {
             continue;
         };
-        if let Some(binding_id) = binding_value_definition_id_for_name(
-            semantic,
-            &assignment.target.name,
-            assignment.target.name_span,
-        ) {
+        if let Some(binding_id) =
+            binding_value_definition_id_for_span(semantic, assignment.target.name_span)
+        {
             binding_values.insert(binding_id, BindingValueFact::scalar(word));
         }
     }
@@ -1792,7 +1788,7 @@ fn collect_binding_values<'a>(
     {
         for operand in &declaration.operands {
             let SemanticDeclarationOperand::Assignment {
-                name,
+                name: _,
                 name_span,
                 value_span,
                 ..
@@ -1805,9 +1801,7 @@ fn collect_binding_values<'a>(
             };
             let standalone_status_or_pid_capture =
                 word_span_is_standalone_status_or_pid_capture(word, *value_span);
-            if let Some(binding_id) =
-                binding_value_definition_id_for_name(semantic, name, *name_span)
-            {
+            if let Some(binding_id) = binding_value_definition_id_for_span(semantic, *name_span) {
                 binding_values.insert(
                     binding_id,
                     BindingValueFact::scalar_with_status_or_pid_capture(
@@ -1826,9 +1820,9 @@ fn collect_binding_values<'a>(
             };
             let values = words.iter().collect::<Vec<_>>().into_boxed_slice();
             for target in &command.targets {
-                if let Some(name) = &target.name
+                if target.name.is_some()
                     && let Some(binding_id) =
-                        binding_value_definition_id_for_name(semantic, name, target.span)
+                        binding_value_definition_id_for_span(semantic, target.span)
                 {
                     binding_values.insert(
                         binding_id,
@@ -1838,11 +1832,9 @@ fn collect_binding_values<'a>(
             }
         }
         Command::Compound(CompoundCommand::Foreach(command)) => {
-            if let Some(binding_id) = binding_value_definition_id_for_name(
-                semantic,
-                &command.variable,
-                command.variable_span,
-            ) {
+            if let Some(binding_id) =
+                binding_value_definition_id_for_span(semantic, command.variable_span)
+            {
                 binding_values.insert(
                     binding_id,
                     BindingValueFact::from_loop_words(
@@ -1852,11 +1844,9 @@ fn collect_binding_values<'a>(
             }
         }
         Command::Compound(CompoundCommand::Select(command)) => {
-            if let Some(binding_id) = binding_value_definition_id_for_name(
-                semantic,
-                &command.variable,
-                command.variable_span,
-            ) {
+            if let Some(binding_id) =
+                binding_value_definition_id_for_span(semantic, command.variable_span)
+            {
                 binding_values.insert(
                     binding_id,
                     BindingValueFact::from_loop_words(
@@ -1869,17 +1859,11 @@ fn collect_binding_values<'a>(
     }
 }
 
-fn binding_value_definition_id_for_name(
+fn binding_value_definition_id_for_span(
     semantic: &SemanticModel,
-    name: &Name,
     span: Span,
 ) -> Option<BindingId> {
-    semantic
-        .bindings_for(name)
-        .iter()
-        .rev()
-        .copied()
-        .find(|binding_id| semantic.binding(*binding_id).span == span)
+    semantic.binding_for_definition_span(span)
 }
 
 fn binding_value_visible_id_for_name(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -533,6 +533,7 @@ pub struct SemanticModel {
     command_topology: OnceLock<CommandTopology>,
     references_sorted_by_start: OnceLock<Vec<ReferenceId>>,
     bindings_sorted_by_start: OnceLock<Vec<BindingId>>,
+    bindings_by_definition_span: OnceLock<FxHashMap<SpanKey, BindingId>>,
     guarded_or_defaulting_reference_offsets_by_name: OnceLock<FxHashMap<Name, Box<[usize]>>>,
     declarations_by_command_span: OnceLock<FxHashMap<SpanKey, usize>>,
     unconditional_function_bindings: OnceLock<FxHashSet<BindingId>>,
@@ -721,6 +722,7 @@ impl SemanticModel {
             command_topology: OnceLock::new(),
             references_sorted_by_start: OnceLock::new(),
             bindings_sorted_by_start: OnceLock::new(),
+            bindings_by_definition_span: OnceLock::new(),
             guarded_or_defaulting_reference_offsets_by_name: OnceLock::new(),
             declarations_by_command_span: OnceLock::new(),
             unconditional_function_bindings: OnceLock::new(),
@@ -906,6 +908,13 @@ impl SemanticModel {
 
     pub fn binding(&self, id: BindingId) -> &Binding {
         &self.bindings[id.index()]
+    }
+
+    pub fn binding_for_definition_span(&self, span: Span) -> Option<BindingId> {
+        let index = self
+            .bindings_by_definition_span
+            .get_or_init(|| build_bindings_by_definition_span(&self.bindings));
+        index.get(&SpanKey::new(span)).copied()
     }
 
     pub fn reference(&self, id: ReferenceId) -> &Reference {
@@ -1407,6 +1416,7 @@ impl SemanticModel {
         if !origin_paths.is_empty() {
             self.import_origins_by_binding.insert(id, origin_paths);
         }
+        self.bindings_by_definition_span.take();
         id
     }
 
@@ -2761,6 +2771,14 @@ fn build_declarations_by_command_span(declarations: &[Declaration]) -> FxHashMap
     let mut index = FxHashMap::with_capacity_and_hasher(declarations.len(), Default::default());
     for (declaration_index, declaration) in declarations.iter().enumerate() {
         index.insert(SpanKey::new(declaration.span), declaration_index);
+    }
+    index
+}
+
+fn build_bindings_by_definition_span(bindings: &[Binding]) -> FxHashMap<SpanKey, BindingId> {
+    let mut index = FxHashMap::with_capacity_and_hasher(bindings.len(), Default::default());
+    for binding in bindings {
+        index.insert(SpanKey::new(binding.span), binding.id);
     }
     index
 }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -550,6 +550,20 @@ fn function_definition_binding_lookup_uses_the_command_span() {
 }
 
 #[test]
+fn binding_lookup_uses_the_definition_span() {
+    let source = "foo=1\nbar=2\n";
+    let model = model(source);
+
+    for name in [Name::from("foo"), Name::from("bar")] {
+        let binding_id = model.bindings_for(&name)[0];
+        assert_eq!(
+            model.binding_for_definition_span(model.binding(binding_id).span),
+            Some(binding_id)
+        );
+    }
+}
+
+#[test]
 fn zsh_multi_name_function_lookup_works_through_any_alias() {
     let source = "flag=1\nfunction music itunes() { echo \"$flag\"; }\nitunes\n";
     let model = model_with_dialect(source, ShellDialect::Zsh);


### PR DESCRIPTION
## Summary
- add a semantic-owned binding lookup by definition span
- replace assignment fact scans over same-name bindings with the semantic API
- cover the new lookup with a semantic regression test

## Validation
- cargo test -p shuck-semantic binding_lookup_uses_the_definition_span
- cargo test -p shuck-linter facts::tests::assignments
- cargo test -p shuck-semantic -p shuck-linter