### PR TITLE
perf(linter): cut facts allocation blocks with SmallVec and BitVec

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -87,12 +87,14 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let mut declaration_assignment_probe_store = ListArena::new();
         let mut command_ids_by_span =
             CommandLookupIndex::with_capacity_and_hasher(capacity.commands, Default::default());
-        let mut command_ids_by_name_word_span =
-            FxHashMap::with_capacity_and_hasher(capacity.commands, Default::default());
+        let mut command_ids_by_name_word_span = FxHashMap::with_capacity_and_hasher(
+            capacity.commands.saturating_div(2),
+            Default::default(),
+        );
         let mut if_condition_command_ids =
-            FxHashSet::with_capacity_and_hasher(capacity.commands / 4, Default::default());
+            DenseCommandIdSet::with_capacity(self.semantic.command_count());
         let mut elif_condition_command_ids =
-            FxHashSet::with_capacity_and_hasher(capacity.commands / 8, Default::default());
+            DenseCommandIdSet::with_capacity(self.semantic.command_count());
         let mut binding_values = FxHashMap::default();
         let mut broken_assoc_key_spans = Vec::new();
         let mut comma_array_assignment_spans = Vec::new();
@@ -103,8 +105,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let mut word_node_ids_by_span =
             FxHashMap::with_capacity_and_hasher(estimated_word_nodes, Default::default());
         let mut word_occurrences = Vec::with_capacity(estimated_word_occurrences);
-        let mut pending_arithmetic_word_occurrences =
-            Vec::with_capacity(capacity.commands.saturating_div(4));
+        let mut pending_arithmetic_word_occurrences = Vec::new();
         let mut compound_assignment_value_word_spans = FxHashSet::default();
         let mut array_assignment_split_word_ids =
             Vec::with_capacity(capacity.commands.saturating_div(8));
@@ -118,7 +119,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let mut arithmetic_summary = ArithmeticFactSummary::default();
         let mut surface_fragments = SurfaceFragmentSink::new(self.source);
         let mut functions = Vec::with_capacity(capacity.functions);
