### PR TITLE
perf(linter): reuse semantic command body indexes

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -1,6 +1,7 @@
 struct LinterFactsBuilder<'a, 'analysis> {
     file: &'a File,
     source: &'a str,
+    semantic_artifacts: &'a LinterSemanticArtifacts<'a>,
     semantic: &'a SemanticModel,
     semantic_analysis: &'analysis SemanticAnalysis<'a>,
     _indexer: &'a Indexer,
@@ -63,6 +64,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         Self {
             file,
             source,
+            semantic_artifacts: semantic,
             semantic: semantic.semantic(),
             semantic_analysis,
             _indexer: indexer,
@@ -453,6 +455,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &command_fact_indices_by_id,
             &command_ids_by_span,
             &command_child_index,
+            self.semantic_artifacts,
             self.source,
         );
 

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -155,6 +155,7 @@ fn populate_substitution_fact_ranges<'a>(
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
+    semantic: &LinterSemanticArtifacts<'a>,
     source: &str,
 ) {
     for index in 0..commands.len() {
@@ -169,6 +170,7 @@ fn populate_substitution_fact_ranges<'a>(
                 command_facts,
                 command_ids_by_span,
                 command_child_index,
+                semantic,
                 source,
             )
         };
@@ -181,6 +183,7 @@ fn build_command_substitution_facts<'a>(
     commands: CommandFacts<'_, 'a>,
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
+    semantic: &LinterSemanticArtifacts<'a>,
     source: &str,
 ) -> Vec<SubstitutionFact> {
     let mut substitutions = Vec::new();
@@ -194,6 +197,7 @@ fn build_command_substitution_facts<'a>(
             command_child_index,
         ),
         host_command_id: fact.id(),
+        semantic,
         source,
     };
 
@@ -303,6 +307,7 @@ struct SubstitutionFactBuildContext<'a, 'b> {
     commands: CommandFacts<'b, 'a>,
     command_relationships: CommandRelationshipContext<'b, 'a>,
     host_command_id: CommandId,
+    semantic: &'b LinterSemanticArtifacts<'a>,
     source: &'b str,
 }
 
@@ -328,6 +333,7 @@ fn collect_or_update_substitution_facts_from_occurrences<'a>(
             context.commands,
             context.command_relationships,
             context.host_command_id,
+            context.semantic,
             context.source,
         );
         substitution_index.insert(key, substitutions.len());
@@ -542,15 +548,10 @@ fn classify_substitution_body<'a>(
     commands: CommandFacts<'_, 'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     parent_id: CommandId,
+    semantic: &LinterSemanticArtifacts<'a>,
     source: &str,
 ) -> SubstitutionBodyFacts {
-    let visits = iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: false,
-        },
-    )
-    .collect::<Vec<_>>();
+    let visits = semantic.command_visits_in_body(body, false);
     let redirect_summary =
         summarize_stmt_seq_redirects(body, parent_id, commands, command_relationships, source);
 
@@ -568,6 +569,7 @@ fn classify_substitution_body<'a>(
             parent_id,
             commands,
             command_relationships,
+            semantic,
             source,
         )
         .into_boxed_slice(),
