### PR TITLE
refactor(linter): reuse semantic conditional traversal

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -296,7 +296,11 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 let glued_closing_bracket_insert_offset =
                     build_glued_closing_bracket_insert_offset(visit.command, self.source);
                 let simple_test = build_simple_test_fact(visit.command, self.source);
-                let conditional = build_conditional_fact(visit.command, self.source);
+                let conditional_expression_visits = self
+                    .semantic_artifacts
+                    .conditional_expression_visits(command_span(visit.command));
+                let conditional =
+                    build_conditional_fact(conditional_expression_visits, self.source);
                 let command_fact = CommandFact {
                     id,
                     key,

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -197,6 +197,24 @@ impl<'a> ConditionalFact<'a> {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ConditionalExpressionVisit<'a> {
+    expression: &'a ConditionalExpr,
+    parent_in_same_logical_group: bool,
+}
+
+impl<'a> ConditionalExpressionVisit<'a> {
+    pub(crate) fn new(
+        expression: &'a ConditionalExpr,
+        parent_in_same_logical_group: bool,
+    ) -> Self {
+        Self {
+            expression,
+            parent_in_same_logical_group,
+        }
+    }
+}
+
 fn collect_command_substitution_command_span(
     command: &Command,
     source: &str,
@@ -2208,14 +2226,25 @@ fn collect_status_parameter_spans_in_fragment(
     collect_status_parameter_spans_in_word(word, source, spans);
 }
 
-fn build_conditional_fact<'a>(command: &'a Command, source: &str) -> Option<ConditionalFact<'a>> {
-    let Command::Compound(CompoundCommand::Conditional(command)) = command else {
+fn build_conditional_fact<'a>(
+    expression_visits: &[ConditionalExpressionVisit<'a>],
+    source: &str,
+) -> Option<ConditionalFact<'a>> {
+    if expression_visits.is_empty() {
         return None;
-    };
-    let mut nodes = Vec::new();
-    collect_conditional_nodes(&command.expression, source, &mut nodes);
+    }
+
+    let mut nodes = Vec::with_capacity(expression_visits.len());
     let mut mixed_logical_operators = Vec::new();
-    collect_mixed_logical_operators(&command.expression, false, &mut mixed_logical_operators);
+    for visit in expression_visits {
+        nodes.push(build_conditional_node(visit.expression, source));
+        collect_mixed_logical_operator(
+            visit.expression,
+            visit.parent_in_same_logical_group,
+            &mut mixed_logical_operators,
+        );
+    }
+
     (!nodes.is_empty()).then_some(ConditionalFact {
         nodes: nodes.into_boxed_slice(),
         mixed_logical_operators: mixed_logical_operators.into_boxed_slice(),
@@ -2238,45 +2267,29 @@ fn command_name_is_plain_command_substitution(word: &Word, source: &str) -> bool
         )
 }
 
-fn collect_mixed_logical_operators(
+fn collect_mixed_logical_operator(
     expression: &ConditionalExpr,
     parent_in_same_logical_group: bool,
     operators: &mut Vec<ConditionalMixedLogicalOperatorFact>,
 ) {
-    match expression {
-        ConditionalExpr::Parenthesized(parenthesized) => {
-            collect_mixed_logical_operators(&parenthesized.expr, false, operators);
-        }
-        ConditionalExpr::Unary(unary) => {
-            collect_mixed_logical_operators(&unary.expr, false, operators);
-        }
-        ConditionalExpr::Binary(binary) => {
-            let left_continues_group = conditional_expr_is_logical_binary(&binary.left);
-            let right_continues_group = conditional_expr_is_logical_binary(&binary.right);
+    let ConditionalExpr::Binary(binary) = expression else {
+        return;
+    };
 
-            collect_mixed_logical_operators(&binary.left, left_continues_group, operators);
-            collect_mixed_logical_operators(&binary.right, right_continues_group, operators);
-
-            if conditional_binary_op_is_logical(binary.op)
-                && !parent_in_same_logical_group
-                && logical_operator_mask(expression) == (LOGICAL_AND_MASK | LOGICAL_OR_MASK)
-            {
-                let grouped_subexpression_spans =
-                    mixed_logical_grouped_subexpression_spans(expression, binary.op);
-                debug_assert!(
-                    !grouped_subexpression_spans.is_empty(),
-                    "mixed logical operators should expose at least one grouping span"
-                );
-                operators.push(ConditionalMixedLogicalOperatorFact {
-                    operator_span: binary.op_span,
-                    grouped_subexpression_spans: grouped_subexpression_spans.into_boxed_slice(),
-                });
-            }
-        }
-        ConditionalExpr::Word(_)
-        | ConditionalExpr::Pattern(_)
-        | ConditionalExpr::Regex(_)
-        | ConditionalExpr::VarRef(_) => {}
+    if conditional_binary_op_is_logical(binary.op)
+        && !parent_in_same_logical_group
+        && logical_operator_mask(expression) == (LOGICAL_AND_MASK | LOGICAL_OR_MASK)
+    {
+        let grouped_subexpression_spans =
+            mixed_logical_grouped_subexpression_spans(expression, binary.op);
+        debug_assert!(
+            !grouped_subexpression_spans.is_empty(),
+            "mixed logical operators should expose at least one grouping span"
+        );
+        operators.push(ConditionalMixedLogicalOperatorFact {
+            operator_span: binary.op_span,
+            grouped_subexpression_spans: grouped_subexpression_spans.into_boxed_slice(),
+        });
     }
 }
 
@@ -2333,39 +2346,8 @@ fn logical_operator_mask(expression: &ConditionalExpr) -> u8 {
     }
 }
 
-fn conditional_expr_is_logical_binary(expression: &ConditionalExpr) -> bool {
-    matches!(
-        expression,
-        ConditionalExpr::Binary(binary) if conditional_binary_op_is_logical(binary.op)
-    )
-}
-
 fn conditional_binary_op_is_logical(operator: ConditionalBinaryOp) -> bool {
     matches!(operator, ConditionalBinaryOp::And | ConditionalBinaryOp::Or)
-}
-
-fn collect_conditional_nodes<'a>(
-    expression: &'a ConditionalExpr,
-    source: &str,
-    nodes: &mut Vec<ConditionalNodeFact<'a>>,
-) {
-    let expression = strip_parenthesized_conditionals(expression);
-    nodes.push(build_conditional_node(expression, source));
-
-    match expression {
-        ConditionalExpr::Binary(expression) => {
-            collect_conditional_nodes(&expression.left, source, nodes);
-            collect_conditional_nodes(&expression.right, source, nodes);
-        }
-        ConditionalExpr::Unary(expression) => {
-            collect_conditional_nodes(&expression.expr, source, nodes);
-        }
-        ConditionalExpr::Parenthesized(_) => unreachable!("parentheses should be stripped"),
-        ConditionalExpr::Word(_)
-        | ConditionalExpr::Pattern(_)
-        | ConditionalExpr::Regex(_)
-        | ConditionalExpr::VarRef(_) => {}
-    }
 }
 
 fn build_conditional_node<'a>(

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -133,6 +133,8 @@ pub struct AnalysisResult {
 pub struct LinterSemanticArtifacts<'a> {
     semantic: SemanticModel,
     command_visits_by_id: Vec<Option<facts::CommandVisit<'a>>>,
+    conditional_expression_visits_by_command_span:
+        FxHashMap<facts::FactSpan, Vec<facts::ConditionalExpressionVisit<'a>>>,
     direct_command_ids_by_body_span: FxHashMap<facts::FactSpan, Vec<CommandId>>,
     suppression_command_spans: Vec<Span>,
     directive_attachment_facts: DirectiveAttachmentFacts,
@@ -169,6 +171,8 @@ impl<'a> LinterSemanticArtifacts<'a> {
         Self {
             semantic,
             command_visits_by_id: observer.command_visits_by_id,
+            conditional_expression_visits_by_command_span: observer
+                .conditional_expression_visits_by_command_span,
             direct_command_ids_by_body_span: observer.direct_command_ids_by_body_span,
             suppression_command_spans,
             directive_attachment_facts,
@@ -187,6 +191,15 @@ impl<'a> LinterSemanticArtifacts<'a> {
 
     pub(crate) fn command_visits_by_id(&self) -> &[Option<facts::CommandVisit<'a>>] {
         &self.command_visits_by_id
+    }
+
+    pub(crate) fn conditional_expression_visits(
+        &self,
+        command_span: Span,
+    ) -> &[facts::ConditionalExpressionVisit<'a>] {
+        self.conditional_expression_visits_by_command_span
+            .get(&facts::FactSpan::new(command_span))
+            .map_or(&[], Vec::as_slice)
     }
 
     pub(crate) fn suppression_command_spans(&self) -> &[Span] {
@@ -265,6 +278,8 @@ impl Deref for LinterSemanticArtifacts<'_> {
 #[derive(Default)]
 struct LintTraversalObserver<'a> {
     command_visits_by_id: Vec<Option<facts::CommandVisit<'a>>>,
+    conditional_expression_visits_by_command_span:
+        FxHashMap<facts::FactSpan, Vec<facts::ConditionalExpressionVisit<'a>>>,
     direct_command_ids_by_body_span: FxHashMap<facts::FactSpan, Vec<CommandId>>,
     suppression_command_spans_by_id: Vec<Option<Span>>,
 }
@@ -286,6 +301,21 @@ impl LintTraversalObserver<'_> {
 }
 
 impl<'a> TraversalObserver<'a> for LintTraversalObserver<'a> {
+    fn conditional_expression(
+        &mut self,
+        command_span: Span,
+        expression: &'a shuck_ast::ConditionalExpr,
+        parent_in_same_logical_group: bool,
+    ) {
+        self.conditional_expression_visits_by_command_span
+            .entry(facts::FactSpan::new(command_span))
+            .or_default()
+            .push(facts::ConditionalExpressionVisit::new(
+                expression,
+                parent_in_same_logical_group,
+            ));
+    }
+
     fn recorded_command(
         &mut self,
         id: CommandId,

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -3,41 +3,112 @@ use super::*;
 impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     pub(super) fn visit_conditional_expr(
         &mut self,
+        command_span: Span,
         expression: &'a ConditionalExpr,
         flow: FlowState,
     ) -> Vec<IsolatedRegion> {
         let mut nested_regions = Vec::new();
-        self.visit_conditional_expr_into(expression, flow, &mut nested_regions);
+        self.visit_conditional_expr_into(command_span, expression, flow, &mut nested_regions);
         nested_regions
     }
 
     pub(super) fn visit_conditional_expr_into(
         &mut self,
+        command_span: Span,
         expression: &'a ConditionalExpr,
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
+        self.visit_conditional_expr_with_context(
+            command_span,
+            expression,
+            flow,
+            nested_regions,
+            false,
+            false,
+        );
+    }
+
+    fn visit_conditional_expr_with_context(
+        &mut self,
+        command_span: Span,
+        expression: &'a ConditionalExpr,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+        parent_in_same_logical_group: bool,
+        arithmetic_operand: bool,
+    ) {
+        let expression = strip_parenthesized_conditional(expression);
+        self.observer.conditional_expression(
+            command_span,
+            expression,
+            parent_in_same_logical_group,
+        );
+
+        if arithmetic_operand
+            && let Some((name, span)) = conditional_arithmetic_operand_name(expression, self.source)
+        {
+            self.add_reference(&name, ReferenceKind::ArithmeticRead, span);
+            return;
+        }
+
         match expression {
             ConditionalExpr::Binary(expr) => {
                 if conditional_binary_op_uses_arithmetic_operands(expr.op) {
-                    self.visit_conditional_arithmetic_operand_into(
+                    self.visit_conditional_expr_with_context(
+                        command_span,
                         &expr.left,
                         flow,
                         nested_regions,
+                        false,
+                        true,
                     );
-                    self.visit_conditional_arithmetic_operand_into(
+                    self.visit_conditional_expr_with_context(
+                        command_span,
                         &expr.right,
                         flow,
                         nested_regions,
+                        false,
+                        true,
                     );
                 } else if matches!(expr.op, ConditionalBinaryOp::And | ConditionalBinaryOp::Or) {
-                    self.visit_conditional_expr_into(&expr.left, flow, nested_regions);
+                    let left_continues_group = conditional_expr_is_logical_binary(&expr.left);
+                    let right_continues_group = conditional_expr_is_logical_binary(&expr.right);
+                    self.visit_conditional_expr_with_context(
+                        command_span,
+                        &expr.left,
+                        flow,
+                        nested_regions,
+                        left_continues_group,
+                        false,
+                    );
                     self.short_circuit_condition_depth += 1;
-                    self.visit_conditional_expr_into(&expr.right, flow, nested_regions);
+                    self.visit_conditional_expr_with_context(
+                        command_span,
+                        &expr.right,
+                        flow,
+                        nested_regions,
+                        right_continues_group,
+                        false,
+                    );
                     self.short_circuit_condition_depth -= 1;
                 } else {
-                    self.visit_conditional_expr_into(&expr.left, flow, nested_regions);
-                    self.visit_conditional_expr_into(&expr.right, flow, nested_regions);
+                    self.visit_conditional_expr_with_context(
+                        command_span,
+                        &expr.left,
+                        flow,
+                        nested_regions,
+                        false,
+                        false,
+                    );
+                    self.visit_conditional_expr_with_context(
+                        command_span,
+                        &expr.right,
+                        flow,
+                        nested_regions,
+                        false,
+                        false,
+                    );
                 }
             }
             ConditionalExpr::Unary(expr) => {
@@ -47,10 +118,14 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 {
                     self.add_reference_if_bound(&name, ReferenceKind::ConditionalOperand, span);
                 }
-                self.visit_conditional_expr_into(&expr.expr, flow, nested_regions);
-            }
-            ConditionalExpr::Parenthesized(expr) => {
-                self.visit_conditional_expr_into(&expr.expr, flow, nested_regions);
+                self.visit_conditional_expr_with_context(
+                    command_span,
+                    &expr.expr,
+                    flow,
+                    nested_regions,
+                    false,
+                    false,
+                );
             }
             ConditionalExpr::Word(word) | ConditionalExpr::Regex(word) => {
                 self.visit_word_into(word, WordVisitKind::Conditional, flow, nested_regions);
@@ -67,21 +142,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     var_ref.name_span,
                 );
             }
+            ConditionalExpr::Parenthesized(_) => unreachable!("parentheses should be stripped"),
         }
-    }
-
-    pub(super) fn visit_conditional_arithmetic_operand_into(
-        &mut self,
-        expression: &'a ConditionalExpr,
-        flow: FlowState,
-        nested_regions: &mut Vec<IsolatedRegion>,
-    ) {
-        if let Some((name, span)) = conditional_arithmetic_operand_name(expression, self.source) {
-            self.add_reference(&name, ReferenceKind::ArithmeticRead, span);
-            return;
-        }
-
-        self.visit_conditional_expr_into(expression, flow, nested_regions);
     }
 
     pub(super) fn visit_optional_arithmetic_expr(
@@ -414,4 +476,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
         }
     }
+}
+
+fn conditional_expr_is_logical_binary(expression: &ConditionalExpr) -> bool {
+    matches!(
+        expression,
+        ConditionalExpr::Binary(binary)
+            if matches!(binary.op, ConditionalBinaryOp::And | ConditionalBinaryOp::Or)
+    )
 }

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -772,7 +772,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
             }
             CompoundCommand::Conditional(command) => {
-                let nested_regions = self.visit_conditional_expr(&command.expression, flow);
+                let nested_regions =
+                    self.visit_conditional_expr(command.span, &command.expression, flow);
                 self.record_command(command.span, nested_regions, RecordedCommandKind::Linear)
             }
             CompoundCommand::Coproc(command) => {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -104,7 +104,7 @@ impl CaseCliDispatch {
 }
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{Command, File, Name, Span, Stmt};
+use shuck_ast::{Command, ConditionalExpr, File, Name, Span, Stmt};
 use shuck_indexer::Indexer;
 use smallvec::{Array, SmallVec};
 use std::path::{Path, PathBuf};
@@ -391,6 +391,14 @@ pub trait TraversalObserver<'a> {
     fn enter_command(&mut self, _command: &Command, _scope: ScopeId, _flow: FlowContext) {}
 
     fn exit_command(&mut self, _command: &Command, _scope: ScopeId) {}
+
+    fn conditional_expression(
+        &mut self,
+        _command_span: Span,
+        _expression: &'a ConditionalExpr,
+        _parent_in_same_logical_group: bool,
+    ) {
+    }
 
     fn recorded_command(
         &mut self,


### PR DESCRIPTION
## Summary

- record conditional expression visits during semantic traversal
- build linter conditional facts from semantic traversal artifacts instead of a linter-local expression walk
- preserve mixed logical operator grouping behavior and rule-facing conditional fact APIs

## Validation

- cargo check -p shuck-semantic -p shuck-linter
- cargo test -p shuck-linter condition
- cargo test -p shuck-linter
- cargo test -p shuck-semantic
- git diff --check