-        let mut function_body_without_braces_spans = Vec::with_capacity(capacity.functions);
+        let mut function_body_without_braces_spans = Vec::new();
         let redundant_return_status_spans = Vec::new();
         let mut getopts_cases = Vec::new();
         let mut condition_status_capture_spans = Vec::new();

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -199,7 +199,7 @@ impl StaticCasePatternBitNfa {
 
         let mut any_char = 0u128;
         let mut any_string = 0u128;
-        let mut literal_masks = Vec::<(char, u128)>::new();
+        let mut literal_masks: SmallVec<[(char, u128); 8]> = SmallVec::new();
 
         for (i, token) in tokens.iter().copied().enumerate() {
             let bit = 1u128 << i;
@@ -211,7 +211,7 @@ impl StaticCasePatternBitNfa {
         }
 
         literal_masks.sort_by_key(|(c, _)| *c);
-        let mut merged: Vec<(char, u128)> = Vec::with_capacity(literal_masks.len());
+        let mut merged: SmallVec<[(char, u128); 8]> = SmallVec::with_capacity(literal_masks.len());
         for (c, mask) in literal_masks {
             match merged.last_mut() {
                 Some((last_c, last_mask)) if *last_c == c => *last_mask |= mask,
@@ -224,7 +224,7 @@ impl StaticCasePatternBitNfa {
             start: 1,
             any_char,
             any_string,
-            literal_masks: merged.into_boxed_slice(),
+            literal_masks: merged.into_vec().into_boxed_slice(),
         };
         nfa.start = nfa.epsilon_closure(nfa.start);
         Some(nfa)
@@ -427,7 +427,7 @@ impl StaticCasePatternMatcher {
 
         let start = (left_nfa.start, right_nfa.start);
         let mut seen = FxHashSet::default();
-        let mut worklist = Vec::with_capacity(32);
+        let mut worklist: SmallVec<[(u128, u128); 32]> = SmallVec::new();
         seen.insert(start);
         worklist.push(start);
 
@@ -465,7 +465,7 @@ impl StaticCasePatternMatcher {
 
         let start = (left_nfa.start, right_nfa.start);
         let mut seen = FxHashSet::default();
-        let mut worklist = Vec::with_capacity(32);
+        let mut worklist: SmallVec<[(u128, u128); 32]> = SmallVec::new();
         seen.insert(start);
         worklist.push(start);
 
@@ -789,7 +789,7 @@ fn summarize_static_case_pattern_tokens(tokens: &[CasePatternToken]) -> StaticCa
     let mut saw_wildcard = false;
     let mut literal_suffix_reversed = String::new();
     let mut saw_suffix_wildcard = false;
-    let mut literal_symbols = Vec::new();
+    let mut literal_symbols: SmallVec<[char; 8]> = SmallVec::new();
 
     for token in tokens {
         match token {
@@ -842,7 +842,7 @@ fn summarize_static_case_pattern_tokens(tokens: &[CasePatternToken]) -> StaticCa
             .rev()
             .collect::<String>()
             .into_boxed_str(),
-        literal_symbols: literal_symbols.into_boxed_slice(),
+        literal_symbols: literal_symbols.into_vec().into_boxed_slice(),
         start_states: case_pattern_epsilon_closure(tokens, [0]).into_boxed_slice(),
     }
 }

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -743,7 +743,7 @@ fn populate_scope_fact_ranges<'a>(
     fact_store: &mut FactStore<'a>,
     command_fact_indices_by_id: &[Option<usize>],
     pipelines: &[PipelineFact<'a>],
-    if_condition_command_ids: &FxHashSet<CommandId>,
+    if_condition_command_ids: &DenseCommandIdSet,
     source: &'a str,
 ) {
     let (pipeline_summaries, pipeline_summary_ids_by_writer) = {
@@ -779,7 +779,7 @@ fn populate_scope_fact_ranges<'a>(
 struct ScopeFactInputs<'facts, 'a> {
     pipeline_summaries: &'facts [PipelineScopeSummary<'a>],
     pipeline_summary_ids_by_writer: &'facts [SmallVec<[usize; 1]>],
-    if_condition_command_ids: &'facts FxHashSet<CommandId>,
+    if_condition_command_ids: &'facts DenseCommandIdSet,
     source: &'a str,
 }
 
@@ -862,7 +862,7 @@ struct PipelineScopeSummary<'a> {
 fn build_pipeline_scope_summaries<'a>(
     commands: CommandFacts<'_, 'a>,
     pipelines: &[PipelineFact<'a>],
-    if_condition_command_ids: &FxHashSet<CommandId>,
+    if_condition_command_ids: &DenseCommandIdSet,
     source: &str,
 ) -> (Vec<PipelineScopeSummary<'a>>, Vec<SmallVec<[usize; 1]>>) {
     let mut summaries = Vec::new();
@@ -920,7 +920,7 @@ fn collect_scope_read_source_words_for_command<'a>(
     command: CommandFactRef<'_, 'a>,
     pipeline_summaries: &[PipelineScopeSummary<'a>],
     pipeline_summary_ids: &[usize],
-    if_condition_command_ids: &FxHashSet<CommandId>,
+    if_condition_command_ids: &DenseCommandIdSet,
     source: &str,
     words: &mut Vec<PathWordFact<'a>>,
 ) {
@@ -1006,7 +1006,7 @@ fn collect_scope_name_write_uses_for_command(
 
 fn collect_own_scope_read_source_words<'a>(
     command: CommandFactRef<'_, 'a>,
-    if_condition_command_ids: &FxHashSet<CommandId>,
+    if_condition_command_ids: &DenseCommandIdSet,
     source: &str,
     words: &mut Vec<PathWordFact<'a>>,
 ) {
@@ -1025,7 +1025,7 @@ fn collect_own_scope_read_source_words<'a>(
     );
     collect_command_redirect_read_source_words(command, source, words);
     collect_command_simple_test_path_words(command, source, words);
-    if !if_condition_command_ids.contains(&command.id()) {
+    if !if_condition_command_ids.contains(command.id()) {
         collect_command_conditional_path_words(command, source, words);
     }
 }
@@ -1083,7 +1083,7 @@ fn collect_own_scope_name_write_uses(
 fn collect_nested_scope_read_source_words<'a>(
     commands: CommandFacts<'_, 'a>,
     command: CommandFactRef<'_, 'a>,
-    if_condition_command_ids: &FxHashSet<CommandId>,
+    if_condition_command_ids: &DenseCommandIdSet,
     source: &str,
     words: &mut Vec<PathWordFact<'a>>,
 ) {

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -2,8 +2,8 @@ use rustc_hash::FxHashSet;
 use shuck_ast::{ConditionalBinaryOp, ConditionalUnaryOp, Span, Word, static_word_text};
 
 use super::{
-    CommandFact, CommandId, ConditionalFact, ConditionalNodeFact, ExpansionContext, FactSpan,
-    SimpleTestFact, SimpleTestSyntax, WordNode, WordOccurrence, word_spans,
+    CommandFact, ConditionalFact, ConditionalNodeFact, DenseCommandIdSet, ExpansionContext,
+    FactSpan, SimpleTestFact, SimpleTestSyntax, WordNode, WordOccurrence, word_spans,
 };
 use crate::facts::occurrence_word;
 
@@ -100,7 +100,7 @@ pub(super) struct ConditionalPortabilityInputs<'a> {
 #[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_conditional_portability_facts<'a>(
     commands: &[CommandFact<'a>],
-    elif_condition_command_ids: &FxHashSet<CommandId>,
+    elif_condition_command_ids: &DenseCommandIdSet,
     inputs: ConditionalPortabilityInputs<'a>,
     source: &str,
 ) -> ConditionalPortabilityFacts {
@@ -110,7 +110,7 @@ pub(super) fn build_conditional_portability_facts<'a>(
         if let Some(conditional) = command.conditional() {
             facts.double_bracket_in_sh.push(command.span());
 
-            if elif_condition_command_ids.contains(&command.id()) {
+            if elif_condition_command_ids.contains(command.id()) {
                 facts.if_elif_bash_test.push(command.span());
             }
 

--- a/crates/shuck-linter/src/facts/core.rs
+++ b/crates/shuck-linter/src/facts/core.rs
@@ -108,6 +108,40 @@ pub(super) struct CommandLookupEntry {
 
 type CommandLookupIndex = FxHashMap<FactSpan, SmallVec<[CommandLookupEntry; 1]>>;
 
+#[derive(Debug, Clone, Default)]
+pub(super) struct DenseCommandIdSet {
+    words: Vec<u64>,
+}
+
+impl DenseCommandIdSet {
+    const BITS: usize = u64::BITS as usize;
+
+    pub(super) fn with_capacity(command_count: usize) -> Self {
+        Self {
+            words: vec![0; command_count.div_ceil(Self::BITS)],
+        }
+    }
+
+    pub(super) fn insert(&mut self, id: CommandId) {
+        let index = id.index();
+        let word = index / Self::BITS;
+        let bit = index % Self::BITS;
+        if word >= self.words.len() {
+            self.words.resize(word + 1, 0);
+        }
+        self.words[word] |= 1u64 << bit;
+    }
+
+    pub(super) fn contains(&self, id: CommandId) -> bool {
+        let index = id.index();
+        let word = index / Self::BITS;
+        let bit = index % Self::BITS;
+        self.words
+            .get(word)
+            .is_some_and(|w| (w & (1u64 << bit)) != 0)
+    }
+}
+
 #[derive(Debug, Clone)]
 struct FactStore<'a> {
     redirect_facts: ListArena<RedirectFact<'a>>,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -11,8 +11,8 @@ pub struct LinterFacts<'a> {
     innermost_command_ids_by_offset: CommandOffsetLookup,
     innermost_command_ids_by_binding_offset: CommandOffsetLookup,
     command_dominance_barrier_flags: Vec<bool>,
-    if_condition_command_ids: FxHashSet<CommandId>,
-    elif_condition_command_ids: FxHashSet<CommandId>,
+    if_condition_command_ids: DenseCommandIdSet,
+    elif_condition_command_ids: DenseCommandIdSet,
     binding_values: FxHashMap<BindingId, BindingValueFact<'a>>,
     broken_assoc_key_spans: Vec<Span>,
     comma_array_assignment_spans: Vec<Span>,
@@ -424,11 +424,11 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn is_if_condition_command(&self, id: CommandId) -> bool {
-        self.if_condition_command_ids.contains(&id)
+        self.if_condition_command_ids.contains(id)
     }
 
     pub fn is_elif_condition_command(&self, id: CommandId) -> bool {
-        self.elif_condition_command_ids.contains(&id)
+        self.elif_condition_command_ids.contains(id)
     }
 
     pub fn presence_tested_names(&self) -> &FxHashSet<Name> {


### PR DESCRIPTION
## Summary

Trim heap pressure in `LinterFactsBuilder::build` and the inner case-pattern loops on the large-corpus fixture (xwmx__nb__nb, 5 iterations): **2,080 MB / 3.99M blocks → 2,062 MB / 3.18M blocks** (-20.13% blocks, -0.86% bytes).

- **DenseCommandIdSet** replaces `FxHashSet<CommandId>` for the if/elif condition command tracking. `CommandId` is a dense `usize` index, so a `Vec<u64>` bitset gives O(1) insert/contains with a single allocation per set instead of 70 HashMap blocks.
- **SmallVec** for the hot inner loops in `case_patterns.rs`:
  - `StaticCasePatternBitNfa::new` literal_masks/merged buffers
  - `subsumes_bitset`/`intersects_bitset` worklists
  - `summarize_static_case_pattern_tokens` literal_symbols
  - Saves ~40k allocation blocks (-53% for `BitNfa::new` alone).
- **Right-size** three over-allocated upfront capacities in `build()`:
  - `command_ids_by_name_word_span` (halved — was 2× over fill)
  - `pending_arithmetic_word_occurrences` and `function_body_without_braces_spans` start empty instead of preallocating per-command/per-function.

## Test plan

- [x] `cargo build -p shuck-cli -p shuck-linter`
- [x] `cargo test -p shuck-linter` (3146 tests pass)
- [x] `cargo fmt --check`
- [x] dhat profile re-run on `xwmx__nb__nb` confirms the -20% blocks delta