### PR TITLE
feat(run): add gbash and bashkit runtimes

### DIFF
--- a/crates/shuck-cli/Cargo.toml
+++ b/crates/shuck-cli/Cargo.toml
@@ -44,6 +44,7 @@ shuck-parser = { workspace = true }
 shuck-run = { workspace = true }
 shuck-semantic = { workspace = true }
 similar = { workspace = true }
+tempfile = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true }
 
@@ -60,7 +61,6 @@ shuck-linter = { workspace = true }
 shuck-parser = { workspace = true }
 shuck-run = { workspace = true }
 shuck-semantic = { workspace = true }
-tempfile = { workspace = true }
 wait-timeout = "0.2"
 walkdir = "2"
 roxmltree = { workspace = true }

--- a/crates/shuck-cli/src/args.rs
+++ b/crates/shuck-cli/src/args.rs
@@ -108,6 +108,10 @@ pub enum TerminalColor {
 pub enum ManagedShellArg {
     /// GNU bash.
     Bash,
+    /// The gbash runtime.
+    Gbash,
+    /// The Bashkit runtime.
+    Bashkit,
     /// Z shell.
     Zsh,
     /// Debian Almquist shell.
@@ -120,6 +124,8 @@ impl From<ManagedShellArg> for shuck_run::Shell {
     fn from(value: ManagedShellArg) -> Self {
         match value {
             ManagedShellArg::Bash => Self::Bash,
+            ManagedShellArg::Gbash => Self::Gbash,
+            ManagedShellArg::Bashkit => Self::Bashkit,
             ManagedShellArg::Zsh => Self::Zsh,
             ManagedShellArg::Dash => Self::Dash,
             ManagedShellArg::Mksh => Self::Mksh,
@@ -411,7 +417,7 @@ impl CheckCommand {
 /// Arguments for `shuck run`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct RunCommand {
-    /// Shell interpreter name (`bash`, `zsh`, `dash`, `mksh`).
+    /// Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`).
     #[arg(short = 's', long, value_enum)]
     pub shell: Option<ManagedShellArg>,
     /// Version constraint (for example `5.2`, `>=5.1,<6`, or `latest`).
@@ -450,7 +456,7 @@ pub struct InstallCommand {
     /// Force a fresh registry fetch even if the local registry cache is still fresh.
     #[arg(long)]
     pub refresh: bool,
-    /// Shell interpreter name (`bash`, `zsh`, `dash`, `mksh`).
+    /// Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`).
     #[arg(required_unless_present = "list", value_enum)]
     pub shell: Option<ManagedShellArg>,
     /// Version constraint to install.
@@ -461,7 +467,7 @@ pub struct InstallCommand {
 /// Arguments for `shuck shell`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct ShellCommand {
-    /// Shell interpreter name (`bash`, `zsh`, `dash`, `mksh`).
+    /// Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`).
     #[arg(short = 's', long, value_enum)]
     pub shell: Option<ManagedShellArg>,
     /// Version constraint (for example `5.2`, `>=5.1,<6`, or `latest`).
@@ -1176,6 +1182,15 @@ mod tests {
         assert_eq!(command.shell_version.as_deref(), Some("5.9"));
         assert!(command.system);
         assert!(command.verbose);
+    }
+
+    #[test]
+    fn parses_extended_managed_shell_names() {
+        let run_command = parse_run(["shuck", "run", "--shell", "gbash", "-c", "echo hi"]);
+        assert_eq!(run_command.shell, Some(ManagedShellArg::Gbash));
+
+        let install_command = parse_install(["shuck", "install", "--list", "bashkit"]);
+        assert_eq!(install_command.shell, Some(ManagedShellArg::Bashkit));
     }
 
     #[test]

--- a/crates/shuck-cli/src/commands/runtime.rs
+++ b/crates/shuck-cli/src/commands/runtime.rs
@@ -1,5 +1,3 @@
-use std::ffi::OsString;
-use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, Stdio};
@@ -239,7 +237,9 @@ fn append_bashkit_run_mode_args(
 ) -> Result<()> {
     if let Some(raw_command) = args.command.as_deref() {
         command.arg("-c");
-        command.arg(bashkit_command_string(raw_command, &args.script_args)?);
+        command.arg(raw_command);
+        command.arg("shuck-run");
+        command.args(&args.script_args);
         return Ok(());
     }
 
@@ -249,7 +249,9 @@ fn append_bashkit_run_mode_args(
             .read_to_string(&mut source)
             .context("read bashkit script from stdin")?;
         command.arg("-c");
-        command.arg(bashkit_command_string(&source, &args.script_args)?);
+        command.arg(source);
+        command.arg("shuck-run");
+        command.args(&args.script_args);
         return Ok(());
     }
 
@@ -263,47 +265,9 @@ fn append_bashkit_run_mode_args(
         cwd.join(script)
     };
 
-    if args.script_args.is_empty() {
-        command.arg(script);
-        return Ok(());
-    }
-
-    let source =
-        fs::read_to_string(&script).with_context(|| format!("read {}", script.display()))?;
-    command.arg("-c");
-    command.arg(bashkit_command_string(&source, &args.script_args)?);
+    command.arg(script);
+    command.args(&args.script_args);
     Ok(())
-}
-
-fn bashkit_command_string(source: &str, script_args: &[OsString]) -> Result<String> {
-    if script_args.is_empty() {
-        return Ok(source.to_owned());
-    }
-
-    let mut command = String::from("set --");
-    for arg in script_args {
-        let arg = arg.to_str().ok_or_else(|| {
-            anyhow!("bashkit only supports UTF-8 script arguments when invoked via `shuck run`")
-        })?;
-        command.push(' ');
-        command.push_str(&shell_single_quote(arg));
-    }
-    command.push('\n');
-    command.push_str(source);
-    Ok(command)
-}
-
-fn shell_single_quote(raw: &str) -> String {
-    let mut quoted = String::from("'");
-    for ch in raw.chars() {
-        if ch == '\'' {
-            quoted.push_str("'\"'\"'");
-        } else {
-            quoted.push(ch);
-        }
-    }
-    quoted.push('\'');
-    quoted
 }
 
 fn apply_runtime_environment(

--- a/crates/shuck-cli/src/commands/runtime.rs
+++ b/crates/shuck-cli/src/commands/runtime.rs
@@ -4,7 +4,7 @@ use std::process::{Command as ProcessCommand, Stdio};
 
 use anyhow::{Result, anyhow};
 #[cfg(unix)]
-use std::os::unix::process::CommandExt;
+use std::os::unix::process::{CommandExt, ExitStatusExt};
 use tempfile::NamedTempFile;
 
 use shuck_run::{ResolutionSource, ResolveOptions, RunConfig, Shell, VersionConstraint};
@@ -318,7 +318,7 @@ fn exec_or_wait(mut command: ProcessCommand) -> Result<ExitStatus> {
 
 fn wait_for_process(mut command: ProcessCommand) -> Result<ExitStatus> {
     let status = command.status()?;
-    Ok(exit_status_from_process(status.code()))
+    Ok(exit_status_from_process(status))
 }
 
 #[cfg(not(unix))]
@@ -331,8 +331,13 @@ pub(crate) fn exec_or_wait_for_test(command: ProcessCommand) -> Result<ExitStatu
     wait_for_process(command)
 }
 
-fn exit_status_from_process(code: Option<i32>) -> ExitStatus {
-    match code {
+fn exit_status_from_process(status: std::process::ExitStatus) -> ExitStatus {
+    #[cfg(unix)]
+    if let Some(signal) = status.signal() {
+        return ExitStatus::Code(128 + signal);
+    }
+
+    match status.code() {
         Some(0) => ExitStatus::Success,
         Some(code) => ExitStatus::Code(code),
         None => ExitStatus::Failure,
@@ -363,5 +368,14 @@ mod tests {
         };
         let status = exec_or_wait_for_test(command).unwrap();
         assert_eq!(status, ExitStatus::Code(7));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wait_mapping_preserves_signal_exit_code() {
+        let mut command = ProcessCommand::new("sh");
+        command.args(["-c", "kill -INT $$"]);
+        let status = exec_or_wait_for_test(command).unwrap();
+        assert_eq!(status, ExitStatus::Code(130));
     }
 }

--- a/crates/shuck-cli/src/commands/runtime.rs
+++ b/crates/shuck-cli/src/commands/runtime.rs
@@ -1,7 +1,10 @@
+use std::ffi::OsString;
+use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, Stdio};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 
@@ -43,7 +46,7 @@ pub(crate) fn run(args: RunCommand, config_arguments: &ConfigArguments) -> Resul
     command.stdout(Stdio::inherit());
     command.stderr(Stdio::inherit());
     apply_runtime_environment(&mut command, &resolved);
-    append_run_mode_args(&mut command, &cwd, &args)?;
+    append_run_mode_args(&mut command, &cwd, resolved.shell, &args)?;
 
     exec_or_wait(command)
 }
@@ -180,7 +183,24 @@ fn runtime_resolution_script(
         .transpose()
 }
 
-fn append_run_mode_args(command: &mut ProcessCommand, cwd: &Path, args: &RunCommand) -> Result<()> {
+fn append_run_mode_args(
+    command: &mut ProcessCommand,
+    cwd: &Path,
+    shell: Shell,
+    args: &RunCommand,
+) -> Result<()> {
+    if shell == Shell::Bashkit {
+        return append_bashkit_run_mode_args(command, cwd, args);
+    }
+
+    append_posix_run_mode_args(command, cwd, args)
+}
+
+fn append_posix_run_mode_args(
+    command: &mut ProcessCommand,
+    cwd: &Path,
+    args: &RunCommand,
+) -> Result<()> {
     if let Some(raw_command) = args.command.as_deref() {
         command.arg("-c");
         command.arg(raw_command);
@@ -210,6 +230,80 @@ fn append_run_mode_args(command: &mut ProcessCommand, cwd: &Path, args: &RunComm
     command.arg(script);
     command.args(&args.script_args);
     Ok(())
+}
+
+fn append_bashkit_run_mode_args(
+    command: &mut ProcessCommand,
+    cwd: &Path,
+    args: &RunCommand,
+) -> Result<()> {
+    if let Some(raw_command) = args.command.as_deref() {
+        command.arg("-c");
+        command.arg(bashkit_command_string(raw_command, &args.script_args)?);
+        return Ok(());
+    }
+
+    if is_stdin_script(args.script.as_deref()) {
+        let mut source = String::new();
+        std::io::stdin()
+            .read_to_string(&mut source)
+            .context("read bashkit script from stdin")?;
+        command.arg("-c");
+        command.arg(bashkit_command_string(&source, &args.script_args)?);
+        return Ok(());
+    }
+
+    let script = args
+        .script
+        .as_deref()
+        .ok_or_else(|| anyhow!("missing script path"))?;
+    let script = if script.is_absolute() {
+        script.to_path_buf()
+    } else {
+        cwd.join(script)
+    };
+
+    if args.script_args.is_empty() {
+        command.arg(script);
+        return Ok(());
+    }
+
+    let source =
+        fs::read_to_string(&script).with_context(|| format!("read {}", script.display()))?;
+    command.arg("-c");
+    command.arg(bashkit_command_string(&source, &args.script_args)?);
+    Ok(())
+}
+
+fn bashkit_command_string(source: &str, script_args: &[OsString]) -> Result<String> {
+    if script_args.is_empty() {
+        return Ok(source.to_owned());
+    }
+
+    let mut command = String::from("set --");
+    for arg in script_args {
+        let arg = arg.to_str().ok_or_else(|| {
+            anyhow!("bashkit only supports UTF-8 script arguments when invoked via `shuck run`")
+        })?;
+        command.push(' ');
+        command.push_str(&shell_single_quote(arg));
+    }
+    command.push('\n');
+    command.push_str(source);
+    Ok(command)
+}
+
+fn shell_single_quote(raw: &str) -> String {
+    let mut quoted = String::from("'");
+    for ch in raw.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\"'\"'");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
 }
 
 fn apply_runtime_environment(

--- a/crates/shuck-cli/src/commands/runtime.rs
+++ b/crates/shuck-cli/src/commands/runtime.rs
@@ -1,10 +1,11 @@
-use std::io::Read;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, Stdio};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
+use tempfile::NamedTempFile;
 
 use shuck_run::{ResolutionSource, ResolveOptions, RunConfig, Shell, VersionConstraint};
 
@@ -44,7 +45,11 @@ pub(crate) fn run(args: RunCommand, config_arguments: &ConfigArguments) -> Resul
     command.stdout(Stdio::inherit());
     command.stderr(Stdio::inherit());
     apply_runtime_environment(&mut command, &resolved);
-    append_run_mode_args(&mut command, &cwd, resolved.shell, &args)?;
+    let temp_script = append_run_mode_args(&mut command, &cwd, resolved.shell, &args)?;
+
+    if temp_script.is_some() {
+        return wait_for_process(command);
+    }
 
     exec_or_wait(command)
 }
@@ -186,12 +191,13 @@ fn append_run_mode_args(
     cwd: &Path,
     shell: Shell,
     args: &RunCommand,
-) -> Result<()> {
+) -> Result<Option<NamedTempFile>> {
     if shell == Shell::Bashkit {
         return append_bashkit_run_mode_args(command, cwd, args);
     }
 
-    append_posix_run_mode_args(command, cwd, args)
+    append_posix_run_mode_args(command, cwd, args)?;
+    Ok(None)
 }
 
 fn append_posix_run_mode_args(
@@ -234,25 +240,19 @@ fn append_bashkit_run_mode_args(
     command: &mut ProcessCommand,
     cwd: &Path,
     args: &RunCommand,
-) -> Result<()> {
+) -> Result<Option<NamedTempFile>> {
     if let Some(raw_command) = args.command.as_deref() {
-        command.arg("-c");
-        command.arg(raw_command);
-        command.arg("shuck-run");
+        let temp_script = write_bashkit_command_script(raw_command)?;
+        command.arg(temp_script.path());
         command.args(&args.script_args);
-        return Ok(());
+        return Ok(Some(temp_script));
     }
 
     if is_stdin_script(args.script.as_deref()) {
-        let mut source = String::new();
-        std::io::stdin()
-            .read_to_string(&mut source)
-            .context("read bashkit script from stdin")?;
-        command.arg("-c");
-        command.arg(source);
-        command.arg("shuck-run");
+        let temp_script = write_bashkit_stdin_script()?;
+        command.arg(temp_script.path());
         command.args(&args.script_args);
-        return Ok(());
+        return Ok(Some(temp_script));
     }
 
     let script = args
@@ -267,7 +267,30 @@ fn append_bashkit_run_mode_args(
 
     command.arg(script);
     command.args(&args.script_args);
-    Ok(())
+    Ok(None)
+}
+
+fn write_bashkit_command_script(source: &str) -> Result<NamedTempFile> {
+    let mut temp_script = tempfile::Builder::new()
+        .prefix("shuck-bashkit-")
+        .suffix(".sh")
+        .tempfile()?;
+    temp_script.write_all(source.as_bytes())?;
+    if !source.ends_with('\n') {
+        temp_script.write_all(b"\n")?;
+    }
+    temp_script.flush()?;
+    Ok(temp_script)
+}
+
+fn write_bashkit_stdin_script() -> Result<NamedTempFile> {
+    let mut temp_script = tempfile::Builder::new()
+        .prefix("shuck-bashkit-")
+        .suffix(".sh")
+        .tempfile()?;
+    std::io::copy(&mut std::io::stdin().lock(), &mut temp_script)?;
+    temp_script.flush()?;
+    Ok(temp_script)
 }
 
 fn apply_runtime_environment(
@@ -293,19 +316,21 @@ fn exec_or_wait(mut command: ProcessCommand) -> Result<ExitStatus> {
     Err(anyhow!(err))
 }
 
-#[cfg(not(unix))]
-fn exec_or_wait(mut command: ProcessCommand) -> Result<ExitStatus> {
+fn wait_for_process(mut command: ProcessCommand) -> Result<ExitStatus> {
     let status = command.status()?;
     Ok(exit_status_from_process(status.code()))
+}
+
+#[cfg(not(unix))]
+fn exec_or_wait(mut command: ProcessCommand) -> Result<ExitStatus> {
+    wait_for_process(command)
 }
 
 #[cfg(test)]
-pub(crate) fn exec_or_wait_for_test(mut command: ProcessCommand) -> Result<ExitStatus> {
-    let status = command.status()?;
-    Ok(exit_status_from_process(status.code()))
+pub(crate) fn exec_or_wait_for_test(command: ProcessCommand) -> Result<ExitStatus> {
+    wait_for_process(command)
 }
 
-#[cfg(any(not(unix), test))]
 fn exit_status_from_process(code: Option<i32>) -> ExitStatus {
     match code {
         Some(0) => ExitStatus::Success,

--- a/crates/shuck-cli/src/config.rs
+++ b/crates/shuck-cli/src/config.rs
@@ -47,7 +47,8 @@ const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
 const CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS: &[&str] = &["report-unreached-nested-definitions"];
 const CONFIG_OVERRIDE_RUN_KEYS: &[&str] = &["shell", "shell-version", "shells"];
-const CONFIG_OVERRIDE_RUN_SHELL_NAMES: &[&str] = &["bash", "zsh", "dash", "mksh"];
+const CONFIG_OVERRIDE_RUN_SHELL_NAMES: &[&str] =
+    &["bash", "gbash", "bashkit", "zsh", "dash", "mksh"];
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
@@ -298,6 +299,20 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                     default: "none",
                     value_type: "string",
                     example: r#"bash = "5.2""#,
+                },
+                ConfigFieldMetadata {
+                    key: "gbash",
+                    docs: "Version constraint for gbash scripts.",
+                    default: "none",
+                    value_type: "string",
+                    example: r#"gbash = "0.0.32""#,
+                },
+                ConfigFieldMetadata {
+                    key: "bashkit",
+                    docs: "Version constraint for Bashkit scripts.",
+                    default: "none",
+                    value_type: "string",
+                    example: r#"bashkit = "0.2.1""#,
                 },
                 ConfigFieldMetadata {
                     key: "zsh",
@@ -927,14 +942,18 @@ mod tests {
     #[test]
     fn inline_config_overrides_validate_supported_run_keys() {
         let config = parse_config_override(
-            "run.shell = 'bash'\nrun.shell-version = '5.2'\nrun.shells.bash = '5.2'",
+            "run.shell = 'gbash'\nrun.shell-version = '0.0'\nrun.shells.gbash = '0.0'\nrun.shells.bashkit = '0.2'",
         )
         .unwrap();
-        assert_eq!(config.run.shell.as_deref(), Some("bash"));
-        assert_eq!(config.run.shell_version.as_deref(), Some("5.2"));
+        assert_eq!(config.run.shell.as_deref(), Some("gbash"));
+        assert_eq!(config.run.shell_version.as_deref(), Some("0.0"));
         assert_eq!(
-            config.run.shells.get("bash").map(String::as_str),
-            Some("5.2")
+            config.run.shells.get("gbash").map(String::as_str),
+            Some("0.0")
+        );
+        assert_eq!(
+            config.run.shells.get("bashkit").map(String::as_str),
+            Some("0.2")
         );
     }
 

--- a/crates/shuck-cli/tests/run_cli.rs
+++ b/crates/shuck-cli/tests/run_cli.rs
@@ -262,8 +262,7 @@ fn run_stdin_with_shell_executes_managed_interpreter() {
 fn run_dry_run_supports_bashkit_shebang_and_config() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
-    let registry =
-        registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
+    let registry = registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
     fs::write(
         tempdir.path().join("shuck.toml"),
         "[run.shells]\nbashkit = '0.2'\n",
@@ -289,8 +288,7 @@ fn run_dry_run_supports_bashkit_shebang_and_config() {
 fn run_bashkit_script_preserves_script_args() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
-    let registry =
-        registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
+    let registry = registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
     let script_path = tempdir.path().join("args.sh");
     let canonical_script_path = fs::canonicalize(tempdir.path()).unwrap().join("args.sh");
     fs::write(
@@ -312,8 +310,7 @@ fn run_bashkit_script_preserves_script_args() {
 fn run_bashkit_stdin_preserves_script_args() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
-    let registry =
-        registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
+    let registry = registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_runtime_env(&mut cmd, tempdir.path(), &registry);

--- a/crates/shuck-cli/tests/run_cli.rs
+++ b/crates/shuck-cli/tests/run_cli.rs
@@ -214,8 +214,7 @@ fn run_command_string_uses_managed_shell_and_sets_env() {
 fn run_command_string_supports_gbash_shell_and_sets_env() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "gbash", "0.0.32");
-    let registry = registry_body("gbash", &[("0.0.32", &archive, &sha256)]);
-    let registry = registry_path(tempdir.path(), &registry);
+    let registry = registry_path(tempdir.path(), "gbash", &[("0.0.32", &archive, &sha256)]);
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_runtime_env(&mut cmd, tempdir.path(), &registry);
@@ -263,8 +262,8 @@ fn run_stdin_with_shell_executes_managed_interpreter() {
 fn run_dry_run_supports_bashkit_shebang_and_config() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
-    let registry = registry_body("bashkit", &[("0.2.1", &archive, &sha256)]);
-    let registry = registry_path(tempdir.path(), &registry);
+    let registry =
+        registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
     fs::write(
         tempdir.path().join("shuck.toml"),
         "[run.shells]\nbashkit = '0.2'\n",
@@ -290,8 +289,8 @@ fn run_dry_run_supports_bashkit_shebang_and_config() {
 fn run_bashkit_script_preserves_script_args() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
-    let registry = registry_body("bashkit", &[("0.2.1", &archive, &sha256)]);
-    let registry = registry_path(tempdir.path(), &registry);
+    let registry =
+        registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
     let script_path = tempdir.path().join("args.sh");
     let canonical_script_path = fs::canonicalize(tempdir.path()).unwrap().join("args.sh");
     fs::write(
@@ -313,8 +312,8 @@ fn run_bashkit_script_preserves_script_args() {
 fn run_bashkit_stdin_preserves_script_args() {
     let tempdir = tempdir().unwrap();
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
-    let registry = registry_body("bashkit", &[("0.2.1", &archive, &sha256)]);
-    let registry = registry_path(tempdir.path(), &registry);
+    let registry =
+        registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
 
     let mut cmd = Command::cargo_bin("shuck").unwrap();
     configure_runtime_env(&mut cmd, tempdir.path(), &registry);

--- a/crates/shuck-cli/tests/run_cli.rs
+++ b/crates/shuck-cli/tests/run_cli.rs
@@ -26,7 +26,7 @@ fn fake_shell_archive(root: &Path, shell: &str, version: &str) -> (PathBuf, Stri
     fs::create_dir_all(&bin_dir).unwrap();
     let shell_path = bin_dir.join(shell);
     let probe = match shell {
-        "bash" | "zsh" => format!(
+        "bash" | "gbash" | "bashkit" | "zsh" => format!(
             "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf '{} {}\\n'\n  exit 0\nfi\nexec /bin/sh \"$@\"\n",
             shell, version
         ),
@@ -211,6 +211,27 @@ fn run_command_string_uses_managed_shell_and_sets_env() {
 }
 
 #[test]
+fn run_command_string_supports_gbash_shell_and_sets_env() {
+    let tempdir = tempdir().unwrap();
+    let (archive, sha256) = fake_shell_archive(tempdir.path(), "gbash", "0.0.32");
+    let registry = registry_body("gbash", &[("0.0.32", &archive, &sha256)]);
+    let registry = registry_path(tempdir.path(), &registry);
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_runtime_env(&mut cmd, tempdir.path(), &registry);
+    cmd.current_dir(tempdir.path()).args([
+        "run",
+        "--shell",
+        "gbash",
+        "--shell-version",
+        "0.0",
+        "-c",
+        "printf '%s|%s\\n' \"$SHUCK_SHELL\" \"$SHUCK_SHELL_VERSION\"",
+    ]);
+    cmd.assert().success().stdout("gbash|0.0.32\n");
+}
+
+#[test]
 fn run_stdin_defaults_to_system_bash() {
     let tempdir = tempdir().unwrap();
     let bin_dir = tempdir.path().join("bin");
@@ -236,6 +257,67 @@ fn run_stdin_with_shell_executes_managed_interpreter() {
         .args(["run", "--shell", "bash", "-"])
         .write_stdin("printf '%s\\n' \"$SHUCK_SHELL\"\n");
     cmd.assert().success().stdout("bash\n");
+}
+
+#[test]
+fn run_dry_run_supports_bashkit_shebang_and_config() {
+    let tempdir = tempdir().unwrap();
+    let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
+    let registry = registry_body("bashkit", &[("0.2.1", &archive, &sha256)]);
+    let registry = registry_path(tempdir.path(), &registry);
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[run.shells]\nbashkit = '0.2'\n",
+    )
+    .unwrap();
+    fs::write(
+        tempdir.path().join("sandbox.sh"),
+        "#!/usr/bin/env bashkit\necho hi\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_runtime_env(&mut cmd, tempdir.path(), &registry);
+    cmd.current_dir(tempdir.path())
+        .args(["run", "--dry-run", "sandbox.sh"]);
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("bashkit 0.2.1"))
+        .stdout(predicate::str::contains("bin/bashkit"));
+}
+
+#[test]
+fn run_bashkit_script_preserves_script_args() {
+    let tempdir = tempdir().unwrap();
+    let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
+    let registry = registry_body("bashkit", &[("0.2.1", &archive, &sha256)]);
+    let registry = registry_path(tempdir.path(), &registry);
+    fs::write(
+        tempdir.path().join("args.sh"),
+        "#!/usr/bin/env bashkit\nprintf '%s|%s\\n' \"$1\" \"$2\"\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_runtime_env(&mut cmd, tempdir.path(), &registry);
+    cmd.current_dir(tempdir.path())
+        .args(["run", "--shell", "bashkit", "args.sh", "--", "one", "two"]);
+    cmd.assert().success().stdout("one|two\n");
+}
+
+#[test]
+fn run_bashkit_stdin_preserves_script_args() {
+    let tempdir = tempdir().unwrap();
+    let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
+    let registry = registry_body("bashkit", &[("0.2.1", &archive, &sha256)]);
+    let registry = registry_path(tempdir.path(), &registry);
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_runtime_env(&mut cmd, tempdir.path(), &registry);
+    cmd.current_dir(tempdir.path())
+        .args(["run", "--shell", "bashkit", "-", "--", "one", "two"])
+        .write_stdin("printf '%s|%s\\n' \"$1\" \"$2\"\n");
+    cmd.assert().success().stdout("one|two\n");
 }
 
 #[test]

--- a/crates/shuck-cli/tests/run_cli.rs
+++ b/crates/shuck-cli/tests/run_cli.rs
@@ -231,6 +231,26 @@ fn run_command_string_supports_gbash_shell_and_sets_env() {
 }
 
 #[test]
+fn run_command_string_supports_bashkit_shell_and_sets_env() {
+    let tempdir = tempdir().unwrap();
+    let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
+    let registry = registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_runtime_env(&mut cmd, tempdir.path(), &registry);
+    cmd.current_dir(tempdir.path()).args([
+        "run",
+        "--shell",
+        "bashkit",
+        "--shell-version",
+        "0.2",
+        "-c",
+        "printf '%s|%s\\n' \"$SHUCK_SHELL\" \"$SHUCK_SHELL_VERSION\"",
+    ]);
+    cmd.assert().success().stdout("bashkit|0.2.1\n");
+}
+
+#[test]
 fn run_stdin_defaults_to_system_bash() {
     let tempdir = tempdir().unwrap();
     let bin_dir = tempdir.path().join("bin");
@@ -317,6 +337,24 @@ fn run_bashkit_stdin_preserves_script_args() {
     cmd.current_dir(tempdir.path())
         .args(["run", "--shell", "bashkit", "-", "--", "one", "two"])
         .write_stdin("printf '%s|%s\\n' \"$1\" \"$2\"\n");
+    cmd.assert().success().stdout("one|two\n");
+}
+
+#[test]
+fn run_bashkit_large_stdin_script_avoids_argv_limits() {
+    let tempdir = tempdir().unwrap();
+    let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
+    let registry = registry_path(tempdir.path(), "bashkit", &[("0.2.1", &archive, &sha256)]);
+
+    let mut source = String::from("#");
+    source.push_str(&"x".repeat(3_000_000));
+    source.push_str("\nprintf '%s|%s\\n' \"$1\" \"$2\"\n");
+
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    configure_runtime_env(&mut cmd, tempdir.path(), &registry);
+    cmd.current_dir(tempdir.path())
+        .args(["run", "--shell", "bashkit", "-", "--", "one", "two"])
+        .write_stdin(source);
     cmd.assert().success().stdout("one|two\n");
 }
 

--- a/crates/shuck-cli/tests/run_cli.rs
+++ b/crates/shuck-cli/tests/run_cli.rs
@@ -292,9 +292,11 @@ fn run_bashkit_script_preserves_script_args() {
     let (archive, sha256) = fake_shell_archive(tempdir.path(), "bashkit", "0.2.1");
     let registry = registry_body("bashkit", &[("0.2.1", &archive, &sha256)]);
     let registry = registry_path(tempdir.path(), &registry);
+    let script_path = tempdir.path().join("args.sh");
+    let canonical_script_path = fs::canonicalize(tempdir.path()).unwrap().join("args.sh");
     fs::write(
-        tempdir.path().join("args.sh"),
-        "#!/usr/bin/env bashkit\nprintf '%s|%s\\n' \"$1\" \"$2\"\n",
+        &script_path,
+        "#!/usr/bin/env bashkit\nprintf '%s|%s|%s\\n' \"$0\" \"$1\" \"$2\"\n",
     )
     .unwrap();
 
@@ -302,7 +304,9 @@ fn run_bashkit_script_preserves_script_args() {
     configure_runtime_env(&mut cmd, tempdir.path(), &registry);
     cmd.current_dir(tempdir.path())
         .args(["run", "--shell", "bashkit", "args.sh", "--", "one", "two"]);
-    cmd.assert().success().stdout("one|two\n");
+    cmd.assert()
+        .success()
+        .stdout(format!("{}|one|two\n", canonical_script_path.display()));
 }
 
 #[test]

--- a/crates/shuck-run/src/system.rs
+++ b/crates/shuck-run/src/system.rs
@@ -139,7 +139,11 @@ pub(crate) fn detect_shell_version(shell: Shell, path: &Path) -> Result<Version>
 
 fn version_probe_commands(shell: Shell) -> Vec<Vec<OsString>> {
     match shell {
-        Shell::Bash | Shell::Zsh => vec![vec![OsString::from("--version")]],
+        Shell::Bash | Shell::Bashkit | Shell::Zsh => vec![vec![OsString::from("--version")]],
+        Shell::Gbash => vec![
+            vec![OsString::from("--version")],
+            vec![OsString::from("version")],
+        ],
         Shell::Dash => vec![
             vec![OsString::from("-V")],
             vec![OsString::from("--version")],

--- a/crates/shuck-run/src/tests.rs
+++ b/crates/shuck-run/src/tests.rs
@@ -147,7 +147,7 @@ fn make_shell_archive(root: &Path, shell: Shell, version: &str) -> (PathBuf, Str
     fs::create_dir_all(&bin_dir).unwrap();
     let shell_path = bin_dir.join(shell.as_str());
     let script = match shell {
-        Shell::Bash | Shell::Zsh => format!(
+        Shell::Bash | Shell::Gbash | Shell::Bashkit | Shell::Zsh => format!(
             "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf '{} {}\\n'\n  exit 0\nfi\nprintf '%s\\n' \"${{SHUCK_SHELL_VERSION}}\"\n",
             shell.as_str(),
             version
@@ -923,6 +923,32 @@ fn failed_version_probe_output_does_not_count_as_a_version() {
     .unwrap();
 
     assert_eq!(resolved.version.as_str(), "0.5.12");
+    assert_eq!(resolved.source, ResolutionSource::System);
+}
+
+#[test]
+fn gbash_version_probe_falls_back_to_version_subcommand() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path_dir = tempdir.path().join("bin");
+    fs::create_dir_all(&path_dir).unwrap();
+    let shell_path = path_dir.join("gbash");
+    fs::write(
+        &shell_path,
+        "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gbash: unknown option --version\\n' 1>&2\n  exit 2\nfi\nif [ \"$1\" = \"version\" ]; then\n  printf 'gbash 0.0.32\\ncommit: abc123\\n'\n  exit 0\nfi\nexit 1\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&shell_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&shell_path, permissions).unwrap();
+
+    let resolved = resolve_system_at_path(
+        Shell::Gbash,
+        &shell_path,
+        &VersionConstraint::parse(">=0.0.30").unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(resolved.version.as_str(), "0.0.32");
     assert_eq!(resolved.source, ResolutionSource::System);
 }
 

--- a/crates/shuck-run/src/types.rs
+++ b/crates/shuck-run/src/types.rs
@@ -9,6 +9,8 @@ use serde::Deserialize;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Shell {
     Bash,
+    Gbash,
+    Bashkit,
     Zsh,
     Dash,
     Mksh,
@@ -18,6 +20,8 @@ impl Shell {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Bash => "bash",
+            Self::Gbash => "gbash",
+            Self::Bashkit => "bashkit",
             Self::Zsh => "zsh",
             Self::Dash => "dash",
             Self::Mksh => "mksh",
@@ -27,6 +31,8 @@ impl Shell {
     pub fn from_name(name: &str) -> Option<Self> {
         match name.trim().to_ascii_lowercase().as_str() {
             "bash" => Some(Self::Bash),
+            "gbash" => Some(Self::Gbash),
+            "bashkit" => Some(Self::Bashkit),
             "zsh" => Some(Self::Zsh),
             "dash" | "sh" => Some(Self::Dash),
             "mksh" | "ksh" => Some(Self::Mksh),
@@ -350,8 +356,9 @@ impl<'a> ResolveOptions<'a> {
 }
 
 pub(crate) fn parse_shell_name(raw: &str) -> Result<Shell> {
-    Shell::from_name(raw)
-        .ok_or_else(|| anyhow!("unsupported shell `{raw}`; expected one of: bash, zsh, dash, mksh"))
+    Shell::from_name(raw).ok_or_else(|| {
+        anyhow!("unsupported shell `{raw}`; expected one of: bash, gbash, bashkit, zsh, dash, mksh")
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/specs/011-run.md
+++ b/specs/011-run.md
@@ -24,7 +24,7 @@ The Python ecosystem solved this with tools like `uv` and `pyenv`. Shell scripts
 
 - Execute shell scripts with a specific shell interpreter at a specific version.
 - Download and cache prebuilt shell binaries on demand.
-- Support bash, zsh, dash, and mksh as managed interpreters.
+- Support bash, gbash, bashkit, zsh, dash, and mksh as managed interpreters.
 - Accept version constraints from `.shuck.toml`, and CLI flags, with clear precedence.
 - Provide `shuck install` to pre-populate the cache and `shuck shell` to enter an interactive session.
 - Fall back to system interpreters when explicitly requested via `--system`.
@@ -47,7 +47,7 @@ shuck run [OPTIONS] [SCRIPT] [-- ARGS...]
 
 | Flag | Short | Description |
 |---|---|---|
-| `--shell <NAME>` | `-s` | Shell interpreter name (`bash`, `zsh`, `dash`, `mksh`) |
+| `--shell <NAME>` | `-s` | Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`) |
 | `--shell-version <CONSTRAINT>` | `-V` | Version constraint (e.g., `5.2`, `>=5.1,<6`, `latest`) |
 | `--system` | | Use the system-installed interpreter instead of a managed one |
 | `--dry-run` | | Resolve and print the interpreter path without executing |
@@ -84,6 +84,8 @@ Pre-downloads a shell interpreter into the global cache without running anything
 
 ```bash
 shuck install bash 5.2
+shuck install gbash 0.0.32
+shuck install bashkit 0.2.1
 shuck install zsh 5.9
 shuck install --list           # Show available shells and versions
 shuck install --list bash      # Show available bash versions
@@ -170,6 +172,8 @@ shell-version = "5.2"
 # Per-shell version pins for the project
 [run.shells]
 bash = "5.2"
+gbash = "0.0.32"
+bashkit = "0.2.1"
 zsh = "5.9"
 dash = "0.5.12"
 mksh = "59c"


### PR DESCRIPTION
## Summary
- add `gbash` and `bashkit` as first-class managed shells for `shuck run`, `shuck install`, and `shuck shell`
- extend config, metadata parsing, shebang inference, and system version probing to recognize both runtimes
- handle `bashkit`'s CLI shape explicitly so stdin and script arguments keep working under `shuck run`
- document the new shell names in the run spec and add CLI/runtime regression coverage

## Why
Users can now target `gbash` and `bashkit` directly through the managed runtime flow instead of treating them as unsupported shells or falling back to ad hoc invocation.

## Validation
- `cargo test -p shuck-run -p shuck-cli`
- `cargo test -p shuck-cli --test run_cli`
