### PR TITLE
test(linter): cover zsh C114 glob qualifier policy

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -44,7 +44,7 @@ fn unquoted_expansion_prefix_spans(fact: WordOccurrenceRef<'_, '_>) -> Vec<Span>
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_unquoted_expansion_prefixes_in_for_glob_words() {
@@ -93,6 +93,48 @@ for i in $DIR/setjmp-aarch64/{setjmp.S,private-*.h}; do :; done
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::GlobWithExpansionInLoop),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_zsh_glob_qualifier_words_with_unquoted_expansion_prefixes() {
+        let source = "\
+#!/bin/zsh
+for m in ${plugin_dir}/*.zwc(.N); do :; done
+for snip ( ${ZINIT[SNIPPETS_DIR]}/**/(._zinit|._zplugin)/mode(D) ) { :; }
+for repo in ${ZINIT[PLUGINS_DIR]}/*; do :; done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobWithExpansionInLoop).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "${plugin_dir}",
+                "${ZINIT[SNIPPETS_DIR]}",
+                "${ZINIT[PLUGINS_DIR]}",
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_quoted_zsh_glob_qualifier_prefixes() {
+        let source = "\
+#!/bin/zsh
+for m in \"${plugin_dir}\"/*.zwc(.N); do :; done
+for snip ( \"${ZINIT[SNIPPETS_DIR]}\"/**/(._zinit|._zplugin)/mode(D) ) { :; }
+for repo in \"${ZINIT[PLUGINS_DIR]}\"/*; do :; done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobWithExpansionInLoop).with_shell(ShellDialect::Zsh),
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");


### PR DESCRIPTION
## Summary

- Keep C114 active for zsh loop glob words that combine an unquoted expansion prefix with glob qualifiers.
- Add focused zsh regressions for the zinit shapes and the quoted-prefix clean forms.

Fixes #807

## Validation

- cargo test -p shuck-linter glob_with_expansion_in_loop -- --nocapture
- cargo test -p shuck-linter reports_zsh_glob_qualifier_words_with_unquoted_expansion_prefixes -- --nocapture
- cargo fmt --check
- target/debug/shuck check --no-cache --select C114 --output-format json /Users/ewhauser/working/zinit