### PR TITLE
docs(rules): spec Google Shell Style rules and stub metadata

### DIFF
--- a/docs/rules/C158.yaml
+++ b/docs/rules/C158.yaml
@@ -1,0 +1,57 @@
+origin: novel
+new_category: Correctness
+new_code: C158
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: An assignment inside a function body modifies a variable that was not declared local to that function.
+rationale: >
+  In Bash, assignments inside a function silently modify the global namespace unless the
+  target is declared with `local`, `declare`, or `readonly` inside that function's scope.
+  This implicit global mutation is a common source of bugs: the calling scope's variable
+  is unexpectedly overwritten, two functions that happen to use the same name interfere
+  with each other, and the function becomes non-reentrant. The Google Shell Style Guide
+  requires all function-internal variables to be explicitly declared `local`. This rule
+  flags assignments to names that have no `local`/`declare`/`readonly` declaration in the
+  enclosing function scope. Variables marked `readonly` at the top level are considered
+  documented intentional globals (controlled by `treat-readonly-as-documented`), as are
+  variables that have been exported (controlled by `treat-export-as-intentional`). This
+  rule is the inverse of C014, which flags `local` used outside a function body. See also
+  C136 (local-cross-reference) and C150 (subshell-local-assignment) for related local-scoping checks.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: treat-readonly-as-documented
+    type: bool
+    default: true
+    description: >
+      When true, global variables declared `readonly` at the top level are treated as
+      intentional globals and assignments to them inside functions are not flagged (they
+      will fail at runtime anyway). Defaults to true.
+  - name: treat-export-as-intentional
+    type: bool
+    default: true
+    description: >
+      When true, variables that have been exported at the top level via `export` are
+      treated as intentional globals and assignments to them inside functions are not
+      flagged. Defaults to true.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      foo() {
+        x=1
+        echo "$x"
+      }
+      foo
+  - kind: valid
+    code: |
+      #!/bin/bash
+      foo() {
+        local x=1
+        echo "$x"
+      }
+      foo

--- a/docs/rules/C158.yaml
+++ b/docs/rules/C158.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: implicit-global-in-function
 new_category: Correctness
 new_code: C158
 runtime_kind: ast

--- a/docs/rules/C159.yaml
+++ b/docs/rules/C159.yaml
@@ -1,0 +1,46 @@
+origin: novel
+new_category: Correctness
+new_code: C159
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A global variable is assigned more than once at the top level or reassigned from inside a function, making it mutable state.
+rationale: >
+  Global variables that are written in multiple places across a script create hidden
+  coupling: any function or top-level statement can silently change a value that other
+  parts of the script rely on, making behavior dependent on evaluation order. The Google
+  Shell Style Guide addresses this by requiring global constants to be declared
+  `readonly`, which makes their value fixed and self-documenting at the declaration site.
+  This rule flags two patterns: a name that receives a plain assignment at the top level
+  and is then assigned again (whether at the top level or from inside a function body),
+  and a name that is assigned at the top level without `readonly` or `declare -r` when
+  it is never intended to change. To resolve the diagnostic, declare the variable
+  `readonly` at its first assignment if it is a constant, or restructure the code so that
+  mutable state lives in a single controlled location. Set `allow-conditional-init` to
+  true (the default) to suppress the rule for the common `var=${var:-default}` init
+  pattern, which is idiomatic and not harmful.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: allow-conditional-init
+    type: bool
+    default: true
+    description: >
+      When true, a second assignment that has the form of a conditional
+      default (`var=${var:-value}`) is not treated as a mutation and does not trigger the
+      rule. Defaults to true.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      count=0
+      count=5
+      echo "$count"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      readonly COUNT=0
+      echo "$COUNT"

--- a/docs/rules/C159.yaml
+++ b/docs/rules/C159.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: mutable-global
 new_category: Correctness
 new_code: C159
 runtime_kind: ast

--- a/docs/rules/C160.yaml
+++ b/docs/rules/C160.yaml
@@ -1,0 +1,46 @@
+origin: novel
+new_category: Correctness
+new_code: C160
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A source or dot command uses a relative path that is not anchored to the script's own directory.
+rationale: >
+  A bare relative path in a `source` or `.` invocation is resolved relative to the
+  current working directory at the time the script runs, not relative to the script
+  file itself. This means the same script behaves differently depending on where it is
+  invoked from: `source ./lib.sh` succeeds when run from the script's directory but
+  fails silently or loads the wrong file when run from any other directory. The correct
+  idiom is to anchor the path to the script's own directory using
+  `"${BASH_SOURCE[0]%/*}/lib.sh"`, `"$(dirname "$0")/lib.sh"`, or
+  `"$(dirname "${BASH_SOURCE[0]}")/lib.sh"`. This rule flags `source` and `.`
+  invocations whose path argument does not begin with one of those anchors or another
+  expression listed in `allowed-anchors`. Absolute paths and paths produced entirely by
+  command substitution that the rule cannot inspect statically are not flagged.
+  Note: ShellCheck may emit SC1090 or SC1091 on source lines it cannot follow; those are
+  independent informational diagnostics about static analysis coverage, not about path anchoring.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: allowed-anchors
+    type: list
+    default: ["${BASH_SOURCE[0]%/*}", "$(dirname \"$0\")", "$(dirname \"${BASH_SOURCE[0]}\")"]
+    description: >
+      List of path prefix expressions that are accepted as script-directory anchors.
+      A source path whose string representation begins with one of these expressions is
+      considered anchored and will not be flagged. Defaults to the three canonical
+      Bash script-directory idioms.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      source ./lib.sh
+      echo "done"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      source "${BASH_SOURCE[0]%/*}/lib.sh"
+      echo "done"

--- a/docs/rules/C160.yaml
+++ b/docs/rules/C160.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: unanchored-source-path
 new_category: Correctness
 new_code: C160
 runtime_kind: ast

--- a/docs/rules/C161.yaml
+++ b/docs/rules/C161.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: function-called-before-defined
 new_category: Correctness
 new_code: C161
 runtime_kind: ast

--- a/docs/rules/C161.yaml
+++ b/docs/rules/C161.yaml
@@ -1,0 +1,33 @@
+origin: novel
+new_category: Correctness
+new_code: C161
+runtime_kind: ast
+shellcheck_code: SC2218
+shellcheck_level: error
+shells:
+  - bash
+description: A function is called at a top-level position that is reached before the function's definition has been evaluated.
+rationale: Shell scripts are interpreted top-to-bottom at runtime. Invoking a function whose definition appears later in the file will fail at the point of the call because the name has not yet been registered. Move the function definition above its first call site, or restructure the script so all function definitions are grouped at the top and executable code runs after them.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: ignore-after-source
+    type: bool
+    default: true
+    description: When enabled, the rule does not flag calls to names that could plausibly be defined by a preceding source command, since the sourced file's contents are opaque at analysis time.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      do_thing
+      do_thing() {
+        echo hi
+      }
+  - kind: valid
+    code: |
+      #!/bin/bash
+      do_thing() {
+        echo hi
+      }
+      do_thing

--- a/docs/rules/C162.yaml
+++ b/docs/rules/C162.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: extra-masked-returns
 new_category: Correctness
 new_code: C162
 runtime_kind: ast

--- a/docs/rules/C162.yaml
+++ b/docs/rules/C162.yaml
@@ -1,0 +1,34 @@
+origin: novel
+new_category: Correctness
+new_code: C162
+runtime_kind: ast
+shellcheck_code: SC2312
+shellcheck_level: info
+shells:
+  - bash
+description: A command substitution's exit status is silently discarded because the substitution appears inside a combined declaration-and-assignment that the default S010 set does not cover.
+rationale: When a command substitution is embedded directly in a combined declaration-and-assignment using forms such as local -r or typeset, the shell assigns the variable before the declaring keyword has a chance to see the substitution's exit status, so a non-zero exit from the substituted command is masked. The S010 rule (SC2155) already flags the most common masking forms — local, declare, and export — because ShellCheck flags those by default. This rule extends the policy to additional forms such as readonly and typeset that ShellCheck reports only when its optional check-extra-masked-returns check is enabled. To make the exit status observable, separate the declaration from the assignment.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: treat-as-masking
+    type: list
+    default: '["readonly", "typeset"]'
+    description: Assignment-declaration forms beyond the S010 set that should be treated as masking a command substitution's exit status.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      foo() {
+        local -r result=$(get_value)
+        echo "$result"
+      }
+  - kind: valid
+    code: |
+      #!/bin/bash
+      foo() {
+        local result
+        result=$(get_value)
+        echo "$result"
+      }

--- a/docs/rules/S040.yaml
+++ b/docs/rules/S040.yaml
@@ -1,4 +1,4 @@
-legacy_code: ""
+origin: novel
 legacy_name: literal-control-escape
 new_category: Style
 new_code: S040

--- a/docs/rules/S078.yaml
+++ b/docs/rules/S078.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: shebang-not-bash
 new_category: Style
 new_code: S078
 runtime_kind: ast

--- a/docs/rules/S078.yaml
+++ b/docs/rules/S078.yaml
@@ -1,0 +1,36 @@
+origin: novel
+new_category: Style
+new_code: S078
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: The shebang interpreter does not match the project's configured shell policy.
+rationale: >
+  Projects that standardize on a specific shell (commonly Bash) should ensure every
+  script's shebang reflects that policy. A mismatch — such as `#!/bin/sh` in a Bash-only
+  codebase — silently changes runtime semantics and can hide compatibility problems or
+  cause subtle behavioral differences between development and production. Enable this rule
+  and set `allowed-shells` to the shell or shells your project supports. Any script whose
+  shebang names a different interpreter will be flagged; change the shebang to an
+  allowed interpreter to resolve the diagnostic.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: allowed-shells
+    type: list
+    default: ["bash"]
+    description: >
+      Interpreter names that are permitted in shebangs. Accepts short names such as
+      "bash", "sh", "zsh", or "ksh". Defaults to ["bash"].
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/sh
+      echo hello
+  - kind: valid
+    code: |
+      #!/bin/bash
+      echo hello

