### PR TITLE
fix(linter): suppress zsh option-map arithmetic keys

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -192,11 +192,26 @@ fn arithmetic_index_uses_zsh_option_map_key_semantics(
     index: &ArithmeticExprNode,
     source: &str,
 ) -> bool {
-    if semantic.assoc_binding_visible_for_lookup(owner_name, command_scope, index.span) {
-        return true;
+    if let Some(binding) =
+        semantic.visible_assoc_lookup_binding_for_lookup(owner_name, command_scope, index.span)
+    {
+        if binding
+            .attributes
+            .contains(shuck_semantic::BindingAttributes::ASSOC)
+        {
+            return true;
+        }
+        if !zsh_option_map_binding_origin(owner_name, binding, source)
+            || zsh_option_map_binding_has_prior_assoc_lookup_blocker(
+                semantic, owner_name, binding, source,
+            )
+        {
+            return false;
+        }
     }
 
     zsh_option_map_binding_permits_implicit_assoc_key(
+        semantic,
         semantic.visible_binding_for_lookup(owner_name, command_scope, index.span),
         owner_name,
         source,
@@ -206,6 +221,7 @@ fn arithmetic_index_uses_zsh_option_map_key_semantics(
 }
 
 fn zsh_option_map_binding_permits_implicit_assoc_key(
+    semantic: &SemanticModel,
     binding: Option<&Binding>,
     owner_name: &Name,
     source: &str,
@@ -218,6 +234,9 @@ fn zsh_option_map_binding_permits_implicit_assoc_key(
     }
 
     zsh_option_map_binding_origin(owner_name, binding, source)
+        && !zsh_option_map_binding_has_prior_assoc_lookup_blocker(
+            semantic, owner_name, binding, source,
+        )
 }
 
 fn zsh_option_map_binding_origin(owner_name: &Name, binding: &Binding, source: &str) -> bool {
@@ -236,6 +255,34 @@ fn zsh_option_map_binding_origin(owner_name: &Name, binding: &Binding, source: &
         | shuck_semantic::BindingOrigin::Declaration { .. }
         | shuck_semantic::BindingOrigin::Nameref { .. } => false,
     }
+}
+
+fn zsh_option_map_binding_has_prior_assoc_lookup_blocker(
+    semantic: &SemanticModel,
+    owner_name: &Name,
+    binding: &Binding,
+    source: &str,
+) -> bool {
+    semantic.bindings_for(owner_name).iter().copied().any(|id| {
+        let candidate = semantic.binding(id);
+        candidate.scope == binding.scope
+            && candidate.span.start.offset < binding.span.start.offset
+            && zsh_option_map_binding_blocks_assoc_lookup(candidate)
+            && !zsh_option_map_binding_origin(owner_name, candidate, source)
+    })
+}
+
+fn zsh_option_map_binding_blocks_assoc_lookup(binding: &Binding) -> bool {
+    binding
+        .attributes
+        .contains(shuck_semantic::BindingAttributes::LOCAL)
+        || !matches!(
+            binding.kind,
+            BindingKind::Assignment
+                | BindingKind::AppendAssignment
+                | BindingKind::ArrayAssignment
+                | BindingKind::ArithmeticAssignment
+        )
 }
 
 fn zsh_option_map_assignment_target(owner_name: &Name, text: &str) -> bool {

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1,3 +1,280 @@
+fn collect_zsh_option_map_arithmetic_suppressed_subscripts(
+    command: &Command,
+    semantic: &SemanticModel,
+    command_scope: ScopeId,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match command {
+        Command::Compound(CompoundCommand::Arithmetic(command)) => {
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                command.expr_ast.as_ref(),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+        }
+        Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                command.init_ast.as_ref(),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                command.condition_ast.as_ref(),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                command.step_ast.as_ref(),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+        }
+        _ => {}
+    }
+}
+
+fn collect_zsh_option_map_suppressed_subscripts_in_expr(
+    expression: Option<&ArithmeticExprNode>,
+    semantic: &SemanticModel,
+    command_scope: ScopeId,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let Some(expression) = expression else {
+        return;
+    };
+
+    match &expression.kind {
+        ArithmeticExpr::Number(_) | ArithmeticExpr::Variable(_) | ArithmeticExpr::ShellWord(_) => {}
+        ArithmeticExpr::Indexed { name, index } => {
+            if arithmetic_index_uses_zsh_option_map_key_semantics(
+                semantic,
+                command_scope,
+                name,
+                index,
+                source,
+            ) {
+                spans.push(index.span);
+            } else {
+                collect_zsh_option_map_suppressed_subscripts_in_expr(
+                    Some(index),
+                    semantic,
+                    command_scope,
+                    source,
+                    spans,
+                );
+            }
+        }
+        ArithmeticExpr::Parenthesized { expression } => {
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                Some(expression),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+        }
+        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                Some(expr),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+        }
+        ArithmeticExpr::Binary { left, right, .. } => {
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                Some(left),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                Some(right),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+        }
+        ArithmeticExpr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                Some(condition),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                Some(then_expr),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                Some(else_expr),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+        }
+        ArithmeticExpr::Assignment { target, value, .. } => {
+            collect_zsh_option_map_suppressed_subscripts_in_lvalue(
+                target,
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+            collect_zsh_option_map_suppressed_subscripts_in_expr(
+                Some(value),
+                semantic,
+                command_scope,
+                source,
+                spans,
+            );
+        }
+    }
+}
+
+fn collect_zsh_option_map_suppressed_subscripts_in_lvalue(
+    target: &ArithmeticLvalue,
+    semantic: &SemanticModel,
+    command_scope: ScopeId,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match target {
+        ArithmeticLvalue::Variable(_) => {}
+        ArithmeticLvalue::Indexed { name, index } => {
+            if arithmetic_index_uses_zsh_option_map_key_semantics(
+                semantic,
+                command_scope,
+                name,
+                index,
+                source,
+            ) {
+                spans.push(index.span);
+            } else {
+                collect_zsh_option_map_suppressed_subscripts_in_expr(
+                    Some(index),
+                    semantic,
+                    command_scope,
+                    source,
+                    spans,
+                );
+            }
+        }
+    }
+}
+
+fn arithmetic_index_uses_zsh_option_map_key_semantics(
+    semantic: &SemanticModel,
+    command_scope: ScopeId,
+    owner_name: &Name,
+    index: &ArithmeticExprNode,
+    source: &str,
+) -> bool {
+    if semantic.assoc_binding_visible_for_lookup(owner_name, command_scope, index.span) {
+        return true;
+    }
+
+    zsh_option_map_binding_permits_implicit_assoc_key(
+        semantic.visible_binding_for_lookup(owner_name, command_scope, index.span),
+        owner_name,
+        source,
+    )
+        && semantic.shell_profile().dialect == shuck_parser::parser::ShellDialect::Zsh
+        && zsh_option_map_subscript_key(owner_name.as_str(), index.span.slice(source))
+}
+
+fn zsh_option_map_binding_permits_implicit_assoc_key(
+    binding: Option<&Binding>,
+    owner_name: &Name,
+    source: &str,
+) -> bool {
+    let Some(binding) = binding else {
+        return true;
+    };
+    if binding.attributes.contains(shuck_semantic::BindingAttributes::ASSOC) {
+        return true;
+    }
+
+    zsh_option_map_binding_origin(owner_name, binding, source)
+}
+
+fn zsh_option_map_binding_origin(owner_name: &Name, binding: &Binding, source: &str) -> bool {
+    match &binding.origin {
+        shuck_semantic::BindingOrigin::Assignment {
+            definition_span, ..
+        } => zsh_option_map_assignment_target(owner_name, definition_span.slice(source)),
+        shuck_semantic::BindingOrigin::ArithmeticAssignment { target_span, .. } => {
+            zsh_option_map_assignment_target(owner_name, target_span.slice(source))
+        }
+        shuck_semantic::BindingOrigin::ParameterDefaultAssignment { .. }
+        | shuck_semantic::BindingOrigin::LoopVariable { .. }
+        | shuck_semantic::BindingOrigin::Imported { .. }
+        | shuck_semantic::BindingOrigin::FunctionDefinition { .. }
+        | shuck_semantic::BindingOrigin::BuiltinTarget { .. }
+        | shuck_semantic::BindingOrigin::Declaration { .. }
+        | shuck_semantic::BindingOrigin::Nameref { .. } => false,
+    }
+}
+
+fn zsh_option_map_assignment_target(owner_name: &Name, text: &str) -> bool {
+    let Some(rest) = text.strip_prefix(owner_name.as_str()) else {
+        return false;
+    };
+    let Some(subscript) = rest.strip_prefix('[').and_then(|rest| rest.strip_suffix(']')) else {
+        return false;
+    };
+
+    zsh_option_map_subscript_key(owner_name.as_str(), subscript)
+}
+
+fn zsh_option_map_subscript_key(owner_name: &str, text: &str) -> bool {
+    if owner_name != "OPTS" {
+        return false;
+    }
+
+    let text = text.trim();
+    let Some((short_option, long_option)) = text.rsplit_once(',') else {
+        return false;
+    };
+    let Some(short_option) = short_option.strip_prefix("opt_-") else {
+        return false;
+    };
+    let Some(long_option) = long_option.strip_prefix("--") else {
+        return false;
+    };
+
+    !short_option.is_empty()
+        && short_option
+            .chars()
+            .all(|ch| ch == '-' || ch == '_' || ch.is_ascii_alphanumeric())
+        && !long_option.is_empty()
+        && long_option
+            .chars()
+            .all(|ch| ch == '-' || ch == '_' || ch.is_ascii_alphanumeric())
+}
+
 fn collect_base_prefix_spans_in_command_parts(
     command: &Command,
     source: &str,

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1022,6 +1022,7 @@ fn build_nonpersistent_assignment_spans(
     commands: &[CommandFact<'_>],
     source: &str,
     suppress_bash_pipefail_pipeline_side_effects: bool,
+    arithmetic_only_suppressed_subscript_spans: &[Span],
 ) -> NonpersistentAssignmentSpans {
     let command_contexts = build_nonpersistent_assignment_command_contexts(commands);
     let prompt_runtime_reads = build_prompt_runtime_read_spans(commands, source)
@@ -1047,6 +1048,13 @@ fn build_nonpersistent_assignment_spans(
     let mut assignment_sites = Vec::new();
 
     for effect in analysis.effects {
+        if arithmetic_only_suppressed_subscript_spans
+            .iter()
+            .any(|span| span_contains(*span, effect.assignment_span))
+        {
+            continue;
+        }
+
         let assignment_binding = semantic.binding(effect.assignment_binding);
         assignment_sites.push(NamedSpan {
             name: effect.name.clone(),
@@ -1070,6 +1078,10 @@ fn build_nonpersistent_assignment_spans(
         subshell_assignment_sites: assignment_sites,
         subshell_later_use_sites: later_use_sites,
     }
+}
+
+fn span_contains(outer: Span, inner: Span) -> bool {
+    outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }
 
 fn build_subshell_loop_assignment_report_spans(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -22,6 +22,7 @@ struct ArithmeticFactSummary {
     arithmetic_score_line_spans: Vec<Span>,
     dollar_in_arithmetic_spans: Vec<Span>,
     arithmetic_command_substitution_spans: Vec<Span>,
+    arithmetic_only_suppressed_subscript_spans: Vec<Span>,
 }
 
 #[derive(Debug, Default)]
@@ -234,6 +235,13 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                         arithmetic: &mut arithmetic_summary,
                         surface: &mut surface_fragments,
                     },
+                );
+                collect_zsh_option_map_arithmetic_suppressed_subscripts(
+                    visit.command,
+                    self.semantic,
+                    scope,
+                    self.source,
+                    &mut arithmetic_summary.arithmetic_only_suppressed_subscript_spans,
                 );
                 collect_base_prefix_spans_in_command_parts(
                     visit.command,
@@ -617,27 +625,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let backtick_command_name_spans = build_backtick_command_name_spans(&commands);
         let dollar_question_after_command_spans =
             build_dollar_question_after_command_spans(&self.file.body, self.source);
-        let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(
-            self.semantic,
-            &commands,
-            self.source,
-            matches!(self.shell, ShellDialect::Bash) && pipefail_enabled_anywhere,
-        );
-        let heredoc_summary =
-            build_heredoc_fact_summary(
-                &commands,
-                locator,
-                self.file.span.end.offset,
-            );
-        let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
-        let literal_brace_spans = build_literal_brace_spans(
-            &word_nodes,
-            &word_occurrences,
-            CommandFacts::new(&commands, &fact_store, &command_fact_indices_by_id),
-            &fact_store,
-            locator,
-            self._indexer.region_index().heredoc_ranges(),
-        );
         let SurfaceFragmentFacts {
             single_quoted,
             dollar_double_quoted,
@@ -664,8 +651,36 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             positional_parameter_trims,
             suppressed_subscript_spans,
             subscript_later_suppression_spans,
-            arithmetic_only_suppressed_subscript_spans,
+            mut arithmetic_only_suppressed_subscript_spans,
         } = surface_fragments.finish();
+        arithmetic_only_suppressed_subscript_spans.extend(
+            arithmetic_summary
+                .arithmetic_only_suppressed_subscript_spans
+                .iter()
+                .copied(),
+        );
+        let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(
+            self.semantic,
+            &commands,
+            self.source,
+            matches!(self.shell, ShellDialect::Bash) && pipefail_enabled_anywhere,
+            &arithmetic_only_suppressed_subscript_spans,
+        );
+        let heredoc_summary =
+            build_heredoc_fact_summary(
+                &commands,
+                locator,
+                self.file.span.end.offset,
+            );
+        let plus_equals_assignment_spans = build_plus_equals_assignment_spans(&commands);
+        let literal_brace_spans = build_literal_brace_spans(
+            &word_nodes,
+            &word_occurrences,
+            CommandFacts::new(&commands, &fact_store, &command_fact_indices_by_id),
+            &fact_store,
+            locator,
+            self._indexer.region_index().heredoc_ranges(),
+        );
         let function_positional_parameter_facts = build_function_positional_parameter_facts(
             self.semantic,
             &commands,

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2558,10 +2558,20 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }) {
             return false;
         }
+        if owner_name.is_some_and(|name| {
+            self.assoc_lookup_binding_blocks_zsh_option_map_fallback(
+                name,
+                owner_name_span,
+                subscript,
+            )
+        }) {
+            return true;
+        }
 
         if self.semantic.shell_profile().dialect == shuck_parser::parser::ShellDialect::Zsh
             && owner_name.is_some_and(|name| {
                 super::zsh_option_map_binding_permits_implicit_assoc_key(
+                    self.semantic,
                     self.binding_visible_for_subscript(name, owner_name_span, subscript),
                     name,
                     self.source,
@@ -2599,6 +2609,29 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 .assoc_binding_visible_for_lookup(owner_name, self.command_scope, lookup_span);
         self.assoc_binding_visibility_memo.insert(key, visible);
         visible
+    }
+
+    fn assoc_lookup_binding_blocks_zsh_option_map_fallback(
+        &self,
+        owner_name: &Name,
+        owner_name_span: Option<Span>,
+        subscript: &Subscript,
+    ) -> bool {
+        let lookup_span = owner_name_span.unwrap_or(subscript.span());
+        self.semantic
+            .visible_assoc_lookup_binding_for_lookup(owner_name, self.command_scope, lookup_span)
+            .is_some_and(|binding| {
+                !binding
+                    .attributes
+                    .contains(shuck_semantic::BindingAttributes::ASSOC)
+                    && (!super::zsh_option_map_binding_origin(owner_name, binding, self.source)
+                        || super::zsh_option_map_binding_has_prior_assoc_lookup_blocker(
+                            self.semantic,
+                            owner_name,
+                            binding,
+                            self.source,
+                        ))
+            })
     }
 
     fn binding_visible_for_subscript(

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2553,9 +2553,29 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             return false;
         }
 
-        !owner_name.is_some_and(|name| {
+        if owner_name.is_some_and(|name| {
             self.assoc_binding_visible_for_subscript(name, owner_name_span, subscript)
-        })
+        }) {
+            return false;
+        }
+
+        if self.semantic.shell_profile().dialect == shuck_parser::parser::ShellDialect::Zsh
+            && owner_name.is_some_and(|name| {
+                super::zsh_option_map_binding_permits_implicit_assoc_key(
+                    self.binding_visible_for_subscript(name, owner_name_span, subscript),
+                    name,
+                    self.source,
+                )
+                    && super::zsh_option_map_subscript_key(
+                        name.as_str(),
+                        subscript.syntax_text(self.source),
+                    )
+            })
+        {
+            return false;
+        }
+
+        true
     }
 
     fn assoc_binding_visible_for_subscript(
@@ -2579,6 +2599,17 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 .assoc_binding_visible_for_lookup(owner_name, self.command_scope, lookup_span);
         self.assoc_binding_visibility_memo.insert(key, visible);
         visible
+    }
+
+    fn binding_visible_for_subscript(
+        &self,
+        owner_name: &Name,
+        owner_name_span: Option<Span>,
+        subscript: &Subscript,
+    ) -> Option<&shuck_semantic::Binding> {
+        let lookup_span = owner_name_span.unwrap_or(subscript.span());
+        self.semantic
+            .visible_binding_for_lookup(owner_name, self.command_scope, lookup_span)
     }
 
     fn collect_array_index_arithmetic_spans(&mut self, word: &Word) {

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -186,6 +186,26 @@ f() {
     }
 
     #[test]
+    fn reports_zsh_option_shaped_indexed_opts_after_option_map_assignment() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local -a OPTS
+  local opt_=1 q=1 quiet=0
+  OPTS[opt_-q,--quiet]=1
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_zsh_option_shaped_caller_indexed_opts_arithmetic_subshells() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -108,6 +108,107 @@ echo \"$count\"
     }
 
     #[test]
+    fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  ( (( !OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_option_map_keys_in_if_arithmetic_conditions() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  (
+    if (( ! OPTS[opt_-q,--quiet] )) {
+      :
+    }
+  )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_option_map_keys_after_option_map_assignment() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  OPTS[opt_-q,--quiet]=1
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_option_shaped_indexed_opts_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local -a OPTS
+  local opt_=1 q=1 quiet=0
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_option_shaped_caller_indexed_opts_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+callee() {
+  local opt_=1 q=1 quiet=0
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+caller() {
+  local -a OPTS
+  callee
+}
+caller
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_for_loop_child_assignments_on_the_loop_keyword() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -165,6 +165,23 @@ f() {
     }
 
     #[test]
+    fn reports_zsh_option_shaped_indexed_opts_after_option_map_assignment() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local -a OPTS
+  local opt_=1 q=1 quiet=0
+  OPTS[opt_-q,--quiet]=1
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_zsh_option_shaped_caller_indexed_opts_arithmetic_subshells() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -99,6 +99,92 @@ echo \"$count\"
     }
 
     #[test]
+    fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  ( (( !OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_option_map_keys_in_if_arithmetic_conditions() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  (
+    if (( ! OPTS[opt_-q,--quiet] )) {
+      :
+    }
+  )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_option_map_keys_after_option_map_assignment() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  OPTS[opt_-q,--quiet]=1
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_option_shaped_indexed_opts_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local -a OPTS
+  local opt_=1 q=1 quiet=0
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_option_shaped_caller_indexed_opts_arithmetic_subshells() {
+        let source = "\
+#!/bin/zsh
+callee() {
+  local opt_=1 q=1 quiet=0
+  ( (( OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+caller() {
+  local -a OPTS
+  callee
+}
+caller
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_bash_pipeline_assignments_when_pipefail_is_enabled() {
         let source = "\
 #!/usr/bin/env bash

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -264,6 +264,21 @@ map+=([assoc_bare_key]=value)
     }
 
     #[test]
+    fn suppresses_zsh_option_map_key_arithmetic_references() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local quiet=0
+  ( (( !OPTS[opt_-q,--quiet] )) )
+  (( quiet ))
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UndefinedVariable));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn subscript_suppression_hides_later_same_name_uses() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1254,6 +1254,21 @@ impl SemanticModel {
         self.visible_binding_from_named_callers(name, current_scope)
     }
 
+    /// Returns a visible binding that decides contextual associative lookups.
+    #[doc(hidden)]
+    pub fn visible_assoc_lookup_binding_for_lookup(
+        &self,
+        name: &Name,
+        current_scope: ScopeId,
+        at: Span,
+    ) -> Option<&Binding> {
+        if let Some(binding) = self.visible_binding_for_assoc_lookup(name, current_scope, at) {
+            return Some(binding);
+        }
+
+        self.visible_assoc_lookup_binding_from_named_callers(name, current_scope)
+    }
+
     /// Returns whether an associative binding is visible for a contextual array lookup.
     pub fn assoc_binding_visible_for_lookup(
         &self,
@@ -1315,6 +1330,40 @@ impl SemanticModel {
         }
 
         false
+    }
+
+    fn visible_assoc_lookup_binding_from_named_callers(
+        &self,
+        name: &Name,
+        current_scope: ScopeId,
+    ) -> Option<&Binding> {
+        let function_names = self.named_function_scope_names(current_scope)?;
+
+        let mut seen = AssocCallerSeenNames::new();
+        let mut worklist = SmallVec::<[Name; 4]>::new();
+        worklist.extend(function_names.iter().cloned());
+
+        while let Some(function_name) = worklist.pop() {
+            if !seen.insert(&function_name) {
+                continue;
+            }
+
+            for call_site in self.call_sites_for(&function_name) {
+                if let Some(binding) = self.visible_binding_for_assoc_lookup(
+                    name,
+                    call_site.scope,
+                    call_site.name_span,
+                ) {
+                    return Some(binding);
+                }
+
+                if let Some(caller_names) = self.named_function_scope_names(call_site.scope) {
+                    worklist.extend(caller_names.iter().cloned());
+                }
+            }
+        }
+
+        None
     }
 
     fn visible_binding_from_named_callers(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1234,6 +1234,26 @@ impl SemanticModel {
             .map(|binding_id| self.binding(binding_id))
     }
 
+    /// Returns a visible binding for a contextual lookup, including named callers.
+    #[doc(hidden)]
+    pub fn visible_binding_for_lookup(
+        &self,
+        name: &Name,
+        current_scope: ScopeId,
+        at: Span,
+    ) -> Option<&Binding> {
+        if let Some(binding_id) = self.previous_visible_binding_id_in_scope_chain(
+            name,
+            current_scope,
+            at.start.offset,
+            None,
+        ) {
+            return Some(self.binding(binding_id));
+        }
+
+        self.visible_binding_from_named_callers(name, current_scope)
+    }
+
     /// Returns whether an associative binding is visible for a contextual array lookup.
     pub fn assoc_binding_visible_for_lookup(
         &self,
@@ -1295,6 +1315,41 @@ impl SemanticModel {
         }
 
         false
+    }
+
+    fn visible_binding_from_named_callers(
+        &self,
+        name: &Name,
+        current_scope: ScopeId,
+    ) -> Option<&Binding> {
+        let function_names = self.named_function_scope_names(current_scope)?;
+
+        let mut seen = AssocCallerSeenNames::new();
+        let mut worklist = SmallVec::<[Name; 4]>::new();
+        worklist.extend(function_names.iter().cloned());
+
+        while let Some(function_name) = worklist.pop() {
+            if !seen.insert(&function_name) {
+                continue;
+            }
+
+            for call_site in self.call_sites_for(&function_name) {
+                if let Some(binding_id) = self.previous_visible_binding_id_in_scope_chain(
+                    name,
+                    call_site.scope,
+                    call_site.name_span.start.offset,
+                    None,
+                ) {
+                    return Some(self.binding(binding_id));
+                }
+
+                if let Some(caller_names) = self.named_function_scope_names(call_site.scope) {
+                    worklist.extend(caller_names.iter().cloned());
+                }
+            }
+        }
+
+        None
     }
 
     fn named_function_scope_names(&self, scope: ScopeId) -> Option<&[Name]> {


### PR DESCRIPTION
## Summary

- suppress zsh `OPTS[opt_-q,--quiet]` option-map keys when collecting arithmetic-only subscript facts
- carry those suppressed arithmetic subscript spans into nonpersistent assignment facts so synthetic `--quiet` updates do not trigger `C150`/`C155`
- keep explicit indexed `OPTS` declarations as real arithmetic, including caller-visible `local -a OPTS` counterexamples

## Root Cause

The parser now keeps zsh unbraced subscripts together, but arithmetic facts still treated option-map keys like `opt_-q,--quiet` as arithmetic expressions when `OPTS` had only an implicit non-associative binding. That manufactured writes to names such as `quiet`, which then surfaced as subshell side-effect diagnostics.

## Validation

- `cargo test -p shuck-linter zsh_option -- --nocapture`
- `cargo test -p shuck-linter suppresses_zsh_option_map_key_arithmetic_references -- --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- `cargo build -p shuck-cli`
- `make test`
- `target/debug/shuck check --no-cache --output-format json /Users/ewhauser/working/zinit`
