### PR TITLE
refactor(semantic): own case CLI reachability

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -479,23 +479,16 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &command_fact_indices_by_id,
             self.source,
         );
-        let function_cli_dispatch_facts = build_function_cli_dispatch_facts(
-            self.semantic,
-            semantic_analysis,
-            self.file,
-            self.source,
-        );
+        let case_cli_dispatches = semantic_analysis.case_cli_dispatches(self.file, self.source);
+        let function_cli_dispatch_facts = build_function_cli_dispatch_facts(&case_cli_dispatches);
         let function_definition_command_ids_by_scope = function_headers
             .iter()
             .filter_map(|header| header.function_scope().map(|scope| (scope, header.command_id())))
             .collect::<FxHashMap<_, _>>();
-        let case_cli_reachable_function_scopes = build_case_cli_reachable_function_scopes(
-            self.semantic,
-            semantic_analysis,
-            &function_headers,
-            &function_cli_dispatch_facts,
-            &commands,
-        );
+        let case_cli_reachable_function_scopes = semantic_analysis
+            .case_cli_reachable_function_scopes(self.file, &case_cli_dispatches)
+            .into_iter()
+            .collect();
         collect_condition_status_capture_from_sequences(
             &self.file.body,
             self.source,

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -118,6 +118,7 @@ impl FunctionCliDispatchFacts {
         self.exported_from_case_cli
     }
 
+    #[cfg(test)]
     pub fn dispatcher_span(self) -> Option<Span> {
         self.dispatcher_span
     }
@@ -178,139 +179,16 @@ fn build_function_header_facts<'a>(
 
 #[cfg_attr(shuck_profiling, inline(never))]
 fn build_function_cli_dispatch_facts(
-    semantic: &SemanticModel,
-    semantic_analysis: &SemanticAnalysis<'_>,
-    file: &File,
-    source: &str,
+    dispatches: &[CaseCliDispatch],
 ) -> FxHashMap<ScopeId, FunctionCliDispatchFacts> {
     let mut facts = FxHashMap::<ScopeId, FunctionCliDispatchFacts>::default();
-
-    for pair in file.body.as_slice().windows(2) {
-        let [case_stmt, trailing_exit_stmt] = pair else {
-            continue;
-        };
-        let Command::Compound(CompoundCommand::Case(case_command)) = &case_stmt.command else {
-            continue;
-        };
-        if case_subject_variable_name(&case_command.word) != Some("1") {
-            continue;
-        }
-        if !stmt_is_top_level_exit(trailing_exit_stmt) {
-            continue;
-        }
-
-        for item in &case_command.cases {
-            let Some(dispatcher_span) = first_positional_dispatch_in_commands(&item.body) else {
-                continue;
-            };
-
-            for pattern in &item.patterns {
-                let Some(name) = static_case_pattern_text(pattern, source) else {
-                    continue;
-                };
-                if !is_plausible_shell_function_name(&name) {
-                    continue;
-                }
-
-                let name = Name::from(name.as_str());
-                let Some(binding_id) = semantic_analysis.visible_function_binding_defined_before(
-                    &name,
-                    semantic.scope_at(dispatcher_span.start.offset),
-                    dispatcher_span.start.offset,
-                ) else {
-                    continue;
-                };
-                let Some(scope) = semantic_analysis.function_scope_for_binding(binding_id) else {
-                    continue;
-                };
-
-                facts
-                    .entry(scope)
-                    .or_default()
-                    .record_dispatch(dispatcher_span);
-            }
-        }
+    for dispatch in dispatches {
+        facts
+            .entry(dispatch.function_scope())
+            .or_default()
+            .record_dispatch(dispatch.dispatcher_span());
     }
-
     facts
-}
-
-#[cfg_attr(shuck_profiling, inline(never))]
-fn build_case_cli_reachable_function_scopes(
-    semantic: &SemanticModel,
-    semantic_analysis: &SemanticAnalysis<'_>,
-    function_headers: &[FunctionHeaderFact<'_>],
-    function_cli_dispatch_facts: &FxHashMap<ScopeId, FunctionCliDispatchFacts>,
-    commands: &[CommandFact<'_>],
-) -> FxHashSet<ScopeId> {
-    let dispatcher_offset = function_headers
-        .iter()
-        .filter_map(|header| {
-            let scope = header.function_scope()?;
-            function_cli_dispatch_facts
-                .get(&scope)
-                .copied()
-                .unwrap_or_default()
-                .dispatcher_span()
-                .map(|span| span.start.offset)
-        })
-        .min();
-    let top_level_exit_offset = commands
-        .iter()
-        .filter(|command| {
-            semantic.syntax_backed_command_parent_id(command.id()).is_none()
-                && semantic.enclosing_function_scope(command.scope()).is_none()
-                && command_fact_is_standalone_exit(command)
-        })
-        .map(|command| command.span().start.offset)
-        .min();
-
-    function_headers
-        .iter()
-        .filter_map(|header| {
-            let scope = header.function_scope()?;
-            (semantic_analysis.function_scope_is_nested(scope)
-                || dispatcher_offset
-                    .is_some_and(|offset| header.function().span.start.offset < offset)
-                || top_level_exit_offset
-                    .is_some_and(|offset| header.function().span.start.offset < offset))
-            .then_some(scope)
-        })
-        .collect()
-}
-
-fn stmt_is_top_level_exit(stmt: &Stmt) -> bool {
-    if stmt.negated || matches!(stmt.terminator, Some(StmtTerminator::Background(_))) {
-        return false;
-    }
-
-    let Command::Builtin(BuiltinCommand::Exit(command)) = &stmt.command else {
-        return false;
-    };
-    if !command.extra_args.is_empty()
-        || !command.assignments.is_empty()
-        || !stmt.redirects.is_empty()
-    {
-        return false;
-    }
-
-    true
-}
-
-fn command_fact_is_standalone_exit(command: &CommandFact<'_>) -> bool {
-    if command.stmt().negated
-        || matches!(
-            command.stmt().terminator,
-            Some(StmtTerminator::Background(_))
-        )
-    {
-        return false;
-    }
-
-    let Command::Builtin(BuiltinCommand::Exit(exit)) = command.command() else {
-        return false;
-    };
-    exit.extra_args.is_empty() && exit.assignments.is_empty() && command.stmt().redirects.is_empty()
 }
 
 fn build_function_parameter_fallback_spans(
@@ -598,111 +476,6 @@ fn function_call_diagnostic_span(
     }
 
     trim_trailing_whitespace_span(command.stmt().span, source)
-}
-
-fn first_positional_dispatch_in_commands(commands: &StmtSeq) -> Option<Span> {
-    commands
-        .iter()
-        .find_map(|stmt| first_positional_dispatch_in_command(&stmt.command))
-}
-
-fn first_positional_dispatch_in_command(command: &Command) -> Option<Span> {
-    match command {
-        Command::Binary(command) => first_positional_dispatch_in_command(&command.left.command)
-            .or_else(|| first_positional_dispatch_in_command(&command.right.command)),
-        Command::Compound(CompoundCommand::BraceGroup(commands))
-        | Command::Compound(CompoundCommand::Subshell(commands)) => {
-            first_positional_dispatch_in_commands(commands)
-        }
-        Command::Compound(CompoundCommand::If(command)) => {
-            first_positional_dispatch_in_commands(&command.condition)
-                .or_else(|| first_positional_dispatch_in_commands(&command.then_branch))
-                .or_else(|| {
-                    command
-                        .elif_branches
-                        .iter()
-                        .find_map(|(condition, branch)| {
-                            first_positional_dispatch_in_commands(condition)
-                                .or_else(|| first_positional_dispatch_in_commands(branch))
-                        })
-                })
-                .or_else(|| {
-                    command
-                        .else_branch
-                        .as_ref()
-                        .and_then(first_positional_dispatch_in_commands)
-                })
-        }
-        Command::Compound(CompoundCommand::While(command)) => {
-            first_positional_dispatch_in_commands(&command.condition)
-                .or_else(|| first_positional_dispatch_in_commands(&command.body))
-        }
-        Command::Compound(CompoundCommand::Until(command)) => {
-            first_positional_dispatch_in_commands(&command.condition)
-                .or_else(|| first_positional_dispatch_in_commands(&command.body))
-        }
-        Command::Compound(CompoundCommand::For(command)) => {
-            first_positional_dispatch_in_commands(&command.body)
-        }
-        Command::Compound(CompoundCommand::Select(command)) => {
-            first_positional_dispatch_in_commands(&command.body)
-        }
-        Command::Compound(CompoundCommand::Case(command)) => command
-            .cases
-            .iter()
-            .find_map(|item| first_positional_dispatch_in_commands(&item.body)),
-        Command::Compound(CompoundCommand::Time(command)) => command
-            .command
-            .as_ref()
-            .and_then(|stmt| first_positional_dispatch_in_command(&stmt.command)),
-        Command::Compound(CompoundCommand::Conditional(_))
-        | Command::Compound(_)
-        | Command::Builtin(_)
-        | Command::Decl(_)
-        | Command::Function(_)
-        | Command::AnonymousFunction(_) => None,
-        Command::Simple(command) => {
-            word_is_plain_positional_parameter(&command.name, "1").then_some(command.name.span)
-        }
-    }
-}
-
-fn word_is_plain_positional_parameter(word: &Word, target: &str) -> bool {
-    let [part] = word.parts.as_slice() else {
-        return false;
-    };
-
-    word_part_is_plain_positional_parameter(&part.kind, target)
-}
-
-fn word_part_is_plain_positional_parameter(part: &WordPart, target: &str) -> bool {
-    match part {
-        WordPart::Variable(name) => name.as_str() == target,
-        WordPart::DoubleQuoted { parts, .. } => {
-            let [part] = parts.as_slice() else {
-                return false;
-            };
-            word_part_is_plain_positional_parameter(&part.kind, target)
-        }
-        WordPart::Parameter(parameter) => match &parameter.syntax {
-            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
-                reference.subscript.is_none() && reference.name.as_str() == target
-            }
-            ParameterExpansionSyntax::Zsh(syntax) => {
-                syntax.length_prefix.is_none()
-                    && syntax.operation.is_none()
-                    && syntax.modifiers.is_empty()
-                    && matches!(
-                        &syntax.target,
-                        ZshExpansionTarget::Reference(reference)
-                            if reference.subscript.is_none()
-                                && reference.name.as_str() == target
-                    )
-            }
-            _ => false,
-        },
-        _ => false,
-    }
 }
 
 fn function_body_without_braces_span(function: &FunctionDef) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -63,7 +63,7 @@ use shuck_indexer::Indexer;
 #[cfg(test)]
 use shuck_parser::parser::Parser;
 use shuck_semantic::{
-    Binding, BindingId, BindingKind, Declaration, DeclarationBuiltin,
+    Binding, BindingId, BindingKind, CaseCliDispatch, Declaration, DeclarationBuiltin,
     DeclarationOperand as SemanticDeclarationOperand, NonpersistentAssignmentAnalysisContext,
     NonpersistentAssignmentAnalysisOptions, NonpersistentAssignmentCommandContext,
     NonpersistentAssignmentExtraRead, OptionValue, Reference, ReferenceId, ReferenceKind, ScopeId,

--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -2,6 +2,11 @@ use super::*;
 use crate::cfg::build_control_flow_graph;
 use crate::dataflow;
 use crate::reachability::{block_reaches_unless, block_reaches_without};
+use shuck_ast::{
+    BourneParameterExpansion, BuiltinCommand, CompoundCommand, ParameterExpansionSyntax, Pattern,
+    PatternPart, StmtSeq, StmtTerminator, Word, WordPart, WordPartNode, ZshExpansionTarget,
+    static_word_text,
+};
 
 #[allow(missing_docs)]
 impl<'model> SemanticAnalysis<'model> {
@@ -118,6 +123,89 @@ impl<'model> SemanticAnalysis<'model> {
             .parent
             .and_then(|parent| self.model.enclosing_function_scope(parent))
             .is_some()
+    }
+
+    pub fn case_cli_dispatches(&self, file: &File, source: &str) -> Vec<CaseCliDispatch> {
+        let mut dispatches = Vec::new();
+
+        for pair in file.body.as_slice().windows(2) {
+            let [case_stmt, trailing_exit_stmt] = pair else {
+                continue;
+            };
+            let Command::Compound(CompoundCommand::Case(case_command)) = &case_stmt.command else {
+                continue;
+            };
+            if case_subject_variable_name(&case_command.word) != Some("1") {
+                continue;
+            }
+            if !stmt_is_standalone_exit(trailing_exit_stmt) {
+                continue;
+            }
+
+            for item in &case_command.cases {
+                let Some(dispatcher_span) = first_positional_dispatch_in_commands(&item.body)
+                else {
+                    continue;
+                };
+
+                for pattern in &item.patterns {
+                    let Some(name) = static_case_pattern_text(pattern, source) else {
+                        continue;
+                    };
+                    if !is_plausible_shell_function_name(&name) {
+                        continue;
+                    }
+
+                    let name = Name::from(name.as_str());
+                    let Some(binding_id) = self.visible_function_binding_defined_before(
+                        &name,
+                        self.model.scope_at(dispatcher_span.start.offset),
+                        dispatcher_span.start.offset,
+                    ) else {
+                        continue;
+                    };
+                    let Some(scope) = self.function_scope_for_binding(binding_id) else {
+                        continue;
+                    };
+
+                    dispatches.push(CaseCliDispatch::new(scope, dispatcher_span));
+                }
+            }
+        }
+
+        dispatches
+    }
+
+    pub fn case_cli_reachable_function_scopes(
+        &self,
+        file: &File,
+        dispatches: &[CaseCliDispatch],
+    ) -> Vec<ScopeId> {
+        let dispatcher_offset = dispatches
+            .iter()
+            .map(|dispatch| dispatch.dispatcher_span().start.offset)
+            .min();
+        let top_level_exit_offset = file
+            .body
+            .iter()
+            .find(|stmt| stmt_is_standalone_exit(stmt))
+            .map(|stmt| stmt.span.start.offset);
+        let mut scopes = self
+            .function_bindings_by_scope()
+            .filter_map(|(scope, bindings)| {
+                let function_start = bindings
+                    .iter()
+                    .map(|binding_id| self.model.binding(*binding_id).span.start.offset)
+                    .min()?;
+                (self.function_scope_is_nested(scope)
+                    || dispatcher_offset.is_some_and(|offset| function_start < offset)
+                    || top_level_exit_offset.is_some_and(|offset| function_start < offset))
+                .then_some(scope)
+            })
+            .collect::<Vec<_>>();
+        scopes.sort_by_key(|scope| self.model.scope(*scope).span.start.offset);
+        scopes.dedup();
+        scopes
     }
 
     pub fn visible_function_binding_defined_before(
@@ -464,4 +552,198 @@ impl<'model> SemanticAnalysis<'model> {
             }
         })
     }
+}
+
+fn stmt_is_standalone_exit(stmt: &Stmt) -> bool {
+    if stmt.negated || matches!(stmt.terminator, Some(StmtTerminator::Background(_))) {
+        return false;
+    }
+
+    let Command::Builtin(BuiltinCommand::Exit(command)) = &stmt.command else {
+        return false;
+    };
+    command.extra_args.is_empty() && command.assignments.is_empty() && stmt.redirects.is_empty()
+}
+
+fn first_positional_dispatch_in_commands(commands: &StmtSeq) -> Option<Span> {
+    commands
+        .iter()
+        .find_map(|stmt| first_positional_dispatch_in_command(&stmt.command))
+}
+
+fn first_positional_dispatch_in_command(command: &Command) -> Option<Span> {
+    match command {
+        Command::Binary(command) => first_positional_dispatch_in_command(&command.left.command)
+            .or_else(|| first_positional_dispatch_in_command(&command.right.command)),
+        Command::Compound(CompoundCommand::BraceGroup(commands))
+        | Command::Compound(CompoundCommand::Subshell(commands)) => {
+            first_positional_dispatch_in_commands(commands)
+        }
+        Command::Compound(CompoundCommand::If(command)) => {
+            first_positional_dispatch_in_commands(&command.condition)
+                .or_else(|| first_positional_dispatch_in_commands(&command.then_branch))
+                .or_else(|| {
+                    command
+                        .elif_branches
+                        .iter()
+                        .find_map(|(condition, branch)| {
+                            first_positional_dispatch_in_commands(condition)
+                                .or_else(|| first_positional_dispatch_in_commands(branch))
+                        })
+                })
+                .or_else(|| {
+                    command
+                        .else_branch
+                        .as_ref()
+                        .and_then(first_positional_dispatch_in_commands)
+                })
+        }
+        Command::Compound(CompoundCommand::While(command)) => {
+            first_positional_dispatch_in_commands(&command.condition)
+                .or_else(|| first_positional_dispatch_in_commands(&command.body))
+        }
+        Command::Compound(CompoundCommand::Until(command)) => {
+            first_positional_dispatch_in_commands(&command.condition)
+                .or_else(|| first_positional_dispatch_in_commands(&command.body))
+        }
+        Command::Compound(CompoundCommand::For(command)) => {
+            first_positional_dispatch_in_commands(&command.body)
+        }
+        Command::Compound(CompoundCommand::Select(command)) => {
+            first_positional_dispatch_in_commands(&command.body)
+        }
+        Command::Compound(CompoundCommand::Case(command)) => command
+            .cases
+            .iter()
+            .find_map(|item| first_positional_dispatch_in_commands(&item.body)),
+        Command::Compound(CompoundCommand::Time(command)) => command
+            .command
+            .as_ref()
+            .and_then(|stmt| first_positional_dispatch_in_command(&stmt.command)),
+        Command::Compound(CompoundCommand::Conditional(_))
+        | Command::Compound(_)
+        | Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => None,
+        Command::Simple(command) => {
+            word_is_plain_positional_parameter(&command.name, "1").then_some(command.name.span)
+        }
+    }
+}
+
+fn word_is_plain_positional_parameter(word: &Word, target: &str) -> bool {
+    let [part] = word.parts.as_slice() else {
+        return false;
+    };
+
+    word_part_is_plain_positional_parameter(&part.kind, target)
+}
+
+fn word_part_is_plain_positional_parameter(part: &WordPart, target: &str) -> bool {
+    match part {
+        WordPart::Variable(name) => name.as_str() == target,
+        WordPart::DoubleQuoted { parts, .. } => {
+            let [part] = parts.as_slice() else {
+                return false;
+            };
+            word_part_is_plain_positional_parameter(&part.kind, target)
+        }
+        WordPart::Parameter(parameter) => match &parameter.syntax {
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
+                reference.subscript.is_none() && reference.name.as_str() == target
+            }
+            ParameterExpansionSyntax::Zsh(syntax) => {
+                syntax.length_prefix.is_none()
+                    && syntax.operation.is_none()
+                    && syntax.modifiers.is_empty()
+                    && matches!(
+                        &syntax.target,
+                        ZshExpansionTarget::Reference(reference)
+                            if reference.subscript.is_none()
+                                && reference.name.as_str() == target
+                    )
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn static_case_pattern_text(pattern: &Pattern, source: &str) -> Option<String> {
+    let mut text = String::new();
+    for part in &pattern.parts {
+        match &part.kind {
+            PatternPart::Literal(literal) => text.push_str(literal.as_str(source, part.span)),
+            PatternPart::Word(word) => text.push_str(static_word_text(word, source)?.as_ref()),
+            PatternPart::AnyString
+            | PatternPart::AnyChar
+            | PatternPart::CharClass(_)
+            | PatternPart::Group { .. } => return None,
+        }
+    }
+    Some(text)
+}
+
+fn case_subject_variable_name(word: &Word) -> Option<&str> {
+    standalone_variable_name_from_word_parts(&word.parts)
+}
+
+fn standalone_variable_name_from_word_parts(parts: &[WordPartNode]) -> Option<&str> {
+    let [part] = parts else {
+        return None;
+    };
+
+    match &part.kind {
+        WordPart::Variable(name) => Some(name.as_str()),
+        WordPart::Parameter(parameter) => match parameter.bourne() {
+            Some(BourneParameterExpansion::Access { reference })
+                if reference.subscript.is_none() =>
+            {
+                Some(reference.name.as_str())
+            }
+            _ => None,
+        },
+        WordPart::DoubleQuoted { parts, .. } => standalone_variable_name_from_word_parts(parts),
+        _ => None,
+    }
+}
+
+fn is_plausible_shell_function_name(name: &str) -> bool {
+    let Some(first) = name.chars().next() else {
+        return false;
+    };
+    if !matches!(first, 'a'..='z' | 'A'..='Z' | '_') {
+        return false;
+    }
+    if !name
+        .chars()
+        .all(|ch| matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '-'))
+    {
+        return false;
+    }
+    !matches!(
+        name,
+        "!" | "{"
+            | "}"
+            | "if"
+            | "then"
+            | "elif"
+            | "else"
+            | "fi"
+            | "do"
+            | "done"
+            | "case"
+            | "esac"
+            | "for"
+            | "in"
+            | "while"
+            | "until"
+            | "time"
+            | "[["
+            | "]]"
+            | "function"
+            | "select"
+            | "coproc"
+    )
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -99,6 +99,32 @@ pub use source_ref::{SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceR
 /// Value-flow query object built over semantic bindings, call sites, CFG, and dataflow.
 pub use value_flow::SemanticValueFlow;
 
+/// A function scope reached through a top-level `case "$1"` style CLI dispatcher.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CaseCliDispatch {
+    function_scope: ScopeId,
+    dispatcher_span: Span,
+}
+
+impl CaseCliDispatch {
+    fn new(function_scope: ScopeId, dispatcher_span: Span) -> Self {
+        Self {
+            function_scope,
+            dispatcher_span,
+        }
+    }
+
+    /// The function body scope selected by the dispatcher.
+    pub fn function_scope(self) -> ScopeId {
+        self.function_scope
+    }
+
+    /// The span of the dynamic positional command used for dispatch.
+    pub fn dispatcher_span(self) -> Span {
+        self.dispatcher_span
+    }
+}
+
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Command, File, Name, Span, Stmt};
 use shuck_indexer::Indexer;

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -613,6 +613,42 @@ fn semantic_analysis_exposes_function_scope_and_call_arity_bindings() {
 }
 
 #[test]
+fn semantic_analysis_exposes_case_cli_dispatch_reachability() {
+    let source = "\
+#!/bin/sh
+start() { echo hi; }
+case \"$1\" in
+  start) \"$1\" ;;
+esac
+exit $?
+late() { echo later; }
+";
+    let output = Parser::with_dialect(source, ShellDialect::Bash)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(source, &output);
+    let model = SemanticModel::build(&output.file, source, &indexer);
+    let analysis = model.analysis();
+    let start_binding = model.function_definitions(&Name::from("start"))[0];
+    let start_scope = analysis
+        .function_scope_for_binding(start_binding)
+        .expect("expected start function scope");
+    let late_binding = model.function_definitions(&Name::from("late"))[0];
+    let late_scope = analysis
+        .function_scope_for_binding(late_binding)
+        .expect("expected late function scope");
+
+    let dispatches = analysis.case_cli_dispatches(&output.file, source);
+    assert_eq!(dispatches.len(), 1);
+    assert_eq!(dispatches[0].function_scope(), start_scope);
+    assert_eq!(dispatches[0].dispatcher_span().slice(source), "\"$1\"");
+
+    let reachable = analysis.case_cli_reachable_function_scopes(&output.file, &dispatches);
+    assert!(reachable.contains(&start_scope));
+    assert!(!reachable.contains(&late_scope));
+}
+
+#[test]
 fn zsh_parameter_modifiers_still_register_references() {
     let model = model_with_profile("print ${(m)foo}\n", ShellProfile::native(ShellDialect::Zsh));
     let unresolved = unresolved_names(&model);


### PR DESCRIPTION
## Summary
- move top-level `case "$1"` CLI dispatch detection into semantic analysis
- expose semantic case CLI reachability for linter facts to consume as an adapter
- add a semantic regression test for dispatch reachability excluding later functions

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter case_cli`
- `cargo test -p shuck-linter`
- `cargo check -p shuck-semantic -p shuck-linter`