### PR TITLE
refactor(linter): internalize directive parsing seam

### DIFF
--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -11,7 +11,7 @@ use shuck_benchmark::configure_benchmark_allocator;
 use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterSettings, Rule, RuleSet, ShellCheckCodeMap, ShellDialect, benchmark_collect_word_facts,
-    lint_file_at_path_with_resolver_and_parse_result_and_directives, parse_directives,
+    lint_file_at_path_with_resolver_and_parse_result_with_comment_directives,
 };
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{SemanticBuildOptions, SemanticModel, SourcePathResolver};
@@ -286,18 +286,12 @@ fn lint_large_corpus_fixture_with_settings(
     let parse_result = parse_large_corpus_fixture(fixture);
     let indexer = Indexer::new(&fixture.source, &parse_result);
     let shellcheck_map = ShellCheckCodeMap::default();
-    let directives = parse_directives(
-        &fixture.source,
-        &parse_result.file,
-        indexer.comment_index(),
-        &shellcheck_map,
-    );
-    let diagnostics = lint_file_at_path_with_resolver_and_parse_result_and_directives(
+    let diagnostics = lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
         &parse_result,
         &fixture.source,
         &indexer,
         &settings,
-        &directives,
+        &shellcheck_map,
         Some(&fixture.path),
         resolver,
     );

--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -11,7 +11,7 @@ use shuck_benchmark::configure_benchmark_allocator;
 use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterSettings, Rule, RuleSet, ShellCheckCodeMap, ShellDialect, benchmark_collect_word_facts,
-    lint_file_at_path_with_resolver_and_parse_result_with_comment_directives,
+    lint_file_at_path_with_resolver_and_parse_result,
 };
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{SemanticBuildOptions, SemanticModel, SourcePathResolver};
@@ -286,7 +286,7 @@ fn lint_large_corpus_fixture_with_settings(
     let parse_result = parse_large_corpus_fixture(fixture);
     let indexer = Indexer::new(&fixture.source, &parse_result);
     let shellcheck_map = ShellCheckCodeMap::default();
-    let diagnostics = lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
+    let diagnostics = lint_file_at_path_with_resolver_and_parse_result(
         &parse_result,
         &fixture.source,
         &indexer,

--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -7,7 +7,7 @@ use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixt
 use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterFacts, LinterSemanticArtifacts, LinterSettings, RuleSet, ShellCheckCodeMap,
-    benchmark_collect_word_facts, benchmark_normalize_commands, lint_file_with_comment_directives,
+    benchmark_collect_word_facts, benchmark_normalize_commands, lint_file,
 };
 use shuck_parser::parser::ParseResult;
 use shuck_semantic::SemanticModel;
@@ -74,14 +74,7 @@ fn lint_source(
 ) -> usize {
     let output = parse_fixture(source);
     let indexer = Indexer::new(source, &output);
-    let diagnostics = lint_file_with_comment_directives(
-        &output,
-        source,
-        &indexer,
-        settings,
-        shellcheck_map,
-        None,
-    );
+    let diagnostics = lint_file(&output, source, &indexer, settings, shellcheck_map, None);
 
     black_box(diagnostics.len())
 }

--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -7,8 +7,7 @@ use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixt
 use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterFacts, LinterSemanticArtifacts, LinterSettings, RuleSet, ShellCheckCodeMap,
-    benchmark_collect_word_facts, benchmark_normalize_commands, lint_file_with_directives,
-    parse_directives,
+    benchmark_collect_word_facts, benchmark_normalize_commands, lint_file_with_comment_directives,
 };
 use shuck_parser::parser::ParseResult;
 use shuck_semantic::SemanticModel;
@@ -75,14 +74,14 @@ fn lint_source(
 ) -> usize {
     let output = parse_fixture(source);
     let indexer = Indexer::new(source, &output);
-    let directives = parse_directives(
+    let diagnostics = lint_file_with_comment_directives(
+        &output,
         source,
-        &output.file,
-        indexer.comment_index(),
+        &indexer,
+        settings,
         shellcheck_map,
+        None,
     );
-    let diagnostics =
-        lint_file_with_directives(&output, source, &indexer, settings, &directives, None);
 
     black_box(diagnostics.len())
 }

--- a/crates/shuck-benchmark/examples/large_corpus_profile.rs
+++ b/crates/shuck-benchmark/examples/large_corpus_profile.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterSettings, RuleSelector, RuleSet, ShellCheckCodeMap, ShellDialect,
-    lint_file_at_path_with_resolver_and_parse_result_and_directives, parse_directives,
+    lint_file_at_path_with_resolver_and_parse_result_with_comment_directives,
 };
 use shuck_parser::parser::Parser;
 use shuck_semantic::SourcePathResolver;
