### PR TITLE
fix(parser): parse zsh $+name subscripts

### DIFF
--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -975,6 +975,48 @@ fn test_zsh_unbraced_array_access_inside_double_quotes_stays_nested() {
 }
 
 #[test]
+fn test_zsh_unbraced_parameter_set_probe_array_access_parses_as_array_access() {
+    let input = "print -r -- $+ice[extract]\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let AstCommand::Simple(command) = &script.body[0].command else {
+        panic!("expected simple command");
+    };
+    let reference = expect_array_access(&command.args[2]);
+    assert_eq!(reference.name.as_str(), "+ice");
+    expect_subscript(reference, input, "extract");
+    assert_eq!(command.args[2].render_syntax(input), "$+ice[extract]");
+}
+
+#[test]
+fn test_zsh_unbraced_parameter_set_probe_array_access_in_conditionals_stays_nested() {
+    let source = "[[ $+ice[extract] -ne 0 ]]\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let (compound, redirects) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional command");
+    };
+
+    assert!(redirects.is_empty());
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Word(left) = binary.left.as_ref() else {
+        panic!("expected word lhs");
+    };
+    let reference = expect_array_access(left);
+    assert_eq!(reference.name.as_str(), "+ice");
+    expect_subscript(reference, source, "extract");
+    assert_eq!(left.render_syntax(source), "$+ice[extract]");
+}
+
+#[test]
 fn test_substring_and_array_slice_attach_arithmetic_companion_asts() {
     let input = "echo ${s:i+1:len*2} ${arr[@]:i:j}\n";
     let script = Parser::new(input).parse().unwrap().file;
@@ -3800,6 +3842,22 @@ fn test_parse_zsh_arithmetic_command_keeps_subscripted_shell_words_intact() {
     };
     let second_expr = second.expr_ast.as_ref().expect("expected arithmetic AST");
     expect_shell_word(second_expr, input, "$cmdnames[(Ie)$point]");
+}
+
+#[test]
+fn test_parse_zsh_arithmetic_command_keeps_parameter_set_probe_shell_words_intact() {
+    let input = "(( $+ice[extract] ))\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Arithmetic(command) = compound else {
+        panic!("expected arithmetic compound command");
+    };
+    let expr = command.expr_ast.as_ref().expect("expected arithmetic AST");
+    expect_shell_word(expr, input, "$+ice[extract]");
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4923,9 +4923,20 @@ impl<'a> Parser<'a> {
                     );
                     current_start = cursor;
                 } else {
-                    let var_name = Self::read_word_while(&mut chars, &mut cursor, |c| {
+                    let mut var_name = String::new();
+                    if self.dialect == ShellDialect::Zsh && chars.peek() == Some(&'+') {
+                        let mut lookahead = chars.clone();
+                        lookahead.next();
+                        if lookahead
+                            .peek()
+                            .is_some_and(|next| next.is_ascii_alphanumeric() || *next == '_')
+                        {
+                            var_name.push(Self::next_word_char_unwrap(&mut chars, &mut cursor));
+                        }
+                    }
+                    var_name.push_str(&Self::read_word_while(&mut chars, &mut cursor, |c| {
                         c.is_ascii_alphanumeric() || c == '_'
-                    });
+                    }));
                     if !var_name.is_empty() {
                         let part = if self.dialect == ShellDialect::Zsh
                             && Self::consume_word_char_if(&mut chars, &mut cursor, '[')


### PR DESCRIPTION
## Summary
- parse unbraced zsh parameter-set probe subscripts like `$+ice[extract]` as a single parameter access
- add parser regressions for word, conditional, and arithmetic contexts
- keep the local zsh bug tracker doc out of this PR

## Testing
- cargo test -p shuck-parser zsh_unbraced_ -- --nocapture
- cargo test -p shuck-parser test_parse_zsh_arithmetic_command_keeps_parameter_set_probe_shell_words_intact -- --nocapture