### PR TITLE
refactor(linter): reuse command stream for conditional fact scans

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -116,6 +116,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let redundant_return_status_spans = Vec::new();
         let mut getopts_cases = Vec::new();
         let mut condition_status_capture_spans = Vec::new();
+        let mut precise_function_guard_suppressions = Vec::new();
         let mut command_substitution_command_spans = Vec::new();
         let mut arithmetic_update_operator_spans = Vec::new();
         let mut base_prefix_arithmetic_spans = Vec::new();
@@ -333,6 +334,17 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 }
 
                 if !nested_word_command {
+                    collect_condition_status_capture_from_direct_body_sequences(
+                        visit.command,
+                        self.source,
+                        &mut condition_status_capture_spans,
+                    );
+                    collect_precise_function_return_guard_suppressions_from_direct_body_sequences(
+                        visit.command,
+                        self.source,
+                        &mut precise_function_guard_suppressions,
+                        context.flow().in_function,
+                    );
                     match visit.command {
                         Command::Compound(CompoundCommand::If(command)) => {
                             collect_condition_status_capture_from_body(
@@ -478,16 +490,16 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             .case_cli_reachable_function_scopes(self.file, &case_cli_dispatches)
             .into_iter()
             .collect();
-        collect_condition_status_capture_from_sequences(
+        collect_condition_status_capture_from_sequence(
             &self.file.body,
             self.source,
             &mut condition_status_capture_spans,
         );
-        let mut precise_function_guard_suppressions = Vec::new();
-        collect_precise_function_return_guard_suppressions(
+        collect_precise_function_return_guard_suppressions_in_seq(
             &self.file.body,
             self.source,
             &mut precise_function_guard_suppressions,
+            false,
         );
         if !precise_function_guard_suppressions.is_empty() {
             condition_status_capture_spans

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -479,7 +479,7 @@ fn collect_condition_status_capture_from_body(
     spans.extend(stmt_spans);
 }
 
-fn collect_condition_status_capture_from_sequences(
+pub(super) fn collect_condition_status_capture_from_sequence(
     commands: &StmtSeq,
     source: &str,
     spans: &mut Vec<Span>,
@@ -507,10 +507,6 @@ fn collect_condition_status_capture_from_sequences(
         segment_start > 0,
     );
 
-    for stmt in commands.iter() {
-        collect_condition_status_capture_from_nested_sequences(stmt, source, spans);
-    }
-
     for (index, stmt) in commands.iter().enumerate() {
         if !sequence_tail_contains_nested_test_command(&commands.as_slice()[index + 1..], source) {
             continue;
@@ -523,6 +519,59 @@ fn collect_condition_status_capture_from_sequences(
         };
 
         collect_status_test_followup_chains_with_sibling_tail(body, source, spans);
+    }
+}
+
+pub(super) fn collect_condition_status_capture_from_direct_body_sequences(
+    command: &Command,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match command {
+        Command::Compound(command) => match command {
+            CompoundCommand::If(command) => {
+                collect_condition_status_capture_from_sequence(&command.then_branch, source, spans);
+                for (_, branch) in &command.elif_branches {
+                    collect_condition_status_capture_from_sequence(branch, source, spans);
+                }
+                if let Some(branch) = &command.else_branch {
+                    collect_condition_status_capture_from_sequence(branch, source, spans);
+                }
+            }
+            CompoundCommand::While(command) => {
+                collect_condition_status_capture_from_sequence(&command.body, source, spans);
+            }
+            CompoundCommand::Until(command) => {
+                collect_condition_status_capture_from_sequence(&command.body, source, spans);
+            }
+            CompoundCommand::For(command) => {
+                collect_condition_status_capture_from_sequence(&command.body, source, spans);
+            }
+            CompoundCommand::Select(command) => {
+                collect_condition_status_capture_from_sequence(&command.body, source, spans);
+            }
+            CompoundCommand::BraceGroup(body) | CompoundCommand::Subshell(body) => {
+                collect_condition_status_capture_from_sequence(body, source, spans);
+            }
+            CompoundCommand::Time(_) => {}
+            CompoundCommand::Always(command) => {
+                collect_condition_status_capture_from_sequence(&command.body, source, spans);
+                collect_condition_status_capture_from_sequence(&command.always_body, source, spans);
+            }
+            CompoundCommand::Case(_)
+            | CompoundCommand::Conditional(_)
+            | CompoundCommand::Repeat(_)
+            | CompoundCommand::Foreach(_)
+            | CompoundCommand::ArithmeticFor(_)
+            | CompoundCommand::Arithmetic(_)
+            | CompoundCommand::Coproc(_) => {}
+        },
+        Command::Simple(_)
+        | Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Binary(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => {}
     }
 }
 
@@ -869,82 +918,6 @@ fn branch_body_logs_status_then_immediately_exits(
     body.iter().nth(1).is_some_and(stmt_is_exit_or_return_builtin)
 }
 
-fn collect_condition_status_capture_from_nested_sequences(
-    stmt: &Stmt,
-    source: &str,
-    spans: &mut Vec<Span>,
-) {
-    match &stmt.command {
-        Command::Binary(command) => {
-            collect_condition_status_capture_from_nested_sequences(&command.left, source, spans);
-            collect_condition_status_capture_from_nested_sequences(&command.right, source, spans);
-        }
-        Command::Compound(command) => match command {
-            CompoundCommand::If(command) => {
-                collect_condition_status_capture_from_sequences(&command.then_branch, source, spans);
-                for (_, branch) in &command.elif_branches {
-                    collect_condition_status_capture_from_sequences(branch, source, spans);
-                }
-                if let Some(branch) = &command.else_branch {
-                    collect_condition_status_capture_from_sequences(branch, source, spans);
-                }
-            }
-            CompoundCommand::While(command) => {
-                collect_condition_status_capture_from_sequences(&command.body, source, spans);
-            }
-            CompoundCommand::Until(command) => {
-                collect_condition_status_capture_from_sequences(&command.body, source, spans);
-            }
-            CompoundCommand::For(command) => {
-                collect_condition_status_capture_from_sequences(&command.body, source, spans);
-            }
-            CompoundCommand::Select(command) => {
-                collect_condition_status_capture_from_sequences(&command.body, source, spans);
-            }
-            CompoundCommand::BraceGroup(body) | CompoundCommand::Subshell(body) => {
-                collect_condition_status_capture_from_sequences(body, source, spans);
-            }
-            CompoundCommand::Case(command) => {
-                let _ = command;
-            }
-            CompoundCommand::Time(command) => {
-                if let Some(inner) = &command.command {
-                    collect_condition_status_capture_from_nested_sequences(inner, source, spans);
-                }
-            }
-            CompoundCommand::Always(command) => {
-                collect_condition_status_capture_from_sequences(&command.body, source, spans);
-                collect_condition_status_capture_from_sequences(
-                    &command.always_body,
-                    source,
-                    spans,
-                );
-            }
-            CompoundCommand::Conditional(_)
-            | CompoundCommand::Repeat(_)
-            | CompoundCommand::Foreach(_)
-            | CompoundCommand::ArithmeticFor(_)
-            | CompoundCommand::Arithmetic(_)
-            | CompoundCommand::Coproc(_) => {}
-        },
-        Command::Function(function) => {
-            collect_condition_status_capture_from_nested_sequences(&function.body, source, spans);
-        }
-        Command::AnonymousFunction(function) => {
-            collect_condition_status_capture_from_nested_sequences(&function.body, source, spans);
-        }
-        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => {}
-    }
-}
-
-fn collect_precise_function_return_guard_suppressions(
-    commands: &StmtSeq,
-    source: &str,
-    spans: &mut Vec<Span>,
-) {
-    collect_precise_function_return_guard_suppressions_in_seq(commands, source, spans, false);
-}
-
 fn collect_precise_function_return_guard_suppressions_in_seq(
     commands: &StmtSeq,
     source: &str,
@@ -968,37 +941,16 @@ fn collect_precise_function_return_guard_suppressions_in_seq(
                 collect_status_parameter_spans_in_return_guard_stmt(stmt, source, spans);
             }
         }
-
-        collect_precise_function_return_guard_suppressions_in_stmt(
-            stmt,
-            source,
-            spans,
-            in_function_like_body,
-        );
     }
 }
 
-fn collect_precise_function_return_guard_suppressions_in_stmt(
-    stmt: &Stmt,
+fn collect_precise_function_return_guard_suppressions_from_direct_body_sequences(
+    command: &Command,
     source: &str,
     spans: &mut Vec<Span>,
     in_function_like_body: bool,
 ) {
-    match &stmt.command {
-        Command::Binary(command) => {
-            collect_precise_function_return_guard_suppressions_in_stmt(
-                &command.left,
-                source,
-                spans,
-                in_function_like_body,
-            );
-            collect_precise_function_return_guard_suppressions_in_stmt(
-                &command.right,
-                source,
-                spans,
-                in_function_like_body,
-            );
-        }
+    match command {
         Command::Compound(command) => match command {
             CompoundCommand::If(command) => {
                 collect_precise_function_return_guard_suppressions_in_seq(
@@ -1064,16 +1016,7 @@ fn collect_precise_function_return_guard_suppressions_in_stmt(
                     in_function_like_body,
                 );
             }
-            CompoundCommand::Time(command) => {
-                if let Some(inner) = &command.command {
-                    collect_precise_function_return_guard_suppressions_in_stmt(
-                        inner,
-                        source,
-                        spans,
-                        in_function_like_body,
-                    );
-                }
-            }
+            CompoundCommand::Time(_) => {}
             CompoundCommand::Always(command) => {
                 collect_precise_function_return_guard_suppressions_in_seq(
                     &command.body,
@@ -1105,23 +1048,12 @@ fn collect_precise_function_return_guard_suppressions_in_stmt(
             | CompoundCommand::Arithmetic(_)
             | CompoundCommand::Coproc(_) => {}
         },
-        Command::Function(function) => {
-            collect_precise_function_return_guard_suppressions_in_stmt(
-                &function.body,
-                source,
-                spans,
-                true,
-            );
-        }
-        Command::AnonymousFunction(function) => {
-            collect_precise_function_return_guard_suppressions_in_stmt(
-                &function.body,
-                source,
-                spans,
-                true,
-            );
-        }
-        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => {}
+        Command::Simple(_)
+        | Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Binary(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => {}
     }
 }
 

--- a/crates/shuck-linter/src/facts/tests/flow.rs
+++ b/crates/shuck-linter/src/facts/tests/flow.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::facts::{
-    collect_precise_function_return_guard_suppressions,
     collect_precise_function_return_guard_suppressions_in_seq,
     stmt_is_non_test_return_status_guard, stmt_is_unary_test_return_status_guard,
 };
@@ -339,14 +338,6 @@ pkg_check() {
             .collect::<Vec<_>>(),
         vec![4, 8]
     );
-
-    let mut spans = Vec::new();
-    collect_precise_function_return_guard_suppressions(&output.file.body, source, &mut spans);
-
-    assert_eq!(
-        spans.iter().map(|span| span.start.line).collect::<Vec<_>>(),
-        vec![4, 8]
-    );
 }
 
 #[test]
@@ -666,6 +657,29 @@ if [ -f later_if ]; then
 elif [ -f later_elif ]; then
   :
 fi
+";
+
+    with_facts(source, None, |_, facts| {
+        assert_eq!(
+            facts
+                .condition_status_capture_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$?"]
+        );
+    });
+}
+
+#[test]
+fn collects_c056_inside_function_body_sequences() {
+    let source = "\
+#!/bin/bash
+helper() {
+  [ -f first ]
+  tend $?
+  [ -f second ]
+}
 ";
 
     with_facts(source, None, |_, facts| {

--- a/crates/shuck-linter/src/rules/correctness/status_capture_after_branch_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/status_capture_after_branch_test.rs
@@ -337,4 +337,25 @@ plain_complex_guard()
             vec!["$?"]
         );
     }
+
+    #[test]
+    fn suppresses_precise_function_return_guards_in_case_bodies() {
+        let source = "\
+#!/bin/bash
+pkg_check() {
+  case \"$mode\" in
+    a)
+      helper || return $?
+      [[ -n \"$path\" ]] || return $?
+      ;;
+  esac
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::StatusCaptureAfterBranchTest),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
- remove the remaining production partial conditionals walks by feeding sequence-local collectors from the existing command stream and direct body sequences
- keep C056 status-capture detection and precise function return-guard suppression behavior, including function-body and case-body coverage
- add focused regressions for the sequence and case-body paths

## Why
These conditionals facts were still recursively walking nested AST bodies during normal linting even though the semantic command stream already exposes the body structure we need. Reusing that stream trims duplicate traversal work and keeps the conditionals collectors aligned with the main production analysis path.

## Validation
- cargo fmt --all
- cargo test -p shuck-linter
- cargo test -p shuck-linter status_capture_after_branch_test -- --nocapture
- cargo test -p shuck-linter collects_c056 -- --nocapture
- cargo test -p shuck-linter recognizes_precise_function_return_guard_shapes -- --nocapture
