### PR TITLE
refactor(config): extract shared shuck-config crate

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -29,6 +29,7 @@
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-cli'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-ast'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-cache'].version" },
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-config'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-format'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-formatter'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-indexer'].version" },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,6 +1808,7 @@ dependencies = [
  "sha2 0.11.0",
  "shuck-ast",
  "shuck-cache",
+ "shuck-config",
  "shuck-extract",
  "shuck-formatter",
  "shuck-indexer",
@@ -1822,6 +1823,19 @@ dependencies = [
  "url",
  "wait-timeout",
  "walkdir",
+]
+
+[[package]]
+name = "shuck-config"
+version = "0.0.32"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "shuck-formatter",
+ "shuck-run",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -1923,6 +1937,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shuck-ast",
+ "shuck-config",
  "shuck-indexer",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ categories = ["command-line-utilities", "development-tools"]
 shuck-ast = { path = "crates/shuck-ast", version = "0.0.32" }
 shuck-benchmark = { path = "crates/shuck-benchmark" }
 shuck-cache = { path = "crates/shuck-cache", version = "0.0.32" }
+shuck-config = { path = "crates/shuck-config", version = "0.0.32" }
 shuck-format = { path = "crates/shuck-format", version = "0.0.32" }
 shuck-formatter = { path = "crates/shuck-formatter", version = "0.0.32" }
 shuck-indexer = { path = "crates/shuck-indexer", version = "0.0.32" }

--- a/crates/shuck-cli/Cargo.toml
+++ b/crates/shuck-cli/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = { workspace = true }
 quick-junit = { workspace = true }
 shuck-ast = { workspace = true }
 shuck-cache = { workspace = true }
+shuck-config = { workspace = true }
 shuck-extract = { workspace = true }
 shuck-formatter = { workspace = true }
 shuck-indexer = { workspace = true }