@@ -316,18 +316,12 @@ fn run_large_corpus_fixture(
     let parsed = Parser::with_dialect(&source, shuck_parser::ShellDialect::Bash).parse();
     let indexer = Indexer::new(&source, &parsed);
     let shellcheck_map = ShellCheckCodeMap::default();
-    let directives = parse_directives(
-        &source,
-        &parsed.file,
-        indexer.comment_index(),
-        &shellcheck_map,
-    );
-    let diagnostics = lint_file_at_path_with_resolver_and_parse_result_and_directives(
+    let diagnostics = lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
         &parsed,
         &source,
         &indexer,
         &settings,
-        &directives,
+        &shellcheck_map,
         Some(&fixture.path),
         Some(resolver),
     );

--- a/crates/shuck-benchmark/examples/large_corpus_profile.rs
+++ b/crates/shuck-benchmark/examples/large_corpus_profile.rs
@@ -10,7 +10,7 @@ use std::time::Instant;
 use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterSettings, RuleSelector, RuleSet, ShellCheckCodeMap, ShellDialect,
-    lint_file_at_path_with_resolver_and_parse_result_with_comment_directives,
+    lint_file_at_path_with_resolver_and_parse_result,
 };
 use shuck_parser::parser::Parser;
 use shuck_semantic::SourcePathResolver;
