### PR TITLE
test(fuzz): disable formatter fuzz targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -37,8 +37,8 @@ jobs:
           - arithmetic_fuzz
           - glob_fuzz
           - recovered_parser_fuzz
-          - formatter_consistency_fuzz
-          - formatter_validity_fuzz
+          # - formatter_consistency_fuzz
+          # - formatter_validity_fuzz
           - linter_no_panic_fuzz
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ fuzzing belongs in the scheduled GitHub Actions workflow or in manual local runs
 Run one target with a longer budget:
 
 ```bash
-make fuzz-run FUZZ_TARGET=formatter_consistency_fuzz FUZZ_ARGS='-max_total_time=60'
+make fuzz-run FUZZ_TARGET=parser_fuzz FUZZ_ARGS='-max_total_time=60'
 ```
 
 Available `cargo-fuzz` targets:
@@ -180,8 +180,6 @@ Available `cargo-fuzz` targets:
 - `arithmetic_fuzz`
 - `glob_fuzz`
 - `recovered_parser_fuzz`
-- `formatter_consistency_fuzz`
-- `formatter_validity_fuzz`
 - `linter_no_panic_fuzz`
 
 Run the CLI generator-driven fuzzer:

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ fuzz-smoke:
 	bash ./scripts/fuzz-init.sh --ci
 	bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) parser_fuzz -- $(FUZZ_SMOKE_ARGS)'
 	bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) recovered_parser_fuzz -- $(FUZZ_SMOKE_ARGS)'
