### PR TITLE
feat(server): bootstrap LSP scaffold

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -36,7 +36,8 @@
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-parser'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-run'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-semantic'].version" },
-        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-extract'].version" }
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-extract'].version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-server'].version" }
       ]
     }
   }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +470,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1023,6 +1054,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lsp-server"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6ada348dbc2703cbe7637b2dda05cff84d3da2819c24abcb305dd613e0ba2e"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.95.1"
+source = "git+https://github.com/astral-sh/lsp-types.git?rev=e15db0593f0ecbbd80599c3f5880e4bf5da1ca0c#e15db0593f0ecbbd80599c3f5880e4bf5da1ca0c"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1335,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "plotters"
@@ -1615,6 +1677,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1729,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.2",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1732,6 +1814,7 @@ dependencies = [
  "shuck-parser",
  "shuck-run",
  "shuck-semantic",
+ "shuck-server",
  "similar",
  "tempfile",
  "toml",
@@ -1825,6 +1908,23 @@ dependencies = [
  "shuck-parser",
  "smallvec",
  "tempfile",
+]
+
+[[package]]
+name = "shuck-server"
+version = "0.0.32"
+dependencies = [
+ "anyhow",
+ "crossbeam",
+ "lsp-server",
+ "lsp-types",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "shuck-ast",
+ "shuck-indexer",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1985,6 +2085,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tikv-jemalloc-sys"
 version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,6 +2175,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2268,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,8 @@ dependencies = [
 [[package]]
 name = "lsp-types"
 version = "0.95.1"
-source = "git+https://github.com/astral-sh/lsp-types.git?rev=e15db0593f0ecbbd80599c3f5880e4bf5da1ca0c#e15db0593f0ecbbd80599c3f5880e4bf5da1ca0c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
 dependencies = [
  "bitflags 1.3.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rustc-hash = "2.0.0"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "std"] }
 lsp-server = "0.7.6"
-lsp-types = { git = "https://github.com/astral-sh/lsp-types.git", rev = "e15db0593f0ecbbd80599c3f5880e4bf5da1ca0c", features = ["proposed"] }
+lsp-types = { version = "0.95.1", features = ["proposed"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ shuck-run = { path = "crates/shuck-run", version = "0.0.32" }
 shuck-semantic = { path = "crates/shuck-semantic", version = "0.0.32" }
 shuck-cli = { path = "crates/shuck-cli", version = "0.0.32" }
 shuck-extract = { path = "crates/shuck-extract", version = "0.0.32" }
+shuck-server = { path = "crates/shuck-server", version = "0.0.32" }
 
 # Error handling
 thiserror = "2"
@@ -37,6 +38,12 @@ anyhow = "1"
 etcetera = "0.8"
 rayon = "1.10"
 annotate-snippets = "0.10"
+crossbeam = "0.8.4"
+rustc-hash = "2.0.0"
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["fmt", "std"] }
+lsp-server = "0.7.6"
+lsp-types = { git = "https://github.com/astral-sh/lsp-types.git", rev = "e15db0593f0ecbbd80599c3f5880e4bf5da1ca0c", features = ["proposed"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/crates/shuck-cli/Cargo.toml
+++ b/crates/shuck-cli/Cargo.toml
@@ -42,6 +42,7 @@ shuck-indexer = { workspace = true }
 shuck-linter = { workspace = true }
 shuck-parser = { workspace = true }
 shuck-run = { workspace = true }
+shuck-server = { workspace = true }
 shuck-semantic = { workspace = true }
 similar = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/shuck-cli/src/args.rs
+++ b/crates/shuck-cli/src/args.rs
@@ -202,6 +202,8 @@ struct GlobalArgs {
 enum StableCommand {
     /// Lint shell files and supported embedded shell scripts.
     Check(Box<CheckCommand>),
+    /// Start the language server over stdio.
+    Server(ServerCommand),
     /// Run a shell script with a managed interpreter.
     Run(RunCommand),
     /// Pre-install a managed shell interpreter or list available versions.
@@ -218,6 +220,8 @@ enum StableCommand {
 enum ExperimentalCommand {
     /// Lint shell files and supported embedded shell scripts.
     Check(Box<CheckCommand>),
+    /// Start the language server over stdio.
+    Server(ServerCommand),
     /// Run a shell script with a managed interpreter.
     Run(RunCommand),
     /// Pre-install a managed shell interpreter or list available versions.
@@ -279,6 +283,7 @@ impl Args {
         } = global;
         let command = match command {
             StableCommand::Check(command) => Command::Check(command),
+            StableCommand::Server(command) => Command::Server(command),
             StableCommand::Run(command) => Command::Run(command),
             StableCommand::Install(command) => Command::Install(command),
             StableCommand::Shell(command) => Command::Shell(command),
@@ -311,6 +316,7 @@ impl Args {
         } = global;
         let command = match command {
             ExperimentalCommand::Check(command) => Command::Check(command),
+            ExperimentalCommand::Server(command) => Command::Server(command),
             ExperimentalCommand::Run(command) => Command::Run(command),
             ExperimentalCommand::Install(command) => Command::Install(command),
             ExperimentalCommand::Shell(command) => Command::Shell(command),
@@ -332,6 +338,8 @@ impl Args {
 pub enum Command {
     /// Lint shell files and supported embedded shell scripts.
     Check(Box<CheckCommand>),
+    /// Start the language server over stdio.
+    Server(ServerCommand),
     /// Run a shell script with a managed interpreter.
     Run(RunCommand),
     /// Pre-install a managed shell interpreter or list available versions.
@@ -352,6 +360,10 @@ fn experimental_enabled() -> bool {
         )
     })
 }
+
+/// Arguments for `shuck server`.
+#[derive(Debug, Clone, Default, ClapArgs)]
+pub struct ServerCommand {}
 
 /// Arguments for `shuck check`.
 #[derive(Debug, Clone, ClapArgs)]

--- a/crates/shuck-cli/src/commands/mod.rs
+++ b/crates/shuck-cli/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub(crate) mod format;
 pub(crate) mod format_stdin;
 pub(crate) mod project_runner;
 pub(crate) mod runtime;
+pub(crate) mod server;

--- a/crates/shuck-cli/src/commands/server.rs
+++ b/crates/shuck-cli/src/commands/server.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+
+use crate::ExitStatus;
+
+pub(crate) fn server() -> Result<ExitStatus> {
+    shuck_server::run()?;
+    Ok(ExitStatus::Success)
+}

--- a/crates/shuck-cli/src/lib.rs
+++ b/crates/shuck-cli/src/lib.rs
@@ -70,6 +70,7 @@ pub fn run(args: Args) -> Result<ExitStatus> {
 
     match command {
         Command::Check(command) => commands::check::check(*command, &config, cache_dir.as_deref()),
+        Command::Server(_command) => commands::server::server(),
         Command::Run(command) => commands::runtime::run(command, &config),
         Command::Install(command) => commands::runtime::install(command),
         Command::Shell(command) => commands::runtime::shell(command, &config),

--- a/crates/shuck-server/Cargo.toml
+++ b/crates/shuck-server/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "shuck-server"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Language server scaffold for shuck"
+
+[dependencies]
+anyhow = { workspace = true }
+crossbeam = { workspace = true }
+lsp-server = { workspace = true }
+lsp-types = { workspace = true }
+rustc-hash = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+shuck-ast = { workspace = true }
+shuck-indexer = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/shuck-server/src/edit.rs
+++ b/crates/shuck-server/src/edit.rs
@@ -1,0 +1,180 @@
+#![allow(dead_code)]
+
+mod range;
+mod text_document;
+
+use lsp_types::{PositionEncodingKind, Url};
+use shuck_ast::TextRange;
+
+pub(crate) use range::RangeExt;
+pub(crate) use text_document::DocumentVersion;
+pub use text_document::TextDocument;
+
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PositionEncoding {
+    #[default]
+    UTF16,
+    UTF32,
+    UTF8,
+}
+
+#[derive(Clone, Debug)]
+pub enum DocumentKey {
+    Text(Url),
+}
+
+impl DocumentKey {
+    pub(crate) fn into_url(self) -> Url {
+        match self {
+            Self::Text(url) => url,
+        }
+    }
+}
+
+impl std::fmt::Display for DocumentKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Text(url) => url.fmt(f),
+        }
+    }
+}
+
+impl From<PositionEncoding> for PositionEncodingKind {
+    fn from(value: PositionEncoding) -> Self {
+        match value {
+            PositionEncoding::UTF8 => PositionEncodingKind::UTF8,
+            PositionEncoding::UTF16 => PositionEncodingKind::UTF16,
+            PositionEncoding::UTF32 => PositionEncodingKind::UTF32,
+        }
+    }
+}
+
+impl TryFrom<&PositionEncodingKind> for PositionEncoding {
+    type Error = ();
+
+    fn try_from(value: &PositionEncodingKind) -> Result<Self, Self::Error> {
+        Ok(if value == &PositionEncodingKind::UTF8 {
+            Self::UTF8
+        } else if value == &PositionEncodingKind::UTF16 {
+            Self::UTF16
+        } else if value == &PositionEncodingKind::UTF32 {
+            Self::UTF32
+        } else {
+            return Err(());
+        })
+    }
+}
+
+fn clamp_offset_to_char_boundary(text: &str, offset: usize) -> usize {
+    let mut clamped = offset.min(text.len());
+    while clamped > 0 && !text.is_char_boundary(clamped) {
+        clamped -= 1;
+    }
+    clamped
+}
+
+fn offset_to_position(
+    text: &str,
+    index: &shuck_indexer::LineIndex,
+    offset: usize,
+    encoding: PositionEncoding,
+) -> lsp_types::Position {
+    let offset = clamp_offset_to_char_boundary(text, offset);
+    let line = index.line_number(shuck_ast::TextSize::new(offset as u32));
+    let line_start = index.line_start(line).map(usize::from).unwrap_or_default();
+    let prefix = &text[line_start..offset];
+    let character = match encoding {
+        PositionEncoding::UTF8 => prefix.len(),
+        PositionEncoding::UTF16 => prefix.encode_utf16().count(),
+        PositionEncoding::UTF32 => prefix.chars().count(),
+    };
+
+    lsp_types::Position {
+        line: u32::try_from(line.saturating_sub(1)).unwrap_or(u32::MAX),
+        character: u32::try_from(character).unwrap_or(u32::MAX),
+    }
+}
+
+fn position_to_offset(
+    text: &str,
+    index: &shuck_indexer::LineIndex,
+    position: lsp_types::Position,
+    encoding: PositionEncoding,
+) -> usize {
+    let line = usize::try_from(position.line).unwrap_or(usize::MAX) + 1;
+    let line = line.min(index.line_count());
+    let line_start = index
+        .line_start(line)
+        .map(usize::from)
+        .unwrap_or(text.len());
+    let line_end = index
+        .line_range(line, text)
+        .map(|range| usize::from(range.end()))
+        .unwrap_or(text.len());
+    let line_text = &text[line_start..line_end];
+    let target = usize::try_from(position.character).unwrap_or(usize::MAX);
+
+    let relative = match encoding {
+        PositionEncoding::UTF8 => target.min(line_text.len()),
+        PositionEncoding::UTF16 => {
+            let mut units = 0usize;
+            let mut offset = line_text.len();
+            for (idx, ch) in line_text.char_indices() {
+                if units >= target {
+                    offset = idx;
+                    break;
+                }
+                units += ch.len_utf16();
+            }
+            if units < target {
+                line_text.len()
+            } else {
+                offset
+            }
+        }
+        PositionEncoding::UTF32 => {
+            let mut chars = 0usize;
+            let mut offset = line_text.len();
+            for (idx, _) in line_text.char_indices() {
+                if chars >= target {
+                    offset = idx;
+                    break;
+                }
+                chars += 1;
+            }
+            if chars < target {
+                line_text.len()
+            } else {
+                offset
+            }
+        }
+    };
+
+    clamp_offset_to_char_boundary(line_text, relative) + line_start
+}
+
+pub(crate) fn to_text_range(
+    range: &lsp_types::Range,
+    text: &str,
+    index: &shuck_indexer::LineIndex,
+    encoding: PositionEncoding,
+) -> TextRange {
+    let start = position_to_offset(text, index, range.start, encoding);
+    let end = position_to_offset(text, index, range.end, encoding);
+    TextRange::new(
+        shuck_ast::TextSize::new(start.min(end) as u32),
+        shuck_ast::TextSize::new(end.max(start) as u32),
+    )
+}
+
+pub(crate) fn to_lsp_range(
+    range: TextRange,
+    text: &str,
+    index: &shuck_indexer::LineIndex,
+    encoding: PositionEncoding,
+) -> lsp_types::Range {
+    lsp_types::Range {
+        start: offset_to_position(text, index, usize::from(range.start()), encoding),
+        end: offset_to_position(text, index, usize::from(range.end()), encoding),
+    }
+}

--- a/crates/shuck-server/src/edit/range.rs
+++ b/crates/shuck-server/src/edit/range.rs
@@ -1,0 +1,43 @@
+use shuck_ast::TextRange;
+
+use crate::PositionEncoding;
+
+pub(crate) trait RangeExt {
+    fn to_text_range(
+        &self,
+        text: &str,
+        index: &shuck_indexer::LineIndex,
+        encoding: PositionEncoding,
+    ) -> TextRange;
+}
+
+pub(crate) trait ToRangeExt {
+    fn to_range(
+        &self,
+        text: &str,
+        index: &shuck_indexer::LineIndex,
+        encoding: PositionEncoding,
+    ) -> lsp_types::Range;
+}
+
+impl RangeExt for lsp_types::Range {
+    fn to_text_range(
+        &self,
+        text: &str,
+        index: &shuck_indexer::LineIndex,
+        encoding: PositionEncoding,
+    ) -> TextRange {
+        crate::edit::to_text_range(self, text, index, encoding)
+    }
+}
+
+impl ToRangeExt for TextRange {
+    fn to_range(
+        &self,
+        text: &str,
+        index: &shuck_indexer::LineIndex,
+        encoding: PositionEncoding,
+    ) -> lsp_types::Range {
+        crate::edit::to_lsp_range(*self, text, index, encoding)
+    }
+}

--- a/crates/shuck-server/src/edit/text_document.rs
+++ b/crates/shuck-server/src/edit/text_document.rs
@@ -1,0 +1,115 @@
+use lsp_types::TextDocumentContentChangeEvent;
+use shuck_indexer::LineIndex;
+
+use crate::PositionEncoding;
+
+use super::RangeExt;
+
+pub(crate) type DocumentVersion = i32;
+
+#[derive(Debug, Clone)]
+pub struct TextDocument {
+    contents: String,
+    index: LineIndex,
+    version: DocumentVersion,
+    language_id: Option<LanguageId>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum LanguageId {
+    Bash,
+    Sh,
+    Zsh,
+    Ksh,
+    Other,
+}
+
+impl From<&str> for LanguageId {
+    fn from(language_id: &str) -> Self {
+        match language_id {
+            "bash" => Self::Bash,
+            "shellscript" | "sh" => Self::Sh,
+            "zsh" => Self::Zsh,
+            "ksh" => Self::Ksh,
+            _ => Self::Other,
+        }
+    }
+}
+
+impl TextDocument {
+    pub fn new(contents: String, version: DocumentVersion) -> Self {
+        let index = LineIndex::new(&contents);
+        Self {
+            contents,
+            index,
+            version,
+            language_id: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_language_id(mut self, language_id: &str) -> Self {
+        self.language_id = Some(LanguageId::from(language_id));
+        self
+    }
+
+    pub fn contents(&self) -> &str {
+        &self.contents
+    }
+
+    pub fn index(&self) -> &LineIndex {
+        &self.index
+    }
+
+    pub fn version(&self) -> DocumentVersion {
+        self.version
+    }
+
+    pub fn language_id(&self) -> Option<LanguageId> {
+        self.language_id
+    }
+
+    pub fn apply_changes(
+        &mut self,
+        changes: Vec<TextDocumentContentChangeEvent>,
+        new_version: DocumentVersion,
+        encoding: PositionEncoding,
+    ) {
+        if let [
+            TextDocumentContentChangeEvent {
+                range: None, text, ..
+            },
+        ] = changes.as_slice()
+        {
+            self.contents.clone_from(text);
+            self.index = LineIndex::new(&self.contents);
+            self.version = new_version;
+            return;
+        }
+
+        let mut new_contents = self.contents.clone();
+        let mut active_index = self.index.clone();
+
+        for change in changes {
+            if let Some(range) = change.range {
+                let range = range.to_text_range(&new_contents, &active_index, encoding);
+                new_contents.replace_range(
+                    usize::from(range.start())..usize::from(range.end()),
+                    &change.text,
+                );
+            } else {
+                new_contents = change.text;
+            }
+            active_index = LineIndex::new(&new_contents);
+        }
+
+        self.contents = new_contents;
+        self.index = active_index;
+        self.version = new_version;
+    }
+
+    pub fn update_version(&mut self, new_version: DocumentVersion) {
+        debug_assert!(new_version >= self.version);
+        self.version = new_version;
+    }
+}

--- a/crates/shuck-server/src/fix.rs
+++ b/crates/shuck-server/src/fix.rs
@@ -1,0 +1,28 @@
+#![allow(dead_code)]
+
+use lsp_types as types;
+
+use crate::session::{Client, DocumentSnapshot, Session};
+
+pub(crate) fn code_actions(
+    _snapshot: DocumentSnapshot,
+    _client: &Client,
+    _params: types::CodeActionParams,
+) -> crate::server::Result<Option<types::CodeActionResponse>> {
+    unimplemented!("shuck LSP code actions are not implemented yet")
+}
+
+pub(crate) fn resolve_code_action(
+    _client: &Client,
+    _action: types::CodeAction,
+) -> crate::server::Result<types::CodeAction> {
+    unimplemented!("shuck LSP code action resolution is not implemented yet")
+}
+
+pub(crate) fn execute_command(
+    _session: &mut Session,
+    _client: &Client,
+    _params: types::ExecuteCommandParams,
+) -> crate::server::Result<Option<serde_json::Value>> {
+    unimplemented!("shuck LSP executeCommand is not implemented yet")
+}

--- a/crates/shuck-server/src/format.rs
+++ b/crates/shuck-server/src/format.rs
@@ -1,0 +1,23 @@
+#![allow(dead_code)]
+
+use lsp_types as types;
+
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) type FormatResponse = Option<Vec<types::TextEdit>>;
+
+pub(crate) fn format_document(
+    _snapshot: DocumentSnapshot,
+    _client: &Client,
+    _params: types::DocumentFormattingParams,
+) -> crate::server::Result<FormatResponse> {
+    unimplemented!("shuck LSP document formatting is not implemented yet")
+}
+
+pub(crate) fn format_range(
+    _snapshot: DocumentSnapshot,
+    _client: &Client,
+    _params: types::DocumentRangeFormattingParams,
+) -> crate::server::Result<FormatResponse> {
+    unimplemented!("shuck LSP range formatting is not implemented yet")
+}

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -1,0 +1,52 @@
+#![allow(missing_docs)]
+#![cfg_attr(not(test), warn(clippy::unwrap_used))]
+
+use std::num::NonZeroUsize;
+
+pub use edit::{DocumentKey, PositionEncoding, TextDocument};
+use lsp_types::CodeActionKind;
+pub use server::Server;
+pub use session::{Client, ClientOptions, DocumentQuery, DocumentSnapshot, Session};
+pub use workspace::{Workspace, Workspaces};
+
+mod edit;
+mod fix;
+mod format;
+mod lint;
+mod logging;
+mod resolve;
+mod server;
+mod session;
+mod workspace;
+
+pub(crate) const SERVER_NAME: &str = "shuck";
+pub(crate) const DIAGNOSTIC_NAME: &str = "Shuck";
+
+pub(crate) const SOURCE_FIX_ALL_SHUCK: CodeActionKind = CodeActionKind::new("source.fixAll.shuck");
+
+pub(crate) type Result<T> = anyhow::Result<T>;
+
+pub(crate) fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+pub fn run() -> Result<()> {
+    let four = NonZeroUsize::try_from(4usize)
+        .map_err(|_| anyhow::anyhow!("failed to create non-zero worker count"))?;
+    let worker_threads = std::thread::available_parallelism()
+        .unwrap_or(four)
+        .min(four);
+
+    let (connection, io_threads) = server::ConnectionInitializer::stdio();
+    let server_result = Server::new(worker_threads, connection)
+        .map_err(|err| err.context("Failed to start server"))?
+        .run();
+
+    let io_result = io_threads.join();
+    match (server_result, io_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(server), Ok(())) => Err(server),
+        (Ok(()), Err(io)) => Err(anyhow::Error::new(io).context("IO thread error")),
+        (Err(server), Err(io)) => Err(server.context(format!("IO thread error: {io}"))),
+    }
+}

--- a/crates/shuck-server/src/lint.rs
+++ b/crates/shuck-server/src/lint.rs
@@ -1,0 +1,7 @@
+use lsp_types as types;
+
+use crate::session::DocumentSnapshot;
+
+pub(crate) fn generate_diagnostics(_snapshot: &DocumentSnapshot) -> Vec<types::Diagnostic> {
+    Vec::new()
+}

--- a/crates/shuck-server/src/logging.rs
+++ b/crates/shuck-server/src/logging.rs
@@ -1,0 +1,36 @@
+use serde::Deserialize;
+use std::path::Path;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::FmtSubscriber;
+
+pub(crate) fn init_logging(log_level: LogLevel, _log_file: Option<&Path>) {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(log_level.level_filter())
+        .with_ansi(false)
+        .finish();
+
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum LogLevel {
+    Error,
+    Warn,
+    #[default]
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LogLevel {
+    fn level_filter(self) -> LevelFilter {
+        match self {
+            Self::Error => LevelFilter::ERROR,
+            Self::Warn => LevelFilter::WARN,
+            Self::Info => LevelFilter::INFO,
+            Self::Debug => LevelFilter::DEBUG,
+            Self::Trace => LevelFilter::TRACE,
+        }
+    }
+}

--- a/crates/shuck-server/src/resolve.rs
+++ b/crates/shuck-server/src/resolve.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+use lsp_types as types;
+
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) fn hover(
+    _snapshot: DocumentSnapshot,
+    _client: &Client,
+    _params: types::HoverParams,
+) -> crate::server::Result<Option<types::Hover>> {
+    unimplemented!("shuck LSP hover is not implemented yet")
+}

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -1,0 +1,201 @@
+use lsp_server::Connection;
+use lsp_types as types;
+use lsp_types::InitializeParams;
+use lsp_types::{
+    ClientCapabilities, CodeActionKind, CodeActionOptions, DiagnosticOptions, OneOf,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    WorkDoneProgressOptions, WorkspaceFoldersServerCapabilities,
+};
+use std::num::NonZeroUsize;
+
+pub(crate) use self::connection::ConnectionInitializer;
+pub use self::connection::ConnectionSender;
+use self::schedule::spawn_main_loop;
+use crate::PositionEncoding;
+pub use crate::server::main_loop::MainLoopSender;
+pub(crate) use crate::server::main_loop::{Event, MainLoopReceiver};
+use crate::session::{AllOptions, Client, Session};
+use crate::workspace::Workspaces;
+pub(crate) use api::Error;
+
+mod api;
+mod connection;
+mod main_loop;
+mod schedule;
+
+pub(crate) type Result<T> = std::result::Result<T, api::Error>;
+
+pub struct Server {
+    connection: Connection,
+    client_capabilities: ClientCapabilities,
+    worker_threads: NonZeroUsize,
+    main_loop_receiver: MainLoopReceiver,
+    main_loop_sender: MainLoopSender,
+    session: Session,
+}
+
+impl Server {
+    pub(crate) fn new(
+        worker_threads: NonZeroUsize,
+        connection: ConnectionInitializer,
+    ) -> crate::Result<Self> {
+        let (id, init_params) = connection.initialize_start()?;
+        let client_capabilities = init_params.capabilities;
+        let position_encoding = Self::find_best_position_encoding(&client_capabilities);
+        let server_capabilities = Self::server_capabilities(position_encoding);
+        let connection = connection.initialize_finish(
+            id,
+            &server_capabilities,
+            crate::SERVER_NAME,
+            crate::version(),
+        )?;
+
+        let (main_loop_sender, main_loop_receiver) = crossbeam::channel::bounded(32);
+
+        let InitializeParams {
+            initialization_options,
+            workspace_folders,
+            ..
+        } = init_params;
+
+        let client = Client::new(main_loop_sender.clone(), connection.sender.clone());
+        let AllOptions { global, workspace } = AllOptions::from_value(
+            initialization_options.unwrap_or(serde_json::Value::Null),
+            &client,
+        );
+
+        crate::logging::init_logging(global.tracing.log_level.unwrap_or_default(), None);
+
+        let workspaces =
+            Workspaces::from_workspace_folders(workspace_folders, workspace.unwrap_or_default())?;
+        let global = global.into_settings(client.clone());
+
+        Ok(Self {
+            connection,
+            client_capabilities: client_capabilities.clone(),
+            worker_threads,
+            main_loop_receiver,
+            main_loop_sender,
+            session: Session::new(
+                &client_capabilities,
+                position_encoding,
+                global,
+                &workspaces,
+                &client,
+            )?,
+        })
+    }
+
+    pub fn run(mut self) -> crate::Result<()> {
+        spawn_main_loop(move || self.main_loop())?
+            .join()
+            .map_err(|_| anyhow::anyhow!("main loop thread panicked"))?
+    }
+
+    fn find_best_position_encoding(client_capabilities: &ClientCapabilities) -> PositionEncoding {
+        client_capabilities
+            .general
+            .as_ref()
+            .and_then(|general| general.position_encodings.as_ref())
+            .and_then(|encodings| {
+                encodings
+                    .iter()
+                    .filter_map(|encoding| PositionEncoding::try_from(encoding).ok())
+                    .max()
+            })
+            .unwrap_or_default()
+    }
+
+    fn server_capabilities(position_encoding: PositionEncoding) -> types::ServerCapabilities {
+        types::ServerCapabilities {
+            position_encoding: Some(position_encoding.into()),
+            code_action_provider: Some(types::CodeActionProviderCapability::Options(
+                CodeActionOptions {
+                    code_action_kinds: Some(
+                        SupportedCodeAction::all()
+                            .map(SupportedCodeAction::to_kind)
+                            .collect(),
+                    ),
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
+                    resolve_provider: Some(true),
+                },
+            )),
+            workspace: Some(types::WorkspaceServerCapabilities {
+                workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                    supported: Some(true),
+                    change_notifications: Some(OneOf::Left(true)),
+                }),
+                file_operations: None,
+            }),
+            document_formatting_provider: Some(OneOf::Left(true)),
+            document_range_formatting_provider: Some(OneOf::Left(true)),
+            diagnostic_provider: Some(types::DiagnosticServerCapabilities::Options(
+                DiagnosticOptions {
+                    identifier: Some(crate::DIAGNOSTIC_NAME.into()),
+                    inter_file_dependencies: false,
+                    workspace_diagnostics: false,
+                    work_done_progress_options: WorkDoneProgressOptions {
+                        work_done_progress: Some(true),
+                    },
+                },
+            )),
+            execute_command_provider: Some(types::ExecuteCommandOptions {
+                commands: SupportedCommand::all()
+                    .map(|command| command.identifier().to_string())
+                    .collect(),
+                work_done_progress_options: WorkDoneProgressOptions {
+                    work_done_progress: Some(false),
+                },
+            }),
+            hover_provider: Some(types::HoverProviderCapability::Simple(true)),
+            text_document_sync: Some(TextDocumentSyncCapability::Options(
+                TextDocumentSyncOptions {
+                    open_close: Some(true),
+                    change: Some(TextDocumentSyncKind::INCREMENTAL),
+                    will_save: Some(false),
+                    will_save_wait_until: Some(false),
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum SupportedCodeAction {
+    QuickFix,
+    SourceFixAll,
+}
+
+impl SupportedCodeAction {
+    fn all() -> impl Iterator<Item = Self> {
+        [Self::QuickFix, Self::SourceFixAll].into_iter()
+    }
+
+    fn to_kind(self) -> CodeActionKind {
+        match self {
+            Self::QuickFix => CodeActionKind::QUICKFIX,
+            Self::SourceFixAll => crate::SOURCE_FIX_ALL_SHUCK,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum SupportedCommand {
+    ApplyAutofix,
+}
+
+impl SupportedCommand {
+    fn all() -> impl Iterator<Item = Self> {
+        [Self::ApplyAutofix].into_iter()
+    }
+
+    fn identifier(self) -> &'static str {
+        match self {
+            Self::ApplyAutofix => "shuck.applyAutofix",
+        }
+    }
+}

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -52,8 +52,11 @@ impl Server {
 
         let (main_loop_sender, main_loop_receiver) = crossbeam::channel::bounded(32);
 
+        #[allow(deprecated)]
         let InitializeParams {
             initialization_options,
+            root_path,
+            root_uri,
             workspace_folders,
             ..
         } = init_params;
@@ -66,8 +69,12 @@ impl Server {
 
         crate::logging::init_logging(global.tracing.log_level.unwrap_or_default(), None);
 
-        let workspaces =
-            Workspaces::from_workspace_folders(workspace_folders, workspace.unwrap_or_default())?;
+        let workspaces = Workspaces::from_workspace_folders(
+            workspace_folders,
+            root_uri,
+            root_path,
+            workspace.unwrap_or_default(),
+        )?;
         let global = global.into_settings(client.clone());
 
         Ok(Self {

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -1,0 +1,299 @@
+use std::panic::UnwindSafe;
+
+use anyhow::anyhow;
+use lsp_server::{self as server, RequestId};
+use lsp_types::{notification::Notification, request::Request};
+use notifications as notification;
+use requests as request;
+
+use crate::server::Result;
+use crate::server::schedule::{BackgroundSchedule, Task};
+use crate::server::{
+    api::traits::{
+        BackgroundDocumentRequestHandler, NotificationHandler, RequestHandler,
+        SyncNotificationHandler, SyncRequestHandler,
+    },
+    schedule,
+};
+use crate::session::{Client, Session};
+
+mod diagnostics;
+mod notifications;
+mod requests;
+mod traits;
+
+macro_rules! define_document_url {
+    ($params:ident: &$p:ty) => {
+        fn document_url($params: &$p) -> std::borrow::Cow<'_, lsp_types::Url> {
+            std::borrow::Cow::Borrowed(&$params.text_document.uri)
+        }
+    };
+}
+
+use define_document_url;
+
+pub(super) fn request(req: server::Request) -> Task {
+    let id = req.id.clone();
+
+    match req.method.as_str() {
+        request::CodeActions::METHOD => {
+            background_request_task::<request::CodeActions>(req, BackgroundSchedule::Worker)
+        }
+        request::CodeActionResolve::METHOD => {
+            sync_request_task::<request::CodeActionResolve>(req)
+        }
+        request::DocumentDiagnostic::METHOD => {
+            background_request_task::<request::DocumentDiagnostic>(req, BackgroundSchedule::Worker)
+        }
+        request::ExecuteCommand::METHOD => sync_request_task::<request::ExecuteCommand>(req),
+        request::Format::METHOD => {
+            background_request_task::<request::Format>(req, BackgroundSchedule::Fmt)
+        }
+        request::FormatRange::METHOD => {
+            background_request_task::<request::FormatRange>(req, BackgroundSchedule::Fmt)
+        }
+        request::Hover::METHOD => {
+            background_request_task::<request::Hover>(req, BackgroundSchedule::Worker)
+        }
+        lsp_types::request::Shutdown::METHOD => sync_request_task::<request::ShutdownHandler>(req),
+        method => {
+            let result: Result<()> = Err(Error::new(
+                anyhow!("Unknown request: {method}"),
+                server::ErrorCode::MethodNotFound,
+            ));
+            return Task::immediate(id, result);
+        }
+    }
+    .unwrap_or_else(|err| {
+        Task::sync(move |_session, client| {
+            client.show_error_message(
+                "Shuck failed to handle a request from the editor. Check the logs for more details.",
+            );
+            respond_silent_error(
+                id,
+                client,
+                lsp_server::ResponseError {
+                    code: err.code as i32,
+                    message: err.to_string(),
+                    data: None,
+                },
+            );
+        })
+    })
+}
+
+pub(super) fn notification(notif: server::Notification) -> Task {
+    match notif.method.as_str() {
+        notification::DidChange::METHOD => sync_notification_task::<notification::DidChange>(notif),
+        notification::DidChangeConfiguration::METHOD => {
+            sync_notification_task::<notification::DidChangeConfiguration>(notif)
+        }
+        notification::DidChangeWatchedFiles::METHOD => {
+            sync_notification_task::<notification::DidChangeWatchedFiles>(notif)
+        }
+        notification::DidChangeWorkspace::METHOD => {
+            sync_notification_task::<notification::DidChangeWorkspace>(notif)
+        }
+        notification::DidClose::METHOD => sync_notification_task::<notification::DidClose>(notif),
+        notification::DidOpen::METHOD => sync_notification_task::<notification::DidOpen>(notif),
+        lsp_types::notification::Cancel::METHOD => {
+            sync_notification_task::<notification::CancelNotificationHandler>(notif)
+        }
+        lsp_types::notification::SetTrace::METHOD => Ok(Task::nothing()),
+        _ => Ok(Task::nothing()),
+    }
+    .unwrap_or_else(|err| {
+        Task::sync(move |_session, client| {
+            tracing::error!("Failed to handle notification: {err}");
+            client.show_error_message(
+                "Shuck failed to handle a notification from the editor. Check the logs for more details.",
+            );
+        })
+    })
+}
+
+fn sync_request_task<R: SyncRequestHandler>(req: server::Request) -> Result<Task>
+where
+    <<R as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
+{
+    let (id, params) = cast_request::<R>(req)?;
+    Ok(Task::sync(move |session, client| {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            R::run(session, client, params)
+        }));
+
+        let response = match result {
+            Ok(result) => result,
+            Err(error) => Err(Error::new(
+                anyhow!(panic_message(&error).unwrap_or("request handler panicked".into())),
+                lsp_server::ErrorCode::InternalError,
+            )),
+        };
+        respond::<R>(&id, response, client);
+    }))
+}
+
+fn background_request_task<R: BackgroundDocumentRequestHandler>(
+    req: server::Request,
+    schedule: schedule::BackgroundSchedule,
+) -> Result<Task>
+where
+    <<R as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
+{
+    let (id, params) = cast_request::<R>(req)?;
+    Ok(Task::background(schedule, move |session: &Session| {
+        let cancellation_token = session
+            .request_queue()
+            .incoming()
+            .cancellation_token(&id)
+            .expect("request should be registered before scheduling");
+        let Some(snapshot) = session.take_snapshot(R::document_url(&params).into_owned()) else {
+            return Box::new(|_| {});
+        };
+        Box::new(move |client| {
+            if cancellation_token.is_cancelled() {
+                return;
+            }
+
+            let result =
+                std::panic::catch_unwind(|| R::run_with_snapshot(snapshot, client, params));
+            let response = match result {
+                Ok(result) => result,
+                Err(error) => Err(Error::new(
+                    anyhow!(panic_message(&error).unwrap_or("request handler panicked".into())),
+                    lsp_server::ErrorCode::InternalError,
+                )),
+            };
+            respond::<R>(&id, response, client);
+        })
+    }))
+}
+
+fn sync_notification_task<N: SyncNotificationHandler>(notif: server::Notification) -> Result<Task> {
+    let params = cast_notification::<N>(notif)?;
+    Ok(Task::sync(move |session, client| {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            N::run(session, client, params)
+        }));
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                tracing::error!("Notification handler failed: {err}");
+                client.show_error_message(
+                    "Shuck encountered a problem. Check the logs for more details.",
+                );
+            }
+            Err(error) => {
+                tracing::error!(
+                    "Notification handler panicked: {}",
+                    panic_message(&error).unwrap_or("unknown panic".into())
+                );
+                client.show_error_message(
+                    "Shuck encountered a panic. Check the logs for more details.",
+                );
+            }
+        }
+    }))
+}
+
+fn cast_request<Req>(
+    request: server::Request,
+) -> Result<(
+    RequestId,
+    <<Req as RequestHandler>::RequestType as Request>::Params,
+)>
+where
+    Req: RequestHandler,
+    <<Req as RequestHandler>::RequestType as Request>::Params: UnwindSafe,
+{
+    request.extract(Req::METHOD).map_err(|err| match err {
+        json_err @ server::ExtractError::JsonError { .. } => Error::new(
+            anyhow!("JSON parsing failure:\n{json_err}"),
+            server::ErrorCode::InvalidParams,
+        ),
+        server::ExtractError::MethodMismatch(_) => unreachable!(),
+    })
+}
+
+fn cast_notification<Notif>(
+    notification: server::Notification,
+) -> Result<<<Notif as NotificationHandler>::NotificationType as Notification>::Params>
+where
+    Notif: NotificationHandler,
+{
+    notification
+        .extract(Notif::METHOD)
+        .map_err(|err| match err {
+            json_err @ server::ExtractError::JsonError { .. } => Error::new(
+                anyhow!("JSON parsing failure:\n{json_err}"),
+                server::ErrorCode::InvalidParams,
+            ),
+            server::ExtractError::MethodMismatch(_) => unreachable!(),
+        })
+}
+
+fn respond<Req>(
+    id: &RequestId,
+    response: Result<<<Req as RequestHandler>::RequestType as Request>::Result>,
+    client: &Client,
+) where
+    Req: RequestHandler,
+    <<Req as RequestHandler>::RequestType as Request>::Result: serde::Serialize,
+{
+    if let Err(err) = client.respond(id, response) {
+        tracing::error!("Failed to send response for {}: {err}", Req::METHOD);
+    }
+}
+
+fn respond_silent_error(id: RequestId, client: &Client, error: lsp_server::ResponseError) {
+    if let Err(send_error) = client.respond_err(id, error) {
+        tracing::error!("Failed to send error response: {send_error}");
+    }
+}
+
+fn panic_message(error: &Box<dyn std::any::Any + Send + 'static>) -> Option<String> {
+    error.downcast_ref::<String>().cloned().or_else(|| {
+        error
+            .downcast_ref::<&'static str>()
+            .map(|msg| (*msg).to_owned())
+    })
+}
+
+#[derive(Debug)]
+pub(crate) struct Error {
+    pub(crate) code: lsp_server::ErrorCode,
+    pub(crate) error: anyhow::Error,
+}
+
+impl Error {
+    pub(crate) fn new(error: anyhow::Error, code: lsp_server::ErrorCode) -> Self {
+        Self { code, error }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(f)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<anyhow::Error> for Error {
+    fn from(error: anyhow::Error) -> Self {
+        Self::new(error, lsp_server::ErrorCode::InternalError)
+    }
+}
+
+pub(crate) trait LSPResult<T> {
+    fn with_failure_code(self, code: lsp_server::ErrorCode) -> Result<T>;
+}
+
+impl<T, E> LSPResult<T> for std::result::Result<T, E>
+where
+    E: Into<anyhow::Error>,
+{
+    fn with_failure_code(self, code: lsp_server::ErrorCode) -> Result<T> {
+        self.map_err(|error| Error::new(error.into(), code))
+    }
+}

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -148,7 +148,17 @@ where
             .cancellation_token(&id)
             .expect("request should be registered before scheduling");
         let Some(snapshot) = session.take_snapshot(R::document_url(&params).into_owned()) else {
-            return Box::new(|_| {});
+            tracing::debug!(
+                "Skipping {} because the document is no longer open",
+                R::METHOD
+            );
+            return Box::new(move |client| {
+                if cancellation_token.is_cancelled() {
+                    return;
+                }
+
+                respond::<R>(&id, R::run_without_snapshot(client, params), client);
+            });
         };
         Box::new(move |client| {
             if cancellation_token.is_cancelled() {
@@ -295,5 +305,83 @@ where
 {
     fn with_failure_code(self, code: lsp_server::ErrorCode) -> Result<T> {
         self.map_err(|error| Error::new(error.into(), code))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam::channel;
+    use lsp_server::{Message, Request as LspRequest, RequestId};
+    use lsp_types::{
+        ClientCapabilities, HoverParams, Position, TextDocumentIdentifier,
+        TextDocumentPositionParams, Url, WorkDoneProgressParams,
+    };
+
+    use super::*;
+    use crate::server::Event;
+    use crate::session::AllOptions;
+    use crate::{PositionEncoding, Workspace, Workspaces};
+
+    fn test_client() -> (Client, channel::Receiver<Event>) {
+        let (event_tx, event_rx) = channel::unbounded();
+        let (connection_tx, _connection_rx) = channel::unbounded::<Message>();
+        (Client::new(event_tx, connection_tx), event_rx)
+    }
+
+    fn test_session(client: &Client) -> Session {
+        let workspace_url = Url::from_file_path(std::env::current_dir().unwrap())
+            .expect("current directory should convert to a file URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_url)]);
+        let AllOptions { global, .. } = AllOptions::from_value(serde_json::Value::Null, client);
+        let global = global.into_settings(client.clone());
+
+        Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::default(),
+            global,
+            &workspaces,
+            client,
+        )
+        .expect("test session should initialize")
+    }
+
+    #[test]
+    fn missing_snapshot_background_request_still_sends_a_response() {
+        let (client, event_rx) = test_client();
+        let mut session = test_session(&client);
+        let uri = Url::parse("file:///tmp/missing.sh").expect("test URI should parse");
+        let request_id: RequestId = 1.into();
+        session
+            .request_queue_mut()
+            .incoming_mut()
+            .register(request_id.clone(), request::Hover::METHOD.to_string());
+
+        let request = LspRequest {
+            id: request_id.clone(),
+            method: request::Hover::METHOD.to_string(),
+            params: serde_json::to_value(HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri },
+                    position: Position::new(0, 0),
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            })
+            .expect("hover params should serialize"),
+        };
+
+        let task = background_request_task::<request::Hover>(request, BackgroundSchedule::Worker)
+            .expect("hover request should schedule");
+        task.run_for_test(&mut session, &client);
+
+        let Event::SendResponse(response) = event_rx
+            .try_recv()
+            .expect("missing snapshot path should enqueue a response")
+        else {
+            panic!("expected queued response event");
+        };
+
+        assert_eq!(response.id, request_id);
+        assert!(response.error.is_none());
+        assert_eq!(response.result, Some(serde_json::Value::Null));
     }
 }

--- a/crates/shuck-server/src/server/api/diagnostics.rs
+++ b/crates/shuck-server/src/server/api/diagnostics.rs
@@ -1,0 +1,30 @@
+use lsp_types as types;
+
+use crate::lint::generate_diagnostics;
+use crate::server::Result;
+use crate::session::{Client, DocumentQuery, DocumentSnapshot};
+
+pub(super) fn publish_diagnostics_for_document(
+    snapshot: &DocumentSnapshot,
+    client: &Client,
+) -> Result<()> {
+    client.send_notification::<types::notification::PublishDiagnostics>(
+        types::PublishDiagnosticsParams {
+            uri: snapshot.query().file_url().clone(),
+            diagnostics: generate_diagnostics(snapshot),
+            version: Some(snapshot.query().document().version()),
+        },
+    )?;
+    Ok(())
+}
+
+pub(super) fn clear_diagnostics_for_document(query: &DocumentQuery, client: &Client) -> Result<()> {
+    client.send_notification::<types::notification::PublishDiagnostics>(
+        types::PublishDiagnosticsParams {
+            uri: query.file_url().clone(),
+            diagnostics: Vec::new(),
+            version: Some(query.document().version()),
+        },
+    )?;
+    Ok(())
+}

--- a/crates/shuck-server/src/server/api/notifications.rs
+++ b/crates/shuck-server/src/server/api/notifications.rs
@@ -1,0 +1,15 @@
+mod cancel;
+mod did_change;
+mod did_change_configuration;
+mod did_change_watched_files;
+mod did_change_workspace;
+mod did_close;
+mod did_open;
+
+pub(super) use cancel::CancelNotificationHandler;
+pub(super) use did_change::DidChange;
+pub(super) use did_change_configuration::DidChangeConfiguration;
+pub(super) use did_change_watched_files::DidChangeWatchedFiles;
+pub(super) use did_change_workspace::DidChangeWorkspace;
+pub(super) use did_close::DidClose;
+pub(super) use did_open::DidOpen;

--- a/crates/shuck-server/src/server/api/notifications/cancel.rs
+++ b/crates/shuck-server/src/server/api/notifications/cancel.rs
@@ -1,0 +1,24 @@
+use lsp_server::RequestId;
+use lsp_types::CancelParams;
+use lsp_types::notification::Cancel;
+
+use crate::server::Result;
+use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
+use crate::session::{Client, Session};
+
+pub(crate) struct CancelNotificationHandler;
+
+impl NotificationHandler for CancelNotificationHandler {
+    type NotificationType = Cancel;
+}
+
+impl SyncNotificationHandler for CancelNotificationHandler {
+    fn run(session: &mut Session, client: &Client, params: CancelParams) -> Result<()> {
+        let id: RequestId = match params.id {
+            lsp_types::NumberOrString::Number(id) => id.into(),
+            lsp_types::NumberOrString::String(id) => id.into(),
+        };
+        let _ = client.cancel(session, id);
+        Ok(())
+    }
+}

--- a/crates/shuck-server/src/server/api/notifications/did_change.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change.rs
@@ -1,0 +1,46 @@
+use lsp_server::ErrorCode;
+use lsp_types as types;
+use lsp_types::notification as notif;
+
+use crate::server::Result;
+use crate::server::api::LSPResult;
+use crate::server::api::diagnostics::publish_diagnostics_for_document;
+use crate::session::{Client, Session};
+
+pub(crate) struct DidChange;
+
+impl super::super::traits::NotificationHandler for DidChange {
+    type NotificationType = notif::DidChangeTextDocument;
+}
+
+impl super::super::traits::SyncNotificationHandler for DidChange {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        types::DidChangeTextDocumentParams {
+            text_document:
+                types::VersionedTextDocumentIdentifier {
+                    uri,
+                    version: new_version,
+                },
+            content_changes,
+        }: types::DidChangeTextDocumentParams,
+    ) -> Result<()> {
+        let key = session.key_from_url(uri);
+        session
+            .update_text_document(&key, content_changes, new_version)
+            .with_failure_code(ErrorCode::InternalError)?;
+
+        if !session.resolved_client_capabilities().pull_diagnostics {
+            let snapshot = session.take_snapshot(key.into_url()).ok_or_else(|| {
+                crate::server::Error::new(
+                    anyhow::anyhow!("failed to take document snapshot after change"),
+                    ErrorCode::InternalError,
+                )
+            })?;
+            publish_diagnostics_for_document(&snapshot, client)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/shuck-server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_configuration.rs
@@ -1,0 +1,22 @@
+use lsp_types as types;
+use lsp_types::notification as notif;
+
+use crate::server::Result;
+use crate::session::{Client, Session};
+
+pub(crate) struct DidChangeConfiguration;
+
+impl super::super::traits::NotificationHandler for DidChangeConfiguration {
+    type NotificationType = notif::DidChangeConfiguration;
+}
+
+impl super::super::traits::SyncNotificationHandler for DidChangeConfiguration {
+    fn run(
+        _session: &mut Session,
+        _client: &Client,
+        _params: types::DidChangeConfigurationParams,
+    ) -> Result<()> {
+        tracing::debug!("Ignoring didChangeConfiguration until client settings are wired");
+        Ok(())
+    }
+}

--- a/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
@@ -1,0 +1,22 @@
+use lsp_types as types;
+use lsp_types::notification as notif;
+
+use crate::server::Result;
+use crate::session::{Client, Session};
+
+pub(crate) struct DidChangeWatchedFiles;
+
+impl super::super::traits::NotificationHandler for DidChangeWatchedFiles {
+    type NotificationType = notif::DidChangeWatchedFiles;
+}
+
+impl super::super::traits::SyncNotificationHandler for DidChangeWatchedFiles {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        params: types::DidChangeWatchedFilesParams,
+    ) -> Result<()> {
+        session.reload_settings(&params.changes, client);
+        Ok(())
+    }
+}

--- a/crates/shuck-server/src/server/api/notifications/did_change_workspace.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_workspace.rs
@@ -1,0 +1,32 @@
+use lsp_types as types;
+use lsp_types::notification as notif;
+
+use crate::server::Result;
+use crate::server::api::LSPResult;
+use crate::session::{Client, Session};
+
+pub(crate) struct DidChangeWorkspace;
+
+impl super::super::traits::NotificationHandler for DidChangeWorkspace {
+    type NotificationType = notif::DidChangeWorkspaceFolders;
+}
+
+impl super::super::traits::SyncNotificationHandler for DidChangeWorkspace {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        params: types::DidChangeWorkspaceFoldersParams,
+    ) -> Result<()> {
+        for folder in params.event.removed {
+            session
+                .close_workspace_folder(&folder.uri)
+                .with_failure_code(lsp_server::ErrorCode::InternalError)?;
+        }
+        for folder in params.event.added {
+            session
+                .open_workspace_folder(folder.uri, client)
+                .with_failure_code(lsp_server::ErrorCode::InternalError)?;
+        }
+        Ok(())
+    }
+}

--- a/crates/shuck-server/src/server/api/notifications/did_close.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_close.rs
@@ -1,0 +1,31 @@
+use lsp_types as types;
+use lsp_types::notification as notif;
+
+use crate::server::Result;
+use crate::server::api::LSPResult;
+use crate::server::api::diagnostics::clear_diagnostics_for_document;
+use crate::session::{Client, Session};
+
+pub(crate) struct DidClose;
+
+impl super::super::traits::NotificationHandler for DidClose {
+    type NotificationType = notif::DidCloseTextDocument;
+}
+
+impl super::super::traits::SyncNotificationHandler for DidClose {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        types::DidCloseTextDocumentParams {
+            text_document: types::TextDocumentIdentifier { uri },
+        }: types::DidCloseTextDocumentParams,
+    ) -> Result<()> {
+        let key = session.key_from_url(uri);
+        if let Some(snapshot) = session.take_snapshot(key.clone().into_url()) {
+            clear_diagnostics_for_document(snapshot.query(), client)?;
+        }
+        session
+            .close_document(&key)
+            .with_failure_code(lsp_server::ErrorCode::InternalError)
+    }
+}

--- a/crates/shuck-server/src/server/api/notifications/did_open.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_open.rs
@@ -1,0 +1,40 @@
+use lsp_types as types;
+use lsp_types::notification as notif;
+
+use crate::TextDocument;
+use crate::server::Result;
+use crate::server::api::diagnostics::publish_diagnostics_for_document;
+use crate::session::{Client, Session};
+
+pub(crate) struct DidOpen;
+
+impl super::super::traits::NotificationHandler for DidOpen {
+    type NotificationType = notif::DidOpenTextDocument;
+}
+
+impl super::super::traits::SyncNotificationHandler for DidOpen {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        types::DidOpenTextDocumentParams {
+            text_document:
+                types::TextDocumentItem {
+                    uri,
+                    text,
+                    version,
+                    language_id,
+                },
+        }: types::DidOpenTextDocumentParams,
+    ) -> Result<()> {
+        let document = TextDocument::new(text, version).with_language_id(&language_id);
+        session.open_text_document(uri.clone(), document);
+
+        if !session.resolved_client_capabilities().pull_diagnostics
+            && let Some(snapshot) = session.take_snapshot(uri)
+        {
+            publish_diagnostics_for_document(&snapshot, client)?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/shuck-server/src/server/api/requests.rs
+++ b/crates/shuck-server/src/server/api/requests.rs
@@ -1,0 +1,22 @@
+mod code_action;
+mod code_action_resolve;
+mod diagnostic;
+mod execute_command;
+mod format;
+mod format_range;
+mod hover;
+mod shutdown;
+
+use super::{
+    define_document_url,
+    traits::{BackgroundDocumentRequestHandler, RequestHandler, SyncRequestHandler},
+};
+
+pub(super) use code_action::CodeActions;
+pub(super) use code_action_resolve::CodeActionResolve;
+pub(super) use diagnostic::DocumentDiagnostic;
+pub(super) use execute_command::ExecuteCommand;
+pub(super) use format::Format;
+pub(super) use format_range::FormatRange;
+pub(super) use hover::Hover;
+pub(super) use shutdown::ShutdownHandler;

--- a/crates/shuck-server/src/server/api/requests/code_action.rs
+++ b/crates/shuck-server/src/server/api/requests/code_action.rs
@@ -13,6 +13,13 @@ impl super::RequestHandler for CodeActions {
 impl super::BackgroundDocumentRequestHandler for CodeActions {
     super::define_document_url!(params: &types::CodeActionParams);
 
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::CodeActionParams,
+    ) -> Result<Option<types::CodeActionResponse>> {
+        Ok(None)
+    }
+
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
         client: &Client,

--- a/crates/shuck-server/src/server/api/requests/code_action.rs
+++ b/crates/shuck-server/src/server/api/requests/code_action.rs
@@ -1,0 +1,23 @@
+use lsp_types::{self as types, request as req};
+
+use crate::fix;
+use crate::server::Result;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct CodeActions;
+
+impl super::RequestHandler for CodeActions {
+    type RequestType = req::CodeActionRequest;
+}
+
+impl super::BackgroundDocumentRequestHandler for CodeActions {
+    super::define_document_url!(params: &types::CodeActionParams);
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::CodeActionParams,
+    ) -> Result<Option<types::CodeActionResponse>> {
+        fix::code_actions(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/shuck-server/src/server/api/requests/code_action_resolve.rs
@@ -1,0 +1,20 @@
+use lsp_types::{self as types, request as req};
+
+use crate::fix;
+use crate::session::{Client, Session};
+
+pub(crate) struct CodeActionResolve;
+
+impl super::RequestHandler for CodeActionResolve {
+    type RequestType = req::CodeActionResolveRequest;
+}
+
+impl super::SyncRequestHandler for CodeActionResolve {
+    fn run(
+        _session: &mut Session,
+        client: &Client,
+        params: types::CodeAction,
+    ) -> crate::server::Result<types::CodeAction> {
+        fix::resolve_code_action(client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/diagnostic.rs
+++ b/crates/shuck-server/src/server/api/requests/diagnostic.rs
@@ -1,0 +1,35 @@
+use lsp_types::{self as types, request as req};
+use types::{
+    DocumentDiagnosticReportResult, FullDocumentDiagnosticReport,
+    RelatedFullDocumentDiagnosticReport,
+};
+
+use crate::lint::generate_diagnostics;
+use crate::server::Result;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct DocumentDiagnostic;
+
+impl super::RequestHandler for DocumentDiagnostic {
+    type RequestType = req::DocumentDiagnosticRequest;
+}
+
+impl super::BackgroundDocumentRequestHandler for DocumentDiagnostic {
+    super::define_document_url!(params: &types::DocumentDiagnosticParams);
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        _client: &Client,
+        _params: types::DocumentDiagnosticParams,
+    ) -> Result<DocumentDiagnosticReportResult> {
+        Ok(DocumentDiagnosticReportResult::Report(
+            types::DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
+                related_documents: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: generate_diagnostics(&snapshot),
+                },
+            }),
+        ))
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/diagnostic.rs
+++ b/crates/shuck-server/src/server/api/requests/diagnostic.rs
@@ -17,6 +17,21 @@ impl super::RequestHandler for DocumentDiagnostic {
 impl super::BackgroundDocumentRequestHandler for DocumentDiagnostic {
     super::define_document_url!(params: &types::DocumentDiagnosticParams);
 
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::DocumentDiagnosticParams,
+    ) -> Result<DocumentDiagnosticReportResult> {
+        Ok(DocumentDiagnosticReportResult::Report(
+            types::DocumentDiagnosticReport::Full(RelatedFullDocumentDiagnosticReport {
+                related_documents: None,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: Vec::new(),
+                },
+            }),
+        ))
+    }
+
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
         _client: &Client,

--- a/crates/shuck-server/src/server/api/requests/execute_command.rs
+++ b/crates/shuck-server/src/server/api/requests/execute_command.rs
@@ -1,0 +1,20 @@
+use lsp_types::{self as types, request as req};
+
+use crate::fix;
+use crate::session::{Client, Session};
+
+pub(crate) struct ExecuteCommand;
+
+impl super::RequestHandler for ExecuteCommand {
+    type RequestType = req::ExecuteCommand;
+}
+
+impl super::SyncRequestHandler for ExecuteCommand {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        params: types::ExecuteCommandParams,
+    ) -> crate::server::Result<Option<serde_json::Value>> {
+        fix::execute_command(session, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/format.rs
+++ b/crates/shuck-server/src/server/api/requests/format.rs
@@ -1,0 +1,22 @@
+use lsp_types::{self as types, request as req};
+
+use crate::format;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct Format;
+
+impl super::RequestHandler for Format {
+    type RequestType = req::Formatting;
+}
+
+impl super::BackgroundDocumentRequestHandler for Format {
+    super::define_document_url!(params: &types::DocumentFormattingParams);
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::DocumentFormattingParams,
+    ) -> crate::server::Result<crate::format::FormatResponse> {
+        format::format_document(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/format.rs
+++ b/crates/shuck-server/src/server/api/requests/format.rs
@@ -12,6 +12,13 @@ impl super::RequestHandler for Format {
 impl super::BackgroundDocumentRequestHandler for Format {
     super::define_document_url!(params: &types::DocumentFormattingParams);
 
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::DocumentFormattingParams,
+    ) -> crate::server::Result<crate::format::FormatResponse> {
+        Ok(None)
+    }
+
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
         client: &Client,

--- a/crates/shuck-server/src/server/api/requests/format_range.rs
+++ b/crates/shuck-server/src/server/api/requests/format_range.rs
@@ -12,6 +12,13 @@ impl super::RequestHandler for FormatRange {
 impl super::BackgroundDocumentRequestHandler for FormatRange {
     super::define_document_url!(params: &types::DocumentRangeFormattingParams);
 
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::DocumentRangeFormattingParams,
+    ) -> crate::server::Result<crate::format::FormatResponse> {
+        Ok(None)
+    }
+
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
         client: &Client,

--- a/crates/shuck-server/src/server/api/requests/format_range.rs
+++ b/crates/shuck-server/src/server/api/requests/format_range.rs
@@ -1,0 +1,22 @@
+use lsp_types::{self as types, request as req};
+
+use crate::format;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct FormatRange;
+
+impl super::RequestHandler for FormatRange {
+    type RequestType = req::RangeFormatting;
+}
+
+impl super::BackgroundDocumentRequestHandler for FormatRange {
+    super::define_document_url!(params: &types::DocumentRangeFormattingParams);
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::DocumentRangeFormattingParams,
+    ) -> crate::server::Result<crate::format::FormatResponse> {
+        format::format_range(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/hover.rs
+++ b/crates/shuck-server/src/server/api/requests/hover.rs
@@ -15,6 +15,13 @@ impl super::BackgroundDocumentRequestHandler for Hover {
         std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
     }
 
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: types::HoverParams,
+    ) -> Result<Option<types::Hover>> {
+        Ok(None)
+    }
+
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
         client: &Client,

--- a/crates/shuck-server/src/server/api/requests/hover.rs
+++ b/crates/shuck-server/src/server/api/requests/hover.rs
@@ -1,0 +1,25 @@
+use lsp_types::{self as types, request as req};
+
+use crate::resolve;
+use crate::server::Result;
+use crate::session::{Client, DocumentSnapshot};
+
+pub(crate) struct Hover;
+
+impl super::RequestHandler for Hover {
+    type RequestType = req::HoverRequest;
+}
+
+impl super::BackgroundDocumentRequestHandler for Hover {
+    fn document_url(params: &types::HoverParams) -> std::borrow::Cow<'_, lsp_types::Url> {
+        std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
+    }
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: types::HoverParams,
+    ) -> Result<Option<types::Hover>> {
+        resolve::hover(snapshot, client, params)
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/shutdown.rs
+++ b/crates/shuck-server/src/server/api/requests/shutdown.rs
@@ -1,0 +1,16 @@
+use crate::Session;
+use crate::server::api::traits::{RequestHandler, SyncRequestHandler};
+use crate::session::Client;
+
+pub(crate) struct ShutdownHandler;
+
+impl RequestHandler for ShutdownHandler {
+    type RequestType = lsp_types::request::Shutdown;
+}
+
+impl SyncRequestHandler for ShutdownHandler {
+    fn run(session: &mut Session, _client: &Client, _params: ()) -> crate::server::Result<()> {
+        session.set_shutdown_requested(true);
+        Ok(())
+    }
+}

--- a/crates/shuck-server/src/server/api/traits.rs
+++ b/crates/shuck-server/src/server/api/traits.rs
@@ -1,0 +1,44 @@
+use lsp_types::notification::Notification as LspNotification;
+use lsp_types::request::Request;
+
+use crate::server::Result;
+use crate::session::{Client, DocumentSnapshot, Session};
+
+pub(super) trait RequestHandler {
+    type RequestType: Request;
+    const METHOD: &'static str = <<Self as RequestHandler>::RequestType as Request>::METHOD;
+}
+
+pub(super) trait SyncRequestHandler: RequestHandler {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        params: <<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
+}
+
+pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
+    fn document_url(
+        params: &<<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> std::borrow::Cow<'_, lsp_types::Url>;
+
+    fn run_with_snapshot(
+        snapshot: DocumentSnapshot,
+        client: &Client,
+        params: <<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> Result<<<Self as RequestHandler>::RequestType as Request>::Result>;
+}
+
+pub(super) trait NotificationHandler {
+    type NotificationType: LspNotification;
+    const METHOD: &'static str =
+        <<Self as NotificationHandler>::NotificationType as LspNotification>::METHOD;
+}
+
+pub(super) trait SyncNotificationHandler: NotificationHandler {
+    fn run(
+        session: &mut Session,
+        client: &Client,
+        params: <<Self as NotificationHandler>::NotificationType as LspNotification>::Params,
+    ) -> Result<()>;
+}

--- a/crates/shuck-server/src/server/api/traits.rs
+++ b/crates/shuck-server/src/server/api/traits.rs
@@ -1,3 +1,5 @@
+use anyhow::anyhow;
+use lsp_server::ErrorCode;
 use lsp_types::notification::Notification as LspNotification;
 use lsp_types::request::Request;
 
@@ -21,6 +23,16 @@ pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
     fn document_url(
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
     ) -> std::borrow::Cow<'_, lsp_types::Url>;
+
+    fn run_without_snapshot(
+        _client: &Client,
+        _params: <<Self as RequestHandler>::RequestType as Request>::Params,
+    ) -> Result<<<Self as RequestHandler>::RequestType as Request>::Result> {
+        Err(crate::server::Error::new(
+            anyhow!("text document URI does not point to an open document"),
+            ErrorCode::InvalidRequest,
+        ))
+    }
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/crates/shuck-server/src/server/connection.rs
+++ b/crates/shuck-server/src/server/connection.rs
@@ -1,0 +1,41 @@
+use lsp_server as lsp;
+
+pub type ConnectionSender = crossbeam::channel::Sender<lsp::Message>;
+
+pub(crate) struct ConnectionInitializer {
+    connection: lsp::Connection,
+}
+
+impl ConnectionInitializer {
+    pub(crate) fn stdio() -> (Self, lsp::IoThreads) {
+        let (connection, threads) = lsp::Connection::stdio();
+        (Self { connection }, threads)
+    }
+
+    pub(super) fn initialize_start(
+        &self,
+    ) -> crate::Result<(lsp::RequestId, lsp_types::InitializeParams)> {
+        let (id, params) = self.connection.initialize_start()?;
+        Ok((id, serde_json::from_value(params)?))
+    }
+
+    pub(super) fn initialize_finish(
+        self,
+        id: lsp::RequestId,
+        server_capabilities: &lsp_types::ServerCapabilities,
+        name: &str,
+        version: &str,
+    ) -> crate::Result<lsp_server::Connection> {
+        self.connection.initialize_finish(
+            id,
+            serde_json::json!({
+                "capabilities": server_capabilities,
+                "serverInfo": {
+                    "name": name,
+                    "version": version
+                }
+            }),
+        )?;
+        Ok(self.connection)
+    }
+}

--- a/crates/shuck-server/src/server/main_loop.rs
+++ b/crates/shuck-server/src/server/main_loop.rs
@@ -14,11 +14,6 @@ pub(crate) type MainLoopReceiver = crossbeam::channel::Receiver<Event>;
 
 impl Server {
     pub(super) fn main_loop(&mut self) -> crate::Result<()> {
-        self.initialize(&Client::new(
-            self.main_loop_sender.clone(),
-            self.connection.sender.clone(),
-        ));
-
         let mut scheduler = schedule::Scheduler::new(self.worker_threads);
         while let Ok(next_event) = self.next_event() {
             let Some(next_event) = next_event else {
@@ -61,6 +56,10 @@ impl Server {
                                     ));
                                 }
                                 return Ok(());
+                            }
+
+                            if notification.method == lsp_types::notification::Initialized::METHOD {
+                                self.on_initialized(&client);
                             }
 
                             api::notification(notification)
@@ -111,7 +110,7 @@ impl Server {
         )
     }
 
-    fn initialize(&mut self, client: &Client) {
+    fn on_initialized(&mut self, client: &Client) {
         let dynamic_registration = self
             .client_capabilities
             .workspace

--- a/crates/shuck-server/src/server/main_loop.rs
+++ b/crates/shuck-server/src/server/main_loop.rs
@@ -1,0 +1,176 @@
+use anyhow::anyhow;
+use crossbeam::select;
+use lsp_server::Message;
+use lsp_types::{
+    self as types, DidChangeWatchedFilesRegistrationOptions, FileSystemWatcher,
+    notification::Notification as _,
+};
+
+use crate::server::{api, schedule};
+use crate::{Server, session::Client};
+
+pub type MainLoopSender = crossbeam::channel::Sender<Event>;
+pub(crate) type MainLoopReceiver = crossbeam::channel::Receiver<Event>;
+
+impl Server {
+    pub(super) fn main_loop(&mut self) -> crate::Result<()> {
+        self.initialize(&Client::new(
+            self.main_loop_sender.clone(),
+            self.connection.sender.clone(),
+        ));
+
+        let mut scheduler = schedule::Scheduler::new(self.worker_threads);
+        while let Ok(next_event) = self.next_event() {
+            let Some(next_event) = next_event else {
+                anyhow::bail!("client exited without proper shutdown sequence");
+            };
+
+            match next_event {
+                Event::Message(msg) => {
+                    let client = Client::new(
+                        self.main_loop_sender.clone(),
+                        self.connection.sender.clone(),
+                    );
+
+                    let task = match msg {
+                        Message::Request(req) => {
+                            self.session
+                                .request_queue_mut()
+                                .incoming_mut()
+                                .register(req.id.clone(), req.method.clone());
+
+                            if self.session.is_shutdown_requested() {
+                                client.respond_err(
+                                    req.id,
+                                    lsp_server::ResponseError {
+                                        code: lsp_server::ErrorCode::InvalidRequest as i32,
+                                        message: "shutdown already requested".to_owned(),
+                                        data: None,
+                                    },
+                                )?;
+                                continue;
+                            }
+
+                            api::request(req)
+                        }
+                        Message::Notification(notification) => {
+                            if notification.method == lsp_types::notification::Exit::METHOD {
+                                if !self.session.is_shutdown_requested() {
+                                    return Err(anyhow!(
+                                        "received exit notification before shutdown request"
+                                    ));
+                                }
+                                return Ok(());
+                            }
+
+                            api::notification(notification)
+                        }
+                        Message::Response(response) => {
+                            if let Some(handler) = self
+                                .session
+                                .request_queue_mut()
+                                .outgoing_mut()
+                                .complete(&response.id)
+                            {
+                                handler(&client, response);
+                            } else {
+                                tracing::error!(
+                                    "Received an unexpected response for request {}",
+                                    response.id
+                                );
+                            }
+                            continue;
+                        }
+                    };
+
+                    scheduler.dispatch(task, &mut self.session, client);
+                }
+                Event::SendResponse(response) => {
+                    if self
+                        .session
+                        .request_queue_mut()
+                        .incoming_mut()
+                        .complete(&response.id)
+                        .is_some()
+                    {
+                        self.connection.sender.send(Message::Response(response))?;
+                    } else {
+                        tracing::trace!("Ignoring response for cancelled request {}", response.id);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn next_event(&self) -> Result<Option<Event>, crossbeam::channel::RecvError> {
+        select!(
+            recv(self.connection.receiver) -> msg => Ok(msg.ok().map(Event::Message)),
+            recv(self.main_loop_receiver) -> event => event.map(Some),
+        )
+    }
+
+    fn initialize(&mut self, client: &Client) {
+        let dynamic_registration = self
+            .client_capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.did_change_watched_files)
+            .and_then(|watched_files| watched_files.dynamic_registration)
+            .unwrap_or_default();
+
+        if !dynamic_registration {
+            tracing::warn!(
+                "LSP client does not support dynamic watched-file registration; config reloads are disabled"
+            );
+            return;
+        }
+
+        let register_options =
+            match serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
+                watchers: vec![
+                    FileSystemWatcher {
+                        glob_pattern: types::GlobPattern::String("**/.shuck.toml".into()),
+                        kind: None,
+                    },
+                    FileSystemWatcher {
+                        glob_pattern: types::GlobPattern::String("**/shuck.toml".into()),
+                        kind: None,
+                    },
+                ],
+            }) {
+                Ok(value) => value,
+                Err(error) => {
+                    tracing::error!("Failed to serialize config watcher registration: {error}");
+                    return;
+                }
+            };
+
+        let params = lsp_types::RegistrationParams {
+            registrations: vec![lsp_types::Registration {
+                id: "shuck-server-watch".into(),
+                method: "workspace/didChangeWatchedFiles".into(),
+                register_options: Some(register_options),
+            }],
+        };
+
+        let response_handler = |_: &Client, ()| {
+            tracing::info!("Registered configuration file watcher");
+        };
+
+        if let Err(err) = client.send_request::<lsp_types::request::RegisterCapability>(
+            &self.session,
+            params,
+            response_handler,
+        ) {
+            tracing::error!("Failed to register configuration file watcher: {err}");
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Event {
+    Message(lsp_server::Message),
+    SendResponse(lsp_server::Response),
+}

--- a/crates/shuck-server/src/server/schedule.rs
+++ b/crates/shuck-server/src/server/schedule.rs
@@ -1,0 +1,59 @@
+use std::num::NonZeroUsize;
+
+use crate::session::{Client, Session};
+
+mod task;
+mod thread;
+
+pub(super) use task::{BackgroundSchedule, Task};
+
+use self::{
+    task::{BackgroundTaskBuilder, SyncTask},
+    thread::{Pool, ThreadPriority},
+};
+
+pub(crate) fn spawn_main_loop(
+    func: impl FnOnce() -> crate::Result<()> + Send + 'static,
+) -> crate::Result<std::thread::JoinHandle<crate::Result<()>>> {
+    const MAIN_THREAD_STACK_SIZE: usize = 2 * 1024 * 1024;
+    Ok(std::thread::Builder::new()
+        .name("shuck:main".into())
+        .stack_size(MAIN_THREAD_STACK_SIZE)
+        .spawn(func)?)
+}
+
+pub(crate) struct Scheduler {
+    fmt_pool: Pool,
+    background_pool: Pool,
+}
+
+impl Scheduler {
+    pub(super) fn new(worker_threads: NonZeroUsize) -> Self {
+        Self {
+            fmt_pool: Pool::new(NonZeroUsize::MIN),
+            background_pool: Pool::new(worker_threads),
+        }
+    }
+
+    pub(super) fn dispatch(&mut self, task: Task, session: &mut Session, client: Client) {
+        match task {
+            Task::Sync(SyncTask { func }) => func(session, &client),
+            Task::Background(BackgroundTaskBuilder { schedule, builder }) => {
+                let static_func = builder(session);
+                let task = move || static_func(&client);
+                match schedule {
+                    BackgroundSchedule::Fmt => {
+                        self.fmt_pool.spawn(ThreadPriority::LatencySensitive, task);
+                    }
+                    BackgroundSchedule::LatencySensitive => {
+                        self.background_pool
+                            .spawn(ThreadPriority::LatencySensitive, task);
+                    }
+                    BackgroundSchedule::Worker => {
+                        self.background_pool.spawn(ThreadPriority::Worker, task);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/shuck-server/src/server/schedule/task.rs
+++ b/crates/shuck-server/src/server/schedule/task.rs
@@ -62,4 +62,12 @@ impl Task {
     pub(crate) fn nothing() -> Self {
         Self::sync(|_, _| {})
     }
+
+    #[cfg(test)]
+    pub(crate) fn run_for_test(self, session: &mut Session, client: &Client) {
+        match self {
+            Self::Background(BackgroundTaskBuilder { builder, .. }) => builder(session)(client),
+            Self::Sync(SyncTask { func }) => func(session, client),
+        }
+    }
 }

--- a/crates/shuck-server/src/server/schedule/task.rs
+++ b/crates/shuck-server/src/server/schedule/task.rs
@@ -1,0 +1,65 @@
+use lsp_server::RequestId;
+use serde::Serialize;
+
+use crate::session::{Client, Session};
+
+type LocalFn = Box<dyn FnOnce(&mut Session, &Client)>;
+type BackgroundFn = Box<dyn FnOnce(&Client) + Send + 'static>;
+type BackgroundFnBuilder = Box<dyn FnOnce(&Session) -> BackgroundFn>;
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Default)]
+pub(in crate::server) enum BackgroundSchedule {
+    Fmt,
+    #[default]
+    Worker,
+    LatencySensitive,
+}
+
+#[must_use]
+pub(in crate::server) enum Task {
+    Background(BackgroundTaskBuilder),
+    Sync(SyncTask),
+}
+
+pub(in crate::server) struct BackgroundTaskBuilder {
+    pub(super) schedule: BackgroundSchedule,
+    pub(super) builder: BackgroundFnBuilder,
+}
+
+pub(in crate::server) struct SyncTask {
+    pub(super) func: LocalFn,
+}
+
+impl Task {
+    pub(crate) fn background(
+        schedule: BackgroundSchedule,
+        func: impl FnOnce(&Session) -> Box<dyn FnOnce(&Client) + Send + 'static> + 'static,
+    ) -> Self {
+        Self::Background(BackgroundTaskBuilder {
+            schedule,
+            builder: Box::new(func),
+        })
+    }
+
+    pub(crate) fn sync(func: impl FnOnce(&mut Session, &Client) + 'static) -> Self {
+        Self::Sync(SyncTask {
+            func: Box::new(func),
+        })
+    }
+
+    pub(crate) fn immediate<R>(id: RequestId, result: crate::server::Result<R>) -> Self
+    where
+        R: Serialize + Send + 'static,
+    {
+        Self::sync(move |_, client| {
+            if let Err(err) = client.respond(&id, result) {
+                tracing::error!("Unable to send immediate response: {err}");
+            }
+        })
+    }
+
+    pub(crate) fn nothing() -> Self {
+        Self::sync(|_, _| {})
+    }
+}

--- a/crates/shuck-server/src/server/schedule/thread.rs
+++ b/crates/shuck-server/src/server/schedule/thread.rs
@@ -1,0 +1,5 @@
+mod pool;
+mod priority;
+
+pub(super) use pool::Pool;
+pub(super) use priority::ThreadPriority;

--- a/crates/shuck-server/src/server/schedule/thread/pool.rs
+++ b/crates/shuck-server/src/server/schedule/thread/pool.rs
@@ -1,0 +1,89 @@
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use crossbeam::channel::{Receiver, Sender};
+
+use super::ThreadPriority;
+
+pub(crate) struct Pool {
+    job_sender: Sender<Job>,
+    _handles: Vec<std::thread::JoinHandle<()>>,
+    extant_tasks: Arc<AtomicUsize>,
+}
+
+struct Job {
+    #[allow(dead_code)]
+    requested_priority: ThreadPriority,
+    f: Box<dyn FnOnce() + Send + 'static>,
+}
+
+impl Pool {
+    pub(crate) fn new(threads: NonZeroUsize) -> Self {
+        let threads = usize::from(threads);
+        let (job_sender, job_receiver) = crossbeam::channel::bounded(std::cmp::min(threads * 2, 4));
+        let extant_tasks = Arc::new(AtomicUsize::new(0));
+
+        let mut handles = Vec::with_capacity(threads);
+        for index in 0..threads {
+            handles.push(spawn_worker(
+                index,
+                job_receiver.clone(),
+                extant_tasks.clone(),
+            ));
+        }
+
+        Self {
+            job_sender,
+            _handles: handles,
+            extant_tasks,
+        }
+    }
+
+    pub(crate) fn spawn<F>(&self, priority: ThreadPriority, f: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        if let Err(error) = self.job_sender.send(Job {
+            requested_priority: priority,
+            f: Box::new(f),
+        }) {
+            tracing::error!("Failed to dispatch background job: {error}");
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        self.extant_tasks.load(Ordering::SeqCst)
+    }
+}
+
+fn spawn_worker(
+    index: usize,
+    job_receiver: Receiver<Job>,
+    extant_tasks: Arc<AtomicUsize>,
+) -> std::thread::JoinHandle<()> {
+    match std::thread::Builder::new()
+        .name(format!("shuck:worker:{index}"))
+        .stack_size(2 * 1024 * 1024)
+        .spawn(move || {
+            for job in job_receiver {
+                extant_tasks.fetch_add(1, Ordering::SeqCst);
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(job.f));
+                extant_tasks.fetch_sub(1, Ordering::SeqCst);
+                if let Err(error) = result {
+                    if let Some(message) = error.downcast_ref::<String>() {
+                        tracing::error!("Worker thread panicked with: {message}; aborting");
+                    } else if let Some(message) = error.downcast_ref::<&str>() {
+                        tracing::error!("Worker thread panicked with: {message}; aborting");
+                    } else {
+                        tracing::error!("Worker thread panicked; aborting");
+                    }
+                    std::process::abort();
+                }
+            }
+        }) {
+        Ok(handle) => handle,
+        Err(error) => panic!("failed to spawn background worker thread: {error}"),
+    }
+}

--- a/crates/shuck-server/src/server/schedule/thread/pool.rs
+++ b/crates/shuck-server/src/server/schedule/thread/pool.rs
@@ -21,7 +21,8 @@ struct Job {
 impl Pool {
     pub(crate) fn new(threads: NonZeroUsize) -> Self {
         let threads = usize::from(threads);
-        let (job_sender, job_receiver) = crossbeam::channel::bounded(std::cmp::min(threads * 2, 4));
+        // Keep the LSP main loop responsive even when background work piles up.
+        let (job_sender, job_receiver) = crossbeam::channel::unbounded();
         let extant_tasks = Arc::new(AtomicUsize::new(0));
 
         let mut handles = Vec::with_capacity(threads);
@@ -85,5 +86,55 @@ fn spawn_worker(
         }) {
         Ok(handle) => handle,
         Err(error) => panic!("failed to spawn background worker thread: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use crossbeam::channel;
+
+    use super::{Pool, ThreadPriority};
+
+    #[test]
+    fn spawn_does_not_block_when_workers_are_busy() {
+        let pool = Arc::new(Pool::new(NonZeroUsize::MIN));
+        let (started_tx, started_rx) = channel::bounded(1);
+        let (release_tx, release_rx) = channel::bounded::<()>(1);
+
+        pool.spawn(ThreadPriority::Worker, move || {
+            started_tx
+                .send(())
+                .expect("test worker should report startup");
+            release_rx
+                .recv()
+                .expect("test should release the blocking worker");
+        });
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("worker should start before the queue is saturated");
+
+        pool.spawn(ThreadPriority::Worker, || {});
+        pool.spawn(ThreadPriority::Worker, || {});
+
+        let pool_for_thread = pool.clone();
+        let (done_tx, done_rx) = channel::bounded(1);
+        std::thread::spawn(move || {
+            pool_for_thread.spawn(ThreadPriority::Worker, || {});
+            done_tx
+                .send(())
+                .expect("test thread should report when spawn returns");
+        });
+
+        done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("spawning should stay non-blocking when the pool backlog grows");
+
+        release_tx
+            .send(())
+            .expect("test should release the blocking worker");
     }
 }

--- a/crates/shuck-server/src/server/schedule/thread/priority.rs
+++ b/crates/shuck-server/src/server/schedule/thread/priority.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ThreadPriority {
+    Worker,
+    LatencySensitive,
+}

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -1,0 +1,160 @@
+#![allow(dead_code)]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use lsp_types::{ClientCapabilities, FileEvent, Url};
+
+use crate::edit::{DocumentKey, DocumentVersion};
+use crate::session::request_queue::RequestQueue;
+use crate::session::settings::{ClientSettings, GlobalClientSettings, ShuckSettings};
+use crate::workspace::Workspaces;
+use crate::{PositionEncoding, TextDocument};
+
+pub(crate) use self::capabilities::ResolvedClientCapabilities;
+pub use self::index::DocumentQuery;
+pub use self::options::ClientOptions;
+pub(crate) use self::options::{AllOptions, WorkspaceOptionsMap};
+pub use client::Client;
+
+mod capabilities;
+mod client;
+mod index;
+mod options;
+mod request_queue;
+mod settings;
+
+pub struct Session {
+    index: index::Index,
+    position_encoding: PositionEncoding,
+    global_settings: GlobalClientSettings,
+    resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
+    request_queue: RequestQueue,
+    shutdown_requested: bool,
+}
+
+pub struct DocumentSnapshot {
+    resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
+    client_settings: Arc<ClientSettings>,
+    document_ref: index::DocumentQuery,
+    position_encoding: PositionEncoding,
+}
+
+impl Session {
+    pub fn new(
+        client_capabilities: &ClientCapabilities,
+        position_encoding: PositionEncoding,
+        global: GlobalClientSettings,
+        workspaces: &Workspaces,
+        client: &Client,
+    ) -> crate::Result<Self> {
+        Ok(Self {
+            index: index::Index::new(workspaces, &global, client)?,
+            position_encoding,
+            global_settings: global,
+            resolved_client_capabilities: Arc::new(ResolvedClientCapabilities::new(
+                client_capabilities,
+            )),
+            request_queue: RequestQueue::new(),
+            shutdown_requested: false,
+        })
+    }
+
+    pub(crate) fn request_queue(&self) -> &RequestQueue {
+        &self.request_queue
+    }
+
+    pub(crate) fn request_queue_mut(&mut self) -> &mut RequestQueue {
+        &mut self.request_queue
+    }
+
+    pub(crate) fn is_shutdown_requested(&self) -> bool {
+        self.shutdown_requested
+    }
+
+    pub(crate) fn set_shutdown_requested(&mut self, requested: bool) {
+        self.shutdown_requested = requested;
+    }
+
+    pub fn key_from_url(&self, url: Url) -> DocumentKey {
+        self.index.key_from_url(url)
+    }
+
+    pub fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
+        let key = self.key_from_url(url);
+        Some(DocumentSnapshot {
+            resolved_client_capabilities: self.resolved_client_capabilities.clone(),
+            client_settings: self
+                .index
+                .client_settings(&key)
+                .unwrap_or_else(|| self.global_settings.to_settings_arc()),
+            document_ref: self.index.make_document_ref(key)?,
+            position_encoding: self.position_encoding,
+        })
+    }
+
+    pub(crate) fn update_text_document(
+        &mut self,
+        key: &DocumentKey,
+        content_changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
+        new_version: DocumentVersion,
+    ) -> crate::Result<()> {
+        self.index
+            .update_text_document(key, content_changes, new_version, self.encoding())
+    }
+
+    pub(crate) fn open_text_document(&mut self, url: Url, document: TextDocument) {
+        self.index.open_text_document(url, document);
+    }
+
+    pub(crate) fn close_document(&mut self, key: &DocumentKey) -> crate::Result<()> {
+        self.index.close_document(key)
+    }
+
+    pub(crate) fn reload_settings(&mut self, changes: &[FileEvent], client: &Client) {
+        self.index.reload_settings(changes, client);
+    }
+
+    pub(crate) fn open_workspace_folder(&mut self, url: Url, client: &Client) -> crate::Result<()> {
+        self.index
+            .open_workspace_folder(url, &self.global_settings, client)
+    }
+
+    pub(crate) fn close_workspace_folder(&mut self, url: &Url) -> crate::Result<()> {
+        self.index.close_workspace_folder(url)
+    }
+
+    pub(crate) fn resolved_client_capabilities(&self) -> &ResolvedClientCapabilities {
+        &self.resolved_client_capabilities
+    }
+
+    pub(crate) fn encoding(&self) -> PositionEncoding {
+        self.position_encoding
+    }
+
+    pub(crate) fn config_file_paths(&self) -> impl Iterator<Item = &Path> {
+        self.index.config_file_paths()
+    }
+}
+
+impl DocumentSnapshot {
+    pub(crate) fn resolved_client_capabilities(&self) -> &ResolvedClientCapabilities {
+        &self.resolved_client_capabilities
+    }
+
+    pub(crate) fn client_settings(&self) -> &ClientSettings {
+        &self.client_settings
+    }
+
+    pub(crate) fn shuck_settings(&self) -> &ShuckSettings {
+        self.document_ref.settings()
+    }
+
+    pub fn query(&self) -> &index::DocumentQuery {
+        &self.document_ref
+    }
+
+    pub(crate) fn encoding(&self) -> PositionEncoding {
+        self.position_encoding
+    }
+}

--- a/crates/shuck-server/src/session/capabilities.rs
+++ b/crates/shuck-server/src/session/capabilities.rs
@@ -1,0 +1,53 @@
+use lsp_types::ClientCapabilities;
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct ResolvedClientCapabilities {
+    pub(crate) code_action_deferred_edit_resolution: bool,
+    pub(crate) apply_edit: bool,
+    pub(crate) document_changes: bool,
+    pub(crate) workspace_refresh: bool,
+    pub(crate) pull_diagnostics: bool,
+}
+
+impl ResolvedClientCapabilities {
+    pub(super) fn new(client_capabilities: &ClientCapabilities) -> Self {
+        let code_action_settings = client_capabilities
+            .text_document
+            .as_ref()
+            .and_then(|doc_settings| doc_settings.code_action.as_ref());
+        let code_action_data_support = code_action_settings
+            .and_then(|settings| settings.data_support)
+            .unwrap_or_default();
+        let code_action_edit_resolution = code_action_settings
+            .and_then(|settings| settings.resolve_support.as_ref())
+            .is_some_and(|resolve_support| resolve_support.properties.contains(&"edit".into()));
+
+        let apply_edit = client_capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.apply_edit)
+            .unwrap_or_default();
+
+        let document_changes = client_capabilities
+            .workspace
+            .as_ref()
+            .and_then(|workspace| workspace.workspace_edit.as_ref())
+            .and_then(|workspace_edit| workspace_edit.document_changes)
+            .unwrap_or_default();
+
+        let pull_diagnostics = client_capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.diagnostic.as_ref())
+            .is_some();
+
+        Self {
+            code_action_deferred_edit_resolution: code_action_data_support
+                && code_action_edit_resolution,
+            apply_edit,
+            document_changes,
+            workspace_refresh: false,
+            pull_diagnostics,
+        }
+    }
+}

--- a/crates/shuck-server/src/session/client.rs
+++ b/crates/shuck-server/src/session/client.rs
@@ -1,0 +1,168 @@
+use std::any::TypeId;
+use std::fmt::Display;
+
+use anyhow::{Context, anyhow};
+use lsp_server::{ErrorCode, Message, Notification, RequestId, ResponseError};
+use serde_json::Value;
+
+use crate::Session;
+use crate::server::{ConnectionSender, Event, MainLoopSender};
+
+pub(crate) type ClientResponseHandler = Box<dyn FnOnce(&Client, lsp_server::Response) + Send>;
+
+#[derive(Clone, Debug)]
+pub struct Client {
+    main_loop_sender: MainLoopSender,
+    client_sender: ConnectionSender,
+}
+
+impl Client {
+    pub fn new(main_loop_sender: MainLoopSender, client_sender: ConnectionSender) -> Self {
+        Self {
+            main_loop_sender,
+            client_sender,
+        }
+    }
+
+    pub(crate) fn send_request<R>(
+        &self,
+        session: &Session,
+        params: R::Params,
+        response_handler: impl FnOnce(&Client, R::Result) + Send + 'static,
+    ) -> crate::Result<()>
+    where
+        R: lsp_types::request::Request,
+    {
+        let response_handler = Box::new(move |client: &Client, response: lsp_server::Response| {
+            match (response.error, response.result) {
+                (Some(err), _) => {
+                    tracing::error!(
+                        "Client request failed (method={} code={}): {}",
+                        R::METHOD,
+                        err.code,
+                        err.message
+                    );
+                }
+                (None, Some(response)) => match serde_json::from_value(response) {
+                    Ok(response) => response_handler(client, response),
+                    Err(error) => {
+                        tracing::error!(
+                            "Failed to deserialize client response for {}: {error}",
+                            R::METHOD
+                        );
+                    }
+                },
+                (None, None) => {
+                    if TypeId::of::<R::Result>() == TypeId::of::<()>() {
+                        match serde_json::from_value(Value::Null) {
+                            Ok(response) => response_handler(client, response),
+                            Err(error) => {
+                                tracing::error!(
+                                    "Failed to deserialize unit client response for {}: {error}",
+                                    R::METHOD
+                                );
+                            }
+                        }
+                    } else {
+                        tracing::error!(
+                            "Client response missing result and error for {}",
+                            R::METHOD
+                        );
+                    }
+                }
+            }
+        });
+
+        let id = session
+            .request_queue()
+            .outgoing()
+            .register(response_handler);
+        self.client_sender
+            .send(Message::Request(lsp_server::Request {
+                id,
+                method: R::METHOD.to_string(),
+                params: serde_json::to_value(params).context("Failed to serialize params")?,
+            }))
+            .with_context(|| format!("Failed to send request {}", R::METHOD))?;
+        Ok(())
+    }
+
+    pub(crate) fn send_notification<N>(&self, params: N::Params) -> crate::Result<()>
+    where
+        N: lsp_types::notification::Notification,
+    {
+        self.client_sender
+            .send(Message::Notification(Notification::new(
+                N::METHOD.to_string(),
+                params,
+            )))
+            .map_err(|error| anyhow!("Failed to send notification {}: {error}", N::METHOD))
+    }
+
+    pub(crate) fn respond<R>(
+        &self,
+        id: &RequestId,
+        result: crate::server::Result<R>,
+    ) -> crate::Result<()>
+    where
+        R: serde::Serialize,
+    {
+        let response = match result {
+            Ok(value) => lsp_server::Response::new_ok(id.clone(), value),
+            Err(crate::server::Error { code, error }) => {
+                lsp_server::Response::new_err(id.clone(), code as i32, error.to_string())
+            }
+        };
+
+        self.main_loop_sender
+            .send(Event::SendResponse(response))
+            .map_err(|error| anyhow!("Failed to queue response {id}: {error}"))
+    }
+
+    pub(crate) fn respond_err(&self, id: RequestId, error: ResponseError) -> crate::Result<()> {
+        self.main_loop_sender
+            .send(Event::SendResponse(lsp_server::Response {
+                id,
+                result: None,
+                error: Some(error),
+            }))
+            .map_err(|send_error| anyhow!("Failed to queue error response: {send_error}"))
+    }
+
+    pub(crate) fn show_message(
+        &self,
+        message: impl Display,
+        message_type: lsp_types::MessageType,
+    ) -> crate::Result<()> {
+        self.send_notification::<lsp_types::notification::ShowMessage>(
+            lsp_types::ShowMessageParams {
+                typ: message_type,
+                message: message.to_string(),
+            },
+        )
+    }
+
+    pub(crate) fn show_error_message(&self, message: impl Display) {
+        if let Err(err) = self.show_message(message, lsp_types::MessageType::ERROR) {
+            tracing::error!("Failed to send error message to client: {err}");
+        }
+    }
+
+    pub(crate) fn cancel(&self, session: &mut Session, id: RequestId) -> crate::Result<()> {
+        let method_name = session.request_queue_mut().incoming_mut().cancel(&id);
+        if let Some(method_name) = method_name {
+            tracing::debug!("Cancelled request id={id} method={method_name}");
+            self.client_sender
+                .send(Message::Response(lsp_server::Response {
+                    id,
+                    result: None,
+                    error: Some(ResponseError {
+                        code: ErrorCode::RequestCanceled as i32,
+                        message: "request was cancelled by client".to_owned(),
+                        data: None,
+                    }),
+                }))?;
+        }
+        Ok(())
+    }
+}

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -1,0 +1,153 @@
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use lsp_types::{FileEvent, Url};
+use rustc_hash::FxHashMap;
+
+use crate::edit::{DocumentKey, DocumentVersion};
+use crate::session::Client;
+use crate::session::settings::{ClientSettings, GlobalClientSettings, ShuckSettings};
+use crate::workspace::Workspaces;
+use crate::{PositionEncoding, TextDocument};
+
+#[derive(Default)]
+pub(crate) struct Index {
+    documents: FxHashMap<Url, Arc<TextDocument>>,
+    workspace_roots: Vec<PathBuf>,
+    client_settings: Arc<ClientSettings>,
+}
+
+#[derive(Clone)]
+pub enum DocumentQuery {
+    Text {
+        file_url: Url,
+        document: Arc<TextDocument>,
+        settings: Arc<ShuckSettings>,
+    },
+}
+
+impl Index {
+    pub(super) fn new(
+        workspaces: &Workspaces,
+        global: &GlobalClientSettings,
+        _client: &Client,
+    ) -> crate::Result<Self> {
+        let workspace_roots = workspaces
+            .iter()
+            .filter_map(|workspace| workspace.url().to_file_path().ok())
+            .collect();
+        Ok(Self {
+            documents: FxHashMap::default(),
+            workspace_roots,
+            client_settings: global.to_settings_arc(),
+        })
+    }
+
+    pub(super) fn key_from_url(&self, url: Url) -> DocumentKey {
+        DocumentKey::Text(url)
+    }
+
+    pub(super) fn make_document_ref(&self, key: DocumentKey) -> Option<DocumentQuery> {
+        let DocumentKey::Text(url) = key;
+        let document = self.documents.get(&url)?.clone();
+        Some(DocumentQuery::Text {
+            file_url: url,
+            document,
+            settings: Arc::new(ShuckSettings),
+        })
+    }
+
+    pub(super) fn client_settings(&self, key: &DocumentKey) -> Option<Arc<ClientSettings>> {
+        let DocumentKey::Text(url) = key;
+        self.documents
+            .contains_key(url)
+            .then(|| self.client_settings.clone())
+    }
+
+    pub(super) fn update_text_document(
+        &mut self,
+        key: &DocumentKey,
+        content_changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
+        new_version: DocumentVersion,
+        encoding: PositionEncoding,
+    ) -> crate::Result<()> {
+        let DocumentKey::Text(url) = key;
+        let Some(document) = self.documents.get_mut(url) else {
+            return Err(anyhow!(
+                "text document URI does not point to an open document"
+            ));
+        };
+
+        std::sync::Arc::make_mut(document).apply_changes(content_changes, new_version, encoding);
+        Ok(())
+    }
+
+    pub(super) fn open_text_document(&mut self, url: Url, document: TextDocument) {
+        self.documents.insert(url, Arc::new(document));
+    }
+
+    pub(super) fn close_document(&mut self, key: &DocumentKey) -> crate::Result<()> {
+        let DocumentKey::Text(url) = key;
+        self.documents
+            .remove(url)
+            .map(|_| ())
+            .ok_or_else(|| anyhow!("document is not open: {url}"))
+    }
+
+    pub(super) fn reload_settings(&mut self, _changes: &[FileEvent], _client: &Client) {}
+
+    pub(super) fn open_workspace_folder(
+        &mut self,
+        url: Url,
+        _global: &GlobalClientSettings,
+        _client: &Client,
+    ) -> crate::Result<()> {
+        let path = url
+            .to_file_path()
+            .map_err(|()| anyhow!("failed to convert workspace URL to file path: {url}"))?;
+        if !self.workspace_roots.contains(&path) {
+            self.workspace_roots.push(path);
+        }
+        Ok(())
+    }
+
+    pub(super) fn close_workspace_folder(&mut self, workspace_url: &Url) -> crate::Result<()> {
+        let path = workspace_url.to_file_path().map_err(|()| {
+            anyhow!("failed to convert workspace URL to file path: {workspace_url}")
+        })?;
+        self.workspace_roots.retain(|root| root != &path);
+        self.documents.retain(|url, _| {
+            url.to_file_path()
+                .map(|file_path| !file_path.starts_with(&path))
+                .unwrap_or(true)
+        });
+        Ok(())
+    }
+
+    pub(super) fn config_file_paths(&self) -> impl Iterator<Item = &Path> {
+        std::iter::empty()
+    }
+}
+
+impl DocumentQuery {
+    pub(crate) fn file_url(&self) -> &Url {
+        match self {
+            Self::Text { file_url, .. } => file_url,
+        }
+    }
+
+    pub(crate) fn document(&self) -> &Arc<TextDocument> {
+        match self {
+            Self::Text { document, .. } => document,
+        }
+    }
+
+    pub(crate) fn settings(&self) -> &ShuckSettings {
+        match self {
+            Self::Text { settings, .. } => settings,
+        }
+    }
+}

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -1,0 +1,49 @@
+use lsp_types::Url;
+use rustc_hash::FxHashMap;
+use serde::Deserialize;
+
+use crate::session::settings::GlobalClientSettings;
+use crate::{Client, logging};
+
+pub(crate) type WorkspaceOptionsMap = FxHashMap<Url, ClientOptions>;
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GlobalOptions {
+    #[serde(default)]
+    client: ClientOptions,
+    #[serde(default)]
+    pub(crate) tracing: TracingOptions,
+}
+
+impl GlobalOptions {
+    pub fn into_settings(self, client: Client) -> GlobalClientSettings {
+        GlobalClientSettings::new(self.client, client)
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientOptions {}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TracingOptions {
+    pub(crate) log_level: Option<logging::LogLevel>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct AllOptions {
+    pub(crate) global: GlobalOptions,
+    pub(crate) workspace: Option<WorkspaceOptionsMap>,
+}
+
+impl AllOptions {
+    pub(crate) fn from_value(value: serde_json::Value, _client: &Client) -> Self {
+        let global = serde_json::from_value::<GlobalOptions>(value).unwrap_or_default();
+        Self {
+            global,
+            workspace: Some(WorkspaceOptionsMap::default()),
+        }
+    }
+}

--- a/crates/shuck-server/src/session/request_queue.rs
+++ b/crates/shuck-server/src/session/request_queue.rs
@@ -1,0 +1,142 @@
+use std::cell::{Cell, OnceCell, RefCell};
+use std::fmt::Formatter;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::time::Instant;
+
+use lsp_server::RequestId;
+use rustc_hash::FxHashMap;
+
+use crate::session::client::ClientResponseHandler;
+
+pub(crate) struct RequestQueue {
+    incoming: Incoming,
+    outgoing: Outgoing,
+}
+
+impl RequestQueue {
+    pub(super) fn new() -> Self {
+        Self {
+            incoming: Incoming::default(),
+            outgoing: Outgoing::default(),
+        }
+    }
+
+    pub(crate) fn outgoing_mut(&mut self) -> &mut Outgoing {
+        &mut self.outgoing
+    }
+
+    pub(crate) fn outgoing(&self) -> &Outgoing {
+        &self.outgoing
+    }
+
+    pub(crate) fn incoming(&self) -> &Incoming {
+        &self.incoming
+    }
+
+    pub(crate) fn incoming_mut(&mut self) -> &mut Incoming {
+        &mut self.incoming
+    }
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct Incoming {
+    pending: FxHashMap<RequestId, PendingRequest>,
+}
+
+impl Incoming {
+    pub(crate) fn register(&mut self, request_id: RequestId, method: String) {
+        self.pending.insert(request_id, PendingRequest::new(method));
+    }
+
+    pub(super) fn cancel(&mut self, request_id: &RequestId) -> Option<String> {
+        self.pending.remove(request_id).map(|mut pending| {
+            if let Some(cancellation_token) = pending.cancellation_token.take() {
+                cancellation_token.cancel();
+            }
+            pending.method
+        })
+    }
+
+    pub(crate) fn cancellation_token(
+        &self,
+        request_id: &RequestId,
+    ) -> Option<RequestCancellationToken> {
+        let pending = self.pending.get(request_id)?;
+        Some(RequestCancellationToken::clone(
+            pending
+                .cancellation_token
+                .get_or_init(RequestCancellationToken::default),
+        ))
+    }
+
+    pub(crate) fn complete(&mut self, request_id: &RequestId) -> Option<(Instant, String)> {
+        self.pending
+            .remove(request_id)
+            .map(|pending| (pending.start_time, pending.method))
+    }
+}
+
+#[derive(Debug)]
+struct PendingRequest {
+    start_time: Instant,
+    method: String,
+    cancellation_token: OnceCell<RequestCancellationToken>,
+}
+
+impl PendingRequest {
+    fn new(method: String) -> Self {
+        Self {
+            start_time: Instant::now(),
+            method,
+            cancellation_token: OnceCell::new(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct RequestCancellationToken(Arc<AtomicBool>);
+
+impl RequestCancellationToken {
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn cancel(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    fn clone(this: &Self) -> Self {
+        Self(this.0.clone())
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct Outgoing {
+    next_request_id: Cell<i32>,
+    response_handlers: RefCell<FxHashMap<RequestId, ClientResponseHandler>>,
+}
+
+impl Outgoing {
+    pub(crate) fn register(&self, handler: ClientResponseHandler) -> RequestId {
+        let id = self.next_request_id.get();
+        self.next_request_id.set(id + 1);
+        self.response_handlers
+            .borrow_mut()
+            .insert(id.into(), handler);
+        id.into()
+    }
+
+    pub(crate) fn complete(&mut self, request_id: &RequestId) -> Option<ClientResponseHandler> {
+        self.response_handlers.get_mut().remove(request_id)
+    }
+}
+
+impl std::fmt::Debug for Outgoing {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Outgoing")
+            .field("next_request_id", &self.next_request_id)
+            .field("response_handlers", &"<response handlers>")
+            .finish()
+    }
+}

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -1,0 +1,37 @@
+use std::sync::{Arc, OnceLock};
+
+use crate::{Client, session::ClientOptions};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ClientSettings;
+
+#[derive(Clone, Debug, Default)]
+pub struct ShuckSettings;
+
+pub struct GlobalClientSettings {
+    options: ClientOptions,
+    settings: OnceLock<Arc<ClientSettings>>,
+    #[allow(dead_code)]
+    client: Client,
+}
+
+impl GlobalClientSettings {
+    pub(super) fn new(options: ClientOptions, client: Client) -> Self {
+        Self {
+            options,
+            settings: OnceLock::new(),
+            client,
+        }
+    }
+
+    fn settings_impl(&self) -> &Arc<ClientSettings> {
+        self.settings.get_or_init(|| {
+            let _ = &self.options;
+            Arc::new(ClientSettings)
+        })
+    }
+
+    pub(super) fn to_settings_arc(&self) -> Arc<ClientSettings> {
+        self.settings_impl().clone()
+    }
+}

--- a/crates/shuck-server/src/workspace.rs
+++ b/crates/shuck-server/src/workspace.rs
@@ -1,0 +1,94 @@
+#![allow(dead_code)]
+
+use std::ops::Deref;
+
+use lsp_types::{Url, WorkspaceFolder};
+
+use crate::session::{ClientOptions, WorkspaceOptionsMap};
+
+#[derive(Debug)]
+pub struct Workspaces(Vec<Workspace>);
+
+impl Workspaces {
+    pub fn new(workspaces: Vec<Workspace>) -> Self {
+        Self(workspaces)
+    }
+
+    pub(crate) fn from_workspace_folders(
+        workspace_folders: Option<Vec<WorkspaceFolder>>,
+        mut workspace_options: WorkspaceOptionsMap,
+    ) -> crate::Result<Self> {
+        let mut client_options_for_url =
+            |url: &Url| workspace_options.remove(url).unwrap_or_default();
+
+        let workspaces =
+            if let Some(folders) = workspace_folders.filter(|folders| !folders.is_empty()) {
+                folders
+                    .into_iter()
+                    .map(|folder| {
+                        let options = client_options_for_url(&folder.uri);
+                        Workspace::new(folder.uri).with_options(options)
+                    })
+                    .collect()
+            } else {
+                let current_dir = std::env::current_dir()?;
+                let uri = Url::from_file_path(current_dir)
+                    .map_err(|()| anyhow::anyhow!("failed to create URL from current directory"))?;
+                let options = client_options_for_url(&uri);
+                vec![Workspace::default(uri).with_options(options)]
+            };
+
+        Ok(Self(workspaces))
+    }
+}
+
+impl Deref for Workspaces {
+    type Target = [Workspace];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+pub struct Workspace {
+    url: Url,
+    options: Option<ClientOptions>,
+    is_default: bool,
+}
+
+impl Workspace {
+    pub fn new(url: Url) -> Self {
+        Self {
+            url,
+            options: None,
+            is_default: false,
+        }
+    }
+
+    pub fn default(url: Url) -> Self {
+        Self {
+            url,
+            options: None,
+            is_default: true,
+        }
+    }
+
+    #[must_use]
+    pub fn with_options(mut self, options: ClientOptions) -> Self {
+        self.options = Some(options);
+        self
+    }
+
+    pub(crate) fn url(&self) -> &Url {
+        &self.url
+    }
+
+    pub(crate) fn options(&self) -> Option<&ClientOptions> {
+        self.options.as_ref()
+    }
+
+    pub(crate) fn is_default(&self) -> bool {
+        self.is_default
+    }
+}

--- a/crates/shuck-server/src/workspace.rs
+++ b/crates/shuck-server/src/workspace.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::ops::Deref;
+use std::path::PathBuf;
 
 use lsp_types::{Url, WorkspaceFolder};
 
@@ -16,6 +17,8 @@ impl Workspaces {
 
     pub(crate) fn from_workspace_folders(
         workspace_folders: Option<Vec<WorkspaceFolder>>,
+        root_uri: Option<Url>,
+        root_path: Option<String>,
         mut workspace_options: WorkspaceOptionsMap,
     ) -> crate::Result<Self> {
         let mut client_options_for_url =
@@ -31,15 +34,29 @@ impl Workspaces {
                     })
                     .collect()
             } else {
-                let current_dir = std::env::current_dir()?;
-                let uri = Url::from_file_path(current_dir)
-                    .map_err(|()| anyhow::anyhow!("failed to create URL from current directory"))?;
+                let uri = default_workspace_uri(root_uri, root_path)?;
                 let options = client_options_for_url(&uri);
                 vec![Workspace::default(uri).with_options(options)]
             };
 
         Ok(Self(workspaces))
     }
+}
+
+fn default_workspace_uri(root_uri: Option<Url>, root_path: Option<String>) -> crate::Result<Url> {
+    if let Some(root_uri) = root_uri {
+        return Ok(root_uri);
+    }
+
+    if let Some(root_path) = root_path
+        && let Ok(root_uri) = Url::from_file_path(PathBuf::from(root_path))
+    {
+        return Ok(root_uri);
+    }
+
+    let current_dir = std::env::current_dir()?;
+    Url::from_file_path(current_dir)
+        .map_err(|()| anyhow::anyhow!("failed to create URL from current directory"))
 }
 
 impl Deref for Workspaces {
@@ -90,5 +107,46 @@ impl Workspace {
 
     pub(crate) fn is_default(&self) -> bool {
         self.is_default
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uses_root_uri_when_workspace_folders_are_missing() {
+        let root_uri = Url::parse("file:///tmp/shuck-root").expect("test URI should parse");
+
+        let workspaces = Workspaces::from_workspace_folders(
+            None,
+            Some(root_uri.clone()),
+            None,
+            WorkspaceOptionsMap::default(),
+        )
+        .expect("workspace fallback should succeed");
+
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].url(), &root_uri);
+        assert!(workspaces[0].is_default());
+    }
+
+    #[test]
+    fn uses_root_path_when_root_uri_is_missing() {
+        let root_path = std::env::temp_dir().join("shuck-server-root-path");
+        let expected_uri =
+            Url::from_file_path(&root_path).expect("temporary directory should convert to a URL");
+
+        let workspaces = Workspaces::from_workspace_folders(
+            None,
+            None,
+            Some(root_path.display().to_string()),
+            WorkspaceOptionsMap::default(),
+        )
+        .expect("workspace fallback should succeed");
+
+        assert_eq!(workspaces.len(), 1);
+        assert_eq!(workspaces[0].url(), &expected_uri);
+        assert!(workspaces[0].is_default());
     }
 }


### PR DESCRIPTION
## Summary

- add a new `shuck-server` crate with Ruff-derived LSP bootstrap, session, edit, scheduling, and request-routing scaffolding
- wire a new `shuck server` CLI subcommand to start the server over stdio
- stub Shuck-specific diagnostics, formatting, hover, and code-action behavior with explicit `unimplemented!()` placeholders for this phase

## Why

- start implementing `specs/018-lsp.md` by landing the initial server codebase shape
- keep the phase-1 scaffold compiling cleanly while deferring real Shuck LSP behavior to follow-up work

## Impact

- introduces the first LSP server crate and CLI entrypoint
- does not yet provide production-ready editor features; unsupported server paths still intentionally panic when invoked

## Validation

- `cargo check -p shuck-server -p shuck-cli`
- `cargo clippy -p shuck-server -p shuck-cli --all-targets -- -D warnings`
- `cargo run -p shuck-cli -- --help | rg "server"`
