### PR TITLE
perf(parser): short-circuit pure-literal source-backed words

### DIFF
--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3311,6 +3311,14 @@ impl<'a> Parser<'a> {
         options: DecodeWordPartsOptions,
         parts: &mut WordPartBuffer,
     ) {
+        if source_backed
+            && !s.is_empty()
+            && let Some(end) = try_pure_literal_end_position(s.as_bytes(), base, options)
+        {
+            Self::push_word_part(parts, WordPart::Literal(LiteralText::source()), base, end);
+            return;
+        }
+
         let mut chars = s.chars().peekable();
         let mut current = String::new();
         let mut current_start = base;
@@ -5989,6 +5997,48 @@ impl<'a> Parser<'a> {
 
         false
     }
+}
+
+#[inline]
+fn try_pure_literal_end_position(
+    bytes: &[u8],
+    base: Position,
+    options: DecodeWordPartsOptions,
+) -> Option<Position> {
+    let backslash_special =
+        options.preserve_quote_fragments || options.preserve_escaped_expansion_literals;
+    let quote_special = options.preserve_quote_fragments;
+    let proc_subst_special = options.parse_process_substitutions;
+
+    let mut newline_count: usize = 0;
+    let mut last_newline: Option<usize> = None;
+
+    for (i, &byte) in bytes.iter().enumerate() {
+        if byte >= 0x80 {
+            return None;
+        }
+        match byte {
+            0 | b'$' | b'`' => return None,
+            b'\\' if backslash_special => return None,
+            b'\'' | b'"' if quote_special => return None,
+            b'<' | b'>' if proc_subst_special => return None,
+            b'\n' => {
+                newline_count += 1;
+                last_newline = Some(i);
+            }
+            _ => {}
+        }
+    }
+
+    let len = bytes.len();
+    Some(Position {
+        line: base.line + newline_count,
+        column: match last_newline {
+            Some(idx) => len - idx,
+            None => base.column + len,
+        },
+        offset: base.offset + len,
+    })
 }
 
 fn source_prefix_ends_inside_double_quotes(prefix: &str) -> bool {


### PR DESCRIPTION
## Summary

`decode_word_parts_into_with_quote_fragments` was the #4 parser hotspot on the airgeddon profile (2.2% own leaf, 5.9% inclusive). For every word, it ran `chars().peekable()`, pushed each character into an owned `String`, then handed that string to `flush_literal_part` → `literal_text` → `source_matches`, which compared it byte-for-byte against the original source slice. When the word contains no expansions/quotes/backticks the cooked string ends up exactly equal to the source slice, so the entire round trip is wasted work.

This adds a single-pass fast path at function entry: `try_pure_literal_end_position` scans the input bytes once, bailing if any byte is an active special (`\0`, `$`, `` ` ``, plus `\\`/`'`/`"`/`<`/`>` when their gating options are set) and otherwise computing the end `Position` inline (newline count + last-newline offset + total length). On hit, the function emits one `WordPart::Literal(LiteralText::source())` covering the whole span and returns — no `String`, no per-char `Position::advance`, no `flush_literal_part`, no `source_matches`.

The fast path is gated on `source_backed` so non-source-backed callers (heredoc bodies, synthesized text) keep going through the slow path unchanged. Non-ASCII bytes also fall back to the slow path so multi-byte char handling is identical to before.

## Profile impact

Airgeddon fixture, 12 iterations at 2000 Hz, attributed-exclusive samples.

| Frame | Before | After |
|---|---:|---:|
| `decode_word_parts...` parent inclusive | 5.9% | 4.9% |
| `decode_word_parts...` own leaf | 2.2% | 1.8% |
| `Position::advanced_by` | 1.5% | <1.6% (off top 10) |
| `flush_literal_part` (sub-frame) | 6.3% of parent | not visible |

Wall-clock numbers are within thermal noise on this machine; the win shows up clearly at the attribution level.

## Test plan

- [x] `cargo test -p shuck-parser --lib` (637 tests pass)
- [x] `cargo test -p shuck-linter --lib` (3146 tests pass)
- [x] `cargo test -p shuck-cli --lib` (143 tests pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-parser --all-targets -- -D warnings`