### PR TITLE
perf(linter): precompute pending-until depths for parse diagnostics

### DIFF
--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -485,17 +485,42 @@ fn until_missing_do_span(
     locator: Locator<'_>,
     parse_diagnostics: &[ParseDiagnostic],
 ) -> Option<Span> {
+    let mut pending_until_flags: Option<Vec<bool>> = None;
     parse_diagnostics
         .iter()
         .find(|diagnostic| {
             is_expected_command_error(&diagnostic.message)
                 && is_done_line(locator, diagnostic.span.start.line)
-                && has_pending_until_without_do_before_line(
-                    locator.source(),
-                    diagnostic.span.start.line,
-                )
+                && {
+                    let flags = pending_until_flags
+                        .get_or_insert_with(|| compute_pending_until_flags(locator.source()));
+                    flags
+                        .get(diagnostic.span.start.line.saturating_sub(1))
+                        .copied()
+                        .unwrap_or(false)
+                }
         })
         .map(|diagnostic| diagnostic.span)
+}
+
+fn compute_pending_until_flags(source: &str) -> Vec<bool> {
+    let mut depth: usize = 0;
+    let mut flags: Vec<bool> = Vec::new();
+    flags.push(false);
+    for line in source.lines() {
+        let text = line.split_once('#').map_or(line, |(before, _)| before);
+        if line_has_command_leading_word(text, "until") {
+            depth += 1;
+        }
+        if depth > 0
+            && (line_has_command_leading_word(text, "do")
+                || line_has_command_leading_word(text, "done"))
+        {
+            depth -= 1;
+        }
+        flags.push(depth > 0);
+    }
+    flags
 }
 
 fn if_bracket_glued_span(
@@ -632,33 +657,6 @@ fn is_done_line(locator: Locator<'_>, line_number: usize) -> bool {
             shell_like_words(text).any(|word| word == "done")
         })
         .unwrap_or(false)
-}
-
-fn has_pending_until_without_do_before_line(source: &str, line_number: usize) -> bool {
-    if line_number <= 1 {
-        return false;
-    }
-
-    let mut pending_until_depth = 0usize;
-    for (index, line) in source.lines().enumerate() {
-        let current_line = index + 1;
-        if current_line >= line_number {
-            break;
-        }
-
-        let text = line.split_once('#').map_or(line, |(before, _)| before);
-        if line_has_command_leading_word(text, "until") {
-            pending_until_depth += 1;
-        }
-        if pending_until_depth > 0
-            && (line_has_command_leading_word(text, "do")
-                || line_has_command_leading_word(text, "done"))
-        {
-            pending_until_depth -= 1;
-        }
-    }
-
-    pending_until_depth > 0
 }
 
 fn line_has_command_leading_word(line: &str, word: &str) -> bool {


### PR DESCRIPTION
## Summary
- `until_missing_do_span` previously called `has_pending_until_without_do_before_line(source, line)` once per candidate parse diagnostic that passed `is_expected_command_error` and `is_done_line`. Each call walked `source.lines()` from line 1 up to the diagnostic line, calling `line_has_command_leading_word` up to 3× per line. Multiple candidates meant repeated prefix rescans.
- Hoist the per-line scan into `compute_pending_until_flags`: walk the source once to build a `Vec<bool>` where `flags[L - 1]` is true iff there is a pending `until` with no matching `do` at the start of line `L`.
- The scan is lazy via `Option::get_or_insert_with` — files that have no diagnostics passing the cheap predicates pay nothing.
- Removes the now-unused `has_pending_until_without_do_before_line`.
- This is independent of #770: it works with either the original `Vec`-based `line_has_command_leading_word` or its byte-loop replacement. If both land, the wins compose because precompute reduces call count and the byte loop reduces per-call cost.

## Profile delta
Fixture: `romkatv__powerlevel10k__internal__p10k.zsh`, 12 iterations, profiling build, 7 warm runs each.

| Run | Baseline (origin/main) | After (this PR) |
|---|---:|---:|
| min | 93.5 ms | 81.4 ms |
| mean | 95.9 ms | 81.7 ms |
| max | 98.7 ms | 82.0 ms |

~15% wall-clock improvement. Ranges do not overlap.

## Test plan
- [x] `cargo fmt`
- [x] `cargo test -p shuck-linter` (3144 passing; existing `UntilMissingDo` parse-error tests cover the refactor)
- [x] `cargo clippy --all-targets -- -D warnings`