@@ -316,7 +316,7 @@ fn run_large_corpus_fixture(
     let parsed = Parser::with_dialect(&source, shuck_parser::ShellDialect::Bash).parse();
     let indexer = Indexer::new(&source, &parsed);
     let shellcheck_map = ShellCheckCodeMap::default();
-    let diagnostics = lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
+    let diagnostics = lint_file_at_path_with_resolver_and_parse_result(
         &parsed,
         &source,
         &indexer,

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -178,7 +178,7 @@ mod tests {
     use serde::Deserialize;
     use shuck_formatter::{FormattedSource, ShellFormatOptions, format_file_ast, format_source};
     use shuck_indexer::Indexer;
-    use shuck_linter::{LinterSettings, ShellCheckCodeMap, lint_file_with_comment_directives};
+    use shuck_linter::{LinterSettings, ShellCheckCodeMap, lint_file};
 
     #[derive(Debug, Deserialize)]
     struct Manifest {
@@ -253,7 +253,7 @@ mod tests {
         for file in TEST_FILES.iter() {
             let output = parse_fixture(file.source);
             let indexer = Indexer::new(file.source, &output);
-            let diagnostics = lint_file_with_comment_directives(
+            let diagnostics = lint_file(
                 &output,
                 file.source,
                 &indexer,

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -178,9 +178,7 @@ mod tests {
     use serde::Deserialize;
     use shuck_formatter::{FormattedSource, ShellFormatOptions, format_file_ast, format_source};
     use shuck_indexer::Indexer;
-    use shuck_linter::{
-        LinterSettings, ShellCheckCodeMap, lint_file_with_directives, parse_directives,
-    };
+    use shuck_linter::{LinterSettings, ShellCheckCodeMap, lint_file_with_comment_directives};
 
     #[derive(Debug, Deserialize)]
     struct Manifest {
@@ -255,18 +253,12 @@ mod tests {
         for file in TEST_FILES.iter() {
             let output = parse_fixture(file.source);
             let indexer = Indexer::new(file.source, &output);
-            let directives = parse_directives(
-                file.source,
-                &output.file,
-                indexer.comment_index(),
-                &shellcheck_map,
-            );
-            let diagnostics = lint_file_with_directives(
+            let diagnostics = lint_file_with_comment_directives(
                 &output,
                 file.source,
                 &indexer,
                 &settings,
-                &directives,
+                &shellcheck_map,
                 None,
             );
 

--- a/crates/shuck-cli/src/commands/check/analyze.rs
+++ b/crates/shuck-cli/src/commands/check/analyze.rs
@@ -144,7 +144,7 @@ pub(super) fn collect_lint_diagnostics(
     source_path: &Path,
 ) -> Vec<shuck_linter::Diagnostic> {
     let indexer = Indexer::new(source, parse_result);
-    shuck_linter::lint_file_with_comment_directives(
+    shuck_linter::lint_file(
         parse_result,
         source,
         &indexer,

--- a/crates/shuck-cli/src/commands/check/analyze.rs
+++ b/crates/shuck-cli/src/commands/check/analyze.rs
@@ -4,9 +4,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use shuck_indexer::Indexer;
-use shuck_linter::{
-    Applicability, LinterSettings, RuleSet, ShellCheckCodeMap, ShellDialect, parse_directives,
-};
+use shuck_linter::{Applicability, LinterSettings, RuleSet, ShellCheckCodeMap, ShellDialect};
 use shuck_parser::{
     Error as ParseError,
     parser::{ParseResult, Parser},
@@ -146,18 +144,12 @@ pub(super) fn collect_lint_diagnostics(
     source_path: &Path,
 ) -> Vec<shuck_linter::Diagnostic> {
     let indexer = Indexer::new(source, parse_result);
-    let directives = parse_directives(
-        source,
-        &parse_result.file,
-        indexer.comment_index(),
-        shellcheck_map,
-    );
-    shuck_linter::lint_file_with_directives(
+    shuck_linter::lint_file_with_comment_directives(
         parse_result,
         source,
         &indexer,
         linter_settings,
-        &directives,
+        shellcheck_map,
         Some(source_path),
     )
 }

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterSettings, Rule, RuleSet, Severity, ShellCheckCodeMap, ShellCheckLevel, ShellDialect,
-    parse_directives, rule_metadata,
+    rule_metadata,
 };
 use shuck_parser::parser::Parser;
 use shuck_semantic::SourcePathResolver;
@@ -932,14 +932,6 @@ fn lint_with_context(
 
     let parse_result = Parser::with_profile(source, shell.shell_profile()).parse();
     let indexer = Indexer::new(source, &parse_result);
-    let shellcheck_map = &options.shellcheck_map;
-    let directives = parse_directives(
-        source,
-        &parse_result.file,
-        indexer.comment_index(),
-        shellcheck_map,
-    );
-
     let explicit = explicit_paths.into_iter().collect::<Vec<_>>();
     let resolver = CompatSourceResolver {
         cwd: canonicalize_or_clone(&std::env::current_dir().map_err(|err| {
@@ -961,15 +953,16 @@ fn lint_with_context(
         rule_options,
     };
 
-    let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result_and_directives(
-        &parse_result,
-        source,
-        &indexer,
-        &settings,
-        &directives,
-        Some(path),
-        Some(&resolver),
-    );
+    let diagnostics =
+        shuck_linter::lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
+            &parse_result,
+            source,
+            &indexer,
+            &settings,
+            &options.shellcheck_map,
+            Some(path),
+            Some(&resolver),
+        );
     let analysis = shuck_linter::analyze_file_at_path_with_resolver(
         &parse_result.file,
         source,

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -953,16 +953,15 @@ fn lint_with_context(
         rule_options,
     };
 
-    let diagnostics =
-        shuck_linter::lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
-            &parse_result,
-            source,
-            &indexer,
-            &settings,
-            &options.shellcheck_map,
-            Some(path),
-            Some(&resolver),
-        );
+    let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result(
+        &parse_result,
+        source,
+        &indexer,
+        &settings,
+        &options.shellcheck_map,
+        Some(path),
+        Some(&resolver),
+    );
     let analysis = shuck_linter::analyze_file_at_path_with_resolver(
         &parse_result.file,
         source,

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -2409,7 +2409,7 @@ fn lint_large_corpus_output(
 ) -> Vec<shuck_linter::Diagnostic> {
     let indexer = shuck_indexer::Indexer::new(source, parse_result);
     let shellcheck_map = shuck_linter::ShellCheckCodeMap::default();
-    shuck_linter::lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
+    shuck_linter::lint_file_at_path_with_resolver_and_parse_result(
         parse_result,
         source,
         &indexer,

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -2409,19 +2409,12 @@ fn lint_large_corpus_output(
 ) -> Vec<shuck_linter::Diagnostic> {
     let indexer = shuck_indexer::Indexer::new(source, parse_result);
     let shellcheck_map = shuck_linter::ShellCheckCodeMap::default();
-    let directives = shuck_linter::parse_directives(
-        source,
-        &parse_result.file,
-        indexer.comment_index(),
-        &shellcheck_map,
-    );
-
-    shuck_linter::lint_file_at_path_with_resolver_and_parse_result_and_directives(
+    shuck_linter::lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
         parse_result,
         source,
         &indexer,
         linter_settings,
-        &directives,
+        &shellcheck_map,
         Some(&fixture.path),
         source_path_resolver,
     )

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -96,11 +96,11 @@ pub use settings::{
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;
+pub(crate) use suppression::parse_directives;
 /// Suppression directives, shellcheck mappings, and rewrite helpers.
 pub use suppression::{
     AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,
     SuppressionDirective, SuppressionIndex, SuppressionSource, add_ignores_to_path,
-    parse_directives,
 };
 /// Trait implemented by rule-specific diagnostic payloads.
 pub use violation::Violation;
@@ -639,7 +639,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
 /// Lints an existing parse result while deriving suppressions from parsed directives
 /// and semantic-collected command spans.
 #[allow(clippy::too_many_arguments)]
-pub fn lint_file_at_path_with_resolver_and_parse_result_and_directives(
+pub(crate) fn lint_file_at_path_with_resolver_and_parse_result_and_directives(
     parse_result: &ParseResult,
     source: &str,
     indexer: &Indexer,
@@ -719,6 +719,36 @@ pub fn lint_file_at_path_with_resolver_and_parse_result_and_directives(
     diagnostics
 }
 
+/// Lints an existing parse result while parsing suppression directives inside the linter.
+///
+/// This keeps directive attachment internal while we migrate it to semantic command visits.
+#[allow(clippy::too_many_arguments)]
+pub fn lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
+    parse_result: &ParseResult,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    shellcheck_map: &ShellCheckCodeMap,
+    source_path: Option<&Path>,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+) -> Vec<Diagnostic> {
+    let directives = parse_directives(
+        source,
+        &parse_result.file,
+        indexer.comment_index(),
+        shellcheck_map,
+    );
+    lint_file_at_path_with_resolver_and_parse_result_and_directives(
+        parse_result,
+        source,
+        indexer,
+        settings,
+        &directives,
+        source_path,
+        source_path_resolver,
+    )
+}
+
 /// Lints an existing parse result located at an optional source path.
 pub fn lint_file(
     parse_result: &ParseResult,
@@ -741,7 +771,7 @@ pub fn lint_file(
 
 /// Lints an existing parse result while deriving suppressions from parsed directives
 /// and semantic-collected command spans.
-pub fn lint_file_with_directives(
+pub(crate) fn lint_file_with_directives(
     parse_result: &ParseResult,
     source: &str,
     indexer: &Indexer,
@@ -755,6 +785,26 @@ pub fn lint_file_with_directives(
         indexer,
         settings,
         directives,
+        source_path,
+        None,
+    )
+}
+
+/// Lints an existing parse result while parsing suppression directives inside the linter.
+pub fn lint_file_with_comment_directives(
+    parse_result: &ParseResult,
+    source: &str,
+    indexer: &Indexer,
+    settings: &LinterSettings,
+    shellcheck_map: &ShellCheckCodeMap,
+    source_path: Option<&Path>,
+) -> Vec<Diagnostic> {
+    lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
+        parse_result,
+        source,
+        indexer,
+        settings,
+        shellcheck_map,
         source_path,
         None,
     )

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -589,51 +589,25 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
     source: &str,
     indexer: &Indexer,
     settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
+    shellcheck_map: &ShellCheckCodeMap,
     source_path: Option<&Path>,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> Vec<Diagnostic> {
-    let shell = resolve_shell(settings, source, source_path);
-
-    let mut diagnostics = analyze_file_at_path_with_resolver_and_shell(
+    let directives = parse_directives(
+        source,
         &parse_result.file,
+        indexer.comment_index(),
+        shellcheck_map,
+    );
+    lint_file_at_path_with_resolver_and_parse_result_and_directives(
+        parse_result,
         source,
         indexer,
         settings,
-        suppression_index,
+        &directives,
         source_path,
         source_path_resolver,
-        shell,
-        parse_error_position(parse_result),
     )
-    .diagnostics;
-
-    diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
-        &parse_result.file,
-        source,
-        Some(parse_result),
-        &settings.rules,
-        shell,
-    ));
-    if parse_result.is_err() {
-        sanitize_diagnostic_spans_cold(&mut diagnostics, source, indexer);
-    }
-
-    for diagnostic in &mut diagnostics {
-        if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
-            diagnostic.severity = severity;
-        }
-    }
-
-    if let Some(suppression_index) = suppression_index {
-        filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
-    }
-    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
-
-    diagnostics
-        .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
-
-    diagnostics
 }
 
 /// Lints an existing parse result while deriving suppressions from parsed directives
@@ -755,7 +729,7 @@ pub fn lint_file(
     source: &str,
     indexer: &Indexer,
     settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
+    shellcheck_map: &ShellCheckCodeMap,
     source_path: Option<&Path>,
 ) -> Vec<Diagnostic> {
     lint_file_at_path_with_resolver_and_parse_result(
@@ -763,7 +737,7 @@ pub fn lint_file(
         source,
         indexer,
         settings,
-        suppression_index,
+        shellcheck_map,
         source_path,
         None,
     )
@@ -1118,7 +1092,7 @@ mod tests {
             source,
             &indexer,
             &LinterSettings::for_rule(Rule::ZshAlwaysBlock),
-            None,
+            &ShellCheckCodeMap::default(),
             None,
         );
 
@@ -2369,7 +2343,7 @@ END
                 source,
                 &indexer,
                 &LinterSettings::default(),
-                None,
+                &ShellCheckCodeMap::default(),
                 path,
             );
 

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -130,7 +130,14 @@ mod tests {
         let indexer = Indexer::new(source, &parse_result);
         let settings =
             LinterSettings::for_rule(Rule::EscapedUnderscore).with_shell(ShellDialect::Sh);
-        lint_file(&parse_result, source, &indexer, &settings, None, Some(path))
+        lint_file(
+            &parse_result,
+            source,
+            &indexer,
+            &settings,
+            &crate::ShellCheckCodeMap::default(),
+            Some(path),
+        )
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -42,7 +42,7 @@ pub enum SuppressionSource {
 /// Parse all suppression directives from a file's comments.
 // TODO: Delete this pre-parsed directive seam once inline directive attachment can be derived
 // from semantic command visits during lint setup. External callers should stay on the
-// comment-driven lint entrypoints so this recursive walk remains internal until it disappears.
+// normal lint entrypoints so this recursive walk remains internal until it disappears.
 pub(crate) fn parse_directives(
     source: &str,
     file: &File,

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -40,7 +40,10 @@ pub enum SuppressionSource {
 }
 
 /// Parse all suppression directives from a file's comments.
-pub fn parse_directives(
+// TODO: Delete this pre-parsed directive seam once inline directive attachment can be derived
+// from semantic command visits during lint setup. External callers should stay on the
+// comment-driven lint entrypoints so this recursive walk remains internal until it disappears.
+pub(crate) fn parse_directives(
     source: &str,
     file: &File,
     comment_index: &CommentIndex,

--- a/crates/shuck-linter/src/suppression/mod.rs
+++ b/crates/shuck-linter/src/suppression/mod.rs
@@ -3,8 +3,9 @@ mod index;
 mod rewrite;
 mod shellcheck_map;
 
+pub(crate) use directive::parse_directives;
 pub(crate) use directive::shellcheck_directive_can_apply_to_following_command;
-pub use directive::{SuppressionAction, SuppressionDirective, SuppressionSource, parse_directives};
+pub use directive::{SuppressionAction, SuppressionDirective, SuppressionSource};
 pub use index::SuppressionIndex;
 pub(crate) use index::{
     first_statement_line, sort_command_spans_for_lookup, statement_suppression_span,

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -6,7 +6,9 @@ use shuck_indexer::Indexer;
 use shuck_parser::parser::{ParseResult, Parser};
 use similar::TextDiff;
 
-use crate::{Applicability, Diagnostic, LinterSettings, ShellDialect, apply_fixes, lint_file};
+use crate::{
+    Applicability, Diagnostic, LinterSettings, ShellDialect, apply_fixes, lint_file_with_directives,
+};
 
 fn infer_shell(source: &str, settings: &LinterSettings, path: Option<&Path>) -> ShellDialect {
     if settings.shell == crate::ShellDialect::Unknown {
@@ -33,14 +35,9 @@ pub struct FixTestResult {
 pub fn test_snippet(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
     let parse_result = parse_for_lint(source, settings, None);
     let indexer = Indexer::new(source, &parse_result);
-    lint_file(
-        &parse_result,
-        source,
-        &indexer,
-        settings,
-        &crate::ShellCheckCodeMap::default(),
-        None,
-    )
+    // Fixture and rule-focused test helpers ignore inline directives by default so
+    // embedded ShellCheck suppressions do not silently mask the rule under test.
+    lint_file_with_directives(&parse_result, source, &indexer, settings, &[], None)
 }
 
 /// Lint a source string while preserving an explicit path for path-sensitive rules.
@@ -51,14 +48,7 @@ pub fn test_snippet_at_path(
 ) -> Vec<Diagnostic> {
     let parse_result = parse_for_lint(source, settings, Some(path));
     let indexer = Indexer::new(source, &parse_result);
-    lint_file(
-        &parse_result,
-        source,
-        &indexer,
-        settings,
-        &crate::ShellCheckCodeMap::default(),
-        Some(path),
-    )
+    lint_file_with_directives(&parse_result, source, &indexer, settings, &[], Some(path))
 }
 
 pub fn test_snippet_with_fix(

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -33,7 +33,14 @@ pub struct FixTestResult {
 pub fn test_snippet(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
     let parse_result = parse_for_lint(source, settings, None);
     let indexer = Indexer::new(source, &parse_result);
-    lint_file(&parse_result, source, &indexer, settings, None, None)
+    lint_file(
+        &parse_result,
+        source,
+        &indexer,
+        settings,
+        &crate::ShellCheckCodeMap::default(),
+        None,
+    )
 }
 
 /// Lint a source string while preserving an explicit path for path-sensitive rules.
@@ -44,7 +51,14 @@ pub fn test_snippet_at_path(
 ) -> Vec<Diagnostic> {
     let parse_result = parse_for_lint(source, settings, Some(path));
     let indexer = Indexer::new(source, &parse_result);
-    lint_file(&parse_result, source, &indexer, settings, None, Some(path))
+    lint_file(
+        &parse_result,
+        source,
+        &indexer,
+        settings,
+        &crate::ShellCheckCodeMap::default(),
+        Some(path),
+    )
 }
 
 pub fn test_snippet_with_fix(

--- a/fuzz/fuzz_targets/formatter_validity_common.rs
+++ b/fuzz/fuzz_targets/formatter_validity_common.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use shuck_formatter::{FormattedSource, ShellDialect as FormatDialect, ShellFormatOptions};
 use shuck_indexer::Indexer;
-use shuck_linter::{Diagnostic, LinterSettings, lint_file};
+use shuck_linter::{Diagnostic, LinterSettings, ShellCheckCodeMap, lint_file};
 use shuck_parser::{ShellDialect as ParseDialect, parser::Parser};
 
 pub(crate) const FORMAT_CASES: [FormatCase; 4] = [
@@ -68,7 +68,14 @@ pub(crate) fn lint_source_strict(
     }
     let indexer = Indexer::new(source, &parse_result);
     let settings = LinterSettings::default().with_analyzed_paths([path.to_path_buf()]);
-    lint_file(&parse_result, source, &indexer, &settings, None, Some(path))
+    lint_file(
+        &parse_result,
+        source,
+        &indexer,
+        &settings,
+        &ShellCheckCodeMap::default(),
+        Some(path),
+    )
 }
 
 pub(crate) fn compare_lint_counts(original: &[Diagnostic], formatted: &[Diagnostic], path: &Path) {

--- a/fuzz/fuzz_targets/linter_common.rs
+++ b/fuzz/fuzz_targets/linter_common.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use shuck_ast::Span;
 use shuck_indexer::Indexer;
-use shuck_linter::{Diagnostic, LinterSettings, lint_file};
+use shuck_linter::{Diagnostic, LinterSettings, ShellCheckCodeMap, lint_file};
 use shuck_parser::{ShellDialect as ParseDialect, parser::Parser};
 
 pub(crate) const LINT_CASES: [LintCase; 4] = [
@@ -69,5 +69,12 @@ pub(crate) fn lint_source_with_recovery(
         Some(path) => LinterSettings::default().with_analyzed_paths([path.to_path_buf()]),
         None => LinterSettings::default(),
     };
-    lint_file(&parse_result, source, &indexer, &settings, None, path)
+    lint_file(
+        &parse_result,
+        source,
+        &indexer,
+        &settings,
+        &ShellCheckCodeMap::default(),
+        path,
+    )
 }


### PR DESCRIPTION
## Summary
- make the pre-parsed directive path internal to `shuck-linter`
- add public lint wrappers that parse comment directives inside the linter instead of exposing `parse_directives`
- leave a TODO on the internal directive parser pointing toward replacing the remaining recursive attachment walk with semantic command visits

## Why
We want the directive attachment walk to stop leaking into other crates while we work toward folding it into the single semantic traversal path.

## Validation
- cargo fmt
- cargo test -p shuck-linter --no-run
- cargo test -p shuck-cli --no-run
- cargo check -p shuck-benchmark --benches --examples
- cargo test -p shuck-benchmark
