### PR TITLE
feat(cli): add google named rule selector

### DIFF
--- a/crates/shuck-cli/src/args.rs
+++ b/crates/shuck-cli/src/args.rs
@@ -439,7 +439,7 @@ fn parse_cli_rule_selector(value: &str) -> Result<RuleSelector, String> {
 /// Rule-selection flags shared by `shuck check`.
 #[derive(Debug, Clone, Default, ClapArgs)]
 pub struct RuleSelectionArgs {
-    /// Comma-separated list of rule codes to enable (or ALL, to enable all rules).
+    /// Comma-separated list of rule selectors to enable (for example `google`, `C`, or `C001`; or ALL to enable all rules).
     #[arg(
         long,
         value_delimiter = ',',
@@ -449,7 +449,7 @@ pub struct RuleSelectionArgs {
         hide_possible_values = true
     )]
     pub select: Option<Vec<RuleSelector>>,
-    /// Comma-separated list of rule codes to disable.
+    /// Comma-separated list of rule selectors to disable.
     #[arg(
         long,
         value_delimiter = ',',
@@ -459,7 +459,7 @@ pub struct RuleSelectionArgs {
         hide_possible_values = true
     )]
     pub ignore: Vec<RuleSelector>,
-    /// Like --select, but adds additional rule codes on top of those already specified.
+    /// Like --select, but adds additional rule selectors on top of those already specified.
     #[arg(
         long,
         value_delimiter = ',',
@@ -501,7 +501,7 @@ pub struct RuleSelectionArgs {
         help_heading = "Rule selection"
     )]
     pub extend_per_file_shell: Vec<PatternShellPair>,
-    /// List of rule codes to treat as eligible for fix. Only applicable when fix itself is enabled (e.g., via `--fix`).
+    /// List of rule selectors to treat as eligible for fix. Only applicable when fix itself is enabled (e.g., via `--fix`).
     #[arg(
         long,
         value_delimiter = ',',
@@ -511,7 +511,7 @@ pub struct RuleSelectionArgs {
         hide_possible_values = true
     )]
     pub fixable: Option<Vec<RuleSelector>>,
-    /// List of rule codes to treat as ineligible for fix. Only applicable when fix itself is enabled (e.g., via `--fix`).
+    /// List of rule selectors to treat as ineligible for fix. Only applicable when fix itself is enabled (e.g., via `--fix`).
     #[arg(
         long,
         value_delimiter = ',',
@@ -521,7 +521,7 @@ pub struct RuleSelectionArgs {
         hide_possible_values = true
     )]
     pub unfixable: Vec<RuleSelector>,
-    /// Like --fixable, but adds additional rule codes on top of those already specified.
+    /// Like --fixable, but adds additional rule selectors on top of those already specified.
     #[arg(
         long,
         value_delimiter = ',',
@@ -1007,6 +1007,33 @@ mod tests {
     }
 
     #[test]
