### PR TITLE
feat(website): add real-world repo benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-large-corpus-hotspots bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view profile-large-corpus profile-large-corpus-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
+.PHONY: build test run check check-scripts setup-hooks setup-large-corpus ensure-cache test-large-corpus large-corpus-report large-corpus-report-from-log large-corpus-report-open test-oracle-shfmt test-oracle-shfmt-fixtures test-oracle-shfmt-benchmark test-oracle-shellcheck-cli fuzz-setup fuzz-list fuzz-smoke fuzz-run fuzz-cli bench bench-save bench-compare bench-parser bench-arithmetic bench-lexer bench-semantic bench-linter bench-formatter bench-large-corpus-hotspots bench-macro bench-macro-single bench-macro-format bench-macro-format-summary bench-macro-format-single bench-macro-site-local bench-repo-corpus profile-parser profile-parser-view profile-arithmetic profile-arithmetic-view profile-formatter profile-formatter-view profile-linter profile-linter-view profile-cli profile-cli-view profile-large-corpus profile-large-corpus-view flame-parser flame-arithmetic flame-formatter flame-linter flame-cli harden-release check-release-security
 
 ARGS ?= --help
 BENCH_FILE ?=
@@ -193,6 +193,20 @@ bench-macro:
 
 bench-macro-site-local: bench-macro
 	$(NIX_DEVELOP) python3 ./scripts/benchmarks/export_website_data.py --repo-root . --bench-dir "$(BENCHMARK_WEBSITE_BENCH_DIR)" --output "$(BENCHMARK_WEBSITE_LOCAL_OUTPUT)" --dataset-id local-m5-max --dataset-name "Apple M5 Max checked-in snapshot" --dataset-description "Checked-in make bench-macro results captured on an Apple M5 Max macOS development machine." --environment-kind local --environment-label "Apple M5 Max macOS snapshot" --notes "Regenerate this checked-in snapshot on the Apple M5 Max machine when you want to refresh the website's local reference numbers."
+
+bench-repo-corpus: ensure-cache
+	cargo build --release -p shuck-cli
+	$(NIX_DEVELOP) ./scripts/benchmarks/run_repo_corpus.sh
+	$(NIX_DEVELOP) python3 ./scripts/benchmarks/export_repo_corpus.py \
+		--repo-root . \
+		--bench-dir .cache/repo-corpus \
+		--manifest .cache/large-corpus/manifest.yaml \
+		--output website/generated/benchmarks/repo-corpus-local.json \
+		--dataset-id repo-corpus-local \
+		--dataset-name "Repo-corpus snapshot (local)" \
+		--dataset-description "Whole-repo benchmarks against curated open-source repositories cloned at pinned commits." \
+		--environment-kind local \
+		--notes "Each repo is shallow-cloned at the SHA in .cache/large-corpus/manifest.yaml so source-following, project-root resolution, and any in-tree .shellcheckrc behave the way they would for an end user. Both tools receive the same filelist (extension match for *.sh / *.bash / *.ksh plus extensionless executables with shell shebangs; symlinks and *.zsh excluded). shellcheck runs without -x, matching its default behavior."
 
 bench-macro-single:
 	test -n "$(BENCH_FILE)"

