### PR TITLE
refactor(linter): reduce recursive AST walks

### DIFF
--- a/crates/shuck-linter/AGENTS.md
+++ b/crates/shuck-linter/AGENTS.md
@@ -171,6 +171,46 @@ When a rule needs information that no fact exposes:
 This keeps repeated structural discovery in one place, keeps rule files cheap,
 and makes the same structural data available to every other rule that needs it.
 
+### Command topology in facts
+
+Fact construction should treat semantic traversal as the owner of command
+topology. The parser AST is still the source of syntax, words, redirects, and
+command-specific payloads, but repeated command-shape questions should be
+answered through semantic command ids and linter semantic artifacts.
+
+The preferred pattern is:
+
+1. The semantic pass records command ids, direct commands in each
+   statement-sequence body, and syntax-backed parent/child relationships.
+2. `LinterSemanticArtifacts::command_topology()` exposes those relationships to
+   fact builders.
+3. Fact builders ask topology questions such as "which commands are in this
+   body?" or "should this visitor descend into this command's children?" instead
+   of adding fresh recursive command walks.
+
+This deliberately does not mean every fact should iterate one flat command
+list. Many linter facts care about local structure: sibling order, body
+boundaries, nested-word depth, list/pipeline segments, or whether a subtree
+should be skipped. The topology layer exists to preserve that structure while
+keeping semantic traversal as the single source of command relationships.
+
+Migration guidelines:
+
+- Use `CommandTopology::for_each_command_visit_in_body` when a fact needs
+  commands in a specific statement-sequence body.
+- Use `CommandTopologyTraversal::SkipChildren` when syntax says a command's
+  descendants should not affect the local fact, such as function bodies or
+  unrelated compound forms.
+- Keep word, arithmetic, conditional-expression, and redirect scans local when
+  they are inspecting syntax payloads rather than discovering command topology.
+- For repeated binary-chain shapes, use shared iterative helpers such as
+  `visit_binary_chain_parts` instead of open-coded recursive descent.
+- Add new relationship queries to the topology layer before adding another
+  command-recursive helper to a fact file.
+- Keep `CommandTopology` linter-private unless a query becomes generally useful
+  outside fact construction. In that case, promote the underlying relationship
+  into `shuck-semantic` and keep `LinterSemanticArtifacts` as a thin adapter.
+
 ## Semantic vs. facts: which to use
 
 - Use `checker.semantic()` for variable bindings, references, scopes,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -363,7 +363,10 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                                 command.elif_branches.iter().enumerate()
                             {
                                 if index > 0
-                                    || !stmt_seq_contains_nested_control_flow(&command.then_branch)
+                                    || !stmt_seq_contains_nested_control_flow(
+                                        &command.then_branch,
+                                        self.semantic_artifacts.command_topology(),
+                                    )
                                 {
                                     collect_condition_status_capture_from_body(
                                         previous_condition,
@@ -1109,16 +1112,12 @@ fn c006_subscript_reference_suppresses_later_references(
     .is_none_or(|name| !matches!(name, "unset" | "[" | "[[" | "test"))
 }
 
-fn stmt_seq_contains_nested_control_flow(body: &StmtSeq) -> bool {
-    body.iter().any(stmt_contains_nested_control_flow)
-}
-
-fn stmt_contains_nested_control_flow(stmt: &Stmt) -> bool {
-    match &stmt.command {
-        Command::Binary(command) => {
-            stmt_contains_nested_control_flow(&command.left)
-                || stmt_contains_nested_control_flow(&command.right)
-        }
+fn stmt_seq_contains_nested_control_flow(
+    body: &StmtSeq,
+    command_topology: CommandTopology<'_, '_>,
+) -> bool {
+    let mut contains = false;
+    command_topology.for_each_command_visit_in_body(body, false, |_, visit| match visit.command {
         Command::Compound(
             CompoundCommand::If(_)
             | CompoundCommand::While(_)
@@ -1127,21 +1126,24 @@ fn stmt_contains_nested_control_flow(stmt: &Stmt) -> bool {
             | CompoundCommand::Select(_)
             | CompoundCommand::Case(_)
             | CompoundCommand::Always(_),
-        ) => true,
-        Command::Compound(CompoundCommand::BraceGroup(body) | CompoundCommand::Subshell(body)) => {
-            body.iter().any(stmt_contains_nested_control_flow)
+        ) => {
+            contains = true;
+            CommandTopologyTraversal::Break
         }
-        Command::Compound(CompoundCommand::Time(command)) => command
-            .command
-            .as_ref()
-            .is_some_and(|stmt| stmt_contains_nested_control_flow(stmt)),
+        Command::Binary(_)
+        | Command::Compound(
+            CompoundCommand::BraceGroup(_)
+            | CompoundCommand::Subshell(_)
+            | CompoundCommand::Time(_),
+        ) => CommandTopologyTraversal::Descend,
         Command::Simple(_)
         | Command::Builtin(_)
         | Command::Decl(_)
         | Command::Compound(_)
         | Command::Function(_)
-        | Command::AnonymousFunction(_) => false,
-    }
+        | Command::AnonymousFunction(_) => CommandTopologyTraversal::SkipChildren,
+    });
+    contains
 }
 
 fn populate_linebreak_in_test_facts(commands: &mut [CommandFact<'_>], source: &str) {

--- a/crates/shuck-linter/src/facts/lists.rs
+++ b/crates/shuck-linter/src/facts/lists.rs
@@ -218,45 +218,31 @@ fn collect_list_segment_facts<'a>(
     source: &str,
     segments: &mut Vec<ListSegmentFact<'a>>,
 ) -> Option<()> {
-    collect_list_stmt_segment_facts(
-        &command.left,
-        command_relationships,
-        parent_id,
-        source,
-        segments,
-    )?;
-    collect_list_stmt_segment_facts(
-        &command.right,
-        command_relationships,
-        parent_id,
-        source,
-        segments,
-    )?;
+    let mut stack = vec![(&command.right, parent_id), (&command.left, parent_id)];
+    while let Some((stmt, parent_id)) = stack.pop() {
+        if let Command::Binary(binary) = &stmt.command
+            && matches!(binary.op, BinaryOp::And | BinaryOp::Or)
+        {
+            let nested_parent_id = command_relationships
+                .child_or_lookup_fact(parent_id, stmt)?
+                .id();
+            stack.push((&binary.right, nested_parent_id));
+            stack.push((&binary.left, nested_parent_id));
+            continue;
+        }
+
+        push_list_stmt_segment_fact(stmt, command_relationships, parent_id, source, segments)?;
+    }
     Some(())
 }
 
-fn collect_list_stmt_segment_facts<'a>(
+fn push_list_stmt_segment_fact<'a>(
     stmt: &Stmt,
     command_relationships: CommandRelationshipContext<'_, 'a>,
     parent_id: CommandId,
     source: &str,
     segments: &mut Vec<ListSegmentFact<'a>>,
 ) -> Option<()> {
-    if let Command::Binary(binary) = &stmt.command
-        && matches!(binary.op, BinaryOp::And | BinaryOp::Or)
-    {
-        let nested_parent_id = command_relationships
-            .child_or_lookup_fact(parent_id, stmt)?
-            .id();
-        return collect_list_segment_facts(
-            binary,
-            command_relationships,
-            nested_parent_id,
-            source,
-            segments,
-        );
-    }
-
     let fact = command_relationships.child_or_lookup_fact(parent_id, stmt)?;
     let id = fact.id();
     let assignment_info = list_segment_assignment_info(fact);

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -41,7 +41,10 @@ use self::{
         rewrite_word_as_single_double_quoted_string,
     },
 };
-use crate::{AmbientShellOptions, LinterSemanticArtifacts, ShellDialect};
+use crate::{
+    AmbientShellOptions, CommandTopology, CommandTopologyTraversal, LinterSemanticArtifacts,
+    ShellDialect,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
     ArithmeticExpansionSyntax, ArithmeticExpr, ArithmeticExprNode, ArithmeticLvalue,

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -1187,24 +1187,19 @@ fn trim_trailing_whitespace_offset(source: &str, end_offset: usize) -> usize {
 }
 
 fn collect_short_circuit_operators(command: &BinaryCommand, operators: &mut Vec<ListOperatorFact>) {
-    if let Command::Binary(left) = &command.left.command
-        && matches!(left.op, BinaryOp::And | BinaryOp::Or)
-    {
-        collect_short_circuit_operators(left, operators);
-    }
-
-    if matches!(command.op, BinaryOp::And | BinaryOp::Or) {
-        operators.push(ListOperatorFact {
-            op: command.op,
-            span: command.op_span,
-        });
-    }
-
-    if let Command::Binary(right) = &command.right.command
-        && matches!(right.op, BinaryOp::And | BinaryOp::Or)
-    {
-        collect_short_circuit_operators(right, operators);
-    }
+    visit_binary_chain_parts(
+        command,
+        |op| matches!(op, BinaryOp::And | BinaryOp::Or),
+        |_| {},
+        |command| {
+            if matches!(command.op, BinaryOp::And | BinaryOp::Or) {
+                operators.push(ListOperatorFact {
+                    op: command.op,
+                    span: command.op_span,
+                });
+            }
+        },
+    );
 }
 
 fn mixed_short_circuit_operator_span(operators: &[ListOperatorFact]) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -1168,21 +1168,12 @@ fn collect_pipeline_parts<'a>(
     segments: &mut Vec<&'a Stmt>,
     operators: &mut Vec<Span>,
 ) {
-    match &command.left.command {
-        Command::Binary(left) if matches!(left.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            collect_pipeline_parts(left, segments, operators);
-        }
-        _ => segments.push(&command.left),
-    }
-
-    operators.push(command.op_span);
-
-    match &command.right.command {
-        Command::Binary(right) if matches!(right.op, BinaryOp::Pipe | BinaryOp::PipeAll) => {
-            collect_pipeline_parts(right, segments, operators);
-        }
-        _ => segments.push(&command.right),
-    }
+    visit_binary_chain_parts(
+        command,
+        |op| matches!(op, BinaryOp::Pipe | BinaryOp::PipeAll),
+        |stmt| segments.push(stmt),
+        |command| operators.push(command.op_span),
+    );
 }
 
 fn stmt_is_raw_ls<'a>(

--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -18,6 +18,47 @@ impl<'a> CommandVisit<'a> {
     }
 }
 
+enum BinaryChainStackItem<'a> {
+    Command(&'a BinaryCommand),
+    Operator(&'a BinaryCommand),
+    Segment(&'a Stmt),
+}
+
+/// Visits the leaf segments and operators of a left/right-associative binary command chain.
+///
+/// List and pipeline facts both need the same topology question: flatten adjacent binary commands
+/// with compatible operators while preserving source order. Keeping the mechanics here prevents
+/// each fact family from maintaining its own recursive AST descent.
+fn visit_binary_chain_parts<'a>(
+    command: &'a BinaryCommand,
+    mut is_chain_operator: impl FnMut(BinaryOp) -> bool,
+    mut visit_segment: impl FnMut(&'a Stmt),
+    mut visit_operator: impl FnMut(&'a BinaryCommand),
+) {
+    let mut stack = vec![BinaryChainStackItem::Command(command)];
+    while let Some(item) = stack.pop() {
+        match item {
+            BinaryChainStackItem::Command(command) => {
+                match &command.right.command {
+                    Command::Binary(right) if is_chain_operator(right.op) => {
+                        stack.push(BinaryChainStackItem::Command(right));
+                    }
+                    _ => stack.push(BinaryChainStackItem::Segment(&command.right)),
+                }
+                stack.push(BinaryChainStackItem::Operator(command));
+                match &command.left.command {
+                    Command::Binary(left) if is_chain_operator(left.op) => {
+                        stack.push(BinaryChainStackItem::Command(left));
+                    }
+                    _ => stack.push(BinaryChainStackItem::Segment(&command.left)),
+                }
+            }
+            BinaryChainStackItem::Operator(command) => visit_operator(command),
+            BinaryChainStackItem::Segment(stmt) => visit_segment(stmt),
+        }
+    }
+}
+
 fn visit_command_substitution_candidate_words<'a>(
     body: &'a StmtSeq,
     semantic: &LinterSemanticArtifacts<'a>,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -198,6 +198,16 @@ impl<'a> LinterSemanticArtifacts<'a> {
         &self.command_visits_by_id
     }
 
+    /// Returns command-shape queries backed by the semantic traversal.
+    ///
+    /// Fact builders should ask this layer for command bodies, descendants, and
+    /// shape-controlled iteration instead of adding new recursive command walks over the parser
+    /// AST. Local word/expression scans still live near their rules, but command topology should
+    /// flow through semantic ids.
+    pub(crate) fn command_topology(&self) -> CommandTopology<'a, '_> {
+        CommandTopology { artifacts: self }
+    }
+
     pub(crate) fn conditional_expression_visits(
         &self,
         command_span: Span,
@@ -263,33 +273,97 @@ impl<'a> LinterSemanticArtifacts<'a> {
         descend_nested_word_commands: bool,
         mut visitor: impl FnMut(facts::CommandVisit<'a>),
     ) {
+        self.command_topology().for_each_command_visit_in_body(
+            body,
+            descend_nested_word_commands,
+            |_, visit| {
+                visitor(visit);
+                CommandTopologyTraversal::Descend
+            },
+        );
+    }
+}
+
+/// Traversal control returned by semantic command-topology visitors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CommandTopologyTraversal {
+    /// Visit children after the current command.
+    Descend,
+    /// Keep the current command but skip its descendants.
+    SkipChildren,
+    /// Stop the traversal immediately.
+    Break,
+}
+
+/// Semantic-backed command-shape queries for linter fact construction.
+///
+/// The semantic pass already records syntax-backed command ids, direct commands for each
+/// statement-sequence body, and parent/child relationships. This wrapper keeps those indexes as
+/// the single source of truth for command topology so facts can migrate away from ad-hoc recursive
+/// AST walks without flattening away local structure like body boundaries, child order, or nested
+/// command-substitution depth.
+#[derive(Clone, Copy)]
+pub(crate) struct CommandTopology<'a, 'artifacts> {
+    artifacts: &'artifacts LinterSemanticArtifacts<'a>,
+}
+
+impl<'a, 'artifacts> CommandTopology<'a, 'artifacts> {
+    /// Returns direct semantic command ids recorded for a statement-sequence body.
+    pub(crate) fn direct_command_ids_in_body(&self, body: &StmtSeq) -> &'artifacts [CommandId] {
         let body_span = facts::FactSpan::new(body.span);
-        let Some(root_ids) = self.direct_command_ids_by_body_span.get(&body_span) else {
+        self.artifacts
+            .direct_command_ids_by_body_span
+            .get(&body_span)
+            .map_or(&[], Vec::as_slice)
+    }
+
+    /// Returns the parser-backed command visit for `id`, if that semantic command has one.
+    pub(crate) fn command_visit(&self, id: CommandId) -> Option<facts::CommandVisit<'a>> {
+        self.artifacts
+            .command_visits_by_id
+            .get(id.index())
+            .and_then(|visit| *visit)
+    }
+
+    /// Iterates command visits inside `body` in semantic source order.
+    ///
+    /// `descend_nested_word_commands` controls whether command substitutions nested inside words
+    /// below this body should be included. The visitor receives the semantic id and parser-backed
+    /// visit, then chooses whether this particular command's children should be traversed.
+    pub(crate) fn for_each_command_visit_in_body(
+        &self,
+        body: &StmtSeq,
+        descend_nested_word_commands: bool,
+        mut visitor: impl FnMut(CommandId, facts::CommandVisit<'a>) -> CommandTopologyTraversal,
+    ) {
+        let root_ids = self.direct_command_ids_in_body(body);
+        if root_ids.is_empty() {
             return;
-        };
+        }
         let baseline_depth = root_ids
             .iter()
-            .filter_map(|id| self.semantic.command_context(*id))
+            .filter_map(|id| self.artifacts.semantic.command_context(*id))
             .map(|context| context.nested_word_command_depth())
             .min()
             .unwrap_or(0);
         let mut stack = root_ids.iter().rev().copied().collect::<Vec<_>>();
         while let Some(id) = stack.pop() {
-            let Some(context) = self.semantic.command_context(id) else {
+            let Some(context) = self.artifacts.semantic.command_context(id) else {
                 continue;
             };
             if !descend_nested_word_commands && context.nested_word_command_depth() > baseline_depth
             {
                 continue;
             }
-            if let Some(visit) = self
-                .command_visits_by_id
-                .get(id.index())
-                .and_then(|visit| *visit)
-            {
-                visitor(visit);
+            if let Some(visit) = self.command_visit(id) {
+                match visitor(id, visit) {
+                    CommandTopologyTraversal::Descend => {}
+                    CommandTopologyTraversal::SkipChildren => continue,
+                    CommandTopologyTraversal::Break => break,
+                }
             }
             for child in self
+                .artifacts
                 .semantic
                 .syntax_backed_command_children(id)
                 .iter()


### PR DESCRIPTION
## Summary

- cherry-pick the semantic traversal reuse commits for conditional and base-prefix facts
- add a linter-private `CommandTopology` query layer over semantic command artifacts
- migrate nested control-flow, list, and pipeline command-shape probes away from recursive AST helper descent
- document the command topology migration boundary in `crates/shuck-linter/AGENTS.md`

## Validation

- `cargo fmt --check`
- `cargo check -p shuck-linter`
- `cargo test -p shuck-linter`
- `make test`
