### PR TITLE
perf(linter): reuse semantic visits for substitution candidates

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1192,7 +1192,7 @@ fn collect_arithmetic_update_operator_spans_in_nested_command_body(
     source: &str,
     spans: &mut Vec<Span>,
 ) {
-    for visit in semantic_artifacts.command_visits_in_body(body, true) {
+    semantic_artifacts.for_each_command_visit_in_body(body, true, |visit| {
         let scope = semantic.scope_at(visit.stmt.span.start.offset);
         collect_arithmetic_update_operator_spans_in_command(
             visit.command,
@@ -1217,7 +1217,7 @@ fn collect_arithmetic_update_operator_spans_in_nested_command_body(
                 );
             }
         }
-    }
+    });
 }
 
 fn collect_arithmetic_update_operator_spans_in_subscript(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -277,12 +277,17 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 }
                 let redirect_facts = build_redirect_facts(
                     visit.redirects,
-                    Some(self.semantic),
+                    Some(self.semantic_artifacts),
                     self.source,
                     command_zsh_options.as_ref(),
                 );
                 let redirect_fact_range = redirect_fact_store.push_many(redirect_facts);
-                let options = CommandOptionFacts::build(visit.command, &normalized, self.source);
+                let options = CommandOptionFacts::build(
+                    visit.command,
+                    &normalized,
+                    self.semantic_artifacts,
+                    self.source,
+                );
                 let declaration_assignment_probes = build_declaration_assignment_probes(
                     visit.command,
                     &normalized,
@@ -830,6 +835,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             );
         LinterFacts {
             semantic: self.semantic,
+            semantic_artifacts: self.semantic_artifacts,
             source,
             commands,
             command_fact_indices_by_id,

--- a/crates/shuck-linter/src/facts/command_options/mod.rs
+++ b/crates/shuck-linter/src/facts/command_options/mod.rs
@@ -726,6 +726,7 @@ impl<'a> CommandOptionFacts<'a> {
     pub(super) fn build(
         command: &'a Command,
         normalized: &NormalizedCommand<'a>,
+        semantic: &LinterSemanticArtifacts<'a>,
         source: &str,
     ) -> Self {
         Self {
@@ -742,9 +743,14 @@ impl<'a> CommandOptionFacts<'a> {
                 .effective_name_is("read")
                 .then(|| ReadCommandFacts {
                     uses_raw_input: read_uses_raw_input(normalized.body_args(), source),
-                    target_name_uses: read_target_name_uses(normalized.body_args(), source),
+                    target_name_uses: read_target_name_uses(
+                        normalized.body_args(),
+                        semantic,
+                        source,
+                    ),
                     array_target_name_uses: read_array_target_name_uses(
                         normalized.body_args(),
+                        semantic,
                         source,
                     ),
                 }),
@@ -787,7 +793,7 @@ impl<'a> CommandOptionFacts<'a> {
             .flatten(),
             mapfile: (normalized.effective_name_is("mapfile")
                 || normalized.effective_name_is("readarray"))
-            .then(|| parse_mapfile_command(normalized.body_args(), source)),
+            .then(|| parse_mapfile_command(normalized.body_args(), semantic, source)),
             xargs: normalized
                 .effective_name_is("xargs")
                 .then(|| parse_xargs_command(normalized.body_args(), source)),

--- a/crates/shuck-linter/src/facts/command_options/read.rs
+++ b/crates/shuck-linter/src/facts/command_options/read.rs
@@ -56,19 +56,25 @@ pub(super) fn read_uses_raw_input(args: &[&Word], source: &str) -> bool {
     false
 }
 
-pub(super) fn read_target_name_uses(args: &[&Word], source: &str) -> Box<[ComparableNameUse]> {
-    read_name_uses(args, source).0
+pub(super) fn read_target_name_uses(
+    args: &[&Word],
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+) -> Box<[ComparableNameUse]> {
+    read_name_uses(args, semantic, source).0
 }
 
 pub(super) fn read_array_target_name_uses(
     args: &[&Word],
+    semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
 ) -> Box<[ComparableNameUse]> {
-    read_name_uses(args, source).1
+    read_name_uses(args, semantic, source).1
 }
 
 fn read_name_uses(
     args: &[&Word],
+    semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
 ) -> (Box<[ComparableNameUse]>, Box<[ComparableNameUse]>) {
     let mut targets = Vec::new();
@@ -82,21 +88,21 @@ fn read_name_uses(
             }
 
             for target in &args[index..] {
-                targets.extend(comparable_read_target_name_uses(target, source));
+                targets.extend(comparable_read_target_name_uses(target, semantic, source));
             }
             break;
         };
 
         if text == "--" {
             for target in &args[index + 1..] {
-                targets.extend(comparable_read_target_name_uses(target, source));
+                targets.extend(comparable_read_target_name_uses(target, semantic, source));
             }
             break;
         }
 
         if !text.starts_with('-') || text == "-" {
             for target in &args[index..] {
-                targets.extend(comparable_read_target_name_uses(target, source));
+                targets.extend(comparable_read_target_name_uses(target, semantic, source));
             }
             break;
         }
@@ -114,7 +120,7 @@ fn read_name_uses(
                         targets.push(target);
                     }
                 } else if let Some(target) = args.get(index + 1) {
-                    let target_uses = comparable_read_target_name_uses(target, source);
+                    let target_uses = comparable_read_target_name_uses(target, semantic, source);
                     array_targets.extend(target_uses.iter().cloned());
                     targets.extend(target_uses);
                     index += 1;

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -1055,7 +1055,7 @@ fn collect_own_scope_name_read_uses(
 
 fn collect_own_scope_heredoc_name_read_uses(
     command: CommandFactRef<'_, '_>,
-    source: &str,
+    _source: &str,
     uses: &mut Vec<ComparableNameUse>,
 ) {
     for redirect in command.redirect_facts() {
@@ -1065,11 +1065,7 @@ fn collect_own_scope_heredoc_name_read_uses(
         ) {
             continue;
         }
-        if let Some(heredoc) = redirect.redirect().heredoc()
-            && heredoc.delimiter.expands_body
-        {
-            uses.extend(comparable_heredoc_name_uses(&heredoc.body, source));
-        }
+        uses.extend(redirect.comparable_name_uses().iter().cloned());
     }
 }
 

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -51,14 +51,14 @@ use shuck_ast::{
     BackgroundOperator, BinaryCommand, BinaryOp, BourneParameterExpansion, BraceQuoteContext,
     BraceSyntaxKind, BuiltinCommand, CaseCommand, CaseItem, CaseTerminator, Command,
     CommandSubstitutionSyntax, CompoundCommand, ConditionalBinaryOp, ConditionalExpr,
-    ConditionalUnaryOp, DeclClause, DeclOperand, File, ForCommand, FunctionDef,
-    HeredocBodyPartNode, IdRange, ListArena, Name, ParameterExpansion, ParameterExpansionSyntax,
-    ParameterOp, Pattern, PatternPart, Position, PrefixMatchKind, Redirect, RedirectKind,
-    SelectCommand, SimpleCommand, SourceText, Span, StaticCommandWrapperTarget, Stmt, StmtSeq,
-    StmtTerminator, Subscript, SubscriptSelector, TextRange, TextSize, VarRef, WhileCommand, Word,
-    WordPart, WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment,
-    ZshQualifiedGlob, is_shell_variable_name, static_command_name_text,
-    static_command_wrapper_target_index, static_word_text, word_is_standalone_status_capture,
+    ConditionalUnaryOp, DeclClause, DeclOperand, File, ForCommand, FunctionDef, IdRange, ListArena,
+    Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart,
+    Position, PrefixMatchKind, Redirect, RedirectKind, SelectCommand, SimpleCommand, SourceText,
+    Span, StaticCommandWrapperTarget, Stmt, StmtSeq, StmtTerminator, Subscript, SubscriptSelector,
+    TextRange, TextSize, VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionOperation,
+    ZshExpansionTarget, ZshGlobSegment, ZshQualifiedGlob, is_shell_variable_name,
+    static_command_name_text, static_command_wrapper_target_index, static_word_text,
+    word_is_standalone_status_capture,
 };
 use shuck_indexer::Indexer;
 #[cfg(test)]

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1,5 +1,6 @@
 pub struct LinterFacts<'a> {
     semantic: &'a SemanticModel,
+    semantic_artifacts: &'a LinterSemanticArtifacts<'a>,
     source: &'a str,
     commands: Vec<CommandFact<'a>>,
     command_fact_indices_by_id: Vec<Option<usize>>,
@@ -1040,7 +1041,12 @@ fn build_possible_variable_misspelling_scope_compat_name_uses(
             command.redirects(),
             facts.source,
             &mut |word| {
-                collect_scope_compat_derived_name_uses(word, facts.source, &mut uses);
+                collect_scope_compat_derived_name_uses(
+                    word,
+                    facts.semantic_artifacts,
+                    facts.source,
+                    &mut uses,
+                );
             },
         );
     }
@@ -1092,6 +1098,7 @@ fn scope_compat_standalone_parameter_name_use(word: &Word) -> Option<ComparableN
 
 fn collect_scope_compat_derived_name_uses(
     word: &Word,
+    semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
     uses: &mut Vec<ComparableNameUse>,
 ) {
@@ -1099,6 +1106,7 @@ fn collect_scope_compat_derived_name_uses(
         analyze_word(word, source, None).quote == WordQuote::FullyQuoted;
     collect_scope_compat_command_substitution_name_uses_in_parts(
         &word.parts,
+        semantic,
         source,
         allow_quoted_derived_words,
         uses,
@@ -1107,6 +1115,7 @@ fn collect_scope_compat_derived_name_uses(
 
 fn collect_scope_compat_command_substitution_name_uses_in_parts(
     parts: &[WordPartNode],
+    semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
     allow_quoted_derived_words: bool,
     uses: &mut Vec<ComparableNameUse>,
@@ -1116,6 +1125,7 @@ fn collect_scope_compat_command_substitution_name_uses_in_parts(
             WordPart::DoubleQuoted { parts, .. } => {
                 collect_scope_compat_command_substitution_name_uses_in_parts(
                     parts,
+                    semantic,
                     source,
                     allow_quoted_derived_words,
                     uses,
@@ -1124,6 +1134,7 @@ fn collect_scope_compat_command_substitution_name_uses_in_parts(
             WordPart::CommandSubstitution { body, .. } => {
                 collect_scope_compat_command_substitution_name_uses(
                     body,
+                    semantic,
                     source,
                     allow_quoted_derived_words,
                     uses,
@@ -1138,6 +1149,7 @@ fn collect_scope_compat_command_substitution_name_uses_in_parts(
                 if let Some(word) = operand_word_ast {
                     collect_scope_compat_command_substitution_name_uses_in_parts(
                         &word.parts,
+                        semantic,
                         source,
                         allow_quoted_derived_words,
                         uses,
@@ -1183,11 +1195,12 @@ fn collect_scope_compat_command_substitution_name_uses_in_parts(
 
 fn collect_scope_compat_command_substitution_name_uses(
     body: &StmtSeq,
+    semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
     allow_quoted_derived_words: bool,
     uses: &mut Vec<ComparableNameUse>,
 ) {
-    visit_command_substitution_candidate_words(body, source, &mut |word| {
+    visit_command_substitution_candidate_words(body, semantic, source, &mut |word| {
         push_scope_compat_command_substitution_word_use(
             word,
             source,

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -178,7 +178,11 @@ pub(crate) fn comparable_path(
     })
 }
 
-pub(crate) fn comparable_name_uses(word: &Word, source: &str) -> Box<[ComparableNameUse]> {
+pub(crate) fn comparable_name_uses(
+    word: &Word,
+    semantic: Option<&LinterSemanticArtifacts<'_>>,
+    source: &str,
+) -> Box<[ComparableNameUse]> {
     let mut uses = Vec::new();
     if let Some(name_use) = standalone_comparable_name_use(word, source) {
         uses.push(name_use);
@@ -187,6 +191,7 @@ pub(crate) fn comparable_name_uses(word: &Word, source: &str) -> Box<[Comparable
         analyze_word(word, source, None).quote == WordQuote::FullyQuoted;
     collect_command_substitution_comparable_name_uses_in_parts(
         &word.parts,
+        semantic,
         source,
         allow_quoted_derived_words,
         &mut uses,
@@ -197,13 +202,15 @@ pub(crate) fn comparable_name_uses(word: &Word, source: &str) -> Box<[Comparable
 
 pub(crate) fn comparable_read_target_name_uses(
     word: &Word,
+    semantic: &LinterSemanticArtifacts<'_>,
     source: &str,
 ) -> Box<[ComparableNameUse]> {
-    comparable_name_uses_with_quoted_literals(word, source)
+    comparable_name_uses_with_quoted_literals(word, Some(semantic), source)
 }
 
 pub(crate) fn comparable_heredoc_name_uses(
     heredoc: &shuck_ast::HeredocBody,
+    semantic: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
 ) -> Box<[ComparableNameUse]> {
     let mut uses = Vec::new();
@@ -228,7 +235,9 @@ pub(crate) fn comparable_heredoc_name_uses(
                 }
             }
             shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
-                collect_command_substitution_comparable_name_uses(body, source, true, &mut uses);
+                collect_command_substitution_comparable_name_uses(
+                    body, semantic, source, true, &mut uses,
+                );
             }
             shuck_ast::HeredocBodyPart::ArithmeticExpansion {
                 expression_word_ast,
@@ -248,6 +257,7 @@ pub(crate) fn comparable_heredoc_name_uses(
 
 fn collect_command_substitution_comparable_name_uses_in_parts(
     parts: &[WordPartNode],
+    semantic: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
     allow_quoted_derived_words: bool,
     uses: &mut Vec<ComparableNameUse>,
@@ -257,6 +267,7 @@ fn collect_command_substitution_comparable_name_uses_in_parts(
             WordPart::DoubleQuoted { parts, .. } => {
                 collect_command_substitution_comparable_name_uses_in_parts(
                     parts,
+                    semantic,
                     source,
                     allow_quoted_derived_words,
                     uses,
@@ -265,6 +276,7 @@ fn collect_command_substitution_comparable_name_uses_in_parts(
             WordPart::CommandSubstitution { body, .. } => {
                 collect_command_substitution_comparable_name_uses(
                     body,
+                    semantic,
                     source,
                     allow_quoted_derived_words,
                     uses,
@@ -288,6 +300,7 @@ fn collect_command_substitution_comparable_name_uses_in_parts(
                 if let Some(word) = operand_word_ast {
                     collect_command_substitution_comparable_name_uses_in_parts(
                         &word.parts,
+                        semantic,
                         source,
                         allow_quoted_derived_words,
                         uses,
@@ -331,11 +344,15 @@ fn collect_command_substitution_comparable_name_uses_in_parts(
 
 fn collect_command_substitution_comparable_name_uses(
     body: &StmtSeq,
+    semantic: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
     allow_quoted_derived_words: bool,
     uses: &mut Vec<ComparableNameUse>,
 ) {
-    visit_command_substitution_candidate_words(body, source, &mut |word| {
+    let Some(semantic) = semantic else {
+        return;
+    };
+    visit_command_substitution_candidate_words(body, semantic, source, &mut |word| {
         if !allow_quoted_derived_words && analyze_word(word, source, None).quote == WordQuote::FullyQuoted
         {
             return;
@@ -372,9 +389,10 @@ fn literal_comparable_name_use(span: Span, text: &str) -> ComparableNameUse {
 
 fn comparable_name_uses_with_quoted_literals(
     word: &Word,
+    semantic: Option<&LinterSemanticArtifacts<'_>>,
     source: &str,
 ) -> Box<[ComparableNameUse]> {
-    let mut uses = comparable_name_uses(word, source).into_vec();
+    let mut uses = comparable_name_uses(word, semantic, source).into_vec();
     if let Some(text) = static_word_text(word, source)
         && comparable_name_text(text.as_ref())
     {
@@ -645,7 +663,7 @@ pub(crate) fn analyze_redirect_target(
 #[cfg_attr(shuck_profiling, inline(never))]
 fn build_redirect_facts<'a>(
     redirects: &'a [Redirect],
-    semantic: Option<&SemanticModel>,
+    semantic: Option<&LinterSemanticArtifacts<'a>>,
     source: &str,
     zsh_options: Option<&ZshOptionState>,
 ) -> Vec<RedirectFact<'a>> {
@@ -663,7 +681,7 @@ fn build_redirect_facts<'a>(
                     if let Some(semantic) = semantic {
                         collect_arithmetic_update_operator_spans_from_parts(
                             &word.parts,
-                            semantic,
+                            semantic.semantic(),
                             source,
                             &mut spans,
                         );
@@ -676,26 +694,41 @@ fn build_redirect_facts<'a>(
                 ExpansionContext::from_redirect_kind(redirect.kind)
                     .and_then(|context| comparable_path(word, source, context, zsh_options))
             }),
-            comparable_name_uses: redirect
-                .word_target()
-                .map_or_else(Vec::new, |word| match redirect.kind {
-                    RedirectKind::Output
-                    | RedirectKind::Clobber
-                    | RedirectKind::Append
-                    | RedirectKind::OutputBoth => {
-                        comparable_name_uses_with_quoted_literals(word, source).into_vec()
-                    }
-                    RedirectKind::Input
-                    | RedirectKind::ReadWrite
-                    | RedirectKind::HereDoc
-                    | RedirectKind::HereDocStrip
-                    | RedirectKind::HereString
-                    | RedirectKind::DupOutput
-                    | RedirectKind::DupInput => comparable_name_uses(word, source).into_vec(),
-                })
-                .into_boxed_slice(),
+            comparable_name_uses: comparable_redirect_name_uses(redirect, semantic, source),
         })
         .collect()
+}
+
+fn comparable_redirect_name_uses(
+    redirect: &Redirect,
+    semantic: Option<&LinterSemanticArtifacts<'_>>,
+    source: &str,
+) -> Box<[ComparableNameUse]> {
+    if let Some(word) = redirect.word_target() {
+        return match redirect.kind {
+            RedirectKind::Output
+            | RedirectKind::Clobber
+            | RedirectKind::Append
+            | RedirectKind::OutputBoth => {
+                comparable_name_uses_with_quoted_literals(word, semantic, source)
+            }
+            RedirectKind::Input
+            | RedirectKind::ReadWrite
+            | RedirectKind::HereDoc
+            | RedirectKind::HereDocStrip
+            | RedirectKind::HereString
+            | RedirectKind::DupOutput
+            | RedirectKind::DupInput => comparable_name_uses(word, semantic, source),
+        };
+    }
+
+    let Some(heredoc) = redirect.heredoc() else {
+        return Box::default();
+    };
+    if !heredoc.delimiter.expands_body {
+        return Box::default();
+    }
+    comparable_heredoc_name_uses(&heredoc.body, semantic, source)
 }
 
 fn brace_fd_redirection_span(redirect: &Redirect, source: &str) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -551,7 +551,18 @@ fn classify_substitution_body<'a>(
     semantic: &LinterSemanticArtifacts<'a>,
     source: &str,
 ) -> SubstitutionBodyFacts {
-    let visits = semantic.command_visits_in_body(body, false);
+    let mut body_has_commands = false;
+    let mut bash_file_slurp = false;
+    let mut body_command_count = 0;
+    semantic.for_each_command_visit_in_body(body, false, |visit| {
+        body_has_commands = true;
+        body_command_count += 1;
+        if body_command_count == 1 {
+            bash_file_slurp = is_bash_file_slurp_command(visit.command, visit.redirects, source);
+        } else {
+            bash_file_slurp = false;
+        }
+    });
     let redirect_summary =
         summarize_stmt_seq_redirects(body, parent_id, commands, command_relationships, source);
 
@@ -587,8 +598,8 @@ fn classify_substitution_body<'a>(
             commands,
             command_relationships.command_ids_by_span,
         ),
-        body_has_commands: !visits.is_empty(),
-        bash_file_slurp: matches!(visits.as_slice(), [visit] if is_bash_file_slurp_command(visit.command, visit.redirects, source)),
+        body_has_commands,
+        bash_file_slurp,
     }
 }
 
@@ -1086,7 +1097,7 @@ fn substitution_body_processed_ls_pipeline_spans<'a>(
     source: &str,
 ) -> Vec<Span> {
     let mut spans = Vec::new();
-    for visit in semantic.command_visits_in_body(body, true) {
+    semantic.for_each_command_visit_in_body(body, true, |visit| {
         collect_processed_ls_pipeline_spans_in_stmt(
             visit.stmt,
             parent_id,
@@ -1095,7 +1106,7 @@ fn substitution_body_processed_ls_pipeline_spans<'a>(
             source,
             &mut spans,
         );
-    }
+    });
     spans
 }
 

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -1,9 +1,12 @@
-// Private AST traversal used only while building linter facts.
+// Shared command/word traversal helpers. Normal fact construction consumes semantic
+// command visits; the recursive command walker is kept only for tests and benchmarking.
+#[cfg(any(test, feature = "benchmarking"))]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct WalkContext {
     loop_depth: usize,
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ConditionKind {
     If,
@@ -12,6 +15,7 @@ enum ConditionKind {
     Until,
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct CommandTraversalContext {
     walk: WalkContext,
@@ -21,6 +25,7 @@ struct CommandTraversalContext {
     in_elif_condition: bool,
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct CommandWalkOptions {
     descend_nested_word_commands: bool,
@@ -43,6 +48,7 @@ impl<'a> CommandVisit<'a> {
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn walk_commands<'a, F>(commands: &'a StmtSeq, options: CommandWalkOptions, visitor: &mut F)
 where
     F: FnMut(CommandVisit<'a>, CommandTraversalContext),
@@ -55,6 +61,7 @@ where
     );
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn iter_commands<'a>(
     commands: &'a StmtSeq,
     options: CommandWalkOptions,
@@ -68,15 +75,11 @@ fn iter_commands<'a>(
 
 fn visit_command_substitution_candidate_words<'a>(
     body: &'a StmtSeq,
+    semantic: &LinterSemanticArtifacts<'a>,
     source: &str,
     visitor: &mut impl FnMut(&'a Word),
 ) {
-    for visit in iter_commands(
-        body,
-        CommandWalkOptions {
-            descend_nested_word_commands: true,
-        },
-    ) {
+    for visit in semantic.command_visits_in_body(body, true) {
         visit_command_substitution_loop_header_words(visit.command, visitor);
         visit_command_argument_words_for_substitutions(visit.command, source, visitor);
     }
@@ -103,6 +106,7 @@ fn visit_command_substitution_loop_header_words<'a>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn zsh_glob_patterns(glob: &shuck_ast::ZshQualifiedGlob) -> impl Iterator<Item = &Pattern> + '_ {
     glob.segments.iter().filter_map(|segment| match segment {
         ZshGlobSegment::Pattern(pattern) => Some(pattern),
@@ -210,6 +214,7 @@ fn visit_arithmetic_words_in_expr<'a>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_optional_arithmetic_words<'a>(
     expression: Option<&'a ArithmeticExprNode>,
     words: &mut Vec<&'a Word>,
@@ -219,6 +224,7 @@ fn collect_optional_arithmetic_words<'a>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_var_ref_subscript_words<'a>(reference: &'a VarRef, words: &mut Vec<&'a Word>) {
     collect_optional_arithmetic_words(
         reference
@@ -229,6 +235,7 @@ fn collect_var_ref_subscript_words<'a>(reference: &'a VarRef, words: &mut Vec<&'
     );
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_arithmetic_lvalue_words<'a>(target: &'a ArithmeticLvalue, words: &mut Vec<&'a Word>) {
     match target {
         ArithmeticLvalue::Variable(_) => {}
@@ -236,6 +243,7 @@ fn collect_arithmetic_lvalue_words<'a>(target: &'a ArithmeticLvalue, words: &mut
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_arithmetic_words<'a>(expression: &'a ArithmeticExprNode, words: &mut Vec<&'a Word>) {
     match &expression.kind {
         ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
@@ -265,6 +273,7 @@ fn collect_arithmetic_words<'a>(expression: &'a ArithmeticExprNode, words: &mut 
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_arithmetic_expression_visits<'a, F>(
     expression: &'a ArithmeticExprNode,
     options: CommandWalkOptions,
@@ -290,6 +299,7 @@ fn visit_arithmetic_lvalue_words<'a>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_command_visits<'a, F>(
     commands: &'a StmtSeq,
     options: CommandWalkOptions,
@@ -303,6 +313,7 @@ fn collect_command_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_command_visit<'a, F>(
     stmt: &'a Stmt,
     options: CommandWalkOptions,
@@ -359,6 +370,7 @@ fn collect_command_visit<'a, F>(
     collect_redirect_visits(&stmt.redirects, options, context, visitor);
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn condition_context(
     context: CommandTraversalContext,
     kind: ConditionKind,
@@ -379,6 +391,7 @@ fn condition_context(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn loop_context(context: CommandTraversalContext) -> CommandTraversalContext {
     CommandTraversalContext {
         walk: WalkContext {
@@ -388,6 +401,7 @@ fn loop_context(context: CommandTraversalContext) -> CommandTraversalContext {
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn nested_word_context(context: CommandTraversalContext) -> CommandTraversalContext {
     CommandTraversalContext {
         nested_word_command: true,
@@ -395,6 +409,7 @@ fn nested_word_context(context: CommandTraversalContext) -> CommandTraversalCont
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_builtin_visits<'a, F>(
     command: &'a BuiltinCommand,
     options: CommandWalkOptions,
@@ -435,6 +450,7 @@ fn collect_builtin_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_compound_visits<'a, F>(
     command: &'a CompoundCommand,
     options: CommandWalkOptions,
@@ -549,6 +565,7 @@ fn collect_compound_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_assignment_visits<'a, F>(
     assignments: &'a [Assignment],
     options: CommandWalkOptions,
@@ -562,6 +579,7 @@ fn collect_assignment_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_assignment_visit<'a, F>(
     assignment: &'a Assignment,
     options: CommandWalkOptions,
@@ -587,6 +605,7 @@ fn collect_assignment_visit<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_word_slice_visits<'a, F>(
     words: &'a [Word],
     options: CommandWalkOptions,
@@ -600,6 +619,7 @@ fn collect_word_slice_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_pattern_slice_visits<'a, F>(
     patterns: &'a [Pattern],
     options: CommandWalkOptions,
@@ -613,6 +633,7 @@ fn collect_pattern_slice_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_word_visits<'a, F>(
     word: &'a Word,
     options: CommandWalkOptions,
@@ -628,6 +649,7 @@ fn collect_word_visits<'a, F>(
     collect_word_part_visits(&word.parts, options, nested_word_context(context), visitor);
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_word_part_visits<'a, F>(
     parts: &'a [WordPartNode],
     options: CommandWalkOptions,
@@ -724,6 +746,7 @@ fn collect_word_part_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_var_ref_word_visits<'a, F>(
     reference: &'a VarRef,
     options: CommandWalkOptions,
@@ -739,6 +762,7 @@ fn collect_var_ref_word_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_parameter_expansion_visits<'a, F>(
     parameter: &'a ParameterExpansion,
     options: CommandWalkOptions,
@@ -850,6 +874,7 @@ fn collect_parameter_expansion_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_zsh_target_visits<'a, F>(
     target: &'a ZshExpansionTarget,
     options: CommandWalkOptions,
@@ -872,6 +897,7 @@ fn collect_zsh_target_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_pattern_visits<'a, F>(
     pattern: &'a Pattern,
     options: CommandWalkOptions,
@@ -894,6 +920,7 @@ fn collect_pattern_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_redirect_visits<'a, F>(
     redirects: &'a [Redirect],
     options: CommandWalkOptions,
@@ -913,6 +940,7 @@ fn collect_redirect_visits<'a, F>(
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_conditional_visits<'a, F>(
     expression: &'a ConditionalExpr,
     options: CommandWalkOptions,
@@ -957,8 +985,9 @@ fn builtin_assignments(command: &BuiltinCommand) -> &[Assignment] {
     }
 }
 
+#[cfg(any(test, feature = "benchmarking"))]
 fn collect_heredoc_body_part_visits<'a, F>(
-    parts: &'a [HeredocBodyPartNode],
+    parts: &'a [shuck_ast::HeredocBodyPartNode],
     options: CommandWalkOptions,
     context: CommandTraversalContext,
     visitor: &mut F,

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -61,7 +61,7 @@ where
     );
 }
 
-#[cfg(any(test, feature = "benchmarking"))]
+#[cfg(test)]
 fn iter_commands<'a>(
     commands: &'a StmtSeq,
     options: CommandWalkOptions,
@@ -79,10 +79,10 @@ fn visit_command_substitution_candidate_words<'a>(
     source: &str,
     visitor: &mut impl FnMut(&'a Word),
 ) {
-    for visit in semantic.command_visits_in_body(body, true) {
+    semantic.for_each_command_visit_in_body(body, true, |visit| {
         visit_command_substitution_loop_header_words(visit.command, visitor);
         visit_command_argument_words_for_substitutions(visit.command, source, visitor);
-    }
+    });
 }
 
 fn visit_command_substitution_loop_header_words<'a>(

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -763,7 +763,11 @@ pub(super) fn wait_option_consumes_argument(text: &str) -> bool {
     p_index + 1 == flags.len()
 }
 
-pub(super) fn parse_mapfile_command(args: &[&Word], source: &str) -> MapfileCommandFacts {
+pub(super) fn parse_mapfile_command(
+    args: &[&Word],
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+) -> MapfileCommandFacts {
     let mut input_fd = Some(0);
     let mut index = 0;
 
@@ -824,7 +828,7 @@ pub(super) fn parse_mapfile_command(args: &[&Word], source: &str) -> MapfileComm
     let target_name_uses = args
         .get(index)
         .filter(|word| !word_starts_with_literal_dash(word, source))
-        .map(|word| comparable_read_target_name_uses(word, source))
+        .map(|word| comparable_read_target_name_uses(word, semantic, source))
         .unwrap_or_default();
 
     MapfileCommandFacts {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -168,16 +168,28 @@ impl<'a> LinterSemanticArtifacts<'a> {
         &self.command_visits_by_id
     }
 
+    #[cfg(test)]
     pub(crate) fn command_visits_in_body(
         &self,
         body: &StmtSeq,
         descend_nested_word_commands: bool,
     ) -> Vec<facts::CommandVisit<'a>> {
-        let Some(root_ids) = self
-            .direct_command_ids_by_body_span
-            .get(&facts::FactSpan::new(body.span))
-        else {
-            return Vec::new();
+        let mut visits = Vec::new();
+        self.for_each_command_visit_in_body(body, descend_nested_word_commands, |visit| {
+            visits.push(visit);
+        });
+        visits
+    }
+
+    pub(crate) fn for_each_command_visit_in_body(
+        &self,
+        body: &StmtSeq,
+        descend_nested_word_commands: bool,
+        mut visitor: impl FnMut(facts::CommandVisit<'a>),
+    ) {
+        let body_span = facts::FactSpan::new(body.span);
+        let Some(root_ids) = self.direct_command_ids_by_body_span.get(&body_span) else {
+            return;
         };
         let baseline_depth = root_ids
             .iter()
@@ -185,7 +197,6 @@ impl<'a> LinterSemanticArtifacts<'a> {
             .map(|context| context.nested_word_command_depth())
             .min()
             .unwrap_or(0);
-        let mut visits = Vec::new();
         let mut stack = root_ids.iter().rev().copied().collect::<Vec<_>>();
         while let Some(id) = stack.pop() {
             let Some(context) = self.semantic.command_context(id) else {
@@ -200,7 +211,7 @@ impl<'a> LinterSemanticArtifacts<'a> {
                 .get(id.index())
                 .and_then(|visit| *visit)
             {
-                visits.push(visit);
+                visitor(visit);
             }
             for child in self
                 .semantic
@@ -211,7 +222,6 @@ impl<'a> LinterSemanticArtifacts<'a> {
                 stack.push(*child);
             }
         }
-        visits
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -1439,6 +1439,30 @@ done
     }
 
     #[test]
+    fn reports_build_flag_family_references_in_nested_command_substitution_arguments() {
+        let source = "\
+#!/bin/bash
+CXXFLAGS=\"${CXXFLAGS//-stdlib=libc++/}\"
+declare -r EXTRA_FLAGS=\"\\
+$(
+printf '%s\\n' \"$(printf '%s\\n' ${CFLAGS})\"
+)\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${CFLAGS}"]
+        );
+    }
+
+    #[test]
     fn reports_shellspec_execdir_case_reference() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/mod.rs
+++ b/crates/shuck-linter/src/rules/mod.rs
@@ -1,4 +1,3 @@
-#[allow(dead_code)]
 pub(crate) mod common;
 pub mod correctness;
 pub mod performance;


### PR DESCRIPTION
## Summary
- reuse semantic command-body visits for command-substitution candidate word collection
- thread semantic artifacts into redirect/read/mapfile comparable-name facts
- keep the legacy recursive fact walker compiled only for tests and benchmarking, with regression coverage for nested substitution arguments

## Verification
- cargo check -p shuck-linter
- cargo test -p shuck-linter possible_variable_misspelling -- --nocapture
- cargo test -p shuck-linter redirect_clobbers_input -- --nocapture
- cargo test -p shuck-linter
- cargo clippy -p shuck-linter --all-targets -- -D warnings
- make test-large-corpus (implementation_diffs=0)