### PR TITLE
docs(semantic): document shuck-semantic public API

### DIFF
--- a/crates/shuck-semantic/src/analysis.rs
+++ b/crates/shuck-semantic/src/analysis.rs
@@ -8,7 +8,6 @@ use shuck_ast::{
     static_word_text,
 };
 
-#[allow(missing_docs)]
 impl<'model> SemanticAnalysis<'model> {
     pub(crate) fn new(model: &'model SemanticModel) -> Self {
         Self {
@@ -31,6 +30,7 @@ impl<'model> SemanticAnalysis<'model> {
         }
     }
 
+    /// Returns the lazily built control-flow graph for the underlying semantic model.
     pub fn cfg(&self) -> &ControlFlowGraph {
         self.cfg.get_or_init(|| {
             build_control_flow_graph(
@@ -58,6 +58,7 @@ impl<'model> SemanticAnalysis<'model> {
         self.unreachable_blocks().contains(&block_id)
     }
 
+    /// Returns the function binding resolved for the call whose callee token spans `name_span`.
     pub fn visible_function_binding_at_call(
         &self,
         name: &Name,
@@ -73,6 +74,7 @@ impl<'model> SemanticAnalysis<'model> {
             .copied()
     }
 
+    /// Iterates call sites for `name` that resolved to a visible function binding.
     pub fn resolved_function_call_sites<'analysis>(
         &'analysis self,
         name: &'analysis Name,
@@ -85,6 +87,10 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    /// Iterates call sites for `name` using resolution suitable for arity-style checks.
+    ///
+    /// When the main visible-function index has no answer for a call site, this falls back to a
+    /// lexical same-name binding search so callers can still reason about nearby definitions.
     pub fn function_call_arity_sites<'analysis>(
         &'analysis self,
         name: &'analysis Name,
@@ -98,6 +104,7 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    /// Returns the function body scope owned by `binding_id`, if it is a function definition.
     pub fn function_scope_for_binding(&self, binding_id: BindingId) -> Option<ScopeId> {
         self.model
             .recorded_program
@@ -106,6 +113,7 @@ impl<'model> SemanticAnalysis<'model> {
             .copied()
     }
 
+    /// Returns whether `scope` is a function nested inside another function.
     pub fn function_scope_is_nested(&self, scope: ScopeId) -> bool {
         self.model
             .scope(scope)
@@ -114,6 +122,7 @@ impl<'model> SemanticAnalysis<'model> {
             .is_some()
     }
 
+    /// Returns top-level `case "$1"` dispatch edges that select function scopes by name.
     pub fn case_cli_dispatches(&self, file: &File, source: &str) -> Vec<CaseCliDispatch> {
         let mut dispatches = Vec::new();
 
@@ -165,6 +174,7 @@ impl<'model> SemanticAnalysis<'model> {
         dispatches
     }
 
+    /// Returns function scopes that participate in a top-level `case "$1"` CLI dispatch pattern.
     pub fn case_cli_reachable_function_scopes(
         &self,
         file: &File,
@@ -197,6 +207,7 @@ impl<'model> SemanticAnalysis<'model> {
         scopes
     }
 
+    /// Returns the latest visible same-name function binding defined before the given call site.
     pub fn visible_function_binding_defined_before(
         &self,
         name: &Name,
@@ -265,6 +276,8 @@ impl<'model> SemanticAnalysis<'model> {
             .map(|(scope, bindings)| (*scope, bindings.as_slice()))
     }
 
+    /// Creates a direct-call reachability engine over this analysis, optionally seeding extra
+    /// synthetic call candidates.
     pub fn direct_function_call_reachability<'analysis>(
         &'analysis self,
         supplemental_calls: impl IntoIterator<Item = FunctionCallCandidate>,
@@ -399,6 +412,10 @@ impl<'model> SemanticAnalysis<'model> {
         )
     }
 
+    /// Returns bindings whose values can reach the named use contained in `at`.
+    ///
+    /// This prefers exact dataflow when a matching reference is available, then falls back to the
+    /// latest lexically visible binding.
     pub fn reaching_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
         let cfg = self.cfg();
         let context = self.model.dataflow_context(cfg);
@@ -462,12 +479,14 @@ impl<'model> SemanticAnalysis<'model> {
             .collect()
     }
 
+    /// Returns the lazily computed dead-code regions for the script.
     pub fn dead_code(&self) -> &[DeadCode] {
         self.dead_code
             .get_or_init(|| dataflow::analyze_dead_code(self.cfg()))
             .as_slice()
     }
 
+    /// Returns whether every CFG block associated with `span` is reachable.
     pub fn is_reachable(&self, span: &Span) -> bool {
         let cfg = self.cfg();
         cfg.block_ids_for_span(*span)

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -3,6 +3,7 @@ use shuck_ast::{Name, Span};
 
 use crate::{DeclarationBuiltin, ReferenceId, ScopeId};
 
+/// Stable identifier for a semantic binding recorded in a [`crate::SemanticModel`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BindingId(pub(crate) u32);
 
@@ -12,96 +13,162 @@ impl BindingId {
     }
 }
 
+/// One semantic name definition discovered in the analyzed file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Binding {
+    /// Unique identifier for this binding.
     pub id: BindingId,
+    /// Bound shell name.
     pub name: Name,
+    /// High-level binding category.
     pub kind: BindingKind,
+    /// Provenance details describing how the binding was introduced.
     pub origin: BindingOrigin,
+    /// Scope that owns the binding.
     pub scope: ScopeId,
+    /// Source span that defines or introduces the binding.
     pub span: Span,
+    /// References that resolved to this binding.
     pub references: Vec<ReferenceId>,
+    /// Attribute flags inferred for the binding.
     pub attributes: BindingAttributes,
 }
 
+/// Provenance details for how a binding entered the semantic model.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BindingOrigin {
+    /// A normal assignment form such as `foo=bar`.
     Assignment {
+        /// Span of the definition site.
         definition_span: Span,
+        /// Classification of the assigned value.
         value: AssignmentValueOrigin,
     },
+    /// A loop variable such as `for foo in ...`.
     LoopVariable {
+        /// Span of the variable definition site.
         definition_span: Span,
+        /// Classification of the loop item source.
         items: LoopValueOrigin,
     },
+    /// An assignment produced by a parameter operator such as `${x:=value}`.
     ParameterDefaultAssignment {
+        /// Span of the operator site that introduces the binding.
         definition_span: Span,
     },
+    /// A binding imported from a sourced file or ambient contract.
     Imported {
+        /// Span associated with the import site.
         definition_span: Span,
     },
+    /// A function definition.
     FunctionDefinition {
+        /// Span of the function definition.
         definition_span: Span,
     },
+    /// A builtin target such as `read foo` or `mapfile arr`.
     BuiltinTarget {
+        /// Span of the target definition site.
         definition_span: Span,
+        /// Builtin command that created the target.
         kind: BuiltinBindingTargetKind,
     },
+    /// An arithmetic assignment such as `(( foo += 1 ))`.
     ArithmeticAssignment {
+        /// Span of the full arithmetic assignment.
         definition_span: Span,
+        /// Span of the assignment target within the expression.
         target_span: Span,
     },
+    /// A declaration builtin operand such as `local foo`.
     Declaration {
+        /// Span of the declaration operand.
         definition_span: Span,
     },
+    /// A nameref declaration such as `declare -n ref=target`.
     Nameref {
+        /// Span of the nameref definition site.
         definition_span: Span,
     },
 }
 
+/// Coarse classification for the right-hand side of an assignment-like binding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssignmentValueOrigin {
+    /// A plain scalar read or concatenation of scalar reads.
     PlainScalarAccess,
+    /// A purely static literal value.
     StaticLiteral,
+    /// A parameter operator result such as `${x:-fallback}`.
     ParameterOperator,
+    /// A transformation that preserves variable identity in a rule-relevant way.
     Transformation,
+    /// An indirect expansion such as `${!name}`.
     IndirectExpansion,
+    /// A command or process substitution.
     CommandOrProcessSubstitution,
+    /// A mixed or partially dynamic value that does not fit a narrower category.
     MixedDynamic,
+    /// An array literal, array expansion, or compound assignment.
     ArrayOrCompound,
+    /// The origin could not be classified precisely.
     Unknown,
 }
 
+/// Coarse classification for the item source of a loop variable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoopValueOrigin {
+    /// The loop iterates a statically known word list.
     StaticWords,
+    /// The loop iterates words produced by expansion.
     ExpandedWords,
+    /// The loop iterates the implicit positional parameter list.
     ImplicitArgv,
 }
 
+/// Builtin command kind that creates a target binding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuiltinBindingTargetKind {
+    /// `read`
     Read,
+    /// `mapfile` or `readarray`
     Mapfile,
+    /// `printf -v`
     Printf,
+    /// `getopts`
     Getopts,
 }
 
+/// High-level category for a semantic binding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BindingKind {
+    /// A normal assignment.
     Assignment,
+    /// A parameter-default assignment from `${x:=...}`.
     ParameterDefaultAssignment,
+    /// An append assignment such as `foo+=bar`.
     AppendAssignment,
+    /// An array assignment or compound assignment.
     ArrayAssignment,
+    /// A declaration builtin target.
     Declaration(DeclarationBuiltin),
+    /// A function definition binding.
     FunctionDefinition,
+    /// A loop variable binding.
     LoopVariable,
+    /// A target created by `read`.
     ReadTarget,
+    /// A target created by `mapfile` or `readarray`.
     MapfileTarget,
+    /// A target created by `printf -v`.
     PrintfTarget,
+    /// A target created by `getopts`.
     GetoptsTarget,
+    /// An arithmetic assignment binding.
     ArithmeticAssignment,
+    /// A nameref binding.
     Nameref,
+    /// A binding imported from another file or ambient contract.
     Imported,
 }
 
@@ -116,24 +183,42 @@ pub(crate) fn is_array_like_binding(binding: &Binding) -> bool {
 }
 
 bitflags! {
+    /// Attribute flags inferred for a binding.
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct BindingAttributes: u32 {
+        /// The binding is exported to child processes.
         const EXPORTED               = 0b0000_0001;
+        /// The binding is readonly.
         const READONLY               = 0b0000_0010;
+        /// The binding is local to a function-like scope.
         const LOCAL                  = 0b0000_0100;
+        /// The binding has integer semantics.
         const INTEGER                = 0b0000_1000;
+        /// The binding is array-like.
         const ARRAY                  = 0b0001_0000;
+        /// The binding is associative-array-like.
         const ASSOC                  = 0b0010_0000;
+        /// The binding is a nameref.
         const NAMEREF                = 0b0100_0000;
+        /// The binding applies lowercase transformation.
         const LOWERCASE              = 0b1000_0000;
+        /// The binding applies uppercase transformation.
         const UPPERCASE              = 0b0001_0000_0000;
+        /// A declaration builtin definitely initializes the binding.
         const DECLARATION_INITIALIZED = 0b0010_0000_0000;
+        /// The binding may have been imported rather than locally defined.
         const IMPORTED_POSSIBLE      = 0b0100_0000_0000;
+        /// The imported binding is a function.
         const IMPORTED_FUNCTION      = 0b1000_0000_0000;
+        /// The binding was initialized to an empty value.
         const EMPTY_INITIALIZER      = 0b0001_0000_0000_0000;
+        /// The binding comes from a file-entry contract.
         const IMPORTED_FILE_ENTRY    = 0b0010_0000_0000_0000;
+        /// The binding's initializer reads its own previous value.
         const SELF_REFERENTIAL_READ  = 0b0100_0000_0000_0000;
+        /// The imported file-entry binding is definitely initialized.
         const IMPORTED_FILE_ENTRY_INITIALIZED = 0b1000_0000_0000_0000;
+        /// The binding is consumed by runtime behavior outside direct syntax reads.
         const EXTERNALLY_CONSUMED    = 0b0001_0000_0000_0000_0000;
     }
 }

--- a/crates/shuck-semantic/src/call_graph.rs
+++ b/crates/shuck-semantic/src/call_graph.rs
@@ -6,41 +6,64 @@ use crate::binding::Binding;
 use crate::scope::ancestor_scopes;
 use crate::{BindingId, Scope, ScopeId, ScopeKind};
 
+/// One syntactic function call site.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallSite {
+    /// Callee name as written at the site.
     pub callee: Name,
+    /// Span of the containing command.
     pub span: Span,
+    /// Span of the callee token itself.
     pub name_span: Span,
+    /// Scope active at the call site.
     pub scope: ScopeId,
+    /// Number of positional arguments passed at the site.
     pub arg_count: usize,
 }
 
+/// Summary call graph derived from discovered function definitions and call sites.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CallGraph {
+    /// Function names reachable from top-level execution.
     pub reachable: FxHashSet<Name>,
+    /// Function-definition bindings that were never reached from the top level.
     pub uncalled: Vec<BindingId>,
+    /// Pairs of same-name function definitions where a later definition overwrites an earlier one.
     pub overwritten: Vec<OverwrittenFunction>,
 }
 
+/// Two same-name function definitions where the second overwrites the first.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OverwrittenFunction {
+    /// Function name shared by both definitions.
     pub name: Name,
+    /// Earlier function-definition binding.
     pub first: BindingId,
+    /// Later function-definition binding.
     pub second: BindingId,
+    /// Whether the earlier definition was called before being overwritten.
     pub first_called: bool,
 }
 
+/// Reason a function definition is considered unreached.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnreachedFunctionReason {
+    /// The definition appears only in unreachable control-flow.
     UnreachableDefinition,
+    /// The script terminates before control can reach the definition.
     ScriptTerminates,
+    /// The enclosing function is not itself reached.
     EnclosingFunctionUnreached,
 }
 
+/// One unreached function definition together with the reason it is unreached.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnreachedFunction {
+    /// Function name.
     pub name: Name,
+    /// Binding for the unreached definition.
     pub binding: BindingId,
+    /// Why the function is unreached.
     pub reason: UnreachedFunctionReason,
 }
 

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -8,6 +8,7 @@ use crate::function_resolution::resolved_function_calls_with_callee_scope;
 use crate::source_closure::SourcePathTemplate;
 use crate::{Binding, BindingId, CallSite, ReferenceId, Scope, ScopeId, SpanKey};
 
