### PR TITLE
refactor(linter): remove suppression fallback walk

### DIFF
--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -10,9 +10,8 @@ use criterion::{
 use shuck_benchmark::configure_benchmark_allocator;
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    LinterSettings, Rule, RuleSet, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
-    benchmark_collect_word_facts, first_statement_line,
-    lint_file_at_path_with_resolver_and_parse_result, parse_directives,
+    LinterSettings, Rule, RuleSet, ShellCheckCodeMap, ShellDialect, benchmark_collect_word_facts,
+    lint_file_at_path_with_resolver_and_parse_result_and_directives, parse_directives,
 };
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{SemanticBuildOptions, SemanticModel, SourcePathResolver};
@@ -293,20 +292,12 @@ fn lint_large_corpus_fixture_with_settings(
         indexer.comment_index(),
         &shellcheck_map,
     );
-    let suppression_index = (!directives.is_empty()).then(|| {
-        SuppressionIndex::new(
-            &directives,
-            &parse_result.file,
-            first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
-        )
-    });
-
-    let diagnostics = lint_file_at_path_with_resolver_and_parse_result(
+    let diagnostics = lint_file_at_path_with_resolver_and_parse_result_and_directives(
         &parse_result,
         &fixture.source,
         &indexer,
         &settings,
-        suppression_index.as_ref(),
+        &directives,
         Some(&fixture.path),
         resolver,
     );

--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -7,8 +7,8 @@ use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixt
 use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterFacts, LinterSemanticArtifacts, LinterSettings, RuleSet, ShellCheckCodeMap,
-    SuppressionIndex, benchmark_collect_word_facts, benchmark_normalize_commands,
-    first_statement_line, lint_file, parse_directives,
+    benchmark_collect_word_facts, benchmark_normalize_commands, lint_file_with_directives,
+    parse_directives,
 };
 use shuck_parser::parser::ParseResult;
 use shuck_semantic::SemanticModel;
@@ -81,21 +81,8 @@ fn lint_source(
         indexer.comment_index(),
         shellcheck_map,
     );
-    let suppression_index = (!directives.is_empty()).then(|| {
-        SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        )
-    });
-    let diagnostics = lint_file(
-        &output,
-        source,
-        &indexer,
-        settings,
-        suppression_index.as_ref(),
-        None,
-    );
+    let diagnostics =
+        lint_file_with_directives(&output, source, &indexer, settings, &directives, None);
 
     black_box(diagnostics.len())
 }

--- a/crates/shuck-benchmark/examples/large_corpus_profile.rs
+++ b/crates/shuck-benchmark/examples/large_corpus_profile.rs
@@ -9,8 +9,8 @@ use std::time::Instant;
 
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    LinterSettings, RuleSelector, RuleSet, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
-    first_statement_line, lint_file_at_path_with_resolver_and_parse_result, parse_directives,
+    LinterSettings, RuleSelector, RuleSet, ShellCheckCodeMap, ShellDialect,
+    lint_file_at_path_with_resolver_and_parse_result_and_directives, parse_directives,
 };
 use shuck_parser::parser::Parser;
 use shuck_semantic::SourcePathResolver;
@@ -322,19 +322,12 @@ fn run_large_corpus_fixture(
         indexer.comment_index(),
         &shellcheck_map,
     );
