### PR TITLE
perf(linter): reuse semantic body indexes for arithmetic scans

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -723,6 +723,7 @@ fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str)
 fn collect_arithmetic_update_operator_spans_in_command(
     command: &Command,
     semantic: &SemanticModel,
+    semantic_artifacts: &LinterSemanticArtifacts<'_>,
     scope: ScopeId,
     source: &str,
     spans: &mut Vec<Span>,
@@ -731,7 +732,12 @@ fn collect_arithmetic_update_operator_spans_in_command(
         Command::Simple(command) => {
             for assignment in &command.assignments {
                 collect_arithmetic_update_operator_spans_in_assignment(
-                    assignment, semantic, scope, source, spans,
+                    assignment,
+                    semantic,
+                    semantic_artifacts,
+                    scope,
+                    source,
+                    spans,
                 );
             }
             collect_arithmetic_update_operator_spans_in_word(
@@ -748,7 +754,12 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Break(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, semantic, scope, source, spans,
+                        assignment,
+                        semantic,
+                        semantic_artifacts,
+                        scope,
+                        source,
+                        spans,
                     );
                 }
                 if let Some(word) = &command.depth {
@@ -761,7 +772,12 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Continue(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, semantic, scope, source, spans,
+                        assignment,
+                        semantic,
+                        semantic_artifacts,
+                        scope,
+                        source,
+                        spans,
                     );
                 }
                 if let Some(word) = &command.depth {
@@ -774,7 +790,12 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Return(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, semantic, scope, source, spans,
+                        assignment,
+                        semantic,
+                        semantic_artifacts,
+                        scope,
+                        source,
+                        spans,
                     );
                 }
                 if let Some(word) = &command.code {
@@ -787,7 +808,12 @@ fn collect_arithmetic_update_operator_spans_in_command(
             BuiltinCommand::Exit(command) => {
                 for assignment in &command.assignments {
                     collect_arithmetic_update_operator_spans_in_assignment(
-                        assignment, semantic, scope, source, spans,
+                        assignment,
+                        semantic,
+                        semantic_artifacts,
+                        scope,
+                        source,
+                        spans,
                     );
                 }
                 if let Some(word) = &command.code {
@@ -801,7 +827,12 @@ fn collect_arithmetic_update_operator_spans_in_command(
         Command::Decl(command) => {
             for assignment in &command.assignments {
                 collect_arithmetic_update_operator_spans_in_assignment(
-                    assignment, semantic, scope, source, spans,
+                    assignment,
+                    semantic,
+                    semantic_artifacts,
+                    scope,
+                    source,
+                    spans,
                 );
             }
             for operand in &command.operands {
@@ -813,7 +844,12 @@ fn collect_arithmetic_update_operator_spans_in_command(
                     }
                     DeclOperand::Assignment(assignment) => {
                         collect_arithmetic_update_operator_spans_in_assignment(
-                            assignment, semantic, scope, source, spans,
+                            assignment,
+                            semantic,
+                            semantic_artifacts,
+                            scope,
+                            source,
+                            spans,
                         );
                     }
                     DeclOperand::Name(_) => {}
@@ -899,6 +935,7 @@ fn collect_arithmetic_update_operator_spans_in_command(
 fn collect_arithmetic_update_operator_spans_in_assignment(
     assignment: &Assignment,
     semantic: &SemanticModel,
+    semantic_artifacts: &LinterSemanticArtifacts<'_>,
     scope: ScopeId,
     source: &str,
     spans: &mut Vec<Span>,
@@ -936,7 +973,11 @@ fn collect_arithmetic_update_operator_spans_in_assignment(
                             );
                         }
                         collect_arithmetic_update_operator_spans_in_subscript_words(
-                            key, semantic, source, spans,
+                            key,
+                            semantic,
+                            semantic_artifacts,
+                            source,
+                            spans,
                         );
                         collect_arithmetic_update_operator_spans_in_word(
                             value, semantic, source, spans,
@@ -1099,6 +1140,7 @@ fn collect_arithmetic_update_operator_spans_in_conditional_expr(
 fn collect_arithmetic_update_operator_spans_in_heredoc_body(
     parts: &[shuck_ast::HeredocBodyPartNode],
     semantic: &SemanticModel,
+    semantic_artifacts: &LinterSemanticArtifacts<'_>,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
@@ -1122,12 +1164,20 @@ fn collect_arithmetic_update_operator_spans_in_heredoc_body(
             }
             shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
                 collect_arithmetic_update_operator_spans_in_nested_command_body(
-                    body, semantic, source, spans,
+                    body,
+                    semantic_artifacts,
+                    semantic,
+                    source,
+                    spans,
                 );
             }
             shuck_ast::HeredocBodyPart::Parameter(parameter) => {
                 collect_arithmetic_update_operator_spans_in_parameter_expansion_with_nested_commands(
-                    parameter, semantic, source, spans,
+                    parameter,
+                    semantic,
+                    semantic_artifacts,
+                    source,
+                    spans,
                 );
             }
             shuck_ast::HeredocBodyPart::Literal(_) | shuck_ast::HeredocBodyPart::Variable(_) => {}
@@ -1137,20 +1187,17 @@ fn collect_arithmetic_update_operator_spans_in_heredoc_body(
 
 fn collect_arithmetic_update_operator_spans_in_nested_command_body(
     body: &StmtSeq,
+    semantic_artifacts: &LinterSemanticArtifacts<'_>,
     semantic: &SemanticModel,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    for visit in iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
+    for visit in semantic_artifacts.command_visits_in_body(body, true) {
         let scope = semantic.scope_at(visit.stmt.span.start.offset);
         collect_arithmetic_update_operator_spans_in_command(
             visit.command,
             semantic,
+            semantic_artifacts,
             scope,
             source,
             spans,
@@ -1164,6 +1211,7 @@ fn collect_arithmetic_update_operator_spans_in_nested_command_body(
                 collect_arithmetic_update_operator_spans_in_heredoc_body(
                     &heredoc.body.parts,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                 );
@@ -1194,16 +1242,17 @@ fn collect_arithmetic_update_operator_spans_in_subscript(
 fn collect_arithmetic_update_operator_spans_in_subscript_words(
     subscript: &Subscript,
     semantic: &SemanticModel,
+    semantic_artifacts: &LinterSemanticArtifacts<'_>,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
     visit_subscript_words(Some(subscript), source, &mut |word| {
-        collect_arithmetic_update_operator_spans_from_parts_impl(
+        collect_arithmetic_update_operator_spans_from_parts_with_nested_commands(
             &word.parts,
             semantic,
+            semantic_artifacts,
             source,
             spans,
-            true,
         );
     });
 }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -245,6 +245,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 collect_arithmetic_update_operator_spans_in_command(
                     visit.command,
                     self.semantic,
+                    self.semantic_artifacts,
                     scope,
                     self.source,
                     &mut arithmetic_update_operator_spans,
@@ -268,6 +269,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                         collect_arithmetic_update_operator_spans_in_heredoc_body(
                             &heredoc.body.parts,
                             self.semantic,
+                            self.semantic_artifacts,
                             self.source,
                             &mut arithmetic_update_operator_spans,
                         );

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1811,6 +1811,53 @@ echo ${foo:-$((10#1))}
 }
 
 #[test]
+fn collects_arithmetic_update_operator_spans_in_nested_heredoc_command_bodies() {
+    let source = "\
+#!/bin/bash
+cat <<EOF
+$(printf '%s' \"$(printf '%s' \"$((i++))\")\")
+${value:-$(printf '%s' \"$(printf '%s' \"$((--j))\")\")}
+EOF
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+
+    assert_eq!(
+        facts
+            .arithmetic_update_operator_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["++", "--"]
+    );
+}
+
+#[test]
+fn collects_arithmetic_update_operator_spans_in_nested_redirect_target_bodies() {
+    let source = "\
+#!/bin/bash
+cat <<EOF
+$(printf '%s' \"$((i++))\" > \"$(printf '%s' \"$((--j))\")\")
+EOF
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+
+    assert_eq!(
+        facts
+            .arithmetic_update_operator_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["++", "--"]
+    );
+}
+
+#[test]
 fn ignores_base_prefix_like_parameter_trim_operands() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/words/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/words/arithmetic.rs
@@ -944,12 +944,32 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    collect_arithmetic_update_operator_spans_from_parts_impl(parts, semantic, source, spans, false);
+    collect_arithmetic_update_operator_spans_from_parts_impl(
+        parts, semantic, None, source, spans, false,
+    );
+}
+
+pub(super) fn collect_arithmetic_update_operator_spans_from_parts_with_nested_commands(
+    parts: &[WordPartNode],
+    semantic: &SemanticModel,
+    semantic_artifacts: &LinterSemanticArtifacts<'_>,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    collect_arithmetic_update_operator_spans_from_parts_impl(
+        parts,
+        semantic,
+        Some(semantic_artifacts),
+        source,
+        spans,
+        true,
+    );
 }
 
 pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
     parts: &[WordPartNode],
     semantic: &SemanticModel,
+    semantic_artifacts: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
     spans: &mut Vec<Span>,
     include_nested_commands: bool,
@@ -960,6 +980,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
                 collect_arithmetic_update_operator_spans_from_parts_impl(
                     parts,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -976,6 +997,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &expression_word_ast.parts,
                         semantic,
+                        semantic_artifacts,
                         source,
                         spans,
                         include_nested_commands,
@@ -986,6 +1008,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
                 collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     parameter,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -999,6 +1022,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1006,6 +1030,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
                 collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
                     operator,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1020,6 +1045,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1044,6 +1070,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1054,6 +1081,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &offset_word_ast.parts,
                         semantic,
+                        semantic_artifacts,
                         source,
                         spans,
                         include_nested_commands,
@@ -1065,6 +1093,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &length_word_ast.parts,
                         semantic,
+                        semantic_artifacts,
                         source,
                         spans,
                         include_nested_commands,
@@ -1079,8 +1108,14 @@ pub(super) fn collect_arithmetic_update_operator_spans_from_parts_impl(
             WordPart::CommandSubstitution { body, .. }
             | WordPart::ProcessSubstitution { body, .. } => {
                 if include_nested_commands {
+                    let semantic_artifacts = semantic_artifacts
+                        .expect("nested command arithmetic scans require semantic artifacts");
                     collect_arithmetic_update_operator_spans_in_nested_command_body(
-                        body, semantic, source, spans,
+                        body,
+                        semantic_artifacts,
+                        semantic,
+                        source,
+                        spans,
                     );
                 }
             }
@@ -1095,13 +1130,14 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_var_ref(
     spans: &mut Vec<Span>,
 ) {
     collect_arithmetic_update_operator_spans_in_var_ref_impl(
-        reference, semantic, source, spans, false,
+        reference, semantic, None, source, spans, false,
     );
 }
 
 pub(super) fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
     reference: &VarRef,
     semantic: &SemanticModel,
+    semantic_artifacts: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
     spans: &mut Vec<Span>,
     include_nested_commands: bool,
@@ -1117,6 +1153,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
         collect_arithmetic_update_operator_spans_from_parts_impl(
             &word.parts,
             semantic,
+            semantic_artifacts,
             source,
             spans,
             include_nested_commands,
@@ -1127,17 +1164,24 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_var_ref_impl(
 pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_with_nested_commands(
     parameter: &ParameterExpansion,
     semantic: &SemanticModel,
+    semantic_artifacts: &LinterSemanticArtifacts<'_>,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
     collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
-        parameter, semantic, source, spans, true,
+        parameter,
+        semantic,
+        Some(semantic_artifacts),
+        source,
+        spans,
+        true,
     );
 }
 
 pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
     parameter: &ParameterExpansion,
     semantic: &SemanticModel,
+    semantic_artifacts: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
     spans: &mut Vec<Span>,
     include_nested_commands: bool,
@@ -1151,6 +1195,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1165,6 +1210,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1173,6 +1219,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                     collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
                         operator,
                         semantic,
+                        semantic_artifacts,
                         source,
                         spans,
                         include_nested_commands,
@@ -1182,6 +1229,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &operand_word_ast.parts,
                         semantic,
+                        semantic_artifacts,
                         source,
                         spans,
                         include_nested_commands,
@@ -1197,6 +1245,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1204,6 +1253,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                 collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
                     operator,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1212,6 +1262,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &operand_word_ast.parts,
                         semantic,
+                        semantic_artifacts,
                         source,
                         spans,
                         include_nested_commands,
@@ -1229,6 +1280,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1239,6 +1291,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &offset_word_ast.parts,
                         semantic,
+                        semantic_artifacts,
                         source,
                         spans,
                         include_nested_commands,
@@ -1250,6 +1303,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                     collect_arithmetic_update_operator_spans_from_parts_impl(
                         &length_word_ast.parts,
                         semantic,
+                        semantic_artifacts,
                         source,
                         spans,
                         include_nested_commands,
@@ -1263,6 +1317,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                 collect_arithmetic_update_operator_spans_in_var_ref_impl(
                     reference,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1272,6 +1327,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                 collect_arithmetic_update_operator_spans_in_parameter_expansion_impl(
                     parameter,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1281,6 +1337,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
                 collect_arithmetic_update_operator_spans_from_parts_impl(
                     &word.parts,
                     semantic,
+                    semantic_artifacts,
                     source,
                     spans,
                     include_nested_commands,
@@ -1294,6 +1351,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_expansion_im
 pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_operator_impl(
     operator: &ParameterOp,
     semantic: &SemanticModel,
+    semantic_artifacts: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
     spans: &mut Vec<Span>,
     include_nested_commands: bool,
@@ -1309,6 +1367,7 @@ pub(super) fn collect_arithmetic_update_operator_spans_in_parameter_operator_imp
         } => collect_arithmetic_update_operator_spans_from_parts_impl(
             &replacement_word_ast.parts,
             semantic,
+            semantic_artifacts,
             source,
             spans,
             include_nested_commands,


### PR DESCRIPTION
## Summary
- replace arithmetic nested command body scans with `LinterSemanticArtifacts::command_visits_in_body`
- thread semantic artifacts through arithmetic word, heredoc, and assignment subscript paths that intentionally inspect nested command bodies
- add a fact-level regression for arithmetic updates inside nested heredoc command substitutions

## Verification
- `cargo fmt --all --check`
- `cargo test -p shuck-linter`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- `make test-large-corpus`

Large corpus summary: blocking=0, implementation_diffs=0, mapping_issues=0, harness_failures=0.