### PR TITLE
fix(run): support shell registry manifests

### DIFF
--- a/crates/shuck-cli/tests/run_cli.rs
+++ b/crates/shuck-cli/tests/run_cli.rs
@@ -7,6 +7,7 @@ use std::process::Command as ProcessCommand;
 
 use assert_cmd::Command;
 use predicates::prelude::*;
+use serde_json::{Map, json};
 use sha2::{Digest, Sha256};
 use tempfile::tempdir;
 use url::Url;
@@ -17,12 +18,6 @@ fn configure_runtime_env(cmd: &mut Command, root: &Path, registry_path: &Path) {
         "SHUCK_RUN_REGISTRY_URL",
         Url::from_file_path(registry_path).unwrap().to_string(),
     );
-}
-
-fn registry_path(root: &Path, body: &str) -> PathBuf {
-    let path = root.join("registry.json");
-    fs::write(&path, body).unwrap();
-    path
 }
 
 fn fake_shell_archive(root: &Path, shell: &str, version: &str) -> (PathBuf, String) {
@@ -64,44 +59,88 @@ fn fake_shell_archive(root: &Path, shell: &str, version: &str) -> (PathBuf, Stri
     (archive_path, sha256)
 }
 
-fn registry_body(shell: &str, versions: &[(&str, &Path, &str)]) -> String {
-    let platform = match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("linux", "x86_64") => "x86_64-linux",
-        ("linux", "aarch64") => "aarch64-linux",
+fn registry_platform() -> &'static str {
+    match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") if cfg!(target_env = "gnu") => "x86_64-linux-gnu",
+        ("linux", "x86_64") if cfg!(target_env = "musl") => "x86_64-linux-musl",
+        ("linux", "aarch64") if cfg!(target_env = "gnu") => "aarch64-linux-gnu",
+        ("linux", "aarch64") if cfg!(target_env = "musl") => "aarch64-linux-musl",
         ("macos", "x86_64") => "x86_64-darwin",
         ("macos", "aarch64") => "aarch64-darwin",
         (os, arch) => panic!("unsupported test platform {arch}-{os}"),
-    };
-    let versions = versions
-        .iter()
-        .map(|(version, archive, sha256)| {
-            format!(
-                r#"
-        "{version}": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url}",
-              "sha256": "{sha256}"
-            }}
-          }}
-        }}"#,
-                url = Url::from_file_path(archive).unwrap(),
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(",");
+    }
+}
 
-    format!(
-        r#"{{
-  "version": 1,
-  "shells": {{
-    "{shell}": {{
-      "versions": {{{versions}
-      }}
-    }}
-  }}
-}}"#
+fn registry_path(root: &Path, shell: &str, versions: &[(&str, &Path, &str)]) -> PathBuf {
+    let root_dir = root.join("registry");
+    let shell_dir = root_dir.join("shells").join(shell);
+    fs::create_dir_all(&shell_dir).unwrap();
+
+    let platform = registry_platform();
+    let mut shell_versions = Map::new();
+    for (version, archive, sha256) in versions {
+        shell_versions.insert(
+            (*version).to_owned(),
+            json!({
+                "manifest_url": format!("{version}.json"),
+            }),
+        );
+        fs::write(
+            shell_dir.join(format!("{version}.json")),
+            format!(
+                "{}\n",
+                serde_json::to_string_pretty(&json!({
+                    "version": 2,
+                    "kind": "shuck.shells.release",
+                    "shell": shell,
+                    "release": version,
+                    "platforms": {
+                        platform: {
+                            "url": Url::from_file_path(archive).unwrap().to_string(),
+                            "sha256": sha256,
+                        }
+                    }
+                }))
+                .unwrap()
+            ),
+        )
+        .unwrap();
+    }
+
+    fs::write(
+        shell_dir.join("index.json"),
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&json!({
+                "version": 2,
+                "kind": "shuck.shells.versions",
+                "shell": shell,
+                "versions": shell_versions,
+            }))
+            .unwrap()
+        ),
     )