--- a/docs/rules/S079.yaml
+++ b/docs/rules/S079.yaml
@@ -1,0 +1,47 @@
+origin: novel
+new_category: Style
+new_code: S079
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: The shebang line does not use the configured invocation form.
+rationale: >
+  Shell projects often standardize on one of two shebang forms: a direct absolute path
+  (e.g., `#!/bin/bash`) or an env-lookup indirection (e.g., `#!/usr/bin/env bash`).
+  Mixing both forms across a codebase makes the launch mechanism inconsistent and can
+  cause scripts to behave differently on systems where the interpreter lives at a
+  non-standard path. Configure `allowed-forms` to enforce one form, or use
+  `allowed-paths` to enumerate the exact shebang strings that are permitted. Any
+  shebang that does not satisfy either constraint will be flagged; update the shebang
+  to an allowed form or path to resolve the diagnostic.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: allowed-forms
+    type: list
+    default: ["env-lookup"]
+    description: >
+      Shebang invocation styles that are permitted. Valid values are "absolute-path"
+      (e.g., #!/bin/bash) and "env-lookup" (e.g., #!/usr/bin/env bash).
+      Defaults to ["env-lookup"].
+  - name: allowed-paths
+    type: list
+    default: ["/bin/bash", "/usr/bin/env bash"]
+    description: >
+      Exact shebang interpreter strings that are always permitted regardless of
+      `allowed-forms`. Compared against the text after `#!` with leading and trailing
+      whitespace stripped.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      x=1
+      echo "$x"
+  - kind: valid
+    code: |
+      #!/usr/bin/env bash
+      x=1
+      echo "$x"

--- a/docs/rules/S079.yaml
+++ b/docs/rules/S079.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: shebang-form-mismatch
 new_category: Style
 new_code: S079
 runtime_kind: ast

--- a/docs/rules/S080.yaml
+++ b/docs/rules/S080.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: script-size-threshold
 new_category: Style
 new_code: S080
 runtime_kind: ast

--- a/docs/rules/S080.yaml
+++ b/docs/rules/S080.yaml
@@ -1,0 +1,56 @@
+origin: novel
+new_category: Style
+new_code: S080
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: The script's line count exceeds the configured size threshold.
+rationale: >
+  Long shell scripts are harder to understand, test, and maintain than short focused ones.
+  The Google Shell Style Guide recommends keeping scripts to around 100 lines or fewer;
+  larger scripts are a signal that the logic should be broken up into multiple files or
+  rewritten in a more structured language. Enable this rule and set `max-lines` to the
+  ceiling appropriate for your codebase. The `count` option controls whether the limit
+  applies to every physical line (`"physical"`, the default) or only to lines that carry
+  code (`"non-comment-non-blank"`, which excludes blank lines and comment-only lines).
+  When the script exceeds the threshold, consider splitting it into smaller modules that
+  source one another.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: max-lines
+    type: integer
+    default: 100
+    description: >
+      Maximum number of lines allowed in a single script. Scripts with more lines than
+      this value will be flagged. Defaults to 100.
+  - name: count
+    type: string
+    default: "physical"
+    description: >
+      Controls which lines are included in the count. "physical" counts every line
+      in the file including blank lines and comments. "non-comment-non-blank" counts
+      only lines that contain executable code. Defaults to "physical".
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # This script is intentionally long to exceed the line threshold.
+      echo "line 1"
+      echo "line 2"
+      echo "line 3"
+      echo "line 4"
+      echo "line 5"
+      echo "line 6"
+      echo "line 7"
+      echo "line 8"
+      echo "line 9"
+      echo "line 10"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # A concise script.
+      echo "done"

--- a/docs/rules/S081.yaml
+++ b/docs/rules/S081.yaml
@@ -1,0 +1,38 @@
+origin: novel
+new_category: Style
+new_code: S081
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: The script does not begin with a comment block describing its purpose.
+rationale: >
+  A file-level header comment answers the first question any reader or operator will
+  ask: "what does this script do?" Without it, understanding the script requires reading
+  all of its logic before its intent becomes clear. The Google Shell Style Guide
+  requires every file to start with a description of its contents. This rule flags
+  scripts where the first non-shebang, non-blank line is not a comment. Add a brief
+  comment block immediately after the shebang (or at the top of the file if there is no
+  shebang) that describes the script's purpose. Set `ignore-shebang-only-files` to true
+  if scripts that contain nothing beyond a shebang should be exempt from the check.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: ignore-shebang-only-files
+    type: bool
+    default: false
+    description: >
+      When true, scripts whose only content is a shebang line are not flagged.
+      Defaults to false.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      ls -la
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # Prints a listing of the current directory with timestamps.
+      ls -la

--- a/docs/rules/S081.yaml
+++ b/docs/rules/S081.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: missing-file-description
 new_category: Style
 new_code: S081
 runtime_kind: ast

--- a/docs/rules/S082.yaml
+++ b/docs/rules/S082.yaml
@@ -1,0 +1,55 @@
+origin: novel
+new_category: Style
+new_code: S082
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A TODO, FIXME, or XXX comment is missing an owner annotation or a message describing the work.
+rationale: >
+  Actionable comment markers such as TODO and FIXME are only useful when a reader
+  can tell who is responsible and what needs to be done. An annotation without an
+  owner — written as `(name)` or `(handle)` immediately after the keyword — cannot
+  be assigned or tracked. An annotation without a message leaves reviewers guessing
+  about the intent. Requiring both fields keeps the comment backlog triageable and
+  prevents stale markers from accumulating without clear accountability. The set of
+  recognized keywords and the two requirements are individually configurable so teams
+  can adopt the policy incrementally.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: kinds
+    type: list
+    default: ["TODO", "FIXME", "XXX"]
+    description: >
+      The comment markers that trigger this rule. Each entry is matched
+      case-sensitively at the start of a comment token. Defaults to
+      ["TODO", "FIXME", "XXX"].
+  - name: require-owner
+    type: bool
+    default: true
+    description: >
+      When true, flags any matching marker that is not followed immediately by
+      a parenthesised owner annotation such as (alice) or (b/12345). Defaults to true.
+  - name: require-message
+    type: bool
+    default: true
+    description: >
+      When true, flags any matching marker whose owner annotation (or the keyword
+      itself, when require-owner is false) is not followed by a non-empty message.
+      Defaults to true.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # TODO finish later
+      # FIXME this is broken
+      echo hi
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # TODO(alice): finish the input validation logic
+      # FIXME(bob): address the edge case for empty arrays
+      echo hi

--- a/docs/rules/S082.yaml
+++ b/docs/rules/S082.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: todo-format
 new_category: Style
 new_code: S082
 runtime_kind: ast

--- a/docs/rules/S083.yaml
+++ b/docs/rules/S083.yaml
@@ -1,0 +1,59 @@
+origin: novel
+new_category: Style
+new_code: S083
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A function definition lacks a leading comment block describing its purpose.
+rationale: >
+  Well-documented functions reduce the cognitive overhead of reading, reviewing, and
+  maintaining shell scripts. A comment block immediately before a function definition
+  tells callers what the function does, what arguments it expects, which global variables
+  it touches, and what it returns — information that is not recoverable from the
+  implementation alone without reading every line. Because mandating a doc block for every
+  trivial two-liner would produce more noise than signal, the rule is configurable: teams
+  can require documentation only for all functions, only for long functions (those above a
+  configurable line threshold), only for functions that accept positional parameters, or
+  only for functions whose names follow a "public" naming convention. The rule fires when a
+  function matching the configured policy has no associated comment block at all; the
+  companion rule S084 checks whether a present comment block covers the required content.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: require-for
+    type: string
+    default: "all"
+    description: >
+      Controls which functions are required to have a doc comment. Accepted values:
+      "all" — every function definition; "exported" — functions whose names do not start
+      with an underscore (treated as the public API); "long" — functions whose body
+      exceeds long-function-line-threshold lines; "parameterized" — functions that
+      reference positional parameters ($1, $@, $*, etc.) in their body. Defaults to "all".
+  - name: long-function-line-threshold
+    type: integer
+    default: 10
+    description: >
+      Minimum body line count for a function to be considered "long" when require-for
+      is set to "long". Functions with fewer lines than this threshold are exempt.
+      Defaults to 10.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      do_work() {
+        local input=$1
+        echo "processing: $input"
+      }
+      do_work "$1"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # Processes the given input string and writes the result to stdout.
+      do_work() {
+        local input=$1
+        echo "processing: $input"
+      }
+      do_work "$1"

--- a/docs/rules/S083.yaml
+++ b/docs/rules/S083.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: missing-function-doc
 new_category: Style
 new_code: S083
 runtime_kind: ast

--- a/docs/rules/S084.yaml
+++ b/docs/rules/S084.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: function-doc-content
 new_category: Style
 new_code: S084
 runtime_kind: ast

--- a/docs/rules/S084.yaml
+++ b/docs/rules/S084.yaml
@@ -1,0 +1,79 @@
+origin: novel
+new_category: Style
+new_code: S084
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A function's leading comment block does not document globals, arguments, outputs, or return values that appear in the function body.
+rationale: >
+  A comment block that exists but omits key information is only marginally better
+  than no comment at all. The Google Shell Style Guide prescribes four structured
+  sections — Globals, Arguments, Outputs, and Returns — each matching a category of
+  observable behavior. When a function reads or modifies a global variable and the
+  Globals section is absent, a caller has no way to know about the side effect without
+  reading the implementation. Similarly, when a function uses positional parameters
+  but the Arguments section is missing, or when it writes to stdout but the Outputs
+  section is absent, the doc block is incomplete. This rule checks that any function
+  whose body contains at least one item from each configured category has a corresponding
+  section header in its comment block. Each category is independently configurable so
+  teams can adopt the policy piecemeal.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: require-globals
+    type: bool
+    default: true
+    description: >
+      When true, flags functions that read or write a non-local variable if the
+      comment block lacks a "Globals:" section. Defaults to true.
+  - name: require-arguments
+    type: bool
+    default: true
+    description: >
+      When true, flags functions that reference positional parameters ($1, $2, $@,
+      $*, etc.) if the comment block lacks an "Arguments:" section. Defaults to true.
+  - name: require-outputs
+    type: bool
+    default: true
+    description: >
+      When true, flags functions that contain an echo or printf statement writing to
+      stdout if the comment block lacks an "Outputs:" section. Defaults to true.
+  - name: require-returns
+    type: bool
+    default: true
+    description: >
+      When true, flags functions that contain an explicit "return N" statement if the
+      comment block lacks a "Returns:" section. Defaults to true.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # Builds an absolute output path.
+      build_path() {
+        local suffix=$1
+        echo "${BASE_DIR}/${suffix}"
+        return 0
+      }
+      build_path "logs"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # Builds an absolute output path by joining BASE_DIR with a suffix.
+      #
+      # Globals:
+      #   BASE_DIR
+      # Arguments:
+      #   $1 - The path suffix to append.
+      # Outputs:
+      #   Writes the constructed path to stdout.
+      # Returns:
+      #   0 always.
+      build_path() {
+        local suffix=$1
+        echo "${BASE_DIR}/${suffix}"
+        return 0
+      }
+      build_path "logs"

--- a/docs/rules/S085.yaml
+++ b/docs/rules/S085.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: missing-main-function
 new_category: Style
 new_code: S085
 runtime_kind: ast

--- a/docs/rules/S085.yaml
+++ b/docs/rules/S085.yaml
@@ -1,0 +1,84 @@
+origin: novel
+new_category: Style
+new_code: S085
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A non-trivial script does not end with a call to the main entry-point function as its last top-level statement.
+rationale: >
+  Structuring a script so that all logic lives inside named functions and a single
+  top-level call dispatches to them makes the script easier to source under test,
+  easier to read in isolation, and easier to compose with other scripts. The Google
+  Shell Style Guide prescribes that non-trivial scripts end with `main "$@"` as
+  their last executable line — this signals clearly where execution begins and keeps
+  the top level free of scattered logic. "Non-trivial" is configurable: the rule
+  stays silent on scripts below a line-count or function-count threshold so that
+  small one-off scripts are not needlessly flagged. The `main-name` option lets
+  projects that use a different entry-point name (e.g. `run` or `entrypoint`) still
+  benefit from the check.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: non-trivial-line-threshold
+    type: integer
+    default: 30
+    description: >
+      Minimum number of lines a script must have before the rule fires.
+      Scripts shorter than this value are considered trivial and are not checked.
+  - name: non-trivial-function-count
+    type: integer
+    default: 2
+    description: >
+      Minimum number of function definitions a script must contain before the rule
+      fires. Scripts with fewer functions are considered trivial and are not checked.
+      Both thresholds must be met for the script to be considered non-trivial.
+  - name: main-name
+    type: string
+    default: "main"
+    description: >
+      Name of the expected entry-point function. The rule checks that the last
+      top-level statement is a call to this name (with or without arguments).
+      Defaults to "main".
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # A non-trivial script that processes files without a main dispatcher.
+
+      readonly LOG_DIR="/var/log/myapp"
+
+      setup() {
+        mkdir -p "${LOG_DIR}"
+      }
+
+      run() {
+        echo "Running from ${LOG_DIR}"
+      }
+
+      # Top-level executable code instead of main "$@"
+      setup
+      run
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # A non-trivial script with a proper main dispatcher.
+
+      readonly LOG_DIR="/var/log/myapp"
+
+      setup() {
+        mkdir -p "${LOG_DIR}"
+      }
+
+      run() {
+        echo "Running from ${LOG_DIR}"
+      }
+
+      main() {
+        setup
+        run
+      }
+
+      main "$@"

--- a/docs/rules/S086.yaml
+++ b/docs/rules/S086.yaml
@@ -1,0 +1,77 @@
+origin: novel
+new_category: Style
+new_code: S086
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: Executable statements appear at the top level of a script outside the set of statement types that are allowed there.
+rationale: >
+  The Google Shell Style Guide prescribes that the top level of a well-structured
+  script should contain only a narrow set of statement types: constant declarations
+  (`readonly`, `declare -r`, and `export`), plain variable declarations without an
+  initialiser, function definitions, source commands, and the single `main "$@"`
+  invocation. Any other executable statement — conditionals, loops, command calls,
+  arithmetic — that appears directly at the top level makes the script harder to
+  source under test, harder to reason about, and easier to accidentally execute side
+  effects when sourced by another script. This rule flags those out-of-place
+  top-level statements. The `allowed-statements` option lets teams extend or
+  restrict the baseline set to match their own policy.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: allowed-statements
+    type: list
+    default: '["constant","declaration","function-definition","source","main-invocation"]'
+    description: >
+      The statement categories that are permitted at the top level. Values are:
+      "constant" (readonly/declare -r/export assignments), "declaration" (declare
+      without an initialiser), "function-definition", "source" (source/.),
+      and "main-invocation" (the configured main-name call). Any top-level statement
+      not matching a category in this list is flagged.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      readonly APP_NAME="myapp"
+
+      greet() {
+        echo "Hello from ${APP_NAME}"
+      }
+
+      # This conditional block is top-level executable code that should
+      # be moved inside a function.
+      if [[ -z "${HOME}" ]]; then
+        echo "No home directory set" >&2
+        exit 1
+      fi
+
+      main() {
+        greet
+      }
+
+      main "$@"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      readonly APP_NAME="myapp"
+
+      check_env() {
+        if [[ -z "${HOME}" ]]; then
+          echo "No home directory set" >&2
+          exit 1
+        fi
+      }
+
+      greet() {
+        echo "Hello from ${APP_NAME}"
+      }
+
+      main() {
+        check_env
+        greet
+      }
+
+      main "$@"

--- a/docs/rules/S086.yaml
+++ b/docs/rules/S086.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: top-level-code-not-minimal
 new_category: Style
 new_code: S086
 runtime_kind: ast

--- a/docs/rules/S087.yaml
+++ b/docs/rules/S087.yaml
@@ -1,0 +1,58 @@
+origin: novel
+new_category: Style
+new_code: S087
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A constant declaration using readonly, declare -r, or export appears after the first function definition in the script.
+rationale: >
+  The Google Shell Style Guide prescribes a clear ordering for the top-level
+  sections of a script: constants and global variables are declared first, then
+  functions are defined, then the entry-point call closes the file. When a constant
+  declaration appears after the first function definition, the established reading
+  order is broken: a reader scanning the file to understand the script's global
+  state has to read past function bodies to find all the constants. Keeping all
+  `readonly`, `declare -r`, and `export` constant declarations above the first
+  function definition makes the global namespace immediately visible at the top
+  of the file and prevents accidental shadowing of a constant by a later definition.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      readonly PREFIX="/usr/local"
+
+      install_files() {
+        echo "Installing to ${PREFIX}/bin/"
+      }
+
+      # This constant appears after a function definition — it should be at the top.
+      readonly VERSION="1.2.3"
+
+      main() {
+        install_files
+        echo "Version: ${VERSION}"
+      }
+
+      main "$@"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # All constants declared before the first function definition.
+      readonly PREFIX="/usr/local"
+      readonly VERSION="1.2.3"
+
+      install_files() {
+        echo "Installing to ${PREFIX}/bin/"
+      }
+
+      main() {
+        install_files
+        echo "Version: ${VERSION}"
+      }
+
+      main "$@"

--- a/docs/rules/S087.yaml
+++ b/docs/rules/S087.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: constants-not-at-top
 new_category: Style
 new_code: S087
 runtime_kind: ast

--- a/docs/rules/S088.yaml
+++ b/docs/rules/S088.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: functions-not-grouped
 new_category: Style
 new_code: S088
 runtime_kind: ast

--- a/docs/rules/S088.yaml
+++ b/docs/rules/S088.yaml
@@ -1,0 +1,68 @@
+origin: novel
+new_category: Style
+new_code: S088
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: Function definitions are not contiguous because an executable statement appears between two function definitions.
+rationale: >
+  The Google Shell Style Guide prescribes that all function definitions in a script
+  should be grouped together as a contiguous block, with no executable statements
+  interspersed between them. When an executable statement (a command call, a loop,
+  a conditional, etc.) appears between two function definitions, the function block
+  is fragmented: readers cannot scan the file and locate all function definitions
+  in one place, and tools that extract or test functions individually have to deal
+  with side-effecting code scattered among the definitions. Grouping all function
+  definitions together — preceded by constants and followed by the entry-point call
+  — keeps each structural section of the script spatially distinct and reinforces
+  the convention that top-level executable code should be minimal.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      readonly WORKDIR="/tmp/work"
+
+      setup() {
+        mkdir -p "${WORKDIR}"
+      }
+
+      # This command is sandwiched between two function definitions.
+      echo "Preparing environment..."
+
+      teardown() {
+        rm -rf "${WORKDIR}"
+      }
+
+      main() {
+        setup
+        teardown
+      }
+
+      main "$@"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      readonly WORKDIR="/tmp/work"
+
+      # All function definitions are grouped together with no executable
+      # statements interspersed.
+      setup() {
+        mkdir -p "${WORKDIR}"
+      }
+
+      teardown() {
+        rm -rf "${WORKDIR}"
+      }
+
+      main() {
+        echo "Preparing environment..."
+        setup
+        teardown
+      }
+
+      main "$@"

--- a/docs/rules/S089.yaml
+++ b/docs/rules/S089.yaml
@@ -1,0 +1,33 @@
+origin: novel
+new_category: Style
+new_code: S089
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A function name does not match the configured naming pattern.
+rationale: Consistent function naming within a codebase reduces cognitive overhead when reading and searching code. The default pattern requires lowercase letters, digits, and underscores, with an optional double-colon namespace separator for library functions. Projects may supply an alternate regex via the `pattern` option to fit their own conventions.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: pattern
+    type: string
+    default: "^[a-z_][a-z0-9_]*(::[a-z_][a-z0-9_]*)?$"
+    description: Regular expression that every function name must match. The default permits snake_case names and optionally a single `pkg::fn` namespace prefix.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      MyFunction() {
+        echo hi
+      }
+      MyFunction
+  - kind: valid
+    code: |
+      #!/bin/bash
+      do_thing() {
+        echo hi
+      }
+      do_thing

--- a/docs/rules/S089.yaml
+++ b/docs/rules/S089.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: function-name-case
 new_category: Style
 new_code: S089
 runtime_kind: ast

--- a/docs/rules/S090.yaml
+++ b/docs/rules/S090.yaml
@@ -1,0 +1,35 @@
+origin: novel
+new_category: Style
+new_code: S090
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: Functions in files identified as libraries do not use a package-qualified name in the form `package::function_name`.
+rationale: Library files expose shared functions that may be sourced into many scripts. Qualifying each function with a package prefix avoids name collisions when multiple libraries are loaded into the same shell session and makes it immediately clear which library a function belongs to. This rule is intentionally scoped to files that match a configurable predicate so that top-level scripts, which are never sourced, are not penalised.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: library-predicate
+    type: string
+    default: "filename-suffix:.lib.sh"
+    description: Predicate that identifies library files. The only supported form today is `filename-suffix:<suffix>`, which matches when the source file path ends with the given suffix.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # mylib.lib.sh
+      parse_input() {
+        local val="$1"
+        echo "${val}"
+      }
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # mylib.lib.sh
+      mylib::parse_input() {
+        local val="$1"
+        echo "${val}"
+      }

--- a/docs/rules/S090.yaml
+++ b/docs/rules/S090.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: package-function-namespace
 new_category: Style
 new_code: S090
 runtime_kind: ast

--- a/docs/rules/S091.yaml
+++ b/docs/rules/S091.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: variable-name-case
 new_category: Style
 new_code: S091
 runtime_kind: ast

--- a/docs/rules/S091.yaml
+++ b/docs/rules/S091.yaml
@@ -1,0 +1,35 @@
+origin: novel
+new_category: Style
+new_code: S091
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A local variable name (or function-scoped assignment target) does not match the configured naming pattern.
+rationale: Using a uniform naming convention for function-local variables makes it straightforward to distinguish them from constants and exported globals at a glance. The default pattern requires lowercase letters, digits, and underscores (snake_case). Projects with different conventions can supply an alternate regex via the `pattern` option.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: pattern
+    type: string
+    default: "^[a-z_][a-z0-9_]*$"
+    description: Regular expression that every local variable name must match. The default enforces lowercase snake_case.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      process_data() {
+        local FooBar=1
+        echo "${FooBar}"
+      }
+      process_data
+  - kind: valid
+    code: |
+      #!/bin/bash
+      process_data() {
+        local foo_bar=1
+        echo "${foo_bar}"
+      }
+      process_data

--- a/docs/rules/S092.yaml
+++ b/docs/rules/S092.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: constant-name-case
 new_category: Style
 new_code: S092
 runtime_kind: ast

--- a/docs/rules/S092.yaml
+++ b/docs/rules/S092.yaml
@@ -1,0 +1,31 @@
+origin: novel
+new_category: Style
+new_code: S092
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A constant declared with `readonly`, `declare -r`, or `export` does not match the configured naming pattern.
+rationale: Naming constants with uppercase letters and underscores (SCREAMING_SNAKE_CASE) is a widely followed convention that visually distinguishes immutable values from mutable locals and from functions. When a reader sees an all-caps name they know immediately that the value will not change within the script. Projects may supply an alternate regex via the `pattern` option.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: pattern
+    type: string
+    default: "^[A-Z_][A-Z0-9_]*$"
+    description: Regular expression that every constant declaration target must match. The default enforces SCREAMING_SNAKE_CASE.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      readonly maxRetries=3
+      readonly backoffMs=100
+      echo "${maxRetries}" "${backoffMs}"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      readonly MAX_RETRIES=3
+      readonly BACKOFF_MS=100
+      echo "${MAX_RETRIES}" "${BACKOFF_MS}"

--- a/docs/rules/S093.yaml
+++ b/docs/rules/S093.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: alias-definition
 new_category: Style
 new_code: S093
 runtime_kind: ast

--- a/docs/rules/S093.yaml
+++ b/docs/rules/S093.yaml
@@ -1,0 +1,35 @@
+origin: novel
+new_category: Style
+new_code: S093
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: An alias is defined in a script; shell functions are preferred over aliases for reusable command sequences.
+rationale: >
+  Aliases are evaluated once at definition time and do not compose well with
+  arguments, pipelines, or conditional logic. They behave differently in
+  non-interactive shells, can shadow built-ins in surprising ways, and are
+  silently ignored in many execution contexts (such as scripts that do not
+  explicitly enable alias expansion). Shell functions provide the same
+  shorthand with full access to positional parameters, local variables, and
+  structured control flow. Projects following Google-style shell conventions
+  replace aliases with named functions, which are unambiguous, testable, and
+  work identically across interactive and non-interactive environments.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      alias ll='ls -lh'
+      ll
+  - kind: valid
+    code: |
+      #!/bin/bash
+      ll() {
+        ls -lh
+      }
+      ll

--- a/docs/rules/S094.yaml
+++ b/docs/rules/S094.yaml
@@ -1,0 +1,55 @@
+origin: novel
+new_category: Style
+new_code: S094
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A function reads or writes a non-local variable that is not named in the function's leading comment block.
+rationale: >
+  Functions that silently depend on or modify global state are a common source of
+  hard-to-trace bugs in shell scripts. When a function reaches outside its own local
+  scope — reading a variable that was set elsewhere, or writing a variable that callers
+  will observe — that dependency should be visible at the call site without requiring a
+  full read of the implementation. The Google Shell Style Guide requires a "Globals:"
+  section that lists each non-local variable the function reads or writes. This rule
+  complements S084 by operating at the variable level: rather than just checking that a
+  Globals section exists, it verifies that each specific non-local variable the function
+  references appears by name in that section. The `treat-readonly-as-documented` option
+  exempts variables that are declared `readonly` at the top level, on the grounds that
+  a readonly constant is part of the script's visible configuration rather than hidden
+  mutable state.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: treat-readonly-as-documented
+    type: bool
+    default: true
+    description: >
+      When true, non-local variables that are declared readonly (via readonly, declare -r,
+      or export with a -r flag) at the top level are treated as self-documenting constants
+      and do not need to appear in the Globals section. Defaults to true.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # Logs a message with a severity prefix.
+      log_message() {
+        echo "[${LOG_LEVEL}] $1"
+      }
+      log_message "started"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # Logs a message with a severity prefix derived from LOG_LEVEL.
+      #
+      # Globals:
+      #   LOG_LEVEL (read)
+      # Arguments:
+      #   $1 - The message text to log.
+      log_message() {
+        echo "[${LOG_LEVEL}] $1"
+      }
+      log_message "started"

--- a/docs/rules/S094.yaml
+++ b/docs/rules/S094.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: undocumented-globals
 new_category: Style
 new_code: S094
 runtime_kind: ast

--- a/docs/rules/S095.yaml
+++ b/docs/rules/S095.yaml
@@ -1,0 +1,58 @@
+origin: novel
+new_category: Style
+new_code: S095
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A script that processes command-line arguments does not provide a usage function or handle the standard help flags.
+rationale: >
+  Scripts that parse positional parameters or option flags create an implicit
+  command-line interface. Without a usage message, callers who encounter an
+  error or who want to understand the script's interface have no in-band way
+  to discover accepted arguments, required parameters, or available options.
+  The Google Shell Style Guide recommends that every script with a non-trivial
+  argument surface include a `usage` function (or equivalent) and respond to
+  `--help` / `-h` with that documentation. This rule fires when a script
+  references positional parameters or uses `getopts` but defines neither a
+  function matching the configured `usage-function-name` nor a branch that
+  handles any of the configured `help-flags`.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: usage-function-name
+    type: string
+    default: "usage"
+    description: >
+      Name of the function that is considered the usage/help handler. The rule
+      treats any function definition whose name matches this value as satisfying
+      the documentation requirement. Defaults to "usage".
+  - name: help-flags
+    type: list
+    default: ["--help", "-h"]
+    description: >
+      String literals that, when matched in a test condition or case branch
+      against a positional parameter, satisfy the help-flag requirement. Defaults
+      to ["--help", "-h"].
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      input_file=$1
+      output_file=$2
+      process "$input_file" "$output_file"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      usage() {
+        printf 'Usage: %s <input> <output>\n' "$0"
+      }
+      if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+        usage
+        exit 0
+      fi
+      input_file=$1
+      output_file=$2
+      process "$input_file" "$output_file"

--- a/docs/rules/S095.yaml
+++ b/docs/rules/S095.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: missing-cli-usage
 new_category: Style
 new_code: S095
 runtime_kind: ast

--- a/docs/rules/S096.yaml
+++ b/docs/rules/S096.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: error-not-on-stderr
 new_category: Style
 new_code: S096
 runtime_kind: ast

--- a/docs/rules/S096.yaml
+++ b/docs/rules/S096.yaml
@@ -1,0 +1,37 @@
+origin: novel
+new_category: Style
+new_code: S096
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A command in an error branch writes output to stdout rather than stderr.
+rationale: >
+  Diagnostic messages — failures, errors, and explanatory text accompanying a
+  non-zero exit — belong on stderr so that callers can separate program output
+  from error text. When error-branch output goes to stdout, the calling script
+  or terminal mixes it with normal output, breaking pipelines and
+  capture-and-inspect patterns. The Google Shell Style Guide explicitly
+  recommends routing all error and diagnostic messages through `>&2`. This rule
+  flags plain writes (such as `echo`, `printf`, or `cat`) that appear in
+  recognizable error branches — `if ! cmd; then ...`, `cmd || { ... }`, or
+  blocks that end with a non-zero `exit` — and lack a `>&2` redirect.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      if ! gzip -t "$1"; then
+        echo "archive validation failed for: $1"
+        exit 1
+      fi
+  - kind: valid
+    code: |
+      #!/bin/bash
+      if ! gzip -t "$1"; then
+        echo "archive validation failed for: $1" >&2
+        exit 1
+      fi

--- a/docs/rules/S097.yaml
+++ b/docs/rules/S097.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: suppression-without-reason
 new_category: Style
 new_code: S097
 runtime_kind: ast

--- a/docs/rules/S097.yaml
+++ b/docs/rules/S097.yaml
@@ -1,0 +1,34 @@
+origin: novel
+new_category: Style
+new_code: S097
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A lint-suppression directive is missing a free-text justification explaining why the suppression is appropriate.
+rationale: >
+  Suppression directives silence diagnostics for everyone who reads the code
+  from that point forward. Without a rationale, the intent behind the
+  suppression is invisible: future maintainers cannot tell whether the code was
+  suppressed because the pattern is intentional, because the rule had a known
+  false-positive, or because the original author simply wanted to stop the
+  warning without investigating it. Requiring a trailing reason — a brief note
+  after the rule code — makes suppressions self-documenting and surfaces
+  suppressions that should be revisited when the surrounding code changes.
+  This rule fires on any `# shuck:` or `# shellcheck` directive that does not
+  include free-text after the code list.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # shuck: disable=S001
+      echo $HOME
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # shuck: disable=S001 -- HOME is controlled by the environment and cannot contain spaces
+      echo $HOME

--- a/docs/rules/S098.yaml
+++ b/docs/rules/S098.yaml
@@ -1,0 +1,56 @@
+origin: novel
+new_category: Style
+new_code: S098
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A suppression directive uses a broad category selector or a file-wide disable outside the configured allowlist.
+rationale: >
+  Wide-scope suppressions — disabling an entire category such as `ALL`, `C`,
+  `S`, or similar prefixes, or issuing a `disable-file` directive — silence
+  large classes of diagnostics at once, often hiding real problems alongside
+  the ones being worked around. Category-level suppressions are almost never
+  intentional; they usually result from copy-paste or from wanting to quiet one
+  noisy rule without looking up its specific code. File-wide disables carry the
+  same risk at a larger scale. This rule flags directives whose selector list
+  contains any entry from the configured `disallowed-selectors`, and also
+  flags `disable-file` directives when `allow-disable-file` is false. Fine-grained
+  per-rule suppressions with justifications (see S097) are the preferred
+  alternative.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: disallowed-selectors
+    type: list
+    default: ["ALL", "C", "S", "P", "X", "K"]
+    description: >
+      Selector strings whose presence in any suppression directive causes this
+      rule to fire. Matched case-sensitively against the raw tokens in the
+      directive. Defaults to the full set of category-level selectors.
+  - name: allow-disable-file
+    type: bool
+    default: false
+    description: >
+      When true, file-wide `disable-file` directives are permitted and will
+      not trigger this rule. Defaults to false.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # shuck: disable-file=ALL
+      process_files() {
+        local f
+        for f in "$@"; do
+          echo "$f"
+        done
+      }
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # shuck: disable=S001 -- pattern glob is intentional here
+      for entry in $GLOB_PATTERN; do
+        echo "$entry"
+      done

--- a/docs/rules/S098.yaml
+++ b/docs/rules/S098.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: blanket-suppression
 new_category: Style
 new_code: S098
 runtime_kind: ast

--- a/docs/rules/S099.yaml
+++ b/docs/rules/S099.yaml
@@ -1,0 +1,30 @@
+origin: novel
+new_category: Style
+new_code: S099
+runtime_kind: ast
+shellcheck_code: SC2230
+shellcheck_level: style
+shells:
+  - bash
+description: A call to `which` locates executables using only the current PATH without honoring shell functions or builtins; prefer the portable `command -v` builtin instead.
+rationale: >
+  The `which` utility is not defined by POSIX and behaves inconsistently across platforms —
+  some versions ignore shell aliases and functions, others consult a separate configuration,
+  and some do not return a non-zero exit code when the command is absent. The shell builtin
+  `command -v` is standardised, respects the shell's own function and alias namespace, and
+  provides the same executable-path lookup without external-process overhead. Replacing
+  `which` with `command -v` makes scripts both more portable and more accurate.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      path=$(which python3)
+      "$path" --version
+  - kind: valid
+    code: |
+      #!/bin/bash
+      path=$(command -v python3)
+      "$path" --version

--- a/docs/rules/S099.yaml
+++ b/docs/rules/S099.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: which-vs-command-v
 new_category: Style
 new_code: S099
 runtime_kind: ast

--- a/docs/rules/S100.yaml
+++ b/docs/rules/S100.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: quote-safe-variables
 new_category: Style
 new_code: S100
 runtime_kind: ast

--- a/docs/rules/S100.yaml
+++ b/docs/rules/S100.yaml
@@ -1,0 +1,40 @@
+origin: novel
+new_category: Style
+new_code: S100
+runtime_kind: ast
+shellcheck_code: SC2248
+shellcheck_level: style
+shells:
+  - bash
+description: A scalar variable expansion appears unquoted even when its value is not expected to contain word-splitting or glob characters.
+rationale: >
+  Even variables that are assigned safe-looking string literals should be double-quoted on
+  expansion. The assignment may change over time, the variable may be exported and set
+  externally, or a future refactor may introduce a value with whitespace. Consistently
+  quoting every expansion eliminates a class of subtle split-and-glob bugs before they
+  materialise, requires no knowledge of what each variable may contain at runtime, and
+  makes it clear to readers that word-splitting was consciously not desired. This rule
+  extends the default unquoted-expansion check to cover expansions that a purely
+  flow-sensitive analysis would consider safe.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: allowed-bare-expansions
+    type: list
+    default: []
+    description: >
+      List of variable names whose expansions are permitted to appear unquoted.
+      Useful for variables that intentionally receive whitespace-split treatment,
+      such as flag arrays passed through a single string. Defaults to an empty list.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      label="build-output"
+      mkdir $label
+  - kind: valid
+    code: |
+      #!/bin/bash
+      label="build-output"
+      mkdir "$label"

--- a/docs/rules/S101.yaml
+++ b/docs/rules/S101.yaml
@@ -1,0 +1,44 @@
+origin: novel
+new_category: Style
+new_code: S101
+runtime_kind: ast
+shellcheck_code: SC2250
+shellcheck_level: style
+shells:
+  - bash
+description: A scalar variable is expanded using the bare `$var` form rather than the brace-delimited `${var}` form.
+rationale: >
+  Consistently using `${var}` instead of `$var` makes the extent of every variable name
+  unambiguous at a glance and avoids surprises when a variable name is followed by a letter,
+  digit, or underscore that could be misread as part of the name. It also simplifies search
+  and refactoring: editors and code-analysis tools can reliably identify every expansion.
+  Special shell parameters (`$0`, `$1`, `$@`, `$$`, etc.) are typically exempt because
+  they cannot be confused with longer names, but named scalar variables benefit most from
+  the braced form.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: exempt-special-params
+    type: bool
+    default: true
+    description: >
+      When true, special shell parameters such as $0, $@, $*, $#, $$, $!, $?, and $-
+      are not required to use the braced form. Defaults to true.
+  - name: exempt-single-digit-positional
+    type: bool
+    default: true
+    description: >
+      When true, single-digit positional parameters ($1 through $9) are not required
+      to use the braced form. Defaults to true.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      greeting="hello"
+      echo "$greeting world"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      greeting="hello"
+      echo "${greeting} world"

--- a/docs/rules/S101.yaml
+++ b/docs/rules/S101.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: require-variable-braces
 new_category: Style
 new_code: S101
 runtime_kind: ast

--- a/docs/rules/S102.yaml
+++ b/docs/rules/S102.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: require-double-brackets
 new_category: Style
 new_code: S102
 runtime_kind: ast

--- a/docs/rules/S102.yaml
+++ b/docs/rules/S102.yaml
@@ -1,0 +1,43 @@
+origin: novel
+new_category: Style
+new_code: S102
+runtime_kind: ast
+shellcheck_code: SC2292
+shellcheck_level: style
+shells:
+  - bash
+description: A test expression uses the POSIX `[ ]` form in a Bash script where the extended `[[ ]]` form is available and preferred.
+rationale: >
+  In Bash (and Ksh), the `[[ ]]` keyword is a first-class language construct rather than
+  a regular command. It avoids several pitfalls of the POSIX `[ ]` form: word splitting
+  and pathname expansion do not occur on unquoted operands, the `&&` and `||` operators
+  work as expected inside the test, pattern matching is built in, and there is no ambiguity
+  between the `-a`/`-o` flags and filenames. Migrating Bash-only scripts to `[[ ]]`
+  eliminates these edge cases and signals to readers that portability to `/bin/sh` is not
+  a goal of the script.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: allow-in-portable-mode
+    type: bool
+    default: false
+    description: >
+      When true, `[ ]` is permitted even when the shell is bash. Useful for scripts
+      that intentionally maintain POSIX compatibility despite using a bash shebang.
+      Defaults to false.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      name="Alice"
+      if [ "$name" = "Alice" ]; then
+        echo "hello"
+      fi
+  - kind: valid
+    code: |
+      #!/bin/bash
+      name="Alice"
+      if [[ "$name" = "Alice" ]]; then
+        echo "hello"
+      fi

--- a/docs/rules/S103.yaml
+++ b/docs/rules/S103.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: avoid-nullary-conditions
 new_category: Style
 new_code: S103
 runtime_kind: ast

--- a/docs/rules/S103.yaml
+++ b/docs/rules/S103.yaml
@@ -1,0 +1,40 @@
+origin: novel
+new_category: Style
+new_code: S103
+runtime_kind: ast
+shellcheck_code: SC2243
+shellcheck_level: style
+shells:
+  - bash
+description: A `[[ ]]` test uses a bare command substitution as its only operand rather than an explicit `-n` test or a direct conditional on the command's exit status.
+rationale: >
+  Writing `[[ $(some_command) ]]` tests whether the command produced any output, not
+  whether it succeeded. This conflates two different notions — non-empty output and
+  zero exit status — and is often unintentional. Using `-n "$(some_command)"` makes the
+  intent explicit: the script is testing for non-empty output. Alternatively, running the
+  command directly as a conditional (`if some_command; then`) tests exit status without
+  capturing output at all. Being explicit avoids silent mismatches between what the
+  author intended and what the shell actually evaluates.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: allow-nullary-on-quoted-expansion
+    type: bool
+    default: false
+    description: >
+      When true, bare quoted variable expansions such as `[[ "$var" ]]` are not
+      flagged; only bare command substitutions are. Defaults to false.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      if [[ $(git status --short) ]]; then
+        echo "uncommitted changes"
+      fi
+  - kind: valid
+    code: |
+      #!/bin/bash
+      if [[ -n $(git status --short) ]]; then
+        echo "uncommitted changes"
+      fi

--- a/docs/rules/S104.yaml
+++ b/docs/rules/S104.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: missing-case-default
 new_category: Style
 new_code: S104
 runtime_kind: ast

--- a/docs/rules/S104.yaml
+++ b/docs/rules/S104.yaml
@@ -1,0 +1,38 @@
+origin: novel
+new_category: Style
+new_code: S104
+runtime_kind: ast
+shellcheck_code: SC2249
+shellcheck_level: style
+shells:
+  - bash
+description: A `case` statement has no catch-all `*)` default branch to handle values that do not match any explicit pattern.
+rationale: >
+  A `case` statement without a `*)` branch silently ignores any input that does not match
+  a named pattern. This makes it easy to overlook typos in values, miss future extensions
+  to an enumeration, or silently fail when upstream code passes an unexpected value. Adding
+  a default branch — even one that just emits a diagnostic and exits — turns a silent no-op
+  into an explicit signal that an unexpected value was received. The pattern is especially
+  important for scripts that dispatch on command-line arguments or environment variables
+  whose set of valid values may grow over time.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      action="${1:-}"
+      case "$action" in
+        start) echo "starting service" ;;
+        stop)  echo "stopping service" ;;
+      esac
+  - kind: valid
+    code: |
+      #!/bin/bash
+      action="${1:-}"
+      case "$action" in
+        start) echo "starting service" ;;
+        stop)  echo "stopping service" ;;
+        *)     echo "unknown action: ${action}" >&2; exit 1 ;;
+      esac

