### PR TITLE
refactor(semantic): extract call payload grouping

### DIFF
--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -93,17 +93,6 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
-    pub(crate) fn visible_function_binding_in_call_context(
-        &self,
-        name: &Name,
-        scope: ScopeId,
-        offset: usize,
-    ) -> Option<BindingId> {
-        self.model
-            .function_binding_lookup()
-            .visible_function_binding(name, scope, offset)
-    }
-
     pub fn function_scope_for_binding(&self, binding_id: BindingId) -> Option<ScopeId> {
         self.model
             .recorded_program

--- a/crates/shuck-semantic/src/function_resolution.rs
+++ b/crates/shuck-semantic/src/function_resolution.rs
@@ -21,6 +21,32 @@ pub(crate) struct ResolvedFunctionCall<'a> {
     pub(crate) callee_scope: ScopeId,
 }
 
+pub(crate) fn call_payloads_by_callee_scope<'a, I, P>(
+    lookup: &FunctionBindingLookup<'_>,
+    function_body_scopes: &FxHashMap<BindingId, ScopeId>,
+    calls: I,
+) -> FxHashMap<ScopeId, Vec<P>>
+where
+    I: IntoIterator<Item = (&'a Name, ScopeId, usize, P)>,
+{
+    let mut grouped = FxHashMap::default();
+
+    for (name, scope, offset, payload) in calls {
+        let Some(function_binding) = lookup.visible_function_binding(name, scope, offset) else {
+            continue;
+        };
+        let Some(callee_scope) = function_body_scopes.get(&function_binding).copied() else {
+            continue;
+        };
+        grouped
+            .entry(callee_scope)
+            .or_insert_with(Vec::new)
+            .push(payload);
+    }
+
+    grouped
+}
+
 impl FunctionBindingLookup<'_> {
     pub(crate) fn visible_function_binding(
         &self,

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -12,7 +12,9 @@ use shuck_indexer::Indexer;
 use shuck_parser::parser::Parser;
 use shuck_parser::{ShellDialect as ParseShellDialect, ShellProfile, ZshOptionState};
 
-use crate::function_resolution::lexically_visible_function_binding_in_scope;
+use crate::function_resolution::{
+    call_payloads_by_callee_scope, lexically_visible_function_binding_in_scope,
+};
 use crate::{
     ContractCertainty, FileContract, FunctionContract, FunctionScopeKind, ProvidedBinding,
     ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel, SourcePathResolver,
@@ -1046,27 +1048,18 @@ fn resolve_literal_call_args_by_scope(
     model: &SemanticModel,
     calls: &[CallInfo],
 ) -> FxHashMap<ScopeId, Vec<Vec<Option<String>>>> {
-    let mut resolved = FxHashMap::default();
-    let analysis = model.analysis();
-
-    for call in calls {
-        let Some(function_binding) = analysis.visible_function_binding_in_call_context(
-            &call.name,
-            call.scope,
-            call.span.start.offset,
-        ) else {
-            continue;
-        };
-        let Some(callee_scope) = analysis.function_scope_for_binding(function_binding) else {
-            continue;
-        };
-        resolved
-            .entry(callee_scope)
-            .or_insert_with(Vec::new)
-            .push(call.args.clone());
-    }
-
-    resolved
+    call_payloads_by_callee_scope(
+        &model.function_binding_lookup(),
+        &model.recorded_program().function_body_scopes,
+        calls.iter().map(|call| {
+            (
+                &call.name,
+                call.scope,
+                call.span.start.offset,
+                call.args.clone(),
+            )
+        }),
+    )
 }
 
 fn resolve_helper_paths(


### PR DESCRIPTION
## Summary
- add a shared semantic helper for grouping call payloads by resolved callee scope
- route source-closure literal call argument grouping through that helper
- remove the now-unused analysis wrapper for visible call-context function lookup

## Validation
- cargo fmt --check
- cargo test -p shuck-semantic resolve_literal_call_args_by_scope
- cargo test -p shuck-semantic