### PR TITLE
refactor(linter): remove checker AST accessor

### DIFF
--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -92,10 +92,6 @@ impl<'a> Checker<'a> {
         self.indexer
     }
 
-    pub fn ast(&self) -> &'a File {
-        self.file
-    }
-
     pub fn source(&self) -> &'a str {
         self.source
     }


### PR DESCRIPTION
## Summary
- remove the unused public `Checker::ast()` accessor
- keep callers on semantic, indexer, source, and facts APIs instead of exposing the parsed AST through `Checker`

## Verification
- cargo fmt --all --check
- cargo test -p shuck-linter
- cargo clippy -p shuck-linter --all-targets -- -D warnings