+    .unwrap();
+
+    let path = root_dir.join("index.json");
+    fs::write(
+        &path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&json!({
+                "version": 2,
+                "kind": "shuck.shells.index",
+                "shells": {
+                    shell: {
+                        "versions_url": format!("shells/{shell}/index.json"),
+                    }
+                }
+            }))
+            .unwrap()
+        ),
+    )
+    .unwrap();
+    path
 }
 
 fn fake_system_shell(path: &Path, name: &str, version: &str) {
@@ -131,8 +170,7 @@ fn top_level_help_includes_runtime_commands() {
 fn run_dry_run_uses_project_config_and_registry() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bash", "5.2.21");
-    let registry = registry_body("bash", &[("5.2.21", &archive, &sha256)]);
-    let registry = registry_path(tempdir.path(), &registry);
+    let registry = registry_path(tempdir.path(), "bash", &[("5.2.21", &archive, &sha256)]);
     fs::write(
         tempdir.path().join("shuck.toml"),
         "[run.shells]\nbash = '5.2'\n",
@@ -158,8 +196,7 @@ fn run_dry_run_uses_project_config_and_registry() {
 fn run_command_string_uses_managed_shell_and_sets_env() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bash", "5.2.21");
-    let registry = registry_body("bash", &[("5.2.21", &archive, &sha256)]);
-    let registry = registry_path(tempdir.path(), &registry);
+    let registry = registry_path(tempdir.path(), "bash", &[("5.2.21", &archive, &sha256)]);
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_runtime_env(&mut cmd, tempdir.path(), &registry);
@@ -191,8 +228,7 @@ fn run_stdin_defaults_to_system_bash() {
 fn run_stdin_with_shell_executes_managed_interpreter() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bash", "5.2.21");
-    let registry = registry_body("bash", &[("5.2.21", &archive, &sha256)]);
-    let registry = registry_path(tempdir.path(), &registry);
+    let registry = registry_path(tempdir.path(), "bash", &[("5.2.21", &archive, &sha256)]);
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_runtime_env(&mut cmd, tempdir.path(), &registry);
@@ -207,14 +243,14 @@ fn install_list_shows_newest_version_first() {
     let tempdir = tempdir().unwrap();
     let (archive_a, sha_a) = fake_shell_archive(tempdir.path(), "bash", "5.1.16");
     let (archive_b, sha_b) = fake_shell_archive(tempdir.path(), "bash", "5.2.21");
-    let registry = registry_body(
+    let registry = registry_path(
+        tempdir.path(),
         "bash",
         &[
             ("5.1.16", &archive_a, &sha_a),
             ("5.2.21", &archive_b, &sha_b),
         ],
     );
-    let registry = registry_path(tempdir.path(), &registry);
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_runtime_env(&mut cmd, tempdir.path(), &registry);
@@ -265,8 +301,7 @@ fn shell_subcommand_defaults_to_managed_bash() {
     let bin_dir = tempdir.path().join("bin");
     fake_system_shell(&bin_dir.join("bash"), "bash", "3.2.57");
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bash", "5.2.21");
-    let registry = registry_body("bash", &[("5.2.21", &archive, &sha256)]);
-    let registry = registry_path(tempdir.path(), &registry);
+    let registry = registry_path(tempdir.path(), "bash", &[("5.2.21", &archive, &sha256)]);
     let path = std::env::join_paths(
         std::iter::once(bin_dir.clone()).chain(std::env::split_paths(
             &std::env::var_os("PATH").unwrap_or_default(),

--- a/crates/shuck-run/src/environment.rs
+++ b/crates/shuck-run/src/environment.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 
-const DEFAULT_REGISTRY_URL: &str = "https://shells.shuck.dev/index.json";
+const DEFAULT_REGISTRY_URL: &str = "https://ewhauser.github.io/shuck-shells/";
 const SHELLS_DIR_ENV: &str = "SHUCK_SHELLS_DIR";
 const REGISTRY_URL_ENV: &str = "SHUCK_RUN_REGISTRY_URL";
 
@@ -33,10 +33,20 @@ impl Environment {
 
 pub(crate) fn current_platform() -> Result<String> {
     match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("linux", "x86_64") => Ok("x86_64-linux".to_owned()),
-        ("linux", "aarch64") => Ok("aarch64-linux".to_owned()),
+        ("linux", "x86_64") => Ok(format!("x86_64-linux-{}", linux_runtime_abi()?)),
+        ("linux", "aarch64") => Ok(format!("aarch64-linux-{}", linux_runtime_abi()?)),
         ("macos", "x86_64") => Ok("x86_64-darwin".to_owned()),
         ("macos", "aarch64") => Ok("aarch64-darwin".to_owned()),
         (os, arch) => anyhow::bail!("unsupported platform {arch}-{os}"),
+    }
+}
+
+fn linux_runtime_abi() -> Result<&'static str> {
+    if cfg!(target_env = "gnu") {
+        Ok("gnu")
+    } else if cfg!(target_env = "musl") {
+        Ok("musl")
+    } else {
+        anyhow::bail!("unsupported linux target environment for shuck run")
     }
 }

--- a/crates/shuck-run/src/managed.rs
+++ b/crates/shuck-run/src/managed.rs
@@ -8,7 +8,7 @@ use tempfile::Builder as TempFileBuilder;
 
 use crate::download::fetch_url_to_path;
 use crate::environment::current_platform;
-use crate::registry::{load_registry, select_version_for_platform};
+use crate::registry::{load_registry, select_release_for_platform};
 use crate::system::detect_shell_version;
 use crate::{
     Environment, ResolutionSource, ResolvedInterpreter, Shell, Version, VersionConstraint,
@@ -23,15 +23,14 @@ pub(crate) fn install_with_environment(
 ) -> Result<ResolvedInterpreter> {
     let registry = load_registry(environment, refresh_registry, verbose)?;
     let platform = current_platform()?;
-    let version = select_version_for_platform(&registry, shell, constraint, &platform)?;
-    let artifact = registry
-        .shells
-        .get(shell.as_str())
-        .and_then(|entry| entry.versions.get(version.as_str()))
-        .and_then(|entry| entry.platforms.get(&platform))
-        .ok_or_else(|| {
-            anyhow!("{shell} {version} does not have a prebuilt binary for {platform}.")
-        })?;
+    let (version, artifact) = select_release_for_platform(
+        &registry,
+        shell,
+        constraint,
+        &platform,
+        refresh_registry,
+        verbose,
+    )?;
 
     let install_dir = environment
         .shells_root

--- a/crates/shuck-run/src/registry.rs
+++ b/crates/shuck-run/src/registry.rs
@@ -77,12 +77,7 @@ impl CachedDocumentRef {
     fn root(environment: &Environment) -> Result<Self> {
         let mut remote_url = Url::parse(&environment.registry_url)
             .with_context(|| format!("parse registry URL `{}`", environment.registry_url))?;
-        if !remote_url.path().ends_with(".json") {
-            let mut path = remote_url.path().to_owned();
-            if !path.ends_with('/') {
-                path.push('/');
-            }
-            remote_url.set_path(&path);
+        if remote_url.path().ends_with('/') {
             remote_url = remote_url
                 .join("index.json")
                 .context("resolve registry root index URL")?;

--- a/crates/shuck-run/src/registry.rs
+++ b/crates/shuck-run/src/registry.rs
@@ -1,38 +1,114 @@
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
 use tempfile::NamedTempFile;
+use url::Url;
 
 use crate::download::fetch_url_to_path;
 use crate::{AvailableShell, Environment, Shell, Version, VersionConstraint};
 
 const REGISTRY_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const REGISTRY_SCHEMA_VERSION: u64 = 2;
+const ROOT_KIND: &str = "shuck.shells.index";
+const SHELL_KIND: &str = "shuck.shells.versions";
+const RELEASE_KIND: &str = "shuck.shells.release";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub(crate) struct RegistryIndex {
-    #[serde(rename = "version")]
-    _version: u64,
     pub(crate) shells: BTreeMap<String, RegistryShell>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug)]
 pub(crate) struct RegistryShell {
-    pub(crate) versions: BTreeMap<String, RegistryVersion>,
+    versions: BTreeMap<String, CachedDocumentRef>,
 }
 
-#[derive(Debug, Deserialize)]
-pub(crate) struct RegistryVersion {
-    pub(crate) platforms: BTreeMap<String, RegistryArtifact>,
+#[derive(Debug, Clone)]
+struct CachedDocumentRef {
+    remote_url: Url,
+    cache_path: PathBuf,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub(crate) struct RegistryArtifact {
     pub(crate) url: String,
     pub(crate) sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RootDocument {
+    version: u64,
+    kind: String,
+    shells: BTreeMap<String, RootShellDocument>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RootShellDocument {
+    versions_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ShellDocument {
+    version: u64,
+    kind: String,
+    shell: String,
+    versions: BTreeMap<String, ShellVersionDocument>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ShellVersionDocument {
+    manifest_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseDocument {
+    version: u64,
+    kind: String,
+    shell: String,
+    release: String,
+    platforms: BTreeMap<String, RegistryArtifact>,
+}
+
+impl CachedDocumentRef {
+    fn root(environment: &Environment) -> Result<Self> {
+        let mut remote_url = Url::parse(&environment.registry_url)
+            .with_context(|| format!("parse registry URL `{}`", environment.registry_url))?;
+        if !remote_url.path().ends_with(".json") {
+            let mut path = remote_url.path().to_owned();
+            if !path.ends_with('/') {
+                path.push('/');
+            }
+            remote_url.set_path(&path);
+            remote_url = remote_url
+                .join("index.json")
+                .context("resolve registry root index URL")?;
+        }
+
+        Ok(Self {
+            remote_url,
+            cache_path: environment.shells_root.join("index.json"),
+        })
+    }
+
+    fn resolve_relative(&self, reference: &str) -> Result<Self> {
+        let remote_url = self
+            .remote_url
+            .join(reference)
+            .with_context(|| format!("resolve registry reference `{reference}`"))?;
+        let cache_parent = self
+            .cache_path
+            .parent()
+            .ok_or_else(|| anyhow!("invalid cache path {}", self.cache_path.display()))?;
+        let cache_path = resolve_cache_path(cache_parent, reference)?;
+        Ok(Self {
+            remote_url,
+            cache_path,
+        })
+    }
 }
 
 pub(crate) fn available_shells(
@@ -69,12 +145,14 @@ pub(crate) fn available_shells(
     available
 }
 
-pub(crate) fn select_version_for_platform(
+pub(crate) fn select_release_for_platform(
     registry: &RegistryIndex,
     shell: Shell,
     constraint: &VersionConstraint,
     platform: &str,
-) -> Result<Version> {
+    refresh: bool,
+    verbose: bool,
+) -> Result<(Version, RegistryArtifact)> {
     let shell_entry = shell_entry(registry, shell)?;
     let mut versions = parsed_versions(shell_entry)?;
     versions.sort();
@@ -85,12 +163,21 @@ pub(crate) fn select_version_for_platform(
             continue;
         }
         matched_constraint = true;
-        if shell_entry
-            .versions
-            .get(version.as_str())
-            .is_some_and(|entry| entry.platforms.contains_key(platform))
-        {
-            return Ok(version);
+        let manifest_ref = shell_entry.versions.get(version.as_str()).ok_or_else(|| {
+            anyhow!(
+                "missing release manifest reference for {shell} {}",
+                version.as_str()
+            )
+        })?;
+        let release = load_release_document(
+            manifest_ref,
+            shell.as_str(),
+            version.as_str(),
+            refresh,
+            verbose,
+        )?;
+        if let Some(artifact) = release.platforms.get(platform) {
+            return Ok((version, artifact.clone()));
         }
     }
 
@@ -111,19 +198,191 @@ pub(crate) fn load_registry(
 ) -> Result<RegistryIndex> {
     fs::create_dir_all(&environment.shells_root)
         .with_context(|| format!("create {}", environment.shells_root.display()))?;
-    let index_path = environment.shells_root.join("index.json");
 
-    let should_refresh =
-        refresh || !index_path.exists() || index_is_stale(&index_path).unwrap_or(true);
+    let root_ref = CachedDocumentRef::root(environment)?;
+    let root = load_document(&root_ref, refresh, verbose, parse_root_document)?;
+
+    let mut shells = BTreeMap::new();
+    for (shell, entry) in root.shells {
+        let shell_ref = root_ref.resolve_relative(&entry.versions_url)?;
+        let shell_document = load_document(&shell_ref, refresh, verbose, |source| {
+            parse_shell_document(source, &shell)
+        })?;
+        let versions = shell_document
+            .versions
+            .into_iter()
+            .map(|(version, version_entry)| {
+                let manifest_ref = shell_ref.resolve_relative(&version_entry.manifest_url)?;
+                Ok((version, manifest_ref))
+            })
+            .collect::<Result<BTreeMap<_, _>>>()?;
+        shells.insert(shell, RegistryShell { versions });
+    }
+
+    Ok(RegistryIndex { shells })
+}
+
+fn resolve_cache_path(base: &Path, reference: &str) -> Result<PathBuf> {
+    let mut resolved = base.to_path_buf();
+    for component in Path::new(reference).components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(segment) => resolved.push(segment),
+            Component::ParentDir => {
+                bail!("registry reference `{reference}` escapes the local cache root")
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                bail!("registry reference `{reference}` must be relative")
+            }
+        }
+    }
+    Ok(resolved)
+}
+
+fn load_release_document(
+    manifest_ref: &CachedDocumentRef,
+    expected_shell: &str,
+    expected_version: &str,
+    refresh: bool,
+    verbose: bool,
+) -> Result<ReleaseDocument> {
+    load_document(manifest_ref, refresh, verbose, |source| {
+        parse_release_document(source, expected_shell, expected_version)
+    })
+}
+
+fn load_document<T, F>(
+    document_ref: &CachedDocumentRef,
+    refresh: bool,
+    verbose: bool,
+    parse: F,
+) -> Result<T>
+where
+    F: Fn(&str) -> Result<T>,
+{
+    let should_refresh = refresh
+        || !document_ref.cache_path.exists()
+        || index_is_stale(&document_ref.cache_path).unwrap_or(true);
     if should_refresh {
-        match refresh_registry_index(environment, &index_path, verbose) {
-            Ok(registry) => return Ok(registry),
-            Err(_err) if index_path.exists() && !refresh => {}
+        match refresh_document(document_ref, verbose, &parse) {
+            Ok(document) => return Ok(document),
+            Err(_err) if document_ref.cache_path.exists() && !refresh => {}
             Err(err) => return Err(err),
         }
     }
 
-    read_registry_index(&index_path)
+    match read_document(&document_ref.cache_path, &parse) {
+        Ok(document) => Ok(document),
+        Err(_err) if !refresh => refresh_document(document_ref, verbose, &parse),
+        Err(err) => Err(err),
+    }
+}
+
+fn refresh_document<T, F>(document_ref: &CachedDocumentRef, verbose: bool, parse: &F) -> Result<T>
+where
+    F: Fn(&str) -> Result<T>,
+{
+    let parent = document_ref
+        .cache_path
+        .parent()
+        .ok_or_else(|| anyhow!("invalid cache path {}", document_ref.cache_path.display()))?;
+    fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+
+    let temp_file = NamedTempFile::new_in(parent)
+        .with_context(|| format!("create temp registry document in {}", parent.display()))?;
+    fetch_url_to_path(document_ref.remote_url.as_str(), temp_file.path(), verbose)
+        .with_context(|| format!("fetch {}", document_ref.remote_url))?;
+    let document = read_document(temp_file.path(), parse)?;
+    match temp_file.persist(&document_ref.cache_path) {
+        Ok(_) => Ok(document),
+        Err(err) => {
+            Err(err.error).with_context(|| format!("replace {}", document_ref.cache_path.display()))
+        }
+    }
+}
+
+fn read_document<T, F>(path: &Path, parse: &F) -> Result<T>
+where
+    F: Fn(&str) -> Result<T>,
+{
+    let source = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    parse(&source).with_context(|| format!("parse {}", path.display()))
+}
+
+fn parse_root_document(source: &str) -> Result<RootDocument> {
+    let document: RootDocument =
+        serde_json::from_str(source).context("decode root registry document")?;
+    if document.version != REGISTRY_SCHEMA_VERSION {
+        bail!(
+            "root registry document version {} is unsupported",
+            document.version
+        );
+    }
+    if document.kind != ROOT_KIND {
+        bail!(
+            "root registry document kind `{}` is unsupported",
+            document.kind
+        );
+    }
+    Ok(document)
+}
+
+fn parse_shell_document(source: &str, expected_shell: &str) -> Result<ShellDocument> {
+    let document: ShellDocument =
+        serde_json::from_str(source).context("decode shell registry document")?;
+    if document.version != REGISTRY_SCHEMA_VERSION {
+        bail!(
+            "shell registry document for `{expected_shell}` has unsupported version {}",
+            document.version
+        );
+    }
+    if document.kind != SHELL_KIND {
+        bail!(
+            "shell registry document for `{expected_shell}` has unsupported kind `{}`",
+            document.kind
+        );
+    }
+    if document.shell != expected_shell {
+        bail!(
+            "shell registry document expected `{expected_shell}`, found `{}`",
+            document.shell
+        );
+    }
+    Ok(document)
+}
+
+fn parse_release_document(
+    source: &str,
+    expected_shell: &str,
+    expected_version: &str,
+) -> Result<ReleaseDocument> {
+    let document: ReleaseDocument =
+        serde_json::from_str(source).context("decode release manifest")?;
+    if document.version != REGISTRY_SCHEMA_VERSION {
+        bail!(
+            "release manifest for `{expected_shell}` `{expected_version}` has unsupported version {}",
+            document.version
+        );
+    }
+    if document.kind != RELEASE_KIND {
+        bail!(
+            "release manifest for `{expected_shell}` `{expected_version}` has unsupported kind `{}`",
+            document.kind
+        );
+    }
+    if document.shell != expected_shell {
+        bail!(
+            "release manifest expected shell `{expected_shell}`, found `{}`",
+            document.shell
+        );
+    }
+    if document.release != expected_version {
+        bail!(
+            "release manifest expected version `{expected_version}`, found `{}`",
+            document.release
+        );
+    }
+    Ok(document)
 }
 
 fn index_is_stale(path: &Path) -> Result<bool> {
@@ -135,31 +394,6 @@ fn index_is_stale(path: &Path) -> Result<bool> {
         .duration_since(modified)
         .unwrap_or_default();
     Ok(age > REGISTRY_MAX_AGE)
-}
-
-fn refresh_registry_index(
-    environment: &Environment,
-    index_path: &Path,
-    verbose: bool,
-) -> Result<RegistryIndex> {
-    let temp_file = NamedTempFile::new_in(&environment.shells_root).with_context(|| {
-        format!(
-            "create temp registry in {}",
-            environment.shells_root.display()
-        )
-    })?;
-    fetch_url_to_path(&environment.registry_url, temp_file.path(), verbose)
-        .with_context(|| format!("fetch {}", environment.registry_url))?;
-    let registry = read_registry_index(temp_file.path())?;
-    match temp_file.persist(index_path) {
-        Ok(_) => Ok(registry),
-        Err(err) => Err(err.error).with_context(|| format!("replace {}", index_path.display())),
-    }
-}
-
-fn read_registry_index(path: &Path) -> Result<RegistryIndex> {
-    let source = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
-    serde_json::from_str(&source).with_context(|| format!("parse {}", path.display()))
 }
 
 fn shell_entry(registry: &RegistryIndex, shell: Shell) -> Result<&RegistryShell> {

--- a/crates/shuck-run/src/tests.rs
+++ b/crates/shuck-run/src/tests.rs
@@ -664,6 +664,79 @@ fn registry_site_root_url_resolves_root_index_document() {
 }
 
 #[test]
+fn explicit_registry_endpoint_url_is_fetched_as_given() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
+    let platform = current_platform().unwrap();
+    let endpoint_path = tempdir.path().join("registry-endpoint");
+
+    fs::create_dir_all(tempdir.path().join("shells/bash")).unwrap();
+    fs::write(
+        &endpoint_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&json!({
+                "version": 2,
+                "kind": "shuck.shells.index",
+                "shells": {
+                    "bash": {
+                        "versions_url": "shells/bash/index.json",
+                    }
+                },
+            }))
+            .unwrap()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("shells/bash/index.json"),
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&json!({
+                "version": 2,
+                "kind": "shuck.shells.versions",
+                "shell": "bash",
+                "versions": {
+                    "5.2.21": {
+                        "manifest_url": "5.2.21.json",
+                    }
+                },
+            }))
+            .unwrap()
+        ),
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("shells/bash/5.2.21.json"),
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&json!({
+                "version": 2,
+                "kind": "shuck.shells.release",
+                "shell": "bash",
+                "release": "5.2.21",
+                "platforms": {
+                    platform: {
+                        "url": Url::from_file_path(archive).unwrap().to_string(),
+                        "sha256": sha256,
+                    }
+                },
+            }))
+            .unwrap()
+        ),
+    )
+    .unwrap();
+
+    let environment = test_environment(
+        tempdir.path(),
+        Url::from_file_path(endpoint_path).unwrap().to_string(),
+    );
+    let loaded = load_registry(&environment, false, false).unwrap();
+
+    assert!(loaded.shells.contains_key("bash"));
+}
+
+#[test]
 fn unresolved_shell_uses_managed_bash_without_implicit_system_fallback() {
     let tempdir = tempfile::tempdir().unwrap();
     let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");

--- a/crates/shuck-run/src/tests.rs
+++ b/crates/shuck-run/src/tests.rs
@@ -4,6 +4,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 use url::Url;
 
@@ -22,10 +23,122 @@ fn test_environment(root: &Path, registry_url: String) -> Environment {
     }
 }
 
-fn write_registry(root: &Path, body: &str) -> PathBuf {
-    let registry_path = root.join("registry.json");
-    fs::write(&registry_path, body).unwrap();
-    registry_path
+#[derive(Clone)]
+struct RegistryEntry {
+    shell: Shell,
+    version: String,
+    platform: String,
+    url: String,
+    sha256: String,
+}
+
+fn registry_entry(
+    shell: Shell,
+    version: &str,
+    platform: &str,
+    archive: &Path,
+    sha256: &str,
+) -> RegistryEntry {
+    RegistryEntry {
+        shell,
+        version: version.to_owned(),
+        platform: platform.to_owned(),
+        url: Url::from_file_path(archive).unwrap().to_string(),
+        sha256: sha256.to_owned(),
+    }
+}
+
+fn write_registry_document(root: &Path, relative_path: &str, document: &Value) -> PathBuf {
+    let path = root.join("registry").join(relative_path);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    let contents = format!("{}\n", serde_json::to_string_pretty(document).unwrap());
+    fs::write(&path, contents).unwrap();
+    path
+}
+
+fn write_registry_site(root: &Path, entries: &[RegistryEntry]) -> PathBuf {
+    let mut grouped = BTreeMap::<String, BTreeMap<String, BTreeMap<String, RegistryEntry>>>::new();
+    for entry in entries {
+        grouped
+            .entry(entry.shell.as_str().to_owned())
+            .or_default()
+            .entry(entry.version.clone())
+            .or_default()
+            .insert(entry.platform.clone(), entry.clone());
+    }
+
+    let mut root_shells = Map::new();
+    for (shell, versions) in &grouped {
+        root_shells.insert(
+            shell.clone(),
+            json!({
+                "versions_url": format!("shells/{shell}/index.json"),
+            }),
+        );
+
+        let mut version_names = versions.keys().cloned().collect::<Vec<_>>();
+        version_names.sort_by(|left, right| {
+            Version::parse(right)
+                .unwrap()
+                .cmp(&Version::parse(left).unwrap())
+        });
+
+        let mut shell_versions = Map::new();
+        for version in version_names {
+            shell_versions.insert(
+                version.clone(),
+                json!({
+                    "manifest_url": format!("{version}.json"),
+                }),
+            );
+
+            let mut platforms = Map::new();
+            for (platform, entry) in versions.get(&version).unwrap() {
+                platforms.insert(
+                    platform.clone(),
+                    json!({
+                        "url": entry.url,
+                        "sha256": entry.sha256,
+                    }),
+                );
+            }
+
+            write_registry_document(
+                root,
+                &format!("shells/{shell}/{version}.json"),
+                &json!({
+                    "version": 2,
+                    "kind": "shuck.shells.release",
+                    "shell": shell,
+                    "release": version,
+                    "platforms": platforms,
+                }),
+            );
+        }
+
+        write_registry_document(
+            root,
+            &format!("shells/{shell}/index.json"),
+            &json!({
+                "version": 2,
+                "kind": "shuck.shells.versions",
+                "shell": shell,
+                "versions": shell_versions,
+            }),
+        );
+    }
+
+    write_registry_document(
+        root,
+        "index.json",
+        &json!({
+            "version": 2,
+            "kind": "shuck.shells.index",
+            "shells": root_shells,
+        }),
+    )
 }
 
 fn make_shell_archive(root: &Path, shell: Shell, version: &str) -> (PathBuf, String) {
@@ -72,31 +185,17 @@ fn make_shell_archive(root: &Path, shell: Shell, version: &str) -> (PathBuf, Str
     (archive_path, sha256)
 }
 
-fn registry_for_archive(shell: Shell, version: &str, archive: &Path, sha256: &str) -> String {
+fn registry_for_archive(
+    root: &Path,
+    shell: Shell,
+    version: &str,
+    archive: &Path,
+    sha256: &str,
+) -> PathBuf {
     let platform = current_platform().unwrap();
-    format!(
-        r#"{{
-  "version": 1,
-  "shells": {{
-    "{shell}": {{
-      "versions": {{
-        "{version}": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url}",
-              "sha256": "{sha256}"
-            }}
-          }}
-        }}
-      }}
-    }}
-  }}
-}}"#,
-        shell = shell.as_str(),
-        version = version,
-        platform = platform,
-        url = Url::from_file_path(archive).unwrap(),
-        sha256 = sha256
+    write_registry_site(
+        root,
+        &[registry_entry(shell, version, &platform, archive, sha256)],
     )
 }
 
@@ -135,8 +234,8 @@ fn parses_exact_and_range_constraints() {
 fn resolves_cli_shell_and_config_version() {
     let tempdir = tempfile::tempdir().unwrap();
     let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
-    let registry = registry_for_archive(Shell::Bash, "5.2.21", &archive, &sha256);
-    let registry_path = write_registry(tempdir.path(), &registry);
+    let registry_path =
+        registry_for_archive(tempdir.path(), Shell::Bash, "5.2.21", &archive, &sha256);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -172,8 +271,7 @@ fn resolves_cli_shell_and_config_version() {
 fn metadata_overrides_project_defaults() {
     let tempdir = tempfile::tempdir().unwrap();
     let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Zsh, "5.9");
-    let registry = registry_for_archive(Shell::Zsh, "5.9", &archive, &sha256);
-    let registry_path = write_registry(tempdir.path(), &registry);
+    let registry_path = registry_for_archive(tempdir.path(), Shell::Zsh, "5.9", &archive, &sha256);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -215,39 +313,13 @@ fn defaults_to_bash_when_only_a_version_constraint_is_provided() {
     let (archive_a, sha_a) = make_shell_archive(tempdir.path(), Shell::Bash, "5.1.16");
     let (archive_b, sha_b) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
     let platform = current_platform().unwrap();
-    let registry = format!(
-        r#"{{
-  "version": 1,
-  "shells": {{
-    "bash": {{
-      "versions": {{
-        "5.1.16": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url_a}",
-              "sha256": "{sha_a}"
-            }}
-          }}
-        }},
-        "5.2.21": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url_b}",
-              "sha256": "{sha_b}"
-            }}
-          }}
-        }}
-      }}
-    }}
-  }}
-}}"#,
-        platform = platform,
-        url_a = Url::from_file_path(archive_a).unwrap(),
-        sha_a = sha_a,
-        url_b = Url::from_file_path(archive_b).unwrap(),
-        sha_b = sha_b
+    let registry_path = write_registry_site(
+        tempdir.path(),
+        &[
+            registry_entry(Shell::Bash, "5.1.16", &platform, &archive_a, &sha_a),
+            registry_entry(Shell::Bash, "5.2.21", &platform, &archive_b, &sha_b),
+        ],
     );
-    let registry_path = write_registry(tempdir.path(), &registry);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -279,43 +351,13 @@ fn cli_shell_override_ignores_mismatched_metadata_version() {
     let (bash_archive, bash_sha) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
     let (zsh_archive, zsh_sha) = make_shell_archive(tempdir.path(), Shell::Zsh, "5.9");
     let platform = current_platform().unwrap();
-    let registry = format!(
-        r#"{{
-  "version": 1,
-  "shells": {{
-    "bash": {{
-      "versions": {{
-        "5.2.21": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{bash_url}",
-              "sha256": "{bash_sha}"
-            }}
-          }}
-        }}
-      }}
-    }},
-    "zsh": {{
-      "versions": {{
-        "5.9": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{zsh_url}",
-              "sha256": "{zsh_sha}"
-            }}
-          }}
-        }}
-      }}
-    }}
-  }}
-}}"#,
-        platform = platform,
-        bash_url = Url::from_file_path(bash_archive).unwrap(),
-        bash_sha = bash_sha,
-        zsh_url = Url::from_file_path(zsh_archive).unwrap(),
-        zsh_sha = zsh_sha
+    let registry_path = write_registry_site(
+        tempdir.path(),
+        &[
+            registry_entry(Shell::Bash, "5.2.21", &platform, &bash_archive, &bash_sha),
+            registry_entry(Shell::Zsh, "5.9", &platform, &zsh_archive, &zsh_sha),
+        ],
     );