+/// Stable identifier for a CFG basic block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BlockId(pub(crate) u32);
 
@@ -17,44 +18,71 @@ impl BlockId {
     }
 }
 
+/// One basic block in the control-flow graph.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BasicBlock {
+    /// Unique identifier for this block.
     pub id: BlockId,
+    /// Command spans represented by the block.
     pub commands: SmallVec<[Span; 1]>,
+    /// Bindings introduced in the block.
     pub bindings: SmallVec<[BindingId; 2]>,
+    /// References recorded in the block.
     pub references: SmallVec<[ReferenceId; 4]>,
 }
 
+/// Edge label describing why control can flow between two blocks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EdgeKind {
+    /// Straight-line control flow.
     Sequential,
+    /// True branch of a conditional.
     ConditionalTrue,
+    /// False branch of a conditional.
     ConditionalFalse,
+    /// Loop back-edge.
     LoopBack,
+    /// Loop exit edge.
     LoopExit,
+    /// Edge into a case arm.
     CaseArm,
+    /// Fallthrough edge between case arms.
     CaseFallthrough,
+    /// Continue edge between case arms.
     CaseContinue,
+    /// Entry into a nested isolated region.
     NestedRegion,
 }
 
+/// Execution-context facts active at a command or block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct FlowContext {
+    /// Whether execution is inside a function body.
     pub in_function: bool,
+    /// Current loop nesting depth.
     pub loop_depth: u32,
+    /// Whether execution is inside a subshell-like environment.
     pub in_subshell: bool,
+    /// Whether execution is inside a brace or block context.
     pub in_block: bool,
+    /// Whether the command's exit status is checked by surrounding syntax.
     pub exit_status_checked: bool,
 }
 
+/// Role a command plays when it appears in a condition list.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandConditionRole {
+    /// An `if` condition command.
     If,
+    /// An `elif` condition command.
     Elif,
+    /// A `while` condition command.
     While,
+    /// An `until` condition command.
     Until,
 }
 
+/// Control-flow graph built from the semantic command stream.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControlFlowGraph {
     blocks: Vec<BasicBlock>,
