### PR TITLE
refactor(semantic): add option-sensitive behavior query

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -1,8 +1,8 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Command, Name, Span};
 use shuck_semantic::{
-    Binding, BindingAttributes, BindingId, BindingKind, DeclarationBuiltin, DeclarationOperand,
-    OptionValue, Reference, ReferenceId, ScopeId,
+    ArrayReferencePolicy, Binding, BindingAttributes, BindingId, BindingKind, DeclarationBuiltin,
+    DeclarationOperand, Reference, ReferenceId, ScopeId,
 };
 
 use crate::{Checker, LinterFacts, Rule, ShellDialect, Violation, WordQuote, facts::CommandId};
@@ -241,8 +241,9 @@ impl<'a, 'src> QuotedBashSourceContext<'a, 'src> {
         }
 
         self.semantic
-            .zsh_ksh_arrays_runtime_state_at(reference.span.start.offset)
-            .is_some_and(|state| state == OptionValue::Off)
+            .shell_behavior_at(reference.span.start.offset)
+            .array_reference_policy()
+            == ArrayReferencePolicy::NativeZshScalar
     }
 
     fn reference_reads_into_same_name_array_writer(&mut self, reference: &Reference) -> bool {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -71,11 +71,52 @@ pub use reference::{Reference, ReferenceId, ReferenceKind};
 /// Scope types and identifiers tracked by the semantic model.
 pub use scope::{FunctionScopeKind, Scope, ScopeId, ScopeKind};
 /// Shell parser option types reused by the semantic analysis layer.
-pub use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionState};
+pub use shuck_parser::{OptionValue, ShellDialect, ShellProfile, ZshEmulationMode, ZshOptionState};
 /// Source-reference records and resolution state.
 pub use source_ref::{SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution};
 /// Value-flow query object built over semantic bindings, call sites, CFG, and dataflow.
 pub use value_flow::SemanticValueFlow;
+
+/// How an unindexed array reference behaves at a source offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArrayReferencePolicy {
+    /// The shell requires an explicit element or selector for array references.
+    RequiresExplicitSelector,
+    /// Native zsh treats an unindexed array reference as a scalar first-element read.
+    NativeZshScalar,
+    /// Runtime option state may select either policy.
+    Ambiguous,
+}
+
+/// Option-sensitive shell behavior visible at a source offset.
+#[derive(Debug)]
+pub struct ShellBehaviorAt<'model> {
+    shell: ShellDialect,
+    zsh_options: Option<&'model ZshOptionState>,
+    runtime_options: Option<ZshOptionState>,
+}
+
+impl ShellBehaviorAt<'_> {
+    fn effective_zsh_options(&self) -> Option<&ZshOptionState> {
+        self.runtime_options.as_ref().or(self.zsh_options)
+    }
+
+    /// Returns the array-reference policy implied by the shell and runtime option state.
+    pub fn array_reference_policy(&self) -> ArrayReferencePolicy {
+        if self.shell != ShellDialect::Zsh {
+            return ArrayReferencePolicy::RequiresExplicitSelector;
+        }
+
+        match self
+            .effective_zsh_options()
+            .map(|options| options.ksh_arrays)
+        {
+            Some(OptionValue::Off) => ArrayReferencePolicy::NativeZshScalar,
+            Some(OptionValue::Unknown) => ArrayReferencePolicy::Ambiguous,
+            Some(OptionValue::On) | None => ArrayReferencePolicy::RequiresExplicitSelector,
+        }
+    }
+}
 
 /// A function scope reached through a top-level `case "$1"` style CLI dispatcher.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -645,9 +686,8 @@ pub struct SemanticModel {
     import_origins_by_binding: FxHashMap<BindingId, Vec<PathBuf>>,
     heuristic_unused_assignments: Vec<BindingId>,
     zsh_option_analysis: Option<ZshOptionAnalysis>,
-    zsh_ksh_arrays_may_enable_anywhere: OnceLock<bool>,
-    zsh_ksh_arrays_runtime_by_function:
-        OnceLock<FxHashMap<ScopeId, OnceLock<Option<ZshOptionAnalysis>>>>,
+    zsh_runtime_ambiguous_entry_mask: OnceLock<zsh_options::ZshOptionMask>,
+    zsh_runtime_by_function: OnceLock<FxHashMap<ScopeId, OnceLock<Option<ZshOptionAnalysis>>>>,
     assoc_lookup_binding_index: OnceLock<AssocLookupBindingIndex>,
     command_topology: OnceLock<CommandTopology>,
     references_sorted_by_start: OnceLock<Vec<ReferenceId>>,
