### PR TITLE
perf(parser): skip zsh glob word probe on non-zsh Word tokens

### DIFF
--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2323,10 +2323,15 @@ impl<'a> Parser<'a> {
     }
 
     fn current_zsh_glob_word_from_source(&mut self) -> Option<Word> {
-        if !matches!(
-            self.current_token_kind,
-            Some(TokenKind::LeftParen | TokenKind::Word)
-        ) {
+        let kind = self.current_token_kind?;
+        if !matches!(kind, TokenKind::LeftParen | TokenKind::Word) {
+            return None;
+        }
+        // Non-zsh dialects only need this path to rescue `(#...)`-leading words
+        // from being misparsed as subshells. For Word-kind tokens the regular
+        // word-decode path already produces the right AST, so skip the byte
+        // walk entirely.
+        if kind == TokenKind::Word && !self.dialect.features().zsh_glob_qualifiers {
             return None;
         }
 


### PR DESCRIPTION
## Summary

`current_zsh_glob_word_from_source` was the #4 parser hotspot (2.5% own leaf) on the airgeddon profile, even though airgeddon is a bash script. The function runs for every word and walks the word's bytes looking for `(#` (zsh extended-glob marker). On non-zsh dialects this byte walk almost never finds anything useful.

The reason the function exists at all on non-zsh: when a word *starts* with `(`, the lexer produces a `LeftParen` token, and without this path `(#i)*.jpg` would be misparsed as a subshell. So for non-zsh dialects we still need the rescue — but only for `LeftParen`-kind tokens. For ordinary `Word`-kind tokens, the regular word-decode path already produces the right AST, and the existing test `test_non_zsh_dialects_do_not_special_case_trailing_glob_qualifiers` confirms this.

This PR gates the function on `kind == TokenKind::Word && !dialect.features().zsh_glob_qualifiers` and returns `None` without scanning in that case. The zsh path is unchanged; the non-zsh `LeftParen` rescue still fires.

## Profile impact

Airgeddon fixture (bash), 12 iterations at 2000 Hz.

| Metric | Before | After |
|---|---:|---:|
| Wall-clock avg/iter | 235 ms | 228 ms |
| Total samples | 5649 | 5526 |
| `current_zsh_glob_word_from_source` rank | #4 (2.5%) | off top 12 |

## Test plan

- [x] `cargo test -p shuck-parser --lib` (637 tests pass; the existing `test_non_zsh_dialects_do_not_special_case_trailing_glob_qualifiers` covers the `LeftParen` rescue)
- [x] `cargo test -p shuck-linter --lib` (3146 tests pass)
- [x] `cargo test -p shuck-cli --lib` (143 tests pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-parser --all-targets -- -D warnings`