### PR TITLE
perf(ast): single-pass Position::advanced_by

### DIFF
--- a/crates/shuck-ast/src/span.rs
+++ b/crates/shuck-ast/src/span.rs
@@ -37,21 +37,30 @@ impl Position {
 
     /// Return a new position advanced by every character in `text`.
     pub fn advanced_by(mut self, text: &str) -> Self {
-        if text.is_ascii() {
-            let len = text.len();
-            match text.rfind('\n') {
-                Some(last_newline) => {
-                    self.line += text.bytes().filter(|byte| *byte == b'\n').count();
-                    self.column = len - last_newline;
+        let bytes = text.as_bytes();
+        let mut newline_count: usize = 0;
+        let mut last_newline: Option<usize> = None;
+
+        for (i, &byte) in bytes.iter().enumerate() {
+            if byte >= 0x80 {
+                for ch in text.chars() {
+                    self.advance(ch);
                 }
-                None => self.column += len,
+                return self;
             }
-            self.offset += len;
-            return self;
+            if byte == b'\n' {
+                newline_count += 1;
+                last_newline = Some(i);
+            }
         }
-        for ch in text.chars() {
-            self.advance(ch);
-        }
+
+        let len = bytes.len();
+        self.offset += len;
+        self.line += newline_count;
+        self.column = match last_newline {
+            Some(idx) => len - idx,
+            None => self.column + len,
+        };
         self
     }
 


### PR DESCRIPTION
## Summary

`Position::advanced_by` was doing up to three separate passes over the input string:

1. `text.is_ascii()` — full SIMD byte scan.
2. `text.rfind('\n')` — backward SIMD scan via `memrchr`.
3. On a newline hit, `text.bytes().filter(|b| *b == b'\n').count()` to count them all.

That works well for long strings, but the dominant call pattern from the parser is 1-2 byte literals (`"("`, `"{"`, `"))"`, `"((", "${"`). At that size, SIMD setup overhead dwarfs the actual work, and the parser issues these calls for every token-level position update.

This PR replaces the multi-pass implementation with a single scalar loop that scans the bytes once, tracks the newline count and last-newline offset inline, and bails to the existing char-by-char path on the first non-ASCII byte. The final line/column/offset update is computed from the accumulated counters at the end.

## Profile impact

Airgeddon fixture (bash), 12 iterations at 2000 Hz.

| Metric | Before | After |
|---|---:|---:|
| `Position::advanced_by` inclusive | 3.3% (180 samples) | 2.4% (132 samples) |
| `core::slice::memchr::memrchr` | 1.4% | gone |
| `next_match_back` | 0.3% | gone |
| Wall-clock avg/iter | 228 ms | 223 ms |
| Total samples | 5526 | 5412 |

The cost that used to split between `advanced_by`'s own leaf, `memrchr`, and `next_match_back` is now consolidated in `advanced_by`'s own leaf and ~27% smaller in absolute terms.

## Test plan

- [x] `cargo test -p shuck-ast --lib` (100 tests pass)
- [x] `cargo test -p shuck-parser --lib` (637 tests pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-ast --all-targets -- -D warnings`