-    let suppression_index = (!directives.is_empty()).then(|| {
-        SuppressionIndex::new(
-            &directives,
-            &parsed.file,
-            first_statement_line(&parsed.file).unwrap_or(u32::MAX),
-        )
-    });
-    let diagnostics = lint_file_at_path_with_resolver_and_parse_result(
+    let diagnostics = lint_file_at_path_with_resolver_and_parse_result_and_directives(
         &parsed,
         &source,
         &indexer,
         &settings,
-        suppression_index.as_ref(),
+        &directives,
         Some(&fixture.path),
         Some(resolver),
     );

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -179,8 +179,7 @@ mod tests {
     use shuck_formatter::{FormattedSource, ShellFormatOptions, format_file_ast, format_source};
     use shuck_indexer::Indexer;
     use shuck_linter::{
-        LinterSettings, ShellCheckCodeMap, SuppressionIndex, first_statement_line, lint_file,
-        parse_directives,
+        LinterSettings, ShellCheckCodeMap, lint_file_with_directives, parse_directives,
     };
 
     #[derive(Debug, Deserialize)]
@@ -262,19 +261,12 @@ mod tests {
                 indexer.comment_index(),
                 &shellcheck_map,
             );
-            let suppression_index = (!directives.is_empty()).then(|| {
-                SuppressionIndex::new(
-                    &directives,
-                    &output.file,
-                    first_statement_line(&output.file).unwrap_or(u32::MAX),
-                )
-            });
-            let diagnostics = lint_file(
+            let diagnostics = lint_file_with_directives(
                 &output,
                 file.source,
                 &indexer,
                 &settings,
-                suppression_index.as_ref(),
+                &directives,
                 None,
             );
 

--- a/crates/shuck-cli/src/commands/check/analyze.rs
+++ b/crates/shuck-cli/src/commands/check/analyze.rs
@@ -5,8 +5,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    Applicability, LinterSettings, RuleSet, ShellCheckCodeMap, ShellDialect, SuppressionIndex,
-    first_statement_line, parse_directives,
+    Applicability, LinterSettings, RuleSet, ShellCheckCodeMap, ShellDialect, parse_directives,
 };
 use shuck_parser::{
     Error as ParseError,
@@ -153,19 +152,12 @@ pub(super) fn collect_lint_diagnostics(
         indexer.comment_index(),
         shellcheck_map,
     );
-    let suppression_index = (!directives.is_empty()).then(|| {
-        SuppressionIndex::new(
-            &directives,
-            &parse_result.file,
-            first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
-        )
-    });
-    shuck_linter::lint_file(
+    shuck_linter::lint_file_with_directives(
         parse_result,
         source,
         &indexer,
         linter_settings,
-        suppression_index.as_ref(),
+        &directives,
         Some(source_path),
     )
 }

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterSettings, Rule, RuleSet, Severity, ShellCheckCodeMap, ShellCheckLevel, ShellDialect,
-    SuppressionIndex, first_statement_line, parse_directives, rule_metadata,
+    parse_directives, rule_metadata,
 };
 use shuck_parser::parser::Parser;
 use shuck_semantic::SourcePathResolver;
@@ -939,13 +939,6 @@ fn lint_with_context(
         indexer.comment_index(),
         shellcheck_map,
     );
-    let suppression_index = (!directives.is_empty()).then(|| {
-        SuppressionIndex::new(
-            &directives,
-            &parse_result.file,
-            first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
-        )
-    });
 
     let explicit = explicit_paths.into_iter().collect::<Vec<_>>();
     let resolver = CompatSourceResolver {
@@ -968,12 +961,12 @@ fn lint_with_context(
         rule_options,
     };
 
-    let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result(
+    let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result_and_directives(
         &parse_result,
         source,
         &indexer,
         &settings,
-        suppression_index.as_ref(),
+        &directives,
         Some(path),
         Some(&resolver),
     );
@@ -982,7 +975,7 @@ fn lint_with_context(
         source,
         &indexer,
         &settings,
-        suppression_index.as_ref(),
+        None,
         Some(path),
         Some(&resolver),
     );

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -2415,20 +2415,13 @@ fn lint_large_corpus_output(
         indexer.comment_index(),
         &shellcheck_map,
     );
-    let suppression_index = (!directives.is_empty()).then(|| {
-        shuck_linter::SuppressionIndex::new(
-            &directives,
-            &parse_result.file,
-            shuck_linter::first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
-        )
-    });
 
-    shuck_linter::lint_file_at_path_with_resolver_and_parse_result(
+    shuck_linter::lint_file_at_path_with_resolver_and_parse_result_and_directives(
         parse_result,
         source,
         &indexer,
         linter_settings,
-        suppression_index.as_ref(),
+        &directives,
         Some(&fixture.path),
         source_path_resolver,
     )

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -100,7 +100,7 @@ pub use shell::ShellDialect;
 pub use suppression::{
     AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,
     SuppressionDirective, SuppressionIndex, SuppressionSource, add_ignores_to_path,
-    first_statement_line, parse_directives,
+    parse_directives,
 };
 /// Trait implemented by rule-specific diagnostic payloads.
 pub use violation::Violation;
@@ -110,11 +110,15 @@ use shuck_ast::{File, Position, Span, Stmt, StmtSeq, TextSize};
 use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{
-    FlowContext, ScopeId, SemanticBuildOptions, SemanticModel, SourcePathResolver,
-    TraversalObserver, build_with_observer_with_options,
+    CommandKind, CompoundCommandKind, FlowContext, ScopeId, SemanticBuildOptions, SemanticModel,
+    SourcePathResolver, TraversalObserver, build_with_observer_with_options,
 };
 use std::ops::Deref;
 use std::path::Path;
+
+use crate::suppression::{
+    first_statement_line, sort_command_spans_for_lookup, statement_suppression_span,
+};
 
 /// Combined semantic model and diagnostic output for a file analysis pass.
 pub struct AnalysisResult {
@@ -129,6 +133,7 @@ pub struct LinterSemanticArtifacts<'a> {
     semantic: SemanticModel,
     command_visits_by_id: Vec<Option<facts::CommandVisit<'a>>>,
     direct_command_ids_by_body_span: FxHashMap<facts::FactSpan, Vec<CommandId>>,
+    suppression_command_spans: Vec<Span>,
 }
 
 impl<'a> LinterSemanticArtifacts<'a> {
@@ -147,10 +152,13 @@ impl<'a> LinterSemanticArtifacts<'a> {
         let mut observer = LintTraversalObserver::default();
         let semantic =
             build_with_observer_with_options(file, source, indexer, &mut observer, options);
+        let mut suppression_command_spans = observer.collect_suppression_command_spans(&semantic);
+        sort_command_spans_for_lookup(&mut suppression_command_spans);
         Self {
             semantic,
             command_visits_by_id: observer.command_visits_by_id,
             direct_command_ids_by_body_span: observer.direct_command_ids_by_body_span,
+            suppression_command_spans,
         }
     }
 
@@ -166,6 +174,10 @@ impl<'a> LinterSemanticArtifacts<'a> {
 
     pub(crate) fn command_visits_by_id(&self) -> &[Option<facts::CommandVisit<'a>>] {
         &self.command_visits_by_id
+    }
+
+    pub(crate) fn suppression_command_spans(&self) -> &[Span] {
+        &self.suppression_command_spans
     }
 
     #[cfg(test)]
@@ -237,6 +249,23 @@ impl Deref for LinterSemanticArtifacts<'_> {
 struct LintTraversalObserver<'a> {
     command_visits_by_id: Vec<Option<facts::CommandVisit<'a>>>,
     direct_command_ids_by_body_span: FxHashMap<facts::FactSpan, Vec<CommandId>>,
+    suppression_command_spans_by_id: Vec<Option<Span>>,
+}
+
+impl LintTraversalObserver<'_> {
+    fn collect_suppression_command_spans(&self, semantic: &SemanticModel) -> Vec<Span> {
+        let mut spans = Vec::new();
+        for id in semantic.commands().iter().copied() {
+            let Some(Some(span)) = self.suppression_command_spans_by_id.get(id.index()) else {
+                continue;
+            };
+            if suppression_span_is_function_body_wrapper(semantic, id) {
+                continue;
+            }
+            spans.push(*span);
+        }
+        spans
+    }
 }
 
 impl<'a> TraversalObserver<'a> for LintTraversalObserver<'a> {
@@ -251,6 +280,14 @@ impl<'a> TraversalObserver<'a> for LintTraversalObserver<'a> {
             self.command_visits_by_id.resize(id.index() + 1, None);
         }
         self.command_visits_by_id[id.index()] = Some(facts::CommandVisit::new(stmt));
+        if self.suppression_command_spans_by_id.len() <= id.index() {
+            self.suppression_command_spans_by_id
+                .resize(id.index() + 1, None);
+        }
+        let span = statement_suppression_span(stmt);
+        if span.start.line != 0 && span.end.line != 0 {
+            self.suppression_command_spans_by_id[id.index()] = Some(span);
+        }
     }
 
     fn recorded_statement_sequence_command(
@@ -264,6 +301,35 @@ impl<'a> TraversalObserver<'a> for LintTraversalObserver<'a> {
             .or_default()
             .push(id);
     }
+}
+
+fn suppression_span_is_function_body_wrapper(semantic: &SemanticModel, id: CommandId) -> bool {
+    matches!(
+        semantic.command_kind(id),
+        CommandKind::Compound(CompoundCommandKind::BraceGroup)
+            | CommandKind::Compound(CompoundCommandKind::Subshell)
+    ) && semantic.command_parent_id(id).is_some_and(|parent| {
+        matches!(
+            semantic.command_kind(parent),
+            CommandKind::Function | CommandKind::AnonymousFunction
+        )
+    })
+}
+
+fn build_suppression_index_from_semantic(
+    directives: &[SuppressionDirective],
+    file: &File,
+    semantic: &LinterSemanticArtifacts<'_>,
+) -> Option<SuppressionIndex> {
+    if directives.is_empty() {
+        return None;
+    }
+
+    Some(SuppressionIndex::from_sorted_command_spans(
+        directives,
+        semantic.suppression_command_spans(),
+        first_statement_line(file).unwrap_or(u32::MAX),
+    ))
 }
 
 /// Builds semantic facts and linter diagnostics for a parsed file.
@@ -570,6 +636,89 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
     diagnostics
 }
 
+/// Lints an existing parse result while deriving suppressions from parsed directives
+/// and semantic-collected command spans.
+#[allow(clippy::too_many_arguments)]
+pub fn lint_file_at_path_with_resolver_and_parse_result_and_directives(
+    parse_result: &ParseResult,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    directives: &[SuppressionDirective],
+    source_path: Option<&Path>,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+) -> Vec<Diagnostic> {
+    let shell = resolve_shell(settings, source, source_path);
+    let mut file_entry_contract_collector =
+        ambient_contracts::AmbientContractCollector::new(source, source_path, shell);
+    let analyzed_paths_fallback =
+        source_path.map(|path| FxHashSet::from_iter([path.to_path_buf()]));
+    let analyzed_paths = settings
+        .analyzed_paths
+        .as_deref()
+        .or(analyzed_paths_fallback.as_ref());
+    let linter_semantic_artifacts = LinterSemanticArtifacts::build_with_options(
+        &parse_result.file,
+        source,
+        indexer,
+        SemanticBuildOptions {
+            source_path,
+            source_path_resolver,
+            file_entry_contract: None,
+            file_entry_contract_collector: Some(&mut file_entry_contract_collector),
+            analyzed_paths,
+            shell_profile: Some(shell.shell_profile()),
+            resolve_source_closure: settings.resolve_source_closure,
+        },
+    );
+    let suppression_index = build_suppression_index_from_semantic(
+        directives,
+        &parse_result.file,
+        &linter_semantic_artifacts,
+    );
+    let checker = Checker::new(
+        &parse_result.file,
+        source,
+        &linter_semantic_artifacts,
+        indexer,
+        &settings.rules,
+        shell,
+        settings.ambient_shell_options,
+        settings.report_environment_style_names,
+        settings.rule_options.clone(),
+        suppression_index.as_ref(),
+        parse_error_position(parse_result),
+    );
+    let mut diagnostics = checker.check();
+
+    diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
+        &parse_result.file,
+        source,
+        Some(parse_result),
+        &settings.rules,
+        shell,
+    ));
+    if parse_result.is_err() {
+        sanitize_diagnostic_spans_cold(&mut diagnostics, source, indexer);
+    }
+
+    for diagnostic in &mut diagnostics {
+        if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
+            diagnostic.severity = severity;
+        }
+    }
+
+    if let Some(suppression_index) = suppression_index.as_ref() {
+        filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
+    }
+    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
+
+    diagnostics
+        .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
+
+    diagnostics
+}
+
 /// Lints an existing parse result located at an optional source path.
 pub fn lint_file(
     parse_result: &ParseResult,
@@ -585,6 +734,27 @@ pub fn lint_file(
         indexer,
         settings,
         suppression_index,
+        source_path,
+        None,
+    )
+}
+
+/// Lints an existing parse result while deriving suppressions from parsed directives
+/// and semantic-collected command spans.
+pub fn lint_file_with_directives(
+    parse_result: &ParseResult,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    directives: &[SuppressionDirective],
+    source_path: Option<&Path>,
+) -> Vec<Diagnostic> {
+    lint_file_at_path_with_resolver_and_parse_result_and_directives(
+        parse_result,
+        source,
+        indexer,
+        settings,
+        directives,
         source_path,
         None,
     )
@@ -714,14 +884,33 @@ mod tests {
     fn lint(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        lint_file(&output, source, &indexer, settings, None, None)
+        let directives = parse_directives(
+            source,
+            &output.file,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        lint_file_with_directives(&output, source, &indexer, settings, &directives, None)
     }
 
     fn lint_path(path: &Path, settings: &LinterSettings) -> Vec<Diagnostic> {
         let source = fs::read_to_string(path).unwrap();
         let output = Parser::new(&source).parse().unwrap();
         let indexer = Indexer::new(&source, &output);
-        lint_file_at_path(&output.file, &source, &indexer, settings, None, Some(path))
+        let directives = parse_directives(
+            &source,
+            &output.file,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        lint_file_with_directives(
+            &output,
+            &source,
+            &indexer,
+            settings,
+            &directives,
+            Some(path),
+        )
     }
 
     fn lint_for_rule(source: &str, rule: Rule) -> Vec<Diagnostic> {
@@ -740,12 +929,18 @@ mod tests {
         let source = fs::read_to_string(path).unwrap();
         let output = Parser::new(&source).parse().unwrap();
         let indexer = Indexer::new(&source, &output);
-        lint_file_at_path_with_resolver(
+        let directives = parse_directives(
+            &source,
             &output.file,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        lint_file_at_path_with_resolver_and_parse_result_and_directives(
+            &output,
             &source,
             &indexer,
             &LinterSettings::for_rule(rule),
-            None,
+            &directives,
             Some(path),
             source_path_resolver,
         )
@@ -754,7 +949,13 @@ mod tests {
     fn lint_named_source(path: &Path, source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        lint_file_at_path(&output.file, source, &indexer, settings, None, Some(path))
+        let directives = parse_directives(
+            source,
+            &output.file,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        lint_file_with_directives(&output, source, &indexer, settings, &directives, Some(path))
     }
 
     fn lint_named_source_with_parse_dialect(
@@ -765,7 +966,13 @@ mod tests {
     ) -> Vec<Diagnostic> {
         let output = Parser::with_dialect(source, parse_dialect).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        lint_file_at_path(&output.file, source, &indexer, settings, None, Some(path))
+        let directives = parse_directives(
+            source,
+            &output.file,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        lint_file_with_directives(&output, source, &indexer, settings, &directives, Some(path))
     }
 
     fn runtime_prelude_source(shebang: &str) -> String {
@@ -2202,11 +2409,9 @@ echo $bar
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
+        let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+        let suppressions =
+            build_suppression_index_from_semantic(&directives, &output.file, &semantic).unwrap();
 
         let echo_foo = match &output.file.body[1].command {
             Command::Simple(command) => command.span,
@@ -2262,27 +2467,7 @@ EOF
   echo \"$later\"
 }
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::UndefinedVariable),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::UndefinedVariable);
 
         assert_eq!(
             diagnostics
@@ -5562,27 +5747,7 @@ terminal() {
 # shellcheck disable=SC2034
 foo=1
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::default(),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint(source, &LinterSettings::default());
         assert!(diagnostics.is_empty());
     }
 
@@ -5601,17 +5766,12 @@ foo=1
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
+        let diagnostics = lint_file_with_directives(
             &output,
             source,
             &indexer,
             &LinterSettings::default(),
-            Some(&suppressions),
+            &directives,
             None,
         );
         assert!(diagnostics.is_empty());
@@ -5626,27 +5786,7 @@ foo=1
 foo=1
 foo=2
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::default(),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint(source, &LinterSettings::default());
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 5);
     }
@@ -5661,27 +5801,7 @@ f() {
   return $?
 }
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::RedundantReturnStatus),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::RedundantReturnStatus);
         assert!(diagnostics.is_empty());
     }
 
@@ -5693,27 +5813,7 @@ f() {
 local foo=bar
 printf '%s\\n' \"$foo\"
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::default(),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint(source, &LinterSettings::default());
         assert!(diagnostics.is_empty());
     }
 
@@ -5727,27 +5827,7 @@ f() {
   echo \"$hard_list\"
 }
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::LocalDeclareCombined),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::LocalDeclareCombined);
         assert!(diagnostics.is_empty());
     }
 
@@ -5758,27 +5838,7 @@ f() {
 # shellcheck disable=SC2316
 `echo hello` | cat
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::BacktickInCommandPosition),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::BacktickInCommandPosition);
         assert!(diagnostics.is_empty());
     }
 
@@ -5789,27 +5849,7 @@ f() {
 # shellcheck disable=all
 [ \"$a\" = 1 -a \"$b\" = 2 ]
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::CompoundTestOperator),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::CompoundTestOperator);
         assert!(diagnostics.is_empty());
     }
 
@@ -5824,27 +5864,7 @@ f() {
 }
 f
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::LocalVariableInSh),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::LocalVariableInSh);
         assert!(diagnostics.is_empty());
     }
 