+    fn parses_named_rule_selection_flags() {
+        let command = parse_check([
+            "shuck",
+            "check",
+            "--select",
+            "google",
+            "--extend-select",
+            "google",
+            "--fixable",
+            "google",
+        ]);
+
+        assert_eq!(
+            command.rule_selection.select,
+            Some(vec![RuleSelector::Named(shuck_linter::NamedGroup::Google)])
+        );
+        assert_eq!(
+            command.rule_selection.extend_select,
+            vec![RuleSelector::Named(shuck_linter::NamedGroup::Google)]
+        );
+        assert_eq!(
+            command.rule_selection.fixable,
+            Some(vec![RuleSelector::Named(shuck_linter::NamedGroup::Google)])
+        );
+    }
+
+    #[test]
     fn parses_per_file_ignore_pairs() {
         let command = parse_check([
             "shuck",
@@ -1030,6 +1057,19 @@ mod tests {
                 pattern: "!src/*.sh".to_owned(),
                 selector: RuleSelector::Category(shuck_linter::Category::Style),
             }]
+        );
+    }
+
+    #[test]
+    fn parses_named_per_file_ignore_pairs() {
+        let command = parse_check(["shuck", "check", "--per-file-ignores", "tests/*.sh:google"]);
+
+        assert_eq!(
+            command.rule_selection.per_file_ignores,
+            Some(vec![PatternRuleSelectorPair {
+                pattern: "tests/*.sh".to_owned(),
+                selector: RuleSelector::Named(shuck_linter::NamedGroup::Google),
+            }])
         );
     }
 

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -619,6 +619,7 @@ fn selector_specificity(selector: &RuleSelector) -> usize {
     match selector {
         RuleSelector::All => 0,
         RuleSelector::Category(_) => 1,
+        RuleSelector::Named(_) => 1,
         RuleSelector::Prefix(prefix) => 2 + prefix.len(),
         RuleSelector::Rule(_) => usize::MAX,
     }
@@ -669,7 +670,8 @@ mod tests {
         EmbeddedFormat, EmbeddedScript, ExtractedDialect, HostLineStart, ImplicitShellFlags,
     };
     use shuck_linter::{
-        Category, LinterSettings, Rule, RuleSelector, RuleSet, ShellCheckCodeMap, ShellDialect,
+        Category, LinterSettings, NamedGroup, Rule, RuleSelector, RuleSet, ShellCheckCodeMap,
+        ShellDialect,
     };
     use shuck_parser::parser::Parser;
     use tempfile::tempdir;
@@ -702,7 +704,7 @@ mod tests {
     };
     use crate::commands::project_runner::PendingProjectFile;
     use crate::config::ConfigArguments;
-    use crate::discover::{FileKind, normalize_path};
+    use crate::discover::{FileKind, ProjectRoot, normalize_path};
 
     #[test]
     fn select_replaces_default_rules() {
@@ -880,6 +882,84 @@ mod tests {
     }
 
     #[test]
+    fn config_select_accepts_named_groups() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[lint]\nselect = ['google']\n",
+        )
+        .unwrap();
+
+        let settings = resolve_project_check_settings(
+            &ProjectRoot {
+                storage_root: tempdir.path().to_path_buf(),
+                canonical_root: fs::canonicalize(tempdir.path()).unwrap(),
+            },
+            &ConfigArguments::default(),
+            &RuleSelectionArgs::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings.linter_settings.rules,
+            NamedGroup::Google.rule_set()
+        );
+    }
+
+    #[test]
+    fn config_extend_select_accepts_named_groups() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[lint]\nextend-select = ['google']\n",
+        )
+        .unwrap();
+
+        let settings = resolve_project_check_settings(
+            &ProjectRoot {
+                storage_root: tempdir.path().to_path_buf(),
+                canonical_root: fs::canonicalize(tempdir.path()).unwrap(),
+            },
+            &ConfigArguments::default(),
+            &RuleSelectionArgs::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings.linter_settings.rules,
+            LinterSettings::default_rules().union(&NamedGroup::Google.rule_set())
+        );
+    }
+
+    #[test]
+    fn named_group_can_be_trimmed_by_exact_rule_ignore() {
+        let rules = apply_rule_selector_layer(
+            RuleSet::EMPTY,
+            Some(&[RuleSelector::Named(NamedGroup::Google)]),
+            &[],
+            &[RuleSelector::Rule(Rule::UnusedAssignment)],
+        );
+
+        assert!(!rules.contains(Rule::UnusedAssignment));
+        assert!(rules.contains(Rule::UnquotedExpansion));
+    }
+
+    #[test]
+    fn named_group_can_be_trimmed_by_prefix_ignore() {
+        let rules = apply_rule_selector_layer(
+            RuleSet::EMPTY,
+            Some(&[RuleSelector::Named(NamedGroup::Google)]),
+            &[],
+            &[RuleSelector::Prefix("S00".to_owned())],
+        );
+
+        assert!(!rules.contains(Rule::UnquotedExpansion));
+        assert!(!rules.contains(Rule::ReadWithoutRaw));
+        assert!(rules.contains(Rule::ExportCommandSubstitution));
+        assert!(rules.contains(Rule::UnusedAssignment));
+    }
+
+    #[test]
     fn per_file_ignores_suppress_matching_rules_only() {
         let tempdir = tempdir().unwrap();
         fs::write(
@@ -986,6 +1066,64 @@ mod tests {
         assert_eq!(
             per_file_shell.shell_for_path(path),
             Some(ShellDialect::Bash)
+        );
+    }
+
+    #[test]
+    fn parses_named_group_rule_selectors() {
+        assert_eq!(
+            parse_rule_selectors(&["google".to_owned()], "lint.select").unwrap(),
+            vec![RuleSelector::Named(NamedGroup::Google)]
+        );
+    }
+
+    #[test]
+    fn select_google_matches_config_extend_select_on_google_only_fixture() {
+        let tempdir = tempdir().unwrap();
+        fs::write(
+            tempdir.path().join("shuck.toml"),
+            "[lint]\nextend-select = ['google']\n",
+        )
+        .unwrap();
+        fs::write(
+            tempdir.path().join("script.sh"),
+            "#!/bin/sh\nunused=1\necho $1\n",
+        )
+        .unwrap();
+
+        let config_report = run_check_with_cwd(
+            &check_args(true),
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        let mut args = check_args(true);
+        args.rule_selection = RuleSelectionArgs {
+            select: Some(vec![RuleSelector::Named(NamedGroup::Google)]),
+            ..RuleSelectionArgs::default()
+        };
+        let cli_report = run_check_with_cwd(
+            &args,
+            &ConfigArguments::default(),
+            tempdir.path(),
+            &cache_root(tempdir.path()),
+        )
+        .unwrap();
+
+        let mut config_codes = diagnostic_codes(&config_report);
+        let mut cli_codes = diagnostic_codes(&cli_report);
+        config_codes.sort();
+        cli_codes.sort();
+
+        assert_eq!(config_codes, cli_codes);
+        assert_eq!(
+            cli_codes,
+            vec![
+                Rule::UnusedAssignment.code().to_owned(),
+                Rule::UnquotedExpansion.code().to_owned(),
+            ]
         );
     }
 

--- a/crates/shuck-cli/src/config.rs
+++ b/crates/shuck-cli/src/config.rs
@@ -192,10 +192,10 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 2] = [
             },
             ConfigFieldMetadata {
                 key: "extend-select",
-                docs: "Enable additional rules on top of the default or explicitly selected rule set.",
+                docs: "Enable additional rules or named selectors on top of the default or explicitly selected rule set.",
                 default: "[]",
                 value_type: "list[selector]",
-                example: r#"extend-select = ["S"]"#,
+                example: r#"extend-select = ["google"]"#,
             },
             ConfigFieldMetadata {
                 key: "fixable",
@@ -220,10 +220,10 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 2] = [
             },
             ConfigFieldMetadata {
                 key: "select",
-                docs: "Replace the default rule set with the selectors listed here.",
+                docs: "Replace the default rule set with the selectors listed here, including named selectors such as `google`.",
                 default: "all implemented non-style rules",
                 value_type: "list[selector]",
-                example: r#"select = ["C", "K"]"#,
+                example: r#"select = ["google"]"#,
             },
             ConfigFieldMetadata {
                 key: "unfixable",

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -19,6 +19,8 @@ mod fix_helpers;
 #[allow(missing_docs)]
 mod locator;
 #[allow(missing_docs)]
+mod named_groups;
+#[allow(missing_docs)]
 mod parse_diagnostics;
 #[allow(missing_docs)]
 mod registry;
@@ -82,11 +84,12 @@ pub(crate) use facts::{
 pub use fix::{Applicability, AppliedFixes, Edit, Fix, FixAvailability, apply_fixes};
 pub(crate) use fix_helpers::leading_static_word_prefix_fix_in_source;
 pub(crate) use locator::Locator;
+/// Rule selector parsing types.
+pub use named_groups::NamedGroup;
 /// Rule identifiers, categories, and registry lookup helpers.
 pub use registry::{Category, Rule, code_to_rule};
 /// Rule metadata lookup utilities.
 pub use rule_metadata::{RuleMetadata, ShellCheckLevel, rule_metadata, rule_metadata_by_code};
-/// Rule selector parsing types.
 pub use rule_selector::{RuleSelector, SelectorParseError};
 /// Sets of enabled or disabled rules.
 pub use rule_set::RuleSet;

--- a/crates/shuck-linter/src/named_groups.rs
+++ b/crates/shuck-linter/src/named_groups.rs
@@ -1,0 +1,72 @@
+use crate::{Rule, RuleSet};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NamedGroup {
+    Google,
+}
+
+impl NamedGroup {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "google" => Some(Self::Google),
+            _ => None,
+        }
+    }
+
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Google => "google",
+        }
+    }
+
+    pub const fn rule_set(self) -> RuleSet {
+        match self {
+            Self::Google => GOOGLE_RULE_SET,
+        }
+    }
+}
+
+const GOOGLE_RULES: [Rule; 17] = [
+    Rule::UnquotedExpansion,
+    Rule::ReadWithoutRaw,
+    Rule::UnquotedCommandSubstitution,
+    Rule::LegacyBackticks,
+    Rule::LegacyArithmeticExpansion,
+    Rule::UnquotedArrayExpansion,
+    Rule::ExportCommandSubstitution,
+    Rule::UnquotedArraySplit,
+    Rule::AvoidLetBuiltin,
+    Rule::GetoptsInvalidFlagHandler,
+    Rule::UnusedAssignment,
+    Rule::UncheckedDirectoryChange,
+    Rule::UndefinedVariable,
+    Rule::ChainedTestBranches,
+    Rule::LeadingGlobArgument,
+    Rule::QuotedArraySlice,
+    Rule::QuotedBashSource,
+];
+
+pub(crate) const GOOGLE_RULE_SET: RuleSet = RuleSet::from_rules(&GOOGLE_RULES);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn google_membership_matches_current_v1_subset() {
+        let mut codes = NamedGroup::Google
+            .rule_set()
+            .iter()
+            .map(Rule::code)
+            .collect::<Vec<_>>();
+        codes.sort_unstable();
+
+        assert_eq!(
+            codes,
+            vec![
+                "C001", "C004", "C006", "C010", "C012", "C099", "C100", "S001", "S002", "S004",
+                "S005", "S006", "S008", "S010", "S017", "S022", "S069",
+            ]
+        );
+    }
+}

