### PR TITLE
docs(specs): add 018 language server spec

### DIFF
--- a/specs/018-lsp.md
+++ b/specs/018-lsp.md
@@ -84,17 +84,35 @@ surface (rule explanations, suppression management, watch-mode parity).
 
 ### Crate Layout
 
-A new workspace crate `crates/shuck-server` provides:
+Two new workspace crates land together:
 
-- A library with the `Server` and supporting types, used by integration
-  tests and any future programmatic embedder.
-- A single public entrypoint, `pub fn run() -> anyhow::Result<()>`, that
-  starts the server over `stdio`.
+- **`crates/shuck-config`** — Configuration types, TOML parsing, project
+  root discovery, and override layering. This is `shuck-cli::config`
+  carved out into a leaf crate so both the CLI and the server can depend
+  on it without forming a cycle. Public surface: `ShuckConfig`,
+  `ConfigArguments` (override layering), `resolve_project_root_for_file`,
+  and the loader that turns a discovered file into a parsed config.
+- **`crates/shuck-server`** — The language server. Provides a library
+  with the `Server` and supporting types and a single public entrypoint,
+  `pub fn run() -> anyhow::Result<()>`, that starts the server over
+  `stdio`.
 
 `shuck-cli` gains a `server` subcommand that calls into `shuck_server::run`.
 The subcommand has no flags in v1; configuration arrives via LSP
 `initializationOptions` and per-workspace `.shuck.toml` / `shuck.toml`
 files.
+
+Dependency direction:
+
+```
+shuck-cli ──► shuck-server ──┐
+    │                        ├──► shuck-config
+    └────────────────────────┘
+```
+
+`shuck-cli` depends on `shuck-server` (for the subcommand) and on
+`shuck-config` (for its own existing config code). `shuck-server` depends
+on `shuck-config` but not on `shuck-cli`. There is no cycle.
 
 Dependencies in `shuck-server/Cargo.toml`:
 
@@ -108,7 +126,12 @@ Dependencies in `shuck-server/Cargo.toml`:
 | `tracing`, `tracing-subscriber` | Logging to file + `window/logMessage` |
 | `rustc-hash` | `FxHashMap` for document/url lookup |
 | `shuck-ast`, `shuck-parser`, `shuck-indexer`, `shuck-linter`, `shuck-formatter` | Analysis pipeline |
-| `shuck-cli` (subset reused via lib re-exports for config discovery) | `.shuck.toml` / `shuck.toml` resolution |
+| `shuck-config` | `.shuck.toml` / `shuck.toml` discovery and override layering |
+
+The carve-out is mechanical: today's `crates/shuck-cli/src/config.rs`,
+together with the project-root walkers and the override-application
+helpers it depends on, moves verbatim into the new crate. `shuck-cli`
+re-imports the same names so existing call sites are unchanged.
 
 The `shuck-cli` subcommand only adds:
 