@@ -75,14 +103,17 @@ pub struct ControlFlowGraph {
 type FlowEdge = (BlockId, EdgeKind);
 
 impl ControlFlowGraph {
+    /// Returns all basic blocks in allocation order.
     pub fn blocks(&self) -> &[BasicBlock] {
         &self.blocks
     }
 
+    /// Returns the block with identifier `id`.
     pub fn block(&self, id: BlockId) -> &BasicBlock {
         &self.blocks[id.index()]
     }
 
+    /// Returns the outgoing edges from block `id`.
     pub fn successors(&self, id: BlockId) -> &[(BlockId, EdgeKind)] {
         self.successors
             .get(id.index())
@@ -90,6 +121,7 @@ impl ControlFlowGraph {
             .unwrap_or(&[])
     }
 
+    /// Returns the incoming predecessors of block `id`.
     pub fn predecessors(&self, id: BlockId) -> &[BlockId] {
         self.predecessors
             .get(id.index())
@@ -97,26 +129,32 @@ impl ControlFlowGraph {
             .unwrap_or(&[])
     }
 
+    /// Returns the entry block for the whole script.
     pub fn entry(&self) -> BlockId {
         self.entry
     }
 
+    /// Returns all exit blocks, including exits caused by explicit termination.
     pub fn exits(&self) -> &[BlockId] {
         &self.exits
     }
 
+    /// Returns exits reachable without an explicit script terminator.
     pub fn natural_exits(&self) -> &[BlockId] {
         &self.natural_exits
     }
 
+    /// Returns blocks that terminate script execution, such as `exit` or top-level `return`.
     pub fn script_terminators(&self) -> &[BlockId] {
         &self.script_terminators
     }
 
+    /// Returns whether every reachable path through the script terminates.
     pub fn script_always_terminates(&self) -> bool {
         self.script_always_terminates
     }
 
+    /// Returns the entry block for `scope`, when the CFG records one.
     pub fn scope_entry(&self, scope: ScopeId) -> Option<BlockId> {
         self.scope_entries.get(&scope).copied()
     }
@@ -125,6 +163,7 @@ impl ControlFlowGraph {
         self.scope_exits.get(&scope).map(SmallVec::as_slice)
     }
 
+    /// Returns blocks proven unreachable.
     pub fn unreachable(&self) -> &[BlockId] {
         &self.unreachable
     }
@@ -141,9 +180,12 @@ impl ControlFlowGraph {
     }
 }
 
+/// Broad category for an unreachable-code cause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnreachableCauseKind {
+    /// A shell terminator such as `exit`, `return`, or fatal control transfer.
     ShellTerminator,
+    /// Loop control such as `break` or `continue`.
     LoopControl,
 }
 
@@ -186,6 +228,7 @@ pub(crate) struct RecordedProgram {
     pub(crate) call_command_spans: FxHashMap<SpanKey, Span>,
 }
 
+/// A statement-sequence item flattened out of structured syntax.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StatementSequenceCommand {
     body_span: Span,
@@ -193,36 +236,49 @@ pub struct StatementSequenceCommand {
 }
 
 impl StatementSequenceCommand {
+    /// Returns the span of the command body without trailing statement punctuation.
     pub fn body_span(&self) -> Span {
         self.body_span
     }
 
+    /// Returns the span of the full statement item.
     pub fn stmt_span(&self) -> Span {
         self.stmt_span
     }
 }
 
+/// Stable identifier for a semantic command in the recorded command stream.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct CommandId(pub(crate) u32);
 
 impl CommandId {
+    /// Returns the zero-based index used by internal command-storage vectors.
     pub fn index(self) -> usize {
         self.0 as usize
     }
 }
 
+/// High-level command category recorded by semantic traversal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CommandKind {
+    /// A simple command.
     Simple,
+    /// A builtin command with one of the tracked control-flow forms.
     Builtin(BuiltinCommandKind),
+    /// A declaration builtin command.
     Decl,
+    /// A binary command such as `[[ ... ]]` or `(( ... ))`.
     Binary,
+    /// A compound command.
     Compound(CompoundCommandKind),
+    /// A named function definition.
     Function,
+    /// An anonymous function-like definition.
     AnonymousFunction,
 }
 
 impl CommandKind {
+    /// Classifies a parsed AST command into a semantic command kind.
     pub fn from_command(command: &Command) -> Self {
         match command {
             Command::Simple(_) => Self::Simple,
@@ -238,11 +294,16 @@ impl CommandKind {
     }
 }
 
+/// Builtin command kinds that affect control flow directly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BuiltinCommandKind {
+    /// `break`
     Break,
+    /// `continue`
     Continue,
+    /// `return`
     Return,
+    /// `exit`
     Exit,
 }
 
@@ -257,23 +318,40 @@ impl BuiltinCommandKind {
     }
 }
 
+/// Compound command kinds tracked by semantic analysis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CompoundCommandKind {
+    /// `if`
     If,
+    /// `for`
     For,
+    /// `repeat`
     Repeat,
+    /// `foreach`
     Foreach,
+    /// Arithmetic `for (( ...; ...; ... ))`
     ArithmeticFor,
+    /// `while`
     While,
+    /// `until`
     Until,
+    /// `case`
     Case,
+    /// `select`
     Select,
+    /// Subshell `( ... )`
     Subshell,
+    /// Brace group `{ ...; }`
     BraceGroup,
+    /// Arithmetic command.
     Arithmetic,
+    /// `time`
     Time,
+    /// Conditional command such as `[[ ... ]]`.
     Conditional,
+    /// `coproc`
     Coproc,
+    /// `always`
     Always,
 }
 

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -5,9 +5,12 @@ use std::path::{Path, PathBuf};
 
 use crate::SourcePathResolver;
 
+/// Confidence attached to a provided binding or function contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ContractCertainty {
+    /// The contract is guaranteed along the observed path.
     Definite,
+    /// The contract may apply, but not on every path.
     Possible,
 }
 
@@ -20,16 +23,22 @@ impl ContractCertainty {
     }
 }
 
+/// Kind of binding described by a contract.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProvidedBindingKind {
+    /// A variable binding.
     Variable,
+    /// A function binding.
     Function,
 }
 
+/// Whether a file-entry provided binding is definitely initialized on entry.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum FileEntryBindingInitialization {
+    /// The binding is ambiently available but not guaranteed initialized.
     #[default]
     AmbientOnly,
+    /// The binding is definitely initialized at file entry.
     Initialized,
 }
 
@@ -42,15 +51,21 @@ impl FileEntryBindingInitialization {
     }
 }
 
+/// One binding provided by an imported file or ambient contract.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ProvidedBinding {
+    /// Provided binding name.
     pub name: Name,
+    /// Provided binding kind.
     pub kind: ProvidedBindingKind,
+    /// Confidence attached to the binding.
     pub certainty: ContractCertainty,
+    /// Whether the binding is initialized at file entry.
     pub file_entry_initialization: FileEntryBindingInitialization,
 }
 
 impl ProvidedBinding {
+    /// Creates a provided binding that is ambiently available but not definitely initialized.
     pub fn new(name: Name, kind: ProvidedBindingKind, certainty: ContractCertainty) -> Self {
         Self {
             name,
@@ -60,6 +75,7 @@ impl ProvidedBinding {
         }
     }
 
+    /// Creates a provided binding that is definitely initialized at file entry.
     pub fn new_file_entry_initialized(
         name: Name,
         kind: ProvidedBindingKind,
@@ -74,15 +90,21 @@ impl ProvidedBinding {
     }
 }
 
+/// Contract for one provided function.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FunctionContract {
+    /// Function name.
     pub name: Name,
+    /// Names the function is expected to read from its caller environment.
     pub required_reads: Vec<Name>,
+    /// Bindings the function may provide to its caller or nested analysis.
     pub provided_bindings: Vec<ProvidedBinding>,
+    /// Source files that contributed this function contract.
     pub origin_paths: Vec<PathBuf>,
 }
 
 impl FunctionContract {
+    /// Creates an empty contract for `name`.
     pub fn new(name: Name) -> Self {
         Self {
             name,
@@ -92,12 +114,14 @@ impl FunctionContract {
         }
     }
 
+    /// Adds a required read if it has not already been recorded.
     pub fn add_required_read(&mut self, name: Name) {
         if !self.required_reads.contains(&name) {
             self.required_reads.push(name);
         }
     }
 
+    /// Adds or merges a provided binding into this function contract.
     pub fn add_provided_binding(&mut self, binding: ProvidedBinding) {
         let mut merged = false;
         for existing in &mut self.provided_bindings {
@@ -116,6 +140,7 @@ impl FunctionContract {
         }
     }
 
+    /// Records a contributing origin path if it has not already been seen.
     pub fn add_origin_path(&mut self, path: PathBuf) {
         if !self.origin_paths.contains(&path) {
             self.origin_paths.push(path);
@@ -163,11 +188,16 @@ impl FunctionContract {
     }
 }
 
+/// Aggregate contract applied at file entry before final semantic resolution.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct FileContract {
+    /// Names required from the ambient environment before the file runs.
     pub required_reads: Vec<Name>,
+    /// Bindings provided by entering the file.
     pub provided_bindings: Vec<ProvidedBinding>,
+    /// Functions provided by entering the file.
     pub provided_functions: Vec<FunctionContract>,
+    /// Whether the file may consume bindings through external runtime behavior.
     pub externally_consumed_bindings: bool,
 }
 
@@ -185,12 +215,14 @@ pub trait FileEntryContractCollector {
 }
 
 impl FileContract {
+    /// Adds a required read if it has not already been recorded.
     pub fn add_required_read(&mut self, name: Name) {
         if !self.required_reads.contains(&name) {
             self.required_reads.push(name);
         }
     }
 
+    /// Adds or merges a provided binding into the file contract.
     pub fn add_provided_binding(&mut self, binding: ProvidedBinding) {
         let mut merged = false;
         for existing in &mut self.provided_bindings {
@@ -209,6 +241,7 @@ impl FileContract {
         }
     }
 
+    /// Adds or merges a provided function into the file contract.
     pub fn add_provided_function(&mut self, function: FunctionContract) {
         let mut merged = false;
         for existing in &mut self.provided_functions {
@@ -287,13 +320,21 @@ impl FileContract {
     }
 }
 
+/// Options that control how a [`crate::SemanticModel`] is built.
 pub struct SemanticBuildOptions<'a> {
+    /// Path of the file being analyzed, used for source-closure resolution and diagnostics.
     pub source_path: Option<&'a Path>,
+    /// Resolver for mapping source-like paths to candidate tracked files.
     pub source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
+    /// Precomputed file-entry contract to apply before analysis.
     pub file_entry_contract: Option<FileContract>,
+    /// Optional observer that can derive a file-entry contract during traversal.
     pub file_entry_contract_collector: Option<&'a mut dyn FileEntryContractCollector>,
+    /// Paths already analyzed in the current source-closure walk.
     pub analyzed_paths: Option<&'a rustc_hash::FxHashSet<PathBuf>>,
+    /// Explicit shell profile to use instead of inferring one from the source.
     pub shell_profile: Option<ShellProfile>,
+    /// Whether sourced-file closure metadata should be resolved and imported.
     pub resolve_source_closure: bool,
 }
 

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -15,54 +15,81 @@ use crate::{
 };
 use std::sync::OnceLock;
 
+/// Materialized reaching-definition sets for each CFG block.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReachingDefinitions {
+    /// Definitions reaching the start of each block.
     pub reaching_in: FxHashMap<BlockId, FxHashSet<BindingId>>,
+    /// Definitions reaching the end of each block.
     pub reaching_out: FxHashMap<BlockId, FxHashSet<BindingId>>,
 }
 
+/// One assignment that was proven unused together with the reason.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnusedAssignment {
+    /// Unused binding.
     pub binding: BindingId,
+    /// Why the assignment is considered unused.
     pub reason: UnusedReason,
 }
 
+/// Reason an assignment is considered unused.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UnusedReason {
-    Overwritten { by: BindingId },
+    /// The value is overwritten before any read.
+    Overwritten {
+        /// Binding that overwrites the unused value.
+        by: BindingId,
+    },
+    /// Control reaches the end of its relevant scope without a read.
     ScopeEnd,
 }
 
+/// One reference that may read an uninitialized binding.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UninitializedReference {
+    /// Reference that may be uninitialized.
     pub reference: ReferenceId,
+    /// How certain the analysis is.
     pub certainty: UninitializedCertainty,
 }
 
+/// Confidence for an uninitialized-reference result.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UninitializedCertainty {
+    /// Every feasible path leaves the reference uninitialized.
     Definite,
+    /// At least one feasible path leaves the reference uninitialized.
     Possible,
 }
 
+/// One region of unreachable code and the syntax that makes it unreachable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeadCode {
+    /// Spans classified as unreachable.
     pub unreachable: Vec<Span>,
+    /// Span of the control-flow construct that causes the region to be unreachable.
     pub cause: Span,
+    /// Broad category for the cause.
     pub cause_kind: UnreachableCauseKind,
 }
 
 #[cfg(test)]
