### PR TITLE
refactor(linter): deny wildcard enum matches in rules

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -32,6 +32,7 @@ mod rule_selector;
 mod rule_set;
 #[allow(missing_docs)]
 /// Rule implementations and rule-oriented helper modules.
+#[deny(clippy::wildcard_enum_match_arm)]
 pub mod rules;
 #[allow(missing_docs)]
 mod settings;

--- a/crates/shuck-linter/src/rules/correctness/a_flag_in_double_bracket.rs
+++ b/crates/shuck-linter/src/rules/correctness/a_flag_in_double_bracket.rs
@@ -32,7 +32,10 @@ pub fn a_flag_in_double_bracket(checker: &mut Checker) {
                     {
                         Some(unary.operator_span())
                     }
-                    _ => None,
+                    ConditionalNodeFact::BareWord(_)
+                    | ConditionalNodeFact::Unary(_)
+                    | ConditionalNodeFact::Binary(_)
+                    | ConditionalNodeFact::Other(_) => None,
                 })
                 .collect::<Vec<_>>()
         })

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -452,7 +452,10 @@ fn append_declaration_assignment_name_spans(checker: &Checker<'_>) -> HashSet<(u
             DeclarationOperand::Assignment {
                 name_span, append, ..
             } if *append => Some((name_span.start.offset, name_span.end.offset)),
-            _ => None,
+            DeclarationOperand::Flag { .. }
+            | DeclarationOperand::Name { .. }
+            | DeclarationOperand::Assignment { .. }
+            | DeclarationOperand::DynamicWord { .. } => None,
         })
         .collect()
 }
@@ -491,7 +494,17 @@ fn binding_establishes_array_history(
         {
             false
         }
-        _ => binding_is_array_like(binding),
+        BindingKind::Assignment
+        | BindingKind::ParameterDefaultAssignment
+        | BindingKind::AppendAssignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::Declaration(_)
+        | BindingKind::FunctionDefinition
+        | BindingKind::LoopVariable
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ArithmeticAssignment
+        | BindingKind::Nameref => binding_is_array_like(binding),
     }
 }
 
@@ -536,7 +549,21 @@ fn declaration_resets_array_history(binding: &Binding) -> bool {
                 .contains(BindingAttributes::DECLARATION_INITIALIZED)
                 && !binding_is_array_like(binding)
         }
-        _ => false,
+        BindingKind::Assignment
+        | BindingKind::ParameterDefaultAssignment
+        | BindingKind::AppendAssignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::FunctionDefinition
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::MapfileTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ArithmeticAssignment
+        | BindingKind::Nameref
+        | BindingKind::Imported
+        | BindingKind::Declaration(DeclarationBuiltin::Export)
+        | BindingKind::Declaration(DeclarationBuiltin::Readonly) => false,
     }
 }
 