--- a/scripts/benchmarks/export_repo_corpus.py
+++ b/scripts/benchmarks/export_repo_corpus.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Aggregate per-repo hyperfine results into a website-friendly JSON dataset.
+
+Reads the directory produced by ``scripts/benchmarks/run_repo_corpus.sh`` plus
+``manifest.yaml`` from the large corpus cache, and emits a single dataset JSON
+that the website ``benchmarks.tsx`` page consumes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument(
+        "--bench-dir",
+        type=Path,
+        required=True,
+        help="Directory containing per-repo subdirectories with bench.json + meta.json.",
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        required=True,
+        help="Path to .cache/large-corpus/manifest.yaml",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--dataset-id", required=True)
+    parser.add_argument("--dataset-name", required=True)
+    parser.add_argument("--dataset-description", required=True)
+    parser.add_argument(
+        "--environment-kind", choices=("local", "ci"), default="local"
+    )
+    parser.add_argument("--environment-label", default="")
+    parser.add_argument(
+        "--source-command", default="make bench-repo-corpus"
+    )
+    parser.add_argument("--notes", default="")
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--measured-runs", type=int, default=3)
+    return parser.parse_args()
+
+
+def run_capture(args: list[str], cwd: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=cwd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout.strip()
+
+
+def read_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def detect_cpu() -> str | None:
+    system = platform.system()
+    if system == "Darwin":
+        return run_capture(
+            ["sysctl", "-n", "machdep.cpu.brand_string"], cwd=Path.cwd()
+        ) or None
+    if system == "Linux":
+        cpuinfo = Path("/proc/cpuinfo")
+        if cpuinfo.exists():
+            for line in cpuinfo.read_text(errors="replace").splitlines():
+                if line.lower().startswith("model name"):
+                    return line.partition(":")[2].strip() or None
+    return platform.processor() or None
+
+
+def detect_os_label() -> str:
+    system = platform.system()
+    if system == "Darwin":
+        version = platform.mac_ver()[0] or platform.release()
+        return f"macOS {version}"
+    if system == "Linux":
+        os_release = Path("/etc/os-release")
+        if os_release.exists():
+            for line in os_release.read_text(errors="replace").splitlines():
+                if line.startswith("PRETTY_NAME="):
+                    return line.partition("=")[2].strip().strip('"')
+        return f"Linux {platform.release()}"
+    return platform.platform()
+
+
+def parse_manifest(manifest_path: Path) -> dict[str, dict[str, str]]:
+    """Parse the simple two-level YAML the corpus downloader emits.
+
+    Returns a mapping ``{ "owner/name": { "commit": ..., "date": ... } }``.
+    """
+    text = manifest_path.read_text(errors="replace")
+    repos: dict[str, dict[str, str]] = {}
+    current: dict[str, str] | None = None
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line or line.startswith("#"):
+            continue
+        match = re.match(r"^\s*-\s*repo:\s*(\S+)\s*$", line)
+        if match:
+            current = {"repo": match.group(1)}
+            repos[match.group(1)] = current
+            continue
+        if current is None:
+            continue
+        kv = re.match(r"^\s+(\w+):\s*(\S.*)$", line)
+        if kv:
+            current[kv.group(1)] = kv.group(2).strip()
+    return repos
+
+
+def detect_shuck_version(repo_root: Path) -> str | None:
+    target_dir = Path(os.environ.get("CARGO_TARGET_DIR", repo_root / "target"))
+    shuck_bin = Path(
+        os.environ.get(
+            "SHUCK_BENCHMARK_SHUCK_BIN", target_dir / "release" / "shuck"
+        )
+    )
+    if shuck_bin.exists():
+        out = run_capture([str(shuck_bin), "--version"], cwd=repo_root)
+        if out:
+            return out.splitlines()[0].strip()
+
+    workspace_toml = repo_root / "Cargo.toml"
+    if workspace_toml.exists():
+        match = re.search(
+            r"(?ms)^\[workspace\.package\]\s+version\s*=\s*\"([^\"]+)\"",
+            workspace_toml.read_text(errors="replace"),
+        )
+        if match:
+            return f"shuck {match.group(1)}"
+    return None
+
+
+def detect_repository_url(repo_root: Path) -> str | None:
+    env_repo = os.environ.get("GITHUB_REPOSITORY")
+    env_server = os.environ.get("GITHUB_SERVER_URL", "https://github.com")
+    if env_repo:
+        return f"{env_server.rstrip('/')}/{env_repo}"
+    remote = run_capture(["git", "config", "--get", "remote.origin.url"], cwd=repo_root)
+    if not remote:
+        return None
+    if remote.startswith("git@github.com:"):
+        remote = "https://github.com/" + remote.removeprefix("git@github.com:")
+    elif remote.startswith("ssh://git@github.com/"):
+        remote = "https://github.com/" + remote.removeprefix("ssh://git@github.com/")
+    remote = re.sub(r"\.git$", "", remote)
+    return remote if remote.startswith("https://github.com/") else None
+
+
+def make_measurement(
+    tool: str, result: dict[str, Any], shuck_mean: float | None
+) -> dict[str, Any]:
+    times = [float(value) for value in result.get("times", [])]
+    memory_usage = [int(value) for value in result.get("memory_usage_byte", [])]
+    exit_codes = sorted({int(code) for code in result.get("exit_codes", [])})
+    mean_seconds = float(result["mean"])
+
+    relative_to_shuck = None
+    if shuck_mean and shuck_mean > 0.0:
+        relative_to_shuck = mean_seconds / shuck_mean
+
+    return {
+        "tool": tool,
+        "command": str(result.get("command", "")),
+        "meanSeconds": mean_seconds,
+        "stddevSeconds": float(result.get("stddev", 0.0)),
+        "medianSeconds": float(result.get("median", mean_seconds)),
+        "minSeconds": float(result.get("min", mean_seconds)),
+        "maxSeconds": float(result.get("max", mean_seconds)),
+        "userSeconds": float(result.get("user", 0.0)),
+        "systemSeconds": float(result.get("system", 0.0)),
+        "meanMemoryBytes": int(sum(memory_usage) / len(memory_usage))
+        if memory_usage
+        else None,
+        "maxMemoryBytes": max(memory_usage) if memory_usage else None,
+        "runCount": len(times) or len(result.get("exit_codes", [])),
+        "exitCodes": exit_codes,
+        "hasFailures": any(code != 0 for code in exit_codes),
+        "relativeToShuck": relative_to_shuck,
+    }
+
+
+def load_repo_cases(
+    bench_dir: Path, manifest: dict[str, dict[str, str]]
+) -> list[dict[str, Any]]:
+    cases: list[dict[str, Any]] = []
+    if not bench_dir.exists():
+        return cases
+
+    for entry in sorted(bench_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        meta_path = entry / "meta.json"
+        bench_path = entry / "bench.json"
+        if not meta_path.exists() or not bench_path.exists():
+            continue
+
+        meta = read_json(meta_path)
+        results = list(read_json(bench_path).get("results", []))
+
+        shuck_result = next(
+            (r for r in results if "shuck" in str(r.get("command", ""))
+             and "shellcheck" not in str(r.get("command", "")).split()[0]),
+            None,
+        )
+        comparison_result = next(
+            (r for r in results if "shellcheck" in str(r.get("command", ""))),
+            None,
+        )
+
+        shuck_mean = float(shuck_result["mean"]) if shuck_result else None
+        measurements: list[dict[str, Any]] = []
+        if shuck_result is not None:
+            measurements.append(make_measurement("shuck", shuck_result, shuck_mean))
+        if comparison_result is not None:
+            measurements.append(
+                make_measurement("shellcheck", comparison_result, shuck_mean)
+            )
+
+        repo_name = meta["repo"]
+        manifest_entry = manifest.get(repo_name, {})
+        # Prefer the SHA the bench script actually checked out; fall back to
+        # the manifest pin when older meta files lack it.
+        commit = meta.get("commit") or manifest_entry.get("commit")
+        commit_short = (
+            meta.get("commitShort")
+            or (commit[:7] if commit else None)
+        )
+        repo_url = f"https://github.com/{repo_name}"
+        commit_url = f"{repo_url}/commit/{commit}" if commit else None
+
+        cases.append(
+            {
+                "slug": meta["repoKey"],
+                "repo": repo_name,
+                "fileCount": int(meta["fileCount"]),
+                "availableFileCount": int(meta.get("availableFileCount", meta["fileCount"])),
+                "truncated": bool(meta.get("truncated", False)),
+                "truncateLimit": int(meta.get("truncateLimit", 0)) or None,
+                "totalBytes": int(meta["totalBytes"]),
+                "totalLines": int(meta["totalLines"]),
+                "commit": commit,
+                "commitShort": commit_short,
+                "captureDate": manifest_entry.get("date"),
+                "repoUrl": repo_url,
+                "commitUrl": commit_url,
+                "measurements": measurements,
+            }
+        )
+    return cases
+
+
+def build_summary(cases: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not cases:
+        return None
+    total_shuck = 0.0
+    total_comparison = 0.0
+    total_files = 0
+    total_lines = 0
+    for case in cases:
+        shuck = next((m for m in case["measurements"] if m["tool"] == "shuck"), None)
+        comparison = next(
+            (m for m in case["measurements"] if m["tool"] != "shuck"), None
+        )
+        if not shuck or not comparison:
+            continue
+        total_shuck += shuck["meanSeconds"]
+        total_comparison += comparison["meanSeconds"]
+        total_files += case["fileCount"]
+        total_lines += case["totalLines"]
+
+    speedup = (
+        total_comparison / total_shuck
+        if total_shuck > 0
+        else None
+    )
+    return {
+        "repoCount": len(cases),
+        "totalFiles": total_files,
+        "totalLines": total_lines,
+        "shuckTotalSeconds": total_shuck,
+        "comparisonTotalSeconds": total_comparison,
+        "speedupRatio": speedup,
+    }
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with NamedTemporaryFile(
+        "w", encoding="utf-8", delete=False, dir=path.parent
+    ) as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+        temp_path = Path(handle.name)
+    temp_path.replace(path)
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    bench_dir = args.bench_dir.resolve()
+
+    manifest = parse_manifest(args.manifest.resolve())
+    cases = load_repo_cases(bench_dir, manifest)
+    summary = build_summary(cases)
+
+    cpu = detect_cpu()
+    generated_at = (
+        datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+    )
+
+    repository_url = detect_repository_url(repo_root)
+    commit_sha = run_capture(["git", "rev-parse", "HEAD"], cwd=repo_root)
+    commit_short = commit_sha[:7] if commit_sha else None
+    commit_url = (
+        f"{repository_url}/commit/{commit_sha}" if repository_url and commit_sha else None
+    )
+
+    shuck_version = detect_shuck_version(repo_root)
+    hyperfine_version = (
+        run_capture(["hyperfine", "--version"], cwd=repo_root) or ""
+    ).splitlines()[0:1]
+    shellcheck_raw = run_capture(["shellcheck", "--version"], cwd=repo_root) or ""
+    shellcheck_version = None
+    for line in shellcheck_raw.splitlines():
+        if line.lower().startswith("version:"):
+            shellcheck_version = line.partition(":")[2].strip()
+            break
+
+    environment_label = args.environment_label.strip()
+    if not environment_label:
+        if args.environment_kind == "local" and cpu:
+            environment_label = f"{cpu} local snapshot"
+        else:
+            environment_label = "Repo-corpus snapshot"
+
+    payload = {
+        "schemaVersion": 1,
+        "available": bool(cases),
+        "id": args.dataset_id,
+        "name": args.dataset_name,
+        "description": args.dataset_description,
+        "generatedAt": generated_at,
+        "commit": {"sha": commit_sha, "shortSha": commit_short},
+        "links": {
+            "repositoryUrl": repository_url,
+            "commitUrl": commit_url,
+            "runUrl": None,
+        },
+        "environment": {
+            "kind": args.environment_kind,
+            "label": environment_label,
+            "os": detect_os_label(),
+            "arch": platform.machine(),
+            "cpu": cpu,
+            "python": platform.python_version(),
+        },
+        "toolVersions": {
+            "shuck": shuck_version,
+            "hyperfine": hyperfine_version[0] if hyperfine_version else None,
+            "shellcheck": shellcheck_version,
+        },
+        "methodology": {
+            "benchmarkCommand": args.source_command,
+            "warmupRuns": args.warmup_runs,
+            "measuredRuns": args.measured_runs,
+            "shuckCommand": "xargs shuck check --no-cache --select ALL <filelist>",
+            "comparisonCommand": "xargs shellcheck --enable=all --severity=style <filelist>",
+            "notes": args.notes or None,
+        },
+        "summary": summary,
+        "cases": cases,
+    }
+
+    write_json_atomic(args.output.resolve(), payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmarks/run_repo_corpus.sh
+++ b/scripts/benchmarks/run_repo_corpus.sh
@@ -1,0 +1,275 @@
+#!/bin/sh
+# Clone curated upstream repos and benchmark shuck vs shellcheck on the
+# real on-disk layout (so source-following, project root resolution, and
+# .shellcheckrc handling all behave the way they would for an end user).
+#
+# For each repo:
+#   1. Clone (shallow) into $clone_dir/<repo_key>/, pinned to the SHA from
+#      .cache/large-corpus/manifest.yaml when fetchable, else default HEAD.
+#   2. Enumerate shell scripts via `git ls-files`: extension match for
+#      *.sh, *.bash, *.ksh, plus extensionless executables whose first
+#      line is a recognized shell shebang. Excludes *.zsh and any path
+#      with whitespace.
+#   3. Run hyperfine with shuck and shellcheck pointed at the same filelist.
+#
+# Outputs go under .cache/repo-corpus/<owner>__<name>/{filelist.txt,bench.json,meta.json}.
+#
+# Environment overrides:
+#   SHUCK_BENCH_REPO_TRUNCATE   max files per repo (default 4000)
+#   SHUCK_BENCH_REPO_WARMUP     hyperfine warmup runs (default 1)
+#   SHUCK_BENCH_REPO_RUNS       hyperfine measured runs (default 3)
+#   SHUCK_BENCH_REPO_REPOS      override the repo list (newline-separated)
+#   SHUCK_BENCHMARK_REPO_CLONE_DIR  where to cache clones (default $TMPDIR/shuck-bench-repos)
+#   SHUCK_BENCHMARK_MANIFEST    manifest path for SHA pinning (optional)
+set -eu
+
+repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)}
+manifest_file=${SHUCK_BENCHMARK_MANIFEST:-"$repo_root/.cache/large-corpus/manifest.yaml"}
+# Cache clones in $HOME so reruns reuse them. We deliberately don't follow
+# $TMPDIR — nix develop overrides it to a per-session path, which would
+# force a re-clone on every invocation. Avoid any path containing `.cache`
+# as a component: shuck's discovery layer hardcodes that as ignored, so
+# cloning under e.g. `~/.cache/shuck-bench-repos` would silently filter
+# every file out of the bench.
+clone_dir=${SHUCK_BENCHMARK_REPO_CLONE_DIR:-"$HOME/.shuck-bench-repos"}
+target_dir=${CARGO_TARGET_DIR:-"$repo_root/target"}
+shuck_bin=${SHUCK_BENCHMARK_SHUCK_BIN:-"$target_dir/release/shuck"}
+out_dir=${SHUCK_BENCHMARK_REPO_OUTPUT_DIR:-"$repo_root/.cache/repo-corpus"}
+truncate_limit=${SHUCK_BENCH_REPO_TRUNCATE:-4000}
+warmup=${SHUCK_BENCH_REPO_WARMUP:-1}
+runs=${SHUCK_BENCH_REPO_RUNS:-3}
+
+if [ ! -x "$shuck_bin" ]; then
+    echo "Error: shuck binary not found at $shuck_bin" >&2
+    echo "Run 'cargo build --release -p shuck-cli' first." >&2
+    exit 1
+fi
+
+for tool in hyperfine shellcheck git; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Error: $tool not found on PATH" >&2
+        exit 1
+    fi
+done
+
+default_repos="
+SlackBuildsOrg/slackbuilds
+bitnami/containers
+acmesh-official/acme.sh
+v1s1t0r1sh3r3/airgeddon
+Bash-it/bash-it
+nvm-sh/nvm
+super-linter/super-linter
+bats-core/bats-core
+dylanaraps/neofetch
+"
+# Repos intentionally not benched here:
+# - alpinelinux/aports: scripts are APKBUILD files (extensionless, sourced
+#   without shebangs) so our discovery picks up only a handful of helper
+#   .sh scripts and the bench measures almost nothing.
+# - CISOfy/lynis: same shape. Logic lives in non-executable extensionless
+#   files under include/ which fail the shebang gate.
+repos=${SHUCK_BENCH_REPO_REPOS:-$default_repos}
+
+# Look up a repo's pinned commit SHA in the manifest. The manifest is the
+# minimal `- repo: foo/bar\n  commit: <sha>\n  ...` two-level YAML the corpus
+# downloader emits, so we hand-parse rather than pulling in a YAML lib.
+manifest_commit() {
+    target=$1
+    [ -f "$manifest_file" ] || { printf ''; return; }
+    awk -v target="$target" '
+        /^  - repo:/ {
+            # field $3 is the repo slug; trim trailing whitespace
+            current=$3
+            sub(/[[:space:]]+$/, "", current)
+            next
+        }
+        /^    commit:/ && current==target {
+            sub(/^[[:space:]]+commit:[[:space:]]*/, "")
+            print
+            exit
+        }
+    ' "$manifest_file"
+}
+
+# Ensure $clone_path is checked out at $desired_commit (or HEAD if unpinned).
+# Idempotent: re-running with the same target SHA is a no-op.
+ensure_clone() {
+    repo=$1
+    clone_path=$2
+    desired_commit=$3
+
+    if [ ! -d "$clone_path/.git" ]; then
+        echo "    cloning https://github.com/$repo.git"
+        rm -rf "$clone_path"
+        git clone --depth=1 --no-tags -q "https://github.com/$repo.git" "$clone_path"
+    fi
+
+    if [ -n "$desired_commit" ]; then
+        current=$(git -C "$clone_path" rev-parse HEAD 2>/dev/null || echo "")
+        if [ "$current" = "$desired_commit" ]; then
+            return
+        fi
+        if ! git -C "$clone_path" cat-file -e "$desired_commit" 2>/dev/null; then
+            echo "    fetching $desired_commit"
+            if ! git -C "$clone_path" fetch --depth=1 -q origin "$desired_commit" 2>/dev/null; then
+                echo "    warning: cannot fetch $desired_commit; using current HEAD"
+                return
+            fi
+        fi
+        # -f because some repos (e.g., SlackBuildsOrg/slackbuilds) ship
+        # case-colliding paths that don't survive a checkout on
+        # case-insensitive filesystems like APFS; git then sees the working
+        # tree as "dirty" and refuses to switch without -f. We lose at most
+        # one file from each collision pair, which is irrelevant for a
+        # benchmark of thousands of scripts.
+        git -C "$clone_path" -c advice.detachedHead=false checkout -f -q "$desired_commit"
+    fi
+}
+
+# Print the absolute paths of shell scripts in $clone_path, one per line:
+# extension match (*.sh, *.bash, *.ksh) plus extensionless executables with
+# a recognized shell shebang. Excludes *.zsh, paths with whitespace, and
+# anything outside the working tree (git ls-files handles .git/ and submodules).
+build_filelist() {
+    clone_path=$1
+
+    git -C "$clone_path" ls-files \
+        | awk -F/ '
+            /[[:space:]]/ { next }
+            /\.zsh$/      { next }
+            /\.(sh|bash|ksh)$/ { print "DIRECT\t" $0; next }
+            { if ($NF !~ /\./) print "MAYBE\t" $0 }
+        ' \
+        | while IFS=$(printf '\t') read -r kind rel; do
+            [ -n "$rel" ] || continue
+            full="$clone_path/$rel"
+            # Skip symlinks: shuck canonicalizes through them and then
+            # complains the resolved target is outside the inferred project
+            # root (e.g., bats-core ships folder1/setup_suite.bash linking
+            # to ../setup_suite.bash). The link's target shows up as its
+            # own entry in `git ls-files` if it's tracked, so we don't
+            # lose coverage by skipping the link itself.
+            [ -f "$full" ] && [ ! -L "$full" ] || continue
+            case "$kind" in
+                DIRECT)
+                    printf '%s\n' "$full"
+                    ;;
+                MAYBE)
+                    [ -x "$full" ] || continue
+                    # Only the first line matters; head -n 1 reads at most a
+                    # buffer, so cost stays bounded on huge files.
+                    if head -n 1 "$full" 2>/dev/null \
+                        | grep -Eq '^#![[:space:]]*(/[^[:space:]]*/)?(env[[:space:]]+)?(ba|k)?sh([[:space:]]|$)'; then
+                        printf '%s\n' "$full"
+                    fi
+                    ;;
+            esac
+        done \
+        | sort -u
+}
+
+mkdir -p "$out_dir" "$clone_dir"
+
+for repo in $repos; do
+    owner=$(echo "$repo" | cut -d/ -f1)
+    name=$(echo "$repo" | cut -d/ -f2)
+    repo_key="${owner}__${name}"
+    repo_out="$out_dir/$repo_key"
+    clone_path="$clone_dir/$repo_key"
+    filelist="$repo_out/filelist.txt"
+
+    mkdir -p "$repo_out"
+
+    desired_commit=$(manifest_commit "$repo" || true)
+    if [ -n "$desired_commit" ]; then
+        echo "==> Preparing $repo @ $(printf '%.7s' "$desired_commit")"
+    else
+        echo "==> Preparing $repo (HEAD)"
+    fi
+    ensure_clone "$repo" "$clone_path" "$desired_commit"
+
+    actual_commit=$(git -C "$clone_path" rev-parse HEAD)
+    actual_commit_short=$(git -C "$clone_path" rev-parse --short=7 HEAD)
+
+    build_filelist "$clone_path" > "$filelist.full"
+
+    # SlackBuilds is dominated by tiny doinst.sh post-install snippets;
+    # alphabetical ordering means truncation keeps an arbitrary prefix
+    # rather than the heaviest scripts. Sort by file size descending so
+    # the truncate cap (and the workload character) skews toward the
+    # largest, most representative scripts.
+    case "$repo_key" in
+        SlackBuildsOrg__slackbuilds)
+            sorted_tmp=$(mktemp)
+            # `xargs wc -c` emits "<bytes> <path>" per file plus a trailing
+            # "<total> total" summary (one per xargs batch). Filter the
+            # summary lines by exact path match.
+            xargs wc -c < "$filelist.full" \
+                | awk 'NF >= 2 && $NF != "total" {
+                    size = $1; $1 = ""; sub(/^[[:space:]]+/, "")
+                    print size "\t" $0
+                  }' \
+                | sort -rn -k1,1 \
+                | cut -f2- \
+                > "$sorted_tmp"
+            mv "$sorted_tmp" "$filelist.full"
+            ;;
+    esac
+
+    available=$(wc -l < "$filelist.full" | tr -d ' ')
+    head -n "$truncate_limit" "$filelist.full" > "$filelist"
+    rm -f "$filelist.full"
+
+    count=$(wc -l < "$filelist" | tr -d ' ')
+    if [ "$count" = "0" ]; then
+        echo "    no shell files found in clone, skipping"
+        continue
+    fi
+
+    # Sum per-file `wc` counts directly. xargs may invoke wc multiple times
+    # when the filelist exceeds ARG_MAX, and each invocation emits its own
+    # "total" summary line, so a `tail -1` over the combined stream only
+    # captures the last batch's subtotal.
+    total_bytes=$(xargs wc -c < "$filelist" | awk '$NF != "total" && NF >= 2 { sum += $1 } END { print sum + 0 }')
+    total_lines=$(xargs wc -l < "$filelist" | awk '$NF != "total" && NF >= 2 { sum += $1 } END { print sum + 0 }')
+    truncated=false
+    if [ "$count" -lt "$available" ]; then
+        truncated=true
+    fi
+
+    echo "==> Benchmarking $repo @ $actual_commit_short: $count files ($total_bytes bytes, $total_lines lines)"
+    if [ "$truncated" = "true" ]; then
+        echo "    (truncated from $available to $truncate_limit per SHUCK_BENCH_REPO_TRUNCATE)"
+    fi
+
+    # xargs reads the filelist from stdin and exec's the tool with all paths
+    # as a single argv (or batches if ARG_MAX would be exceeded). Output is
+    # dropped so hyperfine is timing lint work, not stdout I/O.
+    hyperfine \
+        --ignore-failure \
+        --warmup "$warmup" \
+        --runs "$runs" \
+        --export-json "$repo_out/bench.json" \
+        -n "shuck" "xargs '$shuck_bin' check --no-cache --select ALL <'$filelist' >/dev/null 2>&1" \
+        -n "shellcheck" "xargs shellcheck --enable=all --severity=style <'$filelist' >/dev/null 2>&1"
+
+    cat > "$repo_out/meta.json" <<EOF
+{
+  "repo": "$repo",
+  "repoKey": "$repo_key",
+  "commit": "$actual_commit",
+  "commitShort": "$actual_commit_short",
+  "fileCount": $count,
+  "availableFileCount": $available,
+  "totalBytes": $total_bytes,
+  "totalLines": $total_lines,
+  "truncated": $truncated,
+  "truncateLimit": $truncate_limit
+}
+EOF
+done
+
+echo ""
+echo "==> Done. Per-repo results in $out_dir"
+echo "==> Cached clones in $clone_dir (delete to force re-clone)"