-    let registry_path = write_registry(tempdir.path(), &registry);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -353,39 +395,13 @@ fn shell_specific_config_pin_overrides_generic_shell_version() {
     let (archive_a, sha_a) = make_shell_archive(tempdir.path(), Shell::Bash, "5.1.16");
     let (archive_b, sha_b) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
     let platform = current_platform().unwrap();
-    let registry = format!(
-        r#"{{
-  "version": 1,
-  "shells": {{
-    "bash": {{
-      "versions": {{
-        "5.1.16": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url_a}",
-              "sha256": "{sha_a}"
-            }}
-          }}
-        }},
-        "5.2.21": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url_b}",
-              "sha256": "{sha_b}"
-            }}
-          }}
-        }}
-      }}
-    }}
-  }}
-}}"#,
-        platform = platform,
-        url_a = Url::from_file_path(archive_a).unwrap(),
-        sha_a = sha_a,
-        url_b = Url::from_file_path(archive_b).unwrap(),
-        sha_b = sha_b
+    let registry_path = write_registry_site(
+        tempdir.path(),
+        &[
+            registry_entry(Shell::Bash, "5.1.16", &platform, &archive_a, &sha_a),
+            registry_entry(Shell::Bash, "5.2.21", &platform, &archive_b, &sha_b),
+        ],
     );
