### PR TITLE
ci: publish shuck-extract from crates-publish workflow

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -79,6 +79,7 @@ jobs:
             shuck-semantic
             shuck-linter
             shuck-formatter
+            shuck-extract
             shuck-cli
           )
 


### PR DESCRIPTION
## Summary

`shuck-extract` was missing from the publish list in `.github/workflows/crates-publish.yml`, so `cargo publish -p shuck-cli` has failed on every tag from v0.0.18 through v0.0.26 with:

```
failed to select a version for the requirement `shuck-extract = "^0.0.26"`
candidate versions found which didn't match: 0.0.18
required by package `shuck-cli v0.0.26`
```

`shuck-extract` only depends on external crates (`anyhow`, `saphyr`), so it can be published anywhere before `shuck-cli`. Inserting it directly above `shuck-cli` keeps the change minimal.

This fixes future releases. Backfilling the missing 0.0.18+ versions of `shuck-cli` and `shuck-extract` on crates.io is a separate manual step.

## Test plan

- [ ] After merge, next release tag triggers crates-publish and `shuck-cli` reaches crates.io at the new version
- [ ] `shuck-extract` version on crates.io matches workspace version