+/// Full dataflow result materialized for crate tests.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataflowResult {
+    /// Unused-assignment diagnostics with reasons.
     pub unused_assignments: Vec<UnusedAssignment>,
+    /// Uninitialized-reference diagnostics.
     pub uninitialized_references: Vec<UninitializedReference>,
+    /// Unreachable-code diagnostics.
     pub dead_code: Vec<DeadCode>,
     pub(crate) unused_assignment_ids: Vec<BindingId>,
 }
 
 #[cfg(test)]
 impl DataflowResult {
+    /// Returns the binding ids reported as unused in test-only result materialization.
     pub fn unused_assignment_ids(&self) -> &[BindingId] {
         &self.unused_assignment_ids
     }

--- a/crates/shuck-semantic/src/declaration.rs
+++ b/crates/shuck-semantic/src/declaration.rs
@@ -36,8 +36,8 @@ pub enum DeclarationOperand {
     Flag {
         /// Canonical single-character flag represented by the operand.
         flag: char,
-        flags: CompactString,
         /// Raw flag text, preserving grouped characters.
+        flags: CompactString,
         /// Span of the operand.
         span: Span,
     },

--- a/crates/shuck-semantic/src/declaration.rs
+++ b/crates/shuck-semantic/src/declaration.rs
@@ -3,45 +3,75 @@ use shuck_ast::{Name, Span};
 
 use crate::AssignmentValueOrigin;
 
+/// Declaration builtin that introduced a declaration record.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeclarationBuiltin {
+    /// `declare`
     Declare,
+    /// `local`
     Local,
+    /// `export`
     Export,
+    /// `readonly`
     Readonly,
+    /// `typeset`
     Typeset,
 }
 
+/// One declaration command together with its parsed operands.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Declaration {
+    /// Builtin command that owns the declaration.
     pub builtin: DeclarationBuiltin,
+    /// Span of the declaration command.
     pub span: Span,
+    /// Ordered operands after the builtin name.
     pub operands: Vec<DeclarationOperand>,
 }
 
+/// Operand recorded for a declaration builtin.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DeclarationOperand {
+    /// A flag operand such as `-x`.
     Flag {
+        /// Canonical single-character flag represented by the operand.
         flag: char,
         flags: CompactString,
+        /// Raw flag text, preserving grouped characters.
+        /// Span of the operand.
         span: Span,
     },
+    /// A bare name operand.
     Name {
+        /// Declared name.
         name: Name,
+        /// Span of the operand.
         span: Span,
     },
+    /// A name/value assignment operand.
     Assignment {
+        /// Assigned name.
         name: Name,
+        /// Span of the whole operand.
         operand_span: Span,
+        /// Span of the assignment target portion.
         target_span: Span,
+        /// Span of the name token.
         name_span: Span,
+        /// Span of the value portion.
         value_span: Span,
+        /// Whether the operand uses append syntax like `+=`.
         append: bool,
+        /// Classification of the assigned value.
         value_origin: AssignmentValueOrigin,
+        /// Whether the value contains command substitution syntax.
         has_command_substitution: bool,
+        /// Whether the value contains command or process substitution syntax.
         has_command_or_process_substitution: bool,
     },
+    /// An operand whose runtime word shape is too dynamic to normalize further.
     DynamicWord {
+        /// Span of the dynamic operand.
         span: Span,
     },
 }

--- a/crates/shuck-semantic/src/function_call_reachability.rs
+++ b/crates/shuck-semantic/src/function_call_reachability.rs
@@ -3,31 +3,43 @@ use super::*;
 /// Direct function-call candidate supplied by higher-level analyses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionCallCandidate {
+    /// Callee name.
     pub callee: Name,
+    /// Scope that contains the call.
     pub scope: ScopeId,
+    /// Span of the callee token.
     pub name_span: Span,
+    /// Span of the enclosing command.
     pub command_span: Span,
 }
 
 /// Controls whether transient execution contexts are accepted for a direct-call query.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum FunctionCallPersistence {
+    /// Count calls regardless of whether they happen in transient contexts.
     #[default]
     Any,
+    /// Count only calls whose effects can persist in the parent environment.
     PersistentOnly,
 }
 
 /// Offset and scope constraints for a direct function-call reachability query.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DirectFunctionCallWindow {
+    /// Inclusive lower offset bound for eligible calls.
     pub after_offset: usize,
+    /// Exclusive upper offset bound for eligible calls.
     pub before_offset: usize,
+    /// Whether transient execution contexts are acceptable.
     pub persistence: FunctionCallPersistence,
+    /// Optional scope boundary that eligible calls must stay within.
     pub scope_boundary: Option<ScopeId>,
+    /// Whether the call itself must avoid transient command contexts.
     pub require_non_transient_call: bool,
 }
 
 impl DirectFunctionCallWindow {
+    /// Creates a window that accepts calls before `before_offset`.
     pub fn before_offset(before_offset: usize) -> Self {
         Self {
             after_offset: 0,
@@ -38,6 +50,7 @@ impl DirectFunctionCallWindow {
         }
     }
 
+    /// Creates a window that accepts calls between `after_offset` and `before_offset`.
     pub fn between_offsets(after_offset: usize, before_offset: usize) -> Self {
         Self {
             after_offset,
@@ -48,16 +61,19 @@ impl DirectFunctionCallWindow {
         }
     }
 
+    /// Restricts the window to persistently reachable calls only.
     pub fn persistent(mut self) -> Self {
         self.persistence = FunctionCallPersistence::PersistentOnly;
         self
     }
 
+    /// Requires the call site itself to avoid transient command contexts.
     pub fn require_non_transient_call(mut self) -> Self {
         self.require_non_transient_call = true;
         self
     }
 
+    /// Restricts the window to calls that stay within `scope`.
     pub fn within_scope(mut self, scope: ScopeId) -> Self {
         self.scope_boundary = Some(scope);
         self
@@ -144,12 +160,14 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
         }
     }
 
+    /// Enables an auxiliary activation index that speeds up repeated reachability queries.
     pub fn enable_activation_index(&mut self) {
         if self.activation_index.is_none() {
             self.activation_index = Some(self.build_activation_index());
         }
     }
 
+    /// Returns whether `binding_id` has a direct call that satisfies `window`.
     pub fn binding_has_reachable_direct_call(
         &mut self,
         binding_id: BindingId,
@@ -178,6 +196,7 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
         )
     }
 
+    /// Returns whether `scope` can execute before `before_offset`.
     pub fn scope_can_run_before_offset(
         &mut self,
         scope: ScopeId,
@@ -199,6 +218,7 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
         }
     }
 
