### PR TITLE
refactor(linter): fuse smart-quote scan and trim capacity estimate

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -13,7 +13,6 @@ struct LinterFactsBuilder<'a, 'analysis> {
 #[derive(Debug, Default)]
 struct FactBuildCapacity {
     commands: usize,
-    structural_commands: usize,
     functions: usize,
 }
 
@@ -38,17 +37,11 @@ struct HeredocFactSummary {
 
 #[cfg_attr(shuck_profiling, inline(never))]
 fn estimate_fact_build_capacity(semantic: &SemanticModel) -> FactBuildCapacity {
-    let mut capacity = FactBuildCapacity::default();
-    for context in semantic.command_contexts() {
-        capacity.commands += 1;
-        if context.is_structural() {
-            capacity.structural_commands += 1;
-        }
-        if context.kind() == shuck_semantic::CommandKind::Function {
-            capacity.functions += 1;
-        }
+    let commands = semantic.command_count();
+    FactBuildCapacity {
+        commands,
+        functions: commands.saturating_div(8),
     }
-    capacity
 }
 
 impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -563,12 +563,6 @@ impl<'a> SurfaceFragmentSink<'a> {
 
     pub(super) fn collect_word(&mut self, word: &Word, context: SurfaceScanContext<'_>) -> bool {
         let open_double_quote_count = self.facts.open_double_quotes.len();
-        collect_unicode_smart_quote_spans_in_word_parts(
-            &word.parts,
-            self.source,
-            false,
-            &mut self.facts.unicode_smart_quote_spans,
-        );
         self.zsh_parameter_index_flag_scratch.clear();
         collect_zsh_parameter_index_flag_spans_in_word(
             word.span.slice(self.source),
@@ -586,7 +580,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                 context.assignment_target,
             );
         }
-        self.collect_word_parts(&word.parts, context);
+        self.collect_word_parts(&word.parts, context, false);
         self.facts.open_double_quotes.len() > open_double_quote_count
     }
 
@@ -666,8 +660,29 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    fn collect_word_parts(&mut self, parts: &[WordPartNode], context: SurfaceScanContext<'_>) {
+    fn collect_word_parts(
+        &mut self,
+        parts: &[WordPartNode],
+        context: SurfaceScanContext<'_>,
+        in_double_quote: bool,
+    ) {
         for (index, part) in parts.iter().enumerate() {
+            if let WordPart::Literal(text) = &part.kind
+                && !in_double_quote
+            {
+                let literal = text.as_str(self.source, part.span);
+                for (offset, char) in literal.char_indices() {
+                    if !is_unicode_smart_quote(char) {
+                        continue;
+                    }
+                    let start = part.span.start.advanced_by(&literal[..offset]);
+                    let end = start.advanced_by(char.encode_utf8(&mut [0; 4]));
+                    self.facts
+                        .unicode_smart_quote_spans
+                        .push(Span::from_positions(start, end));
+                }
+            }
+
             if let WordPart::Variable(name) = &part.kind
                 && matches!(
                     name.as_str(),
@@ -715,7 +730,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                             .dollar_double_quoted
                             .push(DollarDoubleQuotedFragmentFact { span: part.span });
                     }
-                    self.collect_word_parts(parts, context);
+                    self.collect_word_parts(parts, context, true);
                 }
                 WordPart::ZshQualifiedGlob(glob) => self.collect_zsh_qualified_glob(glob, context),
                 WordPart::ArithmeticExpansion {
@@ -2843,33 +2858,6 @@ pub(super) fn simple_command_variable_set_operand<'a>(
     let operands = simple_test_operands(command, source)?;
     (operands.len() == 2 && static_word_text(&operands[0], source).as_deref() == Some("-v"))
         .then(|| &operands[1])
-}
-
-fn collect_unicode_smart_quote_spans_in_word_parts(
-    parts: &[WordPartNode],
-    source: &str,
-    quoted: bool,
-    spans: &mut Vec<Span>,
-) {
-    for part in parts {
-        match &part.kind {
-            WordPart::Literal(text) if !quoted => {
-                let literal = text.as_str(source, part.span);
-                for (offset, char) in literal.char_indices() {
-                    if !is_unicode_smart_quote(char) {
-                        continue;
-                    }
-                    let start = part.span.start.advanced_by(&literal[..offset]);
-                    let end = start.advanced_by(char.encode_utf8(&mut [0; 4]));
-                    spans.push(Span::from_positions(start, end));
-                }
-            }
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_unicode_smart_quote_spans_in_word_parts(parts, source, true, spans)
-            }
-            _ => {}
-        }
-    }
 }
 
 fn is_unicode_smart_quote(char: char) -> bool {


### PR DESCRIPTION
## Summary

Two small facts-builder cleanups uncovered while drilling into `LinterFactsBuilder::build` on the airgeddon fixture.

- **Fuse smart-quote scan into the surface walk.** `SurfaceFragmentSink::collect_word_parts` now threads an `in_double_quote` flag and emits unicode smart-quote spans inline as it walks, replacing the standalone pre-pass that re-walked every word. Drops the now-dead `collect_unicode_smart_quote_spans_in_word_parts` helper.
- **Drop the redundant capacity estimation pass.** `estimate_fact_build_capacity` was iterating `semantic.command_contexts()` to compute a `structural_commands` field that was never read (the only consumer used the slice directly). Replaced with a `semantic.command_count()` lookup plus a cheap `commands / 8` heuristic for function buckets.

Wall-clock on the airgeddon profile is flat — these are architectural cleanups, not perf wins. The capacity-estimate change removes ~3% of misattributed first-touch cost from the drilldown so the real next target (`build_command_topology`) shows up cleanly.

## Test plan

- [x] `cargo test -p shuck-linter --lib` (3146 tests pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `samply` profile on airgeddon: wall-clock unchanged within noise