--- a/docs/rules/X082.yaml
+++ b/docs/rules/X082.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: bash-feature-too-new
 new_category: Portability
 new_code: X082
 runtime_kind: ast

--- a/docs/rules/X082.yaml
+++ b/docs/rules/X082.yaml
@@ -1,0 +1,41 @@
+origin: novel
+new_category: Portability
+new_code: X082
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A Bash feature used in the script was introduced in a version newer than the project's configured maximum.
+rationale: >
+  Projects that need to run on older Bash installations (common in CI images, Docker base
+  containers, and enterprise Linux distributions) must stay within the capabilities of
+  the oldest Bash version they support. When the project declares a `max-version` ceiling
+  in its configuration, this rule flags any construct whose introduction in Bash post-dates
+  that ceiling. For example, `EPOCHSECONDS` and `EPOCHREALTIME` are variables that Bash
+  began populating in version 5.0; using them in a project that targets Bash 4.4 creates
+  a silent failure on the older host (the variables are simply empty). The rule's catalog
+  covers builtin variables, parameter transformation operators, and shopt options that
+  have known introduction versions, and it grows as the catalog is extended. Constructs
+  not yet in the catalog are not flagged.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: max-version
+    type: string
+    default: "4.4"
+    description: The maximum Bash version the project targets. Constructs introduced after this version are flagged.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # EPOCHSECONDS was introduced in Bash 5.0; this violates max-version=4.4
+      start=$EPOCHSECONDS
+      echo "start=$start"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # date +%s works on any Bash version and is within the 4.4 ceiling
+      start=$(date +%s)
+      echo "start=$start"

