### PR TITLE
perf(linter): cut three lint-time hotspots on large zsh files

### DIFF
--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -54,11 +54,99 @@ fn build_literal_brace_spans(
         &mut spans,
         &mut scratch,
     );
-    spans.retain(|span| !span_is_plain_parameter_expansion_edge_in_source(*span, source));
-    spans.retain(|span| !span_is_active_brace_expansion_edge_in_source(*span, source));
+    let plain_parameter_expansion_edges = build_plain_parameter_expansion_edge_offsets(source);
+    let active_brace_expansion_edges = build_active_brace_expansion_edge_offsets(source);
+    spans.retain(|span| {
+        !plain_parameter_expansion_edges.contains(&span.start.offset)
+            && !active_brace_expansion_edges.contains(&span.start.offset)
+    });
     spans.sort_by_key(|span| (span.start.offset, span.end.offset));
     spans.dedup_by_key(|span| (span.start.offset, span.end.offset));
     spans
+}
+
+fn build_plain_parameter_expansion_edge_offsets(source: &str) -> FxHashSet<usize> {
+    let mut offsets = FxHashSet::default();
+    let mut index = 0usize;
+
+    while index < source.len() {
+        if source[index..].starts_with("${")
+            && !has_odd_backslash_run_before(source, index)
+            && let Some(end_offset) = find_runtime_parameter_closing_brace(source, index)
+        {
+            let open_brace_offset = index + '$'.len_utf8();
+            let close_brace_offset = end_offset.saturating_sub('}'.len_utf8());
+            offsets.insert(open_brace_offset);
+            offsets.insert(close_brace_offset);
+            index = end_offset;
+            continue;
+        }
+
+        let Some(ch) = source[index..].chars().next() else {
+            break;
+        };
+        let ch_len = ch.len_utf8();
+        if ch == '\\' {
+            index += ch_len;
+            if let Some(escaped) = source[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
+            continue;
+        }
+
+        index += ch_len;
+    }
+
+    offsets
+}
+
+fn build_active_brace_expansion_edge_offsets(source: &str) -> FxHashSet<usize> {
+    let bytes = source.as_bytes();
+    let mut opens = Vec::new();
+    let mut closes = Vec::new();
+    for (offset, byte) in bytes.iter().enumerate() {
+        match byte {
+            b'{' => opens.push(offset),
+            b'}' => closes.push(offset),
+            _ => {}
+        }
+    }
+
+    let mut offsets = FxHashSet::default();
+    for &open_offset in &opens {
+        let close_index = closes.partition_point(|&close| close <= open_offset);
+        let Some(&close_offset) = closes.get(close_index) else {
+            continue;
+        };
+        if active_brace_pair_qualifies(source, open_offset, close_offset) {
+            offsets.insert(open_offset);
+            offsets.insert(close_offset);
+        }
+    }
+    for &close_offset in &closes {
+        let open_index = opens.partition_point(|&open| open < close_offset);
+        if open_index == 0 {
+            continue;
+        }
+        let open_offset = opens[open_index - 1];
+        if active_brace_pair_qualifies(source, open_offset, close_offset) {
+            offsets.insert(open_offset);
+            offsets.insert(close_offset);
+        }
+    }
+
+    offsets
+}
+
+fn active_brace_pair_qualifies(source: &str, open_offset: usize, close_offset: usize) -> bool {
+    if close_offset <= open_offset {
+        return false;
+    }
+    let text = &source[open_offset..=close_offset];
+    brace_text_has_unescaped_comma_or_sequence(text)
+        && text[1..text.len() - 1]
+            .chars()
+            .all(|candidate| !candidate.is_whitespace())
 }
 
 #[derive(Default)]
@@ -205,66 +293,6 @@ fn brace_span_is_plain_parameter_expansion_edge(word: &Word, span: Span, source:
     }
 
     false
-}
-
-fn span_is_plain_parameter_expansion_edge_in_source(span: Span, source: &str) -> bool {
-    let target_offset = span.start.offset;
-    let mut index = 0usize;
-
-    while index < source.len() {
-        if source[index..].starts_with("${")
-            && !has_odd_backslash_run_before(source, index)
-            && let Some(end_offset) = find_runtime_parameter_closing_brace(source, index)
-        {
-            let open_brace_offset = index + '$'.len_utf8();
-            let close_brace_offset = end_offset.saturating_sub('}'.len_utf8());
-            if target_offset == open_brace_offset || target_offset == close_brace_offset {
-                return true;
-            }
-            index = end_offset;
-            continue;
-        }
-
-        let Some(ch) = source[index..].chars().next() else {
-            break;
-        };
-        let ch_len = ch.len_utf8();
-        if ch == '\\' {
-            index += ch_len;
-            if let Some(escaped) = source[index..].chars().next() {
-                index += escaped.len_utf8();
-            }
-            continue;
-        }
-
-        index += ch_len;
-    }
-
-    false
-}
-
-fn span_is_active_brace_expansion_edge_in_source(span: Span, source: &str) -> bool {
-    let offset = span.start.offset;
-    let Some(ch) = source[offset..].chars().next() else {
-        return false;
-    };
-
-    let candidate = match ch {
-        '{' => source[offset..]
-            .find('}')
-            .map(|relative_end| &source[offset..=offset + relative_end]),
-        '}' => source[..offset]
-            .rfind('{')
-            .map(|start| &source[start..=offset]),
-        _ => None,
-    };
-
-    candidate.is_some_and(|text| {
-        brace_text_has_unescaped_comma_or_sequence(text)
-            && text[1..text.len() - 1]
-                .chars()
-                .all(|candidate| !candidate.is_whitespace())
-    })
 }
 
 fn is_find_exec_placeholder_word(
@@ -1493,13 +1521,13 @@ fn find_runtime_parameter_closing_brace(text: &str, start_offset: usize) -> Opti
             && bytes[index + 1] == b'('
             && bytes[index + 2] == b'('
         {
-            index = find_wrapped_arithmetic_end(bytes, index)?;
+            index = find_wrapped_arithmetic_end(text, index)?;
             continue;
         }
 
         if index + 1 < bytes.len() && is_unescaped_dollar(bytes, index) && bytes[index + 1] == b'('
         {
-            index = find_command_substitution_end(bytes, index)?;
+            index = find_command_substitution_end(text, index)?;
             continue;
         }
 
@@ -1512,7 +1540,7 @@ fn find_runtime_parameter_closing_brace(text: &str, start_offset: usize) -> Opti
 
         match bytes[index] {
             b'\'' => index = skip_single_quoted(bytes, index + 1)?,
-            b'"' => index = skip_double_quoted(bytes, index + 1)?,
+            b'"' => index = skip_double_quoted(text, index + 1)?,
             b'`' => index = skip_backticks(bytes, index + 1)?,
             b'}' => {
                 depth -= 1;

--- a/crates/shuck-linter/src/facts/words/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/words/arithmetic.rs
@@ -328,7 +328,7 @@ pub(super) fn collect_wrapped_arithmetic_command_substitution_spans(
             continue;
         }
 
-        let Some(end) = find_command_substitution_end(bytes, index) else {
+        let Some(end) = find_command_substitution_end(text, index) else {
             break;
         };
 
@@ -354,8 +354,8 @@ pub(super) fn is_unescaped_dollar(bytes: &[u8], index: usize) -> bool {
     backslash_count.is_multiple_of(2)
 }
 
-pub(super) fn find_command_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
-    let text = std::str::from_utf8(bytes).ok()?;
+pub(super) fn find_command_substitution_end(text: &str, start: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
     let mut paren_depth = 0usize;
     let mut cursor = start + 2;
 
@@ -370,7 +370,7 @@ pub(super) fn find_command_substitution_end(bytes: &[u8], start: usize) -> Optio
             && bytes[cursor + 1] == b'('
             && bytes[cursor + 2] == b'('
         {
-            cursor = find_wrapped_arithmetic_end(bytes, cursor)?;
+            cursor = find_wrapped_arithmetic_end(text, cursor)?;
             continue;
         }
 
@@ -378,7 +378,7 @@ pub(super) fn find_command_substitution_end(bytes: &[u8], start: usize) -> Optio
             && is_unescaped_dollar(bytes, cursor)
             && bytes[cursor + 1] == b'('
         {
-            cursor = find_command_substitution_end(bytes, cursor)?;
+            cursor = find_command_substitution_end(text, cursor)?;
             continue;
         }
 
@@ -394,13 +394,13 @@ pub(super) fn find_command_substitution_end(bytes: &[u8], start: usize) -> Optio
             && matches!(bytes[cursor], b'<' | b'>')
             && bytes[cursor + 1] == b'('
         {
-            cursor = find_process_substitution_end(bytes, cursor)?;
+            cursor = find_process_substitution_end(text, cursor)?;
             continue;
         }
 
         match bytes[cursor] {
             b'\'' => cursor = skip_single_quoted(bytes, cursor + 1)?,
-            b'"' => cursor = skip_double_quoted(bytes, cursor + 1)?,
+            b'"' => cursor = skip_double_quoted(text, cursor + 1)?,
             b'`' => cursor = skip_backticks(bytes, cursor + 1)?,
             b'(' => {
                 paren_depth += 1;
@@ -418,8 +418,8 @@ pub(super) fn find_command_substitution_end(bytes: &[u8], start: usize) -> Optio
     None
 }
 
-pub(super) fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<usize> {
-    let text = std::str::from_utf8(bytes).ok()?;
+pub(super) fn find_wrapped_arithmetic_end(text: &str, start: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
     let mut paren_depth = 0usize;
     let mut cursor = start + 3;
 
@@ -434,7 +434,7 @@ pub(super) fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<
             && bytes[cursor + 1] == b'('
             && bytes[cursor + 2] == b'('
         {
-            cursor = find_wrapped_arithmetic_end(bytes, cursor)?;
+            cursor = find_wrapped_arithmetic_end(text, cursor)?;
             continue;
         }
 
@@ -442,7 +442,7 @@ pub(super) fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<
             && is_unescaped_dollar(bytes, cursor)
             && bytes[cursor + 1] == b'('
         {
-            cursor = find_command_substitution_end(bytes, cursor)?;
+            cursor = find_command_substitution_end(text, cursor)?;
             continue;
         }
 
@@ -458,13 +458,13 @@ pub(super) fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<
             && matches!(bytes[cursor], b'<' | b'>')
             && bytes[cursor + 1] == b'('
         {
-            cursor = find_process_substitution_end(bytes, cursor)?;
+            cursor = find_process_substitution_end(text, cursor)?;
             continue;
         }
 
         match bytes[cursor] {
             b'\'' => cursor = skip_single_quoted(bytes, cursor + 1)?,
-            b'"' => cursor = skip_double_quoted(bytes, cursor + 1)?,
+            b'"' => cursor = skip_double_quoted(text, cursor + 1)?,
             b'`' => cursor = skip_backticks(bytes, cursor + 1)?,
             b'(' => {
                 paren_depth += 1;
@@ -484,8 +484,8 @@ pub(super) fn find_wrapped_arithmetic_end(bytes: &[u8], start: usize) -> Option<
     None
 }
 
-pub(super) fn find_process_substitution_end(bytes: &[u8], start: usize) -> Option<usize> {
-    let text = std::str::from_utf8(bytes).ok()?;
+pub(super) fn find_process_substitution_end(text: &str, start: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
     let mut paren_depth = 0usize;
     let mut cursor = start + 2;
 
@@ -500,7 +500,7 @@ pub(super) fn find_process_substitution_end(bytes: &[u8], start: usize) -> Optio
             && bytes[cursor + 1] == b'('
             && bytes[cursor + 2] == b'('
         {
-            cursor = find_wrapped_arithmetic_end(bytes, cursor)?;
+            cursor = find_wrapped_arithmetic_end(text, cursor)?;
             continue;
         }
 
@@ -508,7 +508,7 @@ pub(super) fn find_process_substitution_end(bytes: &[u8], start: usize) -> Optio
             && is_unescaped_dollar(bytes, cursor)
             && bytes[cursor + 1] == b'('
         {
-            cursor = find_command_substitution_end(bytes, cursor)?;
+            cursor = find_command_substitution_end(text, cursor)?;
             continue;
         }
 
@@ -524,13 +524,13 @@ pub(super) fn find_process_substitution_end(bytes: &[u8], start: usize) -> Optio
             && matches!(bytes[cursor], b'<' | b'>')
             && bytes[cursor + 1] == b'('
         {
-            cursor = find_process_substitution_end(bytes, cursor)?;
+            cursor = find_process_substitution_end(text, cursor)?;
             continue;
         }
 
         match bytes[cursor] {
             b'\'' => cursor = skip_single_quoted(bytes, cursor + 1)?,
-            b'"' => cursor = skip_double_quoted(bytes, cursor + 1)?,
+            b'"' => cursor = skip_double_quoted(text, cursor + 1)?,
             b'`' => cursor = skip_backticks(bytes, cursor + 1)?,
             b'(' => {
                 paren_depth += 1;
@@ -559,7 +559,8 @@ pub(super) fn skip_single_quoted(bytes: &[u8], start: usize) -> Option<usize> {
     None
 }
 
-pub(super) fn skip_double_quoted(bytes: &[u8], start: usize) -> Option<usize> {
+pub(super) fn skip_double_quoted(text: &str, start: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
     let mut cursor = start;
 
     while cursor < bytes.len() {
@@ -573,7 +574,7 @@ pub(super) fn skip_double_quoted(bytes: &[u8], start: usize) -> Option<usize> {
             && bytes[cursor + 1] == b'('
             && bytes[cursor + 2] == b'('
         {
-            cursor = find_wrapped_arithmetic_end(bytes, cursor)?;
+            cursor = find_wrapped_arithmetic_end(text, cursor)?;
             continue;
         }
 
@@ -581,7 +582,7 @@ pub(super) fn skip_double_quoted(bytes: &[u8], start: usize) -> Option<usize> {
             && is_unescaped_dollar(bytes, cursor)
             && bytes[cursor + 1] == b'('
         {
-            cursor = find_command_substitution_end(bytes, cursor)?;
+            cursor = find_command_substitution_end(text, cursor)?;
             continue;
         }
 

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -12,6 +12,18 @@ use crate::{Binding, BindingKind, Scope, ScopeId, ScopeKind, SpanKey};
 pub(crate) struct ZshOptionAnalysis {
     scope_entries: FxHashMap<ScopeId, ZshOptionState>,
     snapshots: FxHashMap<ScopeId, Vec<ZshOptionSnapshot>>,
+    /// Scopes sorted by `(span.start.offset ASC, span.end.offset DESC)` so a binary search by
+    /// start offset followed by a backward walk yields the deepest containing scope under
+    /// proper scope nesting. Built once per analysis to keep `options_at` off the
+    /// O(commands × scopes) path.
+    scope_index: Vec<ScopeIndexEntry>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ScopeIndexEntry {
+    start: usize,
+    end: usize,
+    scope: ScopeId,
 }
 
 #[derive(Debug, Clone)]
@@ -213,9 +225,20 @@ pub(crate) fn analyze(
         snapshots.sort_by_key(|snapshot| snapshot.offset);
     }
 
+    let mut scope_index: Vec<ScopeIndexEntry> = scopes
+        .iter()
+        .map(|scope| ScopeIndexEntry {
+            start: scope.span.start.offset,
+            end: scope.span.end.offset,
+            scope: scope.id,
+        })
+        .collect();
+    scope_index.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| b.end.cmp(&a.end)));
+
     Some(ZshOptionAnalysis {
         scope_entries: analyzer.scope_entries,
         snapshots: analyzer.snapshots,
+        scope_index,
     })
 }
 
@@ -225,11 +248,14 @@ impl ZshOptionAnalysis {
         scopes: &[Scope],
         offset: usize,
     ) -> Option<&'a ZshOptionState> {
-        let mut scope = scopes
+        let upper = self
+            .scope_index
+            .partition_point(|entry| entry.start <= offset);
+        let mut scope = self.scope_index[..upper]
             .iter()
-            .filter(|scope| contains_offset(scope.span, offset))
-            .min_by_key(|scope| scope.span.end.offset - scope.span.start.offset)
-            .map(|scope| scope.id);
+            .rev()
+            .find(|entry| entry.end >= offset)
+            .map(|entry| entry.scope);
 
         while let Some(scope_id) = scope {
             if let Some(snapshots) = self.snapshots.get(&scope_id)
@@ -756,10 +782,6 @@ fn is_function_scope(scopes: &[Scope], scope: ScopeId) -> bool {
         current = scopes[scope_id.index()].parent;
     }
     false
-}
-
-fn contains_offset(span: shuck_ast::Span, offset: usize) -> bool {
-    span.start.offset <= offset && offset <= span.end.offset
 }
 
 fn field_for_option_name(name: &str) -> Option<ZshOptionField> {


### PR DESCRIPTION
## Summary

Three independent hot paths surfaced when profiling `romkatv/powerlevel10k`'s `internal/p10k.zsh` (~346KB zsh). Each one is replaced with a precomputed index or a smaller per-call payload so the lint loop stops doing O(spans × source) and O(commands × scopes) work.

- `facts::build_literal_brace_spans`: replace two `spans.retain` source rescans with two precomputed offset sets (plain `${...}` edges and active brace-expansion edges) built in single forward walks. Per-span checks become O(1) hash lookups.
- `facts::words::arithmetic::find_{command_substitution, wrapped_arithmetic, process_substitution}_end` and `skip_double_quoted`: take `&str` instead of `&[u8]` so the recursive boundary scan no longer re-validates UTF-8 of the entire byte slice on every cross-call.
- `SemanticModel::zsh_options_at`: precompute a sorted-by-start scope index inside `ZshOptionAnalysis` and binary-search it instead of doing a linear `min_by_key` over every scope on each call.

## Profile (p10k.zsh, 12 iterations)

| | Before | After |
|---|---:|---:|
| Avg lint time | ~95ms | **88.9ms** |
| `zsh_options_at` | top-12 | gone (now 1.9% of total) |
| `build_literal_brace_spans` | top-12 | gone (now 0.9% of total) |
| `find_*_end` family | top-12 | gone |

## Test plan

- [x] `cargo build -p shuck-semantic -p shuck-linter`
- [x] `cargo test -p shuck-semantic` (368 passed)
- [x] `cargo test -p shuck-linter` (3144 passed)
- [x] `cargo clippy -p shuck-semantic -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Reprofile `romkatv__powerlevel10k__internal__p10k.zsh` and confirm wins.