@@ -5855,27 +5875,7 @@ f
 # shellcheck disable=SC2113
 function f { :; }
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::FunctionKeyword),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::FunctionKeyword);
         assert!(diagnostics.is_empty());
     }
 
@@ -5886,27 +5886,7 @@ function f { :; }
 # shellcheck disable=SC2268
 \\command printf '%s\\n' hi
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::BackslashBeforeCommand),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::BackslashBeforeCommand);
         assert!(diagnostics.is_empty());
     }
 
@@ -5917,27 +5897,7 @@ function f { :; }
 # shellcheck disable=SC1012
 echo \\n
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::LiteralControlEscape),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::LiteralControlEscape);
         assert!(diagnostics.is_empty());
     }
 
@@ -5948,27 +5908,7 @@ echo \\n
 # shellcheck disable=SC3042
 let x=1
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::LetCommand),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::LetCommand);
         assert!(diagnostics.is_empty());
     }
 
@@ -5979,27 +5919,7 @@ let x=1
 # shellcheck disable=SC3044
 declare foo=bar
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::DeclareCommand),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::DeclareCommand);
         assert!(diagnostics.is_empty());
     }
 
@@ -6010,27 +5930,7 @@ declare foo=bar
 # shellcheck disable=SC3046
 source ./helpers.sh
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::SourceBuiltinInSh),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::SourceBuiltinInSh);
         assert!(diagnostics.is_empty());
     }
 