-    let registry_path = write_registry(tempdir.path(), &registry);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -423,39 +439,13 @@ fn shebang_without_other_constraints_uses_latest_available_version() {
     let (archive_a, sha_a) = make_shell_archive(tempdir.path(), Shell::Bash, "5.1.16");
     let (archive_b, sha_b) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
     let platform = current_platform().unwrap();
-    let registry = format!(
-        r#"{{
-  "version": 1,
-  "shells": {{
-    "bash": {{
-      "versions": {{
-        "5.1.16": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url_a}",
-              "sha256": "{sha_a}"
-            }}
-          }}
-        }},
-        "5.2.21": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url_b}",
-              "sha256": "{sha_b}"
-            }}
-          }}
-        }}
-      }}
-    }}
-  }}
-}}"#,
-        platform = platform,
-        url_a = Url::from_file_path(archive_a).unwrap(),
-        sha_a = sha_a,
-        url_b = Url::from_file_path(archive_b).unwrap(),
-        sha_b = sha_b
+    let registry_path = write_registry_site(
+        tempdir.path(),
+        &[
+            registry_entry(Shell::Bash, "5.1.16", &platform, &archive_a, &sha_a),
+            registry_entry(Shell::Bash, "5.2.21", &platform, &archive_b, &sha_b),
+        ],
     );