-	bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) formatter_consistency_fuzz -- $(FUZZ_SMOKE_ARGS)'
+	# bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) formatter_consistency_fuzz -- $(FUZZ_SMOKE_ARGS)'
 	bash -lc '$(FUZZ_CARGO_ENV) cd fuzz && cargo +nightly fuzz run $(FUZZ_SANITIZER_ARG) linter_no_panic_fuzz -- $(FUZZ_SMOKE_ARGS)'
 
 fuzz-run:

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -293,16 +293,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "shuck-formatter"
-version = "0.0.32"
-
-[[package]]
 name = "shuck-fuzz"
 version = "0.0.0"
 dependencies = [
  "libfuzzer-sys",
  "shuck-ast",
- "shuck-formatter",
  "shuck-indexer",
  "shuck-linter",
  "shuck-parser",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 libfuzzer-sys = "0.4"
 similar = "2"
 shuck-ast = { path = "../crates/shuck-ast" }
-shuck-formatter = { path = "../crates/shuck-formatter" }
+# shuck-formatter = { path = "../crates/shuck-formatter" }
 shuck-indexer = { path = "../crates/shuck-indexer" }
 shuck-linter = { path = "../crates/shuck-linter" }
 shuck-parser = { path = "../crates/shuck-parser" }
@@ -57,19 +57,19 @@ test = false
 doc = false
 bench = false
 
-[[bin]]
-name = "formatter_consistency_fuzz"
-path = "fuzz_targets/formatter_consistency_fuzz.rs"
-test = false
-doc = false
-bench = false
+# [[bin]]
+# name = "formatter_consistency_fuzz"
+# path = "fuzz_targets/formatter_consistency_fuzz.rs"
+# test = false
+# doc = false
+# bench = false
 
-[[bin]]
-name = "formatter_validity_fuzz"
-path = "fuzz_targets/formatter_validity_fuzz.rs"
-test = false
-doc = false
-bench = false
+# [[bin]]
+# name = "formatter_validity_fuzz"
+# path = "fuzz_targets/formatter_validity_fuzz.rs"
+# test = false
+# doc = false
+# bench = false
 
 [[bin]]
 name = "linter_no_panic_fuzz"

--- a/scripts/fuzz-init.sh
+++ b/scripts/fuzz-init.sh
@@ -6,7 +6,7 @@ ROOT_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
 FUZZ_DIR="${ROOT_DIR}/fuzz"
 CORPUS_DIR="${FUZZ_DIR}/corpus"
 COMMON_CORPUS_DIR="${CORPUS_DIR}/common"
-FORMATTER_CORPUS_DIR="${CORPUS_DIR}/formatter"
+# FORMATTER_CORPUS_DIR="${CORPUS_DIR}/formatter"
 ARTIFACTS_DIR="${FUZZ_DIR}/artifacts"
 
 COMMON_TARGETS=(
@@ -18,10 +18,10 @@ COMMON_TARGETS=(
   linter_no_panic_fuzz
 )
 
-FORMATTER_TARGETS=(
-  formatter_consistency_fuzz
-  formatter_validity_fuzz
-)
+# FORMATTER_TARGETS=(
+#   formatter_consistency_fuzz
+#   formatter_validity_fuzz
+# )
 
 CI_MODE=0
 RUN_CMIN=0
@@ -114,17 +114,17 @@ ensure_toolchain() {
 }
 
 ensure_layout() {
-  mkdir -p "${COMMON_CORPUS_DIR}" "${FORMATTER_CORPUS_DIR}" "${ARTIFACTS_DIR}"
+  mkdir -p "${COMMON_CORPUS_DIR}" "${ARTIFACTS_DIR}"
   find "${COMMON_CORPUS_DIR}" -mindepth 1 -maxdepth 1 -type f -delete
-  find "${FORMATTER_CORPUS_DIR}" -mindepth 1 -maxdepth 1 -type f -delete
+  # find "${FORMATTER_CORPUS_DIR}" -mindepth 1 -maxdepth 1 -type f -delete
   (
     cd "${CORPUS_DIR}"
     for target in "${COMMON_TARGETS[@]}"; do
       ln -snf "common" "${target}"
     done
-    for target in "${FORMATTER_TARGETS[@]}"; do
-      ln -snf "formatter" "${target}"
-    done
+    # for target in "${FORMATTER_TARGETS[@]}"; do
+    #   ln -snf "formatter" "${target}"
+    # done
   )
 }
 
@@ -159,7 +159,7 @@ seed_repo_corpus() {
   seed_from_directory "${COMMON_CORPUS_DIR}" "${ROOT_DIR}/crates/shuck-formatter/tests/oracle-fixtures"
   seed_from_directory "${COMMON_CORPUS_DIR}" "${ROOT_DIR}/crates/shuck-benchmark/resources/files"
   seed_from_directory "${COMMON_CORPUS_DIR}" "${ROOT_DIR}/scripts"
-  seed_from_directory "${FORMATTER_CORPUS_DIR}" "${ROOT_DIR}/crates/shuck-formatter/tests/oracle-fixtures"
+  # seed_from_directory "${FORMATTER_CORPUS_DIR}" "${ROOT_DIR}/crates/shuck-formatter/tests/oracle-fixtures"
 
   if [[ "${CI_MODE}" -eq 0 && -d "${ROOT_DIR}/.cache/large-corpus" && "${USE_LARGE_CORPUS}" -eq 0 ]]; then
     read -r -p "Copy shell fixtures from .cache/large-corpus too? [y/N] " reply


### PR DESCRIPTION
## Summary
- comment out the formatter fuzz bins and formatter dependency in the fuzz crate
- stop wiring formatter targets into fuzz setup, smoke coverage, and the scheduled fuzz workflow
- update the fuzz docs so the advertised target list matches the active harness

## Why
Formatter fuzzing is currently disabled, but the fuzz harness still referenced those targets in its manifest and orchestration paths.

## Validation
- cargo fmt --check
- cargo metadata --manifest-path fuzz/Cargo.toml --format-version 1
- bash -n scripts/fuzz-init.sh
- bash ./scripts/fuzz-init.sh --ci
- bash -lc 'export PATH="$HOME/.cargo/bin:$PATH"; . "$HOME/.cargo/env" >/dev/null 2>&1 || true; cd fuzz && cargo +nightly fuzz list'