### PR TITLE
perf(parser): watermark append-only fields in ParserCheckpoint

### DIFF
--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -5307,11 +5307,13 @@ impl<'a> Parser<'a> {
             current_depth: self.current_depth,
             fuel: self.fuel,
             source_text_pattern_depth: self.source_text_pattern_depth,
-            comments: self.comments.clone(),
+            comments_len: self.comments.len(),
             expand_next_word: self.expand_next_word,
             brace_group_depth: self.brace_group_depth,
-            brace_body_stack: self.brace_body_stack.clone(),
-            syntax_facts: self.syntax_facts.clone(),
+            brace_body_stack_len: self.brace_body_stack.len(),
+            syntax_facts_zsh_brace_if_spans_len: self.syntax_facts.zsh_brace_if_spans.len(),
+            syntax_facts_zsh_always_spans_len: self.syntax_facts.zsh_always_spans.len(),
+            syntax_facts_zsh_case_group_parts_len: self.syntax_facts.zsh_case_group_parts.len(),
             #[cfg(feature = "benchmarking")]
             benchmark_counters: self.benchmark_counters,
         }
@@ -5331,11 +5333,20 @@ impl<'a> Parser<'a> {
         self.current_depth = checkpoint.current_depth;
         self.fuel = checkpoint.fuel;
         self.source_text_pattern_depth = checkpoint.source_text_pattern_depth;
-        self.comments = checkpoint.comments;
+        self.comments.truncate(checkpoint.comments_len);
         self.expand_next_word = checkpoint.expand_next_word;
         self.brace_group_depth = checkpoint.brace_group_depth;
-        self.brace_body_stack = checkpoint.brace_body_stack;
-        self.syntax_facts = checkpoint.syntax_facts;
+        self.brace_body_stack
+            .truncate(checkpoint.brace_body_stack_len);
+        self.syntax_facts
+            .zsh_brace_if_spans
+            .truncate(checkpoint.syntax_facts_zsh_brace_if_spans_len);
+        self.syntax_facts
+            .zsh_always_spans
+            .truncate(checkpoint.syntax_facts_zsh_always_spans_len);
+        self.syntax_facts
+            .zsh_case_group_parts
+            .truncate(checkpoint.syntax_facts_zsh_case_group_parts_len);
         #[cfg(feature = "benchmarking")]
         {
             self.benchmark_counters = checkpoint.benchmark_counters;

--- a/crates/shuck-parser/src/parser/parser_state.rs
+++ b/crates/shuck-parser/src/parser/parser_state.rs
@@ -164,11 +164,16 @@ pub(super) struct ParserCheckpoint<'a> {
     pub(super) current_depth: usize,
     pub(super) source_text_pattern_depth: usize,
     pub(super) fuel: usize,
-    pub(super) comments: Vec<Comment>,
+    // `comments`, `brace_body_stack`, and the `syntax_facts` Vecs are append-only
+    // inside any speculative parse, so we save lengths and truncate on restore
+    // instead of cloning their backing storage.
+    pub(super) comments_len: usize,
     pub(super) expand_next_word: bool,
     pub(super) brace_group_depth: usize,
-    pub(super) brace_body_stack: Vec<BraceBodyContext>,
-    pub(super) syntax_facts: SyntaxFacts,
+    pub(super) brace_body_stack_len: usize,
+    pub(super) syntax_facts_zsh_brace_if_spans_len: usize,
+    pub(super) syntax_facts_zsh_always_spans_len: usize,
+    pub(super) syntax_facts_zsh_case_group_parts_len: usize,
     #[cfg(feature = "benchmarking")]
     pub(super) benchmark_counters: Option<ParserBenchmarkCounters>,
 }


### PR DESCRIPTION
## Summary

- Replace `Vec::clone` calls for `comments`, `brace_body_stack`, and the three `syntax_facts` Vecs in `Parser::checkpoint()` with saved lengths.
- Restore via `Vec::truncate` rather than moving cloned buffers in.
- These fields are strictly append-only inside any speculative parse, so length restore preserves rollback semantics.

## Why

`Parser::checkpoint()` was the dominant heap-allocation hotspot in the parser. dhat on `xwmx_nb` showed 30.22 MB / 3,838 blocks attributed to a single line: `comments: self.comments.clone()`. The other cloned fields (`brace_body_stack`, three `Vec<Span>` inside `SyntaxFacts`) are also append-only inside speculative parses, so the same watermark approach applies.

`comments` is push-only via `capture_comment`. `brace_body_stack` push/pop is balanced inside `parse_brace_enclosed_stmt_seq`, so it never falls below the checkpoint length during a speculative parse. The `syntax_facts` Vecs only grow via the `record_zsh_*` helpers. None of these fields are ever popped, cleared, or truncated outside of their owning push site.

The remaining clones in `ParserCheckpoint` are intentional: `synthetic_tokens`, `alias_replays`, `current_token`, `peeked_token`, and `lexer` may legitimately mutate (push/pop or full rewrite) during a speculative parse, so they still need real preservation. dhat shows none of those contribute meaningful heap on the test fixture.

## Measurements

dhat on `xwmx_nb__nb` (1 iteration, current main vs. branch):

| Metric | Baseline | After fix | Delta |
| --- | ---: | ---: | ---: |
| `parser::checkpoint` heap | 30.22 MB / 3,838 blocks | 0 MB / 0 blocks | eliminated |
| Total heap | 463.82 MB | 433.67 MB | -30.16 MB (-6.5%) |
| Total blocks | 909,738 | 905,725 | -4,013 |
| Peak | 193.66 MB | 193.66 MB | 0 |

Wall-clock (12-iter avg, 6 interleaved trials):

| | mean |
| --- | ---: |
| main | ~146.7 ms |
| fix | ~143.7 ms |

About 2% faster in interleaved runs and consistently inside the noise floor of the slower direction. Allocator pressure relief is the main win; CPU is flat-to-slightly-better.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p shuck-parser` (637 pass)
- [x] `cargo test -p shuck-linter` (3,146 pass)
- [x] `cargo test -p shuck-cli` (all pass)
- [x] dhat heap profile shows `parser::checkpoint` allocations eliminated
- [x] Interleaved CPU passes show no regression