### PR TITLE
perf: cut ~18% of linter allocations on large fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +124,21 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
 
 [[package]]
 name = "bincode"
@@ -454,6 +484,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dhat"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cd11d84628e233de0ce467de10b8633f4ddaecafadefc86e13b84b8739b827"
+dependencies = [
+ "backtrace",
+ "lazy_static",
+ "mintex",
+ "parking_lot",
+ "rustc-hash 1.1.0",
+ "serde",
+ "serde_json",
+ "thousands",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +658,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "globset"
@@ -926,6 +978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +1008,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1033,21 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mintex"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c505b3e17ed6b70a7ed2e67fbb2c560ee327353556120d6e72f5232b6880d536"
 
 [[package]]
 name = "mio"
@@ -1053,6 +1135,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1168,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
 ]
 
 [[package]]
@@ -1327,6 +1441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1483,18 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -1423,6 +1558,12 @@ dependencies = [
  "arraydeque",
  "hashlink",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1535,6 +1676,7 @@ name = "shuck-benchmark"
 version = "0.0.26"
 dependencies = [
  "criterion",
+ "dhat",
  "serde",
  "serde_json",
  "shuck-cli",
@@ -1629,7 +1771,7 @@ dependencies = [
  "anyhow",
  "globset",
  "insta",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_yaml",
  "shuck-ast",
@@ -1659,7 +1801,7 @@ name = "shuck-semantic"
 version = "0.0.26"
 dependencies = [
  "bitflags 2.11.0",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "shuck-ast",
  "shuck-indexer",
  "shuck-parser",
@@ -1817,6 +1959,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "thousands"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "tikv-jemalloc-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,6 +1802,7 @@ name = "shuck-semantic"
 version = "0.0.26"
 dependencies = [
  "bitflags 2.11.0",
+ "compact_str",
  "rustc-hash 2.1.2",
  "shuck-ast",
  "shuck-indexer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,6 +1769,7 @@ name = "shuck-linter"
 version = "0.0.26"
 dependencies = [
  "anyhow",
+ "compact_str",
  "globset",
  "insta",
  "rustc-hash 2.1.2",

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -3791,7 +3791,7 @@ pub struct HeredocDelimiter {
     /// Raw delimiter word with original quoting preserved.
     pub raw: Word,
     /// Cooked delimiter string after quote removal.
-    pub cooked: String,
+    pub cooked: compact_str::CompactString,
     /// Source span of the delimiter token.
     pub span: Span,
     /// Whether the delimiter used shell quoting.
@@ -4978,7 +4978,7 @@ mod tests {
     fn redirect_exposes_heredoc_payload() {
         let delimiter = HeredocDelimiter {
             raw: Word::quoted_literal("EOF"),
-            cooked: "EOF".to_owned(),
+            cooked: "EOF".into(),
             span: Span::new(),
             quoted: true,
             expands_body: false,

--- a/crates/shuck-benchmark/Cargo.toml
+++ b/crates/shuck-benchmark/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 [features]
 large-corpus-hotspots = []
 parser-benchmarking = ["shuck-parser/benchmarking"]
+dhat-heap = ["dep:dhat"]
 
 [dependencies]
 shuck-formatter = { workspace = true, features = ["benchmarking"] }
@@ -22,6 +23,7 @@ shuck-linter = { workspace = true, features = ["benchmarking"] }
 shuck-parser = { workspace = true }
 shuck-semantic = { workspace = true }
 walkdir = "2"
+dhat = { version = "0.3", optional = true }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/crates/shuck-benchmark/examples/large_corpus_profile.rs
+++ b/crates/shuck-benchmark/examples/large_corpus_profile.rs
@@ -15,6 +15,10 @@ use shuck_linter::{
 use shuck_parser::parser::Parser;
 use shuck_semantic::SourcePathResolver;
 
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 const LARGE_CORPUS_ROOT_ENV: &str = "SHUCK_LARGE_CORPUS_ROOT";
 const LARGE_CORPUS_CACHE_DIR_NAME: &str = ".cache/large-corpus";
 const LARGE_CORPUS_STATIC_IGNORE_SUFFIXES: &[&str] = &[
@@ -118,6 +122,9 @@ impl SourcePathResolver for LargeCorpusPathResolver {
 }
 
 fn main() -> Result<()> {
+    #[cfg(feature = "dhat-heap")]
+    let _dhat = dhat::Profiler::new_heap();
+
     let Some(args) = parse_args()? else {
         return Ok(());
     };

--- a/crates/shuck-linter/Cargo.toml
+++ b/crates/shuck-linter/Cargo.toml
@@ -16,6 +16,7 @@ benchmarking = []
 
 [dependencies]
 anyhow = { workspace = true }
+compact_str = { workspace = true }
 globset = { workspace = true }
 rustc-hash = "2"
 smallvec.workspace = true

--- a/crates/shuck-linter/src/facts/misspelling.rs
+++ b/crates/shuck-linter/src/facts/misspelling.rs
@@ -263,7 +263,7 @@ impl MisspellingCandidateLookup {
 
 #[derive(Debug, Clone)]
 struct MisspellingCandidate {
-    name: String,
+    name: CompactString,
     first_span: Span,
 }
 
@@ -284,7 +284,7 @@ pub(super) fn build_possible_variable_misspelling_index(
         .filter(|binding| is_sc2154_defining_binding(binding.kind))
         .filter(|binding| binding.name.as_str().len() >= 4)
         .map(|binding| MisspellingCandidate {
-            name: binding.name.to_string(),
+            name: binding.name.as_str().into(),
             first_span: binding.span,
         })
         .collect();
@@ -434,7 +434,7 @@ fn build_presence_test_entries(
                 presence_test_names_by_name,
             )?;
             Some(MisspellingCandidate {
-                name: name.to_string(),
+                name: name.as_str().into(),
                 first_span,
             })
         })

--- a/crates/shuck-linter/src/facts/misspelling.rs
+++ b/crates/shuck-linter/src/facts/misspelling.rs
@@ -1,4 +1,5 @@
 use super::*;
+use compact_str::CompactString;
 
 const INDEX_BUILD_THRESHOLD: usize = 1024;
 
@@ -152,7 +153,7 @@ impl MisspellingCandidateLookup {
             let name = entry.name.as_str();
             index
                 .casefold_exact
-                .entry(canonical_ascii_uppercase(name).into_boxed_str())
+                .entry(canonical_ascii_uppercase(name).as_str().into())
                 .or_default()
                 .push(id);
 
@@ -628,7 +629,7 @@ fn edit1_deletion_keys(name: &str) -> Vec<Box<str>> {
     keys
 }
 
-fn canonical_ascii_uppercase(name: &str) -> String {
+fn canonical_ascii_uppercase(name: &str) -> CompactString {
     name.chars().map(|char| char.to_ascii_uppercase()).collect()
 }
 

--- a/crates/shuck-linter/src/fix.rs
+++ b/crates/shuck-linter/src/fix.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 
+use compact_str::CompactString;
 use shuck_ast::{Span, TextRange, TextSize};
 
 use crate::Diagnostic;
@@ -29,7 +30,7 @@ pub enum FixAvailability {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Edit {
     range: TextRange,
-    content: String,
+    content: CompactString,
 }
 
 impl Edit {
@@ -38,14 +39,14 @@ impl Edit {
     }
 
     pub fn deletion_at(start: usize, end: usize) -> Self {
-        Self::replacement_at(start, end, String::new())
+        Self::replacement_at(start, end, CompactString::default())
     }
 
-    pub fn replacement(content: impl Into<String>, span: Span) -> Self {
+    pub fn replacement(content: impl Into<CompactString>, span: Span) -> Self {
         Self::replacement_at(span.start.offset, span.end.offset, content)
     }
 
-    pub fn replacement_at(start: usize, end: usize, content: impl Into<String>) -> Self {
+    pub fn replacement_at(start: usize, end: usize, content: impl Into<CompactString>) -> Self {
         let (start, end) = ordered_offsets(start, end);
         Self {
             range: TextRange::new(TextSize::new(start as u32), TextSize::new(end as u32)),
@@ -53,7 +54,7 @@ impl Edit {
         }
     }
 
-    pub fn insertion(offset: usize, content: impl Into<String>) -> Self {
+    pub fn insertion(offset: usize, content: impl Into<CompactString>) -> Self {
         Self::replacement_at(offset, offset, content)
     }
 

--- a/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
+++ b/crates/shuck-linter/src/rules/correctness/c_style_comment.rs
@@ -30,9 +30,11 @@ pub fn c_style_comment(checker: &mut Checker) {
             name.span
                 .slice(checker.source())
                 .starts_with("/*")
-                .then_some(crate::Diagnostic::new(CStyleComment, name.span).with_fix(
-                    Fix::unsafe_edit(Edit::insertion(name.span.start.offset, "# ")),
-                ))
+                .then(|| {
+                    crate::Diagnostic::new(CStyleComment, name.span).with_fix(Fix::unsafe_edit(
+                        Edit::insertion(name.span.start.offset, "# "),
+                    ))
+                })
         };
 
         if let Some(diagnostic) = diagnostic {

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use rustc_hash::FxHashSet;
 use shuck_ast::Span;
 use shuck_semantic::BindingId;
@@ -5,7 +6,7 @@ use shuck_semantic::BindingId;
 use crate::{Checker, Rule, Violation};
 
 pub struct FunctionCalledWithoutArgs {
-    pub name: String,
+    pub name: CompactString,
 }
 
 impl Violation for FunctionCalledWithoutArgs {
@@ -20,7 +21,7 @@ impl Violation for FunctionCalledWithoutArgs {
 
 pub fn function_called_without_args(checker: &mut Checker) {
     let mut reported = FxHashSet::<BindingId>::default();
-    let mut violations = Vec::<(Span, String)>::new();
+    let mut violations = Vec::<(Span, CompactString)>::new();
 
     for header in checker.facts().function_headers() {
         let Some((name, _)) = header.static_name_entry() else {
@@ -53,7 +54,7 @@ pub fn function_called_without_args(checker: &mut Checker) {
 
         violations.push((
             header.function_span_in_source(checker.source()),
-            name.to_string(),
+            name.as_str().into(),
         ));
     }
 

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use rustc_hash::FxHashSet;
 use shuck_ast::Span;
 use shuck_semantic::BindingId;
@@ -5,7 +6,7 @@ use shuck_semantic::BindingId;
 use crate::{Checker, Rule, Violation};
 
 pub struct FunctionReferencesUnsetParam {
-    pub name: String,
+    pub name: CompactString,
 }
 
 impl Violation for FunctionReferencesUnsetParam {
@@ -20,7 +21,7 @@ impl Violation for FunctionReferencesUnsetParam {
 
 pub fn function_references_unset_param(checker: &mut Checker) {
     let mut reported = FxHashSet::<BindingId>::default();
-    let mut violations = Vec::<(Span, String)>::new();
+    let mut violations = Vec::<(Span, CompactString)>::new();
 
     for header in checker.facts().function_headers() {
         let Some((name, _)) = header.static_name_entry() else {
@@ -59,7 +60,7 @@ pub fn function_references_unset_param(checker: &mut Checker) {
                 .zero_arg_diagnostic_spans()
                 .iter()
                 .copied()
-                .map(|span| (span, name.to_string())),
+                .map(|span| (span, name.as_str().into())),
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,4 +1,5 @@
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
+use compact_str::CompactString;
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::Name;
 use shuck_semantic::{
@@ -18,7 +19,7 @@ pub enum FunctionNotReachedReason {
 }
 
 pub struct OverwrittenFunction {
-    pub name: String,
+    pub name: CompactString,
     pub reason: FunctionNotReachedReason,
 }
 
@@ -101,7 +102,7 @@ pub fn overwritten_function(checker: &mut Checker) {
         report_function_definition(
             checker,
             overwritten.first,
-            overwritten.name.to_string(),
+            overwritten.name.as_str().into(),
             FunctionNotReachedReason::Overwritten,
         );
     }
@@ -123,7 +124,7 @@ pub fn overwritten_function(checker: &mut Checker) {
         report_function_definition(
             checker,
             unreached.binding,
-            unreached.name.to_string(),
+            unreached.name.as_str().into(),
             reason,
         );
     }
@@ -422,7 +423,7 @@ fn report_compat_cutoff_function_definitions(checker: &mut Checker<'_>) {
                 &structural_facts.top_level_control,
             )?;
             (!binding_has_direct_call_before_offset(&mut reach, binding.id, cutoff.offset))
-                .then(|| (binding.id, binding.name.to_string(), cutoff.reason))
+                .then(|| (binding.id, binding.name.as_str().into(), cutoff.reason))
         })
         .collect::<Vec<_>>();
 
@@ -469,7 +470,7 @@ fn report_transient_shadowed_file_scope_definitions(checker: &mut Checker<'_>) {
                 return None;
             }
 
-            Some((binding.id, binding.name.to_string()))
+            Some((binding.id, binding.name.as_str().into()))
         })
         .collect::<Vec<_>>();
 
@@ -718,7 +719,7 @@ fn has_non_transient_direct_call_to_binding_between_offsets(
 fn report_function_definition(
     checker: &mut Checker<'_>,
     binding_id: BindingId,
-    name: String,
+    name: CompactString,
     reason: FunctionNotReachedReason,
 ) {
     let binding = checker.semantic().binding(binding_id);

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 use shuck_ast::{Name, Position, Span};
@@ -11,8 +12,8 @@ use super::variable_reference_common::{
 };
 
 pub struct PossibleVariableMisspelling {
-    pub reference: String,
-    pub candidate: String,
+    pub reference: CompactString,
+    pub candidate: CompactString,
 }
 
 impl Violation for PossibleVariableMisspelling {
@@ -164,8 +165,8 @@ pub fn possible_variable_misspelling(checker: &mut Checker) {
         }
         checker.report(
             PossibleVariableMisspelling {
-                reference,
-                candidate,
+                reference: reference.into(),
+                candidate: candidate.into(),
             },
             span,
         );

--- a/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
+++ b/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
@@ -462,9 +462,14 @@ fn expansion_span_is_plain_reference(
     reference: &Reference,
     source: &str,
 ) -> bool {
-    let text = expansion_span.slice(source);
-    text == format!("${}", reference.name.as_str())
-        || text == format!("${{{}}}", reference.name.as_str())
+    let text = expansion_span.slice(source).as_bytes();
+    let name = reference.name.as_str().as_bytes();
+    let plain = text.len() == name.len() + 1 && text.first() == Some(&b'$') && &text[1..] == name;
+    let braced = text.len() == name.len() + 3
+        && text.starts_with(b"${")
+        && text.ends_with(b"}")
+        && &text[2..text.len() - 1] == name;
+    plain || braced
 }
 
 fn sort_and_dedup_spans(spans: &mut Vec<Span>) {

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -1,7 +1,9 @@
+use compact_str::CompactString;
+
 use crate::{Checker, Diagnostic, Rule, Violation};
 
 pub struct SubshellLocalAssignment {
-    pub name: String,
+    pub name: CompactString,
 }
 
 impl Violation for SubshellLocalAssignment {
@@ -22,7 +24,7 @@ pub fn subshell_local_assignment(checker: &mut Checker) {
         for site in facts.subshell_assignment_sites() {
             report(Diagnostic::new(
                 SubshellLocalAssignment {
-                    name: site.name.to_string(),
+                    name: site.name.as_str().into(),
                 },
                 site.span,
             ));

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -1,7 +1,9 @@
+use compact_str::CompactString;
+
 use crate::{Checker, Diagnostic, Rule, Violation};
 
 pub struct SubshellSideEffect {
-    pub name: String,
+    pub name: CompactString,
 }
 
 impl Violation for SubshellSideEffect {
@@ -22,7 +24,7 @@ pub fn subshell_side_effect(checker: &mut Checker) {
         for site in facts.subshell_later_use_sites() {
             report(Diagnostic::new(
                 SubshellSideEffect {
-                    name: site.name.to_string(),
+                    name: site.name.as_str().into(),
                 },
                 site.span,
             ));

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use rustc_hash::FxHashSet;
 use shuck_semantic::UninitializedCertainty;
 
@@ -8,7 +9,7 @@ use super::variable_reference_common::{
 };
 
 pub struct UndefinedVariable {
-    pub name: String,
+    pub name: CompactString,
     pub certainty: UninitializedCertainty,
 }
 
@@ -81,7 +82,7 @@ pub fn undefined_variable(checker: &mut Checker) {
 
         checker.report(
             UndefinedVariable {
-                name: reference.name.to_string(),
+                name: reference.name.as_str().into(),
                 certainty: uninitialized.certainty,
             },
             reference.span,

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use compact_str::CompactString;
 use shuck_semantic::{
     Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin, ReferenceKind,
 };
@@ -9,7 +10,7 @@ use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 type BindingFamilyKey = String;
 
 pub struct UnusedAssignment {
-    pub name: String,
+    pub name: CompactString,
 }
 
 impl Violation for UnusedAssignment {
@@ -175,7 +176,7 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
-        let name = binding.name.to_string();
+        let name: CompactString = binding.name.as_str().into();
         let report_span = report_span_for_binding(checker, binding);
         let fix_span = binding.span;
 

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -1,7 +1,9 @@
+use compact_str::CompactString;
+
 use crate::{Checker, DeclarationKind, Rule, Violation};
 
 pub struct ExportCommandSubstitution {
-    pub name: String,
+    pub name: CompactString,
 }
 
 impl Violation for ExportCommandSubstitution {
@@ -29,7 +31,7 @@ pub fn export_command_substitution(checker: &mut Checker) {
             }
 
             if probe.has_command_substitution() {
-                findings.push((probe.target_name().to_owned(), probe.target_name_span()));
+                findings.push((probe.target_name().into(), probe.target_name_span()));
             }
         }
     }

--- a/crates/shuck-parser/src/parser/heredocs.rs
+++ b/crates/shuck-parser/src/parser/heredocs.rs
@@ -64,7 +64,7 @@ impl<'a> Parser<'a> {
         let delimiter_span = raw_delimiter.span;
         let delimiter = HeredocDelimiter {
             raw: raw_delimiter,
-            cooked: delimiter_text.clone(),
+            cooked: delimiter_text.as_str().into(),
             span: delimiter_span,
             quoted,
             expands_body: !quoted,

--- a/crates/shuck-semantic/Cargo.toml
+++ b/crates/shuck-semantic/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [dependencies]
 bitflags = "2"
+compact_str = { workspace = true }
 rustc-hash = "2"
 smallvec = { workspace = true }
 shuck-ast = { workspace = true }

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -392,7 +392,7 @@ fn update_simple_declaration_flags(
 fn simple_declaration_flag_operand(word: &Word, text: &str) -> DeclarationOperand {
     DeclarationOperand::Flag {
         flag: text.chars().nth(1).unwrap_or('-'),
-        flags: text.to_owned(),
+        flags: text.into(),
         span: word.span,
     }
 }
@@ -455,7 +455,7 @@ fn declaration_operands(operands: &[DeclOperand], source: &str) -> Vec<Declarati
                 let flag = text.chars().nth(1).unwrap_or('-');
                 DeclarationOperand::Flag {
                     flag,
-                    flags: text.into_owned(),
+                    flags: text.as_ref().into(),
                     span: word.span,
                 }
             }
@@ -567,8 +567,8 @@ fn indirect_target_hint_from_word(word: &Word, source: &str) -> Option<IndirectT
     }
 
     Some(IndirectTargetHint::Pattern {
-        prefix,
-        suffix: suffix.to_string(),
+        prefix: prefix.into(),
+        suffix: suffix.into(),
         array_like,
     })
 }
@@ -1658,7 +1658,10 @@ fn classify_dynamic_source_word(word: &Word, source: &str) -> SourceRefKind {
     }
 
     if let Some(variable) = variable {
-        return SourceRefKind::SingleVariableStaticTail { variable, tail };
+        return SourceRefKind::SingleVariableStaticTail {
+            variable,
+            tail: tail.into(),
+        };
     }
 
     SourceRefKind::Dynamic
@@ -1796,7 +1799,7 @@ fn parse_source_directive_override(text: &str, own_line: bool) -> Option<SourceD
             let kind = if value == "/dev/null" {
                 SourceRefKind::DirectiveDevNull
             } else {
-                SourceRefKind::Directive(value.to_string())
+                SourceRefKind::Directive(value.into())
             };
             return Some(SourceDirectiveOverride { kind, own_line });
         }

--- a/crates/shuck-semantic/src/builder/source_refs.rs
+++ b/crates/shuck-semantic/src/builder/source_refs.rs
@@ -7,7 +7,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
 
         if let Some(text) = static_word_text(word, self.source) {
-            return SourceRefKind::Literal(text.into_owned());
+            return SourceRefKind::Literal(text.as_ref().into());
         }
 
         classify_dynamic_source_word(word, self.source)

--- a/crates/shuck-semantic/src/builder/zsh_effects.rs
+++ b/crates/shuck-semantic/src/builder/zsh_effects.rs
@@ -28,7 +28,7 @@ pub(super) fn recorded_simple_command_info(
         .collect::<Vec<_>>();
     let normalized = normalize_command_words(&words, source)
         .expect("recorded simple commands always include a command name");
-    let static_callee = recorded_static_callee(&normalized).map(ToOwned::to_owned);
+    let static_callee = recorded_static_callee(&normalized).map(Into::into);
     let static_args = recorded_static_args(command, &normalized, source);
     let source_path_template = normalized
         .literal_name

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -473,7 +473,7 @@ pub(crate) struct RecordedElifBranch {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct RecordedCommandInfo {
-    pub(crate) static_callee: Option<String>,
+    pub(crate) static_callee: Option<compact_str::CompactString>,
     pub(crate) static_args: Box<[Option<String>]>,
     pub(crate) source_path_template: Option<SourcePathTemplate>,
     pub(crate) zsh_effects: Vec<RecordedZshCommandEffect>,

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -3,7 +3,7 @@ use shuck_ast::Name;
 use shuck_ast::Span;
 use smallvec::SmallVec;
 
-use crate::dense_bit_set::DenseBitSet;
+use crate::dense_bit_set::{DenseBitMatrix, DenseBitSet};
 use crate::function_resolution::resolved_function_calls_with_callee_scope;
 use crate::reachability::block_reaches_without;
 use crate::runtime::RuntimePrelude;
@@ -359,9 +359,9 @@ fn analyze_uninitialized_references_exact(
         }
         let same_block_guard =
             parameter_guard_flow_index.precedes_reference(reference, block_id, name_id);
-        let maybe = maybe_defined[block_id.index()].contains(name_id.index()) || same_block_guard;
+        let maybe = maybe_defined.contains(block_id.index(), name_id.index()) || same_block_guard;
         let definite =
-            definitely_defined[block_id.index()].contains(name_id.index()) || same_block_guard;
+            definitely_defined.contains(block_id.index(), name_id.index()) || same_block_guard;
 
         if !maybe {
             uninitialized_references.push(UninitializedReference {
@@ -1446,10 +1446,10 @@ fn materialize_dense_reaching_definitions(
 
 #[derive(Debug, Clone)]
 struct DenseInitializedNameStates {
-    maybe_in: Vec<DenseBitSet>,
-    maybe_out: Vec<DenseBitSet>,
-    definite_in: Vec<DenseBitSet>,
-    definite_out: Vec<DenseBitSet>,
+    maybe_in: DenseBitMatrix,
+    maybe_out: DenseBitMatrix,
+    definite_in: DenseBitMatrix,
+    definite_out: DenseBitMatrix,
 }
 
 #[derive(Debug, Clone)]
@@ -1864,22 +1864,22 @@ fn compute_initialized_name_states_dense_with_extra_name_gens(
     let entry_blocks = entry_binding_root_blocks(cfg);
     let block_count = cfg.blocks().len();
     let name_count = binding_data.bindings_for_name.len();
-    let mut maybe_gen = vec![DenseBitSet::new(name_count); block_count];
-    let mut definite_gen = vec![DenseBitSet::new(name_count); block_count];
-    let mut overwritten_names = vec![DenseBitSet::new(name_count); block_count];
+    let mut maybe_gen = DenseBitMatrix::zeros(block_count, name_count);
+    let mut definite_gen = DenseBitMatrix::zeros(block_count, name_count);
+    let mut overwritten_names = DenseBitMatrix::zeros(block_count, name_count);
 
     for block in cfg.blocks() {
         let block_index = block.id.index();
         for binding in &block.bindings {
             let name_id = binding_data.binding_name_ids[binding.index()];
-            overwritten_names[block_index].insert(name_id.index());
+            overwritten_names.insert(block_index, name_id.index());
             match binding_initializes_name(&bindings[binding.index()]) {
                 Some(ContractCertainty::Definite) => {
-                    maybe_gen[block_index].insert(name_id.index());
-                    definite_gen[block_index].insert(name_id.index());
+                    maybe_gen.insert(block_index, name_id.index());
+                    definite_gen.insert(block_index, name_id.index());
                 }
                 Some(ContractCertainty::Possible) => {
-                    maybe_gen[block_index].insert(name_id.index());
+                    maybe_gen.insert(block_index, name_id.index());
                 }
                 None => {}
             }
@@ -1887,8 +1887,8 @@ fn compute_initialized_name_states_dense_with_extra_name_gens(
     }
 
     for (block, name) in extra_initialized_names {
-        maybe_gen[block.index()].insert(name.index());
-        definite_gen[block.index()].insert(name.index());
+        maybe_gen.insert(block.index(), name.index());
+        definite_gen.insert(block.index(), name.index());
     }
 
     let mut entry_maybe = DenseBitSet::new(name_count);
@@ -1912,10 +1912,12 @@ fn compute_initialized_name_states_dense_with_extra_name_gens(
         all_names.insert(index);
     }
 
-    let mut maybe_in = vec![DenseBitSet::new(name_count); block_count];
-    let mut maybe_out = vec![DenseBitSet::new(name_count); block_count];
-    let mut definite_in = vec![all_names.clone(); block_count];
-    let mut definite_out = vec![all_names; block_count];
+    let mut maybe_in = DenseBitMatrix::zeros(block_count, name_count);
+    let mut maybe_out = DenseBitMatrix::zeros(block_count, name_count);
+    let mut definite_in = DenseBitMatrix::zeros(block_count, name_count);
+    definite_in.fill_all_rows_from_words(all_names.as_words());
+    let mut definite_out = DenseBitMatrix::zeros(block_count, name_count);
+    definite_out.fill_all_rows_from_words(all_names.as_words());
     let mut incoming_maybe = DenseBitSet::new(name_count);
     let mut incoming_definite = DenseBitSet::new(name_count);
     let mut outgoing_maybe = DenseBitSet::new(name_count);
@@ -1926,7 +1928,7 @@ fn compute_initialized_name_states_dense_with_extra_name_gens(
 
         incoming_maybe.clear();
         for predecessor in cfg.predecessors(block_id) {
-            incoming_maybe.union_with(&maybe_out[predecessor.index()]);
+            incoming_maybe.union_with_words(maybe_out.row(predecessor.index()));
         }
         if entry_blocks.contains(&block_id) {
             incoming_maybe.union_with(&entry_maybe);
@@ -1942,7 +1944,7 @@ fn compute_initialized_name_states_dense_with_extra_name_gens(
         if uses_virtual_entry_boundary {
             incoming_definite.copy_from(&entry_definite);
         } else if let Some(first_predecessor) = predecessors.first() {
-            incoming_definite.copy_from(&definite_out[first_predecessor.index()]);
+            incoming_definite.copy_from_words(definite_out.row(first_predecessor.index()));
         } else {
             incoming_definite.clear();
         }
@@ -1950,21 +1952,23 @@ fn compute_initialized_name_states_dense_with_extra_name_gens(
             if !uses_virtual_entry_boundary && predecessor_index == 0 {
                 continue;
             }
-            incoming_definite.intersect_with(&definite_out[predecessor.index()]);
+            incoming_definite.intersect_with_words(definite_out.row(predecessor.index()));
         }
 
         outgoing_maybe.copy_from(&incoming_maybe);
-        outgoing_maybe.subtract_with(&overwritten_names[block_index]);
-        outgoing_maybe.union_with(&maybe_gen[block_index]);
+        outgoing_maybe.subtract_with_words(overwritten_names.row(block_index));
+        outgoing_maybe.union_with_words(maybe_gen.row(block_index));
 
         outgoing_definite.copy_from(&incoming_definite);
-        outgoing_definite.subtract_with(&overwritten_names[block_index]);
-        outgoing_definite.union_with(&definite_gen[block_index]);
+        outgoing_definite.subtract_with_words(overwritten_names.row(block_index));
+        outgoing_definite.union_with_words(definite_gen.row(block_index));
 
-        maybe_in[block_index].replace_if_changed(&incoming_maybe);
-        definite_in[block_index].replace_if_changed(&incoming_definite);
-        let maybe_out_changed = maybe_out[block_index].replace_if_changed(&outgoing_maybe);
-        let definite_out_changed = definite_out[block_index].replace_if_changed(&outgoing_definite);
+        maybe_in.replace_row_if_changed(block_index, incoming_maybe.as_words());
+        definite_in.replace_row_if_changed(block_index, incoming_definite.as_words());
+        let maybe_out_changed =
+            maybe_out.replace_row_if_changed(block_index, outgoing_maybe.as_words());
+        let definite_out_changed =
+            definite_out.replace_row_if_changed(block_index, outgoing_definite.as_words());
         maybe_out_changed || definite_out_changed
     });
 
@@ -2044,17 +2048,20 @@ pub(crate) fn summarize_scope_provided_bindings(
     let mut definite_counts = FxHashMap::<Name, usize>::default();
 
     for exit_block in &exit_blocks {
-        let maybe_names = &initialized_states.maybe_out[exit_block.index()];
-        let definite_names = &initialized_states.definite_out[exit_block.index()];
-
         for name in &eligible_names {
             let Some(name_id) = exact.names.get(name) else {
                 continue;
             };
-            if maybe_names.contains(name_id.index()) {
+            if initialized_states
+                .maybe_out
+                .contains(exit_block.index(), name_id.index())
+            {
                 *maybe_counts.entry(name.clone()).or_default() += 1;
             }
-            if definite_names.contains(name_id.index()) {
+            if initialized_states
+                .definite_out
+                .contains(exit_block.index(), name_id.index())
+            {
                 *definite_counts.entry(name.clone()).or_default() += 1;
             }
         }

--- a/crates/shuck-semantic/src/declaration.rs
+++ b/crates/shuck-semantic/src/declaration.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use shuck_ast::{Name, Span};
 
 use crate::AssignmentValueOrigin;
@@ -22,7 +23,7 @@ pub struct Declaration {
 pub enum DeclarationOperand {
     Flag {
         flag: char,
-        flags: String,
+        flags: CompactString,
         span: Span,
     },
     Name {

--- a/crates/shuck-semantic/src/dense_bit_set.rs
+++ b/crates/shuck-semantic/src/dense_bit_set.rs
@@ -40,38 +40,62 @@ impl DenseBitSet {
         self.words.fill(0);
     }
 
+    pub(crate) fn as_words(&self) -> &[usize] {
+        &self.words
+    }
+
     pub(crate) fn copy_from(&mut self, other: &Self) {
-        debug_assert_eq!(self.words.len(), other.words.len());
-        self.words.copy_from_slice(&other.words);
+        self.copy_from_words(&other.words);
+    }
+
+    pub(crate) fn copy_from_words(&mut self, words: &[usize]) {
+        debug_assert_eq!(self.words.len(), words.len());
+        self.words.copy_from_slice(words);
     }
 
     pub(crate) fn replace_if_changed(&mut self, other: &Self) -> bool {
-        debug_assert_eq!(self.words.len(), other.words.len());
-        if self.words == other.words {
+        self.replace_if_changed_words(&other.words)
+    }
+
+    pub(crate) fn replace_if_changed_words(&mut self, words: &[usize]) -> bool {
+        debug_assert_eq!(self.words.len(), words.len());
+        if self.words == words {
             false
         } else {
-            self.copy_from(other);
+            self.copy_from_words(words);
             true
         }
     }
 
     pub(crate) fn union_with(&mut self, other: &Self) {
-        debug_assert_eq!(self.words.len(), other.words.len());
-        for (word, other_word) in self.words.iter_mut().zip(&other.words) {
+        self.union_with_words(&other.words);
+    }
+
+    pub(crate) fn union_with_words(&mut self, words: &[usize]) {
+        debug_assert_eq!(self.words.len(), words.len());
+        for (word, other_word) in self.words.iter_mut().zip(words) {
             *word |= *other_word;
         }
     }
 
     pub(crate) fn subtract_with(&mut self, other: &Self) {
-        debug_assert_eq!(self.words.len(), other.words.len());
-        for (word, other_word) in self.words.iter_mut().zip(&other.words) {
+        self.subtract_with_words(&other.words);
+    }
+
+    pub(crate) fn subtract_with_words(&mut self, words: &[usize]) {
+        debug_assert_eq!(self.words.len(), words.len());
+        for (word, other_word) in self.words.iter_mut().zip(words) {
             *word &= !*other_word;
         }
     }
 
     pub(crate) fn intersect_with(&mut self, other: &Self) {
-        debug_assert_eq!(self.words.len(), other.words.len());
-        for (word, other_word) in self.words.iter_mut().zip(&other.words) {
+        self.intersect_with_words(&other.words);
+    }
+
+    pub(crate) fn intersect_with_words(&mut self, words: &[usize]) {
+        debug_assert_eq!(self.words.len(), words.len());
+        for (word, other_word) in self.words.iter_mut().zip(words) {
             *word &= *other_word;
         }
     }
@@ -81,6 +105,77 @@ impl DenseBitSet {
             words: &self.words,
             word_index: 0,
             current_word: 0,
+        }
+    }
+}
+
+/// A flat 2D bitset stored as a single backing buffer. Replaces
+/// `Vec<DenseBitSet>` patterns where every row has the same bit length, so
+/// per-row clones do not allocate independent `Vec<usize>` storage.
+#[derive(Debug, Clone)]
+pub(crate) struct DenseBitMatrix {
+    words_per_row: usize,
+    rows: usize,
+    data: Vec<usize>,
+}
+
+impl DenseBitMatrix {
+    pub(crate) fn zeros(rows: usize, bit_len: usize) -> Self {
+        let words_per_row = bit_len.div_ceil(DenseBitSet::WORD_BITS);
+        Self {
+            words_per_row,
+            rows,
+            data: vec![0; rows * words_per_row],
+        }
+    }
+
+    pub(crate) fn rows(&self) -> usize {
+        self.rows
+    }
+
+    pub(crate) fn row(&self, row: usize) -> &[usize] {
+        let start = row * self.words_per_row;
+        &self.data[start..start + self.words_per_row]
+    }
+
+    pub(crate) fn fill_row_from_words(&mut self, row: usize, src: &[usize]) {
+        debug_assert_eq!(src.len(), self.words_per_row);
+        let start = row * self.words_per_row;
+        self.data[start..start + self.words_per_row].copy_from_slice(src);
+    }
+
+    pub(crate) fn fill_all_rows_from_words(&mut self, src: &[usize]) {
+        debug_assert_eq!(src.len(), self.words_per_row);
+        for row in 0..self.rows {
+            let start = row * self.words_per_row;
+            self.data[start..start + self.words_per_row].copy_from_slice(src);
+        }
+    }
+
+    pub(crate) fn insert(&mut self, row: usize, index: usize) {
+        let word = index / DenseBitSet::WORD_BITS;
+        let bit = index % DenseBitSet::WORD_BITS;
+        self.data[row * self.words_per_row + word] |= 1usize << bit;
+    }
+
+    pub(crate) fn contains(&self, row: usize, index: usize) -> bool {
+        let word = index / DenseBitSet::WORD_BITS;
+        let bit = index % DenseBitSet::WORD_BITS;
+        self.data
+            .get(row * self.words_per_row + word)
+            .is_some_and(|word| (word & (1usize << bit)) != 0)
+    }
+
+    /// Replace `row` with `src` if they differ. Returns whether the row changed.
+    pub(crate) fn replace_row_if_changed(&mut self, row: usize, src: &[usize]) -> bool {
+        debug_assert_eq!(src.len(), self.words_per_row);
+        let start = row * self.words_per_row;
+        let target = &mut self.data[start..start + self.words_per_row];
+        if target == src {
+            false
+        } else {
+            target.copy_from_slice(src);
+            true
         }
     }
 }

--- a/crates/shuck-semantic/src/dense_bit_set.rs
+++ b/crates/shuck-semantic/src/dense_bit_set.rs
@@ -89,10 +89,6 @@ impl DenseBitSet {
         }
     }
 
-    pub(crate) fn intersect_with(&mut self, other: &Self) {
-        self.intersect_with_words(&other.words);
-    }
-
     pub(crate) fn intersect_with_words(&mut self, words: &[usize]) {
         debug_assert_eq!(self.words.len(), words.len());
         for (word, other_word) in self.words.iter_mut().zip(words) {
@@ -129,19 +125,9 @@ impl DenseBitMatrix {
         }
     }
 
-    pub(crate) fn rows(&self) -> usize {
-        self.rows
-    }
-
     pub(crate) fn row(&self, row: usize) -> &[usize] {
         let start = row * self.words_per_row;
         &self.data[start..start + self.words_per_row]
-    }
-
-    pub(crate) fn fill_row_from_words(&mut self, row: usize, src: &[usize]) {
-        debug_assert_eq!(src.len(), self.words_per_row);
-        let start = row * self.words_per_row;
-        self.data[start..start + self.words_per_row].copy_from_slice(src);
     }
 
     pub(crate) fn fill_all_rows_from_words(&mut self, src: &[usize]) {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -329,8 +329,8 @@ pub(crate) enum IndirectTargetHint {
         array_like: bool,
     },
     Pattern {
-        prefix: String,
-        suffix: String,
+        prefix: compact_str::CompactString,
+        suffix: compact_str::CompactString,
         array_like: bool,
     },
 }
@@ -3384,8 +3384,8 @@ fn indirect_target_matches(hint: &IndirectTargetHint, binding: &Binding) -> bool
             array_like,
         } => {
             let name = binding.name.as_str();
-            name.starts_with(prefix)
-                && name.ends_with(suffix)
+            name.starts_with(prefix.as_str())
+                && name.ends_with(suffix.as_str())
                 && (!array_like || binding::is_array_like_binding(binding))
         }
     }

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -57,7 +57,7 @@ struct SourceClosureLookupContext<'a> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct HelperPathResolutionKey {
     source_path: PathBuf,
-    candidate: String,
+    candidate: compact_str::CompactString,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -945,7 +945,7 @@ fn source_candidates(
 ) -> Vec<String> {
     match kind {
         SourceRefKind::DirectiveDevNull => Vec::new(),
-        SourceRefKind::Literal(path) | SourceRefKind::Directive(path) => vec![path.clone()],
+        SourceRefKind::Literal(path) | SourceRefKind::Directive(path) => vec![path.to_string()],
         SourceRefKind::Dynamic | SourceRefKind::SingleVariableStaticTail { .. } => {
             source_candidates_from_template(template, call_args, source_path)
         }
@@ -1099,7 +1099,7 @@ fn resolve_helper_paths_cached(
 ) -> Vec<PathBuf> {
     let key = HelperPathResolutionKey {
         source_path: source_path.to_path_buf(),
-        candidate: candidate.to_owned(),
+        candidate: candidate.into(),
     };
     if let Some(paths) = context.resolved_helper_paths.borrow().get(&key) {
         return paths.clone();

--- a/crates/shuck-semantic/src/source_ref.rs
+++ b/crates/shuck-semantic/src/source_ref.rs
@@ -23,10 +23,7 @@ pub enum SourceRefKind {
     Directive(CompactString),
     DirectiveDevNull,
     Dynamic,
-    SingleVariableStaticTail {
-        variable: Name,
-        tail: CompactString,
-    },
+    SingleVariableStaticTail { variable: Name, tail: CompactString },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/source_ref.rs
+++ b/crates/shuck-semantic/src/source_ref.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use shuck_ast::{Name, Span};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,11 +19,14 @@ pub struct SourceRef {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SourceRefKind {
-    Literal(String),
-    Directive(String),
+    Literal(CompactString),
+    Directive(CompactString),
     DirectiveDevNull,
     Dynamic,
-    SingleVariableStaticTail { variable: Name, tail: String },
+    SingleVariableStaticTail {
+        variable: Name,
+        tail: CompactString,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1416,7 +1416,7 @@ source \"$x\"
 
     assert_eq!(
         model.source_refs()[0].kind,
-        SourceRefKind::Directive("lib.sh".to_string())
+        SourceRefKind::Directive("lib.sh".into())
     );
     assert_eq!(
         model.source_refs()[0].resolution,
@@ -1435,7 +1435,7 @@ source \"$x\"
 
     assert_eq!(
         model.source_refs()[0].kind,
-        SourceRefKind::Directive("lib.sh".to_string())
+        SourceRefKind::Directive("lib.sh".into())
     );
 }
 
@@ -1457,7 +1457,7 @@ source \"$d\"
     assert_eq!(model.source_refs()[1].kind, SourceRefKind::DirectiveDevNull);
     assert_eq!(
         model.source_refs()[2].kind,
-        SourceRefKind::Directive("./helper.sh".to_string())
+        SourceRefKind::Directive("./helper.sh".into())
     );
     assert_eq!(model.source_refs()[3].kind, SourceRefKind::Dynamic);
 }


### PR DESCRIPTION
## Summary

Profiling the `xwmx__nb__nb` corpus fixture under dhat showed ~4M allocations per 5-iteration run. This branch chases the top hotspots and reduces total allocations by ~716k blocks (≈18%) without changing diagnostic output (117 diagnostics, identical).

| Commit | Blocks saved |
|---|---:|
| `perf(semantic): flatten dataflow init-name matrices` | -466,440 |
| `perf(linter): drop format! in expansion_span_is_plain_reference` | -70,670 |
| `perf(linter): store Edit content as CompactString` | -34,460 |
| `perf(linter): canonical_ascii_uppercase returns CompactString` | -41,095 |
| `perf(linter): build C-style comment diagnostic only on match` | -103,380 |

The biggest landmines were:

- A `Vec<DenseBitSet>` per dataflow analysis where every row had identical width — switched to a flat `DenseBitMatrix` so per-row clones do not allocate.
- A `format!` used purely to build a string for equality — replaced with byte-slice comparison.
- `Edit::content` stored as `String`, even though most fix payloads are tiny — switched to `CompactString` (≤24 byte inline storage).
- `canonical_ascii_uppercase` allocating a `String` per misspelling lookup — switched to `CompactString`.
- A `then_some(Diagnostic::new(...))` in `c_style_comment` that paid for a Diagnostic + Fix + Edit on every command, regardless of whether the comment shape actually matched. Switched to `then(|| ...)`.

A `chore(benchmark): add dhat heap profiling feature` commit wires up the `dhat-heap` cargo feature on `shuck-benchmark` so this kind of profiling has a stable entry point.

## Test plan

- [x] `cargo test -p shuck-linter -p shuck-cli` passes after each commit
- [x] `target/profiling/examples/large_corpus_profile xwmx__nb__nb --iterations 5` returns 117 diagnostics throughout (unchanged from baseline)
- [x] dhat baseline → final: 3,985,350 → 3,269,305 blocks