### PR TITLE
docs(website): add shuck run guide

### DIFF
--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import { flattenNav, docsNavigation } from "@/app/lib/docs-navigation";
 // Map of slug paths to their MDX imports
 const pages: Record<string, () => Promise<{ default: React.ComponentType; metadata?: { title?: string; description?: string } }>> = {
   "getting-started": () => import("@/content/getting-started/index.mdx"),
+  "run": () => import("@/content/run/index.mdx"),
   "embedded-scripts": () => import("@/content/embedded-scripts/index.mdx"),
   "configuration": () => import("@/content/configuration/index.mdx"),
   "suppression": () => import("@/content/suppression/index.mdx"),

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -9,6 +9,7 @@ export const docsNavigation: NavItem[] = [
     title: "Getting Started",
     items: [
       { title: "Overview", href: "/docs/getting-started" },
+      { title: "Managed Runtime", href: "/docs/run" },
       { title: "Configuration", href: "/docs/configuration" },
       { title: "Suppression", href: "/docs/suppression" },
       { title: "Settings Reference", href: "/docs/settings" },

--- a/website/content/configuration/index.mdx
+++ b/website/content/configuration/index.mdx
@@ -2,7 +2,7 @@
 
 Shuck can be configured through a `shuck.toml` or `.shuck.toml` file.
 
-This page covers Shuck's stable native configuration for `shuck check`. ShellCheck compatibility mode uses `.shellcheckrc` instead; see the [ShellCheck compatibility guide](/docs/shellcheck-compat).
+This page covers Shuck's stable native configuration for `shuck check`, `shuck run`, and related native commands. ShellCheck compatibility mode uses `.shellcheckrc` instead; see the [ShellCheck compatibility guide](/docs/shellcheck-compat).
 
 ## Default behavior
 
@@ -179,6 +179,24 @@ extend-select = ["S"]
 fixable = ["C"]
 extend-fixable = ["S074"]
 ```
+
+## Runtime settings
+
+The `[run]` section controls managed interpreter defaults for `shuck run`, `shuck install`, and `shuck shell`.
+
+```toml
+[run]
+shell = "bash"
+shell-version = "5.2"
+
+[run.shells]
+bash = "5.2"
+zsh = "5.9"
+```
+
+Use `[run].shell` for a project-wide default interpreter, `[run].shell-version` for a generic version constraint, and `[run.shells]` for per-shell pins that apply after Shuck has resolved the script's shell.
+
+See the dedicated [Managed Runtime guide](/docs/run) for resolution order, inline script metadata, and `--system` behavior. The generated [Settings Reference](/docs/settings) also includes every supported `[run]` key.
 
 ## CLI-only file selection
 

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -45,6 +45,20 @@ echo 'echo $foo' | shuck check -
 shuck check --fix .
 ```
 
+## Managed runtime
+
+Shuck can also run scripts with managed shell interpreters instead of whatever version happens to be installed on your machine.
+
+```bash
+# Run with the resolved interpreter for this script
+shuck run deploy.sh
+
+# Pin a specific shell version
+shuck run --shell bash --shell-version 5.2 deploy.sh
+```
+
+See the dedicated [Managed Runtime guide](/docs/run) for version resolution, inline metadata, `[run]` config, `shuck install`, and `shuck shell`.
+
 ## Suppression
 
 Use inline comments to suppress warnings for a line, a command, or a whole file. Shuck supports both native `# shuck:` directives and ShellCheck-compatible `# shellcheck` directives, including mapped `SC` codes.

--- a/website/content/run/index.mdx
+++ b/website/content/run/index.mdx
@@ -1,0 +1,139 @@
+# Managed Runtime
+
+`shuck run` executes shell scripts with a resolved interpreter version instead of whatever shell happens to be on your machine. That gives you a lightweight way to pin Bash, Zsh, Dash, or mksh versions for local scripts, CI jobs, and one-off commands.
+
+Managed interpreters are downloaded on demand, cached globally, and reused across projects. The related `shuck install` and `shuck shell` commands use the same resolver and cache.
+
+## Basic usage
+
+```bash
+# Run a script with the shell and version Shuck resolves for it
+shuck run deploy.sh
+
+# Pin both the shell and version from the CLI
+shuck run --shell bash --shell-version 5.2 deploy.sh
+
+# Run an inline command string
+shuck run --shell zsh --shell-version 5.9 -c 'print $ZSH_VERSION'
+
+# Read the script from stdin
+printf 'echo hello\n' | shuck run --shell dash -
+
+# Pass arguments through to the script
+shuck run deploy.sh -- --env staging --force
+```
+
+Supported managed shells today are `bash`, `zsh`, `dash`, and `mksh`.
+
+## How resolution works
+
+Shuck resolves the shell name and version separately.
+
+For the shell name, precedence is:
+
+1. `--shell`
+2. Inline script metadata
+3. `[run].shell` in `shuck.toml` or `.shuck.toml`
+4. Shebang or file-extension inference
+5. Default `bash`
+
+For the version constraint, precedence is:
+
+1. `--shell-version`
+2. Inline script metadata
+3. `[run.shells].<shell>`
+4. `[run].shell-version`
+5. `latest`
+
+`[run.shells]` is evaluated after the shell has been resolved, so you can keep different default pins for different interpreters in the same project.
+
+`shuck run` has one special fallback: if you do not provide a script path, metadata, config, shell, or version, it uses the system `bash` on your `PATH`. As soon as Shuck resolves something more specific, it uses the managed-runtime path instead.
+
+## Inline script metadata
+
+Scripts can declare their runtime requirements in a leading metadata block:
+
+```bash
+# /// shuck
+# shell = "bash"
+# version = ">=5.1,<6"
+# [metadata]
+# description = "Deploy the staging stack"
+# ///
+
+set -euo pipefail
+```
+
+The metadata block must stay in the leading comment header, and only one `# /// shuck` block is allowed per script.
+
+Shuck currently understands:
+
+- `shell`
+- `version`
+- an optional `[metadata]` table for informational fields such as `description`
+
+Unknown keys are rejected so typos fail fast.
+
+## Project defaults
+
+Use the `[run]` section in `shuck.toml` or `.shuck.toml` to set project-wide defaults:
+
+```toml
+[run]
+shell = "bash"
+shell-version = "5.2"
+
+[run.shells]
+bash = "5.2"
+zsh = "5.9"
+dash = "0.5.12"
+mksh = "59c"
+```
+
+This is especially useful when a repository mixes shell dialects or needs to hold Bash on a newer version than the one that ships with macOS.
+
+Runtime commands follow the same config discovery and override model as `shuck check`, including `--config` and `--isolated`. See [Configuration](/docs/configuration) for the full config search rules and [Settings Reference](/docs/settings) for the generated key reference.
+
+## System vs managed interpreters
+
+Use `--system` when you explicitly want the interpreter already installed on your machine:
+
+```bash
+shuck run --system --shell bash --shell-version '>=5.1' deploy.sh
+```
+
+Shuck still validates the system interpreter version against your requested constraint. If the version does not match, the command fails and tells you to install a managed version instead.
+
+Without `--system`, Shuck downloads the matching interpreter into `~/.shuck/shells/` and reuses that cached copy for later runs.
+
+## Related commands
+
+`shuck install` preloads interpreters without running a script:
+
+```bash
+shuck install bash 5.2
+shuck install --list
+shuck install --list bash
+```
+
+`shuck shell` starts an interactive managed shell session:
+
+```bash
+shuck shell --shell bash --shell-version 5.2
+```
+
+Unlike `shuck run`, `shuck shell` defaults to a managed Bash session when nothing more specific is configured.
+
+## Runtime environment
+
+Before executing a script, Shuck exports a few environment variables describing the resolved interpreter:
+
+- `SHUCK_SHELL`
+- `SHUCK_SHELL_VERSION`
+- `SHUCK_SHELL_PATH`
+
+For managed interpreters, it also sets `SHELL` to the resolved binary path.
+
+## Current scope
+
+Managed runtime support currently targets Unix-like environments with published managed shell artifacts. `shuck run` does not support Windows yet.

--- a/website/content/settings/index.mdx
+++ b/website/content/settings/index.mdx
@@ -213,3 +213,113 @@ report-unreached-nested-definitions = true
 
 ---
 
+## `[run]`
+
+Interpreter defaults and managed shell version pins for `shuck run` and related commands.
+
+#### `shell`
+
+Default managed shell to use when a script does not declare its own shell.
+
+**Default value**: `none`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[run]
+shell = "bash"
+```
+
+---
+
+#### `shell-version`
+
+Default version constraint to use when no script metadata or per-shell pin is more specific.
+
+**Default value**: `"latest"`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[run]
+shell-version = "5.2"
+```
+
+---
+
+### `[run.shells]`
+
+Per-shell version pins applied after the shell has been resolved for the current script.
+
+#### `bash`
+
+Version constraint for Bash scripts.
+
+**Default value**: `none`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[run.shells]
+bash = "5.2"
+```
+
+---
+
+#### `zsh`
+
+Version constraint for Zsh scripts.
+
+**Default value**: `none`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[run.shells]
+zsh = "5.9"
+```
+
+---
+
+#### `dash`
+
+Version constraint for Dash scripts.
+
+**Default value**: `none`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[run.shells]
+dash = "0.5.12"
+```
+
+---
+
+#### `mksh`
+
+Version constraint for mksh scripts.
+
+**Default value**: `none`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[run.shells]
+mksh = "59c"
+```
+
+---
+


### PR DESCRIPTION
## Summary
- add a dedicated managed runtime guide for `shuck run`, including resolution order, inline metadata, `[run]` config, `--system`, and related `install` and `shell` commands
- wire the new guide into the website docs router and sidebar, and add cross-links from the getting started and configuration pages
- regenerate the settings reference so the `[run]` section is documented alongside the hand-written runtime docs

## Why
`shuck run` is implemented, but the website did not yet explain how to use it or how its runtime configuration fits into the rest of the docs.

## Validation
- `pnpm test`
- `pnpm build`
