### PR TITLE
refactor(linter): consolidate offset-to-position lookups behind Locator

### DIFF
--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -7,8 +7,8 @@ use shuck_indexer::Indexer;
 use shuck_semantic::SemanticAnalysis;
 
 use crate::{
-    AmbientShellOptions, Diagnostic, LinterFacts, LinterRuleOptions, LinterSemanticArtifacts, Rule,
-    RuleSet, ShellDialect, SuppressionIndex, Violation, rules,
+    AmbientShellOptions, Diagnostic, LinterFacts, LinterRuleOptions, LinterSemanticArtifacts,
+    Locator, Rule, RuleSet, ShellDialect, SuppressionIndex, Violation, rules,
 };
 
 pub struct Checker<'a> {
@@ -94,6 +94,10 @@ impl<'a> Checker<'a> {
 
     pub fn source(&self) -> &'a str {
         self.source
+    }
+
+    pub(crate) fn locator(&self) -> Locator<'a> {
+        Locator::new(self.source, self.indexer.line_index())
     }
 
     pub fn facts(&self) -> &LinterFacts<'a> {

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -4,9 +4,10 @@ fn build_literal_brace_spans(
     occurrences: &[WordOccurrence],
     commands: CommandFacts<'_, '_>,
     fact_store: &FactStore<'_>,
-    source: &str,
+    locator: Locator<'_>,
     heredoc_ranges: &[TextRange],
 ) -> Vec<Span> {
+    let source = locator.source();
     let mut spans = Vec::new();
     let mut scratch = LiteralBraceScratch::default();
     scratch.processed_word_nodes.resize(nodes.len(), false);
@@ -41,14 +42,14 @@ fn build_literal_brace_spans(
 
     collect_uncovered_command_brace_spans(
         commands,
-        source,
+        locator,
         heredoc_ranges,
         &mut spans,
         &mut scratch,
     );
     collect_unmatched_command_substitution_brace_spans(
         commands,
-        source,
+        locator,
         heredoc_ranges,
         &mut spans,
         &mut scratch,
@@ -712,11 +713,12 @@ fn collect_unclassified_literal_brace_spans(
 
 fn collect_uncovered_command_brace_spans(
     commands: CommandFacts<'_, '_>,
-    source: &str,
+    locator: Locator<'_>,
     heredoc_ranges: &[TextRange],
     out: &mut Vec<Span>,
     scratch: &mut LiteralBraceScratch,
 ) {
+    let source = locator.source();
     for command in commands {
         let Command::Simple(simple) = command.command() else {
             continue;
@@ -777,8 +779,7 @@ fn collect_uncovered_command_brace_spans(
             if span.start.offset > cursor {
                 collect_raw_literal_brace_spans(
                     RawLiteralBraceScan {
-                        container_span: command_span,
-                        source,
+                        locator,
                         mode: RawLiteralBraceScanMode::All,
                         excluded_ranges: heredoc_ranges,
                     },
@@ -795,8 +796,7 @@ fn collect_uncovered_command_brace_spans(
         if command_span.end.offset > cursor {
             collect_raw_literal_brace_spans(
                 RawLiteralBraceScan {
-                    container_span: command_span,
-                    source,
+                    locator,
                     mode: RawLiteralBraceScanMode::All,
                     excluded_ranges: heredoc_ranges,
                 },
@@ -849,8 +849,7 @@ enum RawLiteralBraceQuoteState {
 
 #[derive(Debug, Clone, Copy)]
 struct RawLiteralBraceScan<'a> {
-    container_span: Span,
-    source: &'a str,
+    locator: Locator<'a>,
     mode: RawLiteralBraceScanMode,
     excluded_ranges: &'a [TextRange],
 }
@@ -881,11 +880,9 @@ fn collect_raw_literal_brace_spans(
     for (start, end) in relevant_excluded.iter().copied() {
         if start > cursor {
             collect_raw_literal_brace_spans_without_exclusions(
-                scan.container_span,
+                scan,
                 cursor,
                 start,
-                scan.source,
-                scan.mode,
                 unmatched_opens,
                 out,
             );
@@ -895,11 +892,9 @@ fn collect_raw_literal_brace_spans(
 
     if scan_end > cursor {
         collect_raw_literal_brace_spans_without_exclusions(
-            scan.container_span,
+            scan,
             cursor,
             scan_end,
-            scan.source,
-            scan.mode,
             unmatched_opens,
             out,
         );
@@ -911,14 +906,15 @@ fn collect_raw_literal_brace_spans(
 }
 
 fn collect_raw_literal_brace_spans_without_exclusions(
-    _container_span: Span,
+    scan: RawLiteralBraceScan<'_>,
     scan_start: usize,
     scan_end: usize,
-    source: &str,
-    mode: RawLiteralBraceScanMode,
     unmatched_opens: &mut Vec<Span>,
     out: &mut Vec<Span>,
 ) {
+    let locator = scan.locator;
+    let source = locator.source();
+    let mode = scan.mode;
     let Some(text) = source.get(scan_start..scan_end) else {
         return;
     };
@@ -1011,7 +1007,7 @@ fn collect_raw_literal_brace_spans_without_exclusions(
                 continue;
             }
 
-            let Some(position) = position_at_offset(source, scan_start + index) else {
+            let Some(position) = locator.position_at_offset(scan_start + index) else {
                 index += ch_len;
                 continue;
             };
@@ -1121,16 +1117,17 @@ fn closing_brace_ends_shell_group(text: &str, index: usize) -> bool {
 
 fn collect_unmatched_command_substitution_brace_spans(
     commands: CommandFacts<'_, '_>,
-    source: &str,
+    locator: Locator<'_>,
     heredoc_ranges: &[TextRange],
     out: &mut Vec<Span>,
     scratch: &mut LiteralBraceScratch,
 ) {
+    let source = locator.source();
     for substitution in commands
         .iter()
         .flat_map(|command| command.substitution_facts())
     {
-        let Some((container_span, body_start, body_end)) =
+        let Some((_container_span, body_start, body_end)) =
             command_substitution_body_offsets(substitution.span(), source)
         else {
             continue;
@@ -1139,8 +1136,7 @@ fn collect_unmatched_command_substitution_brace_spans(
         if body_end > body_start {
             collect_raw_literal_brace_spans(
                 RawLiteralBraceScan {
-                    container_span,
-                    source,
+                    locator,
                     mode: RawLiteralBraceScanMode::UnmatchedOnly,
                     excluded_ranges: heredoc_ranges,
                 },

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -69,6 +69,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
 
     fn build(self) -> LinterFacts<'a> {
         let source = self.source;
+        let line_index = self._indexer.line_index();
+        let locator = crate::Locator::new(source, line_index);
         let semantic_analysis = self.semantic_analysis;
         let capacity = estimate_fact_build_capacity(self.semantic);
         let estimated_word_nodes = capacity.commands.saturating_mul(2);
@@ -203,6 +205,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 build_word_facts_for_command(
                     visit,
                     self.source,
+                    locator,
                     self.semantic,
                     WordFactCommandContext {
                         command_id: id,
@@ -273,7 +276,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 let redirect_facts = build_redirect_facts(
                     visit.redirects,
                     Some(self.semantic_artifacts),
-                    self.source,
+                    locator,
                     command_zsh_options.as_ref(),
                 );
                 let redirect_fact_range = redirect_fact_store.push_many(redirect_facts);
@@ -471,7 +474,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &command_ids_by_span,
             &command_child_index,
             self.semantic_artifacts,
-            self.source,
+            locator,
         );
 
         let presence_tested_names = build_presence_tested_names(
@@ -528,13 +531,13 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &commands,
             &command_fact_indices_by_id,
             &command_ids_by_span,
-            self.source,
+            locator,
         );
         let select_headers = build_select_header_facts(
             &commands,
             &command_fact_indices_by_id,
             &command_ids_by_span,
-            self.source,
+            locator,
         );
         let case_items = build_case_item_facts(&commands, self.source);
         let case_pattern_shadows = build_case_pattern_shadow_facts(&commands, self.source);
@@ -574,23 +577,21 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         annotate_conditional_assignment_value_paths(self.semantic, &lists, &mut binding_values);
         let statement_facts = build_statement_facts(&commands, self.semantic);
         let background_semicolon_spans =
-            build_background_semicolon_spans(&commands, &case_items, self.source);
-        let single_test_subshell_spans =
-            build_single_test_subshell_spans(
-                &commands,
-                &command_fact_indices_by_id,
-                &command_ids_by_span,
-                &command_child_index,
-                self.source,
-            );
-        let subshell_test_group_spans =
-            build_subshell_test_group_spans(
-                &commands,
-                &command_fact_indices_by_id,
-                &command_ids_by_span,
-                &command_child_index,
-                self.source,
-            );
+            build_background_semicolon_spans(&commands, &case_items, locator);
+        let single_test_subshell_spans = build_single_test_subshell_spans(
+            &commands,
+            &command_fact_indices_by_id,
+            &command_ids_by_span,
+            &command_child_index,
+            locator,
+        );
+        let subshell_test_group_spans = build_subshell_test_group_spans(
+            &commands,
+            &command_fact_indices_by_id,
+            &command_ids_by_span,
+            &command_child_index,
+            locator,
+        );
         let shebang_header_facts = build_shebang_header_facts(self.source);
         let errexit_enabled_anywhere = self.ambient_shell_options.errexit
             || shebang_header_facts.enables_errexit
@@ -623,14 +624,18 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             matches!(self.shell, ShellDialect::Bash) && pipefail_enabled_anywhere,
         );
         let heredoc_summary =
-            build_heredoc_fact_summary(&commands, self.source, self.file.span.end.offset);
+            build_heredoc_fact_summary(
+                &commands,
+                locator,
+                self.file.span.end.offset,
+            );
         let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
         let literal_brace_spans = build_literal_brace_spans(
             &word_nodes,
             &word_occurrences,
             CommandFacts::new(&commands, &fact_store, &command_fact_indices_by_id),
             &fact_store,
-            source,
+            locator,
             self._indexer.region_index().heredoc_ranges(),
         );
         let SurfaceFragmentFacts {
@@ -756,6 +761,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 word_index: &word_index,
                 fact_store: &fact_store,
                 source,
+                line_index: self._indexer.line_index(),
             },
         );
         let assignment_like_command_name_spans =
@@ -807,7 +813,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 &subscript_later_suppression_spans,
             );
 
-        let mut backtick_substitution_spans = word_spans::backtick_substitution_spans(source);
+        let mut backtick_substitution_spans = word_spans::backtick_substitution_spans(locator);
         backtick_substitution_spans.retain(|span| {
             !self
                 ._indexer
@@ -815,10 +821,10 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 .is_quoted_heredoc(TextSize::new(span.start.offset as u32))
         });
         let backtick_escaped_parameters =
-            word_spans::backtick_escaped_parameters(source, &backtick_substitution_spans);
+            word_spans::backtick_escaped_parameters(locator, &backtick_substitution_spans);
         let mut backtick_escaped_parameter_reference_spans =
             word_spans::backtick_escaped_parameter_reference_spans(
-                source,
+                locator,
                 &backtick_substitution_spans,
             );
         backtick_escaped_parameter_reference_spans.extend(
@@ -831,13 +837,14 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         backtick_escaped_parameter_reference_spans.dedup();
         let backtick_double_escaped_parameter_spans =
             word_spans::backtick_double_escaped_parameter_spans(
-                source,
+                locator,
                 &backtick_substitution_spans,
             );
         LinterFacts {
             semantic: self.semantic,
             semantic_artifacts: self.semantic_artifacts,
             source,
+            line_index: self._indexer.line_index(),
             commands,
             command_fact_indices_by_id,
             structural_command_ids,

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -619,22 +619,10 @@ fn extend_over_shellcheck_trailing_inline_space(end: Position, source: &str) -> 
     }
 }
 
-fn position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
-    if target_offset > source.len() {
-        return None;
-    }
-
-    let mut position = Position::new();
-    for ch in source[..target_offset].chars() {
-        position.advance(ch);
-    }
-    Some(position)
-}
-
 fn build_background_semicolon_spans(
     commands: &[CommandFact<'_>],
     case_items: &[CaseItemFact<'_>],
-    source: &str,
+    locator: Locator<'_>,
 ) -> Vec<Span> {
     let case_terminator_starts = case_items
         .iter()
@@ -643,7 +631,7 @@ fn build_background_semicolon_spans(
         .collect::<FxHashSet<_>>();
     let mut spans = commands
         .iter()
-        .filter_map(|command| background_semicolon_span(command, &case_terminator_starts, source))
+        .filter_map(|command| background_semicolon_span(command, &case_terminator_starts, locator))
         .collect::<Vec<_>>();
     sort_and_dedup_spans(&mut spans);
     spans
@@ -652,12 +640,13 @@ fn build_background_semicolon_spans(
 fn background_semicolon_span(
     command: &CommandFact<'_>,
     case_terminator_starts: &FxHashSet<usize>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
     if command.stmt().terminator != Some(StmtTerminator::Background(BackgroundOperator::Plain)) {
         return None;
     }
 
+    let source = locator.source();
     let terminator_span = command.stmt().terminator_span?;
     if terminator_span.slice(source) != "&" {
         return None;
@@ -676,8 +665,8 @@ fn background_semicolon_span(
         return None;
     }
 
-    let start = position_at_offset(source, semicolon_offset)?;
-    let end = position_at_offset(source, semicolon_offset + 1)?;
+    let start = locator.position_at_offset(semicolon_offset)?;
+    let end = locator.position_at_offset(semicolon_offset + 1)?;
     Some(Span::from_positions(start, end))
 }
 

--- a/crates/shuck-linter/src/facts/heredocs.rs
+++ b/crates/shuck-linter/src/facts/heredocs.rs
@@ -1,9 +1,10 @@
 #[cfg_attr(shuck_profiling, inline(never))]
 fn build_heredoc_fact_summary(
     commands: &[CommandFact<'_>],
-    source: &str,
+    locator: Locator<'_>,
     file_end: usize,
 ) -> HeredocFactSummary {
+    let source = locator.source();
     let mut summary = HeredocFactSummary::default();
 
     for command in commands {
@@ -47,7 +48,7 @@ fn build_heredoc_fact_summary(
                 heredoc.body.span,
                 delimiter,
                 heredoc.delimiter.strip_tabs,
-                source,
+                locator,
             ) {
                 summary.heredoc_end_space_spans.push(span);
             }
@@ -58,7 +59,7 @@ fn build_heredoc_fact_summary(
                     .extend(spaced_tabstrip_close_spans(
                         heredoc.body.span,
                         delimiter,
-                        source,
+                        locator,
                     ));
             }
 
@@ -70,7 +71,7 @@ fn build_heredoc_fact_summary(
                 heredoc.body.span,
                 delimiter,
                 heredoc.delimiter.strip_tabs,
-                source,
+                locator,
             ) {
                 summary.heredoc_closer_not_alone_spans.push(span);
             }
@@ -97,8 +98,9 @@ fn heredoc_closer_not_alone_span(
     body_span: Span,
     delimiter: &str,
     strip_tabs: bool,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
+    let source = locator.source();
     let mut line_start_offset = body_span.start.offset;
     for raw_line in body_span.slice(source).split_inclusive('\n') {
         let (candidate_line, tab_prefix_len) = normalized_heredoc_line(raw_line, strip_tabs);
@@ -117,8 +119,8 @@ fn heredoc_closer_not_alone_span(
 
         let delimiter_start_offset = line_start_offset + tab_prefix_len + prefix.len();
         let delimiter_end_offset = delimiter_start_offset + delimiter.len();
-        let start = position_at_offset_opt(source, delimiter_start_offset)?;
-        let end = position_at_offset_opt(source, delimiter_end_offset)?;
+        let start = locator.position_at_offset(delimiter_start_offset)?;
+        let end = locator.position_at_offset(delimiter_end_offset)?;
         return Some(Span::from_positions(start, end));
     }
 
@@ -143,8 +145,9 @@ fn heredoc_end_space_span(
     body_span: Span,
     delimiter: &str,
     strip_tabs: bool,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
+    let source = locator.source();
     let line_start_offset = body_span.end.offset;
     let remainder = source.get(line_start_offset..)?;
     let raw_line = remainder.split_inclusive('\n').next().unwrap_or(remainder);
@@ -155,17 +158,22 @@ fn heredoc_end_space_span(
     }
 
     let trailing_start_offset = line_start_offset + tab_prefix_len + delimiter.len();
-    let start = position_at_offset_opt(source, trailing_start_offset)?;
+    let start = locator.position_at_offset(trailing_start_offset)?;
     Some(Span::from_positions(start, start))
 }
 
-fn spaced_tabstrip_close_spans(body_span: Span, delimiter: &str, source: &str) -> Vec<Span> {
+fn spaced_tabstrip_close_spans(
+    body_span: Span,
+    delimiter: &str,
+    locator: Locator<'_>,
+) -> Vec<Span> {
+    let source = locator.source();
     let mut spans = Vec::new();
     let mut line_start_offset = body_span.start.offset;
     for raw_line in body_span.slice(source).split_inclusive('\n') {
         let line_without_newline = raw_line.trim_end_matches('\n').trim_end_matches('\r');
         if is_spaced_tabstrip_close_line(line_without_newline, delimiter)
-            && let Some(position) = position_at_offset_opt(source, line_start_offset)
+            && let Some(position) = locator.position_at_offset(line_start_offset)
         {
             spans.push(Span::from_positions(position, position));
         }
@@ -212,14 +220,3 @@ fn is_spaced_tabstrip_close_line(line: &str, delimiter: &str) -> bool {
     leading.contains(' ') && rest == delimiter
 }
 
-fn position_at_offset_opt(source: &str, target_offset: usize) -> Option<Position> {
-    if target_offset > source.len() {
-        return None;
-    }
-
-    let mut position = Position::new();
-    for ch in source[..target_offset].chars() {
-        position.advance(ch);
-    }
-    Some(position)
-}

--- a/crates/shuck-linter/src/facts/loop_headers.rs
+++ b/crates/shuck-linter/src/facts/loop_headers.rs
@@ -135,7 +135,7 @@ pub(super) fn build_for_header_facts<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Vec<ForHeaderFact<'a>> {
     commands
         .iter()
@@ -153,7 +153,7 @@ pub(super) fn build_for_header_facts<'a>(
                     commands,
                     command_fact_indices_by_id,
                     command_ids_by_span,
-                    source,
+                    locator,
                 ),
             })
         })
@@ -164,7 +164,7 @@ pub(super) fn build_select_header_facts<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Vec<SelectHeaderFact<'a>> {
     commands
         .iter()
@@ -182,7 +182,7 @@ pub(super) fn build_select_header_facts<'a>(
                     commands,
                     command_fact_indices_by_id,
                     command_ids_by_span,
-                    source,
+                    locator,
                 ),
             })
         })
@@ -195,8 +195,9 @@ fn build_loop_header_word_facts<'a>(
     commands: &[CommandFact<'a>],
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Box<[LoopHeaderWordFact<'a>]> {
+    let source = locator.source();
     words
         .into_iter()
         .map(|word| {
@@ -206,7 +207,7 @@ fn build_loop_header_word_facts<'a>(
                 classification,
                 has_all_elements_array_expansion:
                     word_spans::word_has_all_elements_array_expansion_syntax(word)
-                        || !word_spans::all_elements_array_expansion_part_spans(word, source)
+                        || !word_spans::all_elements_array_expansion_part_spans(word, locator)
                             .is_empty(),
                 has_unquoted_command_substitution: classification.has_command_substitution()
                     && !word_spans::unquoted_command_substitution_part_spans(word).is_empty(),

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -43,7 +43,7 @@ use self::{
 };
 use crate::{
     AmbientShellOptions, CommandTopology, CommandTopologyTraversal, LinterSemanticArtifacts,
-    ShellDialect,
+    Locator, ShellDialect,
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{
@@ -61,7 +61,7 @@ use shuck_ast::{
     static_command_name_text, static_command_wrapper_target_index, static_word_text,
     word_is_standalone_status_capture,
 };
-use shuck_indexer::Indexer;
+use shuck_indexer::{Indexer, LineIndex};
 #[cfg(test)]
 use shuck_parser::parser::Parser;
 use shuck_semantic::{

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -2,6 +2,7 @@ pub struct LinterFacts<'a> {
     semantic: &'a SemanticModel,
     semantic_artifacts: &'a LinterSemanticArtifacts<'a>,
     source: &'a str,
+    line_index: &'a LineIndex,
     commands: Vec<CommandFact<'a>>,
     command_fact_indices_by_id: Vec<Option<usize>>,
     structural_command_ids: Vec<CommandId>,
@@ -1068,7 +1069,7 @@ fn build_possible_variable_misspelling_scope_compat_name_uses(
             }
         }
     }
-    uses.extend(build_flag_for_loop_source_name_uses(facts.source).into_iter().filter(|name_use| {
+    uses.extend(build_flag_for_loop_source_name_uses(Locator::new(facts.source, facts.line_index)).into_iter().filter(|name_use| {
         is_interesting_scope_compat_name_use(
             facts.source,
             name_use.key().as_str(),
@@ -1407,7 +1408,8 @@ fn shell_has_brace_expansion(shell: ShellDialect) -> bool {
     )
 }
 
-fn build_flag_for_loop_source_name_uses(source: &str) -> Vec<ComparableNameUse> {
+fn build_flag_for_loop_source_name_uses(locator: Locator<'_>) -> Vec<ComparableNameUse> {
+    let source = locator.source();
     let mut uses = Vec::new();
     let mut line_start = 0;
     for line in source.split_inclusive('\n') {
@@ -1438,8 +1440,8 @@ fn build_flag_for_loop_source_name_uses(source: &str) -> Vec<ComparableNameUse> 
                         .get(name_start + name_len)
                         .is_some_and(|byte| *byte == b'}')
                     && let (Some(start), Some(end)) = (
-                        source_position_at_offset(source, name_start - 2),
-                        source_position_at_offset(source, name_start + name_len + 1),
+                        locator.position_at_offset(name_start - 2),
+                        locator.position_at_offset(name_start + name_len + 1),
                     )
                 {
                     uses.push(ComparableNameUse {
@@ -1463,17 +1465,6 @@ fn is_build_flag_source_name(name: &str) -> bool {
         || name.ends_with("_CXXFLAGS")
         || name.ends_with("_CPPFLAGS")
         || name.ends_with("_LDFLAGS")
-}
-
-fn source_position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
-    if target_offset > source.len() {
-        return None;
-    }
-    let mut position = Position::new();
-    for char in source[..target_offset].chars() {
-        position.advance(char);
-    }
-    Some(position)
 }
 
 fn assignment_value_span(value: &AssignmentValue) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -211,15 +211,16 @@ pub(crate) fn comparable_read_target_name_uses(
 pub(crate) fn comparable_heredoc_name_uses(
     heredoc: &shuck_ast::HeredocBody,
     semantic: Option<&LinterSemanticArtifacts<'_>>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Box<[ComparableNameUse]> {
+    let source = locator.source();
     let mut uses = Vec::new();
     for part in &heredoc.parts {
         match &part.kind {
             shuck_ast::HeredocBodyPart::Variable(name) => {
                 if comparable_name_text(name.as_str()) {
                     uses.push(ComparableNameUse {
-                        span: heredoc_variable_name_span(part.span, source),
+                        span: heredoc_variable_name_span(part.span, locator),
                         key: ComparableNameKey(name.as_str().into()),
                         kind: ComparableNameUseKind::Parameter,
                     });
@@ -438,7 +439,8 @@ fn dedup_comparable_name_uses(uses: &mut Vec<ComparableNameUse>) {
     uses.retain(|name_use| seen.insert((name_use.key.clone(), FactSpan::new(name_use.span))));
 }
 
-fn heredoc_variable_name_span(span: Span, source: &str) -> Span {
+fn heredoc_variable_name_span(span: Span, locator: Locator<'_>) -> Span {
+    let source = locator.source();
     let Some(text) = source.get(span.start.offset..span.end.offset) else {
         return span;
     };
@@ -446,7 +448,7 @@ fn heredoc_variable_name_span(span: Span, source: &str) -> Span {
         return span;
     };
     let start_offset = span.start.offset + relative_start + '$'.len_utf8();
-    let Some(start) = position_at_offset(source, start_offset) else {
+    let Some(start) = locator.position_at_offset(start_offset) else {
         return span;
     };
     Span::from_positions(start, span.end)
@@ -664,9 +666,10 @@ pub(crate) fn analyze_redirect_target(
 fn build_redirect_facts<'a>(
     redirects: &'a [Redirect],
     semantic: Option<&LinterSemanticArtifacts<'a>>,
-    source: &str,
+    locator: Locator<'_>,
     zsh_options: Option<&ZshOptionState>,
 ) -> Vec<RedirectFact<'a>> {
+    let source = locator.source();
     redirects
         .iter()
         .map(|redirect| RedirectFact {
@@ -694,7 +697,11 @@ fn build_redirect_facts<'a>(
                 ExpansionContext::from_redirect_kind(redirect.kind)
                     .and_then(|context| comparable_path(word, source, context, zsh_options))
             }),
-            comparable_name_uses: comparable_redirect_name_uses(redirect, semantic, source),
+            comparable_name_uses: comparable_redirect_name_uses(
+                redirect,
+                semantic,
+                locator,
+            ),
         })
         .collect()
 }
@@ -702,8 +709,9 @@ fn build_redirect_facts<'a>(
 fn comparable_redirect_name_uses(
     redirect: &Redirect,
     semantic: Option<&LinterSemanticArtifacts<'_>>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Box<[ComparableNameUse]> {
+    let source = locator.source();
     if let Some(word) = redirect.word_target() {
         return match redirect.kind {
             RedirectKind::Output
@@ -728,7 +736,7 @@ fn comparable_redirect_name_uses(
     if !heredoc.delimiter.expands_body {
         return Box::default();
     }
-    comparable_heredoc_name_uses(&heredoc.body, semantic, source)
+    comparable_heredoc_name_uses(&heredoc.body, semantic, locator)
 }
 
 fn brace_fd_redirection_span(redirect: &Redirect, source: &str) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -926,7 +926,7 @@ pub(super) fn build_single_test_subshell_spans<'a>(
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Vec<Span> {
     let command_relationships = CommandRelationshipContext::new(
         commands,
@@ -936,7 +936,7 @@ pub(super) fn build_single_test_subshell_spans<'a>(
     );
     commands
         .iter()
-        .filter_map(|fact| single_test_subshell_span(fact, command_relationships, source))
+        .filter_map(|fact| single_test_subshell_span(fact, command_relationships, locator))
         .collect()
 }
 
@@ -945,7 +945,7 @@ pub(super) fn build_subshell_test_group_spans<'a>(
     command_fact_indices_by_id: &[Option<usize>],
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Vec<Span> {
     let command_relationships = CommandRelationshipContext::new(
         commands,
@@ -955,14 +955,14 @@ pub(super) fn build_subshell_test_group_spans<'a>(
     );
     commands
         .iter()
-        .filter_map(|fact| subshell_test_group_span(fact, command_relationships, source))
+        .filter_map(|fact| subshell_test_group_span(fact, command_relationships, locator))
         .collect()
 }
 
 fn single_test_subshell_span<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
     let condition = match fact.command() {
         Command::Compound(CompoundCommand::If(command)) => &command.condition,
@@ -995,8 +995,8 @@ fn single_test_subshell_span<'a>(
     }
 
     Some(subshell_anchor_span(
-        condition_fact.span_in_source(source),
-        source,
+        condition_fact.span_in_source(locator.source()),
+        locator,
     ))
 }
 
@@ -1036,7 +1036,7 @@ fn is_test_condition_fact<'a>(
 fn subshell_test_group_span<'a>(
     fact: &CommandFact<'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
     let Command::Compound(CompoundCommand::Subshell(body)) = fact.command() else {
         return None;
@@ -1046,7 +1046,7 @@ fn subshell_test_group_span<'a>(
         return None;
     }
 
-    Some(subshell_anchor_span(fact.span(), source))
+    Some(subshell_anchor_span(fact.span(), locator))
 }
 
 fn subshell_body_contains_grouped_tests<'a>(
@@ -1146,15 +1146,16 @@ fn subshell_body_analysis<'a>(
     Some(analysis)
 }
 
-fn subshell_anchor_span(span: Span, source: &str) -> Span {
+fn subshell_anchor_span(span: Span, locator: Locator<'_>) -> Span {
+    let source = locator.source();
     let Some(open_paren_offset) = leading_open_paren_offset(source, span.start.offset) else {
         return span;
     };
 
     let end_offset = trim_trailing_whitespace_offset(source, span.end.offset);
     Span::from_positions(
-        position_at_offset_strict(source, open_paren_offset),
-        position_at_offset_strict(source, end_offset),
+        locator.position_at_offset_unchecked(open_paren_offset),
+        locator.position_at_offset_unchecked(end_offset),
     )
 }
 
@@ -1172,15 +1173,6 @@ fn leading_open_paren_offset(source: &str, start_offset: usize) -> Option<usize>
     }
 
     None
-}
-
-fn position_at_offset_strict(source: &str, target_offset: usize) -> Position {
-    source[..target_offset]
-        .chars()
-        .fold(Position::new(), |mut position, ch| {
-            position.advance(ch);
-            position
-        })
 }
 
 fn trim_trailing_whitespace_offset(source: &str, end_offset: usize) -> usize {

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -149,6 +149,7 @@ impl SubstitutionFact {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
+#[allow(clippy::too_many_arguments)]
 fn populate_substitution_fact_ranges<'a>(
     commands: &mut [CommandFact<'a>],
     fact_store: &mut FactStore<'a>,
@@ -156,7 +157,7 @@ fn populate_substitution_fact_ranges<'a>(
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
     semantic: &LinterSemanticArtifacts<'a>,
-    source: &str,
+    locator: Locator<'_>,
 ) {
     for index in 0..commands.len() {
         let substitutions = {
@@ -171,7 +172,7 @@ fn populate_substitution_fact_ranges<'a>(
                 command_ids_by_span,
                 command_child_index,
                 semantic,
-                source,
+                locator,
             )
         };
         commands[index].substitution_facts = fact_store.substitution_facts.push_many(substitutions);
@@ -184,8 +185,9 @@ fn build_command_substitution_facts<'a>(
     command_ids_by_span: &CommandLookupIndex,
     command_child_index: &CommandChildIndex,
     semantic: &LinterSemanticArtifacts<'a>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Vec<SubstitutionFact> {
+    let source = locator.source();
     let mut substitutions = Vec::new();
     let mut substitution_index = FxHashMap::default();
     let context = SubstitutionFactBuildContext {
@@ -198,7 +200,7 @@ fn build_command_substitution_facts<'a>(
         ),
         host_command_id: fact.id(),
         semantic,
-        source,
+        locator,
     };
 
     visit_command_words_for_substitutions(fact.command(), fact.redirects(), source, &mut |word| {
@@ -308,7 +310,7 @@ struct SubstitutionFactBuildContext<'a, 'b> {
     command_relationships: CommandRelationshipContext<'b, 'a>,
     host_command_id: CommandId,
     semantic: &'b LinterSemanticArtifacts<'a>,
-    source: &'b str,
+    locator: Locator<'b>,
 }
 
 fn collect_or_update_substitution_facts_from_occurrences<'a>(
@@ -334,7 +336,7 @@ fn collect_or_update_substitution_facts_from_occurrences<'a>(
             context.command_relationships,
             context.host_command_id,
             context.semantic,
-            context.source,
+            context.locator,
         );
         substitution_index.insert(key, substitutions.len());
         substitutions.push(SubstitutionFact {
@@ -549,8 +551,9 @@ fn classify_substitution_body<'a>(
     command_relationships: CommandRelationshipContext<'_, 'a>,
     parent_id: CommandId,
     semantic: &LinterSemanticArtifacts<'a>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> SubstitutionBodyFacts {
+    let source = locator.source();
     let mut body_has_commands = false;
     let mut body_contains_ls = false;
     let mut bash_file_slurp = false;
@@ -572,7 +575,7 @@ fn classify_substitution_body<'a>(
             CommandTopologyTraversal::Descend
         });
     let redirect_summary =
-        summarize_stmt_seq_redirects(body, parent_id, commands, command_relationships, source);
+        summarize_stmt_seq_redirects(body, parent_id, commands, command_relationships, locator);
     let body_processed_ls_pipeline_spans = substitution_body_processed_ls_pipeline_spans(
         body,
         parent_id,
@@ -622,7 +625,7 @@ fn summarize_stmt_seq_redirects<'a>(
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> RedirectSummary {
     let mut summary = RedirectSummary {
         stdout_intent: SubstitutionOutputIntent::Captured,
@@ -634,8 +637,13 @@ fn summarize_stmt_seq_redirects<'a>(
     let mut saw_stmt = false;
 
     for stmt in &body.stmts {
-        let stmt_summary =
-            summarize_stmt_redirects(stmt, parent_id, commands, command_relationships, source);
+        let stmt_summary = summarize_stmt_redirects(
+            stmt,
+            parent_id,
+            commands,
+            command_relationships,
+            locator,
+        );
         summary = merge_redirect_summaries(summary, stmt_summary, saw_stmt);
         saw_stmt = true;
     }
@@ -648,7 +656,7 @@ fn summarize_stmt_redirects<'a>(
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> RedirectSummary {
     match &stmt.command {
         Command::Binary(binary) => match binary.op {
@@ -661,7 +669,7 @@ fn summarize_stmt_redirects<'a>(
                     child_parent_id,
                     commands,
                     command_relationships,
-                    source,
+                    locator,
                 )
             }
             BinaryOp::And | BinaryOp::Or => {
@@ -673,14 +681,14 @@ fn summarize_stmt_redirects<'a>(
                     child_parent_id,
                     commands,
                     command_relationships,
-                    source,
+                    locator,
                 );
                 let right = summarize_stmt_redirects(
                     &binary.right,
                     child_parent_id,
                     commands,
                     command_relationships,
-                    source,
+                    locator,
                 );
                 merge_redirect_summaries(left, right, true)
             }
@@ -712,7 +720,7 @@ fn summarize_stmt_redirects<'a>(
             parent_id,
             commands,
             command_relationships,
-            source,
+            locator,
         ),
     }
 }
@@ -722,15 +730,16 @@ fn summarize_command_redirects<'a>(
     parent_id: CommandId,
     commands: CommandFacts<'_, 'a>,
     command_relationships: CommandRelationshipContext<'_, 'a>,
-    source: &str,
+    locator: Locator<'_>,
 ) -> RedirectSummary {
+    let source = locator.source();
     if let Some(id) = command_relationships
         .child_id_for_command(parent_id, &stmt.command)
         .or_else(|| command_relationships.id_for_command(&stmt.command))
     {
         summarize_redirect_facts(command_fact_ref(commands, id).redirect_facts(), source)
     } else {
-        let redirect_facts = build_redirect_facts(&stmt.redirects, None, source, None);
+        let redirect_facts = build_redirect_facts(&stmt.redirects, None, locator, None);
         summarize_redirect_facts(&redirect_facts, source)
     }
 }

--- a/crates/shuck-linter/src/facts/word_spans/arrays.rs
+++ b/crates/shuck-linter/src/facts/word_spans/arrays.rs
@@ -4,36 +4,39 @@ pub fn collect_array_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
     collect_array_expansion_spans(&word.parts, false, false, spans);
 }
 
-pub fn all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
+pub fn all_elements_array_expansion_part_spans(word: &Word, locator: Locator<'_>) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_all_elements_array_expansion_part_spans(word, source, &mut spans);
+    collect_all_elements_array_expansion_part_spans(word, locator, &mut spans);
     spans
 }
 
 pub fn collect_all_elements_array_expansion_part_spans(
     word: &Word,
-    source: &str,
+    locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
-    collect_all_elements_array_expansion_spans(&word.parts, source, spans);
+    collect_all_elements_array_expansion_spans(&word.parts, locator, spans);
 }
 
 pub fn word_has_all_elements_array_expansion_syntax(word: &Word) -> bool {
     parts_have_all_elements_array_expansion_syntax(&word.parts)
 }
 
-pub fn direct_all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
+pub fn direct_all_elements_array_expansion_part_spans(
+    word: &Word,
+    locator: Locator<'_>,
+) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_direct_all_elements_array_expansion_part_spans(word, source, &mut spans);
+    collect_direct_all_elements_array_expansion_part_spans(word, locator, &mut spans);
     spans
 }
 
 pub fn collect_direct_all_elements_array_expansion_part_spans(
     word: &Word,
-    source: &str,
+    locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
-    collect_direct_all_elements_array_expansion_spans(&word.parts, word.span, source, spans);
+    collect_direct_all_elements_array_expansion_spans(&word.parts, word.span, locator, spans);
 }
 
 pub fn collect_unquoted_all_elements_array_expansion_part_spans(
@@ -54,8 +57,11 @@ pub fn word_has_quoted_all_elements_array_slice(word: &Word) -> bool {
     !word_quoted_all_elements_array_slice_spans(word).is_empty()
 }
 
-pub fn word_has_direct_all_elements_array_expansion_in_source(word: &Word, source: &str) -> bool {
-    !direct_all_elements_array_expansion_part_spans(word, source).is_empty()
+pub fn word_has_direct_all_elements_array_expansion_in_source(
+    word: &Word,
+    locator: Locator<'_>,
+) -> bool {
+    !direct_all_elements_array_expansion_part_spans(word, locator).is_empty()
 }
 
 pub fn word_quoted_unindexed_bash_source_span_in_source(word: &Word, source: &str) -> Option<Span> {
@@ -121,8 +127,12 @@ pub fn word_folded_positional_at_splat_span_in_source(word: &Word, source: &str)
     Some(first)
 }
 
-pub fn word_folded_all_elements_array_span_in_source(word: &Word, source: &str) -> Option<Span> {
-    let spans = folded_all_elements_array_candidate_spans(word, source)
+pub fn word_folded_all_elements_array_span_in_source(
+    word: &Word,
+    locator: Locator<'_>,
+) -> Option<Span> {
+    let source = locator.source();
+    let spans = folded_all_elements_array_candidate_spans(word, locator)
         .into_iter()
         .filter(|span| !span_is_escaped(*span, source))
         .collect::<Vec<_>>();
@@ -130,7 +140,7 @@ pub fn word_folded_all_elements_array_span_in_source(word: &Word, source: &str) 
 
     if spans.len() == 1
         && (word_has_single_folded_all_elements_array_part(word)
-            || all_elements_array_expansion_is_standalone(word, source))
+            || all_elements_array_expansion_is_standalone(word, locator))
     {
         return None;
     }
@@ -138,22 +148,26 @@ pub fn word_folded_all_elements_array_span_in_source(word: &Word, source: &str) 
     Some(first)
 }
 
-pub(crate) fn folded_all_elements_array_candidate_spans(word: &Word, source: &str) -> Vec<Span> {
+pub(crate) fn folded_all_elements_array_candidate_spans(
+    word: &Word,
+    locator: Locator<'_>,
+) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_folded_all_elements_array_candidate_spans(&word.parts, source, &mut spans);
+    collect_folded_all_elements_array_candidate_spans(&word.parts, locator, &mut spans);
     spans
 }
 
 pub(crate) fn collect_folded_all_elements_array_candidate_spans(
     parts: &[WordPartNode],
-    source: &str,
+    locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
+    let source = locator.source();
     for part in parts {
         match &part.kind {
             WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
-                collect_folded_all_elements_array_candidate_spans(parts, source, spans)
+                collect_folded_all_elements_array_candidate_spans(parts, locator, spans)
             }
             WordPart::Parameter(parameter)
                 if parameter_uses_replacement_all_elements_array_expansion(parameter) =>
@@ -162,7 +176,7 @@ pub(crate) fn collect_folded_all_elements_array_candidate_spans(
             }
             _ if part_uses_direct_all_elements_array_expansion(&part.kind) => {
                 if let Some(span) =
-                    normalize_direct_all_elements_array_expansion_span(part.span, source)
+                    normalize_direct_all_elements_array_expansion_span(part.span, locator)
                 {
                     spans.push(span);
                 }
@@ -173,7 +187,7 @@ pub(crate) fn collect_folded_all_elements_array_candidate_spans(
                 ) =>
             {
                 if let Some(span) =
-                    normalize_nested_direct_all_elements_array_expansion_span(part.span, source)
+                    normalize_nested_direct_all_elements_array_expansion_span(part.span, locator)
                 {
                     spans.push(span);
                 }
@@ -247,17 +261,19 @@ pub(crate) fn collect_array_expansion_spans(
 
 pub(crate) fn collect_all_elements_array_expansion_spans(
     parts: &[WordPartNode],
-    source: &str,
+    locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
+    let source = locator.source();
     for part in parts {
         match &part.kind {
             WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
-                collect_all_elements_array_expansion_spans(parts, source, spans)
+                collect_all_elements_array_expansion_spans(parts, locator, spans)
             }
             WordPart::Variable(name) if name.as_str() == "@" => {
-                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
+                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, locator)
+                {
                     spans.push(span);
                 }
             }
@@ -270,7 +286,8 @@ pub(crate) fn collect_all_elements_array_expansion_spans(
                     Some(SubscriptSelector::At)
                 ) =>
             {
-                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
+                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, locator)
+                {
                     spans.push(span);
                 }
             }
@@ -283,7 +300,8 @@ pub(crate) fn collect_all_elements_array_expansion_spans(
                     Some(SubscriptSelector::At)
                 ) =>
             {
-                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
+                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, locator)
+                {
                     spans.push(span);
                 }
             }
@@ -291,7 +309,8 @@ pub(crate) fn collect_all_elements_array_expansion_spans(
                 kind: PrefixMatchKind::At,
                 ..
             } => {
-                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
+                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, locator)
+                {
                     spans.push(span);
                 }
             }
@@ -300,7 +319,8 @@ pub(crate) fn collect_all_elements_array_expansion_spans(
                     parameter, part.span, source,
                 ) =>
             {
-                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, source) {
+                if let Some(span) = normalize_all_elements_array_expansion_span(part.span, locator)
+                {
                     spans.push(span);
                 }
             }
@@ -389,9 +409,10 @@ pub(crate) fn collect_all_elements_array_slice_spans(
 pub(crate) fn collect_direct_all_elements_array_expansion_spans(
     parts: &[WordPartNode],
     word_span: Span,
-    source: &str,
+    locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
+    let source = locator.source();
     for part in parts {
         if span_inside_escaped_parameter_template(word_span, part.span, source) {
             continue;
@@ -399,11 +420,11 @@ pub(crate) fn collect_direct_all_elements_array_expansion_spans(
         match &part.kind {
             WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
-                collect_direct_all_elements_array_expansion_spans(parts, word_span, source, spans)
+                collect_direct_all_elements_array_expansion_spans(parts, word_span, locator, spans)
             }
             _ if part_uses_direct_all_elements_array_expansion(&part.kind) => {
                 if let Some(span) =
-                    normalize_direct_all_elements_array_expansion_span(part.span, source)
+                    normalize_direct_all_elements_array_expansion_span(part.span, locator)
                 {
                     spans.push(span);
                 }
@@ -414,7 +435,7 @@ pub(crate) fn collect_direct_all_elements_array_expansion_spans(
                 ) =>
             {
                 if let Some(span) =
-                    normalize_nested_direct_all_elements_array_expansion_span(part.span, source)
+                    normalize_nested_direct_all_elements_array_expansion_span(part.span, locator)
                 {
                     spans.push(span);
                 }
@@ -566,8 +587,9 @@ pub(crate) fn collect_quoted_unindexed_bash_source_spans(
 
 pub(crate) fn normalize_all_elements_array_expansion_span(
     span: Span,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
+    let source = locator.source();
     let text = span.slice(source);
     if !span_is_escaped(span, source)
         && (text == "$@" || candidate_is_all_elements_array_expansion(text))
@@ -586,11 +608,11 @@ pub(crate) fn normalize_all_elements_array_expansion_span(
             continue;
         }
 
-        let start = position_at_offset(source, absolute_start)?;
+        let start = locator.position_at_offset(absolute_start)?;
         let remainder = &source[absolute_start..];
 
         if remainder.starts_with("$@") {
-            let end = position_at_offset(source, absolute_start + "$@".len())?;
+            let end = locator.position_at_offset(absolute_start + "$@".len())?;
             return Some(Span::from_positions(start, end));
         }
 
@@ -599,7 +621,7 @@ pub(crate) fn normalize_all_elements_array_expansion_span(
         {
             let candidate = &remainder[..=relative_end];
             if candidate_is_all_elements_array_expansion(candidate) {
-                let end = position_at_offset(source, absolute_start + candidate.len())?;
+                let end = locator.position_at_offset(absolute_start + candidate.len())?;
                 return Some(Span::from_positions(start, end));
             }
         }
@@ -607,13 +629,14 @@ pub(crate) fn normalize_all_elements_array_expansion_span(
         search_from = relative_start + 1;
     }
 
-    widen_all_elements_array_expansion_span(span, source)
+    widen_all_elements_array_expansion_span(span, locator)
 }
 
 pub(crate) fn normalize_direct_all_elements_array_expansion_span(
     span: Span,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
+    let source = locator.source();
     let text = span.slice(source);
     if !span_is_escaped(span, source)
         && (text == "$@" || candidate_is_direct_all_elements_array_expansion(text))
@@ -632,11 +655,11 @@ pub(crate) fn normalize_direct_all_elements_array_expansion_span(
             continue;
         }
 
-        let start = position_at_offset(source, absolute_start)?;
+        let start = locator.position_at_offset(absolute_start)?;
         let remainder = &source[absolute_start..];
 
         if remainder.starts_with("$@") {
-            let end = position_at_offset(source, absolute_start + "$@".len())?;
+            let end = locator.position_at_offset(absolute_start + "$@".len())?;
             return Some(Span::from_positions(start, end));
         }
 
@@ -645,7 +668,7 @@ pub(crate) fn normalize_direct_all_elements_array_expansion_span(
         {
             let candidate = &remainder[..=relative_end];
             if candidate_is_direct_all_elements_array_expansion(candidate) {
-                let end = position_at_offset(source, absolute_start + candidate.len())?;
+                let end = locator.position_at_offset(absolute_start + candidate.len())?;
                 return Some(Span::from_positions(start, end));
             }
         }
@@ -653,13 +676,14 @@ pub(crate) fn normalize_direct_all_elements_array_expansion_span(
         search_from = relative_start + 1;
     }
 
-    widen_direct_all_elements_array_expansion_span(span, source)
+    widen_direct_all_elements_array_expansion_span(span, locator)
 }
 
 pub(crate) fn normalize_nested_direct_all_elements_array_expansion_span(
     span: Span,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
+    let source = locator.source();
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum QuoteState {
         None,
@@ -747,8 +771,8 @@ pub(crate) fn normalize_nested_direct_all_elements_array_expansion_span(
 
         let remainder = &source[absolute_start..];
         if nested_braced_depth == 0 && remainder.starts_with("$@") {
-            let start = position_at_offset(source, absolute_start)?;
-            let end = position_at_offset(source, absolute_start + "$@".len())?;
+            let start = locator.position_at_offset(absolute_start)?;
+            let end = locator.position_at_offset(absolute_start + "$@".len())?;
             return Some(Span::from_positions(start, end));
         }
 
@@ -758,8 +782,8 @@ pub(crate) fn normalize_nested_direct_all_elements_array_expansion_span(
             {
                 let candidate = &remainder[..=relative_end];
                 if candidate_is_direct_all_elements_array_expansion(candidate) {
-                    let start = position_at_offset(source, absolute_start)?;
-                    let end = position_at_offset(source, absolute_start + candidate.len())?;
+                    let start = locator.position_at_offset(absolute_start)?;
+                    let end = locator.position_at_offset(absolute_start + candidate.len())?;
                     return Some(Span::from_positions(start, end));
                 }
             }
@@ -775,7 +799,11 @@ pub(crate) fn normalize_nested_direct_all_elements_array_expansion_span(
     None
 }
 
-pub(crate) fn widen_all_elements_array_expansion_span(span: Span, source: &str) -> Option<Span> {
+pub(crate) fn widen_all_elements_array_expansion_span(
+    span: Span,
+    locator: Locator<'_>,
+) -> Option<Span> {
+    let source = locator.source();
     let text = span.slice(source);
     if !text.contains("[@]") {
         return None;
@@ -789,7 +817,7 @@ pub(crate) fn widen_all_elements_array_expansion_span(span: Span, source: &str) 
         return None;
     }
 
-    let start = position_at_offset(source, start_offset)?;
+    let start = locator.position_at_offset(start_offset)?;
     let remainder = &source[start_offset..];
     let relative_end = remainder.find('}')?;
     let candidate = &remainder[..=relative_end];
@@ -797,14 +825,15 @@ pub(crate) fn widen_all_elements_array_expansion_span(span: Span, source: &str) 
         return None;
     }
 
-    let end = position_at_offset(source, start_offset + candidate.len())?;
+    let end = locator.position_at_offset(start_offset + candidate.len())?;
     Some(Span::from_positions(start, end))
 }
 
 pub(crate) fn widen_direct_all_elements_array_expansion_span(
     span: Span,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
+    let source = locator.source();
     let text = span.slice(source);
     if !text.contains("[@]") {
         return None;
@@ -818,7 +847,7 @@ pub(crate) fn widen_direct_all_elements_array_expansion_span(
         return None;
     }
 
-    let start = position_at_offset(source, start_offset)?;
+    let start = locator.position_at_offset(start_offset)?;
     let remainder = &source[start_offset..];
     let relative_end = remainder.find('}')?;
     let candidate = &remainder[..=relative_end];
@@ -826,7 +855,7 @@ pub(crate) fn widen_direct_all_elements_array_expansion_span(
         return None;
     }
 
-    let end = position_at_offset(source, start_offset + candidate.len())?;
+    let end = locator.position_at_offset(start_offset + candidate.len())?;
     Some(Span::from_positions(start, end))
 }
 
@@ -1382,11 +1411,15 @@ pub(crate) fn positional_at_splat_is_standalone_expansion(word: &Word, source: &
     true
 }
 
-pub(crate) fn all_elements_array_expansion_is_standalone(word: &Word, source: &str) -> bool {
+pub(crate) fn all_elements_array_expansion_is_standalone(
+    word: &Word,
+    locator: Locator<'_>,
+) -> bool {
     if word.parts.len() != 1 {
         return false;
     }
 
+    let source = locator.source();
     let text = word.span.slice(source);
     let body = if word.is_fully_double_quoted() {
         let Some(unquoted) = text
@@ -1400,7 +1433,7 @@ pub(crate) fn all_elements_array_expansion_is_standalone(word: &Word, source: &s
         text
     };
 
-    folded_all_elements_array_candidate_spans(word, source)
+    folded_all_elements_array_candidate_spans(word, locator)
         .first()
         .is_some_and(|span| span.slice(source) == body)
 }
@@ -1408,23 +1441,43 @@ pub(crate) fn all_elements_array_expansion_is_standalone(word: &Word, source: &s
 #[cfg(test)]
 mod tests {
     use shuck_ast::{Span, Word};
+    use shuck_indexer::LineIndex;
     use shuck_parser::parser::Parser;
 
     use super::{
-        all_elements_array_expansion_part_spans, collect_all_elements_array_slice_spans,
-        collect_array_expansion_part_spans,
+        collect_all_elements_array_slice_spans, collect_array_expansion_part_spans,
         collect_unquoted_all_elements_array_expansion_part_spans,
         collect_unquoted_array_expansion_part_spans, span_is_escaped,
-        word_folded_all_elements_array_span_in_source,
-        word_folded_positional_at_splat_span_in_source,
-        word_has_direct_all_elements_array_expansion_in_source,
         word_has_quoted_all_elements_array_slice, word_has_single_positional_at_splat_part,
         word_is_pure_positional_at_splat, word_positional_at_splat_span_in_source,
         word_positional_at_splat_spans, word_quoted_all_elements_array_slice_spans,
         word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
         word_unquoted_star_parameter_spans, word_unquoted_star_splat_spans,
     };
+    use crate::Locator;
     use crate::facts::word_spans::collect_scalar_expansion_part_spans;
+
+    fn all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        super::all_elements_array_expansion_part_spans(word, locator)
+    }
+
+    fn word_folded_all_elements_array_span_in_source(word: &Word, source: &str) -> Option<Span> {
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        super::word_folded_all_elements_array_span_in_source(word, locator)
+    }
+
+    fn word_folded_positional_at_splat_span_in_source(word: &Word, source: &str) -> Option<Span> {
+        super::word_folded_positional_at_splat_span_in_source(word, source)
+    }
+
+    fn word_has_direct_all_elements_array_expansion_in_source(word: &Word, source: &str) -> bool {
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        super::word_has_direct_all_elements_array_expansion_in_source(word, locator)
+    }
 
     fn array_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
         let mut spans = Vec::new();

--- a/crates/shuck-linter/src/facts/word_spans/backticks.rs
+++ b/crates/shuck-linter/src/facts/word_spans/backticks.rs
@@ -2,21 +2,22 @@ use super::*;
 
 pub(crate) fn shellcheck_collapsed_backtick_part_span(
     span: Span,
-    source: &str,
+    locator: Locator<'_>,
     backtick_spans: &[Span],
 ) -> Span {
     let deescaped =
-        shellcheck_deescaped_backtick_part_span(span, source, backtick_spans).unwrap_or(span);
-    collapse_backtick_continuation_span(deescaped, source, backtick_spans).unwrap_or(deescaped)
+        shellcheck_deescaped_backtick_part_span(span, locator, backtick_spans).unwrap_or(span);
+    collapse_backtick_continuation_span(deescaped, locator, backtick_spans).unwrap_or(deescaped)
 }
 
 pub(crate) fn collapse_backtick_continuation_span(
     span: Span,
-    source: &str,
+    locator: Locator<'_>,
     backtick_spans: &[Span],
 ) -> Option<Span> {
+    let source = locator.source();
     let containing_span = containing_backtick_substitution_span(span, backtick_spans)?;
-    let chain_start = continued_line_chain_start(span.start, containing_span, source)?;
+    let chain_start = continued_line_chain_start(span.start, containing_span, locator)?;
     Some(Span::from_positions(
         shellcheck_collapsed_position(chain_start, span.start, source),
         shellcheck_collapsed_position(chain_start, span.end, source),
@@ -25,9 +26,10 @@ pub(crate) fn collapse_backtick_continuation_span(
 
 pub(crate) fn shellcheck_deescaped_backtick_part_span(
     span: Span,
-    source: &str,
+    locator: Locator<'_>,
     backtick_spans: &[Span],
 ) -> Option<Span> {
+    let source = locator.source();
     let containing_span = containing_backtick_substitution_span(span, backtick_spans)?;
     let content_start = containing_span.start.offset.saturating_add('`'.len_utf8());
     let start_removed = backtick_removed_escape_count(source, content_start, span.start.offset)?;
@@ -37,8 +39,8 @@ pub(crate) fn shellcheck_deescaped_backtick_part_span(
     }
 
     Some(Span::from_positions(
-        position_at_offset(source, span.start.offset.checked_sub(start_removed)?)?,
-        position_at_offset(source, span.end.offset.checked_sub(end_removed)?)?,
+        locator.position_at_offset(span.start.offset.checked_sub(start_removed)?)?,
+        locator.position_at_offset(span.end.offset.checked_sub(end_removed)?)?,
     ))
 }
 
@@ -97,7 +99,8 @@ pub(crate) fn backtick_shell_comment_can_start(previous_char: Option<char>) -> b
     })
 }
 
-pub(crate) fn backtick_substitution_spans(source: &str) -> Vec<Span> {
+pub(crate) fn backtick_substitution_spans(locator: Locator<'_>) -> Vec<Span> {
+    let source = locator.source();
     let mut spans = Vec::new();
     let mut contexts = vec![BacktickQuoteContext::default()];
     let mut backtick_start_offsets = Vec::<usize>::new();
@@ -205,11 +208,11 @@ pub(crate) fn backtick_substitution_spans(source: &str) -> Vec<Span> {
             '`' => {
                 if let Some(start_offset) = backtick_start_offsets.pop() {
                     let _ = contexts.pop();
-                    let Some(start) = position_at_offset(source, start_offset) else {
+                    let Some(start) = locator.position_at_offset(start_offset) else {
                         index += ch_len;
                         continue;
                     };
-                    let Some(end) = position_at_offset(source, index + ch_len) else {
+                    let Some(end) = locator.position_at_offset(index + ch_len) else {
                         index += ch_len;
                         continue;
                     };
@@ -242,9 +245,10 @@ pub(crate) fn backtick_substitution_spans(source: &str) -> Vec<Span> {
 }
 
 pub(crate) fn backtick_escaped_parameters(
-    source: &str,
+    locator: Locator<'_>,
     backtick_spans: &[Span],
 ) -> Vec<BacktickEscapedParameter> {
+    let source = locator.source();
     let mut spans = Vec::new();
 
     for backtick_span in backtick_spans {
@@ -289,22 +293,22 @@ pub(crate) fn backtick_escaped_parameters(
                         let expansion_len = parameter.expansion_len();
                         let diagnostic_start_offset = slash_offset.saturating_sub(removed_escapes);
                         let Some(diagnostic_start) =
-                            position_at_offset(source, diagnostic_start_offset)
+                            locator.position_at_offset(diagnostic_start_offset)
                         else {
                             index += escaped.len_utf8();
                             continue;
                         };
                         let Some(diagnostic_end) =
-                            position_at_offset(source, diagnostic_start_offset + expansion_len)
+                            locator.position_at_offset(diagnostic_start_offset + expansion_len)
                         else {
                             index += escaped.len_utf8();
                             continue;
                         };
-                        let Some(reference_start) = position_at_offset(source, index) else {
+                        let Some(reference_start) = locator.position_at_offset(index) else {
                             index += escaped.len_utf8();
                             continue;
                         };
-                        let Some(reference_end) = position_at_offset(source, index + expansion_len)
+                        let Some(reference_end) = locator.position_at_offset(index + expansion_len)
                         else {
                             index += escaped.len_utf8();
                             continue;
@@ -347,9 +351,10 @@ pub(crate) fn backtick_escaped_parameters(
 }
 
 pub(crate) fn backtick_escaped_parameter_reference_spans(
-    source: &str,
+    locator: Locator<'_>,
     backtick_spans: &[Span],
 ) -> Vec<Span> {
+    let source = locator.source();
     let mut spans = Vec::new();
 
     for backtick_span in backtick_spans {
@@ -365,8 +370,8 @@ pub(crate) fn backtick_escaped_parameter_reference_spans(
                 let dollar_offset = index + '\\'.len_utf8();
                 if offset_is_backslash_escaped(base_offset + dollar_offset, source)
                     && let Some(end_offset) = escaped_parameter_template_end(text, dollar_offset)
-                    && let Some(start) = position_at_offset(source, base_offset + dollar_offset)
-                    && let Some(end_position) = position_at_offset(source, base_offset + end_offset)
+                    && let Some(start) = locator.position_at_offset(base_offset + dollar_offset)
+                    && let Some(end_position) = locator.position_at_offset(base_offset + end_offset)
                 {
                     spans.push(Span::from_positions(start, end_position));
                     index = end_offset;
@@ -387,9 +392,10 @@ pub(crate) fn backtick_escaped_parameter_reference_spans(
 }
 
 pub(crate) fn backtick_double_escaped_parameter_spans(
-    source: &str,
+    locator: Locator<'_>,
     backtick_spans: &[Span],
 ) -> Vec<Span> {
+    let source = locator.source();
     let mut spans = Vec::new();
 
     for backtick_span in backtick_spans {
@@ -427,9 +433,9 @@ pub(crate) fn backtick_double_escaped_parameter_spans(
                             escaped_backtick_parameter_syntax(source, index, end)
                     {
                         let expansion_len = parameter.expansion_len();
-                        if let Some(start) = position_at_offset(source, index)
+                        if let Some(start) = locator.position_at_offset(index)
                             && let Some(end_position) =
-                                position_at_offset(source, index + expansion_len)
+                                locator.position_at_offset(index + expansion_len)
                         {
                             spans.push(Span::from_positions(start, end_position));
                         }
@@ -870,8 +876,9 @@ pub(crate) fn escaped_backtick_parameter_syntax(
 pub(crate) fn continued_line_chain_start(
     target: Position,
     containing_span: Span,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Position> {
+    let source = locator.source();
     let original_start = source[..target.offset]
         .rfind('\n')
         .map_or(0, |index| index + 1);
@@ -959,7 +966,7 @@ pub(crate) fn continued_line_chain_start(
     }
 
     (chain_start != original_start)
-        .then(|| position_at_offset(source, chain_start))
+        .then(|| locator.position_at_offset(chain_start))
         .flatten()
 }
 
@@ -1013,16 +1020,32 @@ pub(crate) fn shellcheck_collapsed_position(
 #[cfg(test)]
 mod tests {
     use shuck_ast::Span;
+    use shuck_indexer::LineIndex;
 
     use super::{
         backtick_double_escaped_parameter_spans, backtick_escaped_parameters,
         backtick_substitution_spans, shellcheck_collapsed_backtick_part_span,
     };
-    use crate::facts::word_spans::position_at_offset;
+    use crate::Locator;
 
     fn shellcheck_collapsed_backtick_part_span_in_source(span: Span, source: &str) -> Span {
-        let backtick_spans = backtick_substitution_spans(source);
-        shellcheck_collapsed_backtick_part_span(span, source, &backtick_spans)
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        let backtick_spans = backtick_substitution_spans(locator);
+        shellcheck_collapsed_backtick_part_span(span, locator, &backtick_spans)
+    }
+
+    fn span_at(source: &str, start_offset: usize, end_offset: usize) -> Span {
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        Span::from_positions(
+            locator
+                .position_at_offset(start_offset)
+                .expect("expected start position"),
+            locator
+                .position_at_offset(end_offset)
+                .expect("expected end position"),
+        )
     }
 
     #[test]
@@ -1030,10 +1053,7 @@ mod tests {
         let source = "printf '%s\\n' '`'\\\n  \"$foo\"\\\n  '`'\n";
         let start_offset = source.find("$foo").expect("expected expansion");
         let end_offset = start_offset + "$foo".len();
-        let span = Span::from_positions(
-            position_at_offset(source, start_offset).expect("expected start position"),
-            position_at_offset(source, end_offset).expect("expected end position"),
-        );
+        let span = span_at(source, start_offset, end_offset);
 
         assert_eq!(
             shellcheck_collapsed_backtick_part_span_in_source(span, source),
@@ -1046,10 +1066,7 @@ mod tests {
         let source = "# `\nprintf '%s\\n' \\\n  \"$foo\"\n# `\n";
         let start_offset = source.find("$foo").expect("expected expansion");
         let end_offset = start_offset + "$foo".len();
-        let span = Span::from_positions(
-            position_at_offset(source, start_offset).expect("expected start position"),
-            position_at_offset(source, end_offset).expect("expected end position"),
-        );
+        let span = span_at(source, start_offset, end_offset);
 
         assert_eq!(
             shellcheck_collapsed_backtick_part_span_in_source(span, source),
@@ -1062,10 +1079,7 @@ mod tests {
         let source = "echo `printf '%s\\n' 'foo\\\n$bar'`\n";
         let start_offset = source.find("$bar").expect("expected expansion");
         let end_offset = start_offset + "$bar".len();
-        let span = Span::from_positions(
-            position_at_offset(source, start_offset).expect("expected start position"),
-            position_at_offset(source, end_offset).expect("expected end position"),
-        );
+        let span = span_at(source, start_offset, end_offset);
 
         assert_eq!(
             shellcheck_collapsed_backtick_part_span_in_source(span, source),
@@ -1079,10 +1093,7 @@ mod tests {
         let source = "echo `printf '%s\\n' '\nfoo\\\n$bar'`\n";
         let start_offset = source.find("$bar").expect("expected expansion");
         let end_offset = start_offset + "$bar".len();
-        let span = Span::from_positions(
-            position_at_offset(source, start_offset).expect("expected start position"),
-            position_at_offset(source, end_offset).expect("expected end position"),
-        );
+        let span = span_at(source, start_offset, end_offset);
 
         assert_eq!(
             shellcheck_collapsed_backtick_part_span_in_source(span, source),
@@ -1095,10 +1106,7 @@ mod tests {
         let source = "echo `printf '%s\\n' foo\\\n'$bar\\\n'\n$baz`\n";
         let start_offset = source.find("$baz").expect("expected expansion");
         let end_offset = start_offset + "$baz".len();
-        let span = Span::from_positions(
-            position_at_offset(source, start_offset).expect("expected start position"),
-            position_at_offset(source, end_offset).expect("expected end position"),
-        );
+        let span = span_at(source, start_offset, end_offset);
 
         assert_eq!(
             shellcheck_collapsed_backtick_part_span_in_source(span, source),
@@ -1144,8 +1152,10 @@ mod tests {
     #[test]
     fn backtick_escaped_parameters_keep_quoted_assignment_prefixes_together() {
         let source = "`VAR=\"a b\" OTHER=$(printf '%s\\n' value) \\$cmd arg`";
-        let backtick_spans = backtick_substitution_spans(source);
-        let escaped = backtick_escaped_parameters(source, &backtick_spans);
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        let backtick_spans = backtick_substitution_spans(locator);
+        let escaped = backtick_escaped_parameters(locator, &backtick_spans);
 
         assert_eq!(escaped.len(), 1);
         assert!(escaped[0].standalone_command_name);
@@ -1154,8 +1164,10 @@ mod tests {
     #[test]
     fn backtick_escaped_parameters_accept_append_assignment_prefixes() {
         let source = "`VAR+=x \\$cmd arg`";
-        let backtick_spans = backtick_substitution_spans(source);
-        let escaped = backtick_escaped_parameters(source, &backtick_spans);
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        let backtick_spans = backtick_substitution_spans(locator);
+        let escaped = backtick_escaped_parameters(locator, &backtick_spans);
 
         assert_eq!(escaped.len(), 1);
         assert!(escaped[0].standalone_command_name);
@@ -1164,8 +1176,10 @@ mod tests {
     #[test]
     fn backtick_escaped_parameters_accept_redirection_prefixes() {
         let source = "`>/tmp/out 2>\"/tmp err\" FOO=bar \\$cmd arg`";
-        let backtick_spans = backtick_substitution_spans(source);
-        let escaped = backtick_escaped_parameters(source, &backtick_spans);
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        let backtick_spans = backtick_substitution_spans(locator);
+        let escaped = backtick_escaped_parameters(locator, &backtick_spans);
 
         assert_eq!(escaped.len(), 1);
         assert!(escaped[0].standalone_command_name);
@@ -1174,18 +1188,17 @@ mod tests {
     fn span_for_text(source: &str, text: &str) -> Span {
         let start_offset = source.find(text).expect("expected text");
         let end_offset = start_offset + text.len();
-        Span::from_positions(
-            position_at_offset(source, start_offset).expect("expected start position"),
-            position_at_offset(source, end_offset).expect("expected end position"),
-        )
+        span_at(source, start_offset, end_offset)
     }
 
     #[test]
     fn backtick_double_escaped_parameter_spans_track_quoted_templates() {
         let source =
             r#"`echo "foreach dir {puts \\$dir} literal \\\\$literal"` `echo "plain $missing"`"#;
-        let backtick_spans = backtick_substitution_spans(source);
-        let escaped = backtick_double_escaped_parameter_spans(source, &backtick_spans);
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        let backtick_spans = backtick_substitution_spans(locator);
+        let escaped = backtick_double_escaped_parameter_spans(locator, &backtick_spans);
 
         assert_eq!(
             escaped

--- a/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
+++ b/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
@@ -2,11 +2,11 @@ use super::*;
 
 pub fn collect_command_substitution_part_spans_in_source(
     word: &Word,
-    source: &str,
+    locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
     collect_command_substitution_spans(&word.parts, spans);
-    normalize_command_substitution_spans(spans, source);
+    normalize_command_substitution_spans(spans, locator);
 }
 
 pub fn arithmetic_expansion_part_spans(word: &Word) -> Vec<Span> {
@@ -29,20 +29,20 @@ pub fn unquoted_command_substitution_part_spans(word: &Word) -> Vec<Span> {
 
 pub fn collect_unquoted_command_substitution_part_spans_in_source(
     word: &Word,
-    source: &str,
+    locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
     collect_unquoted_command_substitution_spans(&word.parts, false, spans);
-    normalize_command_substitution_spans(spans, source);
+    normalize_command_substitution_spans(spans, locator);
 }
 
 pub fn collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
     word: &Word,
-    source: &str,
+    locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
     collect_unquoted_dollar_paren_command_substitution_spans(&word.parts, false, spans);
-    normalize_command_substitution_spans(spans, source);
+    normalize_command_substitution_spans(spans, locator);
 }
 
 pub(crate) fn collect_command_substitution_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {
@@ -132,18 +132,19 @@ pub(crate) fn collect_unquoted_dollar_paren_command_substitution_spans(
     }
 }
 
-pub(crate) fn normalize_command_substitution_span(span: Span, source: &str) -> Span {
+pub(crate) fn normalize_command_substitution_span(span: Span, locator: Locator<'_>) -> Span {
+    let source = locator.source();
     let text = span.slice(source);
     if text.starts_with("$(")
         && !text.ends_with(')')
-        && let Some(normalized) = widen_dollar_paren_command_substitution_span(span, source)
+        && let Some(normalized) = widen_dollar_paren_command_substitution_span(span, locator)
     {
         return normalized;
     }
 
     if text.starts_with('`')
         && !text.ends_with('`')
-        && let Some(normalized) = widen_backtick_command_substitution_span(span, source)
+        && let Some(normalized) = widen_backtick_command_substitution_span(span, locator)
     {
         return normalized;
     }
@@ -151,16 +152,17 @@ pub(crate) fn normalize_command_substitution_span(span: Span, source: &str) -> S
     span
 }
 
-pub(crate) fn normalize_command_substitution_spans(spans: &mut [Span], source: &str) {
+pub(crate) fn normalize_command_substitution_spans(spans: &mut [Span], locator: Locator<'_>) {
     for span in spans {
-        *span = normalize_command_substitution_span(*span, source);
+        *span = normalize_command_substitution_span(*span, locator);
     }
 }
 
 pub(crate) fn widen_dollar_paren_command_substitution_span(
     span: Span,
-    source: &str,
+    locator: Locator<'_>,
 ) -> Option<Span> {
+    let source = locator.source();
     let mut index = span.start.offset;
     let bytes = source.as_bytes();
     if bytes.get(index)? != &b'$' || bytes.get(index + 1)? != &b'(' {
@@ -203,8 +205,8 @@ pub(crate) fn widen_dollar_paren_command_substitution_span(
                     depth = depth.saturating_sub(1);
                     index += 1;
                     if depth == 0 {
-                        let start = position_at_offset(source, span.start.offset)?;
-                        let end = position_at_offset(source, index)?;
+                        let start = locator.position_at_offset(span.start.offset)?;
+                        let end = locator.position_at_offset(index)?;
                         return Some(Span::from_positions(start, end));
                     }
                     continue;
@@ -236,8 +238,8 @@ pub(crate) fn widen_dollar_paren_command_substitution_span(
                 depth = depth.saturating_sub(1);
                 index += 1;
                 if depth == 0 {
-                    let start = position_at_offset(source, span.start.offset)?;
-                    let end = position_at_offset(source, index)?;
+                    let start = locator.position_at_offset(span.start.offset)?;
+                    let end = locator.position_at_offset(index)?;
                     return Some(Span::from_positions(start, end));
                 }
             }
@@ -250,7 +252,11 @@ pub(crate) fn widen_dollar_paren_command_substitution_span(
     None
 }
 
-pub(crate) fn widen_backtick_command_substitution_span(span: Span, source: &str) -> Option<Span> {
+pub(crate) fn widen_backtick_command_substitution_span(
+    span: Span,
+    locator: Locator<'_>,
+) -> Option<Span> {
+    let source = locator.source();
     let mut index = span.start.offset;
     let bytes = source.as_bytes();
     if bytes.get(index)? != &b'`' {
@@ -263,8 +269,8 @@ pub(crate) fn widen_backtick_command_substitution_span(span: Span, source: &str)
             b'\\' => index = index.saturating_add(2),
             b'`' => {
                 index += 1;
-                let start = position_at_offset(source, span.start.offset)?;
-                let end = position_at_offset(source, index)?;
+                let start = locator.position_at_offset(span.start.offset)?;
+                let end = locator.position_at_offset(index)?;
                 return Some(Span::from_positions(start, end));
             }
             _ => index += 1,
@@ -277,12 +283,14 @@ pub(crate) fn widen_backtick_command_substitution_span(span: Span, source: &str)
 #[cfg(test)]
 mod tests {
     use shuck_ast::{Span, Word};
+    use shuck_indexer::LineIndex;
     use shuck_parser::parser::Parser;
 
     use super::{
         collect_command_substitution_spans,
         collect_unquoted_dollar_paren_command_substitution_part_spans_in_source,
     };
+    use crate::Locator;
 
     fn command_substitution_part_spans(word: &Word) -> Vec<Span> {
         let mut spans = Vec::new();
@@ -294,9 +302,11 @@ mod tests {
         word: &Word,
         source: &str,
     ) -> Vec<Span> {
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
         let mut spans = Vec::new();
         collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
-            word, source, &mut spans,
+            word, locator, &mut spans,
         );
         spans
     }

--- a/crates/shuck-linter/src/facts/word_spans/expansions.rs
+++ b/crates/shuck-linter/src/facts/word_spans/expansions.rs
@@ -6,9 +6,13 @@ pub fn expansion_part_spans(word: &Word) -> Vec<Span> {
     spans
 }
 
-pub fn collect_active_expansion_spans_in_source(word: &Word, source: &str, spans: &mut Vec<Span>) {
+pub fn collect_active_expansion_spans_in_source(
+    word: &Word,
+    locator: Locator<'_>,
+    spans: &mut Vec<Span>,
+) {
     collect_expansion_spans(&word.parts, spans);
-    normalize_command_substitution_spans(spans, source);
+    normalize_command_substitution_spans(spans, locator);
     spans.extend(
         word.brace_syntax()
             .iter()

--- a/crates/shuck-linter/src/facts/word_spans/mod.rs
+++ b/crates/shuck-linter/src/facts/word_spans/mod.rs
@@ -6,6 +6,7 @@ use shuck_ast::{
 };
 
 use super::BacktickEscapedParameter;
+use crate::Locator;
 
 mod arrays;
 mod backticks;

--- a/crates/shuck-linter/src/facts/word_spans/shell_quoting.rs
+++ b/crates/shuck-linter/src/facts/word_spans/shell_quoting.rs
@@ -425,8 +425,10 @@ mod tests {
     }
 
     fn unquoted_command_substitution_part_spans_in_source(word: &Word, source: &str) -> Vec<Span> {
+        let line_index = shuck_indexer::LineIndex::new(source);
+        let locator = crate::Locator::new(source, &line_index);
         let mut spans = Vec::new();
-        collect_unquoted_command_substitution_part_spans_in_source(word, source, &mut spans);
+        collect_unquoted_command_substitution_part_spans_in_source(word, locator, &mut spans);
         spans
     }
 

--- a/crates/shuck-linter/src/facts/word_spans/source_scan.rs
+++ b/crates/shuck-linter/src/facts/word_spans/source_scan.rs
@@ -11,18 +11,6 @@ pub(crate) fn advance_shell_char(text: &str, index: usize) -> usize {
         .map_or(index + 1, |ch| index + ch.len_utf8())
 }
 
-pub(crate) fn position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
-    if target_offset > source.len() {
-        return None;
-    }
-
-    let mut position = Position::new();
-    for ch in source[..target_offset].chars() {
-        position.advance(ch);
-    }
-    Some(position)
-}
-
 pub(crate) fn collect_scan_span_excluding(
     span: Span,
     excluded: &[Span],

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -401,6 +401,7 @@ pub(super) struct WordFactLookup<'facts, 'a> {
     pub(super) word_index: &'facts FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     pub(super) fact_store: &'facts FactStore<'a>,
     pub(super) source: &'a str,
+    pub(super) line_index: &'facts LineIndex,
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
@@ -424,7 +425,9 @@ pub(super) fn build_echo_to_sed_substitution_spans<'a>(
 
     spans.extend(commands.iter().filter_map(|command| {
         (!pipeline_sed_command_ids.contains(&command.id()))
-            .then(|| sc2001_like_here_string_span(command, backticks, lookup.source))
+            .then(|| {
+                sc2001_like_here_string_span(command, backticks, lookup.source, lookup.line_index)
+            })
             .flatten()
     }));
 
@@ -505,7 +508,13 @@ pub(super) fn sc2001_like_pipeline_span<'a>(
             lookup.source,
         )
     {
-        return sc2001_like_backtick_pipeline_span(commands, pipeline, right, lookup.source);
+        return sc2001_like_backtick_pipeline_span(
+            commands,
+            pipeline,
+            right,
+            lookup.source,
+            lookup.line_index,
+        );
     }
 
     if word_occurrence_is_escaped_double_quoted_dynamic(
@@ -528,6 +537,7 @@ pub(super) fn sc2001_like_here_string_span(
     command: CommandFactRef<'_, '_>,
     backticks: &[BacktickFragmentFact],
     source: &str,
+    line_index: &LineIndex,
 ) -> Option<Span> {
     if !command_is_plain_named(command, "sed") {
         return None;
@@ -547,7 +557,7 @@ pub(super) fn sc2001_like_here_string_span(
     }
 
     if command_is_inside_backtick_fragment(command, backticks) {
-        return sc2001_like_backtick_command_span(command, source);
+        return sc2001_like_backtick_command_span(command, source, line_index);
     }
 
     command_span_with_redirects_and_shellcheck_tail(command, source)
@@ -562,24 +572,30 @@ pub(super) fn sc2001_like_backtick_pipeline_span(
     pipeline: &PipelineFact<'_>,
     sed_command: CommandFactRef<'_, '_>,
     source: &str,
+    line_index: &LineIndex,
 ) -> Option<Span> {
     let first_segment = pipeline.first_segment()?;
     let first = command_fact_ref(commands, first_segment.command_id());
     let start = first.body_name_word()?.span.start;
-    let end = sc2001_like_backtick_sed_script_end(sed_command.body_args(), source)?;
+    let end = sc2001_like_backtick_sed_script_end(sed_command.body_args(), source, line_index)?;
     Some(Span::from_positions(start, end))
 }
 
 pub(super) fn sc2001_like_backtick_command_span(
     command: CommandFactRef<'_, '_>,
     source: &str,
+    line_index: &LineIndex,
 ) -> Option<Span> {
     let start = command.body_name_word()?.span.start;
-    let end = sc2001_like_backtick_sed_script_end(command.body_args(), source)?;
+    let end = sc2001_like_backtick_sed_script_end(command.body_args(), source, line_index)?;
     Some(Span::from_positions(start, end))
 }
 
-pub(super) fn sc2001_like_backtick_sed_script_end(args: &[&Word], source: &str) -> Option<Position> {
+pub(super) fn sc2001_like_backtick_sed_script_end(
+    args: &[&Word],
+    source: &str,
+    line_index: &LineIndex,
+) -> Option<Position> {
     let script_words = match args {
         [flag, words @ ..] if static_word_text(flag, source).as_deref() == Some("-e") => words,
         _ => args,
@@ -601,7 +617,7 @@ pub(super) fn sc2001_like_backtick_sed_script_end(args: &[&Word], source: &str) 
 
     let trim_chars = sc2001_like_backtick_sed_script_trim_chars(script_words, source)?;
     let end_offset = rewind_offset_by_chars(source, raw_script_end, trim_chars)?;
-    position_at_offset(source, end_offset)
+    Locator::new(source, line_index).position_at_offset(end_offset)
 }
 
 pub(super) fn backtick_sed_script_content_end_offset(text: &str, end_offset: usize) -> Option<usize> {

--- a/crates/shuck-linter/src/facts/words/mod.rs
+++ b/crates/shuck-linter/src/facts/words/mod.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::Locator;
 
 include!("expansion.rs");
 include!("occurrence.rs");

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -424,7 +424,13 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.word().parts_with_spans()
     }
 
-    pub fn diagnostic_part_span(self, part: &WordPart, part_span: Span, source: &str) -> Span {
+    pub fn diagnostic_part_span(
+        self,
+        part: &WordPart,
+        part_span: Span,
+        locator: Locator<'_>,
+    ) -> Span {
+        let source = locator.source();
         let adjusted = match part {
             WordPart::Variable(name) => {
                 let expected = format!("${}", name.as_str());
@@ -454,13 +460,13 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
 
         word_spans::shellcheck_collapsed_backtick_part_span(
             adjusted,
-            source,
+            locator,
             self.facts.backtick_substitution_spans(),
         )
     }
 
-    pub fn has_direct_all_elements_array_expansion_in_source(self, source: &str) -> bool {
-        word_spans::word_has_direct_all_elements_array_expansion_in_source(self.word(), source)
+    pub fn has_direct_all_elements_array_expansion_in_source(self, locator: Locator<'_>) -> bool {
+        word_spans::word_has_direct_all_elements_array_expansion_in_source(self.word(), locator)
     }
 
     pub fn has_quoted_all_elements_array_slice(self) -> bool {
@@ -536,8 +542,8 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         word_spans::word_folded_positional_at_splat_span_in_source(self.word(), source)
     }
 
-    pub fn folded_all_elements_array_span_in_source(self, source: &str) -> Option<Span> {
-        word_spans::word_folded_all_elements_array_span_in_source(self.word(), source)
+    pub fn folded_all_elements_array_span_in_source(self, locator: Locator<'_>) -> Option<Span> {
+        word_spans::word_folded_all_elements_array_span_in_source(self.word(), locator)
     }
 
     pub fn zsh_flag_modifier_spans(self) -> Vec<Span> {
@@ -874,9 +880,11 @@ pub(super) fn build_unquoted_command_argument_use_offsets(
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
+#[allow(clippy::too_many_arguments)]
 pub(super) fn build_word_facts_for_command<'a>(
     visit: CommandVisit<'a>,
     source: &'a str,
+    locator: Locator<'a>,
     semantic: &'a SemanticModel,
     context: WordFactCommandContext,
     normalized: &NormalizedCommand<'a>,
@@ -885,6 +893,7 @@ pub(super) fn build_word_facts_for_command<'a>(
 ) {
     let mut collector = WordFactCollector::new(
         source,
+        locator,
         semantic,
         context.command_id,
         context.nested_word_command,
@@ -937,10 +946,11 @@ pub(super) type PendingArithmeticSeenKey = (FactSpan, ExpansionContext, WordFact
 
 pub(super) fn derive_word_fact_data<'a>(
     word: &'a Word,
-    source: &'a str,
+    locator: Locator<'a>,
     span_store: &mut ListArena<Span>,
     scratch: &mut Vec<Span>,
 ) -> WordNodeDerived<'a> {
+    let source = locator.source();
     let may_have_runtime_expansion_spans = word_may_have_runtime_expansion_spans(word);
     let may_have_command_substitution_spans = word_may_have_command_substitution_spans(word);
     let may_have_mixed_quote_spans =
@@ -957,7 +967,7 @@ pub(super) fn derive_word_fact_data<'a>(
             scratch,
             may_have_runtime_expansion_spans || word.has_active_brace_expansion(),
             |spans| {
-                word_spans::collect_active_expansion_spans_in_source(word, source, spans);
+                word_spans::collect_active_expansion_spans_in_source(word, locator, spans);
             },
         ),
         scalar_expansion_spans: push_needed_word_span_list(
@@ -989,7 +999,7 @@ pub(super) fn derive_word_fact_data<'a>(
             scratch,
             may_have_runtime_expansion_spans,
             |spans| {
-                word_spans::collect_all_elements_array_expansion_part_spans(word, source, spans);
+                word_spans::collect_all_elements_array_expansion_part_spans(word, locator, spans);
             },
         ),
         direct_all_elements_array_expansion_spans: push_needed_word_span_list(
@@ -998,7 +1008,7 @@ pub(super) fn derive_word_fact_data<'a>(
             may_have_runtime_expansion_spans,
             |spans| {
                 word_spans::collect_direct_all_elements_array_expansion_part_spans(
-                    word, source, spans,
+                    word, locator, spans,
                 );
             },
         ),
@@ -1025,7 +1035,7 @@ pub(super) fn derive_word_fact_data<'a>(
             scratch,
             may_have_command_substitution_spans,
             |spans| {
-                word_spans::collect_command_substitution_part_spans_in_source(word, source, spans);
+                word_spans::collect_command_substitution_part_spans_in_source(word, locator, spans);
             },
         ),
         unquoted_command_substitution_spans: push_needed_word_span_list(
@@ -1034,7 +1044,7 @@ pub(super) fn derive_word_fact_data<'a>(
             may_have_command_substitution_spans,
             |spans| {
                 word_spans::collect_unquoted_command_substitution_part_spans_in_source(
-                    word, source, spans,
+                    word, locator, spans,
                 );
             },
         ),
@@ -1044,7 +1054,7 @@ pub(super) fn derive_word_fact_data<'a>(
             may_have_command_substitution_spans,
             |spans| {
                 word_spans::collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
-                    word, source, spans,
+                    word, locator, spans,
                 );
             },
         ),
@@ -1210,6 +1220,7 @@ pub(super) fn trailing_literal_char_in_parts(parts: &[WordPartNode], source: &st
 
 pub(super) struct WordFactCollector<'out, 'a, 'norm> {
     source: &'a str,
+    locator: Locator<'a>,
     semantic: &'a SemanticModel,
     command_id: CommandId,
     nested_word_command: bool,
@@ -1257,6 +1268,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     #[allow(clippy::too_many_arguments)]
     fn new(
         source: &'a str,
+        locator: Locator<'a>,
         semantic: &'a SemanticModel,
         command_id: CommandId,
         nested_word_command: bool,
@@ -1267,6 +1279,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     ) -> Self {
         Self {
             source,
+            locator,
             semantic,
             command_id,
             nested_word_command,
@@ -2181,7 +2194,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         let id = WordNodeId::new(self.word_nodes.len());
         let analysis = analyze_word(word, self.source, self.command_zsh_options.as_ref());
         let derived =
-            derive_word_fact_data(word, self.source, self.word_spans, self.word_span_scratch);
+            derive_word_fact_data(word, self.locator, self.word_spans, self.word_span_scratch);
         self.word_nodes.push(WordNode {
             key,
             word,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -17,6 +17,8 @@ mod fix;
 #[allow(missing_docs)]
 mod fix_helpers;
 #[allow(missing_docs)]
+mod locator;
+#[allow(missing_docs)]
 mod parse_diagnostics;
 #[allow(missing_docs)]
 mod registry;
@@ -79,6 +81,7 @@ pub(crate) use facts::{
 /// Autofix types and fix application helpers.
 pub use fix::{Applicability, AppliedFixes, Edit, Fix, FixAvailability, apply_fixes};
 pub(crate) use fix_helpers::leading_static_word_prefix_fix_in_source;
+pub(crate) use locator::Locator;
 /// Rule identifiers, categories, and registry lookup helpers.
 pub use registry::{Category, Rule, code_to_rule};
 /// Rule metadata lookup utilities.
@@ -106,8 +109,9 @@ pub use suppression::{
 pub use violation::Violation;
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::{Command, CompoundCommand, File, Position, Span, Stmt, StmtSeq, TextSize};
-use shuck_indexer::{Indexer, LineIndex};
+use shuck_ast::{Command, CompoundCommand, File, Span, Stmt, StmtSeq, TextSize};
+use shuck_indexer::Indexer;
+
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::{
     CommandKind, CompoundCommandKind, FlowContext, ScopeId, SemanticBuildOptions,
@@ -863,10 +867,10 @@ pub fn lint_file_at_path_with_resolver(
     );
     let mut diagnostics = analysis.diagnostics;
 
+    let locator = Locator::new(source, indexer.line_index());
     diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
         file,
-        source,
-        indexer.line_index(),
+        locator,
         Some(&parse_result),
         &analysis.semantic,
         &settings.rules,
@@ -926,6 +930,7 @@ pub(crate) fn lint_file_at_path_with_resolver_and_parse_result_and_directives(
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
 ) -> Vec<Diagnostic> {
     let shell = resolve_shell(settings, source, source_path);
+    let locator = Locator::new(source, indexer.line_index());
     let mut file_entry_contract_collector =
         ambient_contracts::AmbientContractCollector::new(source, source_path, shell);
     let analyzed_paths_fallback =
@@ -971,15 +976,14 @@ pub(crate) fn lint_file_at_path_with_resolver_and_parse_result_and_directives(
 
     diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
         &parse_result.file,
-        source,
-        indexer.line_index(),
+        locator,
         Some(parse_result),
         &linter_semantic_artifacts,
         &settings.rules,
         shell,
     ));
     if parse_result.is_err() {
-        sanitize_diagnostic_spans_cold(&mut diagnostics, source, indexer);
+        sanitize_diagnostic_spans_cold(&mut diagnostics, locator);
     }
 
     for diagnostic in &mut diagnostics {
@@ -1117,14 +1121,15 @@ fn filter_per_file_ignored_diagnostics(
 
 #[cold]
 #[inline(never)]
-fn sanitize_diagnostic_spans_cold(diagnostics: &mut [Diagnostic], source: &str, indexer: &Indexer) {
+fn sanitize_diagnostic_spans_cold(diagnostics: &mut [Diagnostic], locator: Locator<'_>) {
     for diagnostic in diagnostics {
-        diagnostic.span = sanitize_span(diagnostic.span, source, indexer.line_index());
+        diagnostic.span = sanitize_span(diagnostic.span, locator);
     }
 }
 
 #[cold]
-fn sanitize_span(span: Span, source: &str, line_index: &LineIndex) -> Span {
+fn sanitize_span(span: Span, locator: Locator<'_>) -> Span {
+    let source = locator.source();
     if span.start.offset <= span.end.offset
         && span.end.offset <= source.len()
         && source.is_char_boundary(span.start.offset)
@@ -1156,24 +1161,9 @@ fn sanitize_span(span: Span, source: &str, line_index: &LineIndex) -> Span {
     };
 
     Span::from_positions(
-        position_at_offset(source, line_index, start_offset),
-        position_at_offset(source, line_index, end_offset),
+        locator.position_at_offset_unchecked(start_offset),
+        locator.position_at_offset_unchecked(end_offset),
     )
-}
-
-#[cold]
-fn position_at_offset(source: &str, line_index: &LineIndex, target_offset: usize) -> Position {
-    let line = line_index.line_number(TextSize::new(target_offset as u32));
-    let line_start = line_index
-        .line_start(line)
-        .map(usize::from)
-        .unwrap_or_default();
-
-    Position {
-        line,
-        column: source[line_start..target_offset].chars().count() + 1,
-        offset: target_offset,
-    }
 }
 
 #[cold]

--- a/crates/shuck-linter/src/locator.rs
+++ b/crates/shuck-linter/src/locator.rs
@@ -1,0 +1,59 @@
+//! Source slicing helper bundling the script text with its line index.
+//!
+//! Mirrors the `Locator` pattern from `ruff_linter`. Helpers that need to
+//! resolve byte offsets to [`Position`]s should accept a `Locator<'_>` instead
+//! of separate `source: &str` and `line_index: &LineIndex` parameters; this
+//! keeps signatures compact while still routing every offset lookup through
+//! the precomputed [`LineIndex`].
+
+use shuck_ast::{Position, TextSize};
+use shuck_indexer::LineIndex;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Locator<'a> {
+    source: &'a str,
+    line_index: &'a LineIndex,
+}
+
+impl<'a> Locator<'a> {
+    pub fn new(source: &'a str, line_index: &'a LineIndex) -> Self {
+        Self { source, line_index }
+    }
+
+    pub fn source(&self) -> &'a str {
+        self.source
+    }
+
+    pub fn line_index(&self) -> &'a LineIndex {
+        self.line_index
+    }
+
+    /// Resolve a byte offset to a [`Position`] using the precomputed
+    /// [`LineIndex`]. Returns `None` if `offset` is past the end of the source.
+    #[inline]
+    pub fn position_at_offset(&self, offset: usize) -> Option<Position> {
+        if offset > self.source.len() {
+            return None;
+        }
+        Some(self.position_at_offset_unchecked(offset))
+    }
+
+    /// Same as [`Locator::position_at_offset`] but without the bounds check.
+    /// The caller must guarantee `offset <= source.len()` and that `offset`
+    /// lies on a UTF-8 char boundary.
+    #[inline]
+    pub fn position_at_offset_unchecked(&self, offset: usize) -> Position {
+        let line = self.line_index.line_number(TextSize::new(offset as u32));
+        let line_start = self
+            .line_index
+            .line_start(line)
+            .map(usize::from)
+            .unwrap_or_default();
+
+        Position {
+            line,
+            column: self.source[line_start..offset].chars().count() + 1,
+            offset,
+        }
+    }
+}

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -1,6 +1,7 @@
 use shuck_ast::{File, Position, Span};
-use shuck_indexer::LineIndex;
 use shuck_parser::parser::{ParseDiagnostic, ParseResult};
+
+use crate::Locator;
 
 use crate::rules::correctness::c_prototype_fragment::CPrototypeFragment;
 use crate::rules::correctness::dangling_else::DanglingElse;
@@ -44,13 +45,13 @@ impl Violation for ExtglobInCasePattern {
 
 pub(crate) fn collect_parse_rule_diagnostics(
     file: &File,
-    source: &str,
-    line_index: &LineIndex,
+    locator: Locator<'_>,
     parse_result: Option<&ParseResult>,
     semantic: &LinterSemanticArtifacts<'_>,
     enabled_rules: &RuleSet,
     shell: ShellDialect,
 ) -> Vec<Diagnostic> {
+    let source = locator.source();
     let mut diagnostics = Vec::new();
     let parse_diagnostics = parse_result
         .map(|result| result.diagnostics.as_slice())
@@ -69,7 +70,7 @@ pub(crate) fn collect_parse_rule_diagnostics(
             .push(Diagnostic::new(MissingFi, eof_point(file)).with_fix(missing_fi_fix(source)));
     }
     if enabled_rules.contains(crate::Rule::IfMissingThen)
-        && let Some(span) = if_missing_then_span(source, line_index, parse_diagnostics)
+        && let Some(span) = if_missing_then_span(locator, parse_diagnostics)
     {
         diagnostics.push(Diagnostic::new(IfMissingThen, span));
     }
@@ -89,17 +90,17 @@ pub(crate) fn collect_parse_rule_diagnostics(
         diagnostics.push(Diagnostic::new(DanglingElse, span));
     }
     if enabled_rules.contains(crate::Rule::UntilMissingDo)
-        && let Some(span) = until_missing_do_span(source, line_index, parse_diagnostics)
+        && let Some(span) = until_missing_do_span(locator, parse_diagnostics)
     {
         diagnostics.push(Diagnostic::new(UntilMissingDo, span));
     }
     if enabled_rules.contains(crate::Rule::IfBracketGlued)
-        && let Some(span) = if_bracket_glued_span(source, line_index, parse_diagnostics)
+        && let Some(span) = if_bracket_glued_span(locator, parse_diagnostics)
     {
         diagnostics.push(Diagnostic::new(IfBracketGlued, span));
     }
     if enabled_rules.contains(crate::Rule::LinebreakBeforeAnd) {
-        for span in linebreak_before_and_spans(source, line_index, parse_diagnostics) {
+        for span in linebreak_before_and_spans(locator, parse_diagnostics) {
             diagnostics.push(Diagnostic::new(LinebreakBeforeAnd, span));
         }
     }
@@ -110,7 +111,7 @@ pub(crate) fn collect_parse_rule_diagnostics(
         )
     {
         for diagnostic in parse_diagnostics {
-            if let Some(span) = function_parameter_syntax_span(source, line_index, diagnostic) {
+            if let Some(span) = function_parameter_syntax_span(locator, diagnostic) {
                 diagnostics.push(Diagnostic::new(FunctionParamsInSh, span));
             }
         }
@@ -118,7 +119,7 @@ pub(crate) fn collect_parse_rule_diagnostics(
 
     if enabled_rules.contains(crate::Rule::CPrototypeFragment) {
         for diagnostic in parse_diagnostics {
-            let Some(span) = c_prototype_fragment_span(diagnostic, source, line_index) else {
+            let Some(span) = c_prototype_fragment_span(diagnostic, locator) else {
                 continue;
             };
             diagnostics.push(
@@ -187,8 +188,7 @@ fn is_missing_then_error(message: &str) -> bool {
 }
 
 fn if_missing_then_span(
-    source: &str,
-    line_index: &LineIndex,
+    locator: Locator<'_>,
     parse_diagnostics: &[ParseDiagnostic],
 ) -> Option<Span> {
     parse_diagnostics.iter().find_map(|diagnostic| {
@@ -201,7 +201,7 @@ fn if_missing_then_span(
         let mut line = diagnostic.span.start.line;
         let mut saw_then = false;
         while line > 0 {
-            let text = line_text_at(source, line_index, line)?;
+            let text = line_text_at(locator, line)?;
             let trimmed = text.trim_start();
             if trimmed.is_empty() || trimmed.starts_with('#') {
                 line = line.saturating_sub(1);
@@ -221,8 +221,8 @@ fn if_missing_then_span(
                 if saw_then {
                     return None;
                 }
-                let offset = line_start_offset(line_index, source, line)?;
-                let start = position_at_offset(source, offset)?;
+                let offset = line_start_offset(locator, line)?;
+                let start = locator.position_at_offset(offset)?;
                 return Some(Span::from_positions(start, start));
             }
             if trimmed == "elif" || trimmed.starts_with("elif ") || trimmed.starts_with("elif\t") {
@@ -385,15 +385,14 @@ fn is_function_parameter_syntax_error(message: &str) -> bool {
 }
 
 fn function_parameter_syntax_span(
-    source: &str,
-    line_index: &LineIndex,
+    locator: Locator<'_>,
     diagnostic: &ParseDiagnostic,
 ) -> Option<Span> {
     if !is_function_parameter_syntax_error(&diagnostic.message) {
         return None;
     }
 
-    let line = line_text_at(source, line_index, diagnostic.span.start.line)?;
+    let line = line_text_at(locator, diagnostic.span.start.line)?;
     let search_end = line
         .char_indices()
         .nth(diagnostic.span.start.column.saturating_sub(1))
@@ -405,16 +404,15 @@ fn function_parameter_syntax_span(
             line.get(search_end..)
                 .and_then(|suffix| suffix.find('(').map(|relative| search_end + relative))
         })?;
-    let line_start = line_start_offset(line_index, source, diagnostic.span.start.line)?;
+    let line_start = line_start_offset(locator, diagnostic.span.start.line)?;
     let start_offset = line_start + paren_index;
-    let start = position_at_offset(source, start_offset)?;
-    let end = position_at_offset(source, start_offset + 1)?;
+    let start = locator.position_at_offset(start_offset)?;
+    let end = locator.position_at_offset(start_offset + 1)?;
     Some(Span::from_positions(start, end))
 }
 
 fn linebreak_before_and_spans(
-    source: &str,
-    line_index: &LineIndex,
+    locator: Locator<'_>,
     parse_diagnostics: &[ParseDiagnostic],
 ) -> Vec<Span> {
     parse_diagnostics
@@ -424,17 +422,13 @@ fn linebreak_before_and_spans(
                 return None;
             }
 
-            leading_control_operator_span(source, line_index, diagnostic.span.start.line)
+            leading_control_operator_span(locator, diagnostic.span.start.line)
         })
         .collect()
 }
 
-fn leading_control_operator_span(
-    source: &str,
-    line_index: &LineIndex,
-    line_number: usize,
-) -> Option<Span> {
-    let line = line_text_at(source, line_index, line_number)?;
+fn leading_control_operator_span(locator: Locator<'_>, line_number: usize) -> Option<Span> {
+    let line = line_text_at(locator, line_number)?;
     let text = line.split_once('#').map_or(line, |(before, _)| before);
     let leading_bytes = text
         .bytes()
@@ -473,10 +467,10 @@ fn leading_control_operator_span(
         return None;
     };
 
-    let line_start = line_start_offset(line_index, source, line_number)?;
+    let line_start = line_start_offset(locator, line_number)?;
     let start_offset = line_start + leading_bytes;
-    let start = position_at_offset(source, start_offset)?;
-    let end = position_at_offset(source, start_offset + operator.len())?;
+    let start = locator.position_at_offset(start_offset)?;
+    let end = locator.position_at_offset(start_offset + operator.len())?;
     Some(Span::from_positions(start, end))
 }
 
@@ -488,40 +482,37 @@ fn dangling_else_span(parse_diagnostics: &[ParseDiagnostic]) -> Option<Span> {
 }
 
 fn until_missing_do_span(
-    source: &str,
-    line_index: &LineIndex,
+    locator: Locator<'_>,
     parse_diagnostics: &[ParseDiagnostic],
 ) -> Option<Span> {
     parse_diagnostics
         .iter()
         .find(|diagnostic| {
             is_expected_command_error(&diagnostic.message)
-                && is_done_line(source, line_index, diagnostic.span.start.line)
-                && has_pending_until_without_do_before_line(source, diagnostic.span.start.line)
+                && is_done_line(locator, diagnostic.span.start.line)
+                && has_pending_until_without_do_before_line(
+                    locator.source(),
+                    diagnostic.span.start.line,
+                )
         })
         .map(|diagnostic| diagnostic.span)
 }
 
 fn if_bracket_glued_span(
-    source: &str,
-    line_index: &LineIndex,
+    locator: Locator<'_>,
     parse_diagnostics: &[ParseDiagnostic],
 ) -> Option<Span> {
     parse_diagnostics.iter().find_map(|diagnostic| {
         if !is_expected_command_error(&diagnostic.message) {
             return None;
         }
-        if_bracket_glued_span_on_line(source, line_index, diagnostic.span.start.line)
+        if_bracket_glued_span_on_line(locator, diagnostic.span.start.line)
     })
 }
 
-fn if_bracket_glued_span_on_line(
-    source: &str,
-    line_index: &LineIndex,
-    line_number: usize,
-) -> Option<Span> {
-    let line = line_text_at(source, line_index, line_number)?;
-    let line_offset = line_start_offset(line_index, source, line_number)?;
+fn if_bracket_glued_span_on_line(locator: Locator<'_>, line_number: usize) -> Option<Span> {
+    let line = line_text_at(locator, line_number)?;
+    let line_offset = line_start_offset(locator, line_number)?;
     let bytes = line.as_bytes();
     if bytes.len() < 3 {
         return None;
@@ -605,8 +596,8 @@ fn if_bracket_glued_span_on_line(
 
                 let start_offset = line_offset + index;
                 let end_offset = start_offset + 3;
-                let start = position_at_offset(source, start_offset)?;
-                let end = position_at_offset(source, end_offset)?;
+                let start = locator.position_at_offset(start_offset)?;
+                let end = locator.position_at_offset(end_offset)?;
                 return Some(Span::from_positions(start, end));
             }
             _ => {
@@ -634,8 +625,8 @@ fn shell_comment_starts_at(bytes: &[u8], index: usize) -> bool {
         )
 }
 
-fn is_done_line(source: &str, line_index: &LineIndex, line_number: usize) -> bool {
-    line_text_at(source, line_index, line_number)
+fn is_done_line(locator: Locator<'_>, line_number: usize) -> bool {
+    line_text_at(locator, line_number)
         .map(|line| {
             let text = line.split_once('#').map_or(line, |(before, _)| before);
             shell_like_words(text).contains(&"done")
@@ -820,11 +811,7 @@ fn eof_point(file: &File) -> Span {
     Span::from_positions(file.span.end, file.span.end)
 }
 
-fn c_prototype_fragment_span(
-    diagnostic: &ParseDiagnostic,
-    source: &str,
-    line_index: &LineIndex,
-) -> Option<Span> {
+fn c_prototype_fragment_span(diagnostic: &ParseDiagnostic, locator: Locator<'_>) -> Option<Span> {
     if !diagnostic
         .message
         .starts_with("expected compound command for function body")
@@ -832,9 +819,9 @@ fn c_prototype_fragment_span(
         return None;
     }
     let line = diagnostic.span.start.line;
-    let line_text = line_text_at(source, line_index, line)?;
+    let line_text = line_text_at(locator, line)?;
     let column = find_attached_background_ampersand_column(line_text)?;
-    let line_start_offset = line_start_offset(line_index, source, line)?;
+    let line_start_offset = line_start_offset(locator, line)?;
     let offset = line_start_offset + (column - 1);
     let point = Position {
         line,
@@ -842,17 +829,6 @@ fn c_prototype_fragment_span(
         offset,
     };
     Some(Span::from_positions(point, point))
-}
-
-fn position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
-    if target_offset > source.len() {
-        return None;
-    }
-    let mut position = Position::new();
-    for ch in source[..target_offset].chars() {
-        position.advance(ch);
-    }
-    Some(position)
 }
 
 fn find_attached_background_ampersand_column(line: &str) -> Option<usize> {
@@ -886,12 +862,9 @@ fn find_attached_background_ampersand_column(line: &str) -> Option<usize> {
     None
 }
 
-fn line_text_at<'a>(
-    source: &'a str,
-    line_index: &LineIndex,
-    target_line: usize,
-) -> Option<&'a str> {
-    let range = line_index.line_range(target_line, source)?;
+fn line_text_at<'a>(locator: Locator<'a>, target_line: usize) -> Option<&'a str> {
+    let source = locator.source();
+    let range = locator.line_index().line_range(target_line, source)?;
     let start = usize::from(range.start());
     let end = usize::from(range.end());
     if start == end && start >= source.len() {
@@ -903,10 +876,12 @@ fn line_text_at<'a>(
     Some(text.strip_suffix('\r').unwrap_or(text))
 }
 
-fn line_start_offset(line_index: &LineIndex, source: &str, target_line: usize) -> Option<usize> {
+fn line_start_offset(locator: Locator<'_>, target_line: usize) -> Option<usize> {
+    let line_index = locator.line_index();
     if let Some(start) = line_index.line_start(target_line) {
         return Some(usize::from(start));
     }
+    let source = locator.source();
     // Tolerate diagnostics referencing the implicit empty line at EOF when the
     // source has no trailing newline, matching the previous helper's behavior.
     if target_line == line_index.line_count() + 1
@@ -921,16 +896,15 @@ fn line_start_offset(line_index: &LineIndex, source: &str, target_line: usize) -
 mod tests {
     use shuck_ast::File;
     use shuck_indexer::Indexer;
-    use shuck_parser::parser::{ParseResult, Parser};
-
     use shuck_indexer::LineIndex;
+    use shuck_parser::parser::{ParseResult, Parser};
 
     use super::{
         collect_parse_rule_diagnostics as collect_parse_rule_diagnostics_impl,
         if_bracket_glued_span_on_line, is_expected_command_error, line_contains_shell_word,
     };
     use crate::{
-        Applicability, Diagnostic, LinterSemanticArtifacts, LinterSettings, Rule, RuleSet,
+        Applicability, Diagnostic, LinterSemanticArtifacts, LinterSettings, Locator, Rule, RuleSet,
         ShellDialect,
     };
 
@@ -944,10 +918,10 @@ mod tests {
         let parse_result = parse_result.expect("parse diagnostics tests pass a parse result");
         let indexer = Indexer::new(source, parse_result);
         let semantic = LinterSemanticArtifacts::build(file, source, &indexer);
+        let locator = Locator::new(source, indexer.line_index());
         collect_parse_rule_diagnostics_impl(
             file,
-            source,
-            indexer.line_index(),
+            locator,
             Some(parse_result),
             &semantic,
             enabled_rules,
@@ -1535,8 +1509,9 @@ esac
         ] {
             let source = format!("#!/bin/sh\n{line}\n");
             let line_index = LineIndex::new(&source);
+            let locator = Locator::new(&source, &line_index);
             assert!(
-                if_bracket_glued_span_on_line(&source, &line_index, 2).is_none(),
+                if_bracket_glued_span_on_line(locator, 2).is_none(),
                 "unexpected glued match for `{line}`"
             );
         }
@@ -1546,8 +1521,9 @@ esac
     fn ignores_quoted_if_bracket_prefix_text_on_line() {
         let source = "#!/bin/sh\necho \"if[ literal\"\n";
         let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
 
-        assert!(if_bracket_glued_span_on_line(source, &line_index, 2).is_none());
+        assert!(if_bracket_glued_span_on_line(locator, 2).is_none());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
@@ -17,6 +17,7 @@ impl Violation for ArraySliceInComparison {
 }
 
 pub fn array_slice_in_comparison(checker: &mut Checker) {
+    let locator = checker.locator();
     let direct_operand_spans = [
         ExpansionContext::StringTestOperand,
         ExpansionContext::RegexOperand,
@@ -24,7 +25,7 @@ pub fn array_slice_in_comparison(checker: &mut Checker) {
     .into_iter()
     .flat_map(|context| checker.facts().expansion_word_facts(context))
     .filter(|fact| !fact.is_nested_word_command())
-    .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(checker.source()))
+    .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(locator))
     .map(|fact| fact.span())
     .collect::<Vec<_>>();
 
@@ -34,7 +35,7 @@ pub fn array_slice_in_comparison(checker: &mut Checker) {
         .filter(|fact| !fact.is_nested_word_command())
         .filter(|fact| fact.command_substitution_spans().is_empty())
         .filter(|fact| !fact.is_pure_positional_at_splat())
-        .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(checker.source()))
+        .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(locator))
         .map(|fact| fact.span())
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -1,10 +1,10 @@
 use compact_str::CompactString;
 use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
-use shuck_ast::{Name, Position, Span};
+use shuck_ast::{Name, Span};
 
 use crate::facts::ComparableNameUseKind;
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Locator, Rule, Violation};
 
 use super::variable_reference_common::{
     VariableReferenceFilter, has_same_name_defining_bindings, is_environment_style_name,
@@ -242,7 +242,7 @@ fn heredoc_findings(
             }
 
             findings.push((
-                parameter_reference_span(checker.source(), name_use.span()),
+                parameter_reference_span(checker.locator(), name_use.span()),
                 reference_name.to_owned(),
                 candidate,
             ));
@@ -314,7 +314,7 @@ fn scope_compat_findings(
         }
 
         findings.push((
-            parameter_reference_span(checker.source(), name_use.span),
+            parameter_reference_span(checker.locator(), name_use.span),
             reference_name.to_owned(),
             candidate,
         ));
@@ -537,28 +537,17 @@ fn is_presence_tested_reference_name(
         .is_presence_tested_name(&Name::from(reference_name), reference_span)
 }
 
-fn parameter_reference_span(source: &str, span: Span) -> Span {
+fn parameter_reference_span(locator: Locator<'_>, span: Span) -> Span {
     let Some(previous_offset) = span.start.offset.checked_sub(1) else {
         return span;
     };
-    if source.as_bytes().get(previous_offset) != Some(&b'$') {
+    if locator.source().as_bytes().get(previous_offset) != Some(&b'$') {
         return span;
     }
-    let Some(start) = position_at_offset(source, previous_offset) else {
+    let Some(start) = locator.position_at_offset(previous_offset) else {
         return span;
     };
     Span::from_positions(start, span.end)
-}
-
-fn position_at_offset(source: &str, target_offset: usize) -> Option<Position> {
-    if target_offset > source.len() {
-        return None;
-    }
-    let mut position = Position::new();
-    for char in source[..target_offset].chars() {
-        position.advance(char);
-    }
-    Some(position)
 }
 
 fn looks_like_case_mismatch_reference(name: &str) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
@@ -14,7 +14,7 @@ impl Violation for QuotedArraySlice {
 
 pub fn quoted_array_slice(checker: &mut Checker) {
     let facts = checker.facts();
-    let source = checker.source();
+    let locator = checker.locator();
     let spans = [
         ExpansionContext::AssignmentValue,
         ExpansionContext::DeclarationAssignmentValue,
@@ -23,7 +23,7 @@ pub fn quoted_array_slice(checker: &mut Checker) {
     .flat_map(|context| facts.expansion_word_facts(context))
     .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
     .filter(|fact| !facts.is_compound_assignment_value_word(*fact))
-    .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(source))
+    .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(locator))
     .map(|fact| fact.span())
     .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
+++ b/crates/shuck-linter/src/rules/style/positional_args_in_string.rs
@@ -13,13 +13,14 @@ impl Violation for PositionalArgsInString {
 }
 
 pub fn positional_args_in_string(checker: &mut Checker) {
+    let locator = checker.locator();
     let spans = [
         ExpansionContext::CommandName,
         ExpansionContext::CommandArgument,
     ]
     .into_iter()
     .flat_map(|context| checker.facts().expansion_word_facts(context))
-    .filter_map(|fact| fact.folded_all_elements_array_span_in_source(checker.source()))
+    .filter_map(|fact| fact.folded_all_elements_array_span_in_source(locator))
     .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || PositionalArgsInString);

--- a/crates/shuck-linter/src/rules/style/single_iteration_loop.rs
+++ b/crates/shuck-linter/src/rules/style/single_iteration_loop.rs
@@ -15,7 +15,7 @@ impl Violation for SingleIterationLoop {
 }
 
 pub fn single_iteration_loop(checker: &mut Checker) {
-    let source = checker.source();
+    let locator = checker.locator();
     let spans = checker
         .facts()
         .for_headers()
@@ -37,7 +37,7 @@ pub fn single_iteration_loop(checker: &mut Checker) {
             {
                 return None;
             }
-            if fact.has_direct_all_elements_array_expansion_in_source(source) {
+            if fact.has_direct_all_elements_array_expansion_in_source(locator) {
                 return None;
             }
             let runtime_hazards = fact.runtime_literal().hazards;

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -5,7 +5,7 @@ use shuck_ast::Span;
 
 use self::safe_value::{S001QuoteExposure, SafeValueIndex, SafeValueQuery};
 use crate::{
-    Checker, ExpansionContext, FactSpan, Rule, ShellDialect, Violation, WordOccurrenceRef,
+    Checker, ExpansionContext, FactSpan, Locator, Rule, ShellDialect, Violation, WordOccurrenceRef,
 };
 
 pub struct UnquotedExpansion;
@@ -42,8 +42,10 @@ pub fn unquoted_expansion(checker: &mut Checker) {
         checker.facts().backtick_escaped_parameter_reference_spans();
 
     let mut spans = Vec::new();
+    let locator = checker.locator();
     let report_context = ReportContext {
         source,
+        locator,
         shell: checker.shell(),
         colon_command_ids: &colon_command_ids,
         numeric_test_operand_spans: &numeric_test_operand_spans,
@@ -55,7 +57,7 @@ pub fn unquoted_expansion(checker: &mut Checker) {
         collect_array_assignment_split_reports(
             &mut safe_values,
             &mut spans,
-            source,
+            locator,
             fact,
             &array_assignment_split_spans,
         );
@@ -88,6 +90,7 @@ pub fn unquoted_expansion(checker: &mut Checker) {
 
 struct ReportContext<'a> {
     source: &'a str,
+    locator: Locator<'a>,
     shell: ShellDialect,
     colon_command_ids: &'a FxHashSet<crate::facts::core::CommandId>,
     numeric_test_operand_spans: &'a [Span],
@@ -110,7 +113,7 @@ fn collect_word_fact_reports(
     report_word_expansions(
         spans,
         safe_values,
-        context.source,
+        context.locator,
         fact,
         WordReportOptions {
             context: expansion_context,
@@ -141,7 +144,7 @@ fn collect_arithmetic_word_fact_reports(
     report_word_expansions(
         spans,
         safe_values,
-        context.source,
+        context.locator,
         fact,
         WordReportOptions {
             context: expansion_context,
@@ -220,7 +223,7 @@ fn collect_array_assignment_split_candidate_spans(checker: &Checker) -> Vec<Span
 fn collect_array_assignment_split_reports(
     safe_values: &mut SafeValueIndex<'_>,
     spans: &mut Vec<Span>,
-    source: &str,
+    locator: Locator<'_>,
     fact: WordOccurrenceRef<'_, '_>,
     candidate_spans: &[Span],
 ) {
@@ -251,7 +254,7 @@ fn collect_array_assignment_split_reports(
             continue;
         }
 
-        spans.push(fact.diagnostic_part_span(part, part_span, source));
+        spans.push(fact.diagnostic_part_span(part, part_span, locator));
     }
 }
 
@@ -310,12 +313,13 @@ struct WordReportOptions<'a, F> {
 fn report_word_expansions<F>(
     spans: &mut Vec<Span>,
     safe_values: &mut SafeValueIndex<'_>,
-    source: &str,
+    locator: Locator<'_>,
     fact: WordOccurrenceRef<'_, '_>,
     options: WordReportOptions<'_, F>,
 ) where
     F: Fn(Span) -> bool,
 {
+    let source = locator.source();
     let WordReportOptions {
         context,
         in_colon_command,
@@ -414,7 +418,7 @@ fn report_word_expansions<F>(
             continue;
         }
 
-        spans.push(fact.diagnostic_part_span(part, part_span, source));
+        spans.push(fact.diagnostic_part_span(part, part_span, locator));
     }
 }
 


### PR DESCRIPTION
## Summary

- Bundles `&str` and `&LineIndex` into a single `Locator<'a>` value (modeled after ruff's `Locator`) and threads it through the linter facts builder, parse-diagnostic helpers, and rule helpers that previously took `(source, line_index)` parameter pairs.
- Removes seven copy-pasted `position_at_offset` / `position_at_offset_checked` helpers across `facts/{commands, model, simple_tests, heredocs, word_spans, words}`, `parse_diagnostics`, `lib.rs`, and `possible_variable_misspelling`. Every offset→position lookup now flows through one canonical `LineIndex`-backed implementation on `Locator`.
- No behavior change. `Checker::locator()` is the entry point for rules; fact builders take `Locator<'_>` and call `locator.position_at_offset(...)` instead of carrying the source and line index separately.

## Test plan

- [x] `cargo build -p shuck-cli -p shuck-cache`
- [x] `cargo test -p shuck-linter` (3144 + 8 tests passing)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`