@@ -1080,15 +1082,11 @@ fn substitution_body_processed_ls_pipeline_spans<'a>(
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
+    semantic: &LinterSemanticArtifacts<'a>,
     source: &str,
 ) -> Vec<Span> {
     let mut spans = Vec::new();
-    for visit in iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
+    for visit in semantic.command_visits_in_body(body, true) {
         collect_processed_ls_pipeline_spans_in_stmt(
             visit.stmt,
             parent_id,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -105,8 +105,8 @@ pub use suppression::{
 /// Trait implemented by rule-specific diagnostic payloads.
 pub use violation::Violation;
 
-use rustc_hash::FxHashSet;
-use shuck_ast::{File, Position, Span, Stmt, TextSize};
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::{File, Position, Span, Stmt, StmtSeq, TextSize};
 use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{
@@ -128,6 +128,7 @@ pub struct AnalysisResult {
 pub struct LinterSemanticArtifacts<'a> {
     semantic: SemanticModel,
     command_visits_by_id: Vec<Option<facts::CommandVisit<'a>>>,
+    direct_command_ids_by_body_span: FxHashMap<facts::FactSpan, Vec<CommandId>>,
 }
 
 impl<'a> LinterSemanticArtifacts<'a> {
@@ -148,7 +149,8 @@ impl<'a> LinterSemanticArtifacts<'a> {
             build_with_observer_with_options(file, source, indexer, &mut observer, options);
         Self {
             semantic,
-            command_visits_by_id: observer.into_command_visits_by_id(),
+            command_visits_by_id: observer.command_visits_by_id,
+            direct_command_ids_by_body_span: observer.direct_command_ids_by_body_span,
         }
     }
 
@@ -165,6 +167,52 @@ impl<'a> LinterSemanticArtifacts<'a> {
     pub(crate) fn command_visits_by_id(&self) -> &[Option<facts::CommandVisit<'a>>] {
         &self.command_visits_by_id
     }
+
+    pub(crate) fn command_visits_in_body(
+        &self,
+        body: &StmtSeq,
+        descend_nested_word_commands: bool,
+    ) -> Vec<facts::CommandVisit<'a>> {
+        let Some(root_ids) = self
+            .direct_command_ids_by_body_span
+            .get(&facts::FactSpan::new(body.span))
+        else {
+            return Vec::new();
+        };
+        let baseline_depth = root_ids
+            .iter()
+            .filter_map(|id| self.semantic.command_context(*id))
+            .map(|context| context.nested_word_command_depth())
+            .min()
+            .unwrap_or(0);
+        let mut visits = Vec::new();
+        let mut stack = root_ids.iter().rev().copied().collect::<Vec<_>>();
+        while let Some(id) = stack.pop() {
+            let Some(context) = self.semantic.command_context(id) else {
+                continue;
+            };
+            if !descend_nested_word_commands && context.nested_word_command_depth() > baseline_depth
+            {
+                continue;
+            }
+            if let Some(visit) = self
+                .command_visits_by_id
+                .get(id.index())
+                .and_then(|visit| *visit)
+            {
+                visits.push(visit);
+            }
+            for child in self
+                .semantic
+                .syntax_backed_command_children(id)
+                .iter()
+                .rev()
+            {
+                stack.push(*child);
+            }
+        }
+        visits
+    }
 }
 
 impl Deref for LinterSemanticArtifacts<'_> {
@@ -178,12 +226,7 @@ impl Deref for LinterSemanticArtifacts<'_> {
 #[derive(Default)]
 struct LintTraversalObserver<'a> {
     command_visits_by_id: Vec<Option<facts::CommandVisit<'a>>>,
-}
-
-impl<'a> LintTraversalObserver<'a> {
-    fn into_command_visits_by_id(self) -> Vec<Option<facts::CommandVisit<'a>>> {
-        self.command_visits_by_id
-    }
+    direct_command_ids_by_body_span: FxHashMap<facts::FactSpan, Vec<CommandId>>,
 }
 
 impl<'a> TraversalObserver<'a> for LintTraversalObserver<'a> {
@@ -198,6 +241,18 @@ impl<'a> TraversalObserver<'a> for LintTraversalObserver<'a> {
             self.command_visits_by_id.resize(id.index() + 1, None);
         }
         self.command_visits_by_id[id.index()] = Some(facts::CommandVisit::new(stmt));
+    }
+
+    fn recorded_statement_sequence_command(
+        &mut self,
+        body_span: Span,
+        _stmt_span: Span,
+        id: CommandId,
+    ) {
+        self.direct_command_ids_by_body_span
+            .entry(facts::FactSpan::new(body_span))
+            .or_default()
+            .push(id);
     }
 }
 