@@ -598,7 +625,12 @@ fn command_forces_builtin_resolution(
     for wrapper in command.wrappers() {
         match wrapper {
             WrapperKind::Command | WrapperKind::Builtin => saw_forcing_wrapper = true,
-            _ => return false,
+            WrapperKind::Noglob
+            | WrapperKind::Exec
+            | WrapperKind::Busybox
+            | WrapperKind::FindExec
+            | WrapperKind::FindExecDir
+            | WrapperKind::SudoFamily => return false,
         }
     }
 
@@ -616,7 +648,12 @@ fn command_wrapper_is_shadowed_function(
         let wrapper_name = match wrapper {
             WrapperKind::Command => "command",
             WrapperKind::Builtin => "builtin",
-            _ => return false,
+            WrapperKind::Noglob
+            | WrapperKind::Exec
+            | WrapperKind::Busybox
+            | WrapperKind::FindExec
+            | WrapperKind::FindExecDir
+            | WrapperKind::SudoFamily => return false,
         };
 
         if !lookup_bypasses_functions

--- a/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
+++ b/crates/shuck-linter/src/rules/correctness/chained_test_branches.rs
@@ -76,7 +76,7 @@ fn matches_and_then_or_chain(list: &ListFact<'_>) -> bool {
         match operator.op() {
             BinaryOp::And if !saw_or => saw_and = true,
             BinaryOp::Or if saw_and => saw_or = true,
-            _ => return false,
+            BinaryOp::And | BinaryOp::Or | BinaryOp::Pipe | BinaryOp::PipeAll => return false,
         }
     }
 

--- a/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/constant_comparison_test.rs
@@ -173,7 +173,20 @@ fn evaluate_conditional_comparison(
         ConditionalBinaryOp::PatternNe => {
             (!looks_like_conditional_pattern(right)).then_some(left != right)
         }
-        _ => None,
+        ConditionalBinaryOp::RegexMatch
+        | ConditionalBinaryOp::NewerThan
+        | ConditionalBinaryOp::OlderThan
+        | ConditionalBinaryOp::SameFile
+        | ConditionalBinaryOp::ArithmeticEq
+        | ConditionalBinaryOp::ArithmeticNe
+        | ConditionalBinaryOp::ArithmeticLe
+        | ConditionalBinaryOp::ArithmeticGe
+        | ConditionalBinaryOp::ArithmeticLt
+        | ConditionalBinaryOp::ArithmeticGt
+        | ConditionalBinaryOp::And
+        | ConditionalBinaryOp::Or
+        | ConditionalBinaryOp::LexicalBefore
+        | ConditionalBinaryOp::LexicalAfter => None,
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_output_to_xargs.rs
@@ -135,7 +135,12 @@ fn find_command_span(segment: &PipelineSegmentFact<'_>, fact: CommandFactRef<'_,
                 .unwrap_or(simple.name.span.end);
             Span::from_positions(fact.body_span().start, end)
         }
-        _ => fact.body_span(),
+        Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => fact.body_span(),
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
@@ -59,7 +59,10 @@ fn conditional_file_test_spans(conditional: &ConditionalFact<'_>, source: &str) 
                 .operand()
                 .word()
                 .and_then(|word| reportable_glob_span(word, source)),
-            _ => None,
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => None,
         })
         .collect()
 }

--- a/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/greater_than_in_test.rs
@@ -93,7 +93,15 @@ fn numeric_comparison_redirect_diagnostic(
     let (redirect_data, replacement) = match redirect.redirect().kind {
         RedirectKind::Input => (redirect.redirect(), "-lt"),
         RedirectKind::Output => (redirect.redirect(), "-gt"),
-        _ => return None,
+        RedirectKind::Clobber
+        | RedirectKind::Append
+        | RedirectKind::ReadWrite
+        | RedirectKind::HereDoc
+        | RedirectKind::HereDocStrip
+        | RedirectKind::HereString
+        | RedirectKind::DupOutput
+        | RedirectKind::DupInput
+        | RedirectKind::OutputBoth => return None,
     };
 
     let target = redirect_data.word_target()?;
@@ -208,7 +216,21 @@ fn numeric_double_bracket_operator_diagnostic(
     let replacement = match binary.op() {
         ConditionalBinaryOp::LexicalBefore => "-lt",
         ConditionalBinaryOp::LexicalAfter => "-gt",
-        _ => return None,
+        ConditionalBinaryOp::RegexMatch
+        | ConditionalBinaryOp::NewerThan
+        | ConditionalBinaryOp::OlderThan
+        | ConditionalBinaryOp::SameFile
+        | ConditionalBinaryOp::ArithmeticEq
+        | ConditionalBinaryOp::ArithmeticNe
+        | ConditionalBinaryOp::ArithmeticLe
+        | ConditionalBinaryOp::ArithmeticGe
+        | ConditionalBinaryOp::ArithmeticLt
+        | ConditionalBinaryOp::ArithmeticGt
+        | ConditionalBinaryOp::And
+        | ConditionalBinaryOp::Or
+        | ConditionalBinaryOp::PatternEqShort
+        | ConditionalBinaryOp::PatternEq
+        | ConditionalBinaryOp::PatternNe => return None,
     };
 
     if has_decimal_version_like_operand(binary, source)

--- a/crates/shuck-linter/src/rules/correctness/literal_unary_string_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/literal_unary_string_test.rs
@@ -106,7 +106,10 @@ fn conditional_diagnostics(
             {
                 conditional_diagnostic(unary.op(), unary.operand(), source)
             }
-            _ => None,
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => None,
         })
         .collect()
 }

--- a/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/loop_control_outside_loop.rs
@@ -42,7 +42,13 @@ pub(crate) fn loop_control_violations(
                 keyword_span(command.span, "continue"),
                 "continue",
             )),
