### PR TITLE
refactor(semantic): expose nested function scope query

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -478,6 +478,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             .collect::<FxHashMap<_, _>>();
         let case_cli_reachable_function_scopes = build_case_cli_reachable_function_scopes(
             self.semantic,
+            semantic_analysis,
             &function_headers,
             &function_cli_dispatch_facts,
             &commands,

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -239,6 +239,7 @@ fn build_function_cli_dispatch_facts(
 #[cfg_attr(shuck_profiling, inline(never))]
 fn build_case_cli_reachable_function_scopes(
     semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
     function_headers: &[FunctionHeaderFact<'_>],
     function_cli_dispatch_facts: &FxHashMap<ScopeId, FunctionCliDispatchFacts>,
     commands: &[CommandFact<'_>],
@@ -269,12 +270,7 @@ fn build_case_cli_reachable_function_scopes(
         .iter()
         .filter_map(|header| {
             let scope = header.function_scope()?;
-            let nested = semantic
-                .scope(scope)
-                .parent
-                .and_then(|parent| semantic.enclosing_function_scope(parent))
-                .is_some();
-            (nested
+            (semantic_analysis.function_scope_is_nested(scope)
                 || dispatcher_offset
                     .is_some_and(|offset| header.function().span.start.offset < offset)
                 || top_level_exit_offset

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -342,6 +342,42 @@ late() { echo later; }
 }
 
 #[test]
+fn case_cli_reachable_function_scopes_count_anonymous_parent_functions() {
+    let source = "\
+#!/bin/zsh
+case \"$1\" in
+  start) \"$1\" ;;
+esac
+exit $?
+function {
+  helper() { echo helper; }
+}
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            let helper = facts
+                .function_headers()
+                .iter()
+                .find(|header| {
+                    header
+                        .static_name_entry()
+                        .is_some_and(|(name, _)| name == "helper")
+                })
+                .expect("expected helper header fact");
+
+            assert!(facts.is_case_cli_reachable_function_scope(
+                helper.function_scope().expect("expected helper scope")
+            ));
+        },
+    );
+}
+
+#[test]
 fn function_cli_dispatch_facts_track_case_positional_entrypoints_with_literal_top_level_exit() {
     let source = "\
 #!/bin/sh

--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -115,7 +115,7 @@ impl<'model> SemanticAnalysis<'model> {
         self.model
             .scope(scope)
             .parent
-            .and_then(|parent| self.enclosing_function_scope(parent))
+            .and_then(|parent| self.model.enclosing_function_scope(parent))
             .is_some()
     }
 

--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -111,6 +111,14 @@ impl<'model> SemanticAnalysis<'model> {
             .copied()
     }
 
+    pub fn function_scope_is_nested(&self, scope: ScopeId) -> bool {
+        self.model
+            .scope(scope)
+            .parent
+            .and_then(|parent| self.enclosing_function_scope(parent))
+            .is_some()
+    }
+
     pub fn visible_function_binding_defined_before(
         &self,
         name: &Name,


### PR DESCRIPTION
## Summary
- move nested function-scope classification behind `SemanticAnalysis`
- keep case-CLI dispatch policy in linter facts while reusing the semantic query

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter facts::tests::functions`
- `cargo test -p shuck-linter reports_case_cli_reachable_helper_local_arguments`
- `cargo test -p shuck-linter later_top_level_exit_helpers_block_same_function_bindings`
