### PR TITLE
fix(semantic): preserve zsh arithmetic assoc keys

### DIFF
--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2607,7 +2607,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     ) -> Option<&shuck_semantic::Binding> {
         let lookup_span = owner_name_span.unwrap_or(subscript.span());
         self.semantic
-            .visible_binding_for_assoc_lookup(owner_name, self.command_scope, lookup_span)
+            .visible_binding_for_lookup(owner_name, self.command_scope, lookup_span)
     }
 
     fn collect_array_index_arithmetic_spans(&mut self, word: &Word) {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2553,7 +2553,12 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             return false;
         }
         if self.semantic.shell_profile().dialect == shuck_parser::parser::ShellDialect::Zsh
-            && shuck_semantic::zsh_arithmetic_assoc_option_key_text(subscript.syntax_text(self.source))
+            && owner_name.is_some_and(|name| {
+                shuck_semantic::zsh_arithmetic_assoc_option_key(
+                    name.as_str(),
+                    subscript.syntax_text(self.source),
+                )
+            })
         {
             return false;
         }

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2552,8 +2552,18 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         ) {
             return false;
         }
+
+        if owner_name.is_some_and(|name| {
+            self.assoc_binding_visible_for_subscript(name, owner_name_span, subscript)
+        }) {
+            return false;
+        }
+
         if self.semantic.shell_profile().dialect == shuck_parser::parser::ShellDialect::Zsh
             && owner_name.is_some_and(|name| {
+                self.binding_visible_for_subscript(name, owner_name_span, subscript)
+                    .is_none()
+                    &&
                 shuck_semantic::zsh_arithmetic_assoc_option_key(
                     name.as_str(),
                     subscript.syntax_text(self.source),
@@ -2563,9 +2573,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             return false;
         }
 
-        !owner_name.is_some_and(|name| {
-            self.assoc_binding_visible_for_subscript(name, owner_name_span, subscript)
-        })
+        true
     }
 
     fn assoc_binding_visible_for_subscript(
@@ -2589,6 +2597,17 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 .assoc_binding_visible_for_lookup(owner_name, self.command_scope, lookup_span);
         self.assoc_binding_visibility_memo.insert(key, visible);
         visible
+    }
+
+    fn binding_visible_for_subscript(
+        &self,
+        owner_name: &Name,
+        owner_name_span: Option<Span>,
+        subscript: &Subscript,
+    ) -> Option<&shuck_semantic::Binding> {
+        let lookup_span = owner_name_span.unwrap_or(subscript.span());
+        self.semantic
+            .visible_binding_for_assoc_lookup(owner_name, self.command_scope, lookup_span)
     }
 
     fn collect_array_index_arithmetic_spans(&mut self, word: &Word) {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2552,6 +2552,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         ) {
             return false;
         }
+        if self.semantic.shell_profile().dialect == shuck_parser::parser::ShellDialect::Zsh
+            && shuck_semantic::zsh_arithmetic_assoc_option_key_text(subscript.syntax_text(self.source))
+        {
+            return false;
+        }
 
         !owner_name.is_some_and(|name| {
             self.assoc_binding_visible_for_subscript(name, owner_name_span, subscript)

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -287,6 +287,29 @@ f() {
     }
 
     #[test]
+    fn reports_zsh_option_shaped_caller_indexed_opts_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+caller() {
+  local -a OPTS
+  callee
+}
+callee() {
+  local quiet=0
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+caller
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_ifs_reads_after_pipeline_updates() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -268,6 +268,25 @@ f() {
     }
 
     #[test]
+    fn reports_zsh_option_shaped_indexed_opts_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local -a OPTS
+  local quiet=0
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_ifs_reads_after_pipeline_updates() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -250,6 +250,24 @@ printf '%s\\n' x | while read -r _; do PASS=1; done
     }
 
     #[test]
+    fn ignores_zsh_assoc_option_keys_in_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  ( (( !OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_ifs_reads_after_pipeline_updates() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -99,6 +99,21 @@ echo \"$count\"
     }
 
     #[test]
+    fn ignores_zsh_assoc_option_keys_in_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  ( (( !OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_bash_pipeline_assignments_when_pipefail_is_enabled() {
         let source = "\
 #!/usr/bin/env bash

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -114,6 +114,22 @@ f() {
     }
 
     #[test]
+    fn reports_zsh_option_shaped_indexed_opts_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local -a OPTS
+  local quiet=0
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_bash_pipeline_assignments_when_pipefail_is_enabled() {
         let source = "\
 #!/usr/bin/env bash

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -130,6 +130,26 @@ f() {
     }
 
     #[test]
+    fn reports_zsh_option_shaped_caller_indexed_opts_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+caller() {
+  local -a OPTS
+  callee
+}
+callee() {
+  local quiet=0
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+caller
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_bash_pipeline_assignments_when_pipefail_is_enabled() {
         let source = "\
 #!/usr/bin/env bash

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -262,6 +262,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     ) {
         if self
             .arithmetic_index_uses_associative_word_semantics(owner_name, index.span.start.offset)
+            || self.arithmetic_index_uses_zsh_assoc_option_key_semantics(index)
         {
             self.visit_associative_arithmetic_key_into(index, flow, nested_regions);
             return;
@@ -276,6 +277,14 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         offset: usize,
     ) -> bool {
         self.visible_binding_is_assoc(owner_name, offset)
+    }
+
+    pub(super) fn arithmetic_index_uses_zsh_assoc_option_key_semantics(
+        &self,
+        index: &ArithmeticExprNode,
+    ) -> bool {
+        self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+            && zsh_arithmetic_assoc_option_key_text(index.span.slice(self.source))
     }
 
     pub(super) fn visible_binding_is_assoc(&self, name: &Name, offset: usize) -> bool {
@@ -484,4 +493,20 @@ fn conditional_expr_is_logical_binary(expression: &ConditionalExpr) -> bool {
         ConditionalExpr::Binary(binary)
             if matches!(binary.op, ConditionalBinaryOp::And | ConditionalBinaryOp::Or)
     )
+}
+
+/// Returns true for zsh arithmetic subscript text shaped like an option-spec key.
+pub fn zsh_arithmetic_assoc_option_key_text(text: &str) -> bool {
+    let text = text.trim();
+    let Some((_, long_option)) = text.rsplit_once(',') else {
+        return false;
+    };
+    let Some(long_option) = long_option.strip_prefix("--") else {
+        return false;
+    };
+
+    !long_option.is_empty()
+        && long_option
+            .chars()
+            .all(|ch| ch == '-' || ch == '_' || ch.is_ascii_alphanumeric())
 }

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -498,14 +498,21 @@ fn conditional_expr_is_logical_binary(expression: &ConditionalExpr) -> bool {
 /// Returns true for zsh arithmetic subscript text shaped like an option-spec key.
 pub fn zsh_arithmetic_assoc_option_key_text(text: &str) -> bool {
     let text = text.trim();
-    let Some((_, long_option)) = text.rsplit_once(',') else {
+    let Some((short_option, long_option)) = text.rsplit_once(',') else {
+        return false;
+    };
+    let Some(short_option) = short_option.strip_prefix("opt_-") else {
         return false;
     };
     let Some(long_option) = long_option.strip_prefix("--") else {
         return false;
     };
 
-    !long_option.is_empty()
+    !short_option.is_empty()
+        && short_option
+            .chars()
+            .all(|ch| ch == '-' || ch == '_' || ch.is_ascii_alphanumeric())
+        && !long_option.is_empty()
         && long_option
             .chars()
             .all(|ch| ch == '-' || ch == '_' || ch.is_ascii_alphanumeric())

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -262,7 +262,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     ) {
         if self
             .arithmetic_index_uses_associative_word_semantics(owner_name, index.span.start.offset)
-            || self.arithmetic_index_uses_zsh_assoc_option_key_semantics(index)
+            || self.arithmetic_index_uses_zsh_assoc_option_key_semantics(owner_name, index)
         {
             self.visit_associative_arithmetic_key_into(index, flow, nested_regions);
             return;
@@ -281,10 +281,11 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
     pub(super) fn arithmetic_index_uses_zsh_assoc_option_key_semantics(
         &self,
+        owner_name: &Name,
         index: &ArithmeticExprNode,
     ) -> bool {
         self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
-            && zsh_arithmetic_assoc_option_key_text(index.span.slice(self.source))
+            && zsh_arithmetic_assoc_option_key(owner_name.as_str(), index.span.slice(self.source))
     }
 
     pub(super) fn visible_binding_is_assoc(&self, name: &Name, offset: usize) -> bool {
@@ -495,8 +496,12 @@ fn conditional_expr_is_logical_binary(expression: &ConditionalExpr) -> bool {
     )
 }
 
-/// Returns true for zsh arithmetic subscript text shaped like an option-spec key.
-pub fn zsh_arithmetic_assoc_option_key_text(text: &str) -> bool {
+/// Returns true for zsh arithmetic subscript text shaped like zinit-style option map keys.
+pub fn zsh_arithmetic_assoc_option_key(owner_name: &str, text: &str) -> bool {
+    if owner_name != "OPTS" {
+        return false;
+    }
+
     let text = text.trim();
     let Some((short_option, long_option)) = text.rsplit_once(',') else {
         return false;

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -288,7 +288,67 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             && self
                 .resolve_reference(owner_name, self.current_scope(), index.span.start.offset)
                 .is_none()
+            && !self.zsh_option_key_has_known_non_assoc_caller_binding(owner_name)
             && zsh_arithmetic_assoc_option_key(owner_name.as_str(), index.span.slice(self.source))
+    }
+
+    fn zsh_option_key_has_known_non_assoc_caller_binding(&self, owner_name: &Name) -> bool {
+        let Some(function_names) = self.current_named_function_scope_names() else {
+            return false;
+        };
+
+        let mut seen = FxHashSet::default();
+        let mut worklist = SmallVec::<[Name; 4]>::new();
+        worklist.extend(function_names.iter().cloned());
+
+        while let Some(function_name) = worklist.pop() {
+            if !seen.insert(function_name.clone()) {
+                continue;
+            }
+
+            let Some(call_sites) = self.call_sites.get(&function_name) else {
+                continue;
+            };
+            for call_site in call_sites {
+                if let Some(binding_id) = self.resolve_reference(
+                    owner_name,
+                    call_site.scope,
+                    call_site.name_span.start.offset,
+                ) {
+                    if !self.bindings[binding_id.index()]
+                        .attributes
+                        .contains(BindingAttributes::ASSOC)
+                    {
+                        return true;
+                    }
+                    continue;
+                }
+
+                if let Some(caller_names) = self.named_function_scope_names(call_site.scope) {
+                    worklist.extend(caller_names.iter().cloned());
+                }
+            }
+        }
+
+        false
+    }
+
+    fn current_named_function_scope_names(&self) -> Option<&[Name]> {
+        self.named_function_scope_names(self.current_scope())
+    }
+
+    fn named_function_scope_names(&self, scope: ScopeId) -> Option<&[Name]> {
+        let mut current = Some(scope);
+        while let Some(scope_id) = current {
+            match &self.scopes[scope_id.index()].kind {
+                ScopeKind::Function(FunctionScopeKind::Named(names)) => {
+                    return Some(names.as_slice());
+                }
+                _ => current = self.scopes[scope_id.index()].parent,
+            }
+        }
+
+        None
     }
 
     pub(super) fn visible_binding_is_assoc(&self, name: &Name, offset: usize) -> bool {

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -285,6 +285,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         index: &ArithmeticExprNode,
     ) -> bool {
         self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+            && self
+                .resolve_reference(owner_name, self.current_scope(), index.span.start.offset)
+                .is_none()
             && zsh_arithmetic_assoc_option_key(owner_name.as_str(), index.span.slice(self.source))
     }
 

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -163,6 +163,7 @@ struct DeferredFunction<'a> {
 }
 
 mod arithmetic;
+pub use arithmetic::zsh_arithmetic_assoc_option_key_text;
 mod bindings;
 mod declarations;
 mod inert;

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -163,7 +163,7 @@ struct DeferredFunction<'a> {
 }
 
 mod arithmetic;
-pub use arithmetic::zsh_arithmetic_assoc_option_key_text;
+pub use arithmetic::zsh_arithmetic_assoc_option_key;
 mod bindings;
 mod declarations;
 mod inert;

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1244,8 +1244,13 @@ impl SemanticModel {
         current_scope: ScopeId,
         at: Span,
     ) -> Option<&Binding> {
-        if let Some(binding) = self.visible_binding_for_assoc_lookup(name, current_scope, at) {
-            return Some(binding);
+        if let Some(binding_id) = self.previous_visible_binding_id_in_scope_chain(
+            name,
+            current_scope,
+            at.start.offset,
+            None,
+        ) {
+            return Some(self.binding(binding_id));
         }
 
         self.visible_binding_from_named_callers(name, current_scope)
@@ -1331,12 +1336,13 @@ impl SemanticModel {
             }
 
             for call_site in self.call_sites_for(&function_name) {
-                if let Some(binding) = self.visible_binding_for_assoc_lookup(
+                if let Some(binding_id) = self.previous_visible_binding_id_in_scope_chain(
                     name,
                     call_site.scope,
-                    call_site.name_span,
+                    call_site.name_span.start.offset,
+                    None,
                 ) {
-                    return Some(binding);
+                    return Some(self.binding(binding_id));
                 }
 
                 if let Some(caller_names) = self.named_function_scope_names(call_site.scope) {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1236,6 +1236,21 @@ impl SemanticModel {
             .map(|binding_id| self.binding(binding_id))
     }
 
+    /// Returns a visible binding for a contextual lookup, including named callers.
+    #[doc(hidden)]
+    pub fn visible_binding_for_lookup(
+        &self,
+        name: &Name,
+        current_scope: ScopeId,
+        at: Span,
+    ) -> Option<&Binding> {
+        if let Some(binding) = self.visible_binding_for_assoc_lookup(name, current_scope, at) {
+            return Some(binding);
+        }
+
+        self.visible_binding_from_named_callers(name, current_scope)
+    }
+
     /// Returns whether an associative binding is visible for a contextual array lookup.
     pub fn assoc_binding_visible_for_lookup(
         &self,
@@ -1297,6 +1312,42 @@ impl SemanticModel {
         }
 
         false
+    }
+
+    fn visible_binding_from_named_callers(
+        &self,
+        name: &Name,
+        current_scope: ScopeId,
+    ) -> Option<&Binding> {
+        let Some(function_names) = self.named_function_scope_names(current_scope) else {
+            return None;
+        };
+
+        let mut seen = AssocCallerSeenNames::new();
+        let mut worklist = SmallVec::<[Name; 4]>::new();
+        worklist.extend(function_names.iter().cloned());
+
+        while let Some(function_name) = worklist.pop() {
+            if !seen.insert(&function_name) {
+                continue;
+            }
+
+            for call_site in self.call_sites_for(&function_name) {
+                if let Some(binding) = self.visible_binding_for_assoc_lookup(
+                    name,
+                    call_site.scope,
+                    call_site.name_span,
+                ) {
+                    return Some(binding);
+                }
+
+                if let Some(caller_names) = self.named_function_scope_names(call_site.scope) {
+                    worklist.extend(caller_names.iter().cloned());
+                }
+            }
+        }
+
+        None
     }
 
     fn named_function_scope_names(&self, scope: ScopeId) -> Option<&[Name]> {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1319,9 +1319,7 @@ impl SemanticModel {
         name: &Name,
         current_scope: ScopeId,
     ) -> Option<&Binding> {
-        let Some(function_names) = self.named_function_scope_names(current_scope) else {
-            return None;
-        };
+        let function_names = self.named_function_scope_names(current_scope)?;
 
         let mut seen = AssocCallerSeenNames::new();
         let mut worklist = SmallVec::<[Name; 4]>::new();

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -34,7 +34,7 @@ pub use binding::{
     BuiltinBindingTargetKind, LoopValueOrigin,
 };
 /// Zsh arithmetic subscript helpers shared with linter fact collection.
-pub use builder::zsh_arithmetic_assoc_option_key_text;
+pub use builder::zsh_arithmetic_assoc_option_key;
 /// Call-graph structures derived from the analyzed script.
 pub use call_graph::{
     CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -33,6 +33,8 @@ pub use binding::{
     AssignmentValueOrigin, Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin,
     BuiltinBindingTargetKind, LoopValueOrigin,
 };
+/// Zsh arithmetic subscript helpers shared with linter fact collection.
+pub use builder::zsh_arithmetic_assoc_option_key_text;
 /// Call-graph structures derived from the analyzed script.
 pub use call_graph::{
     CallGraph, CallSite, OverwrittenFunction, UnreachedFunction, UnreachedFunctionReason,

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9145,6 +9145,27 @@ f() {
 }
 
 #[test]
+fn zsh_option_shaped_caller_indexed_opts_indices_still_register_updates() {
+    let source = "\
+#!/bin/zsh
+caller() {
+  local -a OPTS
+  callee
+}
+callee() {
+  local opt_=1 q=1 quiet=1
+  (( OPTS[opt_-q,--quiet] ))
+}
+caller
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    assert_arithmetic_usage(&model, "opt_", 1, 0);
+    assert_arithmetic_usage(&model, "q", 1, 0);
+    assert_arithmetic_usage(&model, "quiet", 1, 1);
+}
+
+#[test]
 fn arithmetic_indexed_writes_preserve_associative_attributes() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9128,6 +9128,23 @@ f() {
 }
 
 #[test]
+fn zsh_option_shaped_indexed_opts_indices_still_register_updates() {
+    let source = "\
+#!/bin/zsh
+f() {
+  local -a OPTS
+  local opt_=1 q=1 quiet=1
+  (( OPTS[opt_-q,--quiet] ))
+}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    assert_arithmetic_usage(&model, "opt_", 1, 0);
+    assert_arithmetic_usage(&model, "q", 1, 0);
+    assert_arithmetic_usage(&model, "quiet", 1, 1);
+}
+
+#[test]
 fn arithmetic_indexed_writes_preserve_associative_attributes() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9112,6 +9112,22 @@ f() {
 }
 
 #[test]
+fn zsh_option_shaped_non_opts_indices_still_register_updates() {
+    let source = "\
+#!/bin/zsh
+f() {
+  local opt_=1 q=1 quiet=1
+  (( arr[opt_-q,--quiet] ))
+}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    assert_arithmetic_usage(&model, "opt_", 1, 0);
+    assert_arithmetic_usage(&model, "q", 1, 0);
+    assert_arithmetic_usage(&model, "quiet", 1, 1);
+}
+
+#[test]
 fn arithmetic_indexed_writes_preserve_associative_attributes() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9097,6 +9097,21 @@ f() {
 }
 
 #[test]
+fn zsh_arithmetic_comma_indices_still_register_updates() {
+    let source = "\
+#!/bin/zsh
+f() {
+  local i=1 quiet=1
+  (( arr[i,--quiet] ))
+}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    assert_arithmetic_usage(&model, "i", 1, 0);
+    assert_arithmetic_usage(&model, "quiet", 1, 1);
+}
+
+#[test]
 fn arithmetic_indexed_writes_preserve_associative_attributes() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9066,6 +9066,37 @@ printf '%s\\n' \"$((box[m_width]))\" \"$((box[$dynamic_key]))\"
 }
 
 #[test]
+fn zsh_arithmetic_option_keys_do_not_register_key_reads_or_updates_without_assoc_binding() {
+    let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  ( (( !OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let unresolved = unresolved_names(&model);
+
+    assert_names_absent(&["opt_", "q"], &unresolved);
+    assert_arithmetic_usage(&model, "quiet", 1, 0);
+}
+
+#[test]
+fn zsh_regular_arithmetic_indices_still_register_updates() {
+    let source = "\
+#!/bin/zsh
+f() {
+  local i=1
+  (( arr[--i] ))
+}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    assert_arithmetic_usage(&model, "i", 1, 1);
+}
+
+#[test]
 fn arithmetic_indexed_writes_preserve_associative_attributes() {
     let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary

- Treat zsh option-spec-shaped arithmetic subscripts like `OPTS[opt_-q,--quiet]` as associative keys when parsing semantic arithmetic reads.
- Reuse that semantic helper from linter word facts so C150/C155 do not invent writes from key text.
- Add focused semantic and linter regressions for the broken zinit shape plus a control case for normal arithmetic index updates.

## Validation

- `cargo test -p shuck-semantic zsh_arithmetic_ -- --nocapture`
- `cargo test -p shuck-semantic zsh_regular_arithmetic_indices_still_register_updates -- --nocapture`
- `cargo test -p shuck-linter ignores_zsh_assoc_option_keys_in_arithmetic_subshells -- --nocapture`
- `cargo build -p shuck-cli`
- `target/debug/shuck check --no-cache --output-format json /Users/ewhauser/working/zinit`

The zinit retest clears the option-key-family C150/C155 findings; remaining C150/C155 reports are different shapes.