-            _ => None,
+            Command::Simple(_)
+            | Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Binary(_)
+            | Command::Compound(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => None,
         })
         .filter(|(command_span, _, keyword)| {
             let inside_function = checker

--- a/crates/shuck-linter/src/rules/correctness/malformed_arithmetic_in_condition.rs
+++ b/crates/shuck-linter/src/rules/correctness/malformed_arithmetic_in_condition.rs
@@ -99,7 +99,9 @@ fn conditional_contains_numeric_comparison(conditional: &crate::ConditionalFact<
                 | ConditionalBinaryOp::ArithmeticLt
                 | ConditionalBinaryOp::ArithmeticGt
         ),
-        _ => false,
+        ConditionalNodeFact::BareWord(_)
+        | ConditionalNodeFact::Unary(_)
+        | ConditionalNodeFact::Other(_) => false,
     })
 }
 

--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -725,7 +725,14 @@ fn report_function_definition(
     let binding = checker.semantic().binding(binding_id);
     let definition_span = match &binding.origin {
         BindingOrigin::FunctionDefinition { definition_span } => *definition_span,
-        _ => binding.span,
+        BindingOrigin::Assignment { .. }
+        | BindingOrigin::LoopVariable { .. }
+        | BindingOrigin::ParameterDefaultAssignment { .. }
+        | BindingOrigin::Imported { .. }
+        | BindingOrigin::BuiltinTarget { .. }
+        | BindingOrigin::ArithmeticAssignment { .. }
+        | BindingOrigin::Declaration { .. }
+        | BindingOrigin::Nameref { .. } => binding.span,
     };
     let diagnostic_span = trim_trailing_function_separator(definition_span, checker.source());
 
@@ -900,7 +907,13 @@ fn apparent_infinite_loop_body_span(
             condition_text_is(source, command.condition.span, &["false"])
                 .then_some(command.body.span)
         }
-        _ => None,
+        shuck_ast::Command::Simple(_)
+        | shuck_ast::Command::Builtin(_)
+        | shuck_ast::Command::Decl(_)
+        | shuck_ast::Command::Binary(_)
+        | shuck_ast::Command::Compound(_)
+        | shuck_ast::Command::Function(_)
+        | shuck_ast::Command::AnonymousFunction(_) => None,
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
@@ -75,7 +75,9 @@ fn collect_conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &
         .iter()
         .filter_map(|node| match node {
             ConditionalNodeFact::Unary(unary) => unary.operand().word().map(|word| word.span),
-            _ => None,
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => None,
         })
         .collect::<Vec<_>>();
     let comparison_operand_spans = conditional
@@ -90,7 +92,10 @@ fn collect_conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &
                     binary.right().word().map(|word| word.span),
                 ])
             }
-            _ => None,
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => None,
         })
         .flatten()
         .flatten()
@@ -112,7 +117,10 @@ fn collect_conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &
                 spans.push(word.span);
             }
         }
-        _ => {}
+        ConditionalNodeFact::BareWord(_)
+        | ConditionalNodeFact::Unary(_)
+        | ConditionalNodeFact::Binary(_)
+        | ConditionalNodeFact::Other(_) => {}
     }
 
     for node in conditional.nodes().iter().skip(1) {
@@ -139,7 +147,10 @@ fn collect_conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &
                     spans.push(word.span);
                 }
             }
-            _ => {}
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => {}
         }
     }
 

--- a/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
+++ b/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
@@ -376,7 +376,18 @@ fn is_test_v_variable_binding(binding: &Binding) -> bool {
         BindingKind::Imported => !binding
             .attributes
             .contains(BindingAttributes::IMPORTED_FUNCTION),
-        _ => true,
+        BindingKind::Assignment
+        | BindingKind::ParameterDefaultAssignment
+        | BindingKind::AppendAssignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::Declaration(_)
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::MapfileTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ArithmeticAssignment
+        | BindingKind::Nameref => true,
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
@@ -61,7 +61,10 @@ fn conditional_string_eq_spans(
                 }
                 spans
             }