--- a/docs/rules/X083.yaml
+++ b/docs/rules/X083.yaml
@@ -1,0 +1,46 @@
+origin: novel
+new_category: Portability
+new_code: X083
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells:
+  - bash
+description: A script that declares a modern-Bash version floor uses constructs that work on much older Bash versions, bypassing the benefit of that floor.
+rationale: >
+  When a project commits to requiring a minimum Bash version — for example, Bash 5.0 — it
+  gains access to features introduced in that release and later. Using pre-floor idioms
+  alongside that requirement weakens the contract: the script could silently be run on a
+  far older interpreter, scripts within the same codebase lose consistency, and developers
+  miss more capable or safer alternatives that the stated minimum already provides. This
+  rule flags patterns that work on Bash versions well below the configured `min-version`
+  when a direct replacement requiring roughly that floor exists. A representative case:
+  piping through `tr '[:lower:]' '[:upper:]'` to fold case is universal across POSIX
+  shells, but a project requiring Bash 4.0+ can use the `${var^^}` expansion instead,
+  eliminating the subshell and external process. The rule's detection is bounded to idioms
+  where the modern alternative is a straightforward substitution; it does not penalise
+  code that legitimately mixes levels for portability reasons elsewhere in the same file.
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: min-version
+    type: string
+    default: "5.0"
+    description: The minimum Bash version the project requires. Constructs that work on versions substantially below this floor are flagged when a version-appropriate replacement exists.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      # Piping through tr works on any POSIX shell; a project requiring Bash 4.0+
+      # can use ${var^^} instead, but a min-version=5.0 project especially should
+      name="hello world"
+      upper=$(printf '%s' "$name" | tr '[:lower:]' '[:upper:]')
+      echo "$upper"
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # ${var^^} case-conversion operator requires Bash 4.0; preferred for a 5.0+ project
+      name="hello world"
+      upper="${name^^}"
+      echo "$upper"

--- a/docs/rules/X083.yaml
+++ b/docs/rules/X083.yaml
@@ -1,4 +1,5 @@
 origin: novel
+legacy_name: bash-feature-too-old
 new_category: Portability
 new_code: X083
 runtime_kind: ast

