### PR TITLE
ci: derive publishable crate list from metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,8 @@ jobs:
       - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
       - name: "Check release workflow security hardening"
         run: python3 scripts/check-release-security.py check
+      - name: "Check release-please crate version coverage"
+        run: python3 scripts/check-release-please-config.py
 
   cargo-fmt:
     name: "cargo fmt"

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -68,7 +68,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          while IFS= read -r crate; do
+          crates_file="$(mktemp)"
+          python3 scripts/workspace-publish-crates.py > "${crates_file}"
+          mapfile -t crates < "${crates_file}"
+          rm -f "${crates_file}"
+          if [ "${#crates[@]}" -eq 0 ]; then
+            echo "No publishable crates found" >&2
+            exit 1
+          fi
+
+          for crate in "${crates[@]}"; do
             echo "::group::Publishing ${crate}"
             cargo publish -p "${crate}" --locked ${PUBLISH_FLAG}
             echo "::endgroup::"
@@ -77,4 +86,4 @@ jobs:
               # depends on it. Skip during dry-run where nothing is uploaded.
               sleep 20
             fi
-          done < <(python3 scripts/workspace-publish-crates.py)
+          done

--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$DRY_RUN_INPUT" = "true" ]; then
             echo "flag=--dry-run" >> "$GITHUB_OUTPUT"
-            echo "Dry-run mode: skipping upload"
+            echo "Dry-run mode: skipping upload (new unpublished internal deps may still fail registry validation)"
           else
             echo "flag=" >> "$GITHUB_OUTPUT"
             echo "Publish mode: uploads enabled"
@@ -68,22 +68,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Publish order follows the internal dependency graph, deepest first.
-          # shuck-benchmark is publish = false and excluded.
-          crates=(
-            shuck-ast
-            shuck-format
-            shuck-parser
-            shuck-indexer
-            shuck-cache
-            shuck-semantic
-            shuck-linter
-            shuck-formatter
-            shuck-extract
-            shuck-cli
-          )
-
-          for crate in "${crates[@]}"; do
+          while IFS= read -r crate; do
             echo "::group::Publishing ${crate}"
             cargo publish -p "${crate}" --locked ${PUBLISH_FLAG}
             echo "::endgroup::"
@@ -92,4 +77,4 @@ jobs:
               # depends on it. Skip during dry-run where nothing is uploaded.
               sleep 20
             fi
-          done
+          done < <(python3 scripts/workspace-publish-crates.py)

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -34,6 +34,7 @@
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-indexer'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-linter'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-parser'].version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-run'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-semantic'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-extract'].version" }
       ]

--- a/scripts/bootstrap-crates-publish.sh
+++ b/scripts/bootstrap-crates-publish.sh
@@ -27,35 +27,43 @@ fi
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-# Publish order follows the internal dependency graph (deepest first). Matches
-# crates-publish.yml so behavior is consistent with CI after bootstrap.
-crates=(
-  shuck-ast
-  shuck-format
-  shuck-parser
-  shuck-indexer
-  shuck-cache
-  shuck-semantic
-  shuck-linter
-  shuck-formatter
-  shuck-cli
-)
+declare -a crates=()
+while IFS= read -r crate; do
+  crates+=("$crate")
+done < <(python3 "$REPO_ROOT/scripts/workspace-publish-crates.py")
+
+if [ "${#crates[@]}" -eq 0 ]; then
+  echo "error: no publishable workspace crates found" >&2
+  exit 1
+fi
 
 workspace_version="$(cargo metadata --format-version 1 --no-deps \
-  | jq -r '.workspace_metadata // empty | .version // empty' )"
+  | jq -r '
+      .workspace_members as $members
+      | [
+          .packages[]
+          | . as $package
+          | select($members | index($package.id))
+          | select(.publish != [])
+          | .version
+        ]
+      | unique
+      | if length == 1 then .[0] else empty end
+    ')"
 if [ -z "$workspace_version" ]; then
-  workspace_version="$(cargo metadata --format-version 1 --no-deps \
-    | jq -r '.packages[] | select(.name=="shuck-cli") | .version')"
+  echo "error: publishable workspace crates do not share one version" >&2
+  exit 1
 fi
 echo "Workspace version: $workspace_version"
 
 publish_flag=""
 if [ "${DRY_RUN:-0}" = "1" ]; then
-  # --no-verify skips the post-package rebuild that resolves deps from
-  # crates.io. Without it, dry-run fails on internal deps (shuck-parser
-  # depends on shuck-ast, which hasn't been uploaded yet).
+  # --no-verify skips the post-package rebuild, but Cargo still validates
+  # registry dependency names during `publish --dry-run`. That means this
+  # mode is only a partial packaging check when a new internal crate name
+  # has not been uploaded to crates.io yet.
   publish_flag="--dry-run --no-verify"