--- a/website/app/lib/benchmarks.ts
+++ b/website/app/lib/benchmarks.ts
@@ -42,6 +42,71 @@ export type BenchmarkCase = {
   fixture?: BenchmarkFixture;
 };
 
+export type RepoCorpusCase = {
+  slug: string;
+  repo: string;
+  fileCount: number;
+  availableFileCount: number;
+  truncated: boolean;
+  truncateLimit: number | null;
+  totalBytes: number;
+  totalLines: number;
+  commit: string | null;
+  commitShort: string | null;
+  captureDate: string | null;
+  repoUrl: string;
+  commitUrl: string | null;
+  measurements: BenchmarkMeasurement[];
+};
+
+export type RepoCorpusDataset = {
+  schemaVersion: number;
+  available: boolean;
+  id: string;
+  name: string;
+  description: string;
+  generatedAt: string;
+  commit: {
+    sha: string | null;
+    shortSha: string | null;
+  };
+  links: {
+    repositoryUrl: string | null;
+    commitUrl: string | null;
+    runUrl: string | null;
+  };
+  environment: {
+    kind: "local" | "ci";
+    label: string;
+    os: string;
+    arch: string;
+    cpu: string | null;
+    python: string;
+  };
+  toolVersions: {
+    shuck: string | null;
+    hyperfine: string | null;
+    shellcheck: string | null;
+  };
+  methodology: {
+    benchmarkCommand: string;
+    warmupRuns: number;
+    measuredRuns: number;
+    shuckCommand: string;
+    comparisonCommand: string;
+    notes: string | null;
+  };
+  summary: {
+    repoCount: number;
+    totalFiles: number;
+    totalLines: number;
+    shuckTotalSeconds: number;
+    comparisonTotalSeconds: number;
+    speedupRatio: number | null;
+  } | null;
+  cases: RepoCorpusCase[];
+};
+
 export type BenchmarkDataset = {
   schemaVersion: number;
   available: boolean;

--- a/website/app/lib/shellcheck-compat-data.generated.json
+++ b/website/app/lib/shellcheck-compat-data.generated.json
@@ -81,7 +81,7 @@
     "repoKey": "bats-core__bats-core",
     "url": "https://github.com/bats-core/bats-core",
     "status": "known_issues",
-    "issueCount": 1
+    "issueCount": 4
   },
   {
     "repo": "bin456789/reinstall",
@@ -102,7 +102,7 @@
     "repoKey": "bittorf__kalua",
     "url": "https://github.com/bittorf/kalua",
     "status": "known_issues",
-    "issueCount": 1
+    "issueCount": 2
   },
   {
     "repo": "CISOfy/lynis",
@@ -150,8 +150,8 @@
     "repo": "docker/docker-bench-security",
     "repoKey": "docker__docker-bench-security",
     "url": "https://github.com/docker/docker-bench-security",
-    "status": "passes",
-    "issueCount": 0
+    "status": "known_issues",
+    "issueCount": 2
   },
   {
     "repo": "dockur/windows",
@@ -207,7 +207,7 @@
     "repoKey": "gentoo__gentoo",
     "url": "https://github.com/gentoo/gentoo",
     "status": "known_issues",
-    "issueCount": 1
+    "issueCount": 3
   },
   {
     "repo": "google/oss-fuzz",
@@ -220,8 +220,8 @@
     "repo": "HariSekhon/DevOps-Bash-tools",
     "repoKey": "HariSekhon__DevOps-Bash-tools",
     "url": "https://github.com/HariSekhon/DevOps-Bash-tools",
-    "status": "passes",
-    "issueCount": 0
+    "status": "known_issues",
+    "issueCount": 1
   },
   {
     "repo": "helmuthdu/aui",
@@ -445,7 +445,7 @@
     "repoKey": "RetroPie__RetroPie-Setup",
     "url": "https://github.com/RetroPie/RetroPie-Setup",
     "status": "known_issues",
-    "issueCount": 1
+    "issueCount": 4
   },
   {
     "repo": "romkatv/powerlevel10k",
@@ -466,7 +466,7 @@
     "repoKey": "rvm__rvm",
     "url": "https://github.com/rvm/rvm",
     "status": "known_issues",
-    "issueCount": 2
+    "issueCount": 3
   },
   {
     "repo": "scop/bash-completion",

--- a/website/content/performance/benchmarks.tsx
+++ b/website/content/performance/benchmarks.tsx
@@ -1,6 +1,12 @@
 import localSnapshotJson from "@/generated/benchmarks/local-m5-max.json";
 import ciSnapshotJson from "@/generated/benchmarks/ci-latest.json";
-import type { BenchmarkDataset, BenchmarkMeasurement } from "@/app/lib/benchmarks";
+import repoCorpusJson from "@/generated/benchmarks/repo-corpus-local.json";
+import type {
+  BenchmarkDataset,
+  BenchmarkMeasurement,
+  RepoCorpusCase,
+  RepoCorpusDataset,
+} from "@/app/lib/benchmarks";
 import {
   describeRelativePerformance,
   formatBytes,
@@ -17,8 +23,16 @@ import {
 
 const localSnapshot = localSnapshotJson as BenchmarkDataset;
 const ciSnapshot = ciSnapshotJson as BenchmarkDataset;
+const repoCorpus = repoCorpusJson as RepoCorpusDataset;
 const snapshots = [localSnapshot, ciSnapshot];
 const corpus = (pickLatestDatasetWithCorpus(snapshots) ?? localSnapshot).corpus;
+
+function getRepoMeasurement(
+  benchmarkCase: RepoCorpusCase,
+  tool: string,
+): BenchmarkMeasurement | undefined {
+  return benchmarkCase.measurements.find((candidate) => candidate.tool === tool);
+}
 
 function measurementText(measurement: BenchmarkMeasurement | undefined) {
   if (!measurement) {
@@ -98,7 +112,7 @@ function SnapshotDetails({ dataset }: { dataset: BenchmarkDataset }) {
 
   return (
     <>
-      <h2>{dataset.name}</h2>
+      <h3>{dataset.name}</h3>
       <p>{dataset.description}</p>
 
       <table>
@@ -191,6 +205,114 @@ function SnapshotDetails({ dataset }: { dataset: BenchmarkDataset }) {
   );
 }
 
+function RepoCorpusSection({ dataset }: { dataset: RepoCorpusDataset }) {
+  if (!dataset.available || dataset.cases.length === 0) {
+    return (
+      <>
+        <h2>On real-world repos</h2>
+        <p>
+          Repo-corpus benchmarks have not been generated for this build. Run{" "}
+          <code>make bench-repo-corpus</code> locally to populate this section.
+        </p>
+      </>
+    );
+  }
+
+  const summary = dataset.summary;
+
+  return (
+    <>
+      <h2>On real-world repos</h2>
+      <p>
+        Each row below is a single linter invocation over every shell script in
+        the corresponding open-source repository. Both tools see the same
+        filtered file list (no <code>.zsh</code> sources, no git hook samples)
+        and lint with all rules enabled.
+      </p>
+
+      {summary ? (
+        <p>
+          <strong>Total across {formatInteger(summary.repoCount)} repos:</strong>{" "}
+          shuck {formatDuration(summary.shuckTotalSeconds)} vs shellcheck{" "}
+          {formatDuration(summary.comparisonTotalSeconds)} ={" "}
+          {formatRatio(summary.speedupRatio)} speedup over{" "}
+          {formatInteger(summary.totalFiles)} files /{" "}
+          {formatInteger(summary.totalLines)} lines.
+        </p>
+      ) : null}
+
+      <table>
+        <thead>
+          <tr>
+            <th>Repo</th>
+            <th>Files</th>
+            <th>Lines</th>
+            <th>shuck</th>
+            <th>shellcheck</th>
+            <th>Speedup</th>
+          </tr>
+        </thead>
+        <tbody>
+          {dataset.cases.map((repoCase) => {
+            const shuck = getRepoMeasurement(repoCase, "shuck");
+            const shellcheck = getRepoMeasurement(repoCase, "shellcheck");
+            return (
+              <tr key={repoCase.slug}>
+                <td>
+                  <strong>
+                    <a href={repoCase.repoUrl}>{repoCase.repo}</a>
+                  </strong>
+                  <br />
+                  <span>
+                    {repoCase.commitUrl && repoCase.commitShort ? (
+                      <a href={repoCase.commitUrl}>{repoCase.commitShort}</a>
+                    ) : (
+                      repoCase.commitShort ?? "n/a"
+                    )}
+                    {repoCase.captureDate ? ` · ${repoCase.captureDate}` : ""}
+                  </span>
+                </td>
+                <td>
+                  {formatInteger(repoCase.fileCount)}
+                  {repoCase.truncated ? (
+                    <>
+                      <br />
+                      <span>
+                        of {formatInteger(repoCase.availableFileCount)}{" "}
+                        (truncated)
+                      </span>
+                    </>
+                  ) : null}
+                </td>
+                <td>
+                  {formatInteger(repoCase.totalLines)}
+                  <br />
+                  <span>{formatBytes(repoCase.totalBytes)}</span>
+                </td>
+                <td>{measurementText(shuck)}</td>
+                <td>{measurementText(shellcheck)}</td>
+                <td>{formatRatio(shellcheck?.relativeToShuck)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      <p>
+        <span>
+          Captured {formatDate(dataset.generatedAt)} on{" "}
+          {dataset.environment.label}.
+          {dataset.toolVersions.shuck ? ` ${dataset.toolVersions.shuck}` : ""}
+          {dataset.toolVersions.shellcheck
+            ? ` vs shellcheck ${dataset.toolVersions.shellcheck}`
+            : ""}
+          .
+        </span>
+      </p>
+    </>
+  );
+}
+
 function CaseTable({ dataset }: { dataset: BenchmarkDataset }) {
   if (!dataset.available) {
     return null;
@@ -198,7 +320,7 @@ function CaseTable({ dataset }: { dataset: BenchmarkDataset }) {
 
   return (
     <>
-      <h3>{dataset.environment.kind === "ci" ? "Linux CI results" : "Apple M5 results"}</h3>
+      <h4>{dataset.environment.kind === "ci" ? "Linux CI results" : "Apple M5 results"}</h4>
       <table>
         <thead>
           <tr>
@@ -259,35 +381,36 @@ export default function BenchmarksDoc() {
       <h1>Benchmarks</h1>
 
       <p>
-        This page publishes the macro CLI benchmark results produced by{" "}
-        <code>make bench-macro</code>. It is intended as a technical reference for
-        engineers evaluating runtime characteristics, not as a cross-machine league
-        table.
+        Two views are published here. The first measures shuck against
+        shellcheck on whole real-world shell repositories &mdash; the
+        situation a developer hits in CI on a changed-files run. The second
+        measures the same comparison on individual fixtures, which is closer
+        to the editor / language-server feedback loop.
       </p>
 
       <p>
-        Two datasets are shown:
+        Compare tools within the same snapshot. Absolute numbers across
+        different machines are useful for rough orientation only.
       </p>
 
-      <ul>
-        <li>
-          A checked-in Apple M5 Max snapshot generated from local benchmark exports.
-        </li>
-        <li>
-          A Linux CI snapshot regenerated during the GitHub Pages deploy for the
-          latest published release.
-        </li>
-      </ul>
+      <RepoCorpusSection dataset={repoCorpus} />
+
+      <h2>On a single file</h2>
 
       <p>
-        Compare tools within the same snapshot. Absolute numbers across different
-        machines are useful for rough orientation only.
+        The fixtures below are individual shell scripts checked into the
+        benchmark crate. Sub-second numbers here are the relevant signal for
+        editor integrations and pre-commit hooks: shuck completing under
+        ~50&nbsp;ms makes lint-on-keystroke practical without debouncing.
+        Two datasets are shown &mdash; a checked-in Apple M5 Max snapshot
+        captured from a local run, and a Linux CI snapshot regenerated during
+        the GitHub Pages deploy for the latest published release.
       </p>
 
-      <h2>Snapshot Overview</h2>
+      <h3>Snapshot overview</h3>
       <OverviewTable />
 
-      <h2>Methodology</h2>
+      <h3>Methodology</h3>
 
       <ul>
         <li>
@@ -315,14 +438,14 @@ export default function BenchmarksDoc() {
         </li>
       </ul>
 
-      <h2>Reproducing Results</h2>
+      <h3>Reproducing results</h3>
 
-      <h3>Refresh the checked-in local snapshot</h3>
+      <h4>Refresh the checked-in local snapshot</h4>
       <pre>
         <code>make bench-macro-site-local</code>
       </pre>
 
-      <h3>Generate a CI-style dataset manually</h3>
+      <h4>Generate a CI-style dataset manually</h4>
       <pre>
         <code>{`./scripts/benchmarks/setup.sh hyperfine shellcheck
 ./scripts/benchmarks/run.sh
@@ -337,6 +460,11 @@ python3 ./scripts/benchmarks/export_website_data.py \\
   --environment-label "GitHub Actions ubuntu-latest"`}</code>
       </pre>
 
+      <h4>Refresh the repo-corpus snapshot</h4>
+      <pre>
+        <code>make bench-repo-corpus</code>
+      </pre>
+
       {snapshots.map((dataset) => (
         <div key={dataset.id}>
           <SnapshotDetails dataset={dataset} />
@@ -344,7 +472,7 @@ python3 ./scripts/benchmarks/export_website_data.py \\
         </div>
       ))}
 
-      <h2>Benchmark Corpus</h2>
+      <h2>Benchmark corpus</h2>
 
       <p>
         The benchmark corpus is vendored into the repository so every run uses the

--- a/website/content/settings/index.mdx
+++ b/website/content/settings/index.mdx
@@ -272,6 +272,40 @@ bash = "5.2"
 
 ---
 
+#### `gbash`
+
+Version constraint for gbash scripts.
+
+**Default value**: `none`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[run.shells]
+gbash = "0.0.32"
+```
+
+---
+
+#### `bashkit`
+
+Version constraint for Bashkit scripts.
+
+**Default value**: `none`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[run.shells]
+bashkit = "0.2.1"
+```
+
+---
+
 #### `zsh`
 
 Version constraint for Zsh scripts.
@@ -319,6 +353,23 @@ Version constraint for mksh scripts.
 ```toml
 [run.shells]
 mksh = "59c"
+```
+
+---
+
+#### `busybox`
+
+Version constraint for BusyBox scripts on Linux hosts.
+
+**Default value**: `none`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[run.shells]
+busybox = "1.36.1"
 ```
 
 ---

--- a/website/generated/benchmarks/repo-corpus-local.json
+++ b/website/generated/benchmarks/repo-corpus-local.json
@@ -1,0 +1,543 @@
+{
+  "schemaVersion": 1,
+  "available": true,
+  "id": "repo-corpus-local",
+  "name": "Repo-corpus snapshot (local)",
+  "description": "Whole-repo benchmarks against curated open-source repositories cloned at pinned commits.",
+  "generatedAt": "2026-05-03T04:29:53Z",
+  "commit": {
+    "sha": "e7c8545ab4ad3195e3d6d6741a42ab8912947aa2",
+    "shortSha": "e7c8545"
+  },
+  "links": {
+    "repositoryUrl": "https://github.com/ewhauser/shuck",
+    "commitUrl": "https://github.com/ewhauser/shuck/commit/e7c8545ab4ad3195e3d6d6741a42ab8912947aa2",
+    "runUrl": null
+  },
+  "environment": {
+    "kind": "local",
+    "label": "Apple M5 Max local snapshot",
+    "os": "macOS 26.4",
+    "arch": "arm64",
+    "cpu": "Apple M5 Max",
+    "python": "3.14.3"
+  },
+  "toolVersions": {
+    "shuck": "shuck 0.0.31",
+    "hyperfine": "hyperfine 1.20.0",
+    "shellcheck": "0.11.0"
+  },
+  "methodology": {
+    "benchmarkCommand": "make bench-repo-corpus",
+    "warmupRuns": 1,
+    "measuredRuns": 3,
+    "shuckCommand": "xargs shuck check --no-cache --select ALL <filelist>",
+    "comparisonCommand": "xargs shellcheck --enable=all --severity=style <filelist>",
+    "notes": "Each repo is shallow-cloned at the SHA in .cache/large-corpus/manifest.yaml so source-following, project-root resolution, and any in-tree .shellcheckrc behave the way they would for an end user. Both tools receive the same filelist (extension match for *.sh / *.bash / *.ksh plus extensionless executables with shell shebangs; symlinks and *.zsh excluded). shellcheck runs without -x, matching its default behavior."
+  },
+  "summary": {
+    "repoCount": 9,
+    "totalFiles": 7671,
+    "totalLines": 614131,
+    "shuckTotalSeconds": 3.583174317673334,
+    "comparisonTotalSeconds": 139.51320398267336,
+    "speedupRatio": 38.93564521674279
+  },
+  "cases": [
+    {
+      "slug": "Bash-it__bash-it",
+      "repo": "Bash-it/bash-it",
+      "fileCount": 343,
+      "availableFileCount": 343,
+      "truncated": false,
+      "truncateLimit": 4000,
+      "totalBytes": 713532,
+      "totalLines": 24432,
+      "commit": "39f60ff4b2a16837d76e8f18da19816c07ca5747",
+      "commitShort": "39f60ff",
+      "captureDate": "2026-04-04",
+      "repoUrl": "https://github.com/Bash-it/bash-it",
+      "commitUrl": "https://github.com/Bash-it/bash-it/commit/39f60ff4b2a16837d76e8f18da19816c07ca5747",
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck",
+          "meanSeconds": 0.14608492733333334,
+          "stddevSeconds": 0.015531569617695579,
+          "medianSeconds": 0.143487163,
+          "minSeconds": 0.132016039,
+          "maxSeconds": 0.16275158,
+          "userSeconds": 0.2621393533333334,
+          "systemSeconds": 0.06264578666666666,
+          "meanMemoryBytes": 49911125,
+          "maxMemoryBytes": 51298304,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck",
+          "meanSeconds": 8.457519413,
+          "stddevSeconds": 2.9000761714688847,
+          "medianSeconds": 8.23357108,
+          "minSeconds": 5.675909788,
+          "maxSeconds": 11.463077371,
+          "userSeconds": 7.637016686666667,
+          "systemSeconds": 0.24985111999999998,
+          "meanMemoryBytes": 134643712,
+          "maxMemoryBytes": 134643712,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 57.894538248301416
+        }
+      ]
+    },
+    {
+      "slug": "SlackBuildsOrg__slackbuilds",
+      "repo": "SlackBuildsOrg/slackbuilds",
+      "fileCount": 3967,
+      "availableFileCount": 3967,
+      "truncated": false,
+      "truncateLimit": 4000,
+      "totalBytes": 1415297,
+      "totalLines": 47203,
+      "commit": "d6997a19df9be310bfab38da902e2af03bdee8d5",
+      "commitShort": "d6997a1",
+      "captureDate": "2026-04-04",
+      "repoUrl": "https://github.com/SlackBuildsOrg/slackbuilds",
+      "commitUrl": "https://github.com/SlackBuildsOrg/slackbuilds/commit/d6997a19df9be310bfab38da902e2af03bdee8d5",
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck",
+          "meanSeconds": 0.6360337818266668,
+          "stddevSeconds": 0.0004258081789918018,
+          "medianSeconds": 0.6360842121600001,
+          "minSeconds": 0.6355850041600001,
+          "maxSeconds": 0.63643212916,
+          "userSeconds": 0.4637459533333333,
+          "systemSeconds": 0.20067843333333335,
+          "meanMemoryBytes": 55705600,
+          "maxMemoryBytes": 55705600,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck",
+          "meanSeconds": 9.634807753826665,
+          "stddevSeconds": 0.29011683428986595,
+          "medianSeconds": 9.57954492016,
+          "minSeconds": 9.37629708716,
+          "maxSeconds": 9.94858125416,
+          "userSeconds": 9.148863953333334,
+          "systemSeconds": 0.4275967666666667,
+          "meanMemoryBytes": 69124096,
+          "maxMemoryBytes": 69124096,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 15.148264178918035
+        }
+      ]
+    },
+    {
+      "slug": "acmesh-official__acme.sh",
+      "repo": "acmesh-official/acme.sh",
+      "fileCount": 249,
+      "availableFileCount": 249,
+      "truncated": false,
+      "truncateLimit": 4000,
+      "totalBytes": 1594418,
+      "totalLines": 53369,
+      "commit": "563415d21fea772b24c1d4703d5245ccb52ce232",
+      "commitShort": "563415d",
+      "captureDate": "2026-04-04",
+      "repoUrl": "https://github.com/acmesh-official/acme.sh",
+      "commitUrl": "https://github.com/acmesh-official/acme.sh/commit/563415d21fea772b24c1d4703d5245ccb52ce232",
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck",
+          "meanSeconds": 0.3274854136133334,
+          "stddevSeconds": 0.004374034508301256,
+          "medianSeconds": 0.32847310828000004,
+          "minSeconds": 0.32270198328000005,
+          "maxSeconds": 0.33128114928,
+          "userSeconds": 0.6663409533333332,
+          "systemSeconds": 0.05393035999999999,
+          "meanMemoryBytes": 138095274,
+          "maxMemoryBytes": 138805248,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck",
+          "meanSeconds": 24.732101246946666,
+          "stddevSeconds": 1.3959572726589187,
+          "medianSeconds": 24.85648569128,
+          "minSeconds": 23.27811410828,
+          "maxSeconds": 26.06170394128,
+          "userSeconds": 23.904968286666662,
+          "systemSeconds": 0.65835236,
+          "meanMemoryBytes": 4580179968,
+          "maxMemoryBytes": 4587880448,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 75.521230011631
+        }
+      ]
+    },
+    {
+      "slug": "bats-core__bats-core",
+      "repo": "bats-core/bats-core",
+      "fileCount": 68,
+      "availableFileCount": 68,
+      "truncated": false,
+      "truncateLimit": 4000,
+      "totalBytes": 167513,
+      "totalLines": 5828,
+      "commit": "d9faff0d7bc32e7adebc6552446f978118d3ab3b",
+      "commitShort": "d9faff0",
+      "captureDate": "2026-04-04",
+      "repoUrl": "https://github.com/bats-core/bats-core",
+      "commitUrl": "https://github.com/bats-core/bats-core/commit/d9faff0d7bc32e7adebc6552446f978118d3ab3b",
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck",
+          "meanSeconds": 0.025517165053333332,
+          "stddevSeconds": 0.0005664154515462412,
+          "medianSeconds": 0.025402790720000002,
+          "minSeconds": 0.02501666472,
+          "maxSeconds": 0.02613203972,
+          "userSeconds": 0.04576626,
+          "systemSeconds": 0.01674811333333333,
+          "meanMemoryBytes": 36225024,
+          "maxMemoryBytes": 36225024,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck",
+          "meanSeconds": 1.1087244290533336,
+          "stddevSeconds": 0.007730520679234642,
+          "medianSeconds": 1.11290616472,
+          "minSeconds": 1.09980379072,
+          "maxSeconds": 1.11346333172,
+          "userSeconds": 1.0670279266666665,
+          "systemSeconds": 0.03129711333333333,
+          "meanMemoryBytes": 87277568,
+          "maxMemoryBytes": 87277568,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 43.450141374874235
+        }
+      ]
+    },
+    {
+      "slug": "bitnami__containers",
+      "repo": "bitnami/containers",
+      "fileCount": 2923,
+      "availableFileCount": 2923,
+      "truncated": false,
+      "truncateLimit": 4000,
+      "totalBytes": 12379909,
+      "totalLines": 420978,
+      "commit": "dbee50edd8096c49144124316540367ea5bb5bd6",
+      "commitShort": "dbee50e",
+      "captureDate": "2026-04-04",
+      "repoUrl": "https://github.com/bitnami/containers",
+      "commitUrl": "https://github.com/bitnami/containers/commit/dbee50edd8096c49144124316540367ea5bb5bd6",
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck",
+          "meanSeconds": 0.9063673931733334,
+          "stddevSeconds": 0.00918578332003181,
+          "medianSeconds": 0.90148462884,
+          "minSeconds": 0.9006541708400001,
+          "maxSeconds": 0.9169633798400001,
+          "userSeconds": 2.13173522,
+          "systemSeconds": 0.6143390333333333,
+          "meanMemoryBytes": 48824320,
+          "maxMemoryBytes": 48824320,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck",
+          "meanSeconds": 57.911236156840005,
+          "stddevSeconds": 0.35689731017037624,
+          "medianSeconds": 57.97415029584,
+          "minSeconds": 57.52706525384,
+          "maxSeconds": 58.23249292084,
+          "userSeconds": 55.96466255333333,
+          "systemSeconds": 1.4209263666666665,
+          "meanMemoryBytes": 184352768,
+          "maxMemoryBytes": 184352768,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 63.89377706327646
+        }
+      ]
+    },
+    {
+      "slug": "dylanaraps__neofetch",
+      "repo": "dylanaraps/neofetch",
+      "fileCount": 1,
+      "availableFileCount": 1,
+      "truncated": false,
+      "truncateLimit": 4000,
+      "totalBytes": 376936,
+      "totalLines": 11592,
+      "commit": "ccd5d9f52609bbdcd5d8fa78c4fdb0f12954125f",
+      "commitShort": "ccd5d9f",
+      "captureDate": "2026-04-04",
+      "repoUrl": "https://github.com/dylanaraps/neofetch",
+      "commitUrl": "https://github.com/dylanaraps/neofetch/commit/ccd5d9f52609bbdcd5d8fa78c4fdb0f12954125f",
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck",
+          "meanSeconds": 0.05146611789333333,
+          "stddevSeconds": 0.0010172139233201284,
+          "medianSeconds": 0.051239145560000005,
+          "minSeconds": 0.05058156256,
+          "maxSeconds": 0.05257764556,
+          "userSeconds": 0.042610706666666665,
+          "systemSeconds": 0.008577406666666667,
+          "meanMemoryBytes": 67026944,
+          "maxMemoryBytes": 67026944,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck",
+          "meanSeconds": 1.65323160356,
+          "stddevSeconds": 0.09197145885723536,
+          "medianSeconds": 1.60166510356,
+          "minSeconds": 1.59861322856,
+          "maxSeconds": 1.7594164785600002,
+          "userSeconds": 1.5897373733333335,
+          "systemSeconds": 0.04688940666666667,
+          "meanMemoryBytes": 557924352,
+          "maxMemoryBytes": 557924352,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 32.12271823156399
+        }
+      ]
+    },
+    {
+      "slug": "nvm-sh__nvm",
+      "repo": "nvm-sh/nvm",
+      "fileCount": 44,
+      "availableFileCount": 44,
+      "truncated": false,
+      "truncateLimit": 4000,
+      "totalBytes": 228721,
+      "totalLines": 7128,
+      "commit": "d200a215594bdda07e130117c9d392fff29cba84",
+      "commitShort": "d200a21",
+      "captureDate": "2026-04-04",
+      "repoUrl": "https://github.com/nvm-sh/nvm",
+      "commitUrl": "https://github.com/nvm-sh/nvm/commit/d200a215594bdda07e130117c9d392fff29cba84",
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck",
+          "meanSeconds": 0.8322489035000001,
+          "stddevSeconds": 0.13833173085377398,
+          "medianSeconds": 0.8973906815000001,
+          "minSeconds": 0.6733725145000001,
+          "maxSeconds": 0.9259835145000002,
+          "userSeconds": 1.1017022133333334,
+          "systemSeconds": 0.1126339,
+          "meanMemoryBytes": 143026858,
+          "maxMemoryBytes": 149602304,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck",
+          "meanSeconds": 10.117963361166666,
+          "stddevSeconds": 2.082698009843345,
+          "medianSeconds": 9.140086263499999,
+          "minSeconds": 8.7041543475,
+          "maxSeconds": 12.5096494725,
+          "userSeconds": 9.752968546666667,
+          "systemSeconds": 0.31316489999999997,
+          "meanMemoryBytes": 3039002624,
+          "maxMemoryBytes": 3039002624,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 12.15737661968174
+        }
+      ]
+    },
+    {
+      "slug": "super-linter__super-linter",
+      "repo": "super-linter/super-linter",
+      "fileCount": 72,
+      "availableFileCount": 72,
+      "truncated": false,
+      "truncateLimit": 4000,
+      "totalBytes": 428115,
+      "totalLines": 11056,
+      "commit": "487d0d80e66b54831132fe7b2095f9388a624462",
+      "commitShort": "487d0d8",
+      "captureDate": "2026-04-04",
+      "repoUrl": "https://github.com/super-linter/super-linter",
+      "commitUrl": "https://github.com/super-linter/super-linter/commit/487d0d80e66b54831132fe7b2095f9388a624462",
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck",
+          "meanSeconds": 0.040522655440000006,
+          "stddevSeconds": 0.0003700612731048734,
+          "medianSeconds": 0.04044484944000001,
+          "minSeconds": 0.04019768344000001,
+          "maxSeconds": 0.040925433440000006,
+          "userSeconds": 0.08233058666666666,
+          "systemSeconds": 0.02003877333333333,
+          "meanMemoryBytes": 43974656,
+          "maxMemoryBytes": 43974656,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck",
+          "meanSeconds": 2.7866067807733335,
+          "stddevSeconds": 0.04793123412135916,
+          "medianSeconds": 2.80616730844,
+          "minSeconds": 2.7319885584400003,
+          "maxSeconds": 2.8216644754400004,
+          "userSeconds": 2.712436586666667,
+          "systemSeconds": 0.057952773333333325,
+          "meanMemoryBytes": 129187840,
+          "maxMemoryBytes": 129187840,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 68.76663808222862
+        }
+      ]
+    },
+    {
+      "slug": "v1s1t0r1sh3r3__airgeddon",
+      "repo": "v1s1t0r1sh3r3/airgeddon",
+      "fileCount": 4,
+      "availableFileCount": 4,
+      "truncated": false,
+      "truncateLimit": 4000,
+      "totalBytes": 2544584,
+      "totalLines": 32545,
+      "commit": "d7e24237acd32b8d38e28e0d9e93001dfee44131",
+      "commitShort": "d7e2423",
+      "captureDate": "2026-04-04",
+      "repoUrl": "https://github.com/v1s1t0r1sh3r3/airgeddon",
+      "commitUrl": "https://github.com/v1s1t0r1sh3r3/airgeddon/commit/d7e24237acd32b8d38e28e0d9e93001dfee44131",
+      "measurements": [
+        {
+          "tool": "shuck",
+          "command": "shuck",
+          "meanSeconds": 0.6174479598400001,
+          "stddevSeconds": 0.020554283463914812,
+          "medianSeconds": 0.60816882084,
+          "minSeconds": 0.6031692378400001,
+          "maxSeconds": 0.64100582084,
+          "userSeconds": 1.0211389466666667,
+          "systemSeconds": 0.060239013333333334,
+          "meanMemoryBytes": 627408896,
+          "maxMemoryBytes": 627408896,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 1.0
+        },
+        {
+          "tool": "shellcheck",
+          "command": "shellcheck",
+          "meanSeconds": 23.111013237506665,
+          "stddevSeconds": 2.960101022344482,
+          "medianSeconds": 21.70212119584,
+          "minSeconds": 21.11852294584,
+          "maxSeconds": 26.51239557084,
+          "userSeconds": 22.265486613333326,
+          "systemSeconds": 0.6582800133333332,
+          "meanMemoryBytes": 4564549632,
+          "maxMemoryBytes": 4568743936,
+          "runCount": 3,
+          "exitCodes": [
+            123
+          ],
+          "hasFailures": true,
+          "relativeToShuck": 37.42989651062325
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `make bench-repo-corpus`, which shallow-clones a curated set of open-source shell repositories at pinned commits, runs `shuck` and `shellcheck` across each repo's full shell filelist via hyperfine, and exports the result as a website dataset.
- Adds a new "On real-world repos" section to `/docs/performance/benchmarks` above the per-fixture results, so visitors see whole-repo timings (the CI changed-files scenario) before the editor-loop microbenchmarks.
- Latest snapshot: **9 repos, 7,671 files, 614,131 lines, shuck 3.58s vs shellcheck 139.51s, 38.9x speedup.**

### What's measured

Each repo is cloned at the SHA pinned in `.cache/large-corpus/manifest.yaml` so source-following, project-root resolution, and any in-tree `.shellcheckrc` behave the way they would for an end user. Both tools receive the same filelist (extension match for `*.sh` / `*.bash` / `*.ksh` plus extensionless executables with shell shebangs; symlinks and `*.zsh` excluded). shellcheck runs without `-x`, matching its default behavior.

| Repo | Commit | Files | Lines | shuck | shellcheck | Speedup |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| acmesh-official/acme.sh | 563415d | 249 | 53,369 | 327ms | 24.73s | 75.5x |
| super-linter/super-linter | 487d0d8 | 72 | 11,056 | 41ms | 2.79s | 68.8x |
| bitnami/containers | dbee50e | 2,923 | 420,978 | 906ms | 57.91s | 63.9x |
| Bash-it/bash-it | 39f60ff | 343 | 24,432 | 146ms | 8.46s | 57.9x |
| bats-core/bats-core | d9faff0 | 68 | 5,828 | 26ms | 1.11s | 43.5x |
| v1s1t0r1sh3r3/airgeddon | d7e2423 | 4 | 32,545 | 617ms | 23.11s | 37.4x |
| dylanaraps/neofetch | ccd5d9f | 1 | 11,592 | 51ms | 1.65s | 32.1x |
| SlackBuildsOrg/slackbuilds | d6997a1 | 3,967 | 47,203 | 636ms | 9.63s | 15.1x |
| nvm-sh/nvm | d200a21 | 44 | 7,128 | 832ms | 10.12s | 12.2x |

## Test plan

- [x] `make bench-repo-corpus` runs end-to-end, regenerates `website/generated/benchmarks/repo-corpus-local.json`
- [x] `pnpm --filter shuck-website build` succeeds (355 pages prerender clean)
- [x] `pnpm --filter shuck-website dev` serves `/docs/performance/benchmarks` with the new section above the fixture results
- [ ] Re-render the site once more on a clean clone before merging