### PR TITLE
feat(run): support BusyBox on Linux

### DIFF
--- a/crates/shuck-cli/src/args.rs
+++ b/crates/shuck-cli/src/args.rs
@@ -118,6 +118,8 @@ pub enum ManagedShellArg {
     Dash,
     /// MirBSD Korn shell.
     Mksh,
+    /// BusyBox shell wrapper (Linux only).
+    Busybox,
 }
 
 impl From<ManagedShellArg> for shuck_run::Shell {
@@ -129,6 +131,7 @@ impl From<ManagedShellArg> for shuck_run::Shell {
             ManagedShellArg::Zsh => Self::Zsh,
             ManagedShellArg::Dash => Self::Dash,
             ManagedShellArg::Mksh => Self::Mksh,
+            ManagedShellArg::Busybox => Self::Busybox,
         }
     }
 }
@@ -417,7 +420,7 @@ impl CheckCommand {
 /// Arguments for `shuck run`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct RunCommand {
-    /// Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`).
+    /// Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`, or Linux-only `busybox`).
     #[arg(short = 's', long, value_enum)]
     pub shell: Option<ManagedShellArg>,
     /// Version constraint (for example `5.2`, `>=5.1,<6`, or `latest`).
@@ -456,7 +459,7 @@ pub struct InstallCommand {
     /// Force a fresh registry fetch even if the local registry cache is still fresh.
     #[arg(long)]
     pub refresh: bool,
-    /// Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`).
+    /// Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`, or Linux-only `busybox`).
     #[arg(required_unless_present = "list", value_enum)]
     pub shell: Option<ManagedShellArg>,
     /// Version constraint to install.
@@ -467,7 +470,7 @@ pub struct InstallCommand {
 /// Arguments for `shuck shell`.
 #[derive(Debug, Clone, ClapArgs)]
 pub struct ShellCommand {
-    /// Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`).
+    /// Shell interpreter name (`bash`, `gbash`, `bashkit`, `zsh`, `dash`, `mksh`, or Linux-only `busybox`).
     #[arg(short = 's', long, value_enum)]
     pub shell: Option<ManagedShellArg>,
     /// Version constraint (for example `5.2`, `>=5.1,<6`, or `latest`).
@@ -1155,6 +1158,18 @@ mod tests {
             command.script_args,
             vec![OsString::from("one"), OsString::from("two")]
         );
+    }
+
+    #[test]
+    fn parses_busybox_shell_variants() {
+        let run = parse_run(["shuck", "run", "--shell", "busybox", "deploy.sh"]);
+        assert_eq!(run.shell, Some(ManagedShellArg::Busybox));
+
+        let install = parse_install(["shuck", "install", "busybox", "1.36"]);
+        assert_eq!(install.shell, Some(ManagedShellArg::Busybox));
+
+        let shell = parse_shell(["shuck", "shell", "--shell", "busybox"]);
+        assert_eq!(shell.shell, Some(ManagedShellArg::Busybox));
     }
 
     #[test]

--- a/crates/shuck-cli/src/commands/runtime.rs
+++ b/crates/shuck-cli/src/commands/runtime.rs
@@ -308,7 +308,9 @@ fn apply_runtime_environment(
     command.env("SHUCK_SHELL_VERSION", resolved.version.as_str());
     command.env("SHUCK_SHELL_PATH", &resolved.path);
 
-    if matches!(resolved.source, ResolutionSource::Managed) {
+    if matches!(resolved.source, ResolutionSource::Managed)
+        && !matches!(resolved.shell, Shell::Busybox)
+    {
         command.env("SHELL", &resolved.path);
     }
 }
@@ -354,7 +356,7 @@ fn exit_status_from_process(status: std::process::ExitStatus) -> ExitStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ffi::OsString;
+    use std::ffi::{OsStr, OsString};
 
     #[test]
     fn stdin_mode_detection_handles_dash_and_empty_script() {
@@ -413,5 +415,25 @@ mod tests {
             collected,
             vec!["sh", "-c", "echo hi", "shuck-run", "one", "two"]
         );
+    }
+
+    #[test]
+    fn managed_busybox_does_not_override_shell_env() {
+        let mut command = ProcessCommand::new("busybox");
+        let resolved = shuck_run::ResolvedInterpreter {
+            shell: Shell::Busybox,
+            version: shuck_run::Version::parse("1.36.1").unwrap(),
+            path: PathBuf::from("/tmp/busybox"),
+            source: ResolutionSource::Managed,
+        };
+
+        apply_runtime_environment(&mut command, &resolved);
+
+        let shell = command
+            .get_envs()
+            .find(|(key, _)| *key == OsStr::new("SHELL"))
+            .and_then(|(_, value)| value)
+            .map(|value| value.to_os_string());
+        assert!(shell.is_none());
     }
 }

--- a/crates/shuck-cli/src/commands/runtime.rs
+++ b/crates/shuck-cli/src/commands/runtime.rs
@@ -45,6 +45,7 @@ pub(crate) fn run(args: RunCommand, config_arguments: &ConfigArguments) -> Resul
     command.stdout(Stdio::inherit());
     command.stderr(Stdio::inherit());
     apply_runtime_environment(&mut command, &resolved);
+    append_shell_launcher_args(&mut command, resolved.shell);
     let temp_script = append_run_mode_args(&mut command, &cwd, resolved.shell, &args)?;
 
     if temp_script.is_some() {
@@ -116,6 +117,7 @@ pub(crate) fn shell(args: ShellCommand, config_arguments: &ConfigArguments) -> R
     command.stdout(Stdio::inherit());
     command.stderr(Stdio::inherit());
     apply_runtime_environment(&mut command, &resolved);
+    append_shell_launcher_args(&mut command, resolved.shell);
     exec_or_wait(command)
 }
 
@@ -293,6 +295,11 @@ fn write_bashkit_stdin_script() -> Result<NamedTempFile> {
     Ok(temp_script)
 }
 
+fn append_shell_launcher_args(command: &mut ProcessCommand, shell: Shell) {
+    if matches!(shell, Shell::Busybox) {
+        command.arg("sh");
+    }
+}
 fn apply_runtime_environment(
     command: &mut ProcessCommand,
     resolved: &shuck_run::ResolvedInterpreter,
@@ -347,6 +354,7 @@ fn exit_status_from_process(status: std::process::ExitStatus) -> ExitStatus {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
 
     #[test]
     fn stdin_mode_detection_handles_dash_and_empty_script() {
@@ -369,7 +377,6 @@ mod tests {
         let status = exec_or_wait_for_test(command).unwrap();
         assert_eq!(status, ExitStatus::Code(7));
     }
-
     #[cfg(unix)]
     #[test]
     fn wait_mapping_preserves_signal_exit_code() {
@@ -377,5 +384,34 @@ mod tests {
         command.args(["-c", "kill -INT $$"]);
         let status = exec_or_wait_for_test(command).unwrap();
         assert_eq!(status, ExitStatus::Code(130));
+    }
+
+    #[test]
+    fn busybox_run_command_invokes_sh_applet() {
+        let mut command = ProcessCommand::new("busybox");
+        append_shell_launcher_args(&mut command, Shell::Busybox);
+
+        let args = RunCommand {
+            shell: None,
+            shell_version: None,
+            system: false,
+            dry_run: false,
+            verbose: false,
+            command: Some("echo hi".to_owned()),
+            script: None,
+            script_args: vec![OsString::from("one"), OsString::from("two")],
+        };
+        let temp_script =
+            append_run_mode_args(&mut command, Path::new("/tmp"), Shell::Busybox, &args).unwrap();
+        assert!(temp_script.is_none());
+
+        let collected = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            collected,
+            vec!["sh", "-c", "echo hi", "shuck-run", "one", "two"]
+        );
     }
 }

--- a/crates/shuck-cli/src/config.rs
+++ b/crates/shuck-cli/src/config.rs
@@ -48,7 +48,7 @@ const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
 const CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS: &[&str] = &["report-unreached-nested-definitions"];
 const CONFIG_OVERRIDE_RUN_KEYS: &[&str] = &["shell", "shell-version", "shells"];
 const CONFIG_OVERRIDE_RUN_SHELL_NAMES: &[&str] =
-    &["bash", "gbash", "bashkit", "zsh", "dash", "mksh"];
+    &["bash", "gbash", "bashkit", "zsh", "dash", "mksh", "busybox"];
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
@@ -334,6 +334,13 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                     default: "none",
                     value_type: "string",
                     example: r#"mksh = "59c""#,
+                },
+                ConfigFieldMetadata {
+                    key: "busybox",
+                    docs: "Version constraint for BusyBox scripts on Linux hosts.",
+                    default: "none",
+                    value_type: "string",
+                    example: r#"busybox = "1.36.1""#,
                 },
             ],
             sections: &[],
@@ -967,6 +974,17 @@ mod tests {
     fn inline_config_overrides_reject_unknown_run_shells_keys() {
         let err = parse_config_override("run.shells.fish = '4.0'").unwrap_err();
         assert!(err.contains("unsupported `[run.shells]` shell `fish`"));
+    }
+
+    #[test]
+    fn inline_config_overrides_accept_busybox_shell_keys() {
+        let config =
+            parse_config_override("run.shell = 'busybox'\nrun.shells.busybox = '1.36.1'").unwrap();
+        assert_eq!(config.run.shell.as_deref(), Some("busybox"));
+        assert_eq!(
+            config.run.shells.get("busybox").map(String::as_str),
+            Some("1.36.1")
+        );
     }
 
     #[test]

--- a/crates/shuck-run/src/managed.rs
+++ b/crates/shuck-run/src/managed.rs
@@ -21,6 +21,7 @@ pub(crate) fn install_with_environment(
     verbose: bool,
     refresh_registry: bool,
 ) -> Result<ResolvedInterpreter> {
+    shell.ensure_supported_on_current_platform()?;
     let registry = load_registry(environment, refresh_registry, verbose)?;
     let platform = current_platform()?;
     let (version, artifact) = select_release_for_platform(

--- a/crates/shuck-run/src/resolve.rs
+++ b/crates/shuck-run/src/resolve.rs
@@ -27,6 +27,7 @@ pub(crate) fn resolve_with_environment(
         .or(config_shell)
         .or(inferred_shell)
         .unwrap_or(Shell::Bash);
+    shell.ensure_supported_on_current_platform()?;
     let defaulted_shell = options.shell.is_none()
         && metadata_shell.is_none()
         && config_shell.is_none()

--- a/crates/shuck-run/src/system.rs
+++ b/crates/shuck-run/src/system.rs
@@ -155,6 +155,7 @@ fn version_probe_commands(shell: Shell) -> Vec<Vec<OsString>> {
             ],
             vec![OsString::from("-V")],
         ],
+        Shell::Busybox => vec![vec![OsString::from("--help")]],
     }
 }
 

--- a/crates/shuck-run/src/tests.rs
+++ b/crates/shuck-run/src/tests.rs
@@ -58,6 +58,17 @@ fn write_registry_document(root: &Path, relative_path: &str, document: &Value) -
     path
 }
 
+fn write_executable_fixture(path: &Path, contents: impl AsRef<[u8]>) {
+    // Write to a sibling temp path first so Linux never sees the final executable
+    // path held open for writing, which can trip ETXTBSY in CI.
+    let temp_path = path.with_extension("tmp");
+    fs::write(&temp_path, contents).unwrap();
+    let mut permissions = fs::metadata(&temp_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&temp_path, permissions).unwrap();
+    fs::rename(&temp_path, path).unwrap();
+}
+
 fn write_registry_site(root: &Path, entries: &[RegistryEntry]) -> PathBuf {
     let mut grouped = BTreeMap::<String, BTreeMap<String, BTreeMap<String, RegistryEntry>>>::new();
     for entry in entries {
@@ -166,10 +177,7 @@ fn make_shell_archive(root: &Path, shell: Shell, version: &str) -> (PathBuf, Str
             version
         ),
     };
-    fs::write(&shell_path, script).unwrap();
-    let mut permissions = fs::metadata(&shell_path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&shell_path, permissions).unwrap();
+    write_executable_fixture(&shell_path, script);
 
     let archive_path = root.join(format!("{}-{version}.tar.gz", shell.as_str()));
     let status = Command::new("/usr/bin/tar")
@@ -557,14 +565,10 @@ fn invalid_cached_install_is_replaced() {
         .join("bin");
     fs::create_dir_all(&install_dir).unwrap();
     let binary_path = install_dir.join("bash");
-    fs::write(
+    write_executable_fixture(
         &binary_path,
         "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'bash 4.4.0\\n'\n  exit 0\nfi\nexit 0\n",
-    )
-    .unwrap();
-    let mut permissions = fs::metadata(&binary_path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&binary_path, permissions).unwrap();
+    );
 
     let resolved = install_with_environment(
         &environment,
@@ -879,14 +883,10 @@ fn busybox_system_resolution_detects_version() {
     let path_dir = tempdir.path().join("bin");
     fs::create_dir_all(&path_dir).unwrap();
     let shell_path = path_dir.join("busybox");
-    fs::write(
+    write_executable_fixture(
         &shell_path,
         "#!/bin/sh\nif [ \"$1\" = \"--help\" ]; then\n  printf 'BusyBox v1.36.1 () multi-call binary.\\n'\n  exit 0\nfi\nexit 0\n",
-    )
-    .unwrap();
-    let mut permissions = fs::metadata(&shell_path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&shell_path, permissions).unwrap();
+    );
 
     let resolved = resolve_system_at_path(
         Shell::Busybox,
@@ -966,14 +966,10 @@ fn system_resolution_checks_version_constraints() {
     let path_dir = tempdir.path().join("bin");
     fs::create_dir_all(&path_dir).unwrap();
     let shell_path = path_dir.join("bash");
-    fs::write(
+    write_executable_fixture(
         &shell_path,
         "#!/bin/sh\nprintf 'GNU bash, version 5.2.21(1)-release\\n'\n",
-    )
-    .unwrap();
-    let mut permissions = fs::metadata(&shell_path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&shell_path, permissions).unwrap();
+    );
 
     let resolved = resolve_system_at_path(
         Shell::Bash,
@@ -997,14 +993,10 @@ fn failed_version_probe_output_does_not_count_as_a_version() {
     let path_dir = tempdir.path().join("bin");
     fs::create_dir_all(&path_dir).unwrap();
     let shell_path = path_dir.join("dash");
-    fs::write(
+    write_executable_fixture(
         &shell_path,
         "#!/bin/sh\nif [ \"$1\" = \"-V\" ]; then\n  printf 'dash: 0: Illegal option -V\\n' 1>&2\n  exit 2\nfi\nif [ \"$1\" = \"--version\" ]; then\n  printf 'dash 0.5.12\\n' 1>&2\n  exit 0\nfi\nexit 0\n",
-    )
-    .unwrap();
-    let mut permissions = fs::metadata(&shell_path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&shell_path, permissions).unwrap();
+    );
 
     let resolved = resolve_system_at_path(
         Shell::Dash,
@@ -1023,14 +1015,10 @@ fn gbash_version_probe_falls_back_to_version_subcommand() {
     let path_dir = tempdir.path().join("bin");
     fs::create_dir_all(&path_dir).unwrap();
     let shell_path = path_dir.join("gbash");
-    fs::write(
+    write_executable_fixture(
         &shell_path,
         "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then\n  printf 'gbash: unknown option --version\\n' 1>&2\n  exit 2\nfi\nif [ \"$1\" = \"version\" ]; then\n  printf 'gbash 0.0.32\\ncommit: abc123\\n'\n  exit 0\nfi\nexit 1\n",
-    )
-    .unwrap();
-    let mut permissions = fs::metadata(&shell_path).unwrap().permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&shell_path, permissions).unwrap();
+    );
 
     let resolved = resolve_system_at_path(
         Shell::Gbash,
@@ -1058,10 +1046,7 @@ fn path_lookup_skips_non_executable_entries() {
     fs::set_permissions(&shadow_bash, shadow_permissions).unwrap();
 
     let real_bash = real_dir.join("bash");
-    fs::write(&real_bash, "#!/bin/sh\nexit 0\n").unwrap();
-    let mut real_permissions = fs::metadata(&real_bash).unwrap().permissions();
-    real_permissions.set_mode(0o755);
-    fs::set_permissions(&real_bash, real_permissions).unwrap();
+    write_executable_fixture(&real_bash, "#!/bin/sh\nexit 0\n");
 
     let path_var = std::env::join_paths([shadow_dir.as_path(), real_dir.as_path()]).unwrap();
     let resolved = find_on_path_in(Some(path_var.as_os_str()), "bash").unwrap();

--- a/crates/shuck-run/src/tests.rs
+++ b/crates/shuck-run/src/tests.rs
@@ -161,6 +161,10 @@ fn make_shell_archive(root: &Path, shell: Shell, version: &str) -> (PathBuf, Str
             "#!/bin/sh\nif [ \"$1\" = \"-c\" ]; then\n  printf '@(#)MIRBSD KSH R{}\\n'\n  exit 0\nfi\nif [ \"$1\" = \"-V\" ]; then\n  printf '@(#)MIRBSD KSH R{}\\n'\n  exit 0\nfi\nprintf '%s\\n' \"${{SHUCK_SHELL_VERSION}}\"\n",
             version, version
         ),
+        Shell::Busybox => format!(
+            "#!/bin/sh\nif [ \"$1\" = \"--help\" ]; then\n  printf 'BusyBox v{} () multi-call binary.\\n'\n  exit 0\nfi\nprintf '%s\\n' \"${{SHUCK_SHELL_VERSION}}\"\n",
+            version
+        ),
     };
     fs::write(&shell_path, script).unwrap();
     let mut permissions = fs::metadata(&shell_path).unwrap().permissions();
@@ -867,6 +871,93 @@ fn lists_available_versions() {
     assert_eq!(available.len(), 1);
     assert_eq!(available[0].versions[0].as_str(), "5.2.21");
     assert_eq!(available[0].versions[1].as_str(), "5.1.16");
+}
+
+#[test]
+fn busybox_system_resolution_detects_version() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let path_dir = tempdir.path().join("bin");
+    fs::create_dir_all(&path_dir).unwrap();
+    let shell_path = path_dir.join("busybox");
+    fs::write(
+        &shell_path,
+        "#!/bin/sh\nif [ \"$1\" = \"--help\" ]; then\n  printf 'BusyBox v1.36.1 () multi-call binary.\\n'\n  exit 0\nfi\nexit 0\n",
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&shell_path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&shell_path, permissions).unwrap();
+
+    let resolved = resolve_system_at_path(
+        Shell::Busybox,
+        &shell_path,
+        &VersionConstraint::parse(">=1.36,<2").unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(resolved.version.as_str(), "1.36.1");
+    assert_eq!(resolved.source, ResolutionSource::System);
+}
+
+#[test]
+fn busybox_resolution_is_linux_only() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let script_path = tempdir.path().join("deploy.sh");
+    fs::write(&script_path, "#!/bin/busybox sh\necho hi\n").unwrap();
+
+    if cfg!(target_os = "linux") {
+        let (archive, sha256) = make_shell_archive(tempdir.path(), Shell::Busybox, "1.36.1");
+        let registry_path =
+            registry_for_archive(tempdir.path(), Shell::Busybox, "1.36.1", &archive, &sha256);
+        let environment = test_environment(
+            tempdir.path(),
+            Url::from_file_path(registry_path).unwrap().to_string(),
+        );
+
+        let resolved = resolve_with_environment(
+            &environment,
+            ResolveOptions {
+                shell: None,
+                version: None,
+                system: false,
+                implicit_system_fallback: false,
+                script: Some(&script_path),
+                config: None,
+                verbose: false,
+                refresh_registry: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(resolved.shell, Shell::Busybox);
+        assert_eq!(resolved.version.as_str(), "1.36.1");
+        assert_eq!(resolved.source, ResolutionSource::Managed);
+        assert!(resolved.path.ends_with("bin/busybox"));
+        return;
+    }
+
+    let environment = test_environment(
+        tempdir.path(),
+        Url::from_file_path(tempdir.path().join("registry.json"))
+            .unwrap()
+            .to_string(),
+    );
+    let err = resolve_with_environment(
+        &environment,
+        ResolveOptions {
+            shell: None,
+            version: None,
+            system: false,
+            implicit_system_fallback: false,
+            script: Some(&script_path),
+            config: None,
+            verbose: false,
+            refresh_registry: false,
+        },
+    )
+    .unwrap_err();
+
+    assert!(err.to_string().contains("only supported on Linux"));
 }
 
 #[test]

--- a/crates/shuck-run/src/types.rs
+++ b/crates/shuck-run/src/types.rs
@@ -14,6 +14,7 @@ pub enum Shell {
     Zsh,
     Dash,
     Mksh,
+    Busybox,
 }
 
 impl Shell {
@@ -25,6 +26,7 @@ impl Shell {
             Self::Zsh => "zsh",
             Self::Dash => "dash",
             Self::Mksh => "mksh",
+            Self::Busybox => "busybox",
         }
     }
 
@@ -36,8 +38,17 @@ impl Shell {
             "zsh" => Some(Self::Zsh),
             "dash" | "sh" => Some(Self::Dash),
             "mksh" | "ksh" => Some(Self::Mksh),
+            "busybox" => Some(Self::Busybox),
             _ => None,
         }
+    }
+
+    pub(crate) fn ensure_supported_on_current_platform(self) -> Result<()> {
+        if self != Self::Busybox || std::env::consts::OS == "linux" {
+            return Ok(());
+        }
+
+        bail!("busybox is only supported on Linux");
     }
 
     pub(crate) fn infer(source: &str, path: Option<&Path>) -> Option<Self> {
@@ -357,7 +368,9 @@ impl<'a> ResolveOptions<'a> {
 
 pub(crate) fn parse_shell_name(raw: &str) -> Result<Shell> {
     Shell::from_name(raw).ok_or_else(|| {
-        anyhow!("unsupported shell `{raw}`; expected one of: bash, gbash, bashkit, zsh, dash, mksh")
+        anyhow!(
+            "unsupported shell `{raw}`; expected one of: bash, gbash, bashkit, zsh, dash, mksh, busybox"
+        )
     })
 }
 


### PR DESCRIPTION
## Summary
- add BusyBox as a managed shell option for `shuck run`, `shuck shell`, and run config parsing
- gate BusyBox resolution to Linux hosts and detect BusyBox versions via `--help` probes
- invoke BusyBox through its `sh` applet so `shuck run` executes scripts correctly

## Why
BusyBox is a multi-call binary rather than a standalone shell executable, so the runtime needed BusyBox-specific launch behavior and an explicit platform guard.

## Validation
- `cargo fmt --all`
- `cargo test -p shuck-run -p shuck-cli`