@@ -848,8 +888,8 @@ impl SemanticModel {
             import_origins_by_binding: FxHashMap::default(),
             heuristic_unused_assignments: built.heuristic_unused_assignments,
             zsh_option_analysis,
-            zsh_ksh_arrays_may_enable_anywhere: OnceLock::new(),
-            zsh_ksh_arrays_runtime_by_function: OnceLock::new(),
+            zsh_runtime_ambiguous_entry_mask: OnceLock::new(),
+            zsh_runtime_by_function: OnceLock::new(),
             assoc_lookup_binding_index: OnceLock::new(),
             command_topology: OnceLock::new(),
             references_sorted_by_start: OnceLock::new(),
@@ -881,46 +921,44 @@ impl SemanticModel {
             .and_then(|analysis| analysis.options_at(&self.scopes, offset))
     }
 
-    fn may_enable_zsh_ksh_arrays_anywhere(&self) -> bool {
+    /// Returns option-sensitive shell behavior visible at `offset`.
+    pub fn shell_behavior_at(&self, offset: usize) -> ShellBehaviorAt<'_> {
+        ShellBehaviorAt {
+            shell: self.shell_profile.dialect,
+            zsh_options: self.zsh_options_at(offset),
+            runtime_options: self.zsh_runtime_options_at(offset),
+        }
+    }
+
+    fn zsh_runtime_ambiguous_entry_mask(&self) -> zsh_options::ZshOptionMask {
         if self.shell_profile.zsh_options().is_none() {
-            return false;
+            return zsh_options::ZshOptionMask::default();
         }
 
-        *self.zsh_ksh_arrays_may_enable_anywhere.get_or_init(|| {
-            crate::zsh_options::may_enable_ksh_arrays_anywhere(&self.recorded_program)
+        *self.zsh_runtime_ambiguous_entry_mask.get_or_init(|| {
+            crate::zsh_options::runtime_ambiguous_entry_mask(&self.recorded_program)
         })
     }
 
-    /// Returns the conservative runtime state for `ksh_arrays` at `offset`.
-    ///
-    /// For function bodies in files that can enable `ksh_arrays`, this merges the ordinary
-    /// zsh-option snapshot with a second pass that re-evaluates the enclosing function under an
-    /// ambiguous `ksh_arrays` entry state. Callers can treat `Off` as a guaranteed native-zsh
-    /// context and anything else as potentially ksh-like.
-    pub fn zsh_ksh_arrays_runtime_state_at(&self, offset: usize) -> Option<OptionValue> {
+    fn zsh_runtime_options_at(&self, offset: usize) -> Option<ZshOptionState> {
         self.shell_profile.zsh_options()?;
-        let ordinary = self.zsh_options_at(offset)?.ksh_arrays;
-        if !self.may_enable_zsh_ksh_arrays_anywhere() {
-            return Some(ordinary);
+        let ordinary = self.zsh_options_at(offset)?.clone();
+        let ambiguous_entry = self.zsh_runtime_ambiguous_entry_mask();
+        if ambiguous_entry.is_empty() {
+            return None;
         }
 
         let scope = self.scope_at(offset);
-        let Some(function_scope) = self.enclosing_function_scope(scope) else {
-            return Some(ordinary);
-        };
-
+        let function_scope = self.enclosing_function_scope(scope)?;
         let ambient = self
-            .zsh_ksh_arrays_runtime_analysis_for_function(function_scope)
-            .and_then(|analysis| analysis.options_at(&self.scopes, offset))
-            .map_or(ordinary, |options| options.ksh_arrays);
+            .zsh_runtime_analysis_for_function(function_scope)
+            .and_then(|analysis| analysis.options_at(&self.scopes, offset));
 
-        Some(ordinary.merge(ambient))
+        Some(ambient.map_or(ordinary.clone(), |options| ordinary.merge(options)))
     }
 
-    fn zsh_ksh_arrays_runtime_by_function(
-        &self,
-    ) -> &FxHashMap<ScopeId, OnceLock<Option<ZshOptionAnalysis>>> {
-        self.zsh_ksh_arrays_runtime_by_function.get_or_init(|| {
+    fn zsh_runtime_by_function(&self) -> &FxHashMap<ScopeId, OnceLock<Option<ZshOptionAnalysis>>> {
+        self.zsh_runtime_by_function.get_or_init(|| {
             self.recorded_program
                 .function_bodies()
                 .keys()
@@ -929,23 +967,29 @@ impl SemanticModel {
         })
     }
 
-    fn zsh_ksh_arrays_runtime_analysis_for_function(
+    fn zsh_runtime_analysis_for_function(
         &self,
         function_scope: ScopeId,
     ) -> Option<&ZshOptionAnalysis> {
-        self.zsh_ksh_arrays_runtime_by_function()
+        self.zsh_runtime_by_function()
             .get(&function_scope)?
-            .get_or_init(|| self.build_zsh_ksh_arrays_runtime_analysis_for_function(function_scope))
+            .get_or_init(|| self.build_zsh_runtime_analysis_for_function(function_scope))
             .as_ref()
     }
 
-    fn build_zsh_ksh_arrays_runtime_analysis_for_function(
+    fn build_zsh_runtime_analysis_for_function(
         &self,
         function_scope: ScopeId,
     ) -> Option<ZshOptionAnalysis> {
         let function_entry_offset = self.scope(function_scope).span.start.offset;
         let mut function_entry = self.zsh_options_at(function_entry_offset)?.clone();
-        function_entry.ksh_arrays = OptionValue::Unknown;
+        for field in self.zsh_runtime_ambiguous_entry_mask().iter() {
+            crate::zsh_options::set_public_option_field(
+                &mut function_entry,
+                field,
+                OptionValue::Unknown,
+            );
+        }
         crate::zsh_options::function_runtime_analysis_with_entry(
             &self.scopes,
             &self.bindings,

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9785,8 +9785,12 @@ fn zsh_option_analysis_treats_dynamic_ksh_arrays_updates_as_unknown() {
     }
 }
 
+fn array_reference_policy_at(model: &SemanticModel, offset: usize) -> ArrayReferencePolicy {
+    model.shell_behavior_at(offset).array_reference_policy()
+}
+
 #[test]
-fn semantic_helper_detects_real_ksh_array_enables() {
+fn semantic_behavior_detects_real_ksh_array_enables() {
     for source in [
         "setopt ksh_arrays\nprint $name\n",
         "setopt ksharrays\nprint $name\n",
@@ -9806,12 +9810,17 @@ fn semantic_helper_detects_real_ksh_array_enables() {
         "mode=ksh\nemulate \"$mode\"\nprint $name\n",
     ] {
         let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
-        assert!(model.may_enable_zsh_ksh_arrays_anywhere(), "{source}");
+        let offset = source.find("print").unwrap();
+        assert_ne!(
+            array_reference_policy_at(&model, offset),
+            ArrayReferencePolicy::NativeZshScalar,
+            "{source}"
+        );
     }
 }
 
 #[test]
-fn semantic_helper_ignores_non_effect_text_for_ksh_arrays() {
+fn semantic_behavior_ignores_non_effect_text_for_ksh_arrays() {
     for source in [
         "# emulate ksh in comments should not count\nprint $name\n",
         "msg='setopt ksh_arrays'\nprint $name\n",
@@ -9821,20 +9830,24 @@ fn semantic_helper_ignores_non_effect_text_for_ksh_arrays() {
         "unsetopt ksh_arrays\nprint $name\n",
     ] {
         let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
-        assert!(!model.may_enable_zsh_ksh_arrays_anywhere(), "{source}");
+        let offset = source.find("print").unwrap();
+        assert_eq!(
+            array_reference_policy_at(&model, offset),
+            ArrayReferencePolicy::NativeZshScalar,
+            "{source}"
+        );
     }
 }
 
 #[test]
-fn semantic_ksh_arrays_helpers_skip_non_zsh_profiles() {
+fn semantic_shell_behavior_uses_selector_policy_for_non_zsh_profiles() {
     let source = "setopt ksh_arrays\nprint $name\n";
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Bash));
     let offset = source.find("print").unwrap();
 
-    assert!(!model.may_enable_zsh_ksh_arrays_anywhere(), "{source}");
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        None,
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::RequiresExplicitSelector,
         "{source}"
     );
 }
@@ -9855,7 +9868,6 @@ $dispatcher
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
     let offset = source.find("print $name").unwrap();
 
-    assert!(model.may_enable_zsh_ksh_arrays_anywhere());
     assert!(
         model
             .zsh_options_at(offset)
@@ -9863,8 +9875,8 @@ $dispatcher
         "{source}"
     );
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        Some(OptionValue::Unknown),
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::Ambiguous,
         "{source}"
     );
 }
@@ -9883,10 +9895,9 @@ $dispatcher
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
     let offset = source.find("print $name").unwrap();
 
-    assert!(model.may_enable_zsh_ksh_arrays_anywhere());
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        Some(OptionValue::Off),
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::NativeZshScalar,
         "{source}"
     );
 }
@@ -9904,7 +9915,6 @@ print $name
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
     let offset = source.find("print $name").unwrap();
 
-    assert!(model.may_enable_zsh_ksh_arrays_anywhere());
     assert!(
         model
             .zsh_options_at(offset)
@@ -9912,8 +9922,8 @@ print $name
         "{source}"
     );
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        Some(OptionValue::On),
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::RequiresExplicitSelector,
         "{source}"
     );
 }
@@ -9930,7 +9940,6 @@ print $name
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
     let offset = source.find("print $name").unwrap();
 
-    assert!(model.may_enable_zsh_ksh_arrays_anywhere());
     assert!(
         model
             .zsh_options_at(offset)
@@ -9938,8 +9947,8 @@ print $name
         "{source}"
     );
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        Some(OptionValue::Unknown),
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::Ambiguous,
         "{source}"
     );
 }
@@ -9958,7 +9967,6 @@ print $name
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
     let offset = source.find("print $name").unwrap();
 
-    assert!(model.may_enable_zsh_ksh_arrays_anywhere());
     assert!(
         model
             .zsh_options_at(offset)
@@ -9966,8 +9974,8 @@ print $name
         "{source}"
     );
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        Some(OptionValue::Off),
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::NativeZshScalar,
         "{source}"
     );
 }
@@ -9985,7 +9993,6 @@ print $name
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
     let offset = source.find("print $name").unwrap();
 
-    assert!(model.may_enable_zsh_ksh_arrays_anywhere());
     assert!(
         model
             .zsh_options_at(offset)
@@ -9993,8 +10000,8 @@ print $name
         "{source}"
     );
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        Some(OptionValue::On),
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::RequiresExplicitSelector,
         "{source}"
     );
 }
@@ -10012,10 +10019,9 @@ print $name
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
     let offset = source.find("print $name").unwrap();
 
-    assert!(model.may_enable_zsh_ksh_arrays_anywhere());
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        Some(OptionValue::Off),
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::NativeZshScalar,
         "{source}"
     );
 }