-  echo "DRY_RUN=1 → cargo publish --dry-run --no-verify (no upload, no rebuild)"
+  echo "DRY_RUN=1 → cargo publish --dry-run --no-verify (no upload; unpublished internal deps may still fail)"
 fi
 
 is_version_on_crates_io() {

--- a/scripts/check-release-please-config.py
+++ b/scripts/check-release-please-config.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Validate release-please version bumps for publishable workspace crates."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def publishable_workspace_crates(repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "scripts" / "workspace-publish-crates.py")],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def configured_jsonpaths(repo_root: Path) -> set[str]:
+    config = json.loads((repo_root / ".release-please-config.json").read_text())
+    package_config = config["packages"]["."]
+    return {
+        entry["jsonpath"]
+        for entry in package_config.get("extra-files", [])
+        if entry.get("path") == "Cargo.toml" and "jsonpath" in entry
+    }
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    expected = {
+        f"$.workspace.dependencies['{crate_name}'].version"
+        for crate_name in publishable_workspace_crates(repo_root)
+    }
+    actual = configured_jsonpaths(repo_root)
+    missing = sorted(expected - actual)
+
+    if missing:
+        for jsonpath in missing:
+            print(f"missing release-please extra-files entry: {jsonpath}", file=sys.stderr)
+        return 1
+
+    print("release-please config covers all publishable workspace crates")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup-trusted-publishers.sh
+++ b/scripts/setup-trusted-publishers.sh
@@ -9,7 +9,7 @@
 #
 # Token needs the `trusted-publishing` scope (create it at crates.io →
 # Account Settings → API Tokens). The caller must be a verified owner of
-# each crate below.
+# each publishable workspace crate.
 #
 # Env vars:
 #   CRATES_IO_TOKEN      Required. API token with trusted-publishing scope.
@@ -30,17 +30,17 @@ REPOSITORY_NAME="${REPOSITORY_NAME:-shuck}"
 WORKFLOW_FILENAME="${WORKFLOW_FILENAME:-crates-publish.yml}"
 ENVIRONMENT="${ENVIRONMENT-release}"
 
-crates=(
-  shuck-ast
-  shuck-format
-  shuck-parser
-  shuck-indexer
-  shuck-cache
-  shuck-semantic
-  shuck-linter
-  shuck-formatter
-  shuck-cli
-)
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+declare -a crates=()
+while IFS= read -r crate; do
+  crates+=("$crate")
+done < <(python3 "$REPO_ROOT/scripts/workspace-publish-crates.py")
+
+if [ "${#crates[@]}" -eq 0 ]; then
+  echo "error: no publishable workspace crates found" >&2
+  exit 1
+fi
 
 configured=0
 skipped=0

--- a/scripts/workspace-publish-crates.py
+++ b/scripts/workspace-publish-crates.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Print publishable workspace crates in dependency order.
+
+This keeps the crates.io publish workflow and the local bootstrap scripts aligned
+with the current Cargo workspace metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from graphlib import TopologicalSorter
+
+
+def load_workspace_metadata() -> dict:
+    result = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def is_publishable(package: dict) -> bool:
+    publish = package.get("publish")
+    return publish != []
+
+
+def main() -> int:
+    metadata = load_workspace_metadata()
+    workspace_member_ids = set(metadata["workspace_members"])
+    workspace_packages = [
+        package for package in metadata["packages"] if package["id"] in workspace_member_ids
+    ]
+
+    workspace_names = {package["name"] for package in workspace_packages}
+    publishable_packages = sorted(
+        (package for package in workspace_packages if is_publishable(package)),
+        key=lambda package: package["name"],
+    )
+    publishable_names = {package["name"] for package in publishable_packages}
+
+    graph: dict[str, tuple[str, ...]] = {}
+    unpublished_dependency_errors: list[str] = []
+
+    for package in publishable_packages:
+        internal_dependencies = set()
+        for dependency in package.get("dependencies", []):
+            if dependency.get("path") is None:
+                continue
+            dependency_name = dependency["name"]
+            if dependency_name not in workspace_names:
+                continue
+            if dependency_name not in publishable_names:
+                unpublished_dependency_errors.append(
+                    f"{package['name']} depends on unpublished workspace crate {dependency_name}"
+                )
+                continue
+            internal_dependencies.add(dependency_name)
+        graph[package["name"]] = tuple(sorted(internal_dependencies))
+
+    if unpublished_dependency_errors:
+        for error in unpublished_dependency_errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    for crate_name in TopologicalSorter(graph).static_order():
+        print(crate_name)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workspace-publish-crates.py
+++ b/scripts/workspace-publish-crates.py
@@ -11,14 +11,17 @@ import json
 import subprocess
 import sys
 from graphlib import TopologicalSorter
+from pathlib import Path
 
 
 def load_workspace_metadata() -> dict:
+    repo_root = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         ["cargo", "metadata", "--format-version", "1", "--no-deps"],
         check=True,
         capture_output=True,
         text=True,
+        cwd=repo_root,
     )
     return json.loads(result.stdout)
 


### PR DESCRIPTION
## Summary
- derive crates.io publish order from Cargo workspace metadata
- include shuck-run in release-please internal dependency bumps
- add a CI guard that fails when a publishable workspace crate is missing from release-please version coverage

## Validation
- python3 scripts/workspace-publish-crates.py
- python3 scripts/check-release-please-config.py
- python3 scripts/check-release-security.py check
- bash -n scripts/bootstrap-crates-publish.sh scripts/setup-trusted-publishers.sh
- python3 -m py_compile scripts/workspace-publish-crates.py scripts/check-release-please-config.py