-            _ => Vec::new(),
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => Vec::new(),
         })
         .collect()
 }

--- a/crates/shuck-linter/src/rules/correctness/sudo_redirection_order.rs
+++ b/crates/shuck-linter/src/rules/correctness/sudo_redirection_order.rs
@@ -53,11 +53,29 @@ fn is_hazardous_sudo_redirect(redirect: &Redirect) -> bool {
 fn sudo_redirect_span(redirect: &Redirect) -> Span {
     let start = match redirect.kind {
         RedirectKind::OutputBoth => redirect.span.start.advanced_by("&"),
-        _ => redirect.span.start,
+        RedirectKind::Output
+        | RedirectKind::Clobber
+        | RedirectKind::Append
+        | RedirectKind::Input
+        | RedirectKind::ReadWrite
+        | RedirectKind::HereDoc
+        | RedirectKind::HereDocStrip
+        | RedirectKind::HereString
+        | RedirectKind::DupOutput
+        | RedirectKind::DupInput => redirect.span.start,
     };
     let end = match redirect.kind {
         RedirectKind::Append => start.advanced_by(">>"),
-        _ => start.advanced_by(">"),
+        RedirectKind::Output
+        | RedirectKind::Clobber
+        | RedirectKind::Input
+        | RedirectKind::ReadWrite
+        | RedirectKind::HereDoc
+        | RedirectKind::HereDocStrip
+        | RedirectKind::HereString
+        | RedirectKind::DupOutput
+        | RedirectKind::DupInput
+        | RedirectKind::OutputBoth => start.advanced_by(">"),
     };
 
     if redirect.kind == RedirectKind::Input {

--- a/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/truthy_literal_test.rs
@@ -112,7 +112,10 @@ fn conditional_diagnostics(
             {
                 conditional_diagnostic(word.operand(), source)
             }
-            _ => None,
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => None,
         })
         .collect()
 }

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
@@ -76,7 +76,12 @@ pub(crate) fn report_span(fact: crate::facts::CommandFactRef<'_, '_>, source: &s
                 .unwrap_or(command.name.span.end);
             Span::from_positions(start, end)
         }
-        _ => fact.span(),
+        Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => fact.span(),
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -204,7 +204,14 @@ fn function_definition_span(
     let binding = checker.semantic().binding(binding);
     match binding.origin {
         BindingOrigin::FunctionDefinition { definition_span } => Some(definition_span),
-        _ => None,
+        BindingOrigin::Assignment { .. }
+        | BindingOrigin::LoopVariable { .. }
+        | BindingOrigin::ParameterDefaultAssignment { .. }
+        | BindingOrigin::Imported { .. }
+        | BindingOrigin::BuiltinTarget { .. }
+        | BindingOrigin::ArithmeticAssignment { .. }
+        | BindingOrigin::Declaration { .. }
+        | BindingOrigin::Nameref { .. } => None,
     }
 }
 

--- a/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
@@ -27,7 +27,13 @@ pub fn c_style_for_in_sh(checker: &mut Checker) {
             Command::Compound(CompoundCommand::ArithmeticFor(_)) => {
                 Some(keyword_span(fact.span_in_source(checker.source()), "for"))
             }
-            _ => None,
+            Command::Simple(_)
+            | Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Binary(_)
+            | Command::Compound(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => None,
         })
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/portability/coproc.rs
+++ b/crates/shuck-linter/src/rules/portability/coproc.rs
@@ -27,7 +27,13 @@ pub fn coproc(checker: &mut Checker) {
             Command::Compound(CompoundCommand::Coproc(_)) => {
                 Some(fact.span_in_source(checker.source()))
             }
-            _ => None,
+            Command::Simple(_)
+            | Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Binary(_)
+            | Command::Compound(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => None,
         })
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/portability/source_common.rs
+++ b/crates/shuck-linter/src/rules/portability/source_common.rs
@@ -34,7 +34,12 @@ fn source_anchor_span(
         Command::Simple(command) => {
             clip_first_line(simple_command_span(command, redirects), source)
         }
-        _ => clip_first_line(fallback, source),
+        Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => clip_first_line(fallback, source),
     }
 }
 

