### PR TITLE
refactor(semantic): reuse lexical function lookup

### DIFF
--- a/crates/shuck-semantic/src/function_resolution.rs
+++ b/crates/shuck-semantic/src/function_resolution.rs
@@ -375,16 +375,38 @@ impl FunctionCallResolver<'_> {
         scope: ScopeId,
         offset: usize,
     ) -> Option<BindingId> {
-        self.scopes[scope.index()]
-            .bindings
-            .get(name)?
-            .iter()
-            .rev()
-            .copied()
-            .find(|binding| {
-                let candidate = &self.bindings[binding.index()];
-                matches!(candidate.kind, BindingKind::FunctionDefinition)
-                    && candidate.span.start.offset <= offset
-            })
+        lexically_visible_function_binding_in_scope(
+            self.scopes,
+            self.bindings,
+            name,
+            scope,
+            scope,
+            offset,
+        )
     }
+}
+
+pub(crate) fn lexically_visible_function_binding_in_scope(
+    scopes: &[Scope],
+    bindings: &[Binding],
+    name: &Name,
+    target_scope: ScopeId,
+    call_scope: ScopeId,
+    offset: usize,
+) -> Option<BindingId> {
+    let candidates = scopes[target_scope.index()].bindings.get(name)?;
+    if target_scope != call_scope {
+        return candidates.iter().rev().copied().find(|binding| {
+            matches!(
+                bindings[binding.index()].kind,
+                BindingKind::FunctionDefinition
+            )
+        });
+    }
+
+    candidates.iter().rev().copied().find(|binding| {
+        let candidate = &bindings[binding.index()];
+        matches!(candidate.kind, BindingKind::FunctionDefinition)
+            && candidate.span.start.offset <= offset
+    })
 }

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -12,9 +12,10 @@ use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile, ZshOptionState};
 
+use crate::function_resolution::lexically_visible_function_binding_in_scope;
 use crate::{
-    BindingId, BindingKind, ContractCertainty, FileContract, FunctionContract, FunctionScopeKind,
-    ProvidedBinding, ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel, SourcePathResolver,
+    ContractCertainty, FileContract, FunctionContract, FunctionScopeKind, ProvidedBinding,
+    ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel, SourcePathResolver,
     SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution, SpanKey, SyntheticRead,
     build_semantic_model_base, infer_explicit_parse_dialect_from_source,
 };
@@ -526,13 +527,20 @@ fn visible_imported_function_contract<'a>(
     offset: usize,
 ) -> Option<&'a ImportedFunctionContractSite> {
     for scope_id in model.ancestor_scopes(scope) {
-        let local = visible_local_function_binding_in_scope(model, name, scope_id, scope, offset)
-            .map(|binding| {
-                (
-                    VisibleFunctionTarget::Local,
-                    model.binding(binding).span.start.offset,
-                )
-            });
+        let local = lexically_visible_function_binding_in_scope(
+            model.scopes(),
+            model.bindings(),
+            name,
+            scope_id,
+            scope,
+            offset,
+        )
+        .map(|binding| {
+            (
+                VisibleFunctionTarget::Local,
+                model.binding(binding).span.start.offset,
+            )
+        });
         let imported =
             visible_imported_function_in_scope(imported_functions, name, scope_id, scope, offset)
                 .map(|site| {
@@ -561,30 +569,6 @@ fn visible_imported_function_contract<'a>(
     }
 
     None
-}
-
-fn visible_local_function_binding_in_scope(
-    model: &SemanticModel,
-    name: &Name,
-    target_scope: ScopeId,
-    call_scope: ScopeId,
-    offset: usize,
-) -> Option<BindingId> {
-    let candidates = model.scopes()[target_scope.index()].bindings.get(name)?;
-    if target_scope != call_scope {
-        return candidates.iter().rev().copied().find(|binding| {
-            matches!(
-                model.binding(*binding).kind,
-                BindingKind::FunctionDefinition
-            )
-        });
-    }
-
-    candidates.iter().rev().copied().find(|binding| {
-        let candidate = model.binding(*binding);
-        matches!(candidate.kind, BindingKind::FunctionDefinition)
-            && candidate.span.start.offset <= offset
-    })
 }
 
 fn visible_imported_function_in_scope<'a>(


### PR DESCRIPTION
## Summary
- move lexical local function lookup into the semantic function-resolution helper layer
- reuse that helper from source-closure imported-function resolution
- keep the dead-code cleanup already on main instead of reintroducing removed fact-layer code

## Tests
- cargo fmt --check
- cargo test -p shuck-semantic
- cargo check -p shuck-linter

Large corpus was not run for this small semantic refactor.