--- a/crates/shuck-cli/src/args.rs
+++ b/crates/shuck-cli/src/args.rs
@@ -12,8 +12,8 @@ use clap::{
 use shuck_formatter::{IndentStyle, ShellDialect};
 use shuck_linter::RuleSelector;
 
-use crate::config::{ConfigArgumentParser, ConfigArguments, SingleConfigArgument};
-use crate::format_settings::FormatSettingsPatch;
+use shuck_config::FormatSettingsPatch;
+use shuck_config::{ConfigArgumentParser, ConfigArguments, SingleConfigArgument};
 
 const STYLES: Styles = Styles::styled()
     .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
@@ -956,7 +956,7 @@ mod tests {
     #[test]
     fn global_config_override_is_available_after_subcommand() {
         let command = StableCli::command();
-        let override_argument = crate::config::ConfigArgumentParser
+        let override_argument = shuck_config::ConfigArgumentParser
             .parse_ref(
                 &command,
                 None,
@@ -979,7 +979,7 @@ mod tests {
         let config_path = tempdir.path().join("shuck.toml");
         std::fs::write(&config_path, "[format]\nfunction-next-line = false\n").unwrap();
         let command = StableCli::command();
-        let override_argument = crate::config::ConfigArgumentParser
+        let override_argument = shuck_config::ConfigArgumentParser
             .parse_ref(
                 &command,
                 None,

--- a/crates/shuck-cli/src/commands/check.rs
+++ b/crates/shuck-cli/src/commands/check.rs
@@ -1,12 +1,12 @@
 use std::path::Path;
 
 use anyhow::{Result, anyhow};
+use shuck_config::ConfigArguments;
 
 use crate::ExitStatus;
 use crate::args::CheckCommand;
 use crate::cache::resolve_cache_root;
 use crate::commands::check_output::{DisplayedDiagnostic, DisplayedDiagnosticKind};
-use crate::config::ConfigArguments;
 
 mod add_ignore;
 mod analyze;

--- a/crates/shuck-cli/src/commands/check/add_ignore.rs
+++ b/crates/shuck-cli/src/commands/check/add_ignore.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Result;
+use shuck_config::ConfigArguments;
 use shuck_linter::add_ignores_to_path;
 
 use super::analyze::read_shared_source;
@@ -13,7 +14,6 @@ use crate::ExitStatus;
 use crate::args::CheckCommand;
 use crate::commands::check_output::DisplayedDiagnostic;
 use crate::commands::project_runner::prepare_project_runs;
-use crate::config::ConfigArguments;
 use crate::discover::{DiscoveryOptions, FileKind};
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -169,8 +169,8 @@ mod tests {
         DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
     };
     use crate::commands::project_runner::PendingProjectFile;
-    use crate::config::ConfigArguments;
     use crate::discover::{FileKind, normalize_path};
+    use shuck_config::ConfigArguments;
 
     #[test]
     fn add_ignore_respects_per_file_shell_overrides() {

--- a/crates/shuck-cli/src/commands/check/analyze.rs
+++ b/crates/shuck-cli/src/commands/check/analyze.rs
@@ -203,8 +203,8 @@ mod tests {
         DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
     };
     use crate::commands::project_runner::PendingProjectFile;
-    use crate::config::ConfigArguments;
     use crate::discover::{FileKind, normalize_path};
+    use shuck_config::ConfigArguments;
 
     #[test]
     fn reports_parse_errors() {

--- a/crates/shuck-cli/src/commands/check/cache.rs
+++ b/crates/shuck-cli/src/commands/check/cache.rs
@@ -271,8 +271,8 @@ mod tests {
         DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
     };
     use crate::commands::project_runner::PendingProjectFile;
-    use crate::config::ConfigArguments;
     use crate::discover::{FileKind, normalize_path};
+    use shuck_config::ConfigArguments;
 
     #[test]
     fn reuses_cached_results() {

--- a/crates/shuck-cli/src/commands/check/display.rs
+++ b/crates/shuck-cli/src/commands/check/display.rs
@@ -224,8 +224,8 @@ mod tests {
         DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
     };
     use crate::commands::project_runner::PendingProjectFile;
-    use crate::config::ConfigArguments;
     use crate::discover::{FileKind, normalize_path};
+    use shuck_config::ConfigArguments;
 
     #[test]
     fn report_output_includes_ansi_styles_when_enabled() {

--- a/crates/shuck-cli/src/commands/check/embedded.rs
+++ b/crates/shuck-cli/src/commands/check/embedded.rs
@@ -366,8 +366,8 @@ mod tests {
         DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
     };
     use crate::commands::project_runner::PendingProjectFile;
-    use crate::config::ConfigArguments;
     use crate::discover::{FileKind, normalize_path};
+    use shuck_config::ConfigArguments;
 
     #[test]
     fn checks_embedded_github_actions_workflows() {

--- a/crates/shuck-cli/src/commands/check/run.rs
+++ b/crates/shuck-cli/src/commands/check/run.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use rayon::prelude::*;
+use shuck_config::ConfigArguments;
 use shuck_linter::{Applicability, LinterSettings, RuleSelector, ShellCheckCodeMap};
 
 use super::CheckReport;
@@ -10,7 +11,6 @@ use super::cache::{CheckCacheData, CheckCacheSettings, push_cached_diagnostics};
 use super::settings::{ResolvedCheckSettings, resolve_project_check_settings};
 use crate::args::{CheckCommand, FileSelectionArgs, RuleSelectionArgs};
 use crate::commands::project_runner::{ProjectRunRequest, prepare_project_runs_with_cache_key};
-use crate::config::ConfigArguments;
 use crate::discover::{DiscoveryOptions, FileKind};
 
 pub(super) fn run_check_with_cwd(
@@ -216,8 +216,8 @@ mod tests {
         DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
     };
     use crate::commands::project_runner::PendingProjectFile;
-    use crate::config::ConfigArguments;
     use crate::discover::{FileKind, normalize_path};
+    use shuck_config::ConfigArguments;
 
     #[test]
     fn parse_failure_with_warning_lint_stays_fatal_under_exit_zero() {

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -5,13 +5,13 @@ use std::sync::Arc;
 use anyhow::{Result, anyhow};
 use globset::{Glob, GlobMatcher};
 use shuck_cache::{CacheKey, CacheKeyHasher};
+use shuck_config::{ConfigArguments, LintConfig, load_project_config};
 use shuck_linter::{
     CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore, Rule, RuleSelector, RuleSet,
     ShellDialect,
 };
 
 use crate::args::{PatternRuleSelectorPair, PatternShellPair, RuleSelectionArgs};
-use crate::config::{ConfigArguments, LintConfig, load_project_config};
 use crate::discover::{ProjectRoot, normalize_path};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -703,8 +703,8 @@ mod tests {
         DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
     };
     use crate::commands::project_runner::PendingProjectFile;
-    use crate::config::ConfigArguments;
     use crate::discover::{FileKind, ProjectRoot, normalize_path};
+    use shuck_config::ConfigArguments;
 
     #[test]
     fn select_replaces_default_rules() {

--- a/crates/shuck-cli/src/commands/check/watch.rs
+++ b/crates/shuck-cli/src/commands/check/watch.rs
@@ -6,14 +6,14 @@ use std::sync::mpsc::{Receiver, TryRecvError, channel};
 
 use anyhow::{Result, anyhow};
 use notify::{RecursiveMode, Watcher, recommended_watcher};
+use shuck_config::{
+    ConfigArguments, discovered_config_path_for_root, resolve_project_root_for_input,
+};
 
 use super::display::print_report;
 use super::run::run_check_with_cwd;
 use crate::ExitStatus;
 use crate::args::CheckCommand;
-use crate::config::{
-    ConfigArguments, discovered_config_path_for_root, resolve_project_root_for_input,
-};
 use crate::discover::{DEFAULT_IGNORED_DIR_NAMES, normalize_path};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -393,8 +393,8 @@ mod tests {
         DisplayPosition, DisplaySpan, DisplayedDiagnostic, DisplayedDiagnosticKind, print_report_to,
     };
     use crate::commands::project_runner::PendingProjectFile;
-    use crate::config::ConfigArguments;
     use crate::discover::{FileKind, normalize_path};
+    use shuck_config::ConfigArguments;
 
     #[test]
     fn watch_event_filter_ignores_access_other_ignored_dirs_and_cache_paths() {

--- a/crates/shuck-cli/src/commands/clean.rs
+++ b/crates/shuck-cli/src/commands/clean.rs
@@ -6,11 +6,11 @@ use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use shuck_cache::{legacy_cache_dir, read_project_root_from_cache_file};
+use shuck_config::{ConfigArguments, resolve_project_root_for_input};
 
 use crate::ExitStatus;
 use crate::args::CleanCommand;
 use crate::cache::resolve_cache_root;
-use crate::config::{ConfigArguments, resolve_project_root_for_input};
 
 pub(crate) fn clean(
     args: CleanCommand,

--- a/crates/shuck-cli/src/commands/format.rs
+++ b/crates/shuck-cli/src/commands/format.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Result, anyhow};
 use serde::{Deserialize, Serialize};
 use shuck_cache::{FileCacheKey, PackageCache};
+use shuck_config::ConfigArguments;
 use shuck_formatter::{
     FormatError, FormattedSource, ShellFormatOptions, format_source, source_is_formatted,
 };
@@ -14,7 +15,6 @@ use crate::ExitStatus;
 use crate::args::FormatCommand;
 use crate::cache::resolve_cache_root;
 use crate::commands::project_runner::{PendingProjectFile, prepare_project_runs};
-use crate::config::ConfigArguments;
 use crate::discover::{DiscoveryOptions, FileKind};
 use crate::format_settings::{ResolvedFormatSettings, resolve_project_format_settings};
 
@@ -310,7 +310,7 @@ mod tests {
 
     use super::*;
     use crate::args::FileSelectionArgs;
-    use crate::config::ConfigArguments;
+    use shuck_config::ConfigArguments;
 
     fn make_file_read_only(path: &Path) {
         let mut permissions = fs::metadata(path).unwrap().permissions();

--- a/crates/shuck-cli/src/commands/format_stdin.rs
+++ b/crates/shuck-cli/src/commands/format_stdin.rs
@@ -2,14 +2,14 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
+use shuck_config::{
+    ConfigArguments, resolve_project_root_for_file, resolve_project_root_for_input,
+};
 use shuck_formatter::{FormatError, FormattedSource, format_source, source_is_formatted};
 
 use crate::ExitStatus;
 use crate::args::FormatCommand;
 use crate::commands::format::{FormatMode, unified_diff, write_parse_error_line};
-use crate::config::{
-    ConfigArguments, resolve_project_root_for_file, resolve_project_root_for_input,
-};
 use crate::format_settings::resolve_project_format_settings;
 use crate::stdin::read_from_stdin;
 

--- a/crates/shuck-cli/src/commands/runtime.rs
+++ b/crates/shuck-cli/src/commands/runtime.rs
@@ -7,14 +7,14 @@ use anyhow::{Result, anyhow};
 use std::os::unix::process::{CommandExt, ExitStatusExt};
 use tempfile::NamedTempFile;
 
+use shuck_config::{
+    ConfigArguments, load_project_config, resolve_project_root_for_file,
+    resolve_project_root_for_input,
+};
 use shuck_run::{ResolutionSource, ResolveOptions, RunConfig, Shell, VersionConstraint};
 
 use crate::ExitStatus;
 use crate::args::{InstallCommand, ManagedShellArg, RunCommand, ShellCommand};
-use crate::config::{
-    ConfigArguments, load_project_config, resolve_project_root_for_file,
-    resolve_project_root_for_input,
-};
 
 pub(crate) fn run(args: RunCommand, config_arguments: &ConfigArguments) -> Result<ExitStatus> {
     let cwd = std::env::current_dir()?;

--- a/crates/shuck-cli/src/config_docs.rs
+++ b/crates/shuck-cli/src/config_docs.rs
@@ -4,7 +4,7 @@
 
 use std::fmt::Write;
 
-use crate::config::{ConfigFieldMetadata, ConfigSectionMetadata, configuration_metadata};
+use shuck_config::{ConfigFieldMetadata, ConfigSectionMetadata, configuration_metadata};
 
 pub fn generate_settings_reference() -> String {
     let mut output = String::new();

--- a/crates/shuck-cli/src/discover.rs
+++ b/crates/shuck-cli/src/discover.rs
@@ -9,9 +9,8 @@ use anyhow::{Context, Result, anyhow};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore::{DirEntry, ParallelVisitor, WalkBuilder, WalkState};
+use shuck_config::{resolve_project_root_for_file, resolve_project_root_for_input};
 use shuck_extract::is_extractable;
-
-use crate::config::{resolve_project_root_for_file, resolve_project_root_for_input};
 
 pub(crate) const DEFAULT_IGNORED_DIR_NAMES: &[&str] = &[
     ".shuck_cache",

--- a/crates/shuck-cli/src/format_settings.rs
+++ b/crates/shuck-cli/src/format_settings.rs
@@ -2,27 +2,11 @@ use std::path::Path;
 
 use anyhow::{Result, anyhow};
 use shuck_cache::{CacheKey, CacheKeyHasher};
+use shuck_config::{ConfigArguments, FormatSettingsPatch, load_project_config};
 use shuck_formatter::{IndentStyle, ShellDialect, ShellFormatOptions};
-
-use crate::config::{ConfigArguments, load_project_config};
 
 const CLI_INDENT_WIDTH_ERROR: &str = "`--indent-width` must be at least 1";
 const CONFIG_INDENT_WIDTH_ERROR: &str = "`[format].indent-width` must be at least 1";
-
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct FormatSettingsPatch {
-    pub dialect: Option<ShellDialect>,
-    pub indent_style: Option<IndentStyle>,
-    pub indent_width: Option<u8>,
-    pub binary_next_line: Option<bool>,
-    pub switch_case_indent: Option<bool>,
-    pub space_redirects: Option<bool>,
-    pub keep_padding: Option<bool>,
-    pub function_next_line: Option<bool>,
-    pub never_split: Option<bool>,
-    pub simplify: Option<bool>,
-    pub minify: Option<bool>,
-}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ResolvedFormatSettings {
@@ -110,16 +94,6 @@ pub(crate) fn resolve_project_format_settings(
     Ok(settings)
 }
 
-pub(crate) fn parse_config_indent_style(value: &str) -> Result<IndentStyle> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "tab" => Ok(IndentStyle::Tab),
-        "space" => Ok(IndentStyle::Space),
-        _ => Err(anyhow!(
-            "unsupported `[format].indent-style` value `{value}`; expected one of: tab, space"
-        )),
-    }
-}
-
 const fn indent_style_key(style: IndentStyle) -> u8 {
     match style {
         IndentStyle::Space => 0,
@@ -146,8 +120,7 @@ mod tests {
 
     use super::*;
     use crate::args::{FileSelectionArgs, FormatCommand};
-    use crate::config::{CONFIG_DIALECT_UNSUPPORTED_ERROR, FormatConfig};
-
+    use shuck_config::{CONFIG_DIALECT_UNSUPPORTED_ERROR, FormatConfig};
     fn format_args() -> FormatCommand {
         FormatCommand {
             files: vec![PathBuf::from(".")],

--- a/crates/shuck-cli/src/lib.rs
+++ b/crates/shuck-cli/src/lib.rs
@@ -12,7 +12,6 @@ pub mod args;
 
 mod cache;
 mod commands;
-mod config;
 #[doc(hidden)]
 pub mod config_docs;
 mod discover;
@@ -27,9 +26,9 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use anyhow::Result;
+use shuck_config::ConfigArguments;
 
 use crate::args::{Args, Command, FormatCommand, TerminalColor};
-use crate::config::ConfigArguments;
 
 /// Exit status returned by [`run`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/crates/shuck-config/Cargo.toml
+++ b/crates/shuck-config/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "shuck-config"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Configuration loading and project-root discovery for shuck"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+shuck-formatter = { workspace = true }
+shuck-run = { workspace = true }
+toml = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs;
@@ -9,13 +11,11 @@ use anyhow::{Context, Result, anyhow};
 use clap::builder::{TypedValueParser, ValueParserFactory};
 use clap::error::{ContextKind, ContextValue, ErrorKind};
 use serde::Deserialize;
+use shuck_formatter::{IndentStyle, ShellDialect};
 use shuck_run::RunConfig;
 
-use crate::discover::normalize_path;
-use crate::format_settings::{FormatSettingsPatch, parse_config_indent_style};
-
 const CONFIG_FILENAMES: [&str; 2] = [".shuck.toml", "shuck.toml"];
-pub(crate) const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
+pub const CONFIG_DIALECT_UNSUPPORTED_ERROR: &str = "`[format].dialect` is not supported; formatter dialect is auto-discovered from the file name or shebang. Use `--dialect` for a per-run override";
 const CONFIG_OVERRIDE_ROOT_KEYS: &[&str] = &["check", "format", "lint", "run"];
 const CONFIG_OVERRIDE_CHECK_KEYS: &[&str] = &["embedded"];
 const CONFIG_OVERRIDE_FORMAT_KEYS: &[&str] = &[
@@ -52,7 +52,7 @@ const CONFIG_OVERRIDE_RUN_SHELL_NAMES: &[&str] =
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default)]
-pub(crate) struct ShuckConfig {
+pub struct ShuckConfig {
     pub check: CheckConfig,
     pub format: FormatConfig,
     pub lint: LintConfig,
@@ -61,13 +61,13 @@ pub(crate) struct ShuckConfig {
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
-pub(crate) struct CheckConfig {
+pub struct CheckConfig {
     pub embedded: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
-pub(crate) struct FormatConfig {
+pub struct FormatConfig {
     pub dialect: Option<toml::Value>,
     pub indent_style: Option<String>,
     pub indent_width: Option<u8>,
@@ -81,7 +81,7 @@ pub(crate) struct FormatConfig {
 
 #[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
-pub(crate) struct LintConfig {
+pub struct LintConfig {
     pub select: Option<Vec<String>>,
     pub ignore: Option<Vec<String>>,
     pub extend_select: Option<Vec<String>>,
@@ -97,7 +97,7 @@ pub(crate) struct LintConfig {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
-pub(crate) struct LintRuleOptionsConfig {
+pub struct LintRuleOptionsConfig {
     pub c001: Option<C001RuleOptionsConfig>,
     pub c063: Option<C063RuleOptionsConfig>,
 }
@@ -115,7 +115,7 @@ impl LintRuleOptionsConfig {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
-pub(crate) struct C001RuleOptionsConfig {
+pub struct C001RuleOptionsConfig {
     pub treat_indirect_expansion_targets_as_used: Option<bool>,
 }
 
@@ -130,7 +130,7 @@ impl C001RuleOptionsConfig {
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
-pub(crate) struct C063RuleOptionsConfig {
+pub struct C063RuleOptionsConfig {
     pub report_unreached_nested_definitions: Option<bool>,
 }
 
@@ -143,8 +143,23 @@ impl C063RuleOptionsConfig {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FormatSettingsPatch {
+    pub dialect: Option<ShellDialect>,
+    pub indent_style: Option<IndentStyle>,
+    pub indent_width: Option<u8>,
+    pub binary_next_line: Option<bool>,
+    pub switch_case_indent: Option<bool>,
+    pub space_redirects: Option<bool>,
+    pub keep_padding: Option<bool>,
+    pub function_next_line: Option<bool>,
+    pub never_split: Option<bool>,
+    pub simplify: Option<bool>,
+    pub minify: Option<bool>,
+}
+
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct ConfigSectionMetadata {
+pub struct ConfigSectionMetadata {
     pub key: &'static str,
     pub docs: &'static str,
     pub fields: &'static [ConfigFieldMetadata],
@@ -152,7 +167,7 @@ pub(crate) struct ConfigSectionMetadata {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct ConfigFieldMetadata {
+pub struct ConfigFieldMetadata {
     pub key: &'static str,
     pub docs: &'static str,
     pub default: &'static str,
@@ -160,7 +175,7 @@ pub(crate) struct ConfigFieldMetadata {
     pub example: &'static str,
 }
 
-pub(crate) fn configuration_metadata() -> &'static [ConfigSectionMetadata] {
+pub fn configuration_metadata() -> &'static [ConfigSectionMetadata] {
     &CONFIGURATION_METADATA
 }
 
@@ -349,14 +364,14 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
 ];
 
 #[derive(Debug, Clone, Default, PartialEq)]
-pub(crate) struct ConfigArguments {
+pub struct ConfigArguments {
     isolated: bool,
     config_file: Option<PathBuf>,
     overrides: ShuckConfig,
 }
 
 impl ConfigArguments {
-    pub(crate) fn from_cli(
+    pub fn from_cli(
         config_options: Vec<SingleConfigArgument>,
         isolated: bool,
     ) -> std::result::Result<Self, clap::Error> {
@@ -413,23 +428,23 @@ You cannot specify more than one configuration file on the command line.
         })
     }
 
-    pub(crate) fn use_config_roots(&self) -> bool {
+    pub fn use_config_roots(&self) -> bool {
         !self.isolated && self.config_file.is_none()
     }
 
-    pub(crate) fn explicit_config_file(&self) -> Option<&Path> {
+    pub fn explicit_config_file(&self) -> Option<&Path> {
         self.config_file.as_deref()
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum SingleConfigArgument {
+pub enum SingleConfigArgument {
     FilePath(PathBuf),
     SettingsOverride(Box<ShuckConfig>),
 }
 
 #[derive(Clone)]
-pub(crate) struct ConfigArgumentParser;
+pub struct ConfigArgumentParser;
 
 impl ValueParserFactory for SingleConfigArgument {
     type Parser = ConfigArgumentParser;
@@ -464,10 +479,7 @@ impl TypedValueParser for ConfigArgumentParser {
     }
 }
 
-pub(crate) fn resolve_project_root_for_input(
-    input: &Path,
-    use_config_roots: bool,
-) -> io::Result<PathBuf> {
+pub fn resolve_project_root_for_input(input: &Path, use_config_roots: bool) -> io::Result<PathBuf> {
     let base_dir = base_dir_for_input(input)?;
     if use_config_roots {
         Ok(find_config_root(&base_dir)?.unwrap_or(base_dir))
@@ -476,7 +488,7 @@ pub(crate) fn resolve_project_root_for_input(
     }
 }
 
-pub(crate) fn resolve_project_root_for_file(
+pub fn resolve_project_root_for_file(
     file: &Path,
     fallback_start: &Path,
     use_config_roots: bool,
@@ -492,7 +504,7 @@ pub(crate) fn resolve_project_root_for_file(
     }
 }
 
-pub(crate) fn load_project_config(
+pub fn load_project_config(
     project_root: &Path,
     config_arguments: &ConfigArguments,
 ) -> Result<ShuckConfig> {
@@ -512,7 +524,7 @@ pub(crate) fn load_project_config(
 }
 
 impl FormatConfig {
-    pub(crate) fn to_patch(&self) -> Result<FormatSettingsPatch> {
+    pub fn to_patch(&self) -> Result<FormatSettingsPatch> {
         if self.dialect.is_some() {
             return Err(anyhow!(CONFIG_DIALECT_UNSUPPORTED_ERROR));
         }
@@ -844,6 +856,16 @@ A `--config` flag must either be a path to a `.toml` configuration file
     error
 }
 
+pub fn parse_config_indent_style(value: &str) -> Result<IndentStyle> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "tab" => Ok(IndentStyle::Tab),
+        "space" => Ok(IndentStyle::Space),
+        _ => Err(anyhow!(
+            "unsupported `[format].indent-style` value `{value}`; expected one of: tab, space"
+        )),
+    }
+}
+
 fn base_dir_for_input(input: &Path) -> io::Result<PathBuf> {
     let normalized = normalize_path(input);
     let metadata = fs::metadata(&normalized)?;
@@ -898,8 +920,12 @@ fn config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
     Ok(None)
 }
 
-pub(crate) fn discovered_config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
+pub fn discovered_config_path_for_root(root: &Path) -> io::Result<Option<PathBuf>> {
     config_path_for_root(root)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.components().collect()
 }
 
 #[cfg(test)]

--- a/crates/shuck-config/tests/public_api.rs
+++ b/crates/shuck-config/tests/public_api.rs
@@ -1,0 +1,92 @@
+use std::fs;
+
+use shuck_config::{
+    CONFIG_DIALECT_UNSUPPORTED_ERROR, ConfigArguments, FormatConfig, ShuckConfig,
+    SingleConfigArgument, discovered_config_path_for_root, load_project_config,
+    resolve_project_root_for_file, resolve_project_root_for_input,
+};
+use tempfile::tempdir;
+
+#[test]
+fn public_api_layers_discovered_config_and_inline_overrides() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[format]\nfunction-next-line = true\n",
+    )
+    .unwrap();
+
+    let override_config = ShuckConfig {
+        format: FormatConfig {
+            indent_width: Some(2),
+            ..FormatConfig::default()
+        },
+        ..ShuckConfig::default()
+    };
+
+    let config = ConfigArguments::from_cli(
+        vec![SingleConfigArgument::SettingsOverride(Box::new(
+            override_config,
+        ))],
+        false,
+    )
+    .unwrap();
+
+    let loaded = load_project_config(tempdir.path(), &config).unwrap();
+    assert_eq!(loaded.format.function_next_line, Some(true));
+    assert_eq!(loaded.format.indent_width, Some(2));
+}
+
+#[test]
+fn public_api_prefers_explicit_config_file_over_discovered_file() {
+    let tempdir = tempdir().unwrap();
+    fs::write(
+        tempdir.path().join("shuck.toml"),
+        "[format]\nfunction-next-line = false\n",
+    )
+    .unwrap();
+
+    let explicit = tempdir.path().join("override.toml");
+    fs::write(&explicit, "[format]\nfunction-next-line = true\n").unwrap();
+
+    let config =
+        ConfigArguments::from_cli(vec![SingleConfigArgument::FilePath(explicit)], false).unwrap();
+
+    let loaded = load_project_config(tempdir.path(), &config).unwrap();
+    assert_eq!(loaded.format.function_next_line, Some(true));
+}
+
+#[test]
+fn public_api_resolves_project_roots_and_discovered_config_paths() {
+    let tempdir = tempdir().unwrap();
+    let nested = tempdir.path().join("nested");
+    let file = nested.join("script.sh");
+
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(tempdir.path().join(".shuck.toml"), "[format]\n").unwrap();
+    fs::write(&file, "#!/bin/sh\necho hi\n").unwrap();
+
+    assert_eq!(
+        resolve_project_root_for_input(&nested, true).unwrap(),
+        tempdir.path()
+    );
+    assert_eq!(
+        resolve_project_root_for_file(&file, &nested, true).unwrap(),
+        tempdir.path()
+    );
+    assert_eq!(
+        discovered_config_path_for_root(tempdir.path()).unwrap(),
+        Some(tempdir.path().join(".shuck.toml"))
+    );
+}
+
+#[test]
+fn public_api_rejects_format_dialect_in_config_patch() {
+    let config = FormatConfig {
+        dialect: Some(toml::Value::String("zsh".to_owned())),
+        ..FormatConfig::default()
+    };
+
+    let err = config.to_patch().unwrap_err();
+    assert_eq!(err.to_string(), CONFIG_DIALECT_UNSUPPORTED_ERROR);
+}

--- a/crates/shuck-server/Cargo.toml
+++ b/crates/shuck-server/Cargo.toml
@@ -17,6 +17,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shuck-ast = { workspace = true }
+shuck-config = { workspace = true }
 shuck-indexer = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
## Summary
- extract the shared config loading and project-root discovery code into a new `shuck-config` crate
- update `shuck-cli` to import `shuck-config` directly instead of keeping a local config module
- add public API integration coverage for config layering and project-root/config-path resolution to support upcoming LSP settings work

## Why
The LSP spec calls for config loading and project-root discovery to be shared between the CLI and the server. This moves that implementation into its own crate so `shuck-server` can depend on it directly without depending on `shuck-cli`.

## Testing
- `cargo test -p shuck-config -p shuck-cli -p shuck-server --quiet`
