### PR TITLE
refactor(linter): reuse semantic visits for parse diagnostics

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -106,7 +106,7 @@ pub use suppression::{
 pub use violation::Violation;
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{File, Position, Span, Stmt, StmtSeq, TextSize};
+use shuck_ast::{Command, CompoundCommand, File, Position, Span, Stmt, StmtSeq, TextSize};
 use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{
@@ -127,6 +127,11 @@ pub struct AnalysisResult {
     pub semantic: SemanticModel,
     /// Diagnostics emitted by linter rules and parse checks.
     pub diagnostics: Vec<Diagnostic>,
+}
+
+struct LinterAnalysisResult<'a> {
+    semantic: LinterSemanticArtifacts<'a>,
+    diagnostics: Vec<Diagnostic>,
 }
 
 /// Semantic model plus linter-private traversal artifacts needed to build facts.
@@ -208,6 +213,35 @@ impl<'a> LinterSemanticArtifacts<'a> {
 
     pub(crate) fn directive_attachment_facts(&self) -> &DirectiveAttachmentFacts {
         &self.directive_attachment_facts
+    }
+
+    pub(crate) fn missing_done_trailing_loop_is_for(
+        &self,
+        body: &StmtSeq,
+        eof_offset: usize,
+    ) -> Option<bool> {
+        let mut trailing_loop_kind = None;
+        self.for_each_command_visit_in_body(body, false, |visit| {
+            if visit.stmt.span.end.offset != eof_offset {
+                return;
+            }
+
+            let is_for_loop = match visit.command {
+                Command::Compound(CompoundCommand::For(_)) => true,
+                Command::Compound(CompoundCommand::While(_) | CompoundCommand::Until(_)) => false,
+                _ => return,
+            };
+
+            let start_offset = visit.stmt.span.start.offset;
+            if trailing_loop_kind
+                .as_ref()
+                .is_none_or(|(best_start, _)| start_offset >= *best_start)
+            {
+                trailing_loop_kind = Some((start_offset, is_for_loop));
+            }
+        });
+
+        trailing_loop_kind.map(|(_, is_for_loop)| is_for_loop)
     }
 
     #[cfg(test)]
@@ -459,6 +493,35 @@ fn analyze_file_at_path_with_resolver_and_shell(
     shell: ShellDialect,
     first_parse_error: Option<(usize, usize)>,
 ) -> AnalysisResult {
+    let result = analyze_linter_file_at_path_with_resolver_and_shell(
+        file,
+        source,
+        indexer,
+        settings,
+        suppression_index,
+        source_path,
+        source_path_resolver,
+        shell,
+        first_parse_error,
+    );
+    AnalysisResult {
+        semantic: result.semantic.into_semantic(),
+        diagnostics: result.diagnostics,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn analyze_linter_file_at_path_with_resolver_and_shell<'a>(
+    file: &'a File,
+    source: &'a str,
+    indexer: &'a Indexer,
+    settings: &LinterSettings,
+    suppression_index: Option<&SuppressionIndex>,
+    source_path: Option<&Path>,
+    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
+    shell: ShellDialect,
+    first_parse_error: Option<(usize, usize)>,
+) -> LinterAnalysisResult<'a> {
     let mut file_entry_contract_collector =
         ambient_contracts::AmbientContractCollector::new(source, source_path, shell);
     let analyzed_paths_fallback =
@@ -513,8 +576,8 @@ fn analyze_file_at_path_with_resolver_and_shell(
 
     diagnostics
         .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
-    AnalysisResult {
-        semantic: linter_semantic_artifacts.into_semantic(),
+    LinterAnalysisResult {
+        semantic: linter_semantic_artifacts,
         diagnostics,
     }
 }
@@ -584,7 +647,7 @@ pub fn lint_file_at_path_with_resolver(
     let shell = resolve_shell(settings, source, source_path);
     let parse_result = parse_for_lint(source, shell);
 
-    let mut diagnostics = analyze_file_at_path_with_resolver_and_shell(
+    let analysis = analyze_linter_file_at_path_with_resolver_and_shell(
         file,
         source,
         indexer,
@@ -594,13 +657,14 @@ pub fn lint_file_at_path_with_resolver(
         source_path_resolver,
         shell,
         parse_error_position(&parse_result),
-    )
-    .diagnostics;
+    );
+    let mut diagnostics = analysis.diagnostics;
 
     diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
-        &parse_result.file,
+        file,
         source,
         Some(&parse_result),
+        &analysis.semantic,
         &settings.rules,
         shell,
     ));
@@ -705,6 +769,7 @@ pub(crate) fn lint_file_at_path_with_resolver_and_parse_result_and_directives(
         &parse_result.file,
         source,
         Some(parse_result),
+        &linter_semantic_artifacts,
         &settings.rules,
         shell,
     ));

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -1,4 +1,4 @@
-use shuck_ast::{Command, CompoundCommand, File, Position, Span, Stmt, StmtSeq};
+use shuck_ast::{File, Position, Span};
 use shuck_parser::parser::{ParseDiagnostic, ParseResult};
 
 use crate::rules::correctness::c_prototype_fragment::CPrototypeFragment;
@@ -14,7 +14,9 @@ use crate::rules::portability::targets_non_zsh_shell;
 use crate::rules::portability::zsh_always_block::ZshAlwaysBlock;
 use crate::rules::portability::zsh_brace_if::ZshBraceIf;
 use crate::rules::style::linebreak_before_and::LinebreakBeforeAnd;
-use crate::{Diagnostic, Edit, Fix, Rule, RuleSet, ShellDialect, Violation};
+use crate::{
+    Diagnostic, Edit, Fix, LinterSemanticArtifacts, Rule, RuleSet, ShellDialect, Violation,
+};
 
 pub struct ExtglobCase;
 pub struct ExtglobInCasePattern;
@@ -43,6 +45,7 @@ pub(crate) fn collect_parse_rule_diagnostics(
     file: &File,
     source: &str,
     parse_result: Option<&ParseResult>,
+    semantic: &LinterSemanticArtifacts<'_>,
     enabled_rules: &RuleSet,
     shell: ShellDialect,
 ) -> Vec<Diagnostic> {
@@ -52,7 +55,7 @@ pub(crate) fn collect_parse_rule_diagnostics(
         .unwrap_or(&[]);
     let missing_done_loop_kind = (enabled_rules.contains(crate::Rule::LoopWithoutEnd)
         || enabled_rules.contains(crate::Rule::MissingDoneInForLoop))
-    .then(|| missing_done_loop_kind(file, source, parse_diagnostics))
+    .then(|| missing_done_loop_kind(file, source, parse_diagnostics, semantic))
     .flatten();
 
     if enabled_rules.contains(crate::Rule::MissingFi)
@@ -653,6 +656,7 @@ fn missing_done_loop_kind(
     file: &File,
     source: &str,
     parse_diagnostics: &[ParseDiagnostic],
+    semantic: &LinterSemanticArtifacts<'_>,
 ) -> Option<MissingDoneLoopKind> {
     if !parse_diagnostics
         .iter()
@@ -661,110 +665,24 @@ fn missing_done_loop_kind(
         return None;
     }
 
-    Some(if missing_done_belongs_to_for_loop(file, source) {
-        MissingDoneLoopKind::For
-    } else {
-        MissingDoneLoopKind::NonFor
-    })
+    Some(
+        if missing_done_belongs_to_for_loop(file, source, semantic) {
+            MissingDoneLoopKind::For
+        } else {
+            MissingDoneLoopKind::NonFor
+        },
+    )
 }
 
-fn missing_done_belongs_to_for_loop(file: &File, source: &str) -> bool {
-    let eof_offset = file.span.end.offset;
-    let mut trailing_loop_kind = None;
-
-    walk_commands(&file.body, &mut |stmt| {
-        if stmt.span.end.offset != eof_offset {
-            return;
-        }
-
-        let is_for_loop = match &stmt.command {
-            Command::Compound(CompoundCommand::For(_)) => true,
-            Command::Compound(CompoundCommand::While(_) | CompoundCommand::Until(_)) => false,
-            _ => return,
-        };
-
-        let start_offset = stmt.span.start.offset;
-        if trailing_loop_kind
-            .as_ref()
-            .is_none_or(|(best_start, _)| start_offset >= *best_start)
-        {
-            trailing_loop_kind = Some((start_offset, is_for_loop));
-        }
-    });
-
-    trailing_loop_kind
-        .map(|(_, is_for_loop)| is_for_loop)
+fn missing_done_belongs_to_for_loop(
+    file: &File,
+    source: &str,
+    semantic: &LinterSemanticArtifacts<'_>,
+) -> bool {
+    semantic
+        .missing_done_trailing_loop_is_for(&file.body, file.span.end.offset)
         .or_else(|| missing_done_loop_kind_from_source(source))
         .unwrap_or(false)
-}
-
-fn walk_commands(commands: &StmtSeq, visit: &mut impl FnMut(&Stmt)) {
-    for stmt in commands.iter() {
-        walk_command(stmt, visit);
-    }
-}
-
-fn walk_command(stmt: &Stmt, visit: &mut impl FnMut(&Stmt)) {
-    visit(stmt);
-
-    match &stmt.command {
-        Command::Binary(command) => {
-            walk_command(&command.left, visit);
-            walk_command(&command.right, visit);
-        }
-        Command::Compound(command) => walk_compound_command(command, visit),
-        Command::Function(function) => walk_command(&function.body, visit),
-        Command::AnonymousFunction(function) => walk_command(&function.body, visit),
-        Command::Simple(_) | Command::Builtin(_) | Command::Decl(_) => {}
-    }
-}
-
-fn walk_compound_command(command: &CompoundCommand, visit: &mut impl FnMut(&Stmt)) {
-    match command {
-        CompoundCommand::If(command) => {
-            walk_commands(&command.condition, visit);
-            walk_commands(&command.then_branch, visit);
-            for (condition, body) in &command.elif_branches {
-                walk_commands(condition, visit);
-                walk_commands(body, visit);
-            }
-            if let Some(body) = &command.else_branch {
-                walk_commands(body, visit);
-            }
-        }
-        CompoundCommand::For(command) => walk_commands(&command.body, visit),
-        CompoundCommand::Repeat(command) => walk_commands(&command.body, visit),
-        CompoundCommand::Foreach(command) => walk_commands(&command.body, visit),
-        CompoundCommand::ArithmeticFor(command) => walk_commands(&command.body, visit),
-        CompoundCommand::While(command) => {
-            walk_commands(&command.condition, visit);
-            walk_commands(&command.body, visit);
-        }
-        CompoundCommand::Until(command) => {
-            walk_commands(&command.condition, visit);
-            walk_commands(&command.body, visit);
-        }
-        CompoundCommand::Case(command) => {
-            for case in &command.cases {
-                walk_commands(&case.body, visit);
-            }
-        }
-        CompoundCommand::Select(command) => walk_commands(&command.body, visit),
-        CompoundCommand::Subshell(commands) | CompoundCommand::BraceGroup(commands) => {
-            walk_commands(commands, visit);
-        }
-        CompoundCommand::Always(command) => {
-            walk_commands(&command.body, visit);
-            walk_commands(&command.always_body, visit);
-        }
-        CompoundCommand::Time(command) => {
-            if let Some(command) = &command.command {
-                walk_command(command, visit);
-            }
-        }
-        CompoundCommand::Coproc(command) => walk_command(&command.body, visit),
-        CompoundCommand::Arithmetic(_) | CompoundCommand::Conditional(_) => {}
-    }
 }
 
 fn missing_done_loop_kind_from_source(source: &str) -> Option<bool> {
@@ -956,13 +874,38 @@ fn line_start_offset(source: &str, target_line: usize) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
-    use shuck_parser::parser::Parser;
+    use shuck_ast::File;
+    use shuck_indexer::Indexer;
+    use shuck_parser::parser::{ParseResult, Parser};
 
     use super::{
-        collect_parse_rule_diagnostics, if_bracket_glued_span_on_line, is_expected_command_error,
-        line_contains_shell_word,
+        collect_parse_rule_diagnostics as collect_parse_rule_diagnostics_impl,
+        if_bracket_glued_span_on_line, is_expected_command_error, line_contains_shell_word,
     };
-    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
+    use crate::{
+        Applicability, Diagnostic, LinterSemanticArtifacts, LinterSettings, Rule, RuleSet,
+        ShellDialect,
+    };
+
+    fn collect_parse_rule_diagnostics(
+        file: &File,
+        source: &str,
+        parse_result: Option<&ParseResult>,
+        enabled_rules: &RuleSet,
+        shell: ShellDialect,
+    ) -> Vec<Diagnostic> {
+        let parse_result = parse_result.expect("parse diagnostics tests pass a parse result");
+        let indexer = Indexer::new(source, parse_result);
+        let semantic = LinterSemanticArtifacts::build(file, source, &indexer);
+        collect_parse_rule_diagnostics_impl(
+            file,
+            source,
+            Some(parse_result),
+            &semantic,
+            enabled_rules,
+            shell,
+        )
+    }
 
     #[test]
     fn maps_missing_fi_parse_error_to_c035_at_end_of_file() {

--- a/crates/shuck-linter/src/rules/mod.rs
+++ b/crates/shuck-linter/src/rules/mod.rs
@@ -93,10 +93,6 @@ mod architecture_tests {
             .unwrap_or_else(|error| panic!("failed to read {}: {error}", traversal_path.display()));
         let forbidden_visibility = [
             "pub(crate) struct CommandVisit",
-            "pub(crate) struct CommandWalkOptions",
-            "pub(crate) fn walk_commands",
-            "pub(crate) fn iter_commands",
-            "pub(crate) fn iter_commands_with_context",
             "pub(crate) fn visit_arithmetic_words",
             "pub(crate) fn visit_var_ref_subscript_words",
             "pub(crate) fn visit_subscript_words",


### PR DESCRIPTION
## Summary
- replace the parse-diagnostics missing-done AST walk with semantic command visits
- keep linter semantic artifacts available for parse diagnostics before converting to the public semantic model
- remove stale architecture-test sentinels for traversal helpers that no longer exist

## Validation
- cargo fmt --check
- cargo test -p shuck-linter parse_diagnostics
- cargo test -p shuck-linter rules::architecture_tests
- cargo test -p shuck-linter
- make test
