### PR TITLE
perf(linter): drop densify-then-compact pass in LinterFactsBuilder

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -74,8 +74,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let estimated_word_nodes = capacity.commands.saturating_mul(2);
         let estimated_word_occurrences = capacity.commands.saturating_mul(3);
 
-        let mut commands_by_id = Vec::with_capacity(self.semantic.command_count());
-        commands_by_id.resize_with(self.semantic.command_count(), || None);
+        let mut commands: Vec<CommandFact<'_>> =
+            Vec::with_capacity(self.semantic.command_count());
         let mut redirect_fact_store = ListArena::new();
         let mut declaration_assignment_probe_store = ListArena::new();
         let mut command_ids_by_span =
@@ -320,8 +320,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     simple_test,
                     conditional,
                 };
-                let previous = commands_by_id[id.index()].replace(command_fact);
-                debug_assert!(previous.is_none(), "duplicate semantic command fact id");
+                commands.push(command_fact);
 
                 if let Command::Function(function) = visit.command {
                     functions.push(FunctionFactInput {
@@ -427,10 +426,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         fact_store.declaration_assignment_probes = declaration_assignment_probe_store;
         fact_store.word_spans = word_spans;
 
-        let mut commands = commands_by_id
-            .into_iter()
-            .flatten()
-            .collect::<Vec<_>>();
         commands.sort_unstable_by(compare_command_facts_by_offset);
         let command_fact_indices_by_id = build_command_fact_indices_by_id(&commands);
         let structural_command_ids = self


### PR DESCRIPTION
## Summary

`LinterFactsBuilder::build` was building `Vec<Option<CommandFact>>` indexed by `CommandId`, populating it sparsely during the build loop, then running `into_iter().flatten().collect::<Vec<_>>()` to compact it back into a dense `Vec<CommandFact>`. The build loop already iterates `command_contexts` in offset order (sorted at the top of `build`), so the ID-indexed intermediate plus its compaction step is pure waste — push facts straight into the offset-ordered Vec.

The trailing `sort_unstable_by(compare_command_facts_by_offset)` is left as a safety net; pdqsort detects sorted runs in O(N), so it's near-noop on the already-sorted data. The previous `Option::replace` debug check is dropped — the upstream invariant (`command_contexts()` filter-maps `Vec<Option<...>>::iter()`, so each `CommandId` appears at most once) covers it.

Considered alternatives (per profile-driven review): `BitVec` doesn't fit (we're storing a 600 B struct, not a flag); `IndexVec<CommandId, Option<CommandFact>>` is the same memory layout we already have, just newtype-safer; a dense `IndexVec<CommandId, CommandFact>` would require `Default` and would still leave half the slots unused. The right shape is just `Vec<CommandFact>` populated in offset order.

## Measurements (large-corpus fixture `xwmx__nb__nb`)

**Wall-clock (3 interleaved rounds, 12 iters each, profiling profile, no instrumentation):**

| Round | Before | After | Δ |
|---:|---:|---:|---:|
| 1 | 139.17 ms | 133.44 ms | −4.1% |
| 2 | 138.62 ms | 132.83 ms | −4.2% |
| 3 | 145.10 ms | 137.07 ms | −5.5% |
| **Mean** | **140.96 ms** | **134.45 ms** | **−4.6%** |

**Heap (dhat, lint-loop attributable):**

| Metric | Before | After | Δ |
|---:|---:|---:|---:|
| Total bytes allocated | 396.9 MB | 351.6 MB | −11.4% |
| Total blocks | 563,744 | 563,729 | −15 (the doubling reallocs) |
| `LinterFactsBuilder::build` tb | 77.6 MB | 32.2 MB | −58% |
| `LinterFactsBuilder::build` peak (gb) | 54.3 MB | 28.7 MB | −47% |

Diagnostic output unchanged (117 → 117 for this fixture).

## Test plan

- [x] `cargo test -p shuck-linter` (3146 unit tests pass)
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo fmt`
- [ ] CI: full workspace tests + large-corpus comparison