### PR TITLE
fix(parser): parse unbraced zsh subscripts

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -3264,11 +3264,16 @@ fn fmt_word_part_with_source_mode(
             fmt_var_ref_with_source(f, reference, source)?;
             f.write_str("}")?;
         }
-        WordPart::ArrayAccess(reference) => {
-            write!(f, "${{")?;
-            fmt_var_ref_with_source(f, reference, source)?;
-            f.write_str("}")?;
-        }
+        WordPart::ArrayAccess(reference) => match source {
+            Some(source) if reference.is_source_backed() && span.end.offset <= source.len() => {
+                f.write_str(span.slice(source))?
+            }
+            _ => {
+                write!(f, "${{")?;
+                fmt_var_ref_with_source(f, reference, source)?;
+                f.write_str("}")?;
+            }
+        },
         WordPart::ArrayLength(reference) => {
             write!(f, "${{#")?;
             fmt_var_ref_with_source(f, reference, source)?;

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -918,6 +918,63 @@ fn test_decl_name_and_array_access_attach_arithmetic_index_asts() {
 }
 
 #[test]
+fn test_zsh_unbraced_array_access_parses_as_array_access() {
+    let input = "print $Plugins[MY_PLUGIN_DIR]\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let reference = expect_array_access(&command.args[0]);
+    assert_eq!(reference.name.as_str(), "Plugins");
+    expect_subscript(reference, input, "MY_PLUGIN_DIR");
+    assert_eq!(
+        command.args[0].render_syntax(input),
+        "$Plugins[MY_PLUGIN_DIR]"
+    );
+}
+
+#[test]
+fn test_zsh_unbraced_array_access_inside_double_quotes_stays_nested() {
+    let source = "[[ -n \"$termcap[ku]\" ]]\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let (compound, redirects) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional command");
+    };
+
+    assert!(redirects.is_empty());
+    let ConditionalExpr::Unary(unary) = &command.expression else {
+        panic!("expected unary conditional");
+    };
+    let ConditionalExpr::Word(word) = unary.expr.as_ref() else {
+        panic!("expected quoted word operand");
+    };
+    let [
+        WordPartNode {
+            kind: WordPart::DoubleQuoted { parts, .. },
+            ..
+        },
+    ] = word.parts.as_slice()
+    else {
+        panic!("expected one double-quoted expansion, got {:?}", word.parts);
+    };
+    let [nested] = parts.as_slice() else {
+        panic!("expected one nested part, got {parts:?}");
+    };
+    let reference = array_access_reference(&nested.kind).expect("expected nested array access");
+    assert_eq!(reference.name.as_str(), "termcap");
+    expect_subscript(reference, source, "ku");
+    assert_eq!(word.render_syntax(source), "\"$termcap[ku]\"");
+}
+
+#[test]
 fn test_substring_and_array_slice_attach_arithmetic_companion_asts() {
     let input = "echo ${s:i+1:len*2} ${arr[@]:i:j}\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4927,12 +4927,27 @@ impl<'a> Parser<'a> {
                         c.is_ascii_alphanumeric() || c == '_'
                     });
                     if !var_name.is_empty() {
-                        Self::push_word_part(
-                            parts,
-                            WordPart::Variable(var_name.into()),
-                            part_start,
-                            cursor,
-                        );
+                        let part = if self.dialect == ShellDialect::Zsh
+                            && Self::consume_word_char_if(&mut chars, &mut cursor, '[')
+                        {
+                            let (index, raw_index) =
+                                self.read_array_index(&mut chars, &mut cursor, source_backed);
+                            let subscript = self.subscript_from_source_text(
+                                index,
+                                raw_index,
+                                SubscriptInterpretation::Contextual,
+                            );
+                            WordPart::ArrayAccess(self.parameter_var_ref(
+                                part_start,
+                                "$",
+                                &var_name,
+                                Some(subscript),
+                                cursor,
+                            ))
+                        } else {
+                            WordPart::Variable(var_name.into())
+                        };
+                        Self::push_word_part(parts, part, part_start, cursor);
                         current_start = cursor;
                     } else {
                         if current.is_empty() {


### PR DESCRIPTION
## Summary
- parse unbraced zsh subscripts like `$name[key]` as array access in zsh mode
- add parser regressions for direct and quoted subscripted references
- preserve source-backed `$name[...]` rendering in nested contexts instead of normalizing to `${name[...]}`

## Why
The parser treated unbraced zsh associative-array access as a bare variable followed by bracket text. That split led to false positives in zsh-heavy code, including the `zinit` sweep.

## Validation
- `cargo test -p shuck-parser zsh_unbraced_array_access`
- `cargo test -p shuck-parser subscript`