--- a/crates/shuck-linter/src/rules/portability/standalone_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/portability/standalone_arithmetic.rs
@@ -27,7 +27,13 @@ pub fn standalone_arithmetic(checker: &mut Checker) {
             Command::Compound(CompoundCommand::Arithmetic(_)) => {
                 Some(fact.span_in_source(checker.source()))
             }
-            _ => None,
+            Command::Simple(_)
+            | Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Binary(_)
+            | Command::Compound(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => None,
         })
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -47,7 +47,15 @@ pub fn escaped_underscore(checker: &mut Checker) {
         })
         .filter(|escape| match escape.source_kind() {
             EscapeScanSourceKind::PatternCharClass => escape.escaped_byte() == b'-',
-            _ => is_regular_plain_word_escape_target(escape.escaped_byte()),
+            EscapeScanSourceKind::WordLiteralPart
+            | EscapeScanSourceKind::RedirectLiteralSegment
+            | EscapeScanSourceKind::DynamicPathCommandName
+            | EscapeScanSourceKind::PatternLiteral
+            | EscapeScanSourceKind::ParameterPatternCharClass
+            | EscapeScanSourceKind::SingleLiteralAssignmentWord
+            | EscapeScanSourceKind::BacktickFragment => {
+                is_regular_plain_word_escape_target(escape.escaped_byte())
+            }
         })
         .collect::<Vec<_>>();
     let non_fixable_spans = escapes

--- a/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/grep_output_in_test.rs
@@ -97,7 +97,10 @@ fn collect_conditional_spans(
             {
                 unary.operand().word().map(|word| word.span)
             }
-            _ => None,
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => None,
         })
         .collect::<Vec<_>>();
     let comparison_operand_spans = conditional
@@ -112,7 +115,10 @@ fn collect_conditional_spans(
                     binary.right().word().map(|word| word.span),
                 ])
             }
-            _ => None,
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => None,
         })
         .flatten()
         .flatten()
@@ -148,7 +154,10 @@ fn collect_conditional_spans(
         {
             spans.push(unary.operator_span());
         }
-        _ => {}
+        ConditionalNodeFact::BareWord(_)
+        | ConditionalNodeFact::Unary(_)
+        | ConditionalNodeFact::Binary(_)
+        | ConditionalNodeFact::Other(_) => {}
     }
 
     for node in conditional.nodes().iter().skip(1) {
@@ -190,7 +199,10 @@ fn collect_conditional_spans(
             {
                 spans.push(unary.operator_span());
             }
-            _ => {}
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => {}
         }
     }
 

--- a/crates/shuck-linter/src/rules/style/syntax.rs
+++ b/crates/shuck-linter/src/rules/style/syntax.rs
@@ -5,6 +5,11 @@ pub fn is_simple_command_named(command: &Command, source: &str, name: &str) -> b
         Command::Simple(command) => {
             static_word_text(&command.name, source).as_deref() == Some(name)
         }
-        _ => false,
+        Command::Builtin(_)
+        | Command::Decl(_)
+        | Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => false,
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -277,7 +277,16 @@ fn should_check_context(context: ExpansionContext, shell: ShellDialect) -> bool 
         | ExpansionContext::RedirectTarget(_)
         | ExpansionContext::DescriptorDupTarget(_) => true,
         ExpansionContext::DeclarationAssignmentValue => shell != ShellDialect::Bash,
-        _ => false,
+        ExpansionContext::AssignmentValue
+        | ExpansionContext::ForList
+        | ExpansionContext::SelectList
+        | ExpansionContext::CasePattern
+        | ExpansionContext::ConditionalPattern
+        | ExpansionContext::StringTestOperand
+        | ExpansionContext::RegexOperand
+        | ExpansionContext::ConditionalVarRefSubscript
+        | ExpansionContext::ParameterPattern
+        | ExpansionContext::TrapAction => false,
     }
 }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -56,7 +56,12 @@ impl SafeValueQuery {
             | ExpansionContext::ConditionalPattern
             | ExpansionContext::ParameterPattern => Some(Self::Pattern),
             ExpansionContext::RegexOperand => Some(Self::Regex),
-            _ => None,
+            ExpansionContext::AssignmentValue
+            | ExpansionContext::ForList
+            | ExpansionContext::SelectList
+            | ExpansionContext::StringTestOperand
+            | ExpansionContext::ConditionalVarRefSubscript
+            | ExpansionContext::TrapAction => None,
         }
     }
 
