### PR TITLE
refactor(semantic): share resolved function call scope lookup

### DIFF
--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -4,6 +4,7 @@ use shuck_parser::ZshEmulationMode;
 use smallvec::{SmallVec, smallvec};
 use std::marker::PhantomData;
 
+use crate::function_resolution::resolved_function_calls_with_callee_scope;
 use crate::source_closure::SourcePathTemplate;
 use crate::{Binding, BindingId, CallSite, ReferenceId, Scope, ScopeId, SpanKey};
 
@@ -791,41 +792,24 @@ fn resolve_script_terminating_call_spans(
     always_exiting_scopes: &FxHashSet<ScopeId>,
     terminating_call_spans: &mut FxHashSet<SpanKey>,
 ) -> bool {
-    let target_names = program
-        .function_body_scopes
-        .iter()
-        .filter(|(_, scope)| always_exiting_scopes.contains(scope))
-        .map(|(binding, _)| bindings[binding.index()].name.clone())
-        .collect::<FxHashSet<_>>();
     let mut changed = false;
 
-    for name in target_names {
-        let Some(sites) = call_sites.get(&name) else {
+    for call in resolved_function_calls_with_callee_scope(
+        call_sites,
+        visible_function_call_bindings,
+        &program.function_body_scopes,
+    ) {
+        if !always_exiting_scopes.contains(&call.callee_scope) {
             continue;
-        };
-
-        for site in sites {
-            let Some(binding) = visible_function_call_bindings
-                .get(&SpanKey::new(site.name_span))
-                .copied()
-            else {
-                continue;
-            };
-            let Some(scope) = program.function_body_scopes.get(&binding).copied() else {
-                continue;
-            };
-            if !always_exiting_scopes.contains(&scope) {
-                continue;
-            }
-            if file_entry_can_return_before_function_definition(
-                program,
-                bindings[binding.index()].span.start.offset,
-            ) {
-                continue;
-            }
-            let command_span = recorded_command_span_for_call_site(program, site);
-            changed |= terminating_call_spans.insert(SpanKey::new(command_span));
         }
+        if file_entry_can_return_before_function_definition(
+            program,
+            bindings[call.binding.index()].span.start.offset,
+        ) {
+            continue;
+        }
+        let command_span = recorded_command_span_for_call_site(program, call.site);
+        changed |= terminating_call_spans.insert(SpanKey::new(command_span));
     }
 
     changed

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -4,6 +4,7 @@ use shuck_ast::Span;
 use smallvec::SmallVec;
 
 use crate::dense_bit_set::DenseBitSet;
+use crate::function_resolution::resolved_function_calls_with_callee_scope;
 use crate::reachability::block_reaches_without;
 use crate::runtime::RuntimePrelude;
 use crate::{
@@ -2628,26 +2629,19 @@ fn resolved_calls_by_scope(
     function_scopes: &FxHashMap<BindingId, ScopeId>,
 ) -> FxHashMap<ScopeId, Vec<ResolvedCallSite>> {
     let mut calls_by_scope: FxHashMap<ScopeId, Vec<ResolvedCallSite>> = FxHashMap::default();
-    for sites in call_sites.values() {
-        for site in sites {
-            let Some(function_binding) = visible_function_call_bindings
-                .get(&SpanKey::new(site.name_span))
-                .copied()
-            else {
-                continue;
-            };
-            let Some(callee_scope) = function_scopes.get(&function_binding).copied() else {
-                continue;
-            };
-            calls_by_scope
-                .entry(site.scope)
-                .or_default()
-                .push(ResolvedCallSite {
-                    offset: site.span.start.offset,
-                    span: site.span,
-                    callee_scope,
-                });
-        }
+    for call in resolved_function_calls_with_callee_scope(
+        call_sites,
+        visible_function_call_bindings,
+        function_scopes,
+    ) {
+        calls_by_scope
+            .entry(call.site.scope)
+            .or_default()
+            .push(ResolvedCallSite {
+                offset: call.site.span.start.offset,
+                span: call.site.span,
+                callee_scope: call.callee_scope,
+            });
     }
     for calls in calls_by_scope.values_mut() {
         calls.sort_by_key(|call| call.offset);

--- a/crates/shuck-semantic/src/function_resolution.rs
+++ b/crates/shuck-semantic/src/function_resolution.rs
@@ -15,6 +15,12 @@ pub(crate) struct FunctionBindingLookup<'a> {
     pub(crate) function_bindings_by_scope: &'a FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>,
 }
 
+pub(crate) struct ResolvedFunctionCall<'a> {
+    pub(crate) site: &'a CallSite,
+    pub(crate) binding: BindingId,
+    pub(crate) callee_scope: ScopeId,
+}
+
 impl FunctionBindingLookup<'_> {
     pub(crate) fn visible_function_binding(
         &self,
@@ -59,6 +65,28 @@ impl FunctionBindingLookup<'_> {
 
         call_bindings
     }
+}
+
+pub(crate) fn resolved_function_calls_with_callee_scope<'a>(
+    call_sites: &'a FxHashMap<Name, SmallVec<[CallSite; 2]>>,
+    visible_function_call_bindings: &'a FxHashMap<SpanKey, BindingId>,
+    function_body_scopes: &'a FxHashMap<BindingId, ScopeId>,
+) -> impl Iterator<Item = ResolvedFunctionCall<'a>> + 'a {
+    call_sites
+        .values()
+        .flat_map(|sites| sites.iter())
+        .filter_map(move |site| {
+            let binding = visible_function_call_bindings
+                .get(&SpanKey::new(site.name_span))
+                .copied()?;
+            let callee_scope = function_body_scopes.get(&binding).copied()?;
+
+            Some(ResolvedFunctionCall {
+                site,
+                binding,
+                callee_scope,
+            })
+        })
 }
 
 pub(crate) fn function_bindings_by_scope(

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -6323,6 +6323,43 @@ main() {
 }
 
 #[test]
+fn resolved_function_calls_feed_dataflow_and_script_termination() {
+    let source = "\
+reader() {
+  printf '%s\\n' \"$value\"
+}
+exit_script() {
+  exit 0
+}
+main() {
+  value=ok
+  reader
+  exit_script
+  printf '%s\\n' never
+}
+main
+";
+    let model = model(source);
+    let analysis = model.analysis();
+    let unused = binding_names(&model, analysis.dataflow().unused_assignment_ids());
+    let unreachable = analysis
+        .dead_code()
+        .iter()
+        .flat_map(|entry| entry.unreachable.iter())
+        .map(|span| span.slice(source).trim_end().to_owned())
+        .collect::<Vec<_>>();
+
+    assert!(
+        !unused.iter().any(|name| name == "value"),
+        "unused bindings: {unused:?}"
+    );
+    assert!(
+        unreachable.contains(&"printf '%s\\n' never".to_owned()),
+        "unreachable spans: {unreachable:?}"
+    );
+}
+
+#[test]
 fn condition_body_after_script_terminating_condition_is_dead() {
     let source = "\
 if exit 0; then


### PR DESCRIPTION
## Summary
- Add a semantic-owned resolved function call iterator that carries call site, binding, and callee scope.
- Reuse that iterator from dataflow and CFG script-terminating call resolution.
- Add a semantic regression covering dataflow read propagation and script-terminating dead-code detection.

## Validation
- cargo test -p shuck-semantic
- make test