@@ -10037,10 +10043,9 @@ print $name
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
     let offset = source.find("print $name").unwrap();
 
-    assert!(model.may_enable_zsh_ksh_arrays_anywhere());
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        Some(OptionValue::Off),
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::NativeZshScalar,
         "{source}"
     );
 }
@@ -10062,7 +10067,6 @@ run_dispatcher enable_ksh
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
     let offset = source.find("print $name").unwrap();
 
-    assert!(model.may_enable_zsh_ksh_arrays_anywhere());
     assert!(
         model
             .zsh_options_at(offset)
@@ -10070,8 +10074,8 @@ run_dispatcher enable_ksh
         "{source}"
     );
     assert_eq!(
-        model.zsh_ksh_arrays_runtime_state_at(offset),
-        Some(OptionValue::Unknown),
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::Ambiguous,
         "{source}"
     );
 }

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -48,7 +48,7 @@ struct ZshOptionSnapshot {
 #[derive(Debug, Clone)]
 struct FunctionSummary {
     final_outward: InternalState,
-    outward_touched: FxHashSet<ZshOptionField>,
+    outward_touched: ZshOptionMask,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -128,7 +128,7 @@ impl InternalState {
 struct EvalState {
     current: InternalState,
     outward: InternalState,
-    outward_touched: FxHashSet<ZshOptionField>,
+    outward_touched: ZshOptionMask,
 }
 
 impl EvalState {
@@ -136,23 +136,22 @@ impl EvalState {
         Self {
             current: entry.clone(),
             outward: entry,
-            outward_touched: FxHashSet::default(),
+            outward_touched: ZshOptionMask::default(),
         }
     }
 
     fn merge(&self, other: &Self) -> Self {
-        let mut outward_touched = self.outward_touched.clone();
-        outward_touched.extend(other.outward_touched.iter().copied());
         Self {
             current: self.current.merge(&other.current),
             outward: self.outward.merge(&other.outward),
-            outward_touched,
+            outward_touched: self.outward_touched.union(other.outward_touched),
         }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum ZshOptionField {
+#[repr(u8)]
+pub(crate) enum ZshOptionField {
     ShWordSplit,
     GlobSubst,
     RcExpandParam,
@@ -212,6 +211,45 @@ impl ZshOptionField {
         Self::CBases,
         Self::OctalZeroes,
     ];
+
+    fn bit(self) -> u32 {
+        1u32 << (self as u8)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub(crate) struct ZshOptionMask(u32);
+
+impl ZshOptionMask {
+    pub(crate) const ALL: Self = Self((1u32 << ZshOptionField::ALL.len()) - 1);
+
+    pub(crate) fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    pub(crate) fn contains(self, field: ZshOptionField) -> bool {
+        self.0 & field.bit() != 0
+    }
+
+    pub(crate) fn insert(&mut self, field: ZshOptionField) {
+        self.0 |= field.bit();
+    }
+
+    fn insert_all(&mut self, fields: impl IntoIterator<Item = ZshOptionField>) {
+        for field in fields {
+            self.insert(field);
+        }
+    }
+
+    fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    pub(crate) fn iter(self) -> impl Iterator<Item = ZshOptionField> {
+        ZshOptionField::ALL
+            .into_iter()
+            .filter(move |field| self.contains(*field))
+    }
 }
 
 pub(crate) fn analyze(
@@ -261,22 +299,34 @@ pub(crate) fn analyze(
     })
 }
 
-pub(crate) fn may_enable_ksh_arrays_anywhere(recorded_program: &RecordedProgram) -> bool {
-    recorded_program.command_infos.values().any(|info| {
-        info.zsh_effects.iter().any(|effect| match effect {
-            RecordedZshCommandEffect::Emulate { mode, .. } => *mode == ZshEmulationMode::Ksh,
-            RecordedZshCommandEffect::EmulateUnknown { .. } => true,
-            RecordedZshCommandEffect::SetOptions { updates } => {
-                updates.iter().any(|update| match update {
-                    RecordedZshOptionUpdate::UnknownName => true,
-                    RecordedZshOptionUpdate::Named { name, enable: true } => {
-                        name.as_ref() == "ksharrays"
+pub(crate) fn runtime_ambiguous_entry_mask(recorded_program: &RecordedProgram) -> ZshOptionMask {
+    let mut mask = ZshOptionMask::default();
+    for info in recorded_program.command_infos.values() {
+        for effect in &info.zsh_effects {
+            match effect {
+                RecordedZshCommandEffect::Emulate { .. } => {
+                    return ZshOptionMask::ALL;
+                }
+                RecordedZshCommandEffect::EmulateUnknown { .. } => {
+                    return ZshOptionMask::ALL;
+                }
+                RecordedZshCommandEffect::SetOptions { updates } => {
+                    for update in updates {
+                        match update {
+                            RecordedZshOptionUpdate::UnknownName => return ZshOptionMask::ALL,
+                            RecordedZshOptionUpdate::Named { name, .. } => {
+                                if let Some(field) = field_for_option_name(name) {
+                                    mask.insert(field);
+                                }
+                            }
+                            RecordedZshOptionUpdate::LocalOptions { .. } => {}
+                        }
                     }
-                    _ => false,
-                })
+                }
             }
-        })
-    })
+        }
+    }
+    mask
 }
 
 pub(crate) fn function_runtime_analysis_with_entry(
@@ -327,6 +377,14 @@ pub(crate) fn function_runtime_analysis_with_entry(
         snapshots: analyzer.snapshots,
         scope_index,
     })
+}
+
+pub(crate) fn set_public_option_field(
+    state: &mut ZshOptionState,
+    field: ZshOptionField,
+    value: OptionValue,
+) {
+    set_option_field(state, field, value);
 }
 
 impl ZshOptionAnalysis {
@@ -397,10 +455,10 @@ impl<'a> Analyzer<'a> {
         leak: LeakBehavior,
         summary: &FunctionSummary,
     ) {
-        for field in &summary.outward_touched {
-            let value = get_option_field(&summary.final_outward.public, *field);
-            set_option_field(&mut state.current.public, *field, value);
-            self.apply_explicit_public_field(state, leak, *field, value);
+        for field in summary.outward_touched.iter() {
+            let value = get_option_field(&summary.final_outward.public, field);
+            set_option_field(&mut state.current.public, field, value);
+            self.apply_explicit_public_field(state, leak, field, value);
         }
         self.apply_emulation_state(state, leak, summary.final_outward.emulation);
     }
@@ -479,7 +537,7 @@ impl<'a> Analyzer<'a> {
         if saw_unresolved_name {
             let unchanged = FunctionSummary {
                 final_outward: state.current.clone(),
-                outward_touched: FxHashSet::default(),
+                outward_touched: ZshOptionMask::default(),
             };
             merged = Some(match merged {
                 Some(accumulated) => accumulated.merge(&unchanged),
@@ -700,7 +758,7 @@ impl<'a> Analyzer<'a> {
         let segments = self.recorded_program.pipeline_segments(segments);
 
         if emulation == EmulationState::Unknown {
-            let mut touched = FxHashSet::default();
+            let mut touched = ZshOptionMask::default();
             for segment in segments {
                 let segment_result = self.analyze_single_command_sequence(
                     segment.scope,
@@ -708,9 +766,9 @@ impl<'a> Analyzer<'a> {
                     EvalState::new(state.current.clone()),
                     LeakBehavior::Never,
                 );
-                touched.extend(segment_result.outward_touched.iter().copied());
+                touched = touched.union(segment_result.outward_touched);
             }
-            for field in touched {
+            for field in touched.iter() {
                 self.apply_explicit_public_field(&mut result, leak, field, OptionValue::Unknown);
             }
             return result;
@@ -807,7 +865,7 @@ impl<'a> Analyzer<'a> {
         if !self.active_function_scopes.insert(scope) {
             return FunctionSummary {
                 final_outward: entry.outward,
-                outward_touched: FxHashSet::default(),
+                outward_touched: ZshOptionMask::default(),
             };
         }
 
@@ -964,18 +1022,18 @@ impl<'a> Analyzer<'a> {
             LeakBehavior::Never => {}
             LeakBehavior::Always => {
                 state.outward.public = next.clone();
-                state.outward_touched.extend(fields.iter().copied());
+                state.outward_touched.insert_all(fields.iter().copied());
             }
             LeakBehavior::Function => match state.current.local_options {
                 OptionValue::On => {}
                 OptionValue::Off => {
                     state.outward.public = next.clone();
-                    state.outward_touched.extend(fields.iter().copied());
+                    state.outward_touched.insert_all(fields.iter().copied());
                 }
                 OptionValue::Unknown => {
                     let merged = state.outward.public.merge(next);
                     state.outward.public = merged;
-                    state.outward_touched.extend(fields.iter().copied());
+                    state.outward_touched.insert_all(fields.iter().copied());
                 }
             },
         }
@@ -1059,11 +1117,9 @@ impl<'a> Analyzer<'a> {
 
 impl FunctionSummary {
     fn merge(&self, other: &Self) -> Self {
-        let mut outward_touched = self.outward_touched.clone();
-        outward_touched.extend(other.outward_touched.iter().copied());
         Self {
             final_outward: self.final_outward.merge(&other.final_outward),
-            outward_touched,
+            outward_touched: self.outward_touched.union(other.outward_touched),
         }
     }
 }

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -304,8 +304,10 @@ pub(crate) fn runtime_ambiguous_entry_mask(recorded_program: &RecordedProgram) -
     for info in recorded_program.command_infos.values() {
         for effect in &info.zsh_effects {
             match effect {
-                RecordedZshCommandEffect::Emulate { .. } => {
-                    return ZshOptionMask::ALL;
+                RecordedZshCommandEffect::Emulate { mode, .. } => {
+                    if *mode == ZshEmulationMode::Ksh {
+                        mask.insert(ZshOptionField::KshArrays);
+                    }
                 }
                 RecordedZshCommandEffect::EmulateUnknown { .. } => {
                     return ZshOptionMask::ALL;


### PR DESCRIPTION
## Summary
- replace zsh touched-field hash sets with a compact option mask
- add a whole-state shell behavior query for option-sensitive callers
- migrate the existing ksh_arrays runtime regression coverage and C100 call site to behavior policy

## Verification
- cargo test -p shuck-semantic zsh_option_analysis --lib
- cargo test -p shuck-semantic semantic_runtime_ksh_arrays_state --lib
- cargo test -p shuck-semantic --lib
- cargo test -p shuck-linter quoted_bash_source --lib
- cargo test -p shuck-linter --lib
- make test
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C100
- rg "zsh_options_at|zsh_ksh_arrays_runtime_state_at|ZshOptionState|OptionValue" crates/shuck-linter/src/rules