@@ -637,7 +692,7 @@ fn ceil_char_boundary(source: &str, offset: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use shuck_ast::{Command, Position, Span};
+    use shuck_ast::{Command, Position, Span, StmtSeq, WordPart, WordPartNode};
     use shuck_parser::Error as ParseError;
     use shuck_parser::parser::{
         ParseDiagnostic, ParseStatus, Parser, ShellDialect as ParseDialect, SyntaxFacts,
@@ -707,6 +762,77 @@ mod tests {
         format!(
             "{shebang}\nprintf '%s\\n' \"$IFS\" \"$USER\" \"$HOME\" \"$SHELL\" \"$PWD\" \"$TERM\" \"$PATH\" \"$CDPATH\" \"$LANG\" \"$LC_ALL\" \"$LC_TIME\" \"$SUDO_USER\" \"$DOAS_USER\"\nprintf '%s\\n' \"$LINENO\" \"$FUNCNAME\" \"${{BASH_SOURCE[0]}}\" \"${{BASH_LINENO[0]}}\" \"$RANDOM\" \"${{BASH_REMATCH[0]}}\" \"$READLINE_LINE\" \"$BASH_VERSION\" \"${{BASH_VERSINFO[0]}}\" \"$OSTYPE\" \"$HISTCONTROL\" \"$HISTSIZE\"\n"
         )
+    }
+
+    fn first_command_substitution_body(parts: &[WordPartNode]) -> Option<&StmtSeq> {
+        for part in parts {
+            match &part.kind {
+                WordPart::CommandSubstitution { body, .. }
+                | WordPart::ProcessSubstitution { body, .. } => return Some(body),
+                WordPart::DoubleQuoted { parts, .. } => {
+                    if let Some(body) = first_command_substitution_body(parts) {
+                        return Some(body);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    fn simple_command_names(visits: Vec<facts::CommandVisit<'_>>, source: &str) -> Vec<String> {
+        visits
+            .into_iter()
+            .filter_map(|visit| {
+                let Command::Simple(command) = visit.command else {
+                    return None;
+                };
+                let span = command.name.span;
+                Some(source[span.start.offset..span.end.offset].to_owned())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn linter_semantic_artifacts_iterate_body_commands_without_deeper_nested_words() {
+        let source = "echo \"$(if probe; then printf \"$(inner)\"; fi)\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+        let Command::Simple(command) = &output.file.body.stmts[0].command else {
+            panic!("expected simple command");
+        };
+        let body = first_command_substitution_body(&command.args[0].parts)
+            .expect("expected command substitution body");
+
+        let same_body_names =
+            simple_command_names(semantic.command_visits_in_body(body, false), source);
+        let nested_names =
+            simple_command_names(semantic.command_visits_in_body(body, true), source);
+
+        assert_eq!(same_body_names, vec!["probe", "printf"]);
+        assert_eq!(nested_names, vec!["probe", "printf", "inner"]);
+    }
+
+    #[test]
+    fn linter_semantic_artifacts_keep_function_body_nested_depths() {
+        let source = "echo \"$(f() { printf \"$(inner)\"; }; f)\"\n";
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+        let Command::Simple(command) = &output.file.body.stmts[0].command else {
+            panic!("expected simple command");
+        };
+        let body = first_command_substitution_body(&command.args[0].parts)
+            .expect("expected command substitution body");
+
+        let same_body_names =
+            simple_command_names(semantic.command_visits_in_body(body, false), source);
+        let nested_names =
+            simple_command_names(semantic.command_visits_in_body(body, true), source);
+
+        assert_eq!(same_body_names, vec!["printf", "f"]);
+        assert_eq!(nested_names, vec!["printf", "inner", "f"]);
     }
 
     #[test]

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -67,6 +67,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             let command = self.visit_stmt(stmt, flow);
             self.recorded_program
                 .push_statement_sequence_command(commands.span, stmt.span);
+            self.observer
+                .recorded_statement_sequence_command(commands.span, stmt.span, command);
             recorded.push(command);
         }
     }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -199,6 +199,7 @@ pub struct SemanticCommandContext {
     flow: FlowContext,
     structural: bool,
     nested_word_command: bool,
+    nested_word_command_depth: usize,
     in_if_condition: bool,
     in_elif_condition: bool,
     condition_role: Option<CommandConditionRole>,
@@ -243,6 +244,11 @@ impl SemanticCommandContext {
     /// Whether this command came from a command-like expansion in a word.
     pub fn is_nested_word_command(&self) -> bool {
         self.nested_word_command
+    }
+
+    /// Number of command-like word-expansion regions enclosing this command.
+    pub fn nested_word_command_depth(&self) -> usize {
+        self.nested_word_command_depth
     }
 
     /// Whether this command is inside an `if` or `elif` condition list.
@@ -383,6 +389,14 @@ pub trait TraversalObserver<'a> {
         _stmt: &'a Stmt,
         _scope: ScopeId,
         _flow: FlowContext,
+    ) {
+    }
+
+    fn recorded_statement_sequence_command(
+        &mut self,
+        _body_span: Span,
+        _stmt_span: Span,
+        _id: CommandId,
     ) {
     }
 
@@ -2132,6 +2146,7 @@ fn build_command_topology(model: &SemanticModel) -> CommandTopology {
     let mut parent_ids = vec![None; command_count];
     let mut child_ids = vec![Vec::new(); command_count];
     let mut nested_region_command_ids = FxHashSet::default();
+    let mut nested_region_root_command_ids = FxHashSet::default();
 
     for id in ids.iter().copied() {
         let command = program.command(id);
@@ -2145,6 +2160,7 @@ fn build_command_topology(model: &SemanticModel) -> CommandTopology {
             &mut parent_ids,
             &mut child_ids,
             &mut nested_region_command_ids,
+            &mut nested_region_root_command_ids,
         );
     }
     let structural_parent_ids = parent_ids.clone();
@@ -2152,6 +2168,12 @@ fn build_command_topology(model: &SemanticModel) -> CommandTopology {
 
     attach_function_body_commands(model, &ids, &mut parent_ids, &mut child_ids);
     attach_containing_command_parents(model, &ids, &mut parent_ids, &mut child_ids);
+    let nested_region_depths = build_nested_region_depths(
+        command_count,
+        &parent_ids,
+        &child_ids,
+        &nested_region_root_command_ids,
+    );
 
     let mut structural_ids = ids
         .iter()
@@ -2186,6 +2208,7 @@ fn build_command_topology(model: &SemanticModel) -> CommandTopology {
         &syntax_backed_ids,
         &structural_ids,
         &nested_region_command_ids,
+        &nested_region_depths,
         &condition_contexts,
     );
 
@@ -2208,6 +2231,7 @@ fn build_command_contexts(
     syntax_backed_ids: &[CommandId],
     structural_ids: &[CommandId],
     nested_region_command_ids: &FxHashSet<CommandId>,
+    nested_region_depths: &[usize],
     condition_contexts: &[CommandConditionContext],
 ) -> Vec<Option<SemanticCommandContext>> {
     let program = model.recorded_program();
@@ -2233,6 +2257,7 @@ fn build_command_contexts(
             flow,
             structural: structural_ids.contains(&id),
             nested_word_command: nested_region_command_ids.contains(&id),
+            nested_word_command_depth: nested_region_depths[id.index()],
             in_if_condition: condition_contexts
                 .get(id.index())
                 .is_some_and(|context| context.in_if_condition),
@@ -2570,6 +2595,7 @@ fn record_command_children(
     parent_ids: &mut [Option<CommandId>],
     child_ids: &mut [Vec<CommandId>],
     nested_region_command_ids: &mut FxHashSet<CommandId>,
+    nested_region_root_command_ids: &mut FxHashSet<CommandId>,
 ) {
     let command = program.command(parent);
     for region in program.nested_regions(command.nested_regions) {
@@ -2577,6 +2603,7 @@ fn record_command_children(
             nested_region_command_ids.insert(child);
         }
         for child in program.commands_in(region.commands).iter().copied() {
+            nested_region_root_command_ids.insert(child);
             assign_command_parent(parent, child, parent_ids, child_ids);
         }
     }
@@ -2672,6 +2699,34 @@ fn would_create_command_parent_cycle(
         current = parent_ids[id.index()];
     }
     false
+}
+
+fn build_nested_region_depths(
+    command_count: usize,
+    parent_ids: &[Option<CommandId>],
+    child_ids: &[Vec<CommandId>],
+    nested_region_root_command_ids: &FxHashSet<CommandId>,
+) -> Vec<usize> {
+    let mut depths = vec![0; command_count];
+    let mut stack = Vec::new();
+    for index in (0..command_count).rev() {
+        let id = CommandId(index as u32);
+        if parent_ids[id.index()].is_none() {
+            stack.push((id, 0));
+        }
+    }
+    while let Some((id, depth)) = stack.pop() {
+        depths[id.index()] = depth;
+        for child in child_ids[id.index()].iter().rev().copied() {
+            let child_depth = if nested_region_root_command_ids.contains(&child) {
+                depth + 1
+            } else {
+                depth
+            };
+            stack.push((child, child_depth));
+        }
+    }
+    depths
 }
 
 fn commands_in_range_recursive(

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -2537,6 +2537,7 @@ EOF
         .command_context(command_id_starting_with(&model, source, "echo").unwrap())
         .unwrap();
     assert!(!echo.is_nested_word_command());
+    assert_eq!(echo.nested_word_command_depth(), 0);
     assert!(echo.is_structural());
     assert_eq!(echo.condition_role(), None);
 
@@ -2544,12 +2545,14 @@ EOF
         .command_context(command_id_starting_with(&model, source, "if probe").unwrap())
         .unwrap();
     assert!(nested_if.is_nested_word_command());
+    assert_eq!(nested_if.nested_word_command_depth(), 1);
     assert_eq!(nested_if.condition_role(), None);
 
     let probe = model
         .command_context(command_id_starting_with(&model, source, "probe").unwrap())
         .unwrap();
     assert!(probe.is_nested_word_command());
+    assert_eq!(probe.nested_word_command_depth(), 1);
     assert!(probe.is_in_if_condition());
     assert!(!probe.is_in_elif_condition());
     assert_eq!(probe.condition_role(), Some(CommandConditionRole::If));
@@ -2558,11 +2561,13 @@ EOF
         .command_context(command_id_starting_with(&model, source, "process").unwrap())
         .unwrap();
     assert!(process.is_nested_word_command());
+    assert_eq!(process.nested_word_command_depth(), 1);
 
     let outer = model
         .command_context(command_id_starting_with(&model, source, "outer").unwrap())
         .unwrap();
     assert!(!outer.is_nested_word_command());
+    assert_eq!(outer.nested_word_command_depth(), 0);
     assert!(outer.is_in_if_condition());
     assert_eq!(outer.condition_role(), Some(CommandConditionRole::If));
 
@@ -2603,6 +2608,7 @@ EOF
         .command_context(command_id_starting_with(&model, source, "heredoc_cmd").unwrap())
         .unwrap();
     assert!(heredoc.is_nested_word_command());
+    assert_eq!(heredoc.nested_word_command_depth(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- record direct statement-sequence command membership through the semantic traversal observer
- expose semantic nested command depth so linter body iterators can distinguish same-body commands from deeper command substitutions
- move substitution body fact scans off the linter-local recursive command iterator

## Verification
- cargo fmt --all --check
- cargo test -p shuck-semantic -p shuck-linter
- cargo clippy -p shuck-semantic -p shuck-linter --all-targets -- -D warnings
- make test-large-corpus