### PR TITLE
perf(linter): walk binary command chains without a heap stack

### DIFF
--- a/crates/shuck-linter/src/facts/traversal.rs
+++ b/crates/shuck-linter/src/facts/traversal.rs
@@ -227,27 +227,27 @@ impl<'a> BinaryCommandChain<'a> {
         mut visit_segment: impl FnMut(&'a Stmt),
         mut visit_operator: impl FnMut(&'a BinaryCommand),
     ) {
-        let mut stack = vec![BinaryChainStackItem::Command(self.root)];
-        while let Some(item) = stack.pop() {
-            match item {
-                BinaryChainStackItem::Command(command) => {
-                    match &command.right.command {
-                        Command::Binary(right) if self.kind.contains(right.op) => {
-                            stack.push(BinaryChainStackItem::Command(right));
-                        }
-                        _ => stack.push(BinaryChainStackItem::Segment(&command.right)),
-                    }
-                    stack.push(BinaryChainStackItem::Operator(command));
-                    match &command.left.command {
-                        Command::Binary(left) if self.kind.contains(left.op) => {
-                            stack.push(BinaryChainStackItem::Command(left));
-                        }
-                        _ => stack.push(BinaryChainStackItem::Segment(&command.left)),
-                    }
-                }
-                BinaryChainStackItem::Operator(command) => visit_operator(command),
-                BinaryChainStackItem::Segment(stmt) => visit_segment(stmt),
+        self.walk(self.root, &mut visit_segment, &mut visit_operator);
+    }
+
+    fn walk(
+        &self,
+        command: &'a BinaryCommand,
+        visit_segment: &mut impl FnMut(&'a Stmt),
+        visit_operator: &mut impl FnMut(&'a BinaryCommand),
+    ) {
+        match &command.left.command {
+            Command::Binary(left) if self.kind.contains(left.op) => {
+                self.walk(left, visit_segment, visit_operator);
             }
+            _ => visit_segment(&command.left),
+        }
+        visit_operator(command);
+        match &command.right.command {
+            Command::Binary(right) if self.kind.contains(right.op) => {
+                self.walk(right, visit_segment, visit_operator);
+            }
+            _ => visit_segment(&command.right),
         }
     }
 
@@ -260,12 +260,6 @@ impl<'a> BinaryCommandChain<'a> {
     pub(super) fn visit_nodes(&self, visitor: impl FnMut(&'a BinaryCommand)) {
         self.visit_parts(|_| {}, visitor);
     }
-}
-
-enum BinaryChainStackItem<'a> {
-    Command(&'a BinaryCommand),
-    Operator(&'a BinaryCommand),
-    Segment(&'a Stmt),
 }
 
 fn visit_command_substitution_candidate_words<'a>(


### PR DESCRIPTION
## Summary
- Rewrite `BinaryCommandChain::visit_parts` to use native recursion instead of a `Vec`-based worklist, removing the per-call heap allocation. The traversal is called from many fact-building paths (test-command classification, body-shape probes, conditional analysis), so the allocation savings show up at the chain-traversal layer rather than in any single rule.
- Drop the now-unused `BinaryChainStackItem` enum.

## Profile impact
On `romkatv__powerlevel10k__internal__p10k.zsh` (12 iterations, samply):

- `stmt_terminals_are_test_commands` drilldown: **4.0% → 1.9%** of `LinterFactsBuilder::build` parent.
- Wall-time median: **72.97ms → 71.39ms** (~1.6ms / ~2%) across paired stash-and-rerun runs:
  - Baseline: 72.70 / 72.97 / 73.23ms
  - Change: 70.52 / 71.09 / 71.21 / 71.39 / 71.53 / 72.14 / 73.99ms

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo test -p shuck-linter`