--- a/crates/shuck-linter/src/rule_selector.rs
+++ b/crates/shuck-linter/src/rule_selector.rs
@@ -2,12 +2,13 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
-use crate::{Category, Rule, RuleSet, code_to_rule};
+use crate::{Category, NamedGroup, Rule, RuleSet, code_to_rule};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RuleSelector {
     All,
     Category(Category),
+    Named(NamedGroup),
     Prefix(String),
     Rule(Rule),
 }
@@ -19,6 +20,7 @@ impl RuleSelector {
             Self::Category(category) => Rule::iter()
                 .filter(|rule| rule.category() == *category)
                 .collect(),
+            Self::Named(group) => group.rule_set(),
             Self::Prefix(prefix) => Rule::iter()
                 .filter(|rule| rule.code().starts_with(prefix))
                 .collect(),
@@ -40,6 +42,10 @@ impl FromStr for RuleSelector {
         let selector = value.trim();
         if selector == "ALL" {
             return Ok(Self::All);
+        }
+
+        if let Some(group) = NamedGroup::from_name(selector) {
+            return Ok(Self::Named(group));
         }
 
         if let Some(rule) = code_to_rule(selector) {
@@ -66,6 +72,12 @@ mod tests {
     fn parses_category_prefixes() {
         let selector = RuleSelector::from_str("C").unwrap();
         assert_eq!(selector, RuleSelector::Category(Category::Correctness));
+    }
+
+    #[test]
+    fn parses_named_groups() {
+        let selector = RuleSelector::from_str("google").unwrap();
+        assert_eq!(selector, RuleSelector::Named(NamedGroup::Google));
     }
 
     #[test]
@@ -106,6 +118,10 @@ mod tests {
         assert_eq!(
             RuleSelector::from_str("SH-092"),
             Err(SelectorParseError::Unknown("SH-092".to_owned()))
+        );
+        assert_eq!(
+            RuleSelector::from_str("goog"),
+            Err(SelectorParseError::Unknown("goog".to_owned()))
         );
     }
 }

--- a/crates/shuck-linter/src/rule_set.rs
+++ b/crates/shuck-linter/src/rule_set.rs
@@ -12,6 +12,19 @@ impl RuleSet {
         Rule::iter().collect()
     }
 
+    pub const fn from_rules(rules: &[Rule]) -> Self {
+        let mut words = [0; WORD_COUNT];
+        let mut index = 0;
+        while index < rules.len() {
+            let rule = rules[index] as usize;
+            let word = rule / 64;
+            let bit = rule % 64;
+            words[word] |= 1u64 << bit;
+            index += 1;
+        }
+        Self(words)
+    }
+
     pub const fn contains(&self, rule: Rule) -> bool {
         let word = (rule as usize) / 64;
         let bit = (rule as usize) % 64;
@@ -103,5 +116,15 @@ mod tests {
 
         set.remove(Rule::UnusedAssignment);
         assert!(set.is_empty());
+    }
+
+    #[test]
+    fn can_be_built_in_const_context() {
+        const RULES: RuleSet = RuleSet::from_rules(&[Rule::UnusedAssignment, Rule::BareRead]);
+
+        assert_eq!(
+            RULES.iter().collect::<Vec<_>>(),
+            vec![Rule::UnusedAssignment, Rule::BareRead]
+        );
     }
 }

--- a/website/content/configuration/index.mdx
+++ b/website/content/configuration/index.mdx
@@ -94,6 +94,7 @@ Replaces the default rule set with the selectors you provide.
 
 Selectors can be:
 
+- A named selector like `google`
 - A full category prefix like `C` or `K`
 - A narrower prefix like `C12`
 - An exact rule code like `S074`
@@ -101,7 +102,7 @@ Selectors can be:
 
 ```toml
 [lint]
-select = ["ALL"]
+select = ["google"]
 ```
 
 ### `ignore`
@@ -120,7 +121,7 @@ Adds more rules on top of the current selection.
 
 ```toml
 [lint]
-extend-select = ["S"]
+extend-select = ["google"]
 ```
 
 ### `per-file-ignores`

--- a/website/content/settings/index.mdx
+++ b/website/content/settings/index.mdx
@@ -67,7 +67,7 @@ extend-per-file-ignores = { "vendor/**" = ["ALL"] }
 
 #### `extend-select`
 
-Enable additional rules on top of the default or explicitly selected rule set.
+Enable additional rules or named selectors on top of the default or explicitly selected rule set.
 
 **Default value**: `[]`
 
@@ -77,7 +77,7 @@ Enable additional rules on top of the default or explicitly selected rule set.
 
 ```toml
 [lint]
-extend-select = ["S"]
+extend-select = ["google"]
 ```
 
 ---
@@ -135,7 +135,7 @@ per-file-ignores = { "scripts/*.sh" = ["S074"] }
 
 #### `select`
 
-Replace the default rule set with the selectors listed here.
+Replace the default rule set with the selectors listed here, including named selectors such as `google`.
 
 **Default value**: `all implemented non-style rules`
 
@@ -145,7 +145,7 @@ Replace the default rule set with the selectors listed here.
 
 ```toml
 [lint]
-select = ["C", "K"]
+select = ["google"]
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add a first-class `google` named rule selector to the linter selector model
- allow `google` everywhere config and CLI already accept rule selectors, including per-file ignores and fixable selectors
- update selector help/docs and regenerate the settings reference with named-selector examples

## Why
The Google shell-style spec defines a partial preset for currently implemented rules, but the config and CLI surfaces only understood categories, prefixes, and exact rule codes. This change wires in named-selector support so users can opt into that preset directly with `--select google` or `extend-select = ["google"]`.

## Impact
Users can enable the Google preset from existing selector fields without any new config keys or flags. The initial membership stays intentionally partial and can grow as more Google-style rules are implemented.

## Validation
- `cargo fmt --all`
- `cargo test -p shuck-cli -p shuck-linter --lib`