+    /// Returns whether `scope` can execute between `after_offset` and `before_offset`.
     pub fn scope_can_run_between_offsets(
         &mut self,
         scope: ScopeId,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -5,49 +5,27 @@
 //!
 //! The semantic model tracks scopes, bindings, references, control flow, and selected dataflow
 //! facts so higher-level crates can reason about shell behavior without re-traversing the AST.
-#[allow(missing_docs)]
 mod analysis;
-#[allow(missing_docs)]
 mod binding;
-#[allow(missing_docs)]
 mod builder;
-#[allow(missing_docs)]
 mod call_graph;
-#[allow(missing_docs)]
 mod cfg;
-#[allow(missing_docs)]
 mod contract;
-#[allow(missing_docs)]
 mod dataflow;
-#[allow(missing_docs)]
 mod declaration;
-#[allow(missing_docs)]
 mod dense_bit_set;
-#[allow(missing_docs)]
 mod function_call_reachability;
-#[allow(missing_docs)]
 mod function_resolution;
-#[allow(missing_docs)]
 mod nonpersistent;
-#[allow(missing_docs)]
 mod reachability;
-#[allow(missing_docs)]
 mod reference;
-#[allow(missing_docs)]
 mod runtime;
-#[allow(missing_docs)]
 mod scope;
-#[allow(missing_docs)]
 mod source_closure;
-#[allow(missing_docs)]
 mod source_ref;
-#[allow(missing_docs)]
 mod uninitialized;
-#[allow(missing_docs)]
 mod unused;
-#[allow(missing_docs)]
 mod value_flow;
-#[allow(missing_docs)]
 mod zsh_options;
 
 /// Binding types and provenance metadata discovered during semantic analysis.
@@ -350,12 +328,13 @@ pub struct FunctionPositionalReferenceSummary {
     uses_unprotected_positional_parameters: bool,
 }
 
-#[allow(missing_docs)]
 impl FunctionPositionalReferenceSummary {
+    /// Returns the highest positional argument index that is definitely required.
     pub fn required_arg_count(self) -> usize {
         self.required_arg_count
     }
 
+    /// Returns whether the function reads positional parameters without a guarding default.
     pub fn uses_unprotected_positional_parameters(self) -> bool {
         self.uses_unprotected_positional_parameters
     }
@@ -390,16 +369,18 @@ pub struct UnreachedFunctionAnalysisOptions {
     pub report_unreached_nested_definitions: bool,
 }
 
-#[allow(missing_docs)]
 impl SyntheticRead {
+    /// Returns the scope where the synthetic read should be considered visible.
     pub fn scope(&self) -> ScopeId {
         self.scope
     }
 
+    /// Returns the span that higher layers should attribute to the synthetic read.
     pub fn span(&self) -> Span {
         self.span
     }
 
+    /// Returns the runtime name read by this synthetic entry.
     pub fn name(&self) -> &Name {
         &self.name
     }
@@ -767,12 +748,13 @@ pub enum SemanticPipelineOperatorKind {
     PipeAll,
 }
 
-#[allow(missing_docs)]
 impl SemanticModel {
+    /// Builds a semantic model for `file` using the default build options.
     pub fn build(file: &File, source: &str, indexer: &Indexer) -> Self {
         Self::build_with_options(file, source, indexer, SemanticBuildOptions::default())
     }
 
+    /// Builds a semantic model for `file` using explicit semantic build options.
     pub fn build_with_options(
         file: &File,
         source: &str,
@@ -859,28 +841,34 @@ impl SemanticModel {
         }
     }
 
+    /// Returns a lazy analysis view that computes CFG, dataflow, and reachability on demand.
     pub fn analysis(&self) -> SemanticAnalysis<'_> {
         SemanticAnalysis::new(self)
     }
 
+    /// Returns the shell profile used when building this model.
     pub fn shell_profile(&self) -> &ShellProfile {
         &self.shell_profile
     }
 
+    /// Returns the zsh option state visible at `offset`, when the model tracks zsh options.
     pub fn zsh_options_at(&self, offset: usize) -> Option<&ZshOptionState> {
         self.zsh_option_analysis
             .as_ref()
             .and_then(|analysis| analysis.options_at(&self.scopes, offset))
     }
 
+    /// Returns all semantic scopes discovered in the file.
     pub fn scopes(&self) -> &[Scope] {
         &self.scopes
     }
 
+    /// Returns the scope identified by `id`.
     pub fn scope(&self, id: ScopeId) -> &Scope {
         &self.scopes[id.index()]
     }
 
+    /// Returns all semantic bindings discovered in the file.
     pub fn bindings(&self) -> &[Binding] {
         &self.bindings
     }
@@ -900,6 +888,7 @@ impl SemanticModel {
         ids.iter().map(|id| &self.bindings[id.index()])
     }
 
+    /// Returns all semantic references discovered in the file.
     pub fn references(&self) -> &[Reference] {
         &self.references
     }
@@ -1033,10 +1022,12 @@ impl SemanticModel {
         }
     }
 
+    /// Returns the binding identified by `id`.
     pub fn binding(&self, id: BindingId) -> &Binding {
         &self.bindings[id.index()]
     }
 
+    /// Returns the binding introduced at exactly `span`, when such a definition is indexed.
     pub fn binding_for_definition_span(&self, span: Span) -> Option<BindingId> {
         let index = self
             .bindings_by_definition_span
@@ -1044,16 +1035,19 @@ impl SemanticModel {
         index.get(&SpanKey::new(span)).copied()
     }
 
+    /// Returns the reference identified by `id`.
     pub fn reference(&self, id: ReferenceId) -> &Reference {
         &self.references[id.index()]
     }
 
+    /// Returns the binding resolved for `id`, if reference resolution succeeded.
     pub fn resolved_binding(&self, id: ReferenceId) -> Option<&Binding> {
         self.resolved
             .get(&id)
             .map(|binding| &self.bindings[binding.index()])
     }
 
+    /// Returns whether `id` names a predefined runtime array variable.
     pub fn reference_is_predefined_runtime_array(&self, id: ReferenceId) -> bool {
         self.predefined_runtime_refs.contains(&id)
             && self
@@ -1062,14 +1056,18 @@ impl SemanticModel {
                 .is_some_and(|reference| self.runtime.is_preinitialized_array(&reference.name))
     }
 
+    /// Returns whether `id` is guarded by parameter-expansion syntax that suppresses missing-name
+    /// diagnostics.
     pub fn is_guarded_parameter_reference(&self, id: ReferenceId) -> bool {
         self.guarded_parameter_refs.contains(&id)
     }
 
+    /// Returns whether `id` appears inside a defaulting parameter operand.
     pub fn is_defaulting_parameter_operand_reference(&self, id: ReferenceId) -> bool {
         self.defaulting_parameter_operand_refs.contains(&id)
     }
 
+    /// Returns bindings that may be targeted by indirect reads through `id`.
     pub fn indirect_targets_for_binding(&self, id: BindingId) -> &[BindingId] {
         self.indirect_targets_by_binding
             .get(&id)
@@ -1077,6 +1075,7 @@ impl SemanticModel {
             .unwrap_or(&[])
     }
 
+    /// Returns bindings that may be targeted by the indirect reference `id`.
     pub fn indirect_targets_for_reference(&self, id: ReferenceId) -> &[BindingId] {
         self.indirect_targets_by_reference
             .get(&id)
@@ -1084,6 +1083,7 @@ impl SemanticModel {
             .unwrap_or(&[])
     }
 
+    /// Returns bindings recorded for `name`, ordered by definition offset.
     pub fn bindings_for(&self, name: &Name) -> &[BindingId] {
         self.binding_index
             .get(name)
@@ -1091,6 +1091,7 @@ impl SemanticModel {
             .unwrap_or(&[])
     }
 
+    /// Returns the latest binding for `name` that is visible at `at`.
     pub fn visible_binding(&self, name: &Name, at: Span) -> Option<&Binding> {
         self.previous_visible_binding(name, at, None)
     }
@@ -1134,6 +1135,8 @@ impl SemanticModel {
     }
 
     #[doc(hidden)]
+    /// Returns whether `binding_id` is lexically visible at `at`.
+    #[doc(hidden)]
     pub fn binding_visible_at(&self, binding_id: BindingId, at: Span) -> bool {
         let binding = self.binding(binding_id);
         binding.span.start.offset <= at.start.offset
@@ -1142,6 +1145,7 @@ impl SemanticModel {
                 .any(|scope| scope == binding.scope)
     }
 
+    /// Returns whether `binding_id` is cleared between its definition and `at`.
     #[doc(hidden)]
     pub fn binding_cleared_before(&self, binding_id: BindingId, at: Span) -> bool {
         let binding = self.binding(binding_id);
@@ -1154,6 +1158,7 @@ impl SemanticModel {
             })
     }
 
+    /// Returns whether `binding_id` and `reference_id` were recorded under the same command span.
     #[doc(hidden)]
     pub fn binding_and_reference_share_command(
         &self,
@@ -1169,6 +1174,8 @@ impl SemanticModel {
         })
     }
 
+    /// Returns the previous visible binding for `name` at `at`, optionally ignoring one exact
+    /// binding span.
     #[doc(hidden)]
     pub fn previous_visible_binding(
         &self,
@@ -1186,6 +1193,7 @@ impl SemanticModel {
         .map(|binding_id| self.binding(binding_id))
     }
 
+    /// Returns the binding visible for an associative-array lookup in `current_scope`.
     #[doc(hidden)]
     pub fn visible_binding_for_assoc_lookup(
         &self,
@@ -1278,10 +1286,12 @@ impl SemanticModel {
             })
     }
 
+    /// Returns whether any binding for `name` exists in the model.
     pub fn defined_anywhere(&self, name: &Name) -> bool {
         self.binding_index.contains_key(name)
     }
 
+    /// Returns whether `name` is defined inside at least one function scope.
     pub fn defined_in_any_function(&self, name: &Name) -> bool {
         self.binding_index.get(name).is_some_and(|bindings| {
             bindings.iter().any(|binding| {
@@ -1293,12 +1303,15 @@ impl SemanticModel {
         })
     }
 
+    /// Returns whether runtime behavior can consume `binding_id` even without a direct read in
+    /// the current file.
     pub fn is_runtime_consumed_binding(&self, binding_id: BindingId) -> bool {
         self.bindings
             .get(binding_id.index())
             .is_some_and(|binding| self.runtime.is_always_used_binding(&binding.name))
     }
 
+    /// Returns whether `name` has a required-read reference in `scope` before `offset`.
     pub fn required_before(&self, name: &Name, scope: ScopeId, offset: usize) -> bool {
         self.references.iter().any(|reference| {
             reference.scope == scope
@@ -1308,22 +1321,26 @@ impl SemanticModel {
         })
     }
 
+    /// Returns whether an ancestor scope outside `scope` defines `name`.
     pub fn maybe_defined_outside(&self, name: &Name, scope: ScopeId) -> bool {
         self.ancestor_scopes(scope)
             .skip(1)
             .any(|scope| self.scopes[scope.index()].bindings.contains_key(name))
     }
 
+    /// Returns references that did not resolve to any binding.
     pub fn unresolved_references(&self) -> &[ReferenceId] {
         &self.unresolved
     }
 
+    /// Returns the innermost semantic scope containing `offset`.
     pub fn scope_at(&self, offset: usize) -> ScopeId {
         self.scope_lookup
             .scope_at(&self.scopes, offset)
             .unwrap_or(ScopeId(0))
     }
 
+    /// Returns the kind metadata for `scope`.
     pub fn scope_kind(&self, scope: ScopeId) -> &ScopeKind {
         &self.scopes[scope.index()].kind
     }
@@ -1335,23 +1352,28 @@ impl SemanticModel {
         )
     }
 
+    /// Iterates `scope` and then each lexical ancestor scope outward.
     pub fn ancestor_scopes(&self, scope: ScopeId) -> impl Iterator<Item = ScopeId> + '_ {
         ancestor_scopes(&self.scopes, scope)
     }
 
+    /// Returns whether `scope` is equal to `ancestor_scope` or nested within it.
     pub fn scope_is_in_scope_or_descendant(&self, scope: ScopeId, ancestor_scope: ScopeId) -> bool {
         self.ancestor_scopes(scope)
             .any(|scope| scope == ancestor_scope)
     }
 
+    /// Returns whether `scope` is strictly nested within `ancestor_scope`.
     pub fn scope_is_descendant_of(&self, scope: ScopeId, ancestor_scope: ScopeId) -> bool {
         scope != ancestor_scope && self.scope_is_in_scope_or_descendant(scope, ancestor_scope)
     }
 
+    /// Returns the nearest enclosing function scope for `scope`, if one exists.
     pub fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
         enclosing_function_scope(&self.scopes, scope)
     }
 
+    /// Iterates transient ancestor scopes between `scope` and its enclosing function boundary.
     #[doc(hidden)]
     pub fn transient_ancestor_scopes_within_function(
         &self,
@@ -1362,11 +1384,13 @@ impl SemanticModel {
             .filter(|scope_id| self.scope_is_transient(*scope_id))
     }
 
+    /// Returns the innermost transient ancestor scope before crossing a function boundary.
     #[doc(hidden)]
     pub fn innermost_transient_scope_within_function(&self, scope: ScopeId) -> Option<ScopeId> {
         self.transient_ancestor_scopes_within_function(scope).next()
     }
 
+    /// Returns the enclosing function scope only when no transient boundary intervenes.
     #[doc(hidden)]
     pub fn enclosing_function_scope_without_transient_boundary(
         &self,
@@ -1456,6 +1480,7 @@ impl SemanticModel {
         })
     }
 
+    /// Returns the most specific recorded flow context associated with `span`.
     pub fn flow_context_at(&self, span: &Span) -> Option<&FlowContext> {
         self.flow_contexts
             .iter()
@@ -1734,6 +1759,7 @@ impl SemanticModel {
         None
     }
 
+    /// Returns same-name function-definition bindings for `name`, ordered by definition offset.
     pub fn function_definitions(&self, name: &Name) -> &[BindingId] {
         self.functions
             .get(name)
@@ -1741,6 +1767,7 @@ impl SemanticModel {
             .unwrap_or(&[])
     }
 
+    /// Returns recorded call sites for `name`.
     pub fn call_sites_for(&self, name: &Name) -> &[CallSite] {
         self.call_sites
             .get(name)
@@ -1748,14 +1775,17 @@ impl SemanticModel {
             .unwrap_or(&[])
     }
 
+    /// Returns the current call-graph summary for the model.
     pub fn call_graph(&self) -> &CallGraph {
         &self.call_graph
     }
 
+    /// Returns declaration commands recorded in the file.
     pub fn declarations(&self) -> &[Declaration] {
         &self.declarations
     }
 
+    /// Returns the declaration recorded for the command with syntax span `span`.
     pub fn declaration_for_command_span(&self, span: Span) -> Option<&Declaration> {
         let index = self
             .declarations_by_command_span
@@ -1765,6 +1795,7 @@ impl SemanticModel {
             .map(|declaration_index| &self.declarations[*declaration_index])
     }
 
+    /// Returns the function-definition binding recorded for command span `span`, if any.
     pub fn function_definition_binding_for_command_span(&self, span: Span) -> Option<BindingId> {
         self.command_bindings
             .get(&SpanKey::new(span))
@@ -1778,14 +1809,17 @@ impl SemanticModel {
             })
     }
 
+    /// Returns source-like file references discovered in the script.
     pub fn source_refs(&self) -> &[SourceRef] {
         &self.source_refs
     }
 
+    /// Returns synthetic reads introduced by contracts or semantic modeling.
     pub fn synthetic_reads(&self) -> &[SyntheticRead] {
         &self.synthetic_reads
     }
 
+    /// Returns origin paths that contributed the imported binding `id`.
     pub fn import_origins_for_binding(&self, id: BindingId) -> &[PathBuf] {
         self.import_origins_by_binding
             .get(&id)
@@ -1793,22 +1827,27 @@ impl SemanticModel {
             .unwrap_or(&[])
     }
 
+    /// Returns flattened statement-sequence commands recorded during traversal.
     pub fn statement_sequence_commands(&self) -> &[StatementSequenceCommand] {
         self.recorded_program.statement_sequence_commands()
     }
 
+    /// Returns the number of recorded semantic commands.
     pub fn command_count(&self) -> usize {
         self.recorded_program.commands().len()
     }
 
+    /// Returns command ids for every syntax-backed recorded command.
     pub fn commands(&self) -> &[CommandId] {
         &self.command_topology().syntax_backed_ids
     }
 
+    /// Returns command ids for the structural command stream.
     pub fn structural_commands(&self) -> &[CommandId] {
         &self.command_topology().structural_ids
     }
 
+    /// Returns the recorded semantic context for `id`.
     pub fn command_context(&self, id: CommandId) -> Option<&SemanticCommandContext> {
         self.command_topology()
             .contexts
@@ -1816,6 +1855,7 @@ impl SemanticModel {
             .and_then(Option::as_ref)
     }
 
+    /// Iterates recorded command contexts in command-id order.
     pub fn command_contexts(&self) -> impl Iterator<Item = &SemanticCommandContext> {
         self.command_topology()
             .contexts
@@ -1823,34 +1863,41 @@ impl SemanticModel {
             .filter_map(Option::as_ref)
     }
 
+    /// Iterates only structural command contexts.
     pub fn structural_command_contexts(&self) -> impl Iterator<Item = &SemanticCommandContext> {
         self.command_contexts()
             .filter(|context| context.is_structural())
     }
 
+    /// Returns the surrounding condition-list role for `id`, if one applies.
     pub fn command_condition_role(&self, id: CommandId) -> Option<CommandConditionRole> {
         self.command_context(id)
             .and_then(SemanticCommandContext::condition_role)
     }
 
+    /// Returns whether `id` came from a command-like expansion inside a word.
     pub fn command_is_nested_word_command(&self, id: CommandId) -> bool {
         self.command_context(id)
             .is_some_and(SemanticCommandContext::is_nested_word_command)
     }
 
+    /// Returns the recorded statement span for `id`.
     pub fn command_span(&self, id: CommandId) -> Span {
         self.recorded_program.command(id).span
     }
 
+    /// Returns the underlying syntax-node span for `id`.
     pub fn command_syntax_span(&self, id: CommandId) -> Span {
         self.recorded_program.command(id).syntax_span
     }
 
+    /// Returns the syntax-backed command kind for `id`.
     pub fn command_kind(&self, id: CommandId) -> CommandKind {
         self.command_syntax_kind(id)
             .expect("semantic command syntax kind is recorded")
     }
 
+    /// Returns the first syntax-backed command recorded for exact syntax span `span`.
     pub fn command_by_span(&self, span: Span) -> Option<CommandId> {
         self.command_topology()
             .ids_by_syntax_span
@@ -1862,6 +1909,7 @@ impl SemanticModel {
             })
     }
 
+    /// Returns the command recorded for exact syntax span `span` and syntax kind `kind`.
     pub fn command_by_span_and_kind(&self, span: Span, kind: CommandKind) -> Option<CommandId> {
         self.command_topology()
             .ids_by_syntax_span
@@ -1873,22 +1921,27 @@ impl SemanticModel {
             })
     }
 
+    /// Returns the structural parent command of `id`, if one exists.
     pub fn command_parent_id(&self, id: CommandId) -> Option<CommandId> {
         self.command_topology().parent_ids[id.index()]
     }
 
+    /// Returns structural child commands nested under `id`.
     pub fn command_children(&self, id: CommandId) -> &[CommandId] {
         &self.command_topology().child_ids[id.index()]
     }
 
+    /// Returns the syntax-backed parent command of `id`, if one exists.
     pub fn syntax_backed_command_parent_id(&self, id: CommandId) -> Option<CommandId> {
         self.command_topology().syntax_backed_parent_ids[id.index()]
     }
 
+    /// Returns syntax-backed child commands nested directly under `id`.
     pub fn syntax_backed_command_children(&self, id: CommandId) -> &[CommandId] {
         &self.command_topology().syntax_backed_child_ids[id.index()]
     }
 
+    /// Returns the innermost syntax-backed command whose syntax span contains `offset`.
     pub fn innermost_command_id_at(&self, offset: usize) -> Option<CommandId> {
         let topology = self.command_topology();
         let mut innermost = None;
@@ -1904,6 +1957,7 @@ impl SemanticModel {
         innermost
     }
 
+    /// Returns the innermost command known to contain `offset` using the topology index.
     pub fn innermost_command_id_containing_offset(&self, offset: usize) -> Option<CommandId> {
         let topology = self.command_topology();
         let upper_bound = topology

--- a/crates/shuck-semantic/src/reachability.rs
+++ b/crates/shuck-semantic/src/reachability.rs
@@ -18,20 +18,22 @@ struct FunctionReachWindow<'a> {
     script_terminators: &'a FxHashSet<BlockId>,
 }
 
-#[allow(missing_docs)]
 impl<'model> SemanticAnalysis<'model> {
+    /// Returns same-name function definitions that are overwritten by a later definition.
     pub fn overwritten_functions(&self) -> &[OverwrittenFunction] {
         self.overwritten_functions
             .get_or_init(|| self.compute_overwritten_functions())
             .as_slice()
     }
 
+    /// Returns function definitions that are not reached by any viable direct call chain.
     pub fn unreached_functions(&self) -> &[UnreachedFunction] {
         self.unreached_functions
             .get_or_init(|| self.compute_unreached_functions_with_options(Default::default()))
             .as_slice()
     }
 
+    /// Returns unreached function definitions using the requested reporting options.
     pub fn unreached_functions_with_options(
         &self,
         options: UnreachedFunctionAnalysisOptions,
@@ -45,6 +47,7 @@ impl<'model> SemanticAnalysis<'model> {
             .as_slice()
     }
 
+    /// Returns reachable CFG blocks that contain `binding_id`.
     pub fn reachable_blocks_for_binding(&self, binding_id: BindingId) -> Vec<BlockId> {
         let unreachable = self.unreachable_blocks();
         self.blocks_containing_binding(binding_id)
@@ -71,11 +74,13 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    /// Returns blocks that would shadow `binding_id` with a later same-name function definition.
     pub fn shadow_function_blocks_for_binding(&self, binding_id: BindingId) -> FxHashSet<BlockId> {
         let binding = self.model.binding(binding_id);
         self.shadow_function_blocks_from_cfg(&binding.name, binding_id, self.unreachable_blocks())
     }
 
+    /// Returns whether some path exists from `starts` to `ends` without entering `avoid`.
     pub fn blocks_have_path_avoiding(
         &self,
         starts: &[BlockId],
@@ -85,6 +90,7 @@ impl<'model> SemanticAnalysis<'model> {
         blocks_have_path_avoiding(self.cfg(), starts, ends, avoid)
     }
 
+    /// Returns whether `scope` runs inside a transient execution context such as a subshell.
     pub fn scope_runs_in_transient_context(&self, scope: ScopeId) -> bool {
         self.model.ancestor_scopes(scope).any(|scope_id| {
             matches!(
@@ -94,10 +100,12 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    /// Returns whether a call site in `scope` runs in a transient execution context.
     pub fn call_site_runs_in_transient_context(&self, scope: ScopeId) -> bool {
         self.scope_runs_in_transient_context(scope)
     }
 
+    /// Returns the nearest non-anonymous enclosing function scope for `scope`.
     pub fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
         self.model.ancestor_scopes(scope).find(|scope_id| {
             matches!(
@@ -107,6 +115,8 @@ impl<'model> SemanticAnalysis<'model> {
         })
     }
 
+    /// Returns whether a call site could resolve to `binding_id` under both lexical visibility and
+    /// CFG reachability constraints.
     pub fn function_call_may_resolve_to_binding(
         &self,
         binding_id: BindingId,

--- a/crates/shuck-semantic/src/reference.rs
+++ b/crates/shuck-semantic/src/reference.rs
@@ -2,6 +2,7 @@ use shuck_ast::{Name, Span};
 
 use crate::ScopeId;
 
+/// Stable identifier for a semantic reference recorded in a [`crate::SemanticModel`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ReferenceId(pub(crate) u32);
 
@@ -11,29 +12,50 @@ impl ReferenceId {
     }
 }
 
+/// One semantic read-like use of a shell name.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Reference {
+    /// Unique identifier for this reference.
     pub id: ReferenceId,
+    /// Referenced shell name.
     pub name: Name,
+    /// Semantic category for the use.
     pub kind: ReferenceKind,
+    /// Scope active at the use site.
     pub scope: ScopeId,
+    /// Source span of the use.
     pub span: Span,
 }
 
+/// Semantic category for a shell name use.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReferenceKind {
+    /// The declared name operand in a command such as `local foo`.
     DeclarationName,
+    /// A normal parameter expansion such as `$foo` or `${foo}`.
     Expansion,
+    /// A read modeled implicitly by semantic analysis rather than direct syntax.
     ImplicitRead,
+    /// A parameter expansion that participates in operator semantics.
     ParameterExpansion,
+    /// A parameter-length expansion such as `${#foo}`.
     Length,
+    /// An array element or slice access.
     ArrayAccess,
+    /// An indirect expansion such as `${!name}`.
     IndirectExpansion,
+    /// A read inside arithmetic evaluation.
     ArithmeticRead,
+    /// A prompt-string expansion.
     PromptExpansion,
+    /// A variable use inside a trap action.
     TrapAction,
+    /// A parameter use inside a pattern operator such as `${x%$pat}`.
     ParameterPattern,
+    /// A variable use inside arithmetic that computes parameter slicing bounds.
     ParameterSliceArithmetic,
+    /// A use inside a conditional command operand.
     ConditionalOperand,
+    /// A required runtime read introduced by contracts or semantic modeling.
     RequiredRead,
 }

--- a/crates/shuck-semantic/src/scope.rs
+++ b/crates/shuck-semantic/src/scope.rs
@@ -3,6 +3,7 @@ use shuck_ast::{Name, Span};
 
 use crate::BindingId;
 
+/// Stable identifier for one semantic scope in a [`crate::SemanticModel`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ScopeId(pub(crate) u32);
 
@@ -36,23 +37,34 @@ pub(crate) fn enclosing_function_scope(scopes: &[Scope], start: ScopeId) -> Opti
     })
 }
 
+/// Lexical scope discovered during semantic traversal.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Scope {
+    /// Unique identifier for this scope.
     pub id: ScopeId,
+    /// Semantic kind of scope.
     pub kind: ScopeKind,
+    /// Lexical parent scope, when one exists.
     pub parent: Option<ScopeId>,
+    /// Source span covered by the scope.
     pub span: Span,
+    /// Bindings introduced directly in this scope, grouped by name.
     pub bindings: FxHashMap<Name, Vec<BindingId>>,
 }
 
+/// Additional classification for function scopes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FunctionScopeKind {
+    /// A function with one or more static names visible from source.
     Named(Vec<Name>),
+    /// A function-like scope whose name is resolved dynamically.
     Dynamic,
+    /// A function body without a user-visible static function name.
     Anonymous,
 }
 
 impl FunctionScopeKind {
+    /// Returns the statically known function names for this scope, if any.
     pub fn static_names(&self) -> &[Name] {
         match self {
             Self::Named(names) => names.as_slice(),
@@ -60,32 +72,42 @@ impl FunctionScopeKind {
         }
     }
 
+    /// Returns whether `name` is one of this scope's statically known names.
     pub fn contains_name(&self, name: &Name) -> bool {
         self.static_names()
             .iter()
             .any(|candidate| candidate == name)
     }
 
+    /// Returns whether `name` matches one of this scope's statically known names.
     pub fn contains_name_str(&self, name: &str) -> bool {
         self.static_names()
             .iter()
             .any(|candidate| candidate.as_str() == name)
     }
 
+    /// Returns whether this function scope is dynamically named.
     pub fn is_dynamic(&self) -> bool {
         matches!(self, Self::Dynamic)
     }
 
+    /// Returns whether this function scope has no user-visible static name.
     pub fn is_anonymous(&self) -> bool {
         matches!(self, Self::Anonymous)
     }
 }
 
+/// High-level category for a semantic scope.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScopeKind {
+    /// The file-level scope.
     File,
+    /// A function body scope.
     Function(FunctionScopeKind),
+    /// A subshell scope such as `( ... )`.
     Subshell,
+    /// A command substitution scope such as `$( ... )`.
     CommandSubstitution,
+    /// A pipeline component scope whose side effects may be transient.
     Pipeline,
 }

--- a/crates/shuck-semantic/src/source_ref.rs
+++ b/crates/shuck-semantic/src/source_ref.rs
@@ -1,35 +1,60 @@
 use compact_str::CompactString;
 use shuck_ast::{Name, Span};
 
+/// Broad diagnostic family for a discovered `source`-style reference.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SourceRefDiagnosticClass {
+    /// The path is dynamic enough that static resolution is not reliable.
     DynamicPath,
+    /// The path is statically identifiable but may not be tracked by the build.
     UntrackedFile,
 }
 
+/// One semantic `source` or `.` reference discovered in the file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceRef {
+    /// Syntactic shape of the referenced path.
     pub kind: SourceRefKind,
+    /// Span of the full `source` command or relevant operand.
     pub span: Span,
+    /// Span of the path-like portion being resolved.
     pub path_span: Span,
+    /// Resolution status computed for this reference.
     pub resolution: SourceRefResolution,
+    /// Whether the path came from an explicitly provided source directive.
     pub explicitly_provided: bool,
+    /// Diagnostic family higher layers should use for unresolved cases.
     pub diagnostic_class: SourceRefDiagnosticClass,
 }
 
+/// Encoded path form for a source-like reference.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SourceRefKind {
+    /// A fully static literal path.
     Literal(CompactString),
+    /// A path injected by a source directive.
     Directive(CompactString),
+    /// A source directive that intentionally resolves to `/dev/null`.
     DirectiveDevNull,
+    /// A path whose value is too dynamic to resolve statically.
     Dynamic,
-    SingleVariableStaticTail { variable: Name, tail: CompactString },
+    /// A path built from one variable plus a static tail suffix.
+    SingleVariableStaticTail {
+        /// Variable that contributes the dynamic prefix.
+        variable: Name,
+        /// Static suffix appended after the variable value.
+        tail: CompactString,
+    },
 }
 
+/// Whether a source-like reference resolved to a tracked target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SourceRefResolution {
+    /// Resolution was not attempted.
     Unchecked,
+    /// Resolution succeeded.
     Resolved,
+    /// Resolution was attempted but no tracked target was found.
     Unresolved,
 }
 

--- a/crates/shuck-semantic/src/uninitialized.rs
+++ b/crates/shuck-semantic/src/uninitialized.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::dataflow;
 
-#[allow(missing_docs)]
 impl<'model> SemanticAnalysis<'model> {
+    /// Returns references that may observe an uninitialized value.
     pub fn uninitialized_references(&self) -> &[UninitializedReference] {
         self.uninitialized_references
             .get_or_init(|| {

--- a/crates/shuck-semantic/src/unused.rs
+++ b/crates/shuck-semantic/src/unused.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::dataflow;
 
-#[allow(missing_docs)]
 impl SemanticModel {
     pub(crate) fn needs_precise_unused_assignments(&self) -> bool {
         if self.heuristic_unused_assignments.is_empty() {
@@ -46,7 +45,6 @@ impl SemanticModel {
     }
 }
 
-#[allow(missing_docs)]
 impl<'model> SemanticAnalysis<'model> {
     /// Returns every binding that dataflow proves is never read again.
     ///

--- a/crates/shuck-semantic/src/value_flow.rs
+++ b/crates/shuck-semantic/src/value_flow.rs
@@ -2,6 +2,10 @@ use std::cell::RefCell;
 
 use super::*;
 
+/// Value-flow query helper layered on top of [`SemanticAnalysis`].
+///
+/// This combines lexical visibility, CFG reachability, and function-call propagation to answer
+/// higher-level questions about which bindings may supply a value at a given use site.
 #[derive(Debug)]
 pub struct SemanticValueFlow<'analysis, 'model> {
     analysis: &'analysis SemanticAnalysis<'model>,
@@ -13,6 +17,7 @@ pub struct SemanticValueFlow<'analysis, 'model> {
 }
 
 impl<'model> SemanticAnalysis<'model> {
+    /// Creates a fresh value-flow query helper for this analysis view.
     pub fn value_flow(&self) -> SemanticValueFlow<'_, 'model> {
         SemanticValueFlow::new(self)
     }
@@ -30,10 +35,13 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         }
     }
 
+    /// Returns bindings that may supply the value of `name` at the use site contained in `at`.
     pub fn reaching_value_bindings_for_name(&self, name: &Name, at: Span) -> Vec<BindingId> {
         self.reaching_value_bindings_for_name_inner(name, at, None)
     }
 
+    /// Returns bindings that may supply the value of `name` at `at`, optionally treating
+    /// `synthetic_use_block` as the use-site block when no direct semantic reference exists.
     pub fn reaching_value_bindings_for_name_with_synthetic_use_block(
         &self,
         name: &Name,
@@ -67,6 +75,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         bindings
     }
 
+    /// Returns value-supplying bindings for `name` at `at`, excluding `bypass_binding`.
     pub fn reaching_value_bindings_bypassing(
         &self,
         name: &Name,
@@ -81,6 +90,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         bindings
     }
 
+    /// Returns visible value-supplying bindings for `name` from ancestor scopes before `at`.
     pub fn ancestor_value_bindings_before(
         &self,
         name: &Name,
@@ -107,6 +117,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         bindings
     }
 
+    /// Returns helper-provided value bindings that can flow in from called functions before `at`.
     pub fn helper_value_bindings_before(&mut self, name: &Name, at: Span) -> Vec<BindingId> {
         let mut bindings = self
             .model()
@@ -119,6 +130,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         bindings
     }
 
+    /// Returns nonlocal bindings for `name` that can flow in from functions called before `at`.
     pub fn nonlocal_value_bindings_from_called_functions_before(
         &mut self,
         name: &Name,
@@ -155,6 +167,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         bindings
     }
 
+    /// Returns call sites outside `scope` that invoke one of the scope's static function names.
     pub fn named_function_call_sites(&self, scope: ScopeId) -> Vec<CallSite> {
         if let Some(cached) = self.named_function_call_sites_memo.borrow().get(&scope) {
             return cached.to_vec();
@@ -183,6 +196,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         caller_sites
     }
 
+    /// Returns directly called function scopes reachable from `scope` before `limit_offset`.
     pub fn called_function_scopes_before(
         &self,
         scope: ScopeId,
@@ -217,6 +231,8 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         scopes
     }
 
+    /// Returns directly called function scopes before `limit_offset` using relaxed
+    /// definition-command matching.
     pub fn called_function_scopes_before_relaxed(
         &self,
         scope: ScopeId,
@@ -256,6 +272,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         scopes
     }
 
+    /// Returns the transitive closure of called function scopes reachable before `limit_offset`.
     pub fn transitively_called_function_scopes_before(
         &self,
         scope: ScopeId,
@@ -273,6 +290,8 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         scopes
     }
 
+    /// Returns the transitive closure of called function scopes before `limit_offset` using
+    /// relaxed definition-command matching.
     pub fn transitively_called_function_scopes_before_relaxed(
         &self,
         scope: ScopeId,
@@ -290,6 +309,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         scopes
     }
 
+    /// Returns whether `bindings` cover every path to the command span `target_span`.
     pub fn value_bindings_cover_all_paths_to_span(
         &self,
         bindings: &[BindingId],
@@ -330,10 +350,12 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         })
     }
 
+    /// Returns whether `binding_id` is lexically visible at `at`.
     pub fn binding_visible_at(&self, binding_id: BindingId, at: Span) -> bool {
         self.model().binding_visible_at(binding_id, at)
     }
 
+    /// Returns whether `binding_id` can contribute a runtime parameter value.
     pub fn binding_can_supply_parameter_value(&self, binding_id: BindingId) -> bool {
         let binding = self.model().binding(binding_id);
         match binding.origin {
@@ -590,6 +612,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         caller_sites
     }
 
+    /// Returns value-supplying bindings for `name` visible to callers of `scope` before `at`.
     pub fn caller_value_bindings_before(
         &mut self,
         name: &Name,


### PR DESCRIPTION
## Summary

- document the public shuck-semantic API surface across SemanticModel, SemanticAnalysis, CFG/call-graph/dataflow result types, contracts, source refs, bindings, scopes, and value-flow helpers
- remove the public-surface `#[allow(missing_docs)]` suppressions so the crate-level `missing_docs` lint now enforces that coverage going forward

## Why

The crate had item-level documentation gaps across its exported types and query methods, and those gaps were being masked by local `missing_docs` suppressions on the public surface.

## Impact

- makes the semantic API much easier to navigate for downstream crates and future refactors
- turns missing public docs back into compiler warnings instead of letting them drift silently

## Validation

- `cargo check -p shuck-semantic --lib`
- `cargo fmt --check`
