### PR TITLE
refactor(linter): reuse semantic visits for base prefix facts

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1,4 +1,8 @@
-fn collect_base_prefix_spans_in_command(command: &Command, source: &str, spans: &mut Vec<Span>) {
+fn collect_base_prefix_spans_in_command_parts(
+    command: &Command,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
     match command {
         Command::Simple(command) => {
             for assignment in &command.assignments {
@@ -117,14 +121,12 @@ fn collect_base_prefix_spans_in_command(command: &Command, source: &str, spans: 
                     for pattern in &item.patterns {
                         collect_base_prefix_spans_in_pattern(pattern, source, spans);
                     }
-                    collect_base_prefix_spans_in_stmt_seq(&item.body, source, spans);
                 }
             }
             CompoundCommand::Select(command) => {
                 for word in &command.words {
                     collect_base_prefix_spans_in_word(word, source, spans);
                 }
-                collect_base_prefix_spans_in_stmt_seq(&command.body, source, spans);
             }
             CompoundCommand::If(_)
             | CompoundCommand::Conditional(_)
@@ -239,9 +241,7 @@ fn collect_base_prefix_spans_in_word_part(
         | WordPart::SingleQuoted { .. }
         | WordPart::Variable(_)
         | WordPart::PrefixMatch { .. } => {}
-        WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
-            collect_base_prefix_spans_in_stmt_seq(body, source, spans);
-        }
+        WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
     }
 }
 
@@ -425,12 +425,6 @@ fn collect_base_prefix_spans_in_arithmetic_zsh_target(
     }
 }
 
-fn collect_base_prefix_spans_in_stmt_seq(body: &StmtSeq, source: &str, spans: &mut Vec<Span>) {
-    for stmt in &body.stmts {
-        collect_base_prefix_spans_in_command(&stmt.command, source, spans);
-    }
-}
-
 fn collect_base_prefix_spans_in_pattern(pattern: &Pattern, source: &str, spans: &mut Vec<Span>) {
     for (part, _) in pattern.parts_with_spans() {
         match part {
@@ -607,9 +601,7 @@ fn collect_base_prefix_spans_in_arithmetic_word_part(
                 collect_base_prefix_spans_in_arithmetic_word(length_word_ast, source, spans);
             }
         }
-        WordPart::CommandSubstitution { body, .. } | WordPart::ProcessSubstitution { body, .. } => {
-            collect_base_prefix_spans_in_stmt_seq(body, source, spans);
-        }
+        WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
         WordPart::ZshQualifiedGlob(_)
         | WordPart::SingleQuoted { .. }
         | WordPart::Variable(_)

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -231,7 +231,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                         surface: &mut surface_fragments,
                     },
                 );
-                collect_base_prefix_spans_in_command(
+                collect_base_prefix_spans_in_command_parts(
                     visit.command,
                     self.source,
                     &mut base_prefix_arithmetic_spans,

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1811,6 +1811,30 @@ echo ${foo:-$((10#1))}
 }
 
 #[test]
+fn collects_base_prefix_arithmetic_spans_from_semantic_nested_command_visits() {
+    let source = "\
+#!/bin/bash
+echo \"$(printf '%s' \"$((10#1))\")\"
+case $mode in
+  run) echo $((10#2)) ;;
+esac
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+
+    assert_eq!(
+        facts
+            .base_prefix_arithmetic_spans()
+            .iter()
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>(),
+        vec!["10#1", "10#2"]
+    );
+}
+
+#[test]
 fn collects_arithmetic_update_operator_spans_in_nested_heredoc_command_bodies() {
     let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- replace the recursive base-prefix command walker with a command-local collector
- rely on existing semantic command visits for nested command bodies
- add regression coverage for command substitution and case-body nested visits

## Verification
- cargo fmt --check
- cargo test -p shuck-linter base_prefix