--- a/docs/rules/validate.sh
+++ b/docs/rules/validate.sh
@@ -112,7 +112,7 @@ check_unique_optional_field() {
     basename=$(basename "${file}")
     value=$(yq -r "${field}" "${file}")
 
-    if [[ -z "${value}" || "${value}" == "null" ]]; then
+    if [[ -z "${value}" || "${value}" == "null" || "${value}" == "~" ]]; then
       continue
     fi
 
@@ -153,22 +153,37 @@ check_unique_optional_field() {
 
 validate_file() {
   local file=$1
-  local basename stem legacy_code new_code rule_path example_path doc_shells source_shells failed=0
+  local basename stem origin legacy_code new_code rule_path example_path doc_shells source_shells failed=0
 
   basename=$(basename "${file}")
   stem=${basename%.yaml}
+  origin=$(yq -r '.origin // "imported"' "${file}")
   legacy_code=$(yq -r '.legacy_code' "${file}")
   new_code=$(yq -r '.new_code' "${file}")
 
   if ! check_yq "${file}" 'type == "!!map"' "root document must be a mapping"; then
     failed=1
   fi
-  if ! check_yq "${file}" '((.legacy_code | type) == "!!str") and (.legacy_code | test("^SH-[0-9]{3}$"))' "legacy_code must look like SH-001"; then
+  if ! check_yq "${file}" '(.origin == null) or (.origin == "imported") or (.origin == "novel")' "origin must be omitted, \"imported\", or \"novel\""; then
     failed=1
   fi
-  if ! check_yq "${file}" '((.legacy_name | type) == "!!str") and ((.legacy_name | length) > 0)' "legacy_name must be a non-empty string"; then
-    failed=1
+
+  if [[ "${origin}" == "imported" ]]; then
+    if ! check_yq "${file}" '((.legacy_code | type) == "!!str") and (.legacy_code | test("^SH-[0-9]{3}$"))' "legacy_code must look like SH-001"; then
+      failed=1
+    fi
+    if ! check_yq "${file}" '((.legacy_name | type) == "!!str") and ((.legacy_name | length) > 0)' "legacy_name must be a non-empty string"; then
+      failed=1
+    fi
+  else
+    if ! check_yq "${file}" '(.legacy_code == null) or (((.legacy_code | type) == "!!str") and (.legacy_code | test("^SH-[0-9]{3}$")))' "legacy_code must be omitted or look like SH-001 for novel rules"; then
+      failed=1
+    fi
+    if ! check_yq "${file}" '(.legacy_name == null) or (((.legacy_name | type) == "!!str") and ((.legacy_name | length) > 0))' "legacy_name must be omitted or a non-empty string for novel rules"; then
+      failed=1
+    fi
   fi
+
   if ! check_yq "${file}" '.new_category == "Correctness" or .new_category == "Style" or .new_category == "Performance" or .new_category == "Portability" or .new_category == "Security"' "new_category must be one of Correctness, Style, Performance, Portability, or Security"; then
     failed=1
   fi
@@ -211,10 +226,30 @@ validate_file() {
   if ! check_yq "${file}" '(.safe_fix == false) or (((.fix_description | type) == "!!str") and ((.fix_description | length) > 0))' "fix_description must be a non-empty string when safe_fix is true"; then
     failed=1
   fi
-  if ! check_yq "${file}" '((.source | type) == "!!map") and ((.source.shell_checks_rule | type) == "!!str") and ((.source.shell_checks_rule | length) > 0) and ((.source.shell_checks_example | type) == "!!str") and ((.source.shell_checks_example | length) > 0)' "source must include shell_checks_rule and shell_checks_example"; then
+  if ! check_yq "${file}" '(.default_enabled == null) or ((.default_enabled | type) == "!!bool")' "default_enabled must be a boolean when present"; then
     failed=1
   fi
-  if ! check_yq "${file}" '((.examples | type) == "!!seq") and ((.examples | length) > 0) and ([.examples[] | (((.kind | type) == "!!str") and ((.kind | length) > 0) and ((.source | type) == "!!str") and ((.source | length) > 0) and ((.code | type) == "!!str") and ((.code | length) > 0))] | all)' "examples must be a non-empty list of entries with kind, source, and code"; then
+  if ! check_yq "${file}" '(.options == null) or (((.options | type) == "!!seq") and ([.options[] | select((.name | type) != "!!str" or (.name | length) == 0 or (.type | type) != "!!str" or (.type | length) == 0 or (.description | type) != "!!str" or (.description | length) == 0)] | length == 0))' "options must be a list of {name, type, default, description} when present"; then
+    failed=1
+  fi
+
+  if [[ "${origin}" == "imported" ]]; then
+    if ! check_yq "${file}" '((.source | type) == "!!map") and ((.source.shell_checks_rule | type) == "!!str") and ((.source.shell_checks_rule | length) > 0) and ((.source.shell_checks_example | type) == "!!str") and ((.source.shell_checks_example | length) > 0)' "source must include shell_checks_rule and shell_checks_example"; then
+      failed=1
+    fi
+    if ! check_yq "${file}" '((.examples | type) == "!!seq") and ((.examples | length) > 0) and ([.examples[] | (((.kind | type) == "!!str") and ((.kind | length) > 0) and ((.source | type) == "!!str") and ((.source | length) > 0) and ((.code | type) == "!!str") and ((.code | length) > 0))] | all)' "examples must be a non-empty list of entries with kind, source, and code"; then
+      failed=1
+    fi
+  else
+    if ! check_yq "${file}" '(.source == null) or ((.source | type) == "!!map")' "source must be omitted or a mapping for novel rules"; then
+      failed=1
+    fi
+    if ! check_yq "${file}" '((.examples | type) == "!!seq") and ((.examples | length) > 0) and ([.examples[] | (((.kind | type) == "!!str") and ((.kind | length) > 0) and ((.code | type) == "!!str") and ((.code | length) > 0))] | all)' "examples must be a non-empty list of entries with kind and code (source optional for novel rules)"; then
+      failed=1
+    fi
+  fi
+
+  if ! check_yq "${file}" '((.examples | type) != "!!seq") or ([.examples[] | select(.kind != "invalid" and .kind != "valid")] | length == 0)' "example kind must be \"invalid\" or \"valid\""; then
     failed=1
   fi
 
@@ -223,12 +258,12 @@ validate_file() {
     failed=1
   fi
 
-  if [[ ! -d "${shell_checks_root}" ]]; then
+  if [[ "${origin}" == "imported" && ! -d "${shell_checks_root}" ]]; then
     printf 'ERROR %s: sibling shell-checks repo not found at %s\n' "${basename}" "${shell_checks_root}" >&2
     failed=1
   fi
 
-  if [[ "${failed}" -eq 0 ]]; then
+  if [[ "${failed}" -eq 0 && "${origin}" == "imported" ]]; then
     rule_path=$(resolve_shell_checks_path "$(yq -r '.source.shell_checks_rule' "${file}")")
     example_path=$(resolve_shell_checks_path "$(yq -r '.source.shell_checks_example' "${file}")")
 
@@ -298,7 +333,7 @@ main() {
     fi
   done
 
-  if ! check_unique_field '.legacy_code' 'legacy_code' "${all_rule_files[@]}"; then
+  if ! check_unique_optional_field '.legacy_code' 'legacy_code' "${all_rule_files[@]}"; then
     failed=1
   fi
 

--- a/specs/017-google-shell-style.md
+++ b/specs/017-google-shell-style.md
@@ -1,0 +1,620 @@
+# 017: Google Shell Style Guide Rules
+
+## Status
+
+Proposed
+
+## Summary
+
+Add a set of opt-in lint rules that cover the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html) — both the rules ShellCheck does not implement (novel shuck rules) and the rules behind ShellCheck's optional checks plus a handful of default-on ShellCheck checks shuck does not yet map. The rules slot into the existing `S` (Style), `C` (Correctness), and `X` (Portability) categories. They are all disabled by default, configurable through `[lint.rule-options.<code>]`, and require new linter facts for file shape, comment-to-function association, TODO parsing, and Bash feature versioning. A new `google` named-group selector pulls the full Google-style preset together — both the new rules and the existing shuck rules that already cover Google-aligned ShellCheck checks.
+
+## Motivation
+
+ShellCheck and shuck's existing rule set already cover a large slice of shell hygiene — quoting, brace expansions, `[[ ]]` over `[ ]`, `read -r`, return-status handling, and so on. The Google Shell Style Guide goes further: it prescribes a *script shape* (where constants live, where functions live, where executable code lives), a *documentation contract* (file headers, function docs that name globals, args, outputs, and return values), and a *naming policy* (snake_case locals, SCREAMING_SNAKE_CASE constants, `package::function` namespaces).
+
+Today shuck has no way to enforce these. Users writing shell at a Google-style codebase fall back to manual review, ad-hoc grep, or independent tooling. The rules in this spec close that gap without competing with ShellCheck on its own ground.
+
+The rules are deliberately opinionated and project-policy oriented, so they must be opt-in and configurable. A monorepo that requires `#!/bin/bash` shebangs, a 100-line script ceiling, and `pkg::function` namespacing should be able to express that policy in `shuck.toml`. A casual user who wants none of it should see no behavior change.
+
+## Design
+
+### Scope
+
+This spec covers two classes of rules:
+
+1. **Novel Google-style rules** — checks the Google guide prescribes that ShellCheck does not implement and that the formatter cannot enforce. These have no `shellcheck_code` mapping and use shuck-only diagnostic wording.
+2. **ShellCheck-mapped rules** — checks the Google guide aligns with that map directly to ShellCheck rules (default-on or optional) shuck has not yet imported. These follow the project's existing conformance pattern (parity testing via `make test-large-corpus`).
+
+Both classes share the same constraints:
+
+- Operate on a single file's source plus its existing `LinterFacts`, `SemanticModel`, and `Indexer`.
+- Do not require filesystem inspection (executable bit, filename casing, repo directory layout).
+- Do not require cross-file resolution (which files are sourced by which, whether a library is sourceable under test).
+
+The rules in the original Google-style proposal that fall outside that scope — shell library exec bit, filename convention, path role, sourced-file main logic, sourceable-under-test approximation — are explicitly deferred. They need a `ProjectContext` layer that the linter does not have today and are tracked separately.
+
+### Rule Inventory
+
+The new rules split into two groups: **novel** rules with no ShellCheck counterpart and **ShellCheck-mapped** rules that import a check shuck has not yet adopted. Numbering picks up after the existing highest rule in each category (`S077`, `C157`, `X081`).
+
+#### Style (S) — novel rules
+
+| Code | Name | Trigger |
+|------|------|---------|
+| S078 | `shebang-not-bash` | Executable script's shebang names a shell other than the configured policy (default `bash`). |
+| S079 | `shebang-form-mismatch` | Shebang line does not match the configured form (e.g., `#!/bin/bash` vs `#!/usr/bin/env bash`). |
+| S080 | `script-size-threshold` | Source line count exceeds configured threshold (default 100). |
+| S081 | `missing-file-description` | First non-shebang, non-blank line is not a comment block describing the file's purpose. |
+| S082 | `todo-format` | A `TODO` / `FIXME` / `XXX` comment lacks a `(name)` or `(handle)` owner annotation, or lacks a message. |
+| S083 | `missing-function-doc` | A function definition has no leading comment block when policy thresholds say it should (visibility, length, parameter use). |
+| S084 | `function-doc-content` | A function's leading comment block does not document the items present in the function: globals read/written, args used, stdout produced, and return values. |
+| S085 | `missing-main-function` | A non-trivial script (configurable predicate) does not call `main "$@"` (or the configured equivalent) as its final top-level statement. |
+| S086 | `top-level-code-not-minimal` | Top-level executable statements appear outside the allowed set (constants, `readonly`, `declare`, function definitions, sourcing, and a single `main "$@"` invocation). |
+| S087 | `constants-not-at-top` | A `readonly` / `declare -r` / `export` constant declaration appears below the first function definition. |
+| S088 | `functions-not-grouped` | Function definitions are not contiguous: an executable statement appears between two function definitions. |
+| S089 | `function-name-case` | A function name does not match the configured naming pattern (default snake_case, optionally allowing `pkg::function`). |
+| S090 | `package-function-namespace` | Functions in files matching the configured library predicate do not use a `package::function_name` form. |
+| S091 | `variable-name-case` | A `local` variable name (or function-scoped assignment target) does not match the configured naming pattern (default snake_case). |
+| S092 | `constant-name-case` | A `readonly` / `declare -r` / `export` target does not match the configured naming pattern (default `SCREAMING_SNAKE_CASE`). |
+| S093 | `alias-definition` | An `alias` builtin call appears in a script. |
+| S094 | `undocumented-globals` | A function reads or writes a non-local variable without that variable being named in the function's leading comment block. |
+| S095 | `missing-cli-usage` | A script that parses arguments (`getopts`, indexing into `$@`/`$1`..`$9`, or referencing `$1` outside a function) does not define a `usage` function or handle `--help`/`-h`. |
+| S096 | `error-not-on-stderr` | A command in a likely error branch (`die`, after a failed `||`, inside an `if ... then` that ends in `exit N` with `N != 0`) writes to stdout without `>&2`. |
+| S097 | `suppression-without-reason` | A `# shuck:` or `# shellcheck` directive does not include trailing free-text justification. |
+| S098 | `blanket-suppression` | A directive disables a wide selector (`ALL`, `S`, `C`, etc.) or uses `disable-file` outside the configured allowlist. |
+
+#### Style (S) — ShellCheck-mapped imports
+
+| Code | Maps to | Name | Trigger |
+|------|---------|------|---------|
+| S099 | SC2230 / `deprecate-which` | `which-vs-command-v` | A script invokes `which`; the Google guide and ShellCheck both prefer `command -v`. |
+| S100 | SC2248 / `quote-safe-variables` | `quote-safe-variables` | Even "safe-looking" expansions are unquoted; the rule extends S001 to cases S001 currently allows. |
+| S101 | SC2250 / `require-variable-braces` | `require-variable-braces` | A scalar expansion uses `$var` form rather than `${var}`. |
+| S102 | SC2292 / `require-double-brackets` | `require-double-brackets` | A test uses `[ ... ]` in Bash where `[[ ... ]]` is preferred. |
+| S103 | SC2243 / `avoid-nullary-conditions` | `avoid-nullary-conditions` | A `[[ ]]` test uses a bare command substitution (`[[ $(cmd) ]]`) where explicit `-n` / `-z` is preferred. |
+| S104 | SC2249 / `add-default-case` | `missing-case-default` | A `case` statement has no `*)` default branch. (Distinct from S069, which covers the `getopts` invalid-flag handler under SC2220.) |
+
+#### Correctness (C) — novel rules
+
+| Code | Name | Trigger |
+|------|------|---------|
+| C158 | `implicit-global-in-function` | An assignment inside a function targets a name that was not declared `local`/`declare`/`readonly` in the function's scope and is not a documented intentional global. |
+| C159 | `mutable-global` | A non-`readonly` global variable is assigned more than once at the top level, or assigned at the top level and reassigned from a function. |
+| C160 | `unanchored-source-path` | A `source` / `.` invocation uses a relative path that does not begin with `"${BASH_SOURCE[0]%/*}"`, `"$(dirname "$0")"`, or another script-dir anchor. |
+
+#### Correctness (C) — ShellCheck-mapped imports
+
+| Code | Maps to | Name | Trigger |
+|------|---------|------|---------|
+| C161 | SC2218 | `function-called-before-defined` | A function is invoked at a top-level position that is reached before the function's definition is evaluated. |
+| C162 | SC2312 / `check-extra-masked-returns` | `extra-masked-returns` | A command-substitution failure is masked in cases beyond the `local`/`declare`/`export` set already covered by S010 (e.g., on the right-hand side of a non-declaration assignment that the rule policy treats as masking). |
+
+#### Portability (X) — novel rules
+
+| Code | Name | Trigger |
+|------|------|---------|
+| X082 | `bash-feature-too-new` | A construct used in the script requires a Bash version newer than the project's configured minimum. |
+| X083 | `bash-feature-too-old` | A construct used in the script is below the project's required modern-Bash floor (e.g., a project that requires Bash 5+ uses syntax that works on 3.2). |
+
+### Relationship to Existing Rules
+
+None of the rules in this spec are implemented today, but several rule families already exist that this spec must integrate with rather than duplicate.
+
+**Shebang cluster.** C060 (non-absolute-shebang), C073 (indented-shebang), C074 (space-after-hash-bang), C075 (shebang-not-on-first-line), S043 (missing-shebang-line), and S053 (duplicate-shebang-flag) already inspect the shebang for placement, indentation, absoluteness, and duplicate flags. They do not classify *which* shell the shebang names or *which form* (`#!/bin/bash` vs `#!/usr/bin/env bash`) it uses. S078 and S079 fill that gap by extending `ShebangHeaderFacts` with `shell` and `form` fields, and they should be documented as "checks the policy of the shebang" while the existing rules cover its mechanics. A rule-doc cross-reference under each shebang rule makes the cluster discoverable.
+
+**`local` policy pair.** C014 (local-top-level) flags `local` used at script scope. C158 (`implicit-global-in-function`) is the inverse: it flags an assignment inside a function that should have used `local`. The rules are complementary and should reference each other in their docs. C136 (local-cross-reference), C150 (subshell-local-assignment), S066 (local-declare-combined), and X003 (local-variable-in-sh) round out the existing `local`-related rules and remain unchanged.
+
+**Alias rules.** S056 (command-substitution-in-alias) and S057 (function-in-alias) inspect alias *bodies* for substitutions and positional parameters. S093 (`alias-definition`) flags the *existence* of any alias in a script. The three rules are independent and can be enabled in any combination.
+
+**Source-command rules.** X042 (sourced-with-args) and X080 (source-inside-function-in-sh) are existing portability rules over `source`/`.`. C160 (`unanchored-source-path`) adds a correctness check that the source target is anchored to the script's directory. The three rules read from the existing source-reference fact set.
+
+**Stderr.** C085 (stderr-before-stdout-redirect) checks the *ordering* of `2>&1` and `>file` redirects. S096 (`error-not-on-stderr`) checks whether error-branch output is *routed* to stderr at all. The two rules touch stderr from opposite directions and do not conflict.
+
+**Quoting and bracing imports.** S001 (SC2086, scalar expansion) and S004 (SC2046, command substitution) cover ShellCheck's default-on quoting checks. S100 (SC2248) extends S001 to flag expansions S001 currently allows when the project policy says even safe-looking expansions should be quoted. S101 (SC2250) is independent: it requires brace form (`${var}`) on every scalar expansion regardless of quoting. S077 (SC1087, `brace-variable-before-bracket`) is a narrower lexical rule about a specific `$var[` ambiguity and remains separate.
+
+**Test-form imports.** S102 (SC2292) flags `[ ... ]` in Bash and prefers `[[ ... ]]`. S103 (SC2243) flags bare command-substitution operands inside `[[ ]]` (`[[ $(cmd) ]]`) and prefers an explicit `-n` test or a direct exit-status conditional. The two rules layer on the existing test-condition fact set (`facts/simple_tests.rs`, `facts/conditionals.rs`); they do not introduce a new fact builder.
+
+**Case-default and getopts pair.** S069 implements the `getopts` invalid-flag handler under SC2220. S104 (`missing-case-default`, mapping SC2249 / `add-default-case`) is a separate rule that flags general `case` statements lacking a `*)` branch. The two rules cover unrelated situations in different ShellCheck codes; they are kept independent so users can enable either.
+
+**Masked-returns pair.** S010 (SC2155) flags returns masked by `local`/`declare`/`export` declaration assignments. C162 (`extra-masked-returns`, mapping SC2312 under ShellCheck's `check-extra-masked-returns` optional check) extends the policy to additional masking forms the optional check covers. C162 reads from the existing assignment fact set with an extended policy filter rather than introducing a new fact.
+
+**Function-call ordering.** C063 (`overwritten-function`) and the existing call-site fact set already track function definitions and invocations. C161 (`function-called-before-defined`, SC2218) reuses the call-site fact set with a top-level evaluation-order filter — invocation positions are compared to the spans of definitions reachable on the same evaluation path. No new fact builder.
+
+**`which` rule.** S099 (SC2230, `which-vs-command-v`) is a structural command-name check with no existing adjacent rule. It reads from the normalized command fact set (`facts/normalized_commands.rs`).
+
+### Default Enablement
+
+Every rule introduced in this spec is **off by default**. They appear in the registry, in the documentation, and in selectors, but a fresh `shuck.toml` does not enable them.
+
+Rationale: these rules encode project policy, not universal correctness. Forcing them on would surprise existing users and would conflict with codebases that intentionally use POSIX `sh`, large shell scripts, or coding conventions other than Google's.
+
+Users opt in via `shuck.toml`:
+
+```toml
+[lint]
+select = ["C", "K"]
+extend-select = [
+    "S078", "S079",         # shebang policy
+    "S081", "S083", "S084", # documentation policy
+    "S085", "S086",         # script shape
+    "S089", "S091", "S092", # naming policy
+    "S097", "S098",         # suppression hygiene
+    "C158", "C160",         # implicit-global / unanchored-source
+]
+```
+
+A `google` named group is also added for convenience, equivalent to the union of every rule in this spec:
+
+```toml
+extend-select = ["google"]
+```
+
+Named groups are a thin selector type that resolves to a static `RuleSet` at config-load time. The existing `RuleSelector` enum gains a `Named(NamedGroup)` variant.
+
+### New Linter Facts
+
+Most rules in this spec need structural information that is not in `LinterFacts` today. Following the project convention from `CLAUDE.md`, the new logic lives in `crates/shuck-linter/src/facts.rs` rather than as ad-hoc walks inside rule files.
+
+#### `FileShape`
+
+Classifies the script's top-level statements into the slots allowed by Google style. Built once per file, consumed by `S080`, `S081`, `S085`, `S086`, `S087`, `S088`, and `S095`.
+
+```rust
+pub struct FileShape {
+    /// Span of the shebang line, if present.
+    pub shebang: Option<ShebangFact>,
+    /// The first non-shebang, non-blank, non-trailing-attribute comment
+    /// block, if present. Used by S081.
+    pub file_header_comment: Option<CommentBlockId>,
+    /// Top-level statements classified by role.
+    pub top_level: Vec<TopLevelEntry>,
+    /// Total source line count (for S080 and "non-trivial" predicates).
+    pub line_count: u32,
+    /// Whether the file ends with a `main "$@"` (or configured equivalent)
+    /// invocation as its last top-level statement.
+    pub trailing_main_call: Option<MainCallFact>,
+}
+
+pub struct TopLevelEntry {
+    pub stmt: StmtId,
+    pub role: TopLevelRole,
+    pub span: Span,
+}
+
+pub enum TopLevelRole {
+    Shebang,
+    Comment,
+    Constant,            // readonly / declare -r / export NAME=...
+    Declaration,         // declare without -r and without rvalue
+    FunctionDefinition,
+    SourceCommand,       // source / . X
+    MainInvocation,      // main "$@" or configured form
+    OtherExecutable,
+}
+```
+
+#### Extending `ShebangHeaderFacts`
+
+A `ShebangHeaderFacts` builder already exists in `crates/shuck-linter/src/facts/comments.rs` and powers C060, C073, C074, C075, S043, and S053. Today it stores anti-pattern spans (indented shebang, missing shebang, duplicate flags, non-absolute shebang) but does not classify the shell name or the shebang form.
+
+S078 and S079 extend that struct rather than introducing a parallel fact:
+
+```rust
+pub struct ShebangHeaderFacts {
+    // ...existing fields...
+
+    /// Classified shell from the shebang's interpreter path. Populated when
+    /// a shebang is present and parseable, regardless of any anti-pattern flags.
+    pub shell: Option<ShebangShell>,
+    /// AbsolutePath: `#!/bin/bash`. EnvLookup: `#!/usr/bin/env bash`. Other: anything else.
+    pub form: Option<ShebangForm>,
+    /// Span of the interpreter token (the path or the `env`-resolved shell).
+    pub interpreter_span: Option<Span>,
+    /// Span of the entire shebang line, used by S078/S079 diagnostics.
+    pub shebang_span: Option<Span>,
+}
+
+pub enum ShebangShell { Bash, Sh, Zsh, Ksh, Dash, Other }
+pub enum ShebangForm  { AbsolutePath, EnvLookup, Other }
+```
+
+The new fields are populated unconditionally — every existing shebang-aware rule already pays the parse cost, so there is no gating concern. The flag list S053 reads remains where it is.
+
+#### `FunctionDocs`
+
+Associates each function definition with the comment block immediately preceding it (after stripping blank lines), and parses Google-style structured fields out of that comment block.
+
+```rust
+pub struct FunctionDocs {
+    pub by_function: FxHashMap<FunctionId, FunctionDocBlock>,
+}
+
+pub struct FunctionDocBlock {
+    pub comments: IdRange<CommentId>,
+    pub span: Span,
+    /// Documented sections recovered from `Globals:`, `Arguments:`,
+    /// `Outputs:`, `Returns:` headings. Detection is permissive: header
+    /// match is case-insensitive and allows `:` or no separator. The
+    /// concrete grammar is documented inline with the parser.
+    pub sections: FunctionDocSections,
+}
+
+pub struct FunctionDocSections {
+    pub globals: Option<DocSection>,
+    pub arguments: Option<DocSection>,
+    pub outputs: Option<DocSection>,
+    pub returns: Option<DocSection>,
+}
+```
+
+`FunctionDocs` powers `S083`, `S084`, and `S094`.
+
+#### `TodoComments`
+
+```rust
+pub struct TodoComment {
+    pub comment_id: CommentId,
+    pub kind: TodoKind,                // TODO | FIXME | XXX
+    pub owner: Option<TodoOwner>,
+    pub message: Option<String>,
+    pub span: Span,
+}
+
+pub enum TodoOwner {
+    Name(String),
+    Url(String),
+    BugReference(String),
+}
+```
+
+Powers `S082`.
+
+#### `SuppressionDirectiveText`
+
+The existing suppression layer (spec 006) parses directives but discards trailing free-text. Powering `S097` and `S098` requires the directive index to retain the trailing reason span and the original selector strings.
+
+```rust
+pub struct SuppressionDirectiveText {
+    pub directive_id: DirectiveId,
+    pub trailing_reason: Option<Span>,  // text after the codes, before EOL
+    pub selector_strings: Vec<String>,  // raw selectors as written
+    pub action: DirectiveAction,
+}
+```
+
+This lives next to the existing `SuppressionIndex` and is built lazily — `S097`/`S098` are off by default, so most runs skip the work.
+
+#### `BashFeatureUse`
+
+Used by `X082`/`X083`. Each entry records a syntactic or builtin use that has a known minimum Bash version.
+
+```rust
+pub struct BashFeatureUse {
+    pub feature: BashFeature,
+    pub min_version: BashVersion,
+    pub span: Span,
+}
+
+pub enum BashFeature {
+    AssocArray,                 // declare -A
+    NamerefDeclareN,            // declare -n
+    GlobstarPattern,            // shopt -s globstar
+    CaseFallthroughSemicolons,  // ;& and ;;&
+    LowercasePatternExpansion,  // ${var,,}
+    SubstringSlicing,           // ${var:offset:len}
+    // ... extended over time
+}
+```
+
+The feature catalog is bounded by what `X082`/`X083` are configured to flag. Unrecognized features are not synthesized.
+
+### Rule-Option Schema
+
+Every rule that needs configuration registers options under `[lint.rule-options.<code>]` matching the existing pattern (see `C001`'s `treat-indirect-expansion-targets-as-used`).
+
+#### S078 / S079 — shebang policy
+
+```toml
+[lint.rule-options.s078]
+allowed-shells = ["bash"]   # also accepts "sh", "zsh", "ksh"
+
+[lint.rule-options.s079]
+allowed-forms = ["env-lookup"]   # "absolute-path" | "env-lookup"
+allowed-paths = ["/bin/bash", "/usr/bin/env bash"]
+```
+
+#### S080 — script size
+
+```toml
+[lint.rule-options.s080]
+max-lines = 100
+count = "physical"   # "physical" | "non-comment-non-blank"
+```
+
+#### S083 — function doc requirement
+
+```toml
+[lint.rule-options.s083]
+require-for = ["all"]            # "all" | "exported" | "long" | "parameterized"
+long-function-line-threshold = 10
+```
+
+#### S085 / S086 — script shape
+
+```toml
+[lint.rule-options.s085]
+non-trivial-line-threshold = 30
+non-trivial-function-count = 2
+main-name = "main"
+
+[lint.rule-options.s086]
+allowed-statements = [
+    "constant", "declaration", "function-definition", "source", "main-invocation"
+]
+```
+
+#### S089 / S091 / S092 — naming
+
+```toml
+[lint.rule-options.s089]
+pattern = "^[a-z_][a-z0-9_]*(::[a-z_][a-z0-9_]*)?$"
+
+[lint.rule-options.s091]
+pattern = "^[a-z_][a-z0-9_]*$"
+
+[lint.rule-options.s092]
+pattern = "^[A-Z_][A-Z0-9_]*$"
+```
+
+#### S090 — package namespace
+
+```toml
+[lint.rule-options.s090]
+library-predicate = "filename-suffix:.lib.sh"
+```
+
+(The library predicate is purely textual — it inspects the source path string passed to the linter. It does not stat the file.)
+
+#### S100 — quote-safe-variables
+
+```toml
+[lint.rule-options.s100]
+# Scalar expansions S001 already considers safe (numeric-only, single-char known-quote-safe)
+# are still flagged unless they appear in this allowlist. Default empty.
+allowed-bare-expansions = []
+```
+
+#### S101 — require-variable-braces
+
+```toml
+[lint.rule-options.s101]
+# Some expansions are unambiguous without braces (single-letter positional `$1`,
+# special params `$?`, `$$`, etc.). The default exempts them.
+exempt-special-params = true
+exempt-single-digit-positional = true
+```
+
+#### S102 — require-double-brackets
+
+```toml
+[lint.rule-options.s102]
+# Only fires in Bash/Ksh/Zsh; ignored when dialect is sh/dash regardless of selection.
+# This option is informational; the rule cannot be enabled in pure-sh contexts anyway.
+allow-in-portable-mode = false
+```
+
+#### S103 — avoid-nullary-conditions
+
+```toml
+[lint.rule-options.s103]
+# Some teams prefer `[[ "$x" ]]` over `[[ -n "$x" ]]`. Default off — the rule
+# fires on bare nullary tests as ShellCheck's optional check does.
+allow-nullary-on-quoted-expansion = false
+```
+
+#### C161 — function-called-before-defined
+
+```toml
+[lint.rule-options.c161]
+# When true, the rule treats sourced files as opaque (any function might be defined
+# inside) and does not flag calls to names that look like they could come from a
+# preceding `source` command.
+ignore-after-source = true
+```
+
+#### C162 — extra-masked-returns
+
+```toml
+[lint.rule-options.c162]
+# Additional assignment forms beyond the S010 set that should be treated as
+# masking. Default matches ShellCheck's check-extra-masked-returns.
+treat-as-masking = ["readonly", "typeset"]
+```
+
+#### S098 — blanket suppressions
+
+```toml
+[lint.rule-options.s098]
+disallowed-selectors = ["ALL", "C", "S", "P", "X", "K"]
+allow-disable-file = false
+```
+
+#### X082 / X083 — Bash version policy
+
+```toml
+[lint.rule-options.x082]
+max-version = "4.4"   # features above this floor are flagged
+
+[lint.rule-options.x083]
+min-version = "5.0"   # features supported only below this floor are flagged
+```
+
+### Checker Integration
+
+Rules dispatch through the existing phase model from spec 005:
+
+- File shape, shebang, file header, TODO, suppression-text, and Bash feature rules slot into a new `check_file_shape` phase that runs after `check_commands` and reads exclusively from `LinterFacts`.
+- Naming and local/global rules slot into the existing `check_bindings` and `check_scopes` phases, gated on the new rule codes.
+- `C160` (`unanchored-source-path`) extends the existing `check_source_refs` phase.
+
+No rule in this spec adds an AST walk inside its rule file. Every rule reads from `LinterFacts` per the project convention. New facts are constructed in `facts.rs` behind `LinterFactsBuilder` flags so they only run when at least one rule that needs them is enabled — the file-shape and function-doc passes are not free.
+
+### CLI and Documentation
+
+Each rule gets a YAML in `docs/rules/`. Rules in this spec set `origin: novel`, which makes `legacy_code`, `legacy_name`, and `source` optional and disables the cross-repo `shell-checks` validation. ShellCheck-mapped rules in this spec still set `shellcheck_code` and `shellcheck_level` so the corpus harness can run parity comparison.
+
+```yaml
+origin: novel
+new_category: Style
+new_code: S081
+runtime_kind: ast
+shellcheck_code: ~
+shellcheck_level: ~
+shells: [bash]
+description: Files do not begin with a comment block describing their purpose.
+rationale: A file-level header comment makes a script's intent discoverable...
+safe_fix: false
+fix_description: ~
+default_enabled: false
+options:
+  - name: ignore-shebang-only-files
+    type: bool
+    default: false
+    description: Skip files whose only content is a shebang.
+examples:
+  - kind: invalid
+    code: |
+      #!/bin/bash
+      ls -la
+  - kind: valid
+    code: |
+      #!/bin/bash
+      # List files with timestamps.
+      ls -la
+```
+
+The validator (`docs/rules/validate.sh`) gains an `origin: imported | novel` field (default `imported` for backwards compatibility), an optional `default_enabled` boolean, and an optional `options` list. Novel rules omit `legacy_code`/`legacy_name`/`source` and use inline `examples[].code` without a `source` field. Existing rules continue to validate without modification.
+
+## Alternatives Considered
+
+### A new `G` category for Google / governance rules
+
+Putting these under their own letter would make selection easy (`--select G`) and would cleanly separate project-policy lints from language-correctness lints. We rejected it: the categories `C/S/P/X/K` are organized by *kind of issue* (correctness, style, performance, portability, security), not by *where the rule comes from*. A dedicated `G` would mix taxonomy levels. The `google` named group provides one-shot selection without polluting the category axis.
+
+### Default-on with a "google" preset toggle
+
+A `[lint] preset = "google"` switch could enable the bundle in one line. We rejected enabling-by-default for any of these rules because they encode policy choices a project must make (which shebang form, what naming pattern, what script size ceiling). The named `google` group covers the same ergonomics for users who do want them all.
+
+### Filesystem-aware rules in this spec
+
+The original proposal included rules that need the executable bit, the filename, and the repo path role. These would require threading a `FileMetadata` (path, mode, project root) through `lint_file` and adding filesystem stats to the linter pipeline. We deferred them: the linter is currently a pure function over source plus an indexer, and breaking that invariant in this spec would entangle the rule additions with an API change that deserves its own design pass.
+
+### Cross-file analysis for sourced-file effects
+
+`Sourced files should not execute main logic` and `sourceable under test` need to know which files are sourced from where. We deferred them rather than approximating: a static "no `exit`, no `cd`, no argument parsing at top level" check has high false-positive rates on the kind of init scripts that legitimately do those things. A future spec can revisit once cross-file source resolution exists.
+
+### Per-rule walks instead of new facts
+
+Several rules (file shape, function docs, TODO scanning) could be implemented as one-off walks inside the rule files. We rejected that: `CLAUDE.md` mandates that rule files stay as cheap filters over `LinterFacts`. Putting file-shape detection in `facts.rs` also lets multiple rules share one pass over the top-level statements rather than each rule re-scanning.
+
+### Embed the Google guide as a hard dependency
+
+We could mirror the Google guide's prescriptions verbatim — fixed snake_case, fixed 80-char line limit, fixed `#!/bin/bash` shebang. Rejected: every team using these rules will deviate at the margins, and a non-configurable rule is a rule that gets turned off entirely. Configurability is the difference between a rule that ships and one that ends up in `extend-ignore`.
+
+## Verification
+
+Each rule lands with:
+
+- A YAML in `docs/rules/SNNN.yaml` or `docs/rules/CNNN.yaml` containing `description`, `rationale`, `examples` (at least one valid and one invalid), `default_enabled: false`, and the rule's option schema.
+- A Rust module in `crates/shuck-linter/src/rules/{style,correctness,portability}/` with a fixture-driven test that asserts the diagnostic span and message on the YAML's invalid example, and asserts no diagnostic on the valid example.
+- A `LinterFacts` extension in `crates/shuck-linter/src/facts.rs` (where applicable) plus a unit test for the fact builder.
+
+End-to-end checks:
+
+- `cargo test -p shuck-linter` — covers per-rule fixtures and fact-builder unit tests.
+- `cargo test -p shuck-cli` — covers CLI integration, including:
+  - `shuck check` with default config produces no diagnostics from any rule in this spec on a fixture that would trigger them.
+  - `shuck check --select google` produces the expected set on the same fixture.
+  - `shuck check --select S078 --shuck-toml <path>` honors the `allowed-shells` option.
+- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=...` runs each new rule against the corpus. The two rule classes verify differently:
+  - **Novel rules** (S078–S098, C158–C160, X082–X083) have no ShellCheck counterpart, so parity comparison is skipped; the harness should treat unmapped shuck-only rules as informational rather than diff-failing. A small change to the corpus runner is in scope for this spec.
+  - **ShellCheck-mapped rules** (S099–S104, C161, C162) follow the existing conformance pattern: the corpus harness compares shuck output against ShellCheck output for the mapped code, and a `docs/bugs/` document captures any deltas before the rule is shipped.
+- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
+
+Documentation checks:
+
+- The generated rule reference includes every new rule with its `default_enabled: false` badge and option schema.
+- The `google` named group resolves at config-load time to exactly the membership listed in the *Google Preset* section below; a unit test asserts the membership.
+
+## Google Preset
+
+The `google` named-group selector resolves to the union of every rule below — both new rules introduced in this spec and existing shuck rules that already cover Google-aligned ShellCheck checks. Existing `C` rules in the table are default-on in shuck regardless of the preset; they appear here for completeness so the preset is a self-contained declaration of what "Google-style linting" means.
+
+| Rule | Status | Default-on in shuck? | Maps to | Source |
+|------|--------|----------------------|---------|--------|
+| S001 | existing | no | SC2086 | quote scalar expansions |
+| S002 | existing | no | SC2162 | `read -r` |
+| S004 | existing | no | SC2046 | quote command substitutions |
+| S005 | existing | no | SC2006 | backticks → `$(...)` |
+| S006 | existing | no | SC2007 | obsolete `$[...]` |
+| S008 | existing | no | SC2068 | unquoted `$@`/`$*` |
+| S010 | existing | no | SC2155 | masked returns in `local`/`declare`/`export` |
+| S017 | existing | no | SC2206 | array assignment from a string |
+| S022 | existing | no | SC2219 | `let` → `$((...))` |
+| S069 | existing | no | SC2220 (getopts flavor) | `getopts` invalid-flag handler |
+| S078 | new | no | — | `shebang-not-bash` |
+| S079 | new | no | — | `shebang-form-mismatch` |
+| S080 | new | no | — | `script-size-threshold` |
+| S081 | new | no | — | `missing-file-description` |
+| S082 | new | no | — | `todo-format` |
+| S083 | new | no | — | `missing-function-doc` |
+| S084 | new | no | — | `function-doc-content` |
+| S085 | new | no | — | `missing-main-function` |
+| S086 | new | no | — | `top-level-code-not-minimal` |
+| S087 | new | no | — | `constants-not-at-top` |
+| S088 | new | no | — | `functions-not-grouped` |
+| S089 | new | no | — | `function-name-case` |
+| S090 | new | no | — | `package-function-namespace` |
+| S091 | new | no | — | `variable-name-case` |
+| S092 | new | no | — | `constant-name-case` |
+| S093 | new | no | — | `alias-definition` |
+| S094 | new | no | — | `undocumented-globals` |
+| S095 | new | no | — | `missing-cli-usage` |
+| S096 | new | no | — | `error-not-on-stderr` |
+| S097 | new | no | — | `suppression-without-reason` |
+| S098 | new | no | — | `blanket-suppression` |
+| S099 | new | no | SC2230 | `which-vs-command-v` |
+| S100 | new | no | SC2248 | `quote-safe-variables` |
+| S101 | new | no | SC2250 | `require-variable-braces` |
+| S102 | new | no | SC2292 | `require-double-brackets` |
+| S103 | new | no | SC2243 | `avoid-nullary-conditions` |
+| S104 | new | no | SC2249 | `missing-case-default` |
+| C001 | existing | yes | SC2034 | unused variables |
+| C004 | existing | yes | SC2164 | `cd` return value |
+| C006 | existing | yes | SC2154 | variable used before assignment |
+| C010 | existing | yes | SC2015 | `A && B \|\| C` masking |
+| C012 | existing | yes | SC2035 | `rm *` glob hazards |
+| C099 | existing | yes | SC2124 | array slicing |
+| C100 | existing | yes | SC2128 | array referenced as scalar |
+| C158 | new | no | — | `implicit-global-in-function` |
+| C159 | new | no | — | `mutable-global` |
+| C160 | new | no | — | `unanchored-source-path` |
+| C161 | new | no | SC2218 | `function-called-before-defined` |
+| C162 | new | no | SC2312 | `extra-masked-returns` |
+| X082 | new | no | — | `bash-feature-too-new` |
+| X083 | new | no | — | `bash-feature-too-old` |
+
+The preset is implemented as a static `RuleSet` constant in `crates/shuck-linter/src/named_groups.rs` (a new module). `RuleSelector::Named(NamedGroup::Google)` resolves to that constant. `extend-select = ["google"]` in `shuck.toml` unions it into the active rule set; existing `C` rules remain on regardless.
+
+A unit test in `named_groups.rs` asserts that the `google` group's membership matches the table above byte-for-byte. The test is the source of truth: if a future PR adds a rule to the group without updating the table, CI fails.
+
+### Excluded from the Preset
+
+For clarity, the following adjacent rules are deliberately **not** in the `google` preset:
+
+- **C014** (`local-top-level`), **C136** (`local-cross-reference`), **C150** (`subshell-local-assignment`), **S066** (`local-declare-combined`), **X003** (`local-variable-in-sh`) — already default-on (the C-prefix ones) or independently selectable; they are useful but not part of Google's prescribed style.
+- **C060**, **C073**, **C074**, **C075**, **S043**, **S053** (shebang mechanics) — orthogonal to Google's *which-shell* policy. A project can select them alongside the preset if desired.
+- **S056**, **S057** (alias contents) — flagged independently from S093 (alias existence). A project that bans aliases entirely (Google policy) only needs S093.
+- **X042**, **X080** (source-command portability) — about portability, not Google style. C160 covers Google's source-anchoring rule.
+
+These exclusions keep the preset focused on the Google guide. Users who want a stricter posture can compose `["google", "C014", "C060", ...]` in `extend-select`.

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -4215,6 +4215,156 @@
     ]
   },
   {
+    "code": "C158",
+    "name": "implicit-global-in-function",
+    "category": "Correctness",
+    "categoryPrefix": "C",
+    "description": "An assignment inside a function body modifies a variable that was not declared local to that function.",
+    "rationale": "In Bash, assignments inside a function silently modify the global namespace unless the target is declared with `local`, `declare`, or `readonly` inside that function's scope. This implicit global mutation is a common source of bugs: the calling scope's variable is unexpectedly overwritten, two functions that happen to use the same name interfere with each other, and the function becomes non-reentrant. The Google Shell Style Guide requires all function-internal variables to be explicitly declared `local`. This rule flags assignments to names that have no `local`/`declare`/`readonly` declaration in the enclosing function scope. Variables marked `readonly` at the top level are considered documented intentional globals (controlled by `treat-readonly-as-documented`), as are variables that have been exported (controlled by `treat-export-as-intentional`). This rule is the inverse of C014, which flags `local` used outside a function body. See also C136 (local-cross-reference) and C150 (subshell-local-assignment) for related local-scoping checks.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nfoo() {\n  x=1\n  echo \"$x\"\n}\nfoo"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nfoo() {\n  local x=1\n  echo \"$x\"\n}\nfoo"
+      }
+    ]
+  },
+  {
+    "code": "C159",
+    "name": "mutable-global",
+    "category": "Correctness",
+    "categoryPrefix": "C",
+    "description": "A global variable is assigned more than once at the top level or reassigned from inside a function, making it mutable state.",
+    "rationale": "Global variables that are written in multiple places across a script create hidden coupling: any function or top-level statement can silently change a value that other parts of the script rely on, making behavior dependent on evaluation order. The Google Shell Style Guide addresses this by requiring global constants to be declared `readonly`, which makes their value fixed and self-documenting at the declaration site. This rule flags two patterns: a name that receives a plain assignment at the top level and is then assigned again (whether at the top level or from inside a function body), and a name that is assigned at the top level without `readonly` or `declare -r` when it is never intended to change. To resolve the diagnostic, declare the variable `readonly` at its first assignment if it is a constant, or restructure the code so that mutable state lives in a single controlled location. Set `allow-conditional-init` to true (the default) to suppress the rule for the common `var=${var:-default}` init pattern, which is idiomatic and not harmful.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\ncount=0\ncount=5\necho \"$count\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nreadonly COUNT=0\necho \"$COUNT\""
+      }
+    ]
+  },
+  {
+    "code": "C160",
+    "name": "unanchored-source-path",
+    "category": "Correctness",
+    "categoryPrefix": "C",
+    "description": "A source or dot command uses a relative path that is not anchored to the script's own directory.",
+    "rationale": "A bare relative path in a `source` or `.` invocation is resolved relative to the current working directory at the time the script runs, not relative to the script file itself. This means the same script behaves differently depending on where it is invoked from: `source ./lib.sh` succeeds when run from the script's directory but fails silently or loads the wrong file when run from any other directory. The correct idiom is to anchor the path to the script's own directory using `\"${BASH_SOURCE[0]%/*}/lib.sh\"`, `\"$(dirname \"$0\")/lib.sh\"`, or `\"$(dirname \"${BASH_SOURCE[0]}\")/lib.sh\"`. This rule flags `source` and `.` invocations whose path argument does not begin with one of those anchors or another expression listed in `allowed-anchors`. Absolute paths and paths produced entirely by command substitution that the rule cannot inspect statically are not flagged. Note: ShellCheck may emit SC1090 or SC1091 on source lines it cannot follow; those are independent informational diagnostics about static analysis coverage, not about path anchoring.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nsource ./lib.sh\necho \"done\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nsource \"${BASH_SOURCE[0]%/*}/lib.sh\"\necho \"done\""
+      }
+    ]
+  },
+  {
+    "code": "C161",
+    "name": "function-called-before-defined",
+    "category": "Correctness",
+    "categoryPrefix": "C",
+    "description": "A function is called at a top-level position that is reached before the function's definition has been evaluated.",
+    "rationale": "Shell scripts are interpreted top-to-bottom at runtime. Invoking a function whose definition appears later in the file will fail at the point of the call because the name has not yet been registered. Move the function definition above its first call site, or restructure the script so all function definitions are grouped at the top and executable code runs after them.",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": "SC2218",
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\ndo_thing\ndo_thing() {\n  echo hi\n}"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\ndo_thing() {\n  echo hi\n}\ndo_thing"
+      }
+    ]
+  },
+  {
+    "code": "C162",
+    "name": "extra-masked-returns",
+    "category": "Correctness",
+    "categoryPrefix": "C",
+    "description": "A command substitution's exit status is silently discarded because the substitution appears inside a combined declaration-and-assignment that the default S010 set does not cover.",
+    "rationale": "When a command substitution is embedded directly in a combined declaration-and-assignment using forms such as local -r or typeset, the shell assigns the variable before the declaring keyword has a chance to see the substitution's exit status, so a non-zero exit from the substituted command is masked. The S010 rule (SC2155) already flags the most common masking forms — local, declare, and export — because ShellCheck flags those by default. This rule extends the policy to additional forms such as readonly and typeset that ShellCheck reports only when its optional check-extra-masked-returns check is enabled. To make the exit status observable, separate the declaration from the assignment.",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": "SC2312",
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nfoo() {\n  local -r result=$(get_value)\n  echo \"$result\"\n}"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nfoo() {\n  local result\n  result=$(get_value)\n  echo \"$result\"\n}"
+      }
+    ]
+  },
+  {
     "code": "S001",
     "name": "unquoted-argument-expansion",
     "category": "Style",
@@ -6322,6 +6472,816 @@
       {
         "kind": "invalid",
         "code": "#!/bin/sh\nprintf '%s\\n' \"$name[0]\"\npattern=\"^$key[[:space:]]*$\""
+      }
+    ]
+  },
+  {
+    "code": "S078",
+    "name": "shebang-not-bash",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "The shebang interpreter does not match the project's configured shell policy.",
+    "rationale": "Projects that standardize on a specific shell (commonly Bash) should ensure every script's shebang reflects that policy. A mismatch — such as `#!/bin/sh` in a Bash-only codebase — silently changes runtime semantics and can hide compatibility problems or cause subtle behavioral differences between development and production. Enable this rule and set `allowed-shells` to the shell or shells your project supports. Any script whose shebang names a different interpreter will be flagged; change the shebang to an allowed interpreter to resolve the diagnostic.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/sh\necho hello"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\necho hello"
+      }
+    ]
+  },
+  {
+    "code": "S079",
+    "name": "shebang-form-mismatch",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "The shebang line does not use the configured invocation form.",
+    "rationale": "Shell projects often standardize on one of two shebang forms: a direct absolute path (e.g., `#!/bin/bash`) or an env-lookup indirection (e.g., `#!/usr/bin/env bash`). Mixing both forms across a codebase makes the launch mechanism inconsistent and can cause scripts to behave differently on systems where the interpreter lives at a non-standard path. Configure `allowed-forms` to enforce one form, or use `allowed-paths` to enumerate the exact shebang strings that are permitted. Any shebang that does not satisfy either constraint will be flagged; update the shebang to an allowed form or path to resolve the diagnostic.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nx=1\necho \"$x\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/usr/bin/env bash\nx=1\necho \"$x\""
+      }
+    ]
+  },
+  {
+    "code": "S080",
+    "name": "script-size-threshold",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "The script's line count exceeds the configured size threshold.",
+    "rationale": "Long shell scripts are harder to understand, test, and maintain than short focused ones. The Google Shell Style Guide recommends keeping scripts to around 100 lines or fewer; larger scripts are a signal that the logic should be broken up into multiple files or rewritten in a more structured language. Enable this rule and set `max-lines` to the ceiling appropriate for your codebase. The `count` option controls whether the limit applies to every physical line (`\"physical\"`, the default) or only to lines that carry code (`\"non-comment-non-blank\"`, which excludes blank lines and comment-only lines). When the script exceeds the threshold, consider splitting it into smaller modules that source one another.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# This script is intentionally long to exceed the line threshold.\necho \"line 1\"\necho \"line 2\"\necho \"line 3\"\necho \"line 4\"\necho \"line 5\"\necho \"line 6\"\necho \"line 7\"\necho \"line 8\"\necho \"line 9\"\necho \"line 10\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# A concise script.\necho \"done\""
+      }
+    ]
+  },
+  {
+    "code": "S081",
+    "name": "missing-file-description",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "The script does not begin with a comment block describing its purpose.",
+    "rationale": "A file-level header comment answers the first question any reader or operator will ask: \"what does this script do?\" Without it, understanding the script requires reading all of its logic before its intent becomes clear. The Google Shell Style Guide requires every file to start with a description of its contents. This rule flags scripts where the first non-shebang, non-blank line is not a comment. Add a brief comment block immediately after the shebang (or at the top of the file if there is no shebang) that describes the script's purpose. Set `ignore-shebang-only-files` to true if scripts that contain nothing beyond a shebang should be exempt from the check.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nls -la"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# Prints a listing of the current directory with timestamps.\nls -la"
+      }
+    ]
+  },
+  {
+    "code": "S082",
+    "name": "todo-format",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A TODO, FIXME, or XXX comment is missing an owner annotation or a message describing the work.",
+    "rationale": "Actionable comment markers such as TODO and FIXME are only useful when a reader can tell who is responsible and what needs to be done. An annotation without an owner — written as `(name)` or `(handle)` immediately after the keyword — cannot be assigned or tracked. An annotation without a message leaves reviewers guessing about the intent. Requiring both fields keeps the comment backlog triageable and prevents stale markers from accumulating without clear accountability. The set of recognized keywords and the two requirements are individually configurable so teams can adopt the policy incrementally.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# TODO finish later\n# FIXME this is broken\necho hi"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# TODO(alice): finish the input validation logic\n# FIXME(bob): address the edge case for empty arrays\necho hi"
+      }
+    ]
+  },
+  {
+    "code": "S083",
+    "name": "missing-function-doc",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A function definition lacks a leading comment block describing its purpose.",
+    "rationale": "Well-documented functions reduce the cognitive overhead of reading, reviewing, and maintaining shell scripts. A comment block immediately before a function definition tells callers what the function does, what arguments it expects, which global variables it touches, and what it returns — information that is not recoverable from the implementation alone without reading every line. Because mandating a doc block for every trivial two-liner would produce more noise than signal, the rule is configurable: teams can require documentation only for all functions, only for long functions (those above a configurable line threshold), only for functions that accept positional parameters, or only for functions whose names follow a \"public\" naming convention. The rule fires when a function matching the configured policy has no associated comment block at all; the companion rule S084 checks whether a present comment block covers the required content.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\ndo_work() {\n  local input=$1\n  echo \"processing: $input\"\n}\ndo_work \"$1\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# Processes the given input string and writes the result to stdout.\ndo_work() {\n  local input=$1\n  echo \"processing: $input\"\n}\ndo_work \"$1\""
+      }
+    ]
+  },
+  {
+    "code": "S084",
+    "name": "function-doc-content",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A function's leading comment block does not document globals, arguments, outputs, or return values that appear in the function body.",
+    "rationale": "A comment block that exists but omits key information is only marginally better than no comment at all. The Google Shell Style Guide prescribes four structured sections — Globals, Arguments, Outputs, and Returns — each matching a category of observable behavior. When a function reads or modifies a global variable and the Globals section is absent, a caller has no way to know about the side effect without reading the implementation. Similarly, when a function uses positional parameters but the Arguments section is missing, or when it writes to stdout but the Outputs section is absent, the doc block is incomplete. This rule checks that any function whose body contains at least one item from each configured category has a corresponding section header in its comment block. Each category is independently configurable so teams can adopt the policy piecemeal.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# Builds an absolute output path.\nbuild_path() {\n  local suffix=$1\n  echo \"${BASE_DIR}/${suffix}\"\n  return 0\n}\nbuild_path \"logs\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# Builds an absolute output path by joining BASE_DIR with a suffix.\n#\n# Globals:\n#   BASE_DIR\n# Arguments:\n#   $1 - The path suffix to append.\n# Outputs:\n#   Writes the constructed path to stdout.\n# Returns:\n#   0 always.\nbuild_path() {\n  local suffix=$1\n  echo \"${BASE_DIR}/${suffix}\"\n  return 0\n}\nbuild_path \"logs\""
+      }
+    ]
+  },
+  {
+    "code": "S085",
+    "name": "missing-main-function",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A non-trivial script does not end with a call to the main entry-point function as its last top-level statement.",
+    "rationale": "Structuring a script so that all logic lives inside named functions and a single top-level call dispatches to them makes the script easier to source under test, easier to read in isolation, and easier to compose with other scripts. The Google Shell Style Guide prescribes that non-trivial scripts end with `main \"$@\"` as their last executable line — this signals clearly where execution begins and keeps the top level free of scattered logic. \"Non-trivial\" is configurable: the rule stays silent on scripts below a line-count or function-count threshold so that small one-off scripts are not needlessly flagged. The `main-name` option lets projects that use a different entry-point name (e.g. `run` or `entrypoint`) still benefit from the check.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# A non-trivial script that processes files without a main dispatcher.\n\nreadonly LOG_DIR=\"/var/log/myapp\"\n\nsetup() {\n  mkdir -p \"${LOG_DIR}\"\n}\n\nrun() {\n  echo \"Running from ${LOG_DIR}\"\n}\n\n# Top-level executable code instead of main \"$@\"\nsetup\nrun"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# A non-trivial script with a proper main dispatcher.\n\nreadonly LOG_DIR=\"/var/log/myapp\"\n\nsetup() {\n  mkdir -p \"${LOG_DIR}\"\n}\n\nrun() {\n  echo \"Running from ${LOG_DIR}\"\n}\n\nmain() {\n  setup\n  run\n}\n\nmain \"$@\""
+      }
+    ]
+  },
+  {
+    "code": "S086",
+    "name": "top-level-code-not-minimal",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "Executable statements appear at the top level of a script outside the set of statement types that are allowed there.",
+    "rationale": "The Google Shell Style Guide prescribes that the top level of a well-structured script should contain only a narrow set of statement types: constant declarations (`readonly`, `declare -r`, and `export`), plain variable declarations without an initialiser, function definitions, source commands, and the single `main \"$@\"` invocation. Any other executable statement — conditionals, loops, command calls, arithmetic — that appears directly at the top level makes the script harder to source under test, harder to reason about, and easier to accidentally execute side effects when sourced by another script. This rule flags those out-of-place top-level statements. The `allowed-statements` option lets teams extend or restrict the baseline set to match their own policy.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nreadonly APP_NAME=\"myapp\"\n\ngreet() {\n  echo \"Hello from ${APP_NAME}\"\n}\n\n# This conditional block is top-level executable code that should\n# be moved inside a function.\nif [[ -z \"${HOME}\" ]]; then\n  echo \"No home directory set\" >&2\n  exit 1\nfi\n\nmain() {\n  greet\n}\n\nmain \"$@\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nreadonly APP_NAME=\"myapp\"\n\ncheck_env() {\n  if [[ -z \"${HOME}\" ]]; then\n    echo \"No home directory set\" >&2\n    exit 1\n  fi\n}\n\ngreet() {\n  echo \"Hello from ${APP_NAME}\"\n}\n\nmain() {\n  check_env\n  greet\n}\n\nmain \"$@\""
+      }
+    ]
+  },
+  {
+    "code": "S087",
+    "name": "constants-not-at-top",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A constant declaration using readonly, declare -r, or export appears after the first function definition in the script.",
+    "rationale": "The Google Shell Style Guide prescribes a clear ordering for the top-level sections of a script: constants and global variables are declared first, then functions are defined, then the entry-point call closes the file. When a constant declaration appears after the first function definition, the established reading order is broken: a reader scanning the file to understand the script's global state has to read past function bodies to find all the constants. Keeping all `readonly`, `declare -r`, and `export` constant declarations above the first function definition makes the global namespace immediately visible at the top of the file and prevents accidental shadowing of a constant by a later definition.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nreadonly PREFIX=\"/usr/local\"\n\ninstall_files() {\n  echo \"Installing to ${PREFIX}/bin/\"\n}\n\n# This constant appears after a function definition — it should be at the top.\nreadonly VERSION=\"1.2.3\"\n\nmain() {\n  install_files\n  echo \"Version: ${VERSION}\"\n}\n\nmain \"$@\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# All constants declared before the first function definition.\nreadonly PREFIX=\"/usr/local\"\nreadonly VERSION=\"1.2.3\"\n\ninstall_files() {\n  echo \"Installing to ${PREFIX}/bin/\"\n}\n\nmain() {\n  install_files\n  echo \"Version: ${VERSION}\"\n}\n\nmain \"$@\""
+      }
+    ]
+  },
+  {
+    "code": "S088",
+    "name": "functions-not-grouped",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "Function definitions are not contiguous because an executable statement appears between two function definitions.",
+    "rationale": "The Google Shell Style Guide prescribes that all function definitions in a script should be grouped together as a contiguous block, with no executable statements interspersed between them. When an executable statement (a command call, a loop, a conditional, etc.) appears between two function definitions, the function block is fragmented: readers cannot scan the file and locate all function definitions in one place, and tools that extract or test functions individually have to deal with side-effecting code scattered among the definitions. Grouping all function definitions together — preceded by constants and followed by the entry-point call — keeps each structural section of the script spatially distinct and reinforces the convention that top-level executable code should be minimal.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nreadonly WORKDIR=\"/tmp/work\"\n\nsetup() {\n  mkdir -p \"${WORKDIR}\"\n}\n\n# This command is sandwiched between two function definitions.\necho \"Preparing environment...\"\n\nteardown() {\n  rm -rf \"${WORKDIR}\"\n}\n\nmain() {\n  setup\n  teardown\n}\n\nmain \"$@\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nreadonly WORKDIR=\"/tmp/work\"\n\n# All function definitions are grouped together with no executable\n# statements interspersed.\nsetup() {\n  mkdir -p \"${WORKDIR}\"\n}\n\nteardown() {\n  rm -rf \"${WORKDIR}\"\n}\n\nmain() {\n  echo \"Preparing environment...\"\n  setup\n  teardown\n}\n\nmain \"$@\""
+      }
+    ]
+  },
+  {
+    "code": "S089",
+    "name": "function-name-case",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A function name does not match the configured naming pattern.",
+    "rationale": "Consistent function naming within a codebase reduces cognitive overhead when reading and searching code. The default pattern requires lowercase letters, digits, and underscores, with an optional double-colon namespace separator for library functions. Projects may supply an alternate regex via the `pattern` option to fit their own conventions.",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nMyFunction() {\n  echo hi\n}\nMyFunction"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\ndo_thing() {\n  echo hi\n}\ndo_thing"
+      }
+    ]
+  },
+  {
+    "code": "S090",
+    "name": "package-function-namespace",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "Functions in files identified as libraries do not use a package-qualified name in the form `package::function_name`.",
+    "rationale": "Library files expose shared functions that may be sourced into many scripts. Qualifying each function with a package prefix avoids name collisions when multiple libraries are loaded into the same shell session and makes it immediately clear which library a function belongs to. This rule is intentionally scoped to files that match a configurable predicate so that top-level scripts, which are never sourced, are not penalised.",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# mylib.lib.sh\nparse_input() {\n  local val=\"$1\"\n  echo \"${val}\"\n}"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# mylib.lib.sh\nmylib::parse_input() {\n  local val=\"$1\"\n  echo \"${val}\"\n}"
+      }
+    ]
+  },
+  {
+    "code": "S091",
+    "name": "variable-name-case",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A local variable name (or function-scoped assignment target) does not match the configured naming pattern.",
+    "rationale": "Using a uniform naming convention for function-local variables makes it straightforward to distinguish them from constants and exported globals at a glance. The default pattern requires lowercase letters, digits, and underscores (snake_case). Projects with different conventions can supply an alternate regex via the `pattern` option.",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nprocess_data() {\n  local FooBar=1\n  echo \"${FooBar}\"\n}\nprocess_data"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nprocess_data() {\n  local foo_bar=1\n  echo \"${foo_bar}\"\n}\nprocess_data"
+      }
+    ]
+  },
+  {
+    "code": "S092",
+    "name": "constant-name-case",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A constant declared with `readonly`, `declare -r`, or `export` does not match the configured naming pattern.",
+    "rationale": "Naming constants with uppercase letters and underscores (SCREAMING_SNAKE_CASE) is a widely followed convention that visually distinguishes immutable values from mutable locals and from functions. When a reader sees an all-caps name they know immediately that the value will not change within the script. Projects may supply an alternate regex via the `pattern` option.",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nreadonly maxRetries=3\nreadonly backoffMs=100\necho \"${maxRetries}\" \"${backoffMs}\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nreadonly MAX_RETRIES=3\nreadonly BACKOFF_MS=100\necho \"${MAX_RETRIES}\" \"${BACKOFF_MS}\""
+      }
+    ]
+  },
+  {
+    "code": "S093",
+    "name": "alias-definition",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "An alias is defined in a script; shell functions are preferred over aliases for reusable command sequences.",
+    "rationale": "Aliases are evaluated once at definition time and do not compose well with arguments, pipelines, or conditional logic. They behave differently in non-interactive shells, can shadow built-ins in surprising ways, and are silently ignored in many execution contexts (such as scripts that do not explicitly enable alias expansion). Shell functions provide the same shorthand with full access to positional parameters, local variables, and structured control flow. Projects following Google-style shell conventions replace aliases with named functions, which are unambiguous, testable, and work identically across interactive and non-interactive environments.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nalias ll='ls -lh'\nll"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nll() {\n  ls -lh\n}\nll"
+      }
+    ]
+  },
+  {
+    "code": "S094",
+    "name": "undocumented-globals",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A function reads or writes a non-local variable that is not named in the function's leading comment block.",
+    "rationale": "Functions that silently depend on or modify global state are a common source of hard-to-trace bugs in shell scripts. When a function reaches outside its own local scope — reading a variable that was set elsewhere, or writing a variable that callers will observe — that dependency should be visible at the call site without requiring a full read of the implementation. The Google Shell Style Guide requires a \"Globals:\" section that lists each non-local variable the function reads or writes. This rule complements S084 by operating at the variable level: rather than just checking that a Globals section exists, it verifies that each specific non-local variable the function references appears by name in that section. The `treat-readonly-as-documented` option exempts variables that are declared `readonly` at the top level, on the grounds that a readonly constant is part of the script's visible configuration rather than hidden mutable state.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# Logs a message with a severity prefix.\nlog_message() {\n  echo \"[${LOG_LEVEL}] $1\"\n}\nlog_message \"started\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# Logs a message with a severity prefix derived from LOG_LEVEL.\n#\n# Globals:\n#   LOG_LEVEL (read)\n# Arguments:\n#   $1 - The message text to log.\nlog_message() {\n  echo \"[${LOG_LEVEL}] $1\"\n}\nlog_message \"started\""
+      }
+    ]
+  },
+  {
+    "code": "S095",
+    "name": "missing-cli-usage",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A script that processes command-line arguments does not provide a usage function or handle the standard help flags.",
+    "rationale": "Scripts that parse positional parameters or option flags create an implicit command-line interface. Without a usage message, callers who encounter an error or who want to understand the script's interface have no in-band way to discover accepted arguments, required parameters, or available options. The Google Shell Style Guide recommends that every script with a non-trivial argument surface include a `usage` function (or equivalent) and respond to `--help` / `-h` with that documentation. This rule fires when a script references positional parameters or uses `getopts` but defines neither a function matching the configured `usage-function-name` nor a branch that handles any of the configured `help-flags`.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\ninput_file=$1\noutput_file=$2\nprocess \"$input_file\" \"$output_file\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nusage() {\n  printf 'Usage: %s <input> <output>\\n' \"$0\"\n}\nif [[ \"$1\" == \"--help\" || \"$1\" == \"-h\" ]]; then\n  usage\n  exit 0\nfi\ninput_file=$1\noutput_file=$2\nprocess \"$input_file\" \"$output_file\""
+      }
+    ]
+  },
+  {
+    "code": "S096",
+    "name": "error-not-on-stderr",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A command in an error branch writes output to stdout rather than stderr.",
+    "rationale": "Diagnostic messages — failures, errors, and explanatory text accompanying a non-zero exit — belong on stderr so that callers can separate program output from error text. When error-branch output goes to stdout, the calling script or terminal mixes it with normal output, breaking pipelines and capture-and-inspect patterns. The Google Shell Style Guide explicitly recommends routing all error and diagnostic messages through `>&2`. This rule flags plain writes (such as `echo`, `printf`, or `cat`) that appear in recognizable error branches — `if ! cmd; then ...`, `cmd || { ... }`, or blocks that end with a non-zero `exit` — and lack a `>&2` redirect.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nif ! gzip -t \"$1\"; then\n  echo \"archive validation failed for: $1\"\n  exit 1\nfi"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nif ! gzip -t \"$1\"; then\n  echo \"archive validation failed for: $1\" >&2\n  exit 1\nfi"
+      }
+    ]
+  },
+  {
+    "code": "S097",
+    "name": "suppression-without-reason",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A lint-suppression directive is missing a free-text justification explaining why the suppression is appropriate.",
+    "rationale": "Suppression directives silence diagnostics for everyone who reads the code from that point forward. Without a rationale, the intent behind the suppression is invisible: future maintainers cannot tell whether the code was suppressed because the pattern is intentional, because the rule had a known false-positive, or because the original author simply wanted to stop the warning without investigating it. Requiring a trailing reason — a brief note after the rule code — makes suppressions self-documenting and surfaces suppressions that should be revisited when the surrounding code changes. This rule fires on any `# shuck:` or `# shellcheck` directive that does not include free-text after the code list.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# shuck: disable=S001\necho $HOME"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# shuck: disable=S001 -- HOME is controlled by the environment and cannot contain spaces\necho $HOME"
+      }
+    ]
+  },
+  {
+    "code": "S098",
+    "name": "blanket-suppression",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A suppression directive uses a broad category selector or a file-wide disable outside the configured allowlist.",
+    "rationale": "Wide-scope suppressions — disabling an entire category such as `ALL`, `C`, `S`, or similar prefixes, or issuing a `disable-file` directive — silence large classes of diagnostics at once, often hiding real problems alongside the ones being worked around. Category-level suppressions are almost never intentional; they usually result from copy-paste or from wanting to quiet one noisy rule without looking up its specific code. File-wide disables carry the same risk at a larger scale. This rule flags directives whose selector list contains any entry from the configured `disallowed-selectors`, and also flags `disable-file` directives when `allow-disable-file` is false. Fine-grained per-rule suppressions with justifications (see S097) are the preferred alternative.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# shuck: disable-file=ALL\nprocess_files() {\n  local f\n  for f in \"$@\"; do\n    echo \"$f\"\n  done\n}"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# shuck: disable=S001 -- pattern glob is intentional here\nfor entry in $GLOB_PATTERN; do\n  echo \"$entry\"\ndone"
+      }
+    ]
+  },
+  {
+    "code": "S099",
+    "name": "which-vs-command-v",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A call to `which` locates executables using only the current PATH without honoring shell functions or builtins; prefer the portable `command -v` builtin instead.",
+    "rationale": "The `which` utility is not defined by POSIX and behaves inconsistently across platforms — some versions ignore shell aliases and functions, others consult a separate configuration, and some do not return a non-zero exit code when the command is absent. The shell builtin `command -v` is standardised, respects the shell's own function and alias namespace, and provides the same executable-path lookup without external-process overhead. Replacing `which` with `command -v` makes scripts both more portable and more accurate.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": "SC2230",
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\npath=$(which python3)\n\"$path\" --version"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\npath=$(command -v python3)\n\"$path\" --version"
+      }
+    ]
+  },
+  {
+    "code": "S100",
+    "name": "quote-safe-variables",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A scalar variable expansion appears unquoted even when its value is not expected to contain word-splitting or glob characters.",
+    "rationale": "Even variables that are assigned safe-looking string literals should be double-quoted on expansion. The assignment may change over time, the variable may be exported and set externally, or a future refactor may introduce a value with whitespace. Consistently quoting every expansion eliminates a class of subtle split-and-glob bugs before they materialise, requires no knowledge of what each variable may contain at runtime, and makes it clear to readers that word-splitting was consciously not desired. This rule extends the default unquoted-expansion check to cover expansions that a purely flow-sensitive analysis would consider safe.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": "SC2248",
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nlabel=\"build-output\"\nmkdir $label"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nlabel=\"build-output\"\nmkdir \"$label\""
+      }
+    ]
+  },
+  {
+    "code": "S101",
+    "name": "require-variable-braces",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A scalar variable is expanded using the bare `$var` form rather than the brace-delimited `${var}` form.",
+    "rationale": "Consistently using `${var}` instead of `$var` makes the extent of every variable name unambiguous at a glance and avoids surprises when a variable name is followed by a letter, digit, or underscore that could be misread as part of the name. It also simplifies search and refactoring: editors and code-analysis tools can reliably identify every expansion. Special shell parameters (`$0`, `$1`, `$@`, `$$`, etc.) are typically exempt because they cannot be confused with longer names, but named scalar variables benefit most from the braced form.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": "SC2250",
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\ngreeting=\"hello\"\necho \"$greeting world\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\ngreeting=\"hello\"\necho \"${greeting} world\""
+      }
+    ]
+  },
+  {
+    "code": "S102",
+    "name": "require-double-brackets",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A test expression uses the POSIX `[ ]` form in a Bash script where the extended `[[ ]]` form is available and preferred.",
+    "rationale": "In Bash (and Ksh), the `[[ ]]` keyword is a first-class language construct rather than a regular command. It avoids several pitfalls of the POSIX `[ ]` form: word splitting and pathname expansion do not occur on unquoted operands, the `&&` and `||` operators work as expected inside the test, pattern matching is built in, and there is no ambiguity between the `-a`/`-o` flags and filenames. Migrating Bash-only scripts to `[[ ]]` eliminates these edge cases and signals to readers that portability to `/bin/sh` is not a goal of the script.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": "SC2292",
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nname=\"Alice\"\nif [ \"$name\" = \"Alice\" ]; then\n  echo \"hello\"\nfi"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nname=\"Alice\"\nif [[ \"$name\" = \"Alice\" ]]; then\n  echo \"hello\"\nfi"
+      }
+    ]
+  },
+  {
+    "code": "S103",
+    "name": "avoid-nullary-conditions",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A `[[ ]]` test uses a bare command substitution as its only operand rather than an explicit `-n` test or a direct conditional on the command's exit status.",
+    "rationale": "Writing `[[ $(some_command) ]]` tests whether the command produced any output, not whether it succeeded. This conflates two different notions — non-empty output and zero exit status — and is often unintentional. Using `-n \"$(some_command)\"` makes the intent explicit: the script is testing for non-empty output. Alternatively, running the command directly as a conditional (`if some_command; then`) tests exit status without capturing output at all. Being explicit avoids silent mismatches between what the author intended and what the shell actually evaluates.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": "SC2243",
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\nif [[ $(git status --short) ]]; then\n  echo \"uncommitted changes\"\nfi"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\nif [[ -n $(git status --short) ]]; then\n  echo \"uncommitted changes\"\nfi"
+      }
+    ]
+  },
+  {
+    "code": "S104",
+    "name": "missing-case-default",
+    "category": "Style",
+    "categoryPrefix": "S",
+    "description": "A `case` statement has no catch-all `*)` default branch to handle values that do not match any explicit pattern.",
+    "rationale": "A `case` statement without a `*)` branch silently ignores any input that does not match a named pattern. This makes it easy to overlook typos in values, miss future extensions to an enumeration, or silently fail when upstream code passes an unexpected value. Adding a default branch — even one that just emits a diagnostic and exits — turns a silent no-op into an explicit signal that an unexpected value was received. The pattern is especially important for scripts that dispatch on command-line arguments or environment variables whose set of valid values may grow over time.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": "SC2249",
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\naction=\"${1:-}\"\ncase \"$action\" in\n  start) echo \"starting service\" ;;\n  stop)  echo \"stopping service\" ;;\nesac"
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\naction=\"${1:-}\"\ncase \"$action\" in\n  start) echo \"starting service\" ;;\n  stop)  echo \"stopping service\" ;;\n  *)     echo \"unknown action: ${action}\" >&2; exit 1 ;;\nesac"
       }
     ]
   },