-    let registry_path = write_registry(tempdir.path(), &registry);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -486,13 +476,13 @@ fn shebang_without_other_constraints_uses_latest_available_version() {
 fn checksum_mismatch_aborts_install() {
     let tempdir = tempfile::tempdir().unwrap();
     let (archive, _sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
-    let registry = registry_for_archive(
+    let registry_path = registry_for_archive(
+        tempdir.path(),
         Shell::Bash,
         "5.2.21",
         &archive,
         "0000000000000000000000000000000000000000000000000000000000000000",
     );
-    let registry_path = write_registry(tempdir.path(), &registry);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -514,8 +504,8 @@ fn checksum_mismatch_aborts_install() {
 fn partial_install_directory_is_replaced() {
     let tempdir = tempfile::tempdir().unwrap();
     let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
-    let registry = registry_for_archive(Shell::Bash, "5.2.21", &archive, &sha256);
-    let registry_path = write_registry(tempdir.path(), &registry);
+    let registry_path =
+        registry_for_archive(tempdir.path(), Shell::Bash, "5.2.21", &archive, &sha256);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -548,8 +538,8 @@ fn partial_install_directory_is_replaced() {
 fn invalid_cached_install_is_replaced() {
     let tempdir = tempfile::tempdir().unwrap();
     let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
-    let registry = registry_for_archive(Shell::Bash, "5.2.21", &archive, &sha256);
-    let registry_path = write_registry(tempdir.path(), &registry);
+    let registry_path =
+        registry_for_archive(tempdir.path(), Shell::Bash, "5.2.21", &archive, &sha256);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -596,39 +586,19 @@ fn install_picks_latest_version_with_current_platform_artifact() {
     let (archive_old, sha_old) = make_shell_archive(tempdir.path(), Shell::Bash, "5.1.16");
     let (archive_new, sha_new) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
     let platform = current_platform().unwrap();
-    let registry = format!(
-        r#"{{
-  "version": 1,
-  "shells": {{
-    "bash": {{
-      "versions": {{
-        "5.1.16": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url_old}",
-              "sha256": "{sha_old}"
-            }}
-          }}
-        }},
-        "5.2.21": {{
-          "platforms": {{
-            "other-platform": {{
-              "url": "{url_new}",
-              "sha256": "{sha_new}"
-            }}
-          }}
-        }}
-      }}
-    }}
-  }}
-}}"#,
-        platform = platform,
-        url_old = Url::from_file_path(archive_old).unwrap(),
-        sha_old = sha_old,
-        url_new = Url::from_file_path(archive_new).unwrap(),
-        sha_new = sha_new
+    let registry_path = write_registry_site(
+        tempdir.path(),
+        &[
+            registry_entry(Shell::Bash, "5.1.16", &platform, &archive_old, &sha_old),
+            registry_entry(
+                Shell::Bash,
+                "5.2.21",
+                "other-platform",
+                &archive_new,
+                &sha_new,
+            ),
+        ],
     );
-    let registry_path = write_registry(tempdir.path(), &registry);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -651,8 +621,8 @@ fn install_picks_latest_version_with_current_platform_artifact() {
 fn failed_refresh_keeps_last_good_registry() {
     let tempdir = tempfile::tempdir().unwrap();
     let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
-    let good_registry = registry_for_archive(Shell::Bash, "5.2.21", &archive, &sha256);
-    let good_registry_path = write_registry(tempdir.path(), &good_registry);
+    let good_registry_path =
+        registry_for_archive(tempdir.path(), Shell::Bash, "5.2.21", &archive, &sha256);
     let bad_registry_path = tempdir.path().join("bad-registry.json");
     fs::write(&bad_registry_path, "{not json").unwrap();
 
@@ -677,11 +647,28 @@ fn failed_refresh_keeps_last_good_registry() {
 }
 
 #[test]
+fn registry_site_root_url_resolves_root_index_document() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
+    let registry_path =
+        registry_for_archive(tempdir.path(), Shell::Bash, "5.2.21", &archive, &sha256);
+    let registry_root = registry_path.parent().unwrap();
+
+    let environment = test_environment(
+        tempdir.path(),
+        Url::from_directory_path(registry_root).unwrap().to_string(),
+    );
+    let loaded = load_registry(&environment, false, false).unwrap();
+
+    assert!(loaded.shells.contains_key("bash"));
+}
+
+#[test]
 fn unresolved_shell_uses_managed_bash_without_implicit_system_fallback() {
     let tempdir = tempfile::tempdir().unwrap();
     let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
-    let registry = registry_for_archive(Shell::Bash, "5.2.21", &archive, &sha256);
-    let registry_path = write_registry(tempdir.path(), &registry);
+    let registry_path =
+        registry_for_archive(tempdir.path(), Shell::Bash, "5.2.21", &archive, &sha256);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -711,8 +698,8 @@ fn unresolved_shell_uses_managed_bash_without_implicit_system_fallback() {
 fn non_utf8_script_still_resolves_with_explicit_shell_and_version() {
     let tempdir = tempfile::tempdir().unwrap();
     let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
-    let registry = registry_for_archive(Shell::Bash, "5.2.21", &archive, &sha256);
-    let registry_path = write_registry(tempdir.path(), &registry);
+    let registry_path =
+        registry_for_archive(tempdir.path(), Shell::Bash, "5.2.21", &archive, &sha256);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),
@@ -788,39 +775,13 @@ fn lists_available_versions() {
     let (archive_a, sha_a) = make_shell_archive(tempdir.path(), Shell::Bash, "5.1.16");
     let (archive_b, sha_b) = make_shell_archive(tempdir.path(), Shell::Bash, "5.2.21");
     let platform = current_platform().unwrap();
-    let registry = format!(
-        r#"{{
-  "version": 1,
-  "shells": {{
-    "bash": {{
-      "versions": {{
-        "5.1.16": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url_a}",
-              "sha256": "{sha_a}"
-            }}
-          }}
-        }},
-        "5.2.21": {{
-          "platforms": {{
-            "{platform}": {{
-              "url": "{url_b}",
-              "sha256": "{sha_b}"
-            }}
-          }}
-        }}
-      }}
-    }}
-  }}
-}}"#,
-        platform = platform,
-        url_a = Url::from_file_path(archive_a).unwrap(),
-        sha_a = sha_a,
-        url_b = Url::from_file_path(archive_b).unwrap(),
-        sha_b = sha_b
+    let registry_path = write_registry_site(
+        tempdir.path(),
+        &[
+            registry_entry(Shell::Bash, "5.1.16", &platform, &archive_a, &sha_a),
+            registry_entry(Shell::Bash, "5.2.21", &platform, &archive_b, &sha_b),
+        ],
     );