@@ -456,8 +479,8 @@ applied as overrides on top of the discovered config (see
 
 1. **Discovered config.** When a document opens, the server walks up from
    the document's path to find the nearest `.shuck.toml` / `shuck.toml`,
-   parses it through the existing `shuck-cli::config` loader, and caches
-   the resolved `ShuckConfig` in a per-workspace `ShuckSettingsIndex`.
+   parses it through the `shuck-config` loader, and caches the resolved
+   `ShuckConfig` in a per-workspace `ShuckSettingsIndex`.
 
 2. **Client overrides.** LSP `initializationOptions.shuck` (and dynamic
    `workspace/configuration` responses on
@@ -629,9 +652,12 @@ once the file-level server is stable.
 
 Build and unit:
 
-- `cargo build -p shuck-server`
-- `cargo test -p shuck-server`
-- `cargo clippy -p shuck-server --all-targets -- -D warnings`
+- `cargo build -p shuck-config -p shuck-server -p shuck-cli`
+- `cargo test -p shuck-config -p shuck-server`
+- `cargo clippy -p shuck-config -p shuck-server --all-targets -- -D warnings`
+- The dependency graph remains acyclic: `cargo tree -p shuck-server`
+  must not list `shuck-cli`, and `cargo tree -p shuck-cli` must list
+  `shuck-server` and `shuck-config` exactly once each.
 
 Unit tests live next to each handler and exercise:
 

--- a/specs/018-lsp.md
+++ b/specs/018-lsp.md
@@ -1,0 +1,673 @@
+# 018: Language Server (`shuck server`)
+
+## Status
+
+Accepted
+
+## Summary
+
+Add a Language Server Protocol (LSP) server to shuck so editors get real-time
+diagnostics, quick fixes, formatting, and rule documentation directly from the
+same crates that power `shuck check` and `shuck format`. The server lives in a
+new `shuck-server` crate, ships behind a `shuck server` subcommand, and reuses
+`shuck-parser`, `shuck-indexer`, `shuck-linter`, and `shuck-formatter` against
+in-memory document state. The architecture is a `lsp-server` + `lsp-types`
+event loop with a thread-pool scheduler that splits work between local
+(mutable, blocking) and background (snapshot-based, parallel) tasks. Embedded
+scripts (GitHub Actions, composite actions) are explicitly deferred to a later
+spec.
+
+## Motivation
+
+Today, the only way to see a shuck diagnostic in an editor is to run
+`shuck check` from a terminal or wire shuck up through a generic linter
+extension. Both paths add friction:
+
+- **Latency.** Spawning `shuck check` per save costs process startup, config
+  resolution, and cache warm-up on every keystroke save. Most editors will not
+  do it at all on each keystroke.
+- **Lossy diagnostics.** Generic LSP-over-CLI bridges (e.g. `efm-langserver`,
+  `null-ls`) parse stdout text. They lose rule metadata, fix availability,
+  ShellCheck-mapped codes, suppression directives, and exact spans for
+  multi-line diagnostics.
+- **No interactivity.** There is no quick-fix flow, no insertion of
+  `# shuck: ignore=...` directives, no formatter integration, no hover for
+  rule documentation. Users get diagnostics, not actions.
+
+A first-party language server fixes all three. It runs in-process with shared
+state across the workspace, returns structured diagnostics with attached
+fixes, and exposes the formatter as a code action and a formatting request.
+It is also the natural home for any future feature that needs an editor
+surface (rule explanations, suppression management, watch-mode parity).
+
+## Design
+
+### Goals
+
+- Real-time diagnostics for shell scripts open in the editor, both through
+  push (`textDocument/publishDiagnostics`) and pull
+  (`textDocument/diagnostic`) flows.
+- Code actions for: per-diagnostic quick fixes, "fix all in document",
+  and inserting a suppression directive on the offending line. New
+  directives are emitted as `# shuck: ignore=CODE` (matching the CLI's
+  `shuck check --add-ignore`); directives already on the line — in either
+  shuck or ShellCheck form — are recognized and merged rather than
+  duplicated.
+- Formatting requests for full document and ranges via `shuck-formatter`.
+- Hover over a rule code inside a `# shuck:` or `# shellcheck` directive
+  shows the rule's name, message, fix availability, and explanation.
+- Per-workspace `.shuck.toml` / `shuck.toml` resolution that mirrors
+  `shuck check` and reloads automatically when the config file changes on
+  disk.
+- Cancellation: late-arriving cancel notifications must abort in-flight
+  background analysis cleanly.
+- Panic safety: a handler panic is reported to the client and logged; it
+  does not bring down the server.
+
+### Non-Goals
+
+- Embedded shell extraction (GitHub Actions workflows, composite actions).
+  The plumbing exists in `shuck-extract`, but mapping LSP positions across
+  extracted scripts and host YAML adds enough surface area to deserve its
+  own spec. Tracked separately.
+- Notebook documents. There is no shell-notebook ecosystem to support.
+- Cross-file analysis. Diagnostics are file-local in `shuck check` today;
+  the server inherits that scope.
+- Document symbols, go-to-definition, find references, rename, completion.
+  None of these have semantic backing in `shuck-linter` today, and adding
+  them is independent work.
+- Async runtimes. The server is built on synchronous threads with snapshot
+  passing — no `tokio`, no `async-lsp`.
+- Reusing `shuck-cache`. Cache entries are keyed by file mtime and
+  permissions and will not match an unsaved in-memory buffer; the LSP path
+  always re-runs analysis on the live buffer.
+
+### Crate Layout
+
+A new workspace crate `crates/shuck-server` provides:
+
+- A library with the `Server` and supporting types, used by integration
+  tests and any future programmatic embedder.
+- A single public entrypoint, `pub fn run() -> anyhow::Result<()>`, that
+  starts the server over `stdio`.
+
+`shuck-cli` gains a `server` subcommand that calls into `shuck_server::run`.
+The subcommand has no flags in v1; configuration arrives via LSP
+`initializationOptions` and per-workspace `.shuck.toml` / `shuck.toml`
+files.
+
+Dependencies in `shuck-server/Cargo.toml`:
+
+| Dep | Purpose |
+|-----|---------|
+| `lsp-server` | JSON-RPC connection, request/response framing |
+| `lsp-types` | LSP type definitions |
+| `crossbeam-channel` | Event channel between main loop and handlers |
+| `serde`, `serde_json` | Initialization options, code action `data` payloads |
+| `anyhow`, `thiserror` | Error plumbing |
+| `tracing`, `tracing-subscriber` | Logging to file + `window/logMessage` |
+| `rustc-hash` | `FxHashMap` for document/url lookup |
+| `shuck-ast`, `shuck-parser`, `shuck-indexer`, `shuck-linter`, `shuck-formatter` | Analysis pipeline |
+| `shuck-cli` (subset reused via lib re-exports for config discovery) | `.shuck.toml` / `shuck.toml` resolution |
+
+The `shuck-cli` subcommand only adds:
+
+```rust
+// in crates/shuck-cli/src/commands/server.rs
+pub(crate) fn server() -> anyhow::Result<crate::ExitStatus> {
+    shuck_server::run()?;
+    Ok(crate::ExitStatus::Success)
+}
+```
+
+### Process Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Editor (VS Code, Neovim, Helix, ...)                            │
+└──────────────────────────────────────────────────────────────────┘
+                  │ stdin / stdout (JSON-RPC)
+                  ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  IO threads (lsp-server)                                         │
+│  - Reader thread: stdin → connection.receiver                    │
+│  - Writer thread: connection.sender → stdout                     │
+└──────────────────────────────────────────────────────────────────┘
+                  │ Message
+                  ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  Main loop thread (high priority, 2 MiB stack)                   │
+│  - Owns &mut Session                                             │
+│  - Selects on { connection.receiver, main_loop_receiver }        │
+│  - Routes Request / Notification / Response → Task               │
+│  - Runs sync tasks inline                                        │
+│  - Hands background tasks to Scheduler                           │
+└──────────────────────────────────────────────────────────────────┘
+                  │ Task
+                  ▼
+┌─────────────────────────────────┬────────────────────────────────┐
+│ background_pool (≤ N=min(cpus,4)│ fmt_pool (1 thread)            │
+│   threads, default Worker prio) │   formatting requests          │
+│   - diagnostics (pull + push)   │   isolated so a slow format    │
+│   - codeAction / resolve        │   does not block hovers        │
+│   - hover                       │                                │
+│   - executeCommand fix-all      │                                │
+└─────────────────────────────────┴────────────────────────────────┘
+                  │ MainLoopSender::send(Event::SendResponse(...))
+                  ▼
+              (back to main loop, then to writer thread)
+```
+
+The main loop is the only mutator of session state. Background tasks receive
+an immutable `DocumentSnapshot` whose internals are `Arc`-backed, so a
+subsequent local task that updates the document does not invalidate
+in-flight analysis — the snapshot still points at the version it captured.
+This is the same data-race-avoidance pattern that makes synchronous LSP
+servers viable without locks.
+
+### Core Types
+
+```rust
+// crates/shuck-server/src/lib.rs
+pub use edit::{DocumentKey, PositionEncoding, TextDocument};
+pub use server::Server;
+pub use session::{Client, ClientOptions, DocumentQuery, DocumentSnapshot, Session};
+pub use workspace::{Workspace, Workspaces};
+
+pub fn run() -> anyhow::Result<()> { ... }
+```
+
+`Session` holds mutable global state:
+
+```rust
+pub struct Session {
+    index: Index,                                 // documents + per-workspace settings
+    position_encoding: PositionEncoding,
+    global_settings: GlobalClientSettings,
+    resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
+    request_queue: RequestQueue,                  // pending IDs + cancellation tokens
+    shutdown_requested: bool,
+}
+```
+
+`DocumentSnapshot` is the read-only handle background tasks receive:
+
+```rust
+pub struct DocumentSnapshot {
+    resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
+    client_settings: Arc<ClientSettings>,
+    document_ref: DocumentQuery,                  // includes Arc<TextDocument>
+    position_encoding: PositionEncoding,
+}
+
+pub enum DocumentQuery {
+    Text {
+        file_url: Url,
+        document: Arc<TextDocument>,
+        settings: Arc<ShuckSettings>,             // resolved .shuck.toml / shuck.toml for this file
+    },
+}
+```
+
+`TextDocument` is the buffer the server keeps current with did-change edits:
+
+```rust
+pub struct TextDocument {
+    contents: String,
+    index: LineIndex,
+    version: i32,
+    language_id: Option<LanguageId>,
+}
+
+pub enum LanguageId {
+    Bash,
+    Sh,
+    Zsh,
+    Ksh,
+    Other,
+}
+```
+
+`LanguageId` is read from the LSP `did_open` event when the editor sets it
+(`shellscript`, `bash`, `zsh`); shuck falls back to extension- and
+shebang-based detection from `shuck-cli::discover` for files where the
+client did not declare a language.
+
+### Capabilities
+
+The server advertises the following on `initialize`:
+
+| Capability | Value |
+|------------|-------|
+| `positionEncoding` | Negotiated; UTF-8 preferred, UTF-16 fallback (always supported), UTF-32 lowest priority |
+| `textDocumentSync` | `INCREMENTAL`, `openClose: true` |
+| `diagnosticProvider` | `interFileDependencies: false`, `workspaceDiagnostics: false`, `identifier: "Shuck"`, work-done progress on |
+| `documentFormattingProvider` | `true` |
+| `documentRangeFormattingProvider` | `true` |
+| `codeActionProvider` | Kinds: `quickfix`, `source.fixAll.shuck`. `resolveProvider: true` so the editor can defer the heavy edit computation to `codeAction/resolve` |
+| `executeCommandProvider` | Commands: `shuck.applyAutofix`, `shuck.applyFormat`, `shuck.applyDirective`, `shuck.printDebugInformation` |
+| `hoverProvider` | `true` |
+| `workspace.workspaceFolders` | `supported: true`, `changeNotifications: true` |
+
+Pull diagnostics are the modern path; push diagnostics are emitted from
+notification handlers when `resolved_client_capabilities.pull_diagnostics`
+is `false` so older clients still see live errors.
+
+### Request Routing
+
+Requests fan out by method into typed handlers:
+
+| Method | Handler | Schedule |
+|--------|---------|----------|
+| `textDocument/diagnostic` | `DocumentDiagnostic` | Background, Worker |
+| `textDocument/codeAction` | `CodeActions` | Background, Worker |
+| `codeAction/resolve` | `CodeActionResolve` | Background, Worker |
+| `textDocument/formatting` | `Format` | Background, Fmt |
+| `textDocument/rangeFormatting` | `FormatRange` | Background, Fmt |
+| `textDocument/hover` | `Hover` | Background, Worker |
+| `workspace/executeCommand` | `ExecuteCommand` | Sync (mutates state, applies WorkspaceEdit through client) |
+| `shutdown` | `Shutdown` | Sync |
+
+Notifications are always sync because they mutate the index:
+
+| Method | Handler |
+|--------|---------|
+| `textDocument/didOpen` | `DidOpen` |
+| `textDocument/didChange` | `DidChange` |
+| `textDocument/didClose` | `DidClose` |
+| `workspace/didChangeConfiguration` | `DidChangeConfiguration` |
+| `workspace/didChangeWatchedFiles` | `DidChangeWatchedFiles` (reload `ShuckSettings` for the touched workspace) |
+| `workspace/didChangeWorkspaceFolders` | `DidChangeWorkspace` |
+| `$/cancelRequest` | `CancelNotificationHandler` |
+| `exit` | terminates the loop after a previously seen `shutdown` |
+
+A `Task` enum with `Sync(SyncTask)` and `Background(BackgroundTaskBuilder)`
+variants is dispatched by a `Scheduler`. Sync tasks get `&mut Session`;
+background builders get `&Session`, capture an `Arc`-backed snapshot, and
+return a `'static` closure that runs on the chosen pool. The split mirrors
+the read/write distinction without needing locks.
+
+### Document Lifecycle
+
+1. `did_open` registers a `TextDocument` in `Index::documents` keyed by
+   `Url`. Settings for the document are looked up by walking up from the
+   file path to find `.shuck.toml` / `shuck.toml`; results are cached per
+   workspace folder.
+2. `did_change` applies LSP `TextDocumentContentChangeEvent` ranges to the
+   buffer using the negotiated position encoding, recomputes `LineIndex`,
+   and bumps the version.
+3. After every successful sync update, if the client does not support pull
+   diagnostics, the handler immediately publishes diagnostics for the
+   document.
+4. `did_close` removes the entry from the index. Any in-flight background
+   tasks complete against their captured snapshot — they drop the snapshot
+   when finished.
+
+### Diagnostics Pipeline
+
+For both push and pull, the path is the same and runs on the snapshot:
+
+```rust
+fn check(query: &DocumentQuery, encoding: PositionEncoding) -> Vec<Diagnostic> {
+    let settings = query.settings();
+    let source = query.document().contents();
+    let dialect = settings.dialect_for(query.file_url(), query.language_id());
+
+    let parsed = shuck_parser::parser::parse(source, dialect, profile);
+    let indexer = shuck_indexer::Indexer::new(&parsed.file, source);
+    let suppressions = shuck_linter::SuppressionIndex::build(source, &indexer);
+    let analysis = shuck_linter::analyze_file_at_path(
+        &parsed.file,
+        source,
+        &indexer,
+        &settings.linter,
+        Some(&suppressions),
+        query.file_path().as_deref(),
+    );
+
+    analysis.diagnostics
+        .into_iter()
+        .map(|d| to_lsp_diagnostic(d, source, &line_index, encoding, &analysis.fixes))
+        .collect()
+}
+```
+
+Each emitted `lsp_types::Diagnostic` carries:
+
+- `code`: rule code (`SH-NNN`); `code_description.href` when we have a docs
+  URL.
+- `source`: `"shuck"`.
+- `severity`: mapped from `shuck_linter::Severity` (Error, Warning, Info,
+  Hint).
+- `message`: rule message verbatim.
+- `data`: serialized `AssociatedDiagnosticData` so `codeAction/resolve` can
+  look up the fix and the directive insertion edit without re-running
+  analysis:
+
+```rust
+#[derive(Serialize, Deserialize)]
+struct AssociatedDiagnosticData {
+    title: String,
+    code: String,                                 // "SH-001"
+    edits: Vec<lsp_types::TextEdit>,              // empty if no fix
+    directive_edit: Option<lsp_types::TextEdit>,  // appended `# shuck: ignore=SH-NNN`
+    applicability: Applicability,                 // Safe | Unsafe
+}
+```
+
+Spans become `lsp_types::Range` through a `ToRangeExt` helper that converts
+byte offsets into the negotiated position encoding using `LineIndex`.
+
+### Code Actions
+
+Three families are supported:
+
+1. **Quick Fix (per diagnostic).**
+   For each diagnostic with non-empty `edits`, emit a
+   `CodeActionKind::QUICKFIX` action whose title is
+   `"Shuck (SH-NNN): {fix_title}"`. Unsafe fixes are emitted only if
+   `client_settings.unsafe_fixes` is true (default `false`, parallel to
+   `shuck check --unsafe-fixes`).
+
+2. **Insert directive (per diagnostic).**
+   For each diagnostic, emit a `CodeActionKind::QUICKFIX` action whose
+   edit is `directive_edit`. Directive shape follows the existing
+   `shuck check --add-ignore` behavior:
+   - If no suppression directive is on the line, append a new inline
+     comment `# shuck: ignore=SH-NNN`.
+   - If a `# shuck: ignore=...` or `# shellcheck disable=...` directive is
+     already on the line, merge the new code into the existing list,
+     preserving the directive's source style (shuck stays shuck,
+     ShellCheck stays ShellCheck) and any trailing reason comment.
+   - Trailing carriage returns are preserved when rewriting an existing
+     directive.
+   Title format: `"Shuck (SH-NNN): Disable for this line"`. The actual
+   edit is produced by reusing `shuck_linter::add_ignores_to_path`'s
+   `build_ignore_edit` helper, lifted out of the file-rewriting wrapper
+   so the LSP can call it against the in-memory buffer.
+
+3. **Fix all (source action).**
+   `CodeActionKind` is `source.fixAll.shuck`. Computes the merged
+   `WorkspaceEdit` of every safe fix in the document. If the client
+   supports deferred resolve (`code_action_deferred_edit_resolution`), the
+   action is returned without an `edit`, with a `data: Url` payload, and
+   the editor calls `codeAction/resolve` to fetch it.
+
+A `WorkspaceEditTracker` deduplicates per-URL edits and produces either
+`documentChanges` or the legacy `changes` map based on client capabilities.
+
+The directive insertion path lives in `shuck-linter` (alongside the
+existing `add_ignores_to_path`) so the LSP and CLI share one source of
+truth for placement rules, code merging, and shuck/ShellCheck directive
+recognition.
+
+### Hover
+
+Triggered on `textDocument/hover`. The handler:
+
+1. Snapshots the document, looks at the line under the cursor.
+2. Reuses `shuck_linter::parse_directives` to recognize either form on
+   that line — `# shuck: disable=...`, `# shuck: disable-file=...`,
+   `# shuck: ignore=...`, or `# shellcheck disable=...`.
+3. Locates the rule code under the cursor: shuck-native `SH-NNN` or
+   ShellCheck-style `SCNNNN`. ShellCheck codes are resolved through
+   `ShellCheckCodeMap` to the corresponding shuck rule when one exists.
+4. Looks up rule metadata via `shuck_linter::rule_metadata_by_code`.
+5. Returns Markdown of the form:
+
+   ```
+   # {Rule Name} ({Code})
+
+   {message}
+
+   {fix availability badge}
+
+   {explanation}
+
+   See also: SC2086 (mapped ShellCheck rule)
+   ```
+
+If no directive is on the line, hover returns `None`. Hover content for
+shell builtins or expansions is explicitly out of scope until shuck has
+semantic data to back it.
+
+### Formatting
+
+Both `documentFormatting` and `documentRangeFormatting` route to the
+`fmt_pool`. Implementation:
+
+1. Resolve the formatter settings from `ShuckSettings`.
+2. Call `shuck_formatter::format_source` against the buffer.
+3. Diff the formatted result against the source using the existing
+   `Replacement` helper to emit a single minimal `TextEdit` (or a per-range
+   edit). The minimal-replacement strategy avoids "everything is changed"
+   gutters in clients that color the diff.
+
+If the document is excluded by the formatter's exclude patterns, the
+handler returns an empty edit list rather than an error.
+
+### Settings Resolution
+
+Shuck already has a layered config story for the CLI: `.shuck.toml` /
+`shuck.toml` is discovered from disk, and CLI `--config k=v` flags are
+applied as overrides on top of the discovered config (see
+`ConfigArguments::apply_overrides`). The LSP uses that same model with
+`ClientOptions` filling the role `--config` plays in the CLI.
+
+1. **Discovered config.** When a document opens, the server walks up from
+   the document's path to find the nearest `.shuck.toml` / `shuck.toml`,
+   parses it through the existing `shuck-cli::config` loader, and caches
+   the resolved `ShuckConfig` in a per-workspace `ShuckSettingsIndex`.
+
+2. **Client overrides.** LSP `initializationOptions.shuck` (and dynamic
+   `workspace/configuration` responses on
+   `workspace/didChangeConfiguration`) deserialize into `ClientOptions`,
+   which carries the same fields the on-disk config exposes plus a few
+   editor-only knobs:
+
+   ```rust
+   #[derive(Deserialize, Default)]
+   #[serde(rename_all = "camelCase")]
+   pub struct ClientOptions {
+       // Maps onto fields ShuckConfig already understands
+       lint: Option<LintOptions>,        // select / extend_select / ignore / preview
+       format: Option<FormatOptions>,    // preview, line_length
+       exclude: Option<Vec<String>>,
+
+       // Editor-only behavior
+       fix_all: Option<bool>,            // enable source.fixAll.shuck
+       unsafe_fixes: Option<bool>,       // include unsafe fixes in code actions
+       show_syntax_errors: Option<bool>, // surface parser errors as diagnostics
+   }
+   ```
+
+   The `lint`/`format`/`exclude` portions are converted into a partial
+   `ShuckConfig` and applied through the same `apply_overrides` path the
+   CLI uses. The result is the per-document `ShuckSettings` stored on the
+   `DocumentQuery`.
+
+The config-file watcher is registered dynamically on `initialize` if the
+client supports `workspace.didChangeWatchedFiles.dynamicRegistration`.
+Watched globs:
+
+```
+**/.shuck.toml
+**/shuck.toml
+```
+
+A `didChangeWatchedFiles` event triggers `Index::reload_settings`, which
+re-parses the affected files and refreshes the workspace's
+`ShuckSettingsIndex`. Open documents pick up the new settings on the next
+analysis.
+
+### Cancellation
+
+`Session::request_queue` tracks every incoming request ID with a
+`CancellationToken`. Background tasks check the token both before scheduling
+(in the builder) and inside the work closure before responding. A
+`$/cancelRequest` notification flips the token and immediately responds
+with `RequestCancelled`, so the eventual handler completion is dropped.
+
+### Panic Safety
+
+A panic hook installed at `Server::run` time:
+
+1. Logs `panic_info` and a backtrace via `tracing::error!`.
+2. Writes the same to `stderr` directly (in case logging is not yet wired).
+3. Sends a `window/showMessage` of severity `Error` to the client so the
+   user sees that the server failed.
+
+Background handlers wrap the work closure in `std::panic::catch_unwind` and
+convert a panic into an `InternalError` response. The main loop itself does
+not unwind unless something goes catastrophically wrong with the channel.
+
+### `shuck.applyAutofix` and Friends
+
+The execute-command handler is sync because applying a workspace edit
+requires sending a `workspace/applyEdit` request to the client, awaiting
+its response, and updating the index when the edit lands. Supported
+commands:
+
+| Command | Behavior |
+|---------|----------|
+| `shuck.applyAutofix` | Compute fix-all edits for the given document URI and send `workspace/applyEdit` |
+| `shuck.applyFormat` | Run the formatter and send `workspace/applyEdit` |
+| `shuck.applyDirective` | Insert a `# shuck: ignore=CODE` directive for the given diagnostic, merging into an existing shuck or ShellCheck directive on the line if one is present (used when the editor wants a one-shot command instead of a code action) |
+| `shuck.printDebugInformation` | Log session state (open docs, workspaces, settings) to the trace channel; useful for bug reports |
+
+### Logging
+
+Two sinks:
+
+- **`tracing-subscriber`** to a per-session log file path (default off,
+  enabled by `shuck.tracing.logFile`). Levels are configurable via
+  `shuck.tracing.logLevel` (`error` | `warn` | `info` | `debug` | `trace`).
+- **`window/logMessage`** for warnings/errors the user should see; tied
+  through the existing `Client` wrapper.
+
+Filtered output keeps `lsp-server` and `lsp-types` noise out of `info`
+logs.
+
+## Alternatives Considered
+
+### Use `tower-lsp`
+
+`tower-lsp` provides an `async` framework with batteries included and is
+well-known in the Rust LSP world. We reject it because the scheduler does
+not give the linter the read/write contract this design needs. The
+project's analysis pipeline is synchronous and CPU-bound; coercing it
+through `async` adds runtime cost without unlocking concurrency we cannot
+already get from a thread pool. Known scheduler bugs in the framework also
+introduce out-of-order handler execution that can race with mutable state.
+A direct `lsp-server` + `lsp-types` loop with an explicit local/background
+split avoids all of that and matches the architecture proven by other
+high-throughput Rust LSPs.
+
+### Spawn `shuck check --watch` and parse JSON
+
+`shuck check` already supports `--watch` and JSON output. We could shim
+that into LSP through a generic linter bridge. We reject this for three
+reasons: process startup per workspace remains expensive; JSON output
+loses the directive-edit and fix payloads needed for code actions; and
+hover, formatting, and pull diagnostics cannot be expressed at all
+through a one-shot CLI run. A dedicated LSP server is the only way to get
+parity with editor expectations.
+
+### Reuse `shuck-cache` for in-memory documents
+
+`shuck-cache` stores analysis results keyed by file mtime and permissions.
+Open buffers in an editor are unsaved most of the time and would never
+match a cache key, so every analysis would still run from scratch — the
+cache adds I/O without reducing work. Background tasks already capture
+`Arc`-backed snapshots, which is the right granularity for in-memory
+incremental analysis. The on-disk cache continues to serve `shuck check`
+unchanged.
+
+### Single global thread pool
+
+A single shared pool would simplify the scheduler at the cost of head-of-
+line blocking: a slow format request could starve a hover or diagnostic
+that the user is actively waiting on. Splitting the formatting pool from
+the worker pool keeps interactive paths responsive even when a large
+file is being formatted.
+
+### Push diagnostics only
+
+Push-only is simpler but loses the work-done progress reporting and
+explicit refresh control that pull diagnostics provide. Pull diagnostics
+are also where the LSP ecosystem is moving. We support both: pull where
+the client opts in, push as a fallback so older clients still light up.
+
+### Embedded scripts in v1
+
+Supporting GitHub Actions and composite actions in the LSP requires
+extracting embedded scripts from YAML, mapping diagnostics back through
+`shuck-extract`'s position remapper, and answering surprising questions
+about how to serve formatting on extracted ranges. The plumbing exists,
+but the LSP integration is large enough to deserve its own design pass
+once the file-level server is stable.
+
+## Security Considerations
+
+- The server reads from `stdin` and writes to `stdout`. It does not bind
+  to a network port and never accepts connections from anywhere else.
+- It reads files from disk only inside workspace folders the client
+  declares, plus their parent directories during `.shuck.toml` /
+  `shuck.toml` discovery.
+  The discovery walk stops at filesystem roots and at workspace bounds.
+- Configuration files are parsed with the existing TOML loader, which
+  rejects unknown fields and bounds string lengths the same way
+  `shuck check` does.
+- `executeCommand` only runs the four commands enumerated above. There is
+  no shell-out, no arbitrary command execution, and no `eval` of
+  client-provided strings.
+- Panic backtraces are sent to the client log channel; they may contain
+  fragments of source text under analysis. This is the same exposure the
+  CLI already has when it panics.
+
+## Verification
+
+Build and unit:
+
+- `cargo build -p shuck-server`
+- `cargo test -p shuck-server`
+- `cargo clippy -p shuck-server --all-targets -- -D warnings`
+
+Unit tests live next to each handler and exercise:
+
+- A markdown / non-shell document returns no diagnostics, no code actions,
+  and no hover (mirrors `shuck check`'s file filter).
+- A shell document with a known violation returns a diagnostic carrying a
+  fix and a directive edit; the matching `codeAction` request returns at
+  least one `quickfix` action.
+- `codeAction/resolve` reconstructs the same edit the unresolved action
+  promised.
+- Range formatting on a buffer that is already formatted returns an empty
+  edit list rather than a no-op replacement.
+- Hover over a rule code inside `# shuck: ignore=SH-NNN` or
+  `# shellcheck disable=SCNNNN` returns Markdown that includes the rule
+  name and a fix-availability marker.
+- A `did_change` followed by a `cancelRequest` for the in-flight diagnostic
+  drops the response without writing to the wire.
+
+Integration:
+
+- A scripted manual test harness (`crates/shuck-server/tests/manual/`)
+  runs the server against a staged workspace and replays a recorded LSP
+  session, asserting on the JSON-RPC transcript.
+- Manual smoke tests in VS Code (with the existing extension shim) and
+  Neovim (`nvim-lspconfig`) covering: open file, edit, save, quick fix,
+  fix all, format on save, hover.
+
+Performance:
+
+- `cargo bench -p shuck-benchmark --bench check_command` continues to
+  pass; the LSP path reuses the same analysis crates and must not regress.
+- A latency check that asserts pull-diagnostics round-trip on a 5 KiB
+  script completes in under 50 ms on a developer machine. Numbers are
+  recorded in `crates/shuck-server/tests/perf.md` rather than committed
+  as a hard threshold.
+
+The server is correct when an editor session shows the same diagnostics,
+in the same spans, with the same applicable fixes, as
+`shuck check --output-format json` for the same buffer contents.


### PR DESCRIPTION
## Summary

- Adds `specs/018-lsp.md` (Accepted) describing a `shuck server` LSP that reuses the existing parser, indexer, linter, and formatter against in-memory document state.
- Architecture is a synchronous `lsp-server` + `lsp-types` event loop with a worker thread pool plus a dedicated format pool, mirroring the local-vs-background task split that keeps mutable session state lock-free.
- Capabilities in v1: pull and push diagnostics, code actions (quick fix, `source.fixAll.shuck`, directive insertion), full and range formatting, hover over rule codes, executeCommand. Embedded scripts, notebooks, and cross-file analysis are explicitly deferred.
- Directive insertion emits `# shuck: ignore=SH-NNN` and merges into an existing `# shuck:` or `# shellcheck` directive on the line, sharing logic with `shuck check --add-ignore`.
- Settings flow: discovered `.shuck.toml` / `shuck.toml` is the base; LSP `ClientOptions` apply as overrides through the same `apply_overrides` path the CLI uses for `--config`. No new precedence concept, no on-disk cache reuse.

## Test plan

- [ ] Spec reviewed for scope, alternatives, and verification steps
- [ ] Decision on whether to land this and start scaffolding `crates/shuck-server` in a follow-up PR