### PR TITLE
fix(semantic): model zsh predefined runtime names

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -1294,6 +1294,12 @@ mod tests {
         )
     }
 
+    fn zsh_runtime_prelude_source(shebang: &str) -> String {
+        format!(
+            "{shebang}\nprintf '%s\\n' \"${{options[xtrace]}}\" \"${{functions[typeset]}}\" \"${{path[1]}}\" \"${{pipestatus[1]}}\" \"$MATCH\" \"$ZSH_VERSION\"\n"
+        )
+    }
+
     fn first_command_substitution_body(parts: &[WordPartNode]) -> Option<&StmtSeq> {
         for part in parts {
             match &part.kind {
@@ -4525,6 +4531,14 @@ printf '%s %s\\n' \"${#}\" \"${$}\"
     #[test]
     fn undefined_variable_ignores_bash_runtime_vars_in_bash_scripts() {
         let source = runtime_prelude_source("#!/bin/bash");
+        let diagnostics = lint_for_rule(&source, Rule::UndefinedVariable);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn undefined_variable_ignores_zsh_runtime_vars_in_zsh_scripts() {
+        let source = zsh_runtime_prelude_source("#!/bin/zsh");
         let diagnostics = lint_for_rule(&source, Rule::UndefinedVariable);
 
         assert!(diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -86,7 +86,7 @@ pub fn possible_variable_misspelling(checker: &mut Checker) {
         if !looks_like_case_mismatch_reference(reference.name.as_str()) {
             continue;
         }
-        if is_known_runtime_name(reference.name.as_str()) {
+        if is_known_runtime_or_environment_name(checker, reference.name.as_str()) {
             continue;
         }
         if is_internal_placeholder_name(reference.name.as_str()) {
@@ -194,7 +194,8 @@ fn heredoc_findings(
             if !looks_like_case_mismatch_reference(reference_name) {
                 continue;
             }
-            if is_known_runtime_name(reference_name) || is_internal_placeholder_name(reference_name)
+            if is_known_runtime_or_environment_name(checker, reference_name)
+                || is_internal_placeholder_name(reference_name)
             {
                 continue;
             }
@@ -272,7 +273,9 @@ fn scope_compat_findings(
         if !looks_like_case_mismatch_reference(reference_name) {
             continue;
         }
-        if is_known_runtime_name(reference_name) || is_internal_placeholder_name(reference_name) {
+        if is_known_runtime_or_environment_name(checker, reference_name)
+            || is_internal_placeholder_name(reference_name)
+        {
             continue;
         }
         if has_prior_guarded_reference(guarded_name_offsets, reference_name, name_use.span) {
@@ -780,41 +783,9 @@ fn source_suffix_matches(source: &str, offset: usize, suffix: &str) -> bool {
         .is_some_and(|source_suffix| source_suffix.eq_ignore_ascii_case(suffix.as_bytes()))
 }
 
-fn is_known_runtime_name(name: &str) -> bool {
-    matches!(
-        name,
-        "IFS"
-            | "USER"
-            | "HOME"
-            | "SHELL"
-            | "PWD"
-            | "TERM"
-            | "PATH"
-            | "CDPATH"
-            | "LANG"
-            | "SUDO_USER"
-            | "DOAS_USER"
-            | "PPID"
-            | "HOSTNAME"
-            | "SECONDS"
-            | "LINENO"
-            | "FUNCNAME"
-            | "BASH_SOURCE"
-            | "BASH_LINENO"
-            | "RANDOM"
-            | "PIPESTATUS"
-            | "BASH_REMATCH"
-            | "READLINE_LINE"
-            | "BASH_VERSION"
-            | "BASH_VERSINFO"
-            | "OSTYPE"
-            | "HISTCONTROL"
-            | "HISTSIZE"
-            | "EUID"
-            | "TMPDIR"
-            | "GEM_HOME"
-            | "GEM_PATH"
-    ) || name.starts_with("LC_")
+fn is_known_runtime_or_environment_name(checker: &Checker<'_>, name: &str) -> bool {
+    checker.semantic().name_is_predefined_runtime(name)
+        || matches!(name, "PPID" | "EUID" | "TMPDIR" | "GEM_HOME" | "GEM_PATH")
 }
 
 fn is_internal_placeholder_name(name: &str) -> bool {
@@ -877,7 +848,7 @@ fn is_shell_name_byte(byte: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_exact_uppercase_fold_matches() {
@@ -1547,6 +1518,43 @@ echo \"$OS_NAME\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$HOSTID", "$OS_NAME"]
+        );
+    }
+
+    #[test]
+    fn ignores_zsh_runtime_names_in_zsh_scripts() {
+        let source = "\
+#!/bin/zsh
+echo \"$path\"
+echo \"$MATCH\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn keeps_non_zsh_match_misspelling_reports() {
+        let source = "\
+#!/bin/sh
+match=demo
+echo \"$MATCH\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$MATCH"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -785,7 +785,6 @@ fn source_suffix_matches(source: &str, offset: usize, suffix: &str) -> bool {
 
 fn is_known_runtime_or_environment_name(checker: &Checker<'_>, name: &str) -> bool {
     checker.semantic().name_is_known_runtime(name)
-        || matches!(name, "PPID" | "EUID" | "TMPDIR" | "GEM_HOME" | "GEM_PATH")
 }
 
 fn is_internal_placeholder_name(name: &str) -> bool {
@@ -1563,6 +1562,27 @@ echo \"$MATCH\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$MATCH"]
+        );
+    }
+
+    #[test]
+    fn keeps_bash_completion_names_reportable_in_sh() {
+        let source = "\
+#!/bin/sh
+comp_words=demo
+echo \"$COMP_WORDS\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PossibleVariableMisspelling),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$COMP_WORDS"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
+++ b/crates/shuck-linter/src/rules/correctness/possible_variable_misspelling.rs
@@ -784,7 +784,7 @@ fn source_suffix_matches(source: &str, offset: usize, suffix: &str) -> bool {
 }
 
 fn is_known_runtime_or_environment_name(checker: &Checker<'_>, name: &str) -> bool {
-    checker.semantic().name_is_predefined_runtime(name)
+    checker.semantic().name_is_known_runtime(name)
         || matches!(name, "PPID" | "EUID" | "TMPDIR" | "GEM_HOME" | "GEM_PATH")
 }
 
@@ -1098,9 +1098,17 @@ echo \"$PATH\"
 gem_home=1
 gem_path=1
 euid=1
+bash_version=1
+ostype=1
+histsize=1
+funcname=1
 echo \"$GEM_HOME\"
 echo \"$GEM_PATH\"
 echo \"$EUID\"
+echo \"$BASH_VERSION\"
+echo \"$OSTYPE\"
+echo \"$HISTSIZE\"
+echo \"$FUNCNAME\"
 tmpdir=1
 echo \"$TMPDIR\"
 ";

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -190,7 +190,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             span: file.span,
             bindings: FxHashMap::default(),
         };
-        let runtime = RuntimePrelude::new(bash_runtime_vars_enabled);
+        let runtime = RuntimePrelude::new(shell_profile.dialect, bash_runtime_vars_enabled);
         let mut builder = Self {
             source,
             file_entry_contract_collector,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1064,6 +1064,11 @@ impl SemanticModel {
                 .is_some_and(|reference| self.runtime.is_preinitialized_array(&reference.name))
     }
 
+    /// Returns whether `name` is provided by the shell runtime for this model's dialect.
+    pub fn name_is_predefined_runtime(&self, name: &str) -> bool {
+        self.runtime.is_preinitialized(&Name::from(name))
+    }
+
     /// Returns whether `id` is guarded by parameter-expansion syntax that suppresses missing-name
     /// diagnostics.
     pub fn is_guarded_parameter_reference(&self, id: ReferenceId) -> bool {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1069,6 +1069,11 @@ impl SemanticModel {
         self.runtime.is_preinitialized(&Name::from(name))
     }
 
+    /// Returns whether `name` is a well-known shell runtime name in any supported dialect.
+    pub fn name_is_known_runtime(&self, name: &str) -> bool {
+        self.runtime.is_known_runtime_name(&Name::from(name))
+    }
+
     /// Returns whether `id` is guarded by parameter-expansion syntax that suppresses missing-name
     /// diagnostics.
     pub fn is_guarded_parameter_reference(&self, id: ReferenceId) -> bool {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1069,7 +1069,8 @@ impl SemanticModel {
         self.runtime.is_preinitialized(&Name::from(name))
     }
 
-    /// Returns whether `name` is a well-known shell runtime name in any supported dialect.
+    /// Returns whether `name` is a well-known runtime-style name that typo suppression should
+    /// ignore for this model's shell dialect.
     pub fn name_is_known_runtime(&self, name: &str) -> bool {
         self.runtime.is_known_runtime_name(&Name::from(name))
     }

--- a/crates/shuck-semantic/src/runtime.rs
+++ b/crates/shuck-semantic/src/runtime.rs
@@ -218,6 +218,14 @@ impl RuntimePrelude {
                 && contains_name(self.zsh_preinitialized, name))
     }
 
+    pub(crate) fn is_known_runtime_name(&self, name: &Name) -> bool {
+        contains_name(self.common_preinitialized, name)
+            || contains_name(self.bash_preinitialized, name)
+            || is_locale_binding(name)
+            || (self.shell_dialect == ShellDialect::Zsh
+                && contains_name(self.zsh_preinitialized, name))
+    }
+
     pub(crate) fn is_preinitialized_array(&self, name: &Name) -> bool {
         (self.bash_enabled && contains_name(BASH_PREINITIALIZED_ARRAYS, name))
             || (self.shell_dialect == ShellDialect::Zsh

--- a/crates/shuck-semantic/src/runtime.rs
+++ b/crates/shuck-semantic/src/runtime.rs
@@ -1,4 +1,5 @@
 use shuck_ast::{Name, Word};
+use shuck_parser::ShellDialect;
 
 const COMMON_PREINITIALIZED: &[&str] = &[
     "IFS",
@@ -88,6 +89,94 @@ const BASH_PREINITIALIZED_ARRAYS: &[&str] = &[
     "PIPESTATUS",
 ];
 
+const ZSH_PREINITIALIZED: &[&str] = &[
+    "ARGC",
+    "BUFFER",
+    "COLUMNS",
+    "CURSOR",
+    "KEYS",
+    "LBUFFER",
+    "LINES",
+    "MAILPATH",
+    "MANPATH",
+    "MATCH",
+    "MBEGIN",
+    "MEND",
+    "MODULE_PATH",
+    "NUMERIC",
+    "POSTDISPLAY",
+    "PSVAR",
+    "RBUFFER",
+    "WIDGET",
+    "ZSH_ARGZERO",
+    "ZSH_EVAL_CONTEXT",
+    "ZSH_NAME",
+    "ZSH_PATCHLEVEL",
+    "ZSH_SUBSHELL",
+    "ZSH_VERSION",
+    "aliases",
+    "argv",
+    "cdpath",
+    "commands",
+    "dirstack",
+    "fpath",
+    "funcfiletrace",
+    "functions",
+    "funcsourcetrace",
+    "funcstack",
+    "historywords",
+    "jobdirs",
+    "jobstates",
+    "jobtexts",
+    "mailpath",
+    "manpath",
+    "module_path",
+    "options",
+    "parameters",
+    "path",
+    "pipestatus",
+    "psvar",
+    // Zsh populates these in regex and ZLE contexts, but they are still
+    // reserved runtime-provided names rather than user-defined locals.
+    "region_highlight",
+    "signals",
+    "status",
+    "termcap",
+    "terminfo",
+    "widgets",
+    "zsh_eval_context",
+];
+
+const ZSH_PREINITIALIZED_ARRAYS: &[&str] = &[
+    "aliases",
+    "argv",
+    "cdpath",
+    "commands",
+    "dirstack",
+    "fpath",
+    "funcfiletrace",
+    "functions",
+    "funcsourcetrace",
+    "funcstack",
+    "historywords",
+    "jobdirs",
+    "jobstates",
+    "jobtexts",
+    "mailpath",
+    "manpath",
+    "module_path",
+    "options",
+    "parameters",
+    "path",
+    "pipestatus",
+    "psvar",
+    "signals",
+    "termcap",
+    "terminfo",
+    "widgets",
+    "zsh_eval_context",
+];
+
 const ALWAYS_USED_BINDINGS: &[&str] = &["IFS", "PATH", "CDPATH", "COMPREPLY", "FLAGS_PARENT"];
 const BASH_ALWAYS_USED_BINDINGS: &[&str] = &["COMPREPLY"];
 const EMPTY_IMPLICIT_READS: &[&str] = &[];
@@ -95,19 +184,23 @@ const READ_IMPLICIT_READS: &[&str] = &["IFS"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct RuntimePrelude {
+    shell_dialect: ShellDialect,
     bash_enabled: bool,
     common_preinitialized: &'static [&'static str],
     bash_preinitialized: &'static [&'static str],
+    zsh_preinitialized: &'static [&'static str],
     always_used_bindings: &'static [&'static str],
     bash_always_used_bindings: &'static [&'static str],
 }
 
 impl RuntimePrelude {
-    pub(crate) fn new(bash_enabled: bool) -> Self {
+    pub(crate) fn new(shell_dialect: ShellDialect, bash_enabled: bool) -> Self {
         Self {
+            shell_dialect,
             bash_enabled,
             common_preinitialized: COMMON_PREINITIALIZED,
             bash_preinitialized: BASH_PREINITIALIZED,
+            zsh_preinitialized: ZSH_PREINITIALIZED,
             always_used_bindings: ALWAYS_USED_BINDINGS,
             bash_always_used_bindings: BASH_ALWAYS_USED_BINDINGS,
         }
@@ -121,10 +214,14 @@ impl RuntimePrelude {
         contains_name(self.common_preinitialized, name)
             || is_locale_binding(name)
             || (self.bash_enabled && contains_name(self.bash_preinitialized, name))
+            || (self.shell_dialect == ShellDialect::Zsh
+                && contains_name(self.zsh_preinitialized, name))
     }
 
     pub(crate) fn is_preinitialized_array(&self, name: &Name) -> bool {
-        self.bash_enabled && contains_name(BASH_PREINITIALIZED_ARRAYS, name)
+        (self.bash_enabled && contains_name(BASH_PREINITIALIZED_ARRAYS, name))
+            || (self.shell_dialect == ShellDialect::Zsh
+                && contains_name(ZSH_PREINITIALIZED_ARRAYS, name))
     }
 
     pub(crate) fn is_always_used_binding(&self, name: &Name) -> bool {

--- a/crates/shuck-semantic/src/runtime.rs
+++ b/crates/shuck-semantic/src/runtime.rs
@@ -89,6 +89,43 @@ const BASH_PREINITIALIZED_ARRAYS: &[&str] = &[
     "PIPESTATUS",
 ];
 
+const COMMON_KNOWN_RUNTIME_NAMES: &[&str] = &[
+    "IFS",
+    "USER",
+    "HOME",
+    "SHELL",
+    "PWD",
+    "TERM",
+    "PATH",
+    "CDPATH",
+    "LANG",
+    "SUDO_USER",
+    "DOAS_USER",
+    "PPID",
+    "HOSTNAME",
+    "SECONDS",
+    "EUID",
+    "TMPDIR",
+    "GEM_HOME",
+    "GEM_PATH",
+];
+
+const BASH_KNOWN_RUNTIME_NAMES: &[&str] = &[
+    "LINENO",
+    "FUNCNAME",
+    "BASH_SOURCE",
+    "BASH_LINENO",
+    "RANDOM",
+    "PIPESTATUS",
+    "BASH_REMATCH",
+    "READLINE_LINE",
+    "BASH_VERSION",
+    "BASH_VERSINFO",
+    "OSTYPE",
+    "HISTCONTROL",
+    "HISTSIZE",
+];
+
 const ZSH_PREINITIALIZED: &[&str] = &[
     "ARGC",
     "BUFFER",
@@ -219,8 +256,8 @@ impl RuntimePrelude {
     }
 
     pub(crate) fn is_known_runtime_name(&self, name: &Name) -> bool {
-        contains_name(self.common_preinitialized, name)
-            || contains_name(self.bash_preinitialized, name)
+        contains_name(COMMON_KNOWN_RUNTIME_NAMES, name)
+            || contains_name(BASH_KNOWN_RUNTIME_NAMES, name)
             || is_locale_binding(name)
             || (self.shell_dialect == ShellDialect::Zsh
                 && contains_name(self.zsh_preinitialized, name))

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -287,6 +287,12 @@ fn bash_runtime_source(shebang: &str) -> String {
     )
 }
 
+fn zsh_runtime_source(shebang: &str) -> String {
+    format!(
+        "{shebang}\nprintf '%s\\n' \"${{options[xtrace]}}\" \"${{functions[typeset]}}\" \"${{aliases[ls]}}\" \"${{commands[printf]}}\" \"${{parameters[path]}}\" \"${{termcap[ku]}}\" \"${{terminfo[kcuu1]}}\" \"${{path[1]}}\" \"${{pipestatus[1]}}\" \"${{funcstack[1]}}\" \"${{funcfiletrace[1]}}\" \"${{funcsourcetrace[1]}}\" \"${{psvar[1]}}\" \"${{widgets[widget]}}\" \"${{zsh_eval_context[1]}}\" \"${{module_path[1]}}\" \"${{manpath[1]}}\" \"${{mailpath[1]}}\" \"${{historywords[1]}}\" \"${{jobdirs[1]}}\" \"${{jobstates[1]}}\" \"${{jobtexts[1]}}\" \"${{signals[1]}}\" \"$MATCH\" \"$MBEGIN\" \"$MEND\" \"$BUFFER\" \"$LBUFFER\" \"$RBUFFER\" \"$CURSOR\" \"$WIDGET\" \"$KEYS\" \"$NUMERIC\" \"$POSTDISPLAY\" \"$region_highlight\" \"$LINES\" \"$COLUMNS\" \"$ZSH_VERSION\" \"$ZSH_NAME\" \"$ZSH_PATCHLEVEL\" \"$ZSH_SUBSHELL\" \"$ZSH_ARGZERO\"\n"
+    )
+}
+
 #[test]
 fn creates_file_and_function_scopes_and_resolves_local_shadowing() {
     let source = "VAR=global\nf() { local VAR=local; echo $VAR; }\n";
@@ -7081,6 +7087,87 @@ fn bash_runtime_array_references_are_classified() {
         .find(|reference| reference.name == "RANDOM")
         .unwrap();
     assert!(!model.reference_is_predefined_runtime_array(random.id));
+}
+
+#[test]
+fn zsh_runtime_vars_are_not_marked_uninitialized_in_zsh_scripts() {
+    let source = zsh_runtime_source("#!/bin/zsh");
+    let model = model(&source);
+    let names = [
+        "options",
+        "functions",
+        "aliases",
+        "commands",
+        "parameters",
+        "termcap",
+        "terminfo",
+        "path",
+        "pipestatus",
+        "funcstack",
+        "funcfiletrace",
+        "funcsourcetrace",
+        "psvar",
+        "widgets",
+        "zsh_eval_context",
+        "module_path",
+        "manpath",
+        "mailpath",
+        "historywords",
+        "jobdirs",
+        "jobstates",
+        "jobtexts",
+        "signals",
+        "MATCH",
+        "MBEGIN",
+        "MEND",
+        "BUFFER",
+        "LBUFFER",
+        "RBUFFER",
+        "CURSOR",
+        "WIDGET",
+        "KEYS",
+        "NUMERIC",
+        "POSTDISPLAY",
+        "region_highlight",
+        "LINES",
+        "COLUMNS",
+        "ZSH_VERSION",
+        "ZSH_NAME",
+        "ZSH_PATCHLEVEL",
+        "ZSH_SUBSHELL",
+        "ZSH_ARGZERO",
+    ];
+
+    let unresolved = unresolved_names(&model);
+    let uninitialized = uninitialized_names(&model);
+
+    assert_names_absent(&names, &unresolved);
+    assert_names_absent(&names, &uninitialized);
+}
+
+#[test]
+fn zsh_runtime_array_references_are_classified() {
+    let source = "\
+#!/bin/zsh
+printf '%s\\n' \"${path[1]}\" \"${options[xtrace]}\" \"${pipestatus[1]}\" \"$ZSH_VERSION\"
+";
+    let model = model(source);
+
+    for name in ["path", "options", "pipestatus"] {
+        let reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.name == name)
+            .unwrap();
+        assert!(model.reference_is_predefined_runtime_array(reference.id));
+    }
+
+    let version = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "ZSH_VERSION")
+        .unwrap();
+    assert!(!model.reference_is_predefined_runtime_array(version.id));
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- add a dialect-aware zsh runtime prelude in `shuck-semantic` so predefined zsh variables and arrays are modeled as runtime-provided names
- expose a semantic helper for predefined runtime names and reuse it in `PossibleVariableMisspelling` instead of duplicating the shell runtime table in the linter
- add targeted semantic and linter coverage for zsh runtime references and the related undefined-variable and misspelling behavior

## Why

Zsh built-ins like `options`, `path`, `pipestatus`, and `MATCH` were being treated as ordinary user variables. That produced false positives in zsh-heavy codebases such as `zinit`, especially for undefined-variable and possible-misspelling diagnostics.

The root cause was that the semantic runtime prelude only modeled common and bash-specific names, while the misspelling rule separately maintained its own runtime-name allowlist.

## Impact

This reduces zsh false positives for the runtime-name issue without changing the parser-side unbraced subscript bug. Non-zsh misspelling behavior stays intact because the shared runtime check is still dialect-aware, and the typo rule keeps only a small environment-name exception bucket.

## Validation

- `cargo test -p shuck-linter possible_variable_misspelling`
- `cargo test -p shuck-linter undefined_variable_ignores_zsh_runtime_vars_in_zsh_scripts`
- `cargo test -p shuck-semantic zsh_runtime`