-    let registry_path = write_registry(tempdir.path(), &registry);
     let environment = test_environment(
         tempdir.path(),
         Url::from_file_path(registry_path).unwrap().to_string(),

--- a/specs/011-run.md
+++ b/specs/011-run.md
@@ -203,31 +203,55 @@ Managed interpreters live in `~/.shuck/shells/`:
     ...
 ```
 
-Each interpreter is stored under `<shell>/<version>/<platform>/`. The platform triple follows `<arch>-<os>` (e.g., `x86_64-linux`, `aarch64-darwin`).
+Each interpreter is stored under `<shell>/<version>/<platform>/`. The platform name follows the published shell archive target, using `<arch>-darwin` on macOS and `<arch>-linux-<abi>` on Linux (for example, `x86_64-linux-gnu`, `aarch64-linux-musl`, `aarch64-darwin`).
 
 #### Registry
 
-A registry index maps shell names and versions to download URLs and checksums. The index is fetched from a well-known URL and cached locally as `~/.shuck/shells/index.json`.
+A registry discovery site maps shell names and versions to release manifests and checksums. The root discovery document is fetched from a well-known URL and cached locally as `~/.shuck/shells/index.json`, with nested shell and release documents cached under the same directory tree.
 
 ```json
 {
-  "version": 1,
+  "version": 2,
+  "kind": "shuck.shells.index",
   "shells": {
     "bash": {
-      "versions": {
-        "5.2.21": {
-          "platforms": {
-            "x86_64-linux": {
-              "url": "https://shells.shuck.dev/bash/5.2.21/x86_64-linux.tar.gz",
-              "sha256": "abc123..."
-            },
-            "aarch64-darwin": {
-              "url": "https://shells.shuck.dev/bash/5.2.21/aarch64-darwin.tar.gz",
-              "sha256": "def456..."
-            }
-          }
-        }
-      }
+      "versions_url": "shells/bash/index.json"
+    }
+  }
+}
+```
+
+Each per-shell index points at per-version manifests:
+
+```json
+{
+  "version": 2,
+  "kind": "shuck.shells.versions",
+  "shell": "bash",
+  "versions": {
+    "5.2.21": {
+      "manifest_url": "5.2.21.json"
+    }
+  }
+}
+```
+
+And each manifest carries the platform download URLs and checksums:
+
+```json
+{
+  "version": 2,
+  "kind": "shuck.shells.release",
+  "shell": "bash",
+  "release": "5.2.21",
+  "platforms": {
+    "x86_64-linux-gnu": {
+      "url": "https://github.com/ewhauser/shuck-shells/releases/download/bash-5.2.21/bash-5.2.21-x86_64-linux-gnu.tar.gz",
+      "sha256": "abc123..."
+    },
+    "aarch64-darwin": {
+      "url": "https://github.com/ewhauser/shuck-shells/releases/download/bash-5.2.21/bash-5.2.21-aarch64-darwin.tar.gz",
+      "sha256": "def456..."
     }
   }
 }


### PR DESCRIPTION
## Summary

- update `shuck-run` to consume the v2 `shuck-shells` registry site with root, per-shell, and per-release manifest documents
- resolve registry references relative to the configured registry URL and cache nested documents locally
- switch the default registry URL to `https://ewhauser.github.io/shuck-shells/` and select Linux `gnu`/`musl` platform artifacts
- update run tests and the run spec to cover the new registry layout

## Validation

- `cargo test -p shuck-run`
- `cargo test -p shuck-cli --test run_cli`
- `cargo test -p shuck-cli`
- `cargo run -p shuck-cli -- run --shell bash -c 'echo hello world'`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