@@ -1013,7 +1018,13 @@ impl<'a> SafeValueIndex<'a> {
                                 .iter()
                                 .any(|word| span_contains(word.span, at))
                     }
-                    _ => false,
+                    Command::Simple(_)
+                    | Command::Builtin(_)
+                    | Command::Decl(_)
+                    | Command::Binary(_)
+                    | Command::Compound(_)
+                    | Command::Function(_)
+                    | Command::AnonymousFunction(_) => false,
                 }
             })
     }
@@ -1038,7 +1049,13 @@ impl<'a> SafeValueIndex<'a> {
                                 .iter()
                                 .any(|word| span_contains(word.span, at))
                     }
-                    _ => false,
+                    Command::Simple(_)
+                    | Command::Builtin(_)
+                    | Command::Decl(_)
+                    | Command::Binary(_)
+                    | Command::Compound(_)
+                    | Command::Function(_)
+                    | Command::AnonymousFunction(_) => false,
                 }
             })
     }
@@ -1628,7 +1645,14 @@ impl<'a> SafeValueIndex<'a> {
                 value: AssignmentValueOrigin::PlainScalarAccess,
                 ..
             } => self.plain_scalar_field_safe_binding_class(binding_id, query, visiting),
-            _ => None,
+            BindingOrigin::Assignment { .. }
+            | BindingOrigin::LoopVariable { .. }
+            | BindingOrigin::ParameterDefaultAssignment { .. }
+            | BindingOrigin::Imported { .. }
+            | BindingOrigin::FunctionDefinition { .. }
+            | BindingOrigin::BuiltinTarget { .. }
+            | BindingOrigin::ArithmeticAssignment { .. }
+            | BindingOrigin::Nameref { .. } => None,
         }
     }
 
@@ -2038,8 +2062,15 @@ impl<'a> SafeValueIndex<'a> {
                 {
                     status_bindings.push(binding_id);
                 }
+                BindingOrigin::Assignment { .. }
+                | BindingOrigin::LoopVariable { .. }
+                | BindingOrigin::ParameterDefaultAssignment { .. }
+                | BindingOrigin::Imported { .. }
+                | BindingOrigin::FunctionDefinition { .. }
+                | BindingOrigin::BuiltinTarget { .. }
+                | BindingOrigin::ArithmeticAssignment { .. }
+                | BindingOrigin::Nameref { .. } => return false,
                 BindingOrigin::Declaration { .. } => {}
-                _ => return false,
             }
         }
 
@@ -3211,7 +3242,16 @@ impl<'a> SafeValueIndex<'a> {
                     BindingOrigin::Declaration { .. } => binding.attributes.intersects(
                         BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
                     ),
-                    _ => self.binding_can_supply_parameter_value(binding_id),
+                    BindingOrigin::Assignment { .. }
+                    | BindingOrigin::LoopVariable { .. }
+                    | BindingOrigin::ParameterDefaultAssignment { .. }
+                    | BindingOrigin::Imported { .. }
+                    | BindingOrigin::FunctionDefinition { .. }
+                    | BindingOrigin::BuiltinTarget { .. }
+                    | BindingOrigin::ArithmeticAssignment { .. }
+                    | BindingOrigin::Nameref { .. } => {
+                        self.binding_can_supply_parameter_value(binding_id)
+                    }
                 };
                 binding.scope == scope
                     && binding.span.end.offset <= at.start.offset
@@ -3705,7 +3745,7 @@ impl<'a> SafeValueIndex<'a> {
             ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { .. }) => {
                 S001QuoteExposure::QuoteInertNonEmpty
             }