@@ -8529,6 +9489,66 @@
       {
         "kind": "invalid",
         "code": "#!/bin/sh\n# shellcheck disable=2154\necho \"${*%%dBm*}\" > /tmp/signal.txt\necho \"${@##*.}\""
+      }
+    ]
+  },
+  {
+    "code": "X082",
+    "name": "bash-feature-too-new",
+    "category": "Portability",
+    "categoryPrefix": "X",
+    "description": "A Bash feature used in the script was introduced in a version newer than the project's configured maximum.",
+    "rationale": "Projects that need to run on older Bash installations (common in CI images, Docker base containers, and enterprise Linux distributions) must stay within the capabilities of the oldest Bash version they support. When the project declares a `max-version` ceiling in its configuration, this rule flags any construct whose introduction in Bash post-dates that ceiling. For example, `EPOCHSECONDS` and `EPOCHREALTIME` are variables that Bash began populating in version 5.0; using them in a project that targets Bash 4.4 creates a silent failure on the older host (the variables are simply empty). The rule's catalog covers builtin variables, parameter transformation operators, and shopt options that have known introduction versions, and it grows as the catalog is extended. Constructs not yet in the catalog are not flagged.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# EPOCHSECONDS was introduced in Bash 5.0; this violates max-version=4.4\nstart=$EPOCHSECONDS\necho \"start=$start\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# date +%s works on any Bash version and is within the 4.4 ceiling\nstart=$(date +%s)\necho \"start=$start\""
+      }
+    ]
+  },
+  {
+    "code": "X083",
+    "name": "bash-feature-too-old",
+    "category": "Portability",
+    "categoryPrefix": "X",
+    "description": "A script that declares a modern-Bash version floor uses constructs that work on much older Bash versions, bypassing the benefit of that floor.",
+    "rationale": "When a project commits to requiring a minimum Bash version — for example, Bash 5.0 — it gains access to features introduced in that release and later. Using pre-floor idioms alongside that requirement weakens the contract: the script could silently be run on a far older interpreter, scripts within the same codebase lose consistency, and developers miss more capable or safer alternatives that the stated minimum already provides. This rule flags patterns that work on Bash versions well below the configured `min-version` when a direct replacement requiring roughly that floor exists. A representative case: piping through `tr '[:lower:]' '[:upper:]'` to fold case is universal across POSIX shells, but a project requiring Bash 4.0+ can use the `${var^^}` expansion instead, eliminating the subshell and external process. The rule's detection is bounded to idioms where the modern alternative is a straightforward substitution; it does not penalise code that legitimately mixes levels for portability reasons elsewhere in the same file.\n",
+    "shells": [
+      "bash"
+    ],
+    "shellcheckCode": null,
+    "implemented": false,
+    "status": "planned",
+    "hasKnownShellcheckDivergences": false,
+    "severity": null,
+    "fixStatus": "none",
+    "fixAvailability": "none",
+    "fixSafety": null,
+    "fixDescription": null,
+    "examples": [
+      {
+        "kind": "invalid",
+        "code": "#!/bin/bash\n# Piping through tr works on any POSIX shell; a project requiring Bash 4.0+\n# can use ${var^^} instead, but a min-version=5.0 project especially should\nname=\"hello world\"\nupper=$(printf '%s' \"$name\" | tr '[:lower:]' '[:upper:]')\necho \"$upper\""
+      },
+      {
+        "kind": "valid",
+        "code": "#!/bin/bash\n# ${var^^} case-conversion operator requires Bash 4.0; preferred for a 5.0+ project\nname=\"hello world\"\nupper=\"${name^^}\"\necho \"$upper\""
       }
     ]
   },


