### PR TITLE
refactor(linter): reuse semantic walk for directive attachment

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -589,7 +589,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let comment_double_quote_nesting_spans =
             build_comment_double_quote_nesting_spans(self.source, self._indexer);
         let trailing_directive_comment_spans = build_trailing_directive_comment_spans(
-            self.file,
+            self.semantic_artifacts.directive_attachment_facts(),
             &case_items,
             self.source,
             self._indexer,

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -376,7 +376,7 @@ fn build_comment_double_quote_nesting_spans(source: &str, indexer: &Indexer) -> 
 }
 
 fn build_trailing_directive_comment_spans(
-    file: &File,
+    directive_attachment_facts: &crate::suppression::DirectiveAttachmentFacts,
     case_items: &[CaseItemFact<'_>],
     source: &str,
     indexer: &Indexer,
@@ -409,7 +409,7 @@ fn build_trailing_directive_comment_spans(
             if case_item_label_comment(case_items, line, comment_start) {
                 return None;
             }
-            if shellcheck_directive_can_apply_to_following_command(source, file, comment.range) {
+            if directive_attachment_facts.can_apply_to_following_command(comment.range) {
                 return None;
             }
 

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -41,7 +41,6 @@ use self::{
         rewrite_word_as_single_double_quoted_string,
     },
 };
-use crate::suppression::shellcheck_directive_can_apply_to_following_command;
 use crate::{AmbientShellOptions, LinterSemanticArtifacts, ShellDialect};
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -117,6 +117,7 @@ use std::ops::Deref;
 use std::path::Path;
 
 use crate::suppression::{
+    DirectiveAttachmentFacts, DirectiveCommandVisit, filter_attached_directives,
     first_statement_line, sort_command_spans_for_lookup, statement_suppression_span,
 };
 
@@ -134,6 +135,7 @@ pub struct LinterSemanticArtifacts<'a> {
     command_visits_by_id: Vec<Option<facts::CommandVisit<'a>>>,
     direct_command_ids_by_body_span: FxHashMap<facts::FactSpan, Vec<CommandId>>,
     suppression_command_spans: Vec<Span>,
+    directive_attachment_facts: DirectiveAttachmentFacts,
 }
 
 impl<'a> LinterSemanticArtifacts<'a> {
@@ -154,11 +156,22 @@ impl<'a> LinterSemanticArtifacts<'a> {
             build_with_observer_with_options(file, source, indexer, &mut observer, options);
         let mut suppression_command_spans = observer.collect_suppression_command_spans(&semantic);
         sort_command_spans_for_lookup(&mut suppression_command_spans);
+        let directive_attachment_facts = DirectiveAttachmentFacts::from_command_visits(
+            source,
+            indexer.comment_index(),
+            observer.command_visits_by_id.iter().filter_map(|visit| {
+                visit.map(|visit| DirectiveCommandVisit {
+                    stmt: visit.stmt,
+                    command: visit.command,
+                })
+            }),
+        );
         Self {
             semantic,
             command_visits_by_id: observer.command_visits_by_id,
             direct_command_ids_by_body_span: observer.direct_command_ids_by_body_span,
             suppression_command_spans,
+            directive_attachment_facts,
         }
     }
 
@@ -178,6 +191,10 @@ impl<'a> LinterSemanticArtifacts<'a> {
 
     pub(crate) fn suppression_command_spans(&self) -> &[Span] {
         &self.suppression_command_spans
+    }
+
+    pub(crate) fn directive_attachment_facts(&self) -> &DirectiveAttachmentFacts {
+        &self.directive_attachment_facts
     }
 
     #[cfg(test)]
@@ -319,14 +336,21 @@ fn suppression_span_is_function_body_wrapper(semantic: &SemanticModel, id: Comma
 fn build_suppression_index_from_semantic(
     directives: &[SuppressionDirective],
     file: &File,
+    source: &str,
     semantic: &LinterSemanticArtifacts<'_>,
 ) -> Option<SuppressionIndex> {
     if directives.is_empty() {
         return None;
     }
 
+    let directives =
+        filter_attached_directives(source, directives, semantic.directive_attachment_facts());
+    if directives.is_empty() {
+        return None;
+    }
+
     Some(SuppressionIndex::from_sorted_command_spans(
-        directives,
+        &directives,
         semantic.suppression_command_spans(),
         first_statement_line(file).unwrap_or(u32::MAX),
     ))
@@ -593,12 +617,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_result(
     source_path: Option<&Path>,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> Vec<Diagnostic> {
-    let directives = parse_directives(
-        source,
-        &parse_result.file,
-        indexer.comment_index(),
-        shellcheck_map,
-    );
+    let directives = parse_directives(source, indexer.comment_index(), shellcheck_map);
     lint_file_at_path_with_resolver_and_parse_result_and_directives(
         parse_result,
         source,
@@ -648,6 +667,7 @@ pub(crate) fn lint_file_at_path_with_resolver_and_parse_result_and_directives(
     let suppression_index = build_suppression_index_from_semantic(
         directives,
         &parse_result.file,
+        source,
         &linter_semantic_artifacts,
     );
     let checker = Checker::new(
@@ -706,12 +726,7 @@ pub fn lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
     source_path: Option<&Path>,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> Vec<Diagnostic> {
-    let directives = parse_directives(
-        source,
-        &parse_result.file,
-        indexer.comment_index(),
-        shellcheck_map,
-    );
+    let directives = parse_directives(source, indexer.comment_index(), shellcheck_map);
     lint_file_at_path_with_resolver_and_parse_result_and_directives(
         parse_result,
         source,
@@ -910,7 +925,6 @@ mod tests {
         let indexer = Indexer::new(source, &output);
         let directives = parse_directives(
             source,
-            &output.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
@@ -923,7 +937,6 @@ mod tests {
         let indexer = Indexer::new(&source, &output);
         let directives = parse_directives(
             &source,
-            &output.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
@@ -955,7 +968,6 @@ mod tests {
         let indexer = Indexer::new(&source, &output);
         let directives = parse_directives(
             &source,
-            &output.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
@@ -975,7 +987,6 @@ mod tests {
         let indexer = Indexer::new(source, &output);
         let directives = parse_directives(
             source,
-            &output.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
@@ -992,7 +1003,6 @@ mod tests {
         let indexer = Indexer::new(source, &output);
         let directives = parse_directives(
             source,
-            &output.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
@@ -2429,13 +2439,13 @@ echo $bar
         let indexer = Indexer::new(source, &output);
         let directives = parse_directives(
             source,
-            &output.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
         let suppressions =
-            build_suppression_index_from_semantic(&directives, &output.file, &semantic).unwrap();
+            build_suppression_index_from_semantic(&directives, &output.file, source, &semantic)
+                .unwrap();
 
         let echo_foo = match &output.file.body[1].command {
             Command::Simple(command) => command.span,
@@ -5786,7 +5796,6 @@ foo=1
         let indexer = Indexer::new(source, &output);
         let directives = parse_directives(
             source,
-            &output.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -569,7 +569,6 @@ greet
         let indexer = Indexer::new(source, &parse_result);
         let directives = parse_directives(
             source,
-            &parse_result.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -1,10 +1,4 @@
-use shuck_ast::{
-    ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue, ArrayElem, Assignment, AssignmentValue,
-    BourneParameterExpansion, BuiltinCommand, CaseItem, Command, CompoundCommand, ConditionalExpr,
-    DeclOperand, File, FunctionDef, HeredocBodyPartNode, ParameterExpansion,
-    ParameterExpansionSyntax, Pattern, PatternPart, Redirect, Stmt, StmtSeq, TextRange, TextSize,
-    VarRef, Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment,
-};
+use shuck_ast::{CaseItem, Command, CompoundCommand, Stmt, StmtSeq, TextRange, TextSize};
 use shuck_indexer::{CommentIndex, IndexedComment};
 
 use crate::{Rule, code_to_rule};
@@ -39,13 +33,12 @@ pub enum SuppressionSource {
     ShellCheck,
 }
 
-/// Parse all suppression directives from a file's comments.
-// TODO: Delete this pre-parsed directive seam once inline directive attachment can be derived
-// from semantic command visits during lint setup. External callers should stay on the
-// normal lint entrypoints so this recursive walk remains internal until it disappears.
+/// Parse all suppression directive candidates from a file's comments.
+///
+/// Structural attachment for inline directives is validated after semantic traversal, once
+/// command/header facts are available without another recursive AST walk.
 pub(crate) fn parse_directives(
     source: &str,
-    file: &File,
     comment_index: &CommentIndex,
     shellcheck_map: &ShellCheckCodeMap,
 ) -> Vec<SuppressionDirective> {
@@ -56,11 +49,9 @@ pub(crate) fn parse_directives(
             continue;
         };
 
-        if let Some(directive) = parse_shuck_directive(source, &comment, file, shellcheck_map) {
+        if let Some(directive) = parse_shuck_directive(&comment, shellcheck_map) {
             directives.push(directive);
-        } else if let Some(directive) =
-            parse_shellcheck_directive(source, &comment, file, shellcheck_map)
-        {
+        } else if let Some(directive) = parse_shellcheck_directive(&comment, shellcheck_map) {
             directives.push(directive);
         }
     }
@@ -127,9 +118,7 @@ fn is_horizontal_whitespace(text: &str) -> bool {
 }
 
 fn parse_shuck_directive(
-    source: &str,
     comment: &NormalizedComment<'_>,
-    file: &File,
     shellcheck_map: &ShellCheckCodeMap,
 ) -> Option<SuppressionDirective> {
     let body = strip_comment_prefix(comment.text);
@@ -144,14 +133,6 @@ fn parse_shuck_directive(
         return None;
     }
 
-    if action == SuppressionAction::Disable
-        && !comment.is_own_line
-        && !shellcheck_directive_can_apply_to_following_command(source, file, comment.range)
-        && !is_case_label_directive(comment, file)
-    {
-        return None;
-    }
-
     Some(SuppressionDirective {
         action,
         source: SuppressionSource::Shuck,
@@ -162,9 +143,7 @@ fn parse_shuck_directive(
 }
 
 fn parse_shellcheck_directive(
-    source: &str,
     comment: &NormalizedComment<'_>,
-    file: &File,
     shellcheck_map: &ShellCheckCodeMap,
 ) -> Option<SuppressionDirective> {
     let remainder = shellcheck_comment_remainder(comment.text)?;
@@ -190,13 +169,6 @@ fn parse_shellcheck_directive(
         return None;
     }
 
-    if !comment.is_own_line
-        && !shellcheck_directive_can_apply_to_following_command(source, file, comment.range)
-        && !is_case_label_directive(comment, file)
-    {
-        return None;
-    }
-
     Some(SuppressionDirective {
         action: SuppressionAction::Disable,
         source: SuppressionSource::ShellCheck,
@@ -206,9 +178,130 @@ fn parse_shellcheck_directive(
     })
 }
 
-pub(crate) fn shellcheck_directive_can_apply_to_following_command(
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DirectiveCommandVisit<'a> {
+    pub(crate) stmt: &'a Stmt,
+    pub(crate) command: &'a Command,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DirectiveAttachmentFacts {
+    following_command_ranges: Vec<RangeKey>,
+    case_label_ranges: Vec<RangeKey>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct RangeKey {
+    start: u32,
+    end: u32,
+}
+
+impl RangeKey {
+    fn new(range: TextRange) -> Self {
+        Self {
+            start: range.start().to_u32(),
+            end: range.end().to_u32(),
+        }
+    }
+}
+
+impl DirectiveAttachmentFacts {
+    pub(crate) fn from_command_visits<'a>(
+        source: &str,
+        comment_index: &CommentIndex,
+        visits: impl IntoIterator<Item = DirectiveCommandVisit<'a>>,
+    ) -> Self {
+        let visits = visits.into_iter().collect::<Vec<_>>();
+        let mut following_command_ranges = Vec::new();
+        let mut case_label_ranges = Vec::new();
+
+        for indexed_comment in comment_index.comments() {
+            let Some(comment) = normalized_comment(source, indexed_comment) else {
+                continue;
+            };
+            if comment.is_own_line {
+                continue;
+            }
+
+            if directive_can_apply_to_following_command(source, &visits, comment.range) {
+                push_comment_range_keys(
+                    &mut following_command_ranges,
+                    comment.range,
+                    indexed_comment.range,
+                );
+            }
+            if directive_is_case_label(comment, &visits) {
+                push_comment_range_keys(
+                    &mut case_label_ranges,
+                    comment.range,
+                    indexed_comment.range,
+                );
+            }
+        }
+
+        following_command_ranges.sort_unstable();
+        following_command_ranges.dedup();
+        case_label_ranges.sort_unstable();
+        case_label_ranges.dedup();
+
+        Self {
+            following_command_ranges,
+            case_label_ranges,
+        }
+    }
+
+    pub(crate) fn can_apply_to_following_command(&self, comment_range: TextRange) -> bool {
+        self.following_command_ranges
+            .binary_search(&RangeKey::new(comment_range))
+            .is_ok()
+    }
+
+    pub(crate) fn is_case_label_directive(&self, comment_range: TextRange) -> bool {
+        self.case_label_ranges
+            .binary_search(&RangeKey::new(comment_range))
+            .is_ok()
+    }
+
+    fn accepts_inline_directive(&self, directive: &SuppressionDirective) -> bool {
+        self.can_apply_to_following_command(directive.range)
+            || self.is_case_label_directive(directive.range)
+    }
+}
+
+fn push_comment_range_keys(keys: &mut Vec<RangeKey>, normalized: TextRange, indexed: TextRange) {
+    keys.push(RangeKey::new(normalized));
+    if indexed != normalized {
+        keys.push(RangeKey::new(indexed));
+    }
+}
+
+pub(crate) fn filter_attached_directives(
     source: &str,
-    file: &File,
+    directives: &[SuppressionDirective],
+    attachment_facts: &DirectiveAttachmentFacts,
+) -> Vec<SuppressionDirective> {
+    directives
+        .iter()
+        .filter(|directive| {
+            directive.action != SuppressionAction::Disable
+                || directive_is_own_line(source, directive.range)
+                || attachment_facts.accepts_inline_directive(directive)
+        })
+        .cloned()
+        .collect()
+}
+
+fn directive_is_own_line(source: &str, range: TextRange) -> bool {
+    let comment_start = usize::from(range.start()).min(source.len());
+    let line_start = source[..comment_start]
+        .rfind('\n')
+        .map_or(0, |index| index + 1);
+    is_horizontal_whitespace(&source[line_start..comment_start])
+}
+
+fn directive_can_apply_to_following_command(
+    source: &str,
+    visits: &[DirectiveCommandVisit<'_>],
     comment_range: TextRange,
 ) -> bool {
     let Some(context) = inline_directive_context(source, comment_range) else {
@@ -219,217 +312,214 @@ pub(crate) fn shellcheck_directive_can_apply_to_following_command(
         return true;
     }
 
-    command_visits(&file.body)
-        .into_iter()
-        .any(|visit| match visit.command {
-            Command::Compound(CompoundCommand::If(command)) => {
-                let if_header = command.condition.first().is_some_and(|stmt| {
+    visits.iter().any(|visit| match visit.command {
+        Command::Compound(CompoundCommand::If(command)) => {
+            let if_header = command.condition.first().is_some_and(|stmt| {
+                next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                    && command_start_segment_matches(
+                        source,
+                        visit.stmt.span.start.offset,
+                        context.comment_start,
+                        "if",
+                    )
+            });
+
+            let then_header = body_header_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.then_branch,
+                &context,
+                "then",
+            ) || body_opener_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.then_branch,
+                &context,
+                '{',
+            );
+
+            let mut previous_branch_end = command.then_branch.span.end.offset;
+            let mut elif_header = false;
+            let mut elif_body_header = false;
+            for (condition, branch) in &command.elif_branches {
+                elif_header |= condition.first().is_some_and(|stmt| {
                     next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                        && command_start_segment_matches(
+                        && gap_segment_ends_with_keyword(
                             source,
-                            visit.stmt.span.start.offset,
+                            previous_branch_end,
                             context.comment_start,
-                            "if",
+                            "elif",
                         )
                 });
-
-                let then_header = body_header_matches(
+                elif_body_header |= body_header_matches(
                     source,
-                    command.condition.span.end.offset,
-                    &command.then_branch,
+                    condition.span.end.offset,
+                    branch,
                     &context,
                     "then",
                 ) || body_opener_matches(
                     source,
-                    command.condition.span.end.offset,
-                    &command.then_branch,
+                    condition.span.end.offset,
+                    branch,
                     &context,
                     '{',
                 );
+                previous_branch_end = branch.span.end.offset;
+            }
 
-                let mut previous_branch_end = command.then_branch.span.end.offset;
-                let mut elif_header = false;
-                let mut elif_body_header = false;
-                for (condition, branch) in &command.elif_branches {
-                    elif_header |= condition.first().is_some_and(|stmt| {
-                        next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                            && gap_segment_ends_with_keyword(
-                                source,
-                                previous_branch_end,
-                                context.comment_start,
-                                "elif",
-                            )
-                    });
-                    elif_body_header |= body_header_matches(
-                        source,
-                        condition.span.end.offset,
-                        branch,
-                        &context,
-                        "then",
-                    ) || body_opener_matches(
-                        source,
-                        condition.span.end.offset,
-                        branch,
-                        &context,
-                        '{',
-                    );
-                    previous_branch_end = branch.span.end.offset;
-                }
-
-                let else_header = command.else_branch.as_ref().is_some_and(|branch| {
-                    branch.first().is_some_and(|stmt| {
-                        next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                            && (gap_segment_ends_with_keyword(
-                                source,
-                                previous_branch_end,
-                                context.comment_start,
-                                "else",
-                            ) || gap_segment_ends_with_char(
-                                source,
-                                previous_branch_end,
-                                context.comment_start,
-                                '{',
-                            ))
-                    })
-                });
-
-                if_header || then_header || elif_header || elif_body_header || else_header
-            }
-            Command::Compound(CompoundCommand::For(command)) => {
-                body_header_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    "do",
-                ) || body_opener_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    '{',
-                )
-            }
-            Command::Compound(CompoundCommand::Repeat(command)) => {
-                body_header_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    "do",
-                ) || body_opener_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    '{',
-                )
-            }
-            Command::Compound(CompoundCommand::Foreach(command)) => {
-                body_header_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    "do",
-                ) || body_opener_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    '{',
-                )
-            }
-            Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
-                body_header_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    "do",
-                ) || body_opener_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    '{',
-                )
-            }
-            Command::Compound(CompoundCommand::While(command)) => {
-                loop_header_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.condition,
-                    context,
-                    "while",
-                ) || body_header_matches(
-                    source,
-                    command.condition.span.end.offset,
-                    &command.body,
-                    &context,
-                    "do",
-                ) || body_opener_matches(
-                    source,
-                    command.condition.span.end.offset,
-                    &command.body,
-                    &context,
-                    '{',
-                )
-            }
-            Command::Compound(CompoundCommand::Until(command)) => {
-                loop_header_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.condition,
-                    context,
-                    "until",
-                ) || body_header_matches(
-                    source,
-                    command.condition.span.end.offset,
-                    &command.body,
-                    &context,
-                    "do",
-                ) || body_opener_matches(
-                    source,
-                    command.condition.span.end.offset,
-                    &command.body,
-                    &context,
-                    '{',
-                )
-            }
-            Command::Compound(CompoundCommand::Select(command)) => {
-                body_header_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    "do",
-                ) || body_opener_matches(
-                    source,
-                    visit.stmt.span.start.offset,
-                    &command.body,
-                    &context,
-                    '{',
-                )
-            }
-            Command::Compound(CompoundCommand::Subshell(body)) => {
-                body.first().is_some_and(|stmt| {
+            let else_header = command.else_branch.as_ref().is_some_and(|branch| {
+                branch.first().is_some_and(|stmt| {
                     next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                        && context.prefix.trim_end().ends_with('(')
+                        && (gap_segment_ends_with_keyword(
+                            source,
+                            previous_branch_end,
+                            context.comment_start,
+                            "else",
+                        ) || gap_segment_ends_with_char(
+                            source,
+                            previous_branch_end,
+                            context.comment_start,
+                            '{',
+                        ))
                 })
-            }
-            Command::Compound(CompoundCommand::BraceGroup(body)) => {
-                body.first().is_some_and(|stmt| {
-                    next_command_starts_after_comment_line(stmt.span.start.offset, &context)
-                        && context.prefix.trim_end().ends_with('{')
-                })
-            }
-            _ => false,
-        })
+            });
+
+            if_header || then_header || elif_header || elif_body_header || else_header
+        }
+        Command::Compound(CompoundCommand::For(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::Repeat(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::Foreach(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::While(command)) => {
+            loop_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.condition,
+                context,
+                "while",
+            ) || body_header_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::Until(command)) => {
+            loop_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.condition,
+                context,
+                "until",
+            ) || body_header_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                command.condition.span.end.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::Select(command)) => {
+            body_header_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                "do",
+            ) || body_opener_matches(
+                source,
+                visit.stmt.span.start.offset,
+                &command.body,
+                &context,
+                '{',
+            )
+        }
+        Command::Compound(CompoundCommand::Subshell(body)) => body.first().is_some_and(|stmt| {
+            next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                && context.prefix.trim_end().ends_with('(')
+        }),
+        Command::Compound(CompoundCommand::BraceGroup(body)) => body.first().is_some_and(|stmt| {
+            next_command_starts_after_comment_line(stmt.span.start.offset, &context)
+                && context.prefix.trim_end().ends_with('{')
+        }),
+        _ => false,
+    })
 }
 
-fn is_case_label_directive(comment: &NormalizedComment<'_>, file: &File) -> bool {
-    command_visits(&file.body).into_iter().any(|visit| {
+fn directive_is_case_label(
+    comment: NormalizedComment<'_>,
+    visits: &[DirectiveCommandVisit<'_>],
+) -> bool {
+    visits.iter().any(|visit| {
         let Command::Compound(CompoundCommand::Case(command)) = visit.command else {
             return false;
         };
@@ -437,567 +527,8 @@ fn is_case_label_directive(comment: &NormalizedComment<'_>, file: &File) -> bool
         command
             .cases
             .iter()
-            .any(|case| case_label_directive(case, comment))
+            .any(|case| case_label_directive(case, &comment))
     })
-}
-
-#[derive(Clone, Copy)]
-struct DirectiveCommandVisit<'a> {
-    stmt: &'a Stmt,
-    command: &'a Command,
-}
-
-fn command_visits(commands: &StmtSeq) -> Vec<DirectiveCommandVisit<'_>> {
-    let mut visits = Vec::new();
-    collect_command_visits(commands, &mut visits);
-    visits
-}
-
-fn collect_command_visits<'a>(commands: &'a StmtSeq, visits: &mut Vec<DirectiveCommandVisit<'a>>) {
-    for stmt in commands.iter() {
-        collect_command_visit(stmt, visits);
-    }
-}
-
-fn collect_command_visit<'a>(stmt: &'a Stmt, visits: &mut Vec<DirectiveCommandVisit<'a>>) {
-    visits.push(DirectiveCommandVisit {
-        stmt,
-        command: &stmt.command,
-    });
-
-    match &stmt.command {
-        Command::Simple(command) => {
-            collect_assignment_visits(&command.assignments, visits);
-            collect_word_visits(&command.name, visits);
-            collect_word_slice_visits(&command.args, visits);
-        }
-        Command::Builtin(command) => collect_builtin_visits(command, visits),
-        Command::Decl(command) => {
-            collect_assignment_visits(&command.assignments, visits);
-            for operand in &command.operands {
-                match operand {
-                    DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => {
-                        collect_word_visits(word, visits);
-                    }
-                    DeclOperand::Name(_) => {}
-                    DeclOperand::Assignment(assignment) => {
-                        collect_assignment_visit(assignment, visits);
-                    }
-                }
-            }
-        }
-        Command::Binary(command) => {
-            collect_command_visit(&command.left, visits);
-            collect_command_visit(&command.right, visits);
-        }
-        Command::Compound(command) => collect_compound_visits(command, visits),
-        Command::Function(FunctionDef { header, body, .. }) => {
-            for entry in &header.entries {
-                collect_word_visits(&entry.word, visits);
-            }
-            collect_command_visit(body, visits);
-        }
-        Command::AnonymousFunction(function) => {
-            collect_word_slice_visits(&function.args, visits);
-            collect_command_visit(&function.body, visits);
-        }
-    }
-
-    collect_redirect_visits(&stmt.redirects, visits);
-}
-
-fn collect_builtin_visits<'a>(
-    command: &'a BuiltinCommand,
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    match command {
-        BuiltinCommand::Break(command) => {
-            collect_assignment_visits(&command.assignments, visits);
-            if let Some(word) = &command.depth {
-                collect_word_visits(word, visits);
-            }
-            collect_word_slice_visits(&command.extra_args, visits);
-        }
-        BuiltinCommand::Continue(command) => {
-            collect_assignment_visits(&command.assignments, visits);
-            if let Some(word) = &command.depth {
-                collect_word_visits(word, visits);
-            }
-            collect_word_slice_visits(&command.extra_args, visits);
-        }
-        BuiltinCommand::Return(command) => {
-            collect_assignment_visits(&command.assignments, visits);
-            if let Some(word) = &command.code {
-                collect_word_visits(word, visits);
-            }
-            collect_word_slice_visits(&command.extra_args, visits);
-        }
-        BuiltinCommand::Exit(command) => {
-            collect_assignment_visits(&command.assignments, visits);
-            if let Some(word) = &command.code {
-                collect_word_visits(word, visits);
-            }
-            collect_word_slice_visits(&command.extra_args, visits);
-        }
-    }
-}
-
-fn collect_compound_visits<'a>(
-    command: &'a CompoundCommand,
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    match command {
-        CompoundCommand::If(command) => {
-            collect_command_visits(&command.condition, visits);
-            collect_command_visits(&command.then_branch, visits);
-            for (condition, body) in &command.elif_branches {
-                collect_command_visits(condition, visits);
-                collect_command_visits(body, visits);
-            }
-            if let Some(body) = &command.else_branch {
-                collect_command_visits(body, visits);
-            }
-        }
-        CompoundCommand::For(command) => {
-            if let Some(words) = &command.words {
-                collect_word_slice_visits(words, visits);
-            }
-            collect_command_visits(&command.body, visits);
-        }
-        CompoundCommand::Repeat(command) => {
-            collect_word_visits(&command.count, visits);
-            collect_command_visits(&command.body, visits);
-        }
-        CompoundCommand::Foreach(command) => {
-            collect_word_slice_visits(&command.words, visits);
-            collect_command_visits(&command.body, visits);
-        }
-        CompoundCommand::ArithmeticFor(command) => collect_command_visits(&command.body, visits),
-        CompoundCommand::While(command) => {
-            collect_command_visits(&command.condition, visits);
-            collect_command_visits(&command.body, visits);
-        }
-        CompoundCommand::Until(command) => {
-            collect_command_visits(&command.condition, visits);
-            collect_command_visits(&command.body, visits);
-        }
-        CompoundCommand::Case(command) => {
-            collect_word_visits(&command.word, visits);
-            for case in &command.cases {
-                collect_pattern_slice_visits(&case.patterns, visits);
-                collect_command_visits(&case.body, visits);
-            }
-        }
-        CompoundCommand::Select(command) => {
-            collect_word_slice_visits(&command.words, visits);
-            collect_command_visits(&command.body, visits);
-        }
-        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
-            collect_command_visits(commands, visits);
-        }
-        CompoundCommand::Always(command) => {
-            collect_command_visits(&command.body, visits);
-            collect_command_visits(&command.always_body, visits);
-        }
-        CompoundCommand::Arithmetic(_) => {}
-        CompoundCommand::Time(command) => {
-            if let Some(command) = &command.command {
-                collect_command_visit(command, visits);
-            }
-        }
-        CompoundCommand::Conditional(command) => {
-            collect_conditional_visits(&command.expression, visits);
-        }
-        CompoundCommand::Coproc(command) => collect_command_visit(&command.body, visits),
-    }
-}
-
-fn collect_assignment_visits<'a>(
-    assignments: &'a [Assignment],
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    for assignment in assignments {
-        collect_assignment_visit(assignment, visits);
-    }
-}
-
-fn collect_assignment_visit<'a>(
-    assignment: &'a Assignment,
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    match &assignment.value {
-        AssignmentValue::Scalar(word) => collect_word_visits(word, visits),
-        AssignmentValue::Compound(array) => {
-            for element in &array.elements {
-                match element {
-                    ArrayElem::Sequential(word) => collect_word_visits(word, visits),
-                    ArrayElem::Keyed { value, .. } | ArrayElem::KeyedAppend { value, .. } => {
-                        collect_word_visits(value, visits);
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn collect_word_slice_visits<'a>(words: &'a [Word], visits: &mut Vec<DirectiveCommandVisit<'a>>) {
-    for word in words {
-        collect_word_visits(word, visits);
-    }
-}
-
-fn collect_pattern_slice_visits<'a>(
-    patterns: &'a [Pattern],
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    for pattern in patterns {
-        collect_pattern_visits(pattern, visits);
-    }
-}
-
-fn collect_pattern_visits<'a>(pattern: &'a Pattern, visits: &mut Vec<DirectiveCommandVisit<'a>>) {
-    for (part, _) in pattern.parts_with_spans() {
-        match part {
-            PatternPart::Group { patterns, .. } => collect_pattern_slice_visits(patterns, visits),
-            PatternPart::Word(word) => collect_word_visits(word, visits),
-            PatternPart::Literal(_)
-            | PatternPart::AnyString
-            | PatternPart::AnyChar
-            | PatternPart::CharClass(_) => {}
-        }
-    }
-}
-
-fn collect_word_visits<'a>(word: &'a Word, visits: &mut Vec<DirectiveCommandVisit<'a>>) {
-    collect_word_part_visits(&word.parts, visits);
-}
-
-fn collect_word_part_visits<'a>(
-    parts: &'a [WordPartNode],
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    for part in parts {
-        match &part.kind {
-            WordPart::ZshQualifiedGlob(glob) => {
-                for pattern in zsh_glob_patterns(glob) {
-                    collect_pattern_visits(pattern, visits);
-                }
-            }
-            WordPart::DoubleQuoted { parts, .. } => collect_word_part_visits(parts, visits),
-            WordPart::ArithmeticExpansion { expression_ast, .. } => {
-                if let Some(expression_ast) = expression_ast.as_ref() {
-                    visit_arithmetic_words(expression_ast, &mut |word| {
-                        collect_word_visits(word, visits);
-                    });
-                }
-            }
-            WordPart::CommandSubstitution { body, .. }
-            | WordPart::ProcessSubstitution { body, .. } => collect_command_visits(body, visits),
-            WordPart::Parameter(parameter) => collect_parameter_expansion_visits(parameter, visits),
-            WordPart::ParameterExpansion {
-                reference,
-                operand_word_ast,
-                ..
-            }
-            | WordPart::IndirectExpansion {
-                reference,
-                operand_word_ast,
-                ..
-            } => {
-                collect_var_ref_word_visits(reference, visits);
-                if let Some(word) = operand_word_ast.as_ref() {
-                    collect_word_visits(word, visits);
-                }
-            }
-            WordPart::Length(reference)
-            | WordPart::ArrayAccess(reference)
-            | WordPart::ArrayLength(reference)
-            | WordPart::ArrayIndices(reference)
-            | WordPart::Transformation { reference, .. } => {
-                collect_var_ref_word_visits(reference, visits);
-            }
-            WordPart::Substring {
-                reference,
-                offset_ast,
-                offset_word_ast,
-                length_ast,
-                length_word_ast,
-                ..
-            }
-            | WordPart::ArraySlice {
-                reference,
-                offset_ast,
-                offset_word_ast,
-                length_ast,
-                length_word_ast,
-                ..
-            } => {
-                collect_var_ref_word_visits(reference, visits);
-                if let Some(expression) = offset_ast.as_ref() {
-                    visit_arithmetic_words(expression, &mut |word| {
-                        collect_word_visits(word, visits);
-                    });
-                } else {
-                    collect_word_visits(offset_word_ast, visits);
-                }
-                if let Some(expression) = length_ast.as_ref() {
-                    visit_arithmetic_words(expression, &mut |word| {
-                        collect_word_visits(word, visits);
-                    });
-                } else if let Some(word) = length_word_ast.as_ref() {
-                    collect_word_visits(word, visits);
-                }
-            }
-            WordPart::Literal(_)
-            | WordPart::SingleQuoted { .. }
-            | WordPart::Variable(_)
-            | WordPart::PrefixMatch { .. } => {}
-        }
-    }
-}
-
-fn zsh_glob_patterns(glob: &shuck_ast::ZshQualifiedGlob) -> impl Iterator<Item = &Pattern> + '_ {
-    glob.segments.iter().filter_map(|segment| match segment {
-        ZshGlobSegment::Pattern(pattern) => Some(pattern),
-        ZshGlobSegment::InlineControl(_) => None,
-    })
-}
-
-fn collect_var_ref_word_visits<'a>(
-    reference: &'a VarRef,
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    let Some(subscript) = reference.subscript.as_deref() else {
-        return;
-    };
-    if subscript.selector().is_some() {
-        return;
-    }
-    if let Some(expression) = subscript.arithmetic_ast.as_ref() {
-        visit_arithmetic_words(expression, &mut |word| {
-            collect_word_visits(word, visits);
-        });
-    } else if let Some(word) = subscript.word_ast() {
-        collect_word_visits(word, visits);
-    }
-}
-
-fn collect_parameter_expansion_visits<'a>(
-    parameter: &'a ParameterExpansion,
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    match &parameter.syntax {
-        ParameterExpansionSyntax::Bourne(syntax) => match syntax {
-            BourneParameterExpansion::Access { reference }
-            | BourneParameterExpansion::Length { reference }
-            | BourneParameterExpansion::Indices { reference }
-            | BourneParameterExpansion::Transformation { reference, .. } => {
-                collect_var_ref_word_visits(reference, visits);
-            }
-            BourneParameterExpansion::Indirect {
-                reference,
-                operand_word_ast,
-                ..
-            } => {
-                collect_var_ref_word_visits(reference, visits);
-                if let Some(word) = operand_word_ast.as_ref() {
-                    collect_word_visits(word, visits);
-                }
-            }
-            BourneParameterExpansion::Operation {
-                reference,
-                operator,
-                operand_word_ast,
-                ..
-            } => {
-                collect_var_ref_word_visits(reference, visits);
-                if let Some(word) = operand_word_ast.as_ref() {
-                    collect_word_visits(word, visits);
-                }
-                if let Some(word) = operator.replacement_word_ast() {
-                    collect_word_visits(word, visits);
-                }
-            }
-            BourneParameterExpansion::Slice {
-                reference,
-                offset_ast,
-                offset_word_ast,
-                length_ast,
-                length_word_ast,
-                ..
-            } => {
-                collect_var_ref_word_visits(reference, visits);
-                if let Some(expression) = offset_ast.as_ref() {
-                    visit_arithmetic_words(expression, &mut |word| {
-                        collect_word_visits(word, visits);
-                    });
-                } else {
-                    collect_word_visits(offset_word_ast, visits);
-                }
-                if let Some(expression) = length_ast.as_ref() {
-                    visit_arithmetic_words(expression, &mut |word| {
-                        collect_word_visits(word, visits);
-                    });
-                } else if let Some(word) = length_word_ast.as_ref() {
-                    collect_word_visits(word, visits);
-                }
-            }
-            BourneParameterExpansion::PrefixMatch { .. } => {}
-        },
-        ParameterExpansionSyntax::Zsh(syntax) => {
-            collect_zsh_target_visits(&syntax.target, visits);
-
-            for modifier in &syntax.modifiers {
-                if let Some(word) = modifier.argument_word_ast() {
-                    collect_word_visits(word, visits);
-                }
-            }
-
-            if let Some(operation) = &syntax.operation {
-                match operation {
-                    shuck_ast::ZshExpansionOperation::PatternOperation { .. }
-                    | shuck_ast::ZshExpansionOperation::Defaulting { .. }
-                    | shuck_ast::ZshExpansionOperation::TrimOperation { .. }
-                    | shuck_ast::ZshExpansionOperation::Unknown { .. } => {
-                        if let Some(word) = operation.operand_word_ast() {
-                            collect_word_visits(word, visits);
-                        }
-                    }
-                    shuck_ast::ZshExpansionOperation::ReplacementOperation { .. } => {
-                        if let Some(word) = operation.pattern_word_ast() {
-                            collect_word_visits(word, visits);
-                        }
-                        if let Some(word) = operation.replacement_word_ast() {
-                            collect_word_visits(word, visits);
-                        }
-                    }
-                    shuck_ast::ZshExpansionOperation::Slice { .. } => {
-                        if let Some(word) = operation.offset_word_ast() {
-                            collect_word_visits(word, visits);
-                        }
-                        if let Some(word) = operation.length_word_ast() {
-                            collect_word_visits(word, visits);
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn collect_zsh_target_visits<'a>(
-    target: &'a ZshExpansionTarget,
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    match target {
-        ZshExpansionTarget::Reference(reference) => collect_var_ref_word_visits(reference, visits),
-        ZshExpansionTarget::Nested(parameter) => {
-            collect_parameter_expansion_visits(parameter, visits);
-        }
-        ZshExpansionTarget::Word(word) => collect_word_visits(word, visits),
-        ZshExpansionTarget::Empty => {}
-    }
-}
-
-fn collect_redirect_visits<'a>(
-    redirects: &'a [Redirect],
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    for redirect in redirects {
-        if let Some(word) = redirect.word_target() {
-            collect_word_visits(word, visits);
-        } else if let Some(heredoc) = redirect.heredoc()
-            && heredoc.delimiter.expands_body
-        {
-            collect_heredoc_body_part_visits(&heredoc.body.parts, visits);
-        }
-    }
-}
-
-fn collect_heredoc_body_part_visits<'a>(
-    parts: &'a [HeredocBodyPartNode],
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    for part in parts {
-        match &part.kind {
-            shuck_ast::HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
-                if let Some(expression_ast) = expression_ast.as_ref() {
-                    visit_arithmetic_words(expression_ast, &mut |word| {
-                        collect_word_visits(word, visits);
-                    });
-                }
-            }
-            shuck_ast::HeredocBodyPart::CommandSubstitution { body, .. } => {
-                collect_command_visits(body, visits);
-            }
-            shuck_ast::HeredocBodyPart::Literal(_)
-            | shuck_ast::HeredocBodyPart::Variable(_)
-            | shuck_ast::HeredocBodyPart::Parameter(_) => {}
-        }
-    }
-}
-
-fn collect_conditional_visits<'a>(
-    expression: &'a ConditionalExpr,
-    visits: &mut Vec<DirectiveCommandVisit<'a>>,
-) {
-    match expression {
-        ConditionalExpr::Binary(expr) => {
-            collect_conditional_visits(&expr.left, visits);
-            collect_conditional_visits(&expr.right, visits);
-        }
-        ConditionalExpr::Unary(expr) => collect_conditional_visits(&expr.expr, visits),
-        ConditionalExpr::Parenthesized(expr) => collect_conditional_visits(&expr.expr, visits),
-        ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
-            collect_word_visits(word, visits);
-        }
-        ConditionalExpr::Pattern(pattern) => collect_pattern_visits(pattern, visits),
-        ConditionalExpr::VarRef(_) => {}
-    }
-}
-
-fn visit_arithmetic_words<'a>(
-    expression: &'a ArithmeticExprNode,
-    visitor: &mut impl FnMut(&'a Word),
-) {
-    match &expression.kind {
-        ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) => {}
-        ArithmeticExpr::Indexed { index, .. } => visit_arithmetic_words(index, visitor),
-        ArithmeticExpr::ShellWord(word) => visitor(word),
-        ArithmeticExpr::Parenthesized { expression } => {
-            visit_arithmetic_words(expression, visitor);
-        }
-        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
-            visit_arithmetic_words(expr, visitor);
-        }
-        ArithmeticExpr::Binary { left, right, .. } => {
-            visit_arithmetic_words(left, visitor);
-            visit_arithmetic_words(right, visitor);
-        }
-        ArithmeticExpr::Conditional {
-            condition,
-            then_expr,
-            else_expr,
-        } => {
-            visit_arithmetic_words(condition, visitor);
-            visit_arithmetic_words(then_expr, visitor);
-            visit_arithmetic_words(else_expr, visitor);
-        }
-        ArithmeticExpr::Assignment { target, value, .. } => {
-            visit_arithmetic_lvalue_words(target, visitor);
-            visit_arithmetic_words(value, visitor);
-        }
-    }
-}
-
-fn visit_arithmetic_lvalue_words<'a>(
-    target: &'a ArithmeticLvalue,
-    visitor: &mut impl FnMut(&'a Word),
-) {
-    match target {
-        ArithmeticLvalue::Variable(_) => {}
-        ArithmeticLvalue::Indexed { index, .. } => visit_arithmetic_words(index, visitor),
-    }
 }
 
 fn case_label_directive(case: &CaseItem, comment: &NormalizedComment<'_>) -> bool {
@@ -1210,6 +741,8 @@ mod tests {
     use shuck_indexer::Indexer;
     use shuck_parser::parser::{Parser, ShellDialect};
 
+    use crate::LinterSemanticArtifacts;
+
     use super::*;
 
     fn directives(source: &str) -> Vec<SuppressionDirective> {
@@ -1219,12 +752,13 @@ mod tests {
     fn directives_with_dialect(source: &str, dialect: ShellDialect) -> Vec<SuppressionDirective> {
         let output = Parser::with_dialect(source, dialect).parse().unwrap();
         let indexer = Indexer::new(source, &output);
-        parse_directives(
+        let directives = parse_directives(
             source,
-            &output.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
-        )
+        );
+        let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+        filter_attached_directives(source, &directives, semantic.directive_attachment_facts())
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -211,31 +211,33 @@ impl DirectiveAttachmentFacts {
         comment_index: &CommentIndex,
         visits: impl IntoIterator<Item = DirectiveCommandVisit<'a>>,
     ) -> Self {
+        let candidate_comments = comment_index
+            .comments()
+            .iter()
+            .filter_map(|indexed_comment| {
+                let comment = normalized_comment(source, indexed_comment)?;
+                (!comment.is_own_line && comment_may_need_inline_attachment(comment.text))
+                    .then_some((comment, indexed_comment.range))
+            })
+            .collect::<Vec<_>>();
+        if candidate_comments.is_empty() {
+            return Self::default();
+        }
+
         let visits = visits.into_iter().collect::<Vec<_>>();
         let mut following_command_ranges = Vec::new();
         let mut case_label_ranges = Vec::new();
 
-        for indexed_comment in comment_index.comments() {
-            let Some(comment) = normalized_comment(source, indexed_comment) else {
-                continue;
-            };
-            if comment.is_own_line {
-                continue;
-            }
-
+        for (comment, indexed_range) in candidate_comments {
             if directive_can_apply_to_following_command(source, &visits, comment.range) {
                 push_comment_range_keys(
                     &mut following_command_ranges,
                     comment.range,
-                    indexed_comment.range,
+                    indexed_range,
                 );
             }
             if directive_is_case_label(comment, &visits) {
-                push_comment_range_keys(
-                    &mut case_label_ranges,
-                    comment.range,
-                    indexed_comment.range,
-                );
+                push_comment_range_keys(&mut case_label_ranges, comment.range, indexed_range);
             }
         }
 
@@ -266,6 +268,22 @@ impl DirectiveAttachmentFacts {
         self.can_apply_to_following_command(directive.range)
             || self.is_case_label_directive(directive.range)
     }
+}
+
+fn comment_may_need_inline_attachment(text: &str) -> bool {
+    let body = strip_comment_prefix(text);
+    if let Some(remainder) = strip_prefix_ignore_ascii_case(body, "shuck:") {
+        let Some((action, _)) = remainder.split_once('=') else {
+            return false;
+        };
+        return parse_shuck_action(action.trim()) == Some(SuppressionAction::Disable);
+    }
+
+    shellcheck_comment_remainder(text).is_some_and(|remainder| {
+        remainder
+            .split_ascii_whitespace()
+            .any(|part| strip_prefix_ignore_ascii_case(part, "disable=").is_some())
+    })
 }
 
 fn push_comment_range_keys(keys: &mut Vec<RangeKey>, normalized: TextRange, indexed: TextRange) {

--- a/crates/shuck-linter/src/suppression/index.rs
+++ b/crates/shuck-linter/src/suppression/index.rs
@@ -252,7 +252,10 @@ mod tests {
     use shuck_parser::parser::{Parser, ShellDialect};
 
     use super::*;
-    use crate::{LinterSemanticArtifacts, ShellCheckCodeMap, parse_directives};
+    use crate::{
+        LinterSemanticArtifacts, ShellCheckCodeMap, parse_directives,
+        suppression::filter_attached_directives,
+    };
 
     fn suppression_index(source: &str) -> SuppressionIndex {
         suppression_index_with_dialect(source, ShellDialect::Bash)
@@ -263,11 +266,12 @@ mod tests {
         let indexer = Indexer::new(source, &output);
         let directives = parse_directives(
             source,
-            &output.file,
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
         let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+        let directives =
+            filter_attached_directives(source, &directives, semantic.directive_attachment_facts());
         SuppressionIndex::from_sorted_command_spans(
             &directives,
             semantic.suppression_command_spans(),

--- a/crates/shuck-linter/src/suppression/mod.rs
+++ b/crates/shuck-linter/src/suppression/mod.rs
@@ -4,7 +4,9 @@ mod rewrite;
 mod shellcheck_map;
 
 pub(crate) use directive::parse_directives;
-pub(crate) use directive::shellcheck_directive_can_apply_to_following_command;
+pub(crate) use directive::{
+    DirectiveAttachmentFacts, DirectiveCommandVisit, filter_attached_directives,
+};
 pub use directive::{SuppressionAction, SuppressionDirective, SuppressionSource};
 pub use index::SuppressionIndex;
 pub(crate) use index::{

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -112,12 +112,7 @@ fn analyze_source(
     let shell = resolve_shell(settings, source, Some(path));
     let parse_result = parse_for_lint(source, shell);
     let indexer = Indexer::new(source, &parse_result);
-    let directives = parse_directives(
-        source,
-        &parse_result.file,
-        indexer.comment_index(),
-        shellcheck_map,
-    );
+    let directives = parse_directives(source, indexer.comment_index(), shellcheck_map);
     let diagnostics = lint_file_with_directives(
         &parse_result,
         source,


### PR DESCRIPTION
## Summary

- parse suppression directive candidates directly from `CommentIndex` instead of passing the full AST into directive parsing
- derive inline directive attachment facts from the existing semantic command visits
- reuse those attachment facts for suppression index construction and trailing directive comment facts

## Why

The directive parser was still doing its own recursive AST walk to decide whether inline disable comments attached to control-flow headers, case labels, or nested command bodies. This folds that structural decision into the semantic traversal we already run, removing the separate directive-owned full AST walk while preserving the existing suppression behavior.

## Validation

- `cargo check -p shuck-linter`
- `cargo test -p shuck-linter suppression`
- `cargo test -p shuck-linter`
- `git diff --check`
