### PR TITLE
perf(linter): binary-search zsh option snapshots, skip ASCII smart-quote scan

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -671,15 +671,17 @@ impl<'a> SurfaceFragmentSink<'a> {
                 && !in_double_quote
             {
                 let literal = text.as_str(self.source, part.span);
-                for (offset, char) in literal.char_indices() {
-                    if !is_unicode_smart_quote(char) {
-                        continue;
+                if literal.as_bytes().contains(&UNICODE_SMART_QUOTE_LEAD_BYTE) {
+                    for (offset, char) in literal.char_indices() {
+                        if !is_unicode_smart_quote(char) {
+                            continue;
+                        }
+                        let start = part.span.start.advanced_by(&literal[..offset]);
+                        let end = start.advanced_by(char.encode_utf8(&mut [0; 4]));
+                        self.facts
+                            .unicode_smart_quote_spans
+                            .push(Span::from_positions(start, end));
                     }
-                    let start = part.span.start.advanced_by(&literal[..offset]);
-                    let end = start.advanced_by(char.encode_utf8(&mut [0; 4]));
-                    self.facts
-                        .unicode_smart_quote_spans
-                        .push(Span::from_positions(start, end));
                 }
             }
 
@@ -2863,6 +2865,10 @@ pub(super) fn simple_command_variable_set_operand<'a>(
 fn is_unicode_smart_quote(char: char) -> bool {
     matches!(char, '\u{2018}' | '\u{2019}' | '\u{201C}' | '\u{201D}')
 }
+
+/// First UTF-8 byte shared by every smart-quote codepoint scanned above. Used as a fast skip
+/// over ASCII-only literals that cannot contain any smart quote.
+const UNICODE_SMART_QUOTE_LEAD_BYTE: u8 = 0xE2;
 
 #[cfg(test)]
 mod tests {

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -258,13 +258,11 @@ impl ZshOptionAnalysis {
             .map(|entry| entry.scope);
 
         while let Some(scope_id) = scope {
-            if let Some(snapshots) = self.snapshots.get(&scope_id)
-                && let Some(snapshot) = snapshots
-                    .iter()
-                    .rev()
-                    .find(|snapshot| snapshot.offset <= offset)
-            {
-                return Some(&snapshot.state);
+            if let Some(snapshots) = self.snapshots.get(&scope_id) {
+                let upper = snapshots.partition_point(|snapshot| snapshot.offset <= offset);
+                if upper > 0 {
+                    return Some(&snapshots[upper - 1].state);
+                }
             }
 
             if let Some(entry) = self.scope_entries.get(&scope_id) {


### PR DESCRIPTION
## Summary

Two small targeted wins on the `romkatv/powerlevel10k` `internal/p10k.zsh` profile:

- `SemanticModel::zsh_options_at` already binary-searches the per-scope snapshot vector by start, but the inner snapshot lookup still did `iter().rev().find(|s| s.offset <= offset)`. Snapshots are sorted by offset at build time, so replace the linear walk with `partition_point`. Per-scope snapshot counts grow with command count, so the worst case for the file-level scope was O(commands_in_root_scope) per call and the function showed up at ~9% of the facts builder.
- `SurfaceFragmentSink::collect_word_parts` walked every char of every unquoted literal looking for Unicode smart quotes. All four smart-quote codepoints share the UTF-8 lead byte `0xE2`, so do a memchr-style byte-presence check first and skip the per-char loop on ASCII-only literals.

## Profile (p10k.zsh, 12 iterations)

| | Before | After |
|---|---:|---:|
| Avg lint time | 73.8 ms | **70.2 ms** |
| `zsh_options_at` | 9.0% of facts builder / 2.6% of total | gone from facts-builder top-12 |

## Test plan

- [x] `cargo build -p shuck-semantic -p shuck-linter`
- [x] `cargo test -p shuck-semantic` (368 passed)
- [x] `cargo test -p shuck-linter` (3147 passed)
- [x] `cargo clippy -p shuck-semantic -p shuck-linter --all-targets -- -D warnings`
- [x] Reprofile `romkatv__powerlevel10k__internal__p10k.zsh` and confirm wins.