### PR DESCRIPTION
## Summary

- Spec 017 covering 34 new lint rules drawn from the Google Shell Style Guide that ShellCheck does not enforce by default. All default-off, all reuse existing C/S/P/X/K categories. Includes a `google` named-group preset that unions the new rules with related existing rules.
- Rule metadata YAMLs for every new rule: S078–S104 (Style), C158–C162 (Correctness), X082–X083 (Portability). Of these, 7 map to ShellCheck optional checks (S099–S104, C161, C162); the rest are novel.
- Schema extension: `origin: novel | imported`. Novel rules can omit `legacy_code` and `source` (no shell-checks predecessor). `validate.sh` updated to gate those fields conditionally and to validate the new optional `default_enabled` and `options` fields.
- S040 was a pre-existing novel rule with `legacy_code: ""`; migrated to `origin: novel` so it passes the updated validator.

## Validation

- All 35 affected YAMLs pass `bash docs/rules/validate.sh`.
- ShellCheck binary used as a black-box oracle (no source/wiki/doc references, per CLAUDE.md clean-room policy):
  - SC-mapped rules: confirmed the listed SC code fires on the invalid example and not on the valid one.
  - Novel rules: confirmed no default or optional SC code shadows the rule on its invalid example.
- Three SC-code corrections from oracle results applied to spec and YAMLs:
  - S104 → SC2249 / `add-default-case` (not SC2220, which is exclusively the `getopts` flavor already covered by S069)
  - C162 → SC2312 (the actual code emitted under `check-extra-masked-returns`)
  - S103 invalid example uses bare command substitution `[[ \$(cmd) ]]` (the form SC2243 fires on)

## Test plan

- [ ] `bash docs/rules/validate.sh` shows OK for all 35 affected files
- [ ] Spec 017 reads cleanly end-to-end and the Google Preset table matches the listed code numbers
- [ ] No unrelated YAMLs flipped status under the validator update (only pre-existing missing-shell-checks-repo and empty-examples errors remain)

## Out of scope

This PR is spec + metadata only; no Rust code changes. Implementing each rule against the LinterFacts extension point is follow-up work tracked per-rule.