@@ -6041,27 +5941,7 @@ source ./helpers.sh
 # shellcheck disable=SC2112
 function f() { :; }
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::FunctionKeywordInSh),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::FunctionKeywordInSh);
         assert!(diagnostics.is_empty());
     }
 
@@ -6072,27 +5952,7 @@ function f() { :; }
 # shellcheck disable=SC2321
 arr[$((1+1))]=x
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::ArrayIndexArithmetic),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::ArrayIndexArithmetic);
         assert!(diagnostics.is_empty());
     }
 
@@ -6105,27 +5965,7 @@ f() {
   source ./helpers.sh
 }
 ";
-        let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let directives = parse_directives(
-            source,
-            &output.file,
-            indexer.comment_index(),
-            &ShellCheckCodeMap::default(),
-        );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &output.file,
-            first_statement_line(&output.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::SourceInsideFunctionInSh),
-            Some(&suppressions),
-            None,
-        );
+        let diagnostics = lint_for_rule(source, Rule::SourceInsideFunctionInSh);
         assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -76,8 +76,7 @@ mod tests {
 
     use crate::test::test_snippet;
     use crate::{
-        LinterSettings, Rule, ShellCheckCodeMap, SuppressionIndex, first_statement_line, lint_file,
-        parse_directives,
+        LinterSettings, Rule, ShellCheckCodeMap, lint_file_with_directives, parse_directives,
     };
 
     #[test]
@@ -574,17 +573,12 @@ greet
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        let suppressions = SuppressionIndex::new(
-            &directives,
-            &parse_result.file,
-            first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
-        );
-        let diagnostics = lint_file(
+        let diagnostics = lint_file_with_directives(
             &parse_result,
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
-            Some(&suppressions),
+            &directives,
             None,
         );
 

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -1,9 +1,7 @@
 use rustc_hash::FxHashMap;
 use shuck_ast::{
-    ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, ArrayElem, Assignment, AssignmentValue,
-    BuiltinCommand, Command, CompoundCommand, ConditionalExpr, DeclOperand, File, FunctionDef,
-    HeredocBodyPartNode, Pattern, PatternPart, Redirect, Span, Stmt, StmtSeq, TextSize, VarRef,
-    Word, WordPart, WordPartNode,
+    BuiltinCommand, Command, CompoundCommand, File, HeredocBodyPartNode, Redirect, Span, Stmt,
+    TextSize,
 };
 
 use crate::Rule;
@@ -17,8 +15,12 @@ pub struct SuppressionIndex {
 }
 
 impl SuppressionIndex {
-    /// Build from parsed directives.
-    pub fn new(directives: &[SuppressionDirective], file: &File, first_stmt_line: u32) -> Self {
+    /// Build from parsed directives and a precomputed suppression command ordering.
+    pub(crate) fn from_sorted_command_spans(
+        directives: &[SuppressionDirective],
+        sorted_command_spans: &[Span],
+        first_stmt_line: u32,
+    ) -> Self {
         let mut ordered = directives.iter().collect::<Vec<_>>();
         ordered.sort_by_key(|directive| {
             (
@@ -28,16 +30,11 @@ impl SuppressionIndex {
             )
         });
 
-        let mut sorted_command_spans: Option<Vec<Span>> = None;
         let mut by_rule = FxHashMap::default();
         for directive in ordered {
             let directive_range = (matches!(directive.action, SuppressionAction::Disable)
                 && directive.line >= first_stmt_line)
-                .then(|| {
-                    let spans =
-                        sorted_command_spans.get_or_insert_with(|| collect_command_spans(file));
-                    next_command_range_after(spans, directive.range.end())
-                })
+                .then(|| next_command_range_after(sorted_command_spans, directive.range.end()))
                 .flatten();
 
             for &rule in &directive.codes {
@@ -79,7 +76,7 @@ impl SuppressionIndex {
 }
 
 /// First command line in the file, if any.
-pub fn first_statement_line(file: &File) -> Option<u32> {
+pub(crate) fn first_statement_line(file: &File) -> Option<u32> {
     file.body
         .iter()
         .filter_map(|command| u32::try_from(command.span.start.line).ok())
@@ -143,21 +140,16 @@ fn merge_overlapping_ranges(ranges: &mut Vec<LineRange>) {
     *ranges = merged;
 }
 
-fn collect_command_spans(file: &File) -> Vec<Span> {
-    let mut spans = Vec::new();
-    for command in file.body.iter() {
-        walk_command(command, &mut |span| {
-            if span.start.line != 0 && span.end.line != 0 {
-                spans.push(span);
-            }
-        });
-    }
-    // Stable sort preserves walk order so a parent statement keeps priority over
-    // its children when both share the same start offset (e.g. a binary command
-    // and its left operand). The lookup picks the first span at each start
-    // offset, matching the previous behavior of `consider_command`.
-    spans.sort_by_key(|span| span.start.offset);
-    spans
+pub(crate) fn sort_command_spans_for_lookup(spans: &mut [Span]) {
+    // Sort by start offset first, then prefer wider spans when two commands
+    // start at the same byte offset so parent statements keep priority over
+    // children during `next_command_range_after`.
+    spans.sort_by(|left, right| {
+        left.start
+            .offset
+            .cmp(&right.start.offset)
+            .then_with(|| right.end.offset.cmp(&left.end.offset))
+    });
 }
 
 fn next_command_range_after(spans: &[Span], offset: TextSize) -> Option<LineRange> {
@@ -179,102 +171,7 @@ fn line_range(span: Span) -> Option<LineRange> {
     })
 }
 
-fn walk_commands<F>(commands: &StmtSeq, visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    for command in commands.iter() {
-        walk_command(command, visit);
-    }
-}
-
-fn walk_command<F>(stmt: &Stmt, visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    visit(statement_suppression_span(stmt));
-
-    match &stmt.command {
-        Command::Simple(command) => {
-            walk_assignments(&command.assignments, visit);
-            walk_word(&command.name, visit);
-            walk_words(&command.args, visit);
-        }
-        Command::Builtin(BuiltinCommand::Break(command)) => {
-            walk_assignments(&command.assignments, visit);
-            if let Some(word) = &command.depth {
-                walk_word(word, visit);
-            }
-            walk_words(&command.extra_args, visit);
-        }
-        Command::Builtin(BuiltinCommand::Continue(command)) => {
-            walk_assignments(&command.assignments, visit);
-            if let Some(word) = &command.depth {
-                walk_word(word, visit);
-            }
-            walk_words(&command.extra_args, visit);
-        }
-        Command::Builtin(BuiltinCommand::Return(command)) => {
-            walk_assignments(&command.assignments, visit);
-            if let Some(word) = &command.code {
-                walk_word(word, visit);
-            }
-            walk_words(&command.extra_args, visit);
-        }
-        Command::Builtin(BuiltinCommand::Exit(command)) => {
-            walk_assignments(&command.assignments, visit);
-            if let Some(word) = &command.code {
-                walk_word(word, visit);
-            }
-            walk_words(&command.extra_args, visit);
-        }
-        Command::Decl(command) => {
-            walk_assignments(&command.assignments, visit);
-            for operand in &command.operands {
-                match operand {
-                    DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => walk_word(word, visit),
-                    DeclOperand::Name(_) => {}
-                    DeclOperand::Assignment(assignment) => walk_assignment(assignment, visit),
-                }
-            }
-        }
-        Command::Binary(command) => {
-            walk_command(&command.left, visit);
-            walk_command(&command.right, visit);
-        }
-        Command::Compound(command) => {
-            walk_compound(command, visit);
-        }
-        Command::Function(FunctionDef { header, body, .. }) => {
-            for entry in &header.entries {
-                walk_word(&entry.word, visit);
-            }
-            walk_function_body(body, visit);
-        }
-        Command::AnonymousFunction(function) => {
-            walk_words(&function.args, visit);
-            walk_function_body(&function.body, visit);
-        }
-    }
-
-    walk_redirects(&stmt.redirects, visit);
-}
-
-fn walk_function_body<F>(stmt: &Stmt, visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    match &stmt.command {
-        Command::Compound(CompoundCommand::BraceGroup(commands))
-        | Command::Compound(CompoundCommand::Subshell(commands)) => {
-            walk_commands(commands, visit);
-            walk_redirects(&stmt.redirects, visit);
-        }
-        _ => walk_command(stmt, visit),
-    }
-}
-
-fn statement_suppression_span(stmt: &Stmt) -> Span {
+pub(crate) fn statement_suppression_span(stmt: &Stmt) -> Span {
     let mut span = command_suppression_base_span(stmt);
     extend_span_with_redirects(&mut span, &stmt.redirects);
     span
@@ -349,284 +246,13 @@ fn extend_span(span: &mut Span, extension: Span) {
     }
 }
 
-fn walk_compound<F>(command: &CompoundCommand, visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    match command {
-        CompoundCommand::If(command) => {
-            walk_commands(&command.condition, visit);
-            walk_commands(&command.then_branch, visit);
-            for (condition, body) in &command.elif_branches {
-                walk_commands(condition, visit);
-                walk_commands(body, visit);
-            }
-            if let Some(body) = &command.else_branch {
-                walk_commands(body, visit);
-            }
-        }
-        CompoundCommand::For(command) => {
-            if let Some(words) = &command.words {
-                walk_words(words, visit);
-            }
-            walk_commands(&command.body, visit);
-        }
-        CompoundCommand::Repeat(command) => {
-            walk_word(&command.count, visit);
-            walk_commands(&command.body, visit);
-        }
-        CompoundCommand::Foreach(command) => {
-            walk_words(&command.words, visit);
-            walk_commands(&command.body, visit);
-        }
-        CompoundCommand::ArithmeticFor(command) => walk_commands(&command.body, visit),
-        CompoundCommand::While(command) => {
-            walk_commands(&command.condition, visit);
-            walk_commands(&command.body, visit);
-        }
-        CompoundCommand::Until(command) => {
-            walk_commands(&command.condition, visit);
-            walk_commands(&command.body, visit);
-        }
-        CompoundCommand::Case(command) => {
-            walk_word(&command.word, visit);
-            for case in &command.cases {
-                walk_patterns(&case.patterns, visit);
-                walk_commands(&case.body, visit);
-            }
-        }
-        CompoundCommand::Select(command) => {
-            walk_words(&command.words, visit);
-            walk_commands(&command.body, visit);
-        }
-        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
-            walk_commands(commands, visit);
-        }
-        CompoundCommand::Always(command) => {
-            walk_commands(&command.body, visit);
-            walk_commands(&command.always_body, visit);
-        }
-        CompoundCommand::Arithmetic(_) => {}
-        CompoundCommand::Time(command) => {
-            if let Some(command) = &command.command {
-                walk_command(command, visit);
-            }
-        }
-        CompoundCommand::Conditional(command) => walk_conditional_expr(&command.expression, visit),
-        CompoundCommand::Coproc(command) => walk_command(&command.body, visit),
-    }
-}
-
-fn walk_assignments<F>(assignments: &[Assignment], visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    for assignment in assignments {
-        walk_assignment(assignment, visit);
-    }
-}
-
-fn walk_assignment<F>(assignment: &Assignment, visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    match &assignment.value {
-        AssignmentValue::Scalar(word) => walk_word(word, visit),
-        AssignmentValue::Compound(array) => {
-            for element in &array.elements {
-                match element {
-                    ArrayElem::Sequential(word) => walk_word(word, visit),
-                    ArrayElem::Keyed { value, .. } | ArrayElem::KeyedAppend { value, .. } => {
-                        walk_word(value, visit)
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn walk_words<F>(words: &[Word], visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    for word in words {
-        walk_word(word, visit);
-    }
-}
-
-fn walk_patterns<F>(patterns: &[Pattern], visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    for pattern in patterns {
-        walk_pattern(pattern, visit);
-    }
-}
-
-fn walk_word<F>(word: &Word, visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    walk_word_parts(&word.parts, visit);
-}
-
-fn walk_pattern<F>(pattern: &Pattern, visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    for (part, _) in pattern.parts_with_spans() {
-        match part {
-            PatternPart::Group { patterns, .. } => walk_patterns(patterns, visit),
-            PatternPart::Word(word) => walk_word(word, visit),
-            PatternPart::Literal(_)
-            | PatternPart::AnyString
-            | PatternPart::AnyChar
-            | PatternPart::CharClass(_) => {}
-        }
-    }
-}
-
-fn walk_word_parts<F>(parts: &[WordPartNode], visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    for part in parts {
-        match &part.kind {
-            WordPart::DoubleQuoted { parts, .. } => walk_word_parts(parts, visit),
-            WordPart::ArithmeticExpansion { expression_ast, .. } => {
-                if let Some(expression_ast) = expression_ast.as_ref() {
-                    visit_arithmetic_words(expression_ast, &mut |word| {
-                        walk_word(word, visit);
-                    });
-                }
-            }
-            WordPart::CommandSubstitution { body, .. }
-            | WordPart::ProcessSubstitution { body, .. } => walk_commands(body, visit),
-            _ => {}
-        }
-    }
-}
-
-fn walk_redirects<F>(redirects: &[Redirect], visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    for redirect in redirects {
-        if let Some(word) = redirect.word_target() {
-            walk_word(word, visit);
-        } else if let Some(heredoc) = redirect.heredoc()
-            && heredoc.delimiter.expands_body
-        {
-            walk_heredoc_body_parts(&heredoc.body.parts, visit);
-        }
-    }
-}
-
-fn walk_heredoc_body_parts<F>(parts: &[HeredocBodyPartNode], visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    for part in parts {
-        match &part.kind {
-            shuck_ast::HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
-                if let Some(expression_ast) = expression_ast.as_ref() {
-                    visit_arithmetic_words(expression_ast, &mut |word| {
-                        walk_word(word, visit);
-                    });
-                }
-            }
-            shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
-                walk_commands(body, visit)
-            }
-            shuck_ast::HeredocBodyPart::Literal(_)
-            | shuck_ast::HeredocBodyPart::Variable(_)
-            | shuck_ast::HeredocBodyPart::Parameter(_) => {}
-        }
-    }
-}
-
-fn walk_conditional_expr<F>(expression: &ConditionalExpr, visit: &mut F)
-where
-    F: FnMut(Span),
-{
-    match expression {
-        ConditionalExpr::Binary(expr) => {
-            walk_conditional_expr(&expr.left, visit);
-            walk_conditional_expr(&expr.right, visit);
-        }
-        ConditionalExpr::Unary(expr) => walk_conditional_expr(&expr.expr, visit),
-        ConditionalExpr::Parenthesized(expr) => walk_conditional_expr(&expr.expr, visit),
-        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => walk_word(word, visit),
-        ConditionalExpr::Pattern(pattern) => walk_pattern(pattern, visit),
-        ConditionalExpr::VarRef(reference) => {
-            visit_var_ref_subscript_words(reference, &mut |word| {
-                walk_word(word, visit);
-            });
-        }
-    }
-}
-
-fn visit_var_ref_subscript_words<'a>(reference: &'a VarRef, visitor: &mut impl FnMut(&'a Word)) {
-    if let Some(expression) = reference
-        .subscript
-        .as_ref()
-        .and_then(|subscript| subscript.arithmetic_ast.as_ref())
-    {
-        visit_arithmetic_words(expression, visitor);
-    }
-}
-
-fn visit_arithmetic_words<'a>(
-    expression: &'a ArithmeticExprNode,
-    visitor: &mut impl FnMut(&'a Word),
-) {
-    match &expression.kind {
-        ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
-        ArithmeticExpr::Indexed { index, .. } => visit_arithmetic_words(index, visitor),
-        ArithmeticExpr::ShellWord(word) => visitor(word),
-        ArithmeticExpr::Parenthesized { expression } => {
-            visit_arithmetic_words(expression, visitor);
-        }
-        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
-            visit_arithmetic_words(expr, visitor);
-        }
-        ArithmeticExpr::Binary { left, right, .. } => {
-            visit_arithmetic_words(left, visitor);
-            visit_arithmetic_words(right, visitor);
-        }
-        ArithmeticExpr::Conditional {
-            condition,
-            then_expr,
-            else_expr,
-        } => {
-            visit_arithmetic_words(condition, visitor);
-            visit_arithmetic_words(then_expr, visitor);
-            visit_arithmetic_words(else_expr, visitor);
-        }
-        ArithmeticExpr::Assignment { target, value, .. } => {
-            visit_arithmetic_lvalue_words(target, visitor);
-            visit_arithmetic_words(value, visitor);
-        }
-    }
-}
-
-fn visit_arithmetic_lvalue_words<'a>(
-    target: &'a ArithmeticLvalue,
-    visitor: &mut impl FnMut(&'a Word),
-) {
-    match target {
-        ArithmeticLvalue::Variable(_) => {}
-        ArithmeticLvalue::Indexed { index, .. } => visit_arithmetic_words(index, visitor),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use shuck_indexer::Indexer;
     use shuck_parser::parser::{Parser, ShellDialect};
 
     use super::*;
-    use crate::{ShellCheckCodeMap, parse_directives};
+    use crate::{LinterSemanticArtifacts, ShellCheckCodeMap, parse_directives};
 
     fn suppression_index(source: &str) -> SuppressionIndex {
         suppression_index_with_dialect(source, ShellDialect::Bash)
@@ -641,9 +267,10 @@ mod tests {
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        SuppressionIndex::new(
+        let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+        SuppressionIndex::from_sorted_command_spans(
             &directives,
-            &output.file,
+            semantic.suppression_command_spans(),
             first_statement_line(&output.file).unwrap_or(u32::MAX),
         )
     }

--- a/crates/shuck-linter/src/suppression/mod.rs
+++ b/crates/shuck-linter/src/suppression/mod.rs
@@ -5,6 +5,9 @@ mod shellcheck_map;
 
 pub(crate) use directive::shellcheck_directive_can_apply_to_following_command;
 pub use directive::{SuppressionAction, SuppressionDirective, SuppressionSource, parse_directives};
-pub use index::{SuppressionIndex, first_statement_line};
+pub use index::SuppressionIndex;
+pub(crate) use index::{
+    first_statement_line, sort_command_spans_for_lookup, statement_suppression_span,
+};
 pub use rewrite::{AddIgnoreParseError, AddIgnoreResult, add_ignores_to_path};
 pub use shellcheck_map::ShellCheckCodeMap;

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -11,11 +11,10 @@ use shuck_parser::{
     parser::{ParseResult, Parser},
 };
 
-use crate::{Diagnostic, LinterSettings, Rule, ShellDialect, lint_file};
+use crate::{Diagnostic, LinterSettings, Rule, ShellDialect, lint_file_with_directives};
 
 use super::{
-    ShellCheckCodeMap, SuppressionAction, SuppressionDirective, SuppressionIndex,
-    SuppressionSource, first_statement_line, parse_directives,
+    ShellCheckCodeMap, SuppressionAction, SuppressionDirective, SuppressionSource, parse_directives,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -119,19 +118,12 @@ fn analyze_source(
         indexer.comment_index(),
         shellcheck_map,
     );
-    let suppression_index = (!directives.is_empty()).then(|| {
-        SuppressionIndex::new(
-            &directives,
-            &parse_result.file,
-            first_statement_line(&parse_result.file).unwrap_or(u32::MAX),
-        )
-    });
-    let diagnostics = lint_file(
+    let diagnostics = lint_file_with_directives(
         &parse_result,
         source,
         &indexer,
         settings,
-        suppression_index.as_ref(),
+        &directives,
         Some(path),
     );
     let strict_parse_error = strict_parse_error(&parse_result);

--- a/specs/006-suppressions.md
+++ b/specs/006-suppressions.md
@@ -291,7 +291,7 @@ pub fn lint_file(
 }
 ```
 
-The `SuppressionIndex` is built **before** the linter entry point is called — the caller (CLI pipeline) constructs it from the comment index and passes it in. This keeps the linter crate's dependency on suppression parsing explicit and optional.
+The directives-aware linter entry points now build the `SuppressionIndex` from semantic-collected command spans after directive parsing. This keeps suppression scoping aligned with the semantic traversal instead of requiring a second AST walk.
 
 ### Data Flow
 
@@ -302,9 +302,8 @@ Source text
     → shuck-parser::Parser::parse()       → ParseOutput (Script + Comments)
     → shuck-indexer::Indexer::new()        → Indexer (includes CommentIndex)
     → parse_directives()                   → Vec<SuppressionDirective>
-    → SuppressionIndex::new()              → SuppressionIndex
     → shuck-semantic::SemanticModel::new() → SemanticModel
-    → shuck-linter::lint_file()
+    → shuck-linter::lint_file_with_directives()
                                              → Vec<Diagnostic>  (filtered by suppressions)
     → CLI formats and prints diagnostics
 ```


### PR DESCRIPTION
## Summary
- remove the standalone suppression fallback walker and keep suppression span collection on the semantic traversal path
- route the remaining CLI, compat, rewrite, benchmark, bench, and example call sites through the directives-aware linter entrypoints
- migrate suppression-focused tests to the directives-aware helpers and update the suppression design note

## Why
The fallback constructor made it easy to accidentally reintroduce a second AST walk for suppression scoping. This change removes that escape hatch so suppression indexing stays on the semantic-collected command span path.

## Impact
This keeps production and supporting tooling on one suppression-index construction path and reduces the recursive AST surface in `shuck-linter`.

## Validation
- cargo fmt
- cargo test -p shuck-linter --no-run
- cargo test -p shuck-linter suppression::index::tests
- cargo test -p shuck-linter respects_suppressed_paired_function_argument_warning
- cargo test -p shuck-cli --no-run
- cargo test -p shuck-benchmark --no-run
- cargo check -p shuck-benchmark --benches --examples
- cargo test -p shuck-benchmark