-            _ => {
+            ParameterExpansionSyntax::Bourne(_) | ParameterExpansionSyntax::Zsh(_) => {
                 if self.parameter_part_is_safe(parameter, at, query) {
                     S001QuoteExposure::QuoteInertNonEmpty
                 } else {
@@ -4065,7 +4105,13 @@ impl<'a> SafeValueIndex<'a> {
                 {
                     Some(command.body.span)
                 }
-                _ => None,
+                Command::Simple(_)
+                | Command::Builtin(_)
+                | Command::Decl(_)
+                | Command::Binary(_)
+                | Command::Compound(_)
+                | Command::Function(_)
+                | Command::AnonymousFunction(_) => None,
             })
             .min_by_key(|span| span.end.offset - span.start.offset)
     }
@@ -4156,9 +4202,25 @@ fn plain_scalar_reference_name_from_part(part: &WordPart) -> Option<Name> {
             {
                 Some(reference.name.clone())
             }
-            _ => None,
+            ParameterExpansionSyntax::Bourne(_) | ParameterExpansionSyntax::Zsh(_) => None,
         },
-        _ => None,
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => None,
     }
 }
 
@@ -4207,7 +4269,22 @@ fn part_is_safe_special_parameter_access(part: &WordPart) -> bool {
             Some(BourneParameterExpansion::Access { reference })
                 if safe_special_parameter(&reference.name) && reference.subscript.is_none()
         ),
-        _ => false,
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
     }
 }
 
@@ -4253,7 +4330,23 @@ fn parts_have_arithmetic_expansion(parts: &[WordPartNode]) -> bool {
     parts.iter().any(|part| match &part.kind {
         WordPart::ArithmeticExpansion { .. } => true,
         WordPart::DoubleQuoted { parts, .. } => parts_have_arithmetic_expansion(parts),
-        _ => false,
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::Parameter(_)
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
     })
 }
 
@@ -4271,7 +4364,22 @@ fn part_contains_special_parameter_slice(part: &WordPart) -> bool {
             .any(|part| part_contains_special_parameter_slice(&part.kind)),
         WordPart::Substring { reference, .. } => special_parameter_slice_reference(reference),
         WordPart::Parameter(parameter) => parameter_contains_special_parameter_slice(parameter),
-        _ => false,
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
     }
 }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -5364,11 +5364,20 @@ done
             .into_iter()
             .next()
             .expect("expected reaching loop binding");
-        let definition_span = match semantic.binding(binding_id).origin {
+        let definition_span = match &semantic.binding(binding_id).origin {
             BindingOrigin::LoopVariable {
                 definition_span, ..
-            } => definition_span,
-            ref other => panic!("expected loop-variable binding, got {other:?}"),
+            } => *definition_span,
+            other @ BindingOrigin::Assignment { .. }
+            | other @ BindingOrigin::ParameterDefaultAssignment { .. }
+            | other @ BindingOrigin::Imported { .. }
+            | other @ BindingOrigin::FunctionDefinition { .. }
+            | other @ BindingOrigin::BuiltinTarget { .. }
+            | other @ BindingOrigin::ArithmeticAssignment { .. }
+            | other @ BindingOrigin::Declaration { .. }
+            | other @ BindingOrigin::Nameref { .. } => {
+                panic!("expected loop-variable binding, got {other:?}")
+            }
         };
 
         assert!(

--- a/crates/shuck-linter/src/rules/style/x_prefix_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/x_prefix_in_test.rs
@@ -74,7 +74,10 @@ fn conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &str) -> 
                     None
                 }
             }
-            _ => None,
+            ConditionalNodeFact::BareWord(_)
+            | ConditionalNodeFact::Unary(_)
+            | ConditionalNodeFact::Binary(_)
+            | ConditionalNodeFact::Other(_) => None,
         })
         .collect()
 }


### PR DESCRIPTION
## Summary
- deny `clippy::wildcard_enum_match_arm` on `shuck-linter`'s `rules` module
- replace wildcard enum match arms across rule files with explicit variants
- preserve rule behavior while making future enum growth fail loudly at compile time

## Why
Wildcard enum arms in behavior-sensitive rule code make it easier for new variants to slip through silently. This change turns those cases into compiler-enforced updates instead.

## Validation
- `cargo clippy -p shuck-linter --lib -- -D warnings`
- `cargo test -p shuck-linter --lib`
