### PR TITLE
refactor(linter): reuse semantic command child index

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -439,9 +439,10 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     .is_some_and(Option::is_some)
             })
             .collect::<Vec<_>>();
-        let command_child_ids_by_parent =
-            build_linter_command_child_ids_by_parent(self.semantic, &command_fact_indices_by_id);
-        let command_child_index = CommandChildIndex::from_parent_lists(command_child_ids_by_parent);
+        let command_child_index = CommandChildIndex::from_semantic_syntax_backed_children(
+            self.semantic,
+            &command_fact_indices_by_id,
+        );
 
         populate_linebreak_in_test_facts(&mut commands, self.source);
         populate_substitution_fact_ranges(
@@ -961,28 +962,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             conditional_portability,
         }
     }
-}
-
-fn build_linter_command_child_ids_by_parent(
-    semantic: &SemanticModel,
-    command_fact_indices_by_id: &[Option<usize>],
-) -> Vec<Vec<CommandId>> {
-    let mut children_by_parent = vec![Vec::new(); semantic.command_count()];
-    for child in semantic.commands().iter().copied() {
-        if !command_fact_exists(command_fact_indices_by_id, child) {
-            continue;
-        }
-        if let Some(parent) = semantic.syntax_backed_command_parent_id(child) {
-            children_by_parent[parent.index()].push(child);
-        }
-    }
-    children_by_parent
-}
-
-fn command_fact_exists(command_fact_indices_by_id: &[Option<usize>], id: CommandId) -> bool {
-    command_fact_indices_by_id
-        .get(id.index())
-        .is_some_and(Option::is_some)
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -129,13 +129,35 @@ pub(crate) struct CommandChildIndex {
 }
 
 impl CommandChildIndex {
-    fn from_parent_lists(children_by_parent: Vec<Vec<CommandId>>) -> Self {
-        let total_children = children_by_parent.iter().map(Vec::len).sum();
+    fn from_semantic_syntax_backed_children(
+        semantic: &SemanticModel,
+        command_fact_indices_by_id: &[Option<usize>],
+    ) -> Self {
+        let total_children = semantic
+            .commands()
+            .iter()
+            .copied()
+            .map(|parent| {
+                semantic
+                    .syntax_backed_command_children(parent)
+                    .iter()
+                    .copied()
+                    .filter(|child| command_fact_exists(command_fact_indices_by_id, *child))
+                    .count()
+            })
+            .sum();
         let mut ids = ListArena::with_capacity(total_children);
-        let mut by_parent = Vec::with_capacity(children_by_parent.len());
+        let mut by_parent = Vec::with_capacity(semantic.command_count());
+        by_parent.resize_with(semantic.command_count(), IdRange::empty);
 
-        for children in children_by_parent {
-            by_parent.push(ids.push_many(children));
+        for parent in semantic.commands().iter().copied() {
+            by_parent[parent.index()] = ids.push_many(
+                semantic
+                    .syntax_backed_command_children(parent)
+                    .iter()
+                    .copied()
+                    .filter(|child| command_fact_exists(command_fact_indices_by_id, *child)),
+            );
         }
 
         Self { ids, by_parent }
@@ -147,6 +169,12 @@ impl CommandChildIndex {
             .copied()
             .map_or(&[], |range| self.ids.get(range))
     }
+}
+
+fn command_fact_exists(command_fact_indices_by_id: &[Option<usize>], id: CommandId) -> bool {
+    command_fact_indices_by_id
+        .get(id.index())
+        .is_some_and(Option::is_some)
 }
 
 impl<'a> FactStore<'a> {


### PR DESCRIPTION
## Summary
- build the linter command-child index from semantic syntax-backed child lists
- keep the existing linter fact-presence filter while removing the local parent-id reconstruction

## Validation
- cargo fmt --check
- cargo test -p shuck-linter