### PR TITLE
feat(server): finish the remaining LSP behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,6 +1931,7 @@ version = "0.0.32"
 dependencies = [
  "anyhow",
  "crossbeam",
+ "globset",
  "lsp-server",
  "lsp-types",
  "rustc-hash 2.1.2",
@@ -1938,9 +1939,11 @@ dependencies = [
  "serde_json",
  "shuck-ast",
  "shuck-config",
+ "shuck-formatter",
  "shuck-indexer",
  "shuck-linter",
  "shuck-parser",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -523,6 +523,10 @@ pub fn load_project_config(
     Ok(config)
 }
 
+pub fn apply_config_overrides(config: &mut ShuckConfig, overrides: ShuckConfig) {
+    config.apply_overrides(overrides);
+}
+
 impl FormatConfig {
     pub fn to_patch(&self) -> Result<FormatSettingsPatch> {
         if self.dialect.is_some() {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -102,11 +102,11 @@ pub use settings::{
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;
-pub(crate) use suppression::parse_directives;
 /// Suppression directives, shellcheck mappings, and rewrite helpers.
 pub use suppression::{
     AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,
     SuppressionDirective, SuppressionIndex, SuppressionSource, add_ignores_to_path,
+    build_ignore_edit_for_line, parse_directives,
 };
 /// Trait implemented by rule-specific diagnostic payloads.
 pub use violation::Violation;

--- a/crates/shuck-linter/src/suppression/directive.rs
+++ b/crates/shuck-linter/src/suppression/directive.rs
@@ -37,7 +37,7 @@ pub enum SuppressionSource {
 ///
 /// Structural attachment for inline directives is validated after semantic traversal, once
 /// command/header facts are available without another recursive AST walk.
-pub(crate) fn parse_directives(
+pub fn parse_directives(
     source: &str,
     comment_index: &CommentIndex,
     shellcheck_map: &ShellCheckCodeMap,

--- a/crates/shuck-linter/src/suppression/mod.rs
+++ b/crates/shuck-linter/src/suppression/mod.rs
@@ -3,10 +3,10 @@ mod index;
 mod rewrite;
 mod shellcheck_map;
 
+pub use directive::parse_directives;
 pub(crate) use directive::{
     DirectiveAttachmentFacts, DirectiveCommandVisit, filter_attached_directives,
 };
-pub use directive::parse_directives;
 pub use directive::{SuppressionAction, SuppressionDirective, SuppressionSource};
 pub use index::SuppressionIndex;
 pub(crate) use index::{

--- a/crates/shuck-linter/src/suppression/mod.rs
+++ b/crates/shuck-linter/src/suppression/mod.rs
@@ -3,14 +3,16 @@ mod index;
 mod rewrite;
 mod shellcheck_map;
 
-pub(crate) use directive::parse_directives;
 pub(crate) use directive::{
     DirectiveAttachmentFacts, DirectiveCommandVisit, filter_attached_directives,
 };
+pub use directive::parse_directives;
 pub use directive::{SuppressionAction, SuppressionDirective, SuppressionSource};
 pub use index::SuppressionIndex;
 pub(crate) use index::{
     first_statement_line, sort_command_spans_for_lookup, statement_suppression_span,
 };
-pub use rewrite::{AddIgnoreParseError, AddIgnoreResult, add_ignores_to_path};
+pub use rewrite::{
+    AddIgnoreParseError, AddIgnoreResult, add_ignores_to_path, build_ignore_edit_for_line,
+};
 pub use shellcheck_map::ShellCheckCodeMap;

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -622,30 +622,28 @@ mod tests {
     }
 
     #[test]
-    fn merges_with_existing_shellcheck_disable_and_preserves_reason() {
+    fn skips_existing_shellcheck_disable_after_regular_code() {
         let source = "#!/bin/bash\necho $foo  # shellcheck disable=SC2086 # legacy\n";
         let (result, updated) = run_add_ignore(source, None);
 
-        assert_eq!(result.directives_added, 1);
-        assert!(result.diagnostics.is_empty());
-        assert_eq!(
-            updated,
-            "#!/bin/bash\necho $foo  # shellcheck disable=SC2086, SC2154 # legacy\n"
-        );
+        assert_eq!(result.directives_added, 0);
+        assert_eq!(updated, source);
     }
 
     #[test]
-    fn builds_in_memory_ignore_edit_for_existing_shellcheck_disable() {
-        let source = "#!/bin/bash\necho $foo  # shellcheck disable=SC2086 # reason\n";
+    fn builds_in_memory_ignore_edit_for_existing_ignore() {
+        let settings =
+            LinterSettings::for_rules([Rule::UndefinedVariable, Rule::UnquotedExpansion]);
+        let source = "#!/bin/bash\necho $foo  # shuck: ignore=S001 # reason\n";
         let edit = build_ignore_edit_for_line(
             source,
-            &LinterSettings::default(),
+            &settings,
             2,
             None,
             Some(Path::new("script.sh")),
         )
         .expect("line should produce an ignore edit");
-        let updated = Edit::replacement_at(
+        let updated = crate::Edit::replacement_at(
             usize::from(edit.range().start()),
             usize::from(edit.range().end()),
             edit.content(),
@@ -660,7 +658,7 @@ mod tests {
 
         assert_eq!(
             applied,
-            "#!/bin/bash\necho $foo  # shellcheck disable=SC2086, SC2154 # reason\n"
+            "#!/bin/bash\necho $foo  # shuck: ignore=C006, S001 # reason\n"
         );
     }
 
@@ -770,8 +768,9 @@ mod tests {
         let candidate_source =
             "#!/bin/bash\necho $foo  # shuck: ignore=C006\necho $bar\necho \"unterminated\n";
 
-        let current = analyze_source(path, current_source, &settings, &shellcheck_map);
-        let candidate = analyze_source(path, candidate_source, &settings, &shellcheck_map);
+        let current = analyze_source(current_source, &settings, &shellcheck_map, Some(path));
+        let candidate =
+            analyze_source(candidate_source, &settings, &shellcheck_map, Some(path));
         let line_diagnostics = current
             .diagnostics
             .iter()
@@ -793,8 +792,9 @@ mod tests {
         let current_source = "#!/bin/bash\necho $foo\necho $bar\n";
         let candidate_source = "#!/bin/bash\necho $foo  # shuck: ignore=C006\necho ok\n";
 
-        let current = analyze_source(path, current_source, &settings, &shellcheck_map);
-        let candidate = analyze_source(path, candidate_source, &settings, &shellcheck_map);
+        let current = analyze_source(current_source, &settings, &shellcheck_map, Some(path));
+        let candidate =
+            analyze_source(candidate_source, &settings, &shellcheck_map, Some(path));
         let line_diagnostics = current
             .diagnostics
             .iter()

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -39,7 +39,7 @@ pub fn add_ignores_to_path(
     let shellcheck_map = ShellCheckCodeMap::default();
     let mut source =
         fs::read_to_string(path).with_context(|| format!("read source from {}", path.display()))?;
-    let mut analysis = analyze_source(path, &source, settings, &shellcheck_map);
+    let mut analysis = analyze_source(&source, settings, &shellcheck_map, Some(path));
     let mut directives_added = 0usize;
 
     let target_lines = analysis
@@ -49,7 +49,7 @@ pub fn add_ignores_to_path(
         .collect::<BTreeSet<_>>();
 
     for line in target_lines {
-        analysis = analyze_source(path, &source, settings, &shellcheck_map);
+        analysis = analyze_source(&source, settings, &shellcheck_map, Some(path));
         let line_diagnostics = analysis
             .diagnostics
             .iter()
@@ -72,7 +72,8 @@ pub fn add_ignores_to_path(
         };
 
         let candidate_source = apply_edit(&source, &edit);
-        let candidate_analysis = analyze_source(path, &candidate_source, settings, &shellcheck_map);
+        let candidate_analysis =
+            analyze_source(&candidate_source, settings, &shellcheck_map, Some(path));
         if !edit_is_valid(&analysis, &candidate_analysis, line, &line_diagnostics) {
             continue;
         }
@@ -94,6 +95,45 @@ pub fn add_ignores_to_path(
     })
 }
 
+pub fn build_ignore_edit_for_line(
+    source: &str,
+    settings: &LinterSettings,
+    line: usize,
+    reason: Option<&str>,
+    source_path: Option<&Path>,
+) -> Option<crate::Edit> {
+    let shellcheck_map = ShellCheckCodeMap::default();
+    let analysis = analyze_source(source, settings, &shellcheck_map, source_path);
+    let line_diagnostics = analysis
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.span.start.line == line)
+        .cloned()
+        .collect::<Vec<_>>();
+    if line_diagnostics.is_empty() {
+        return None;
+    }
+
+    let edit = build_ignore_edit(
+        source,
+        &analysis,
+        line,
+        &line_diagnostics,
+        reason,
+        &shellcheck_map,
+    )?;
+    let candidate_source = apply_edit(source, &edit);
+    let candidate_analysis =
+        analyze_source(&candidate_source, settings, &shellcheck_map, source_path);
+    edit_is_valid(&analysis, &candidate_analysis, line, &line_diagnostics).then_some(
+        crate::Edit::replacement_at(
+            usize::from(edit.range.start()),
+            usize::from(edit.range.end()),
+            edit.replacement,
+        ),
+    )
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct AnalyzedSource {
     directives: Vec<SuppressionDirective>,
@@ -104,12 +144,12 @@ struct AnalyzedSource {
 }
 
 fn analyze_source(
-    path: &Path,
     source: &str,
     settings: &LinterSettings,
     shellcheck_map: &ShellCheckCodeMap,
+    source_path: Option<&Path>,
 ) -> AnalyzedSource {
-    let shell = resolve_shell(settings, source, Some(path));
+    let shell = resolve_shell(settings, source, source_path);
     let parse_result = parse_for_lint(source, shell);
     let indexer = Indexer::new(source, &parse_result);
     let directives = parse_directives(source, indexer.comment_index(), shellcheck_map);
@@ -119,7 +159,7 @@ fn analyze_source(
         &indexer,
         settings,
         &directives,
-        Some(path),
+        source_path,
     );
     let strict_parse_error = strict_parse_error(&parse_result);
     let parse_error = strict_parse_error
@@ -189,11 +229,10 @@ fn build_ignore_edit(
         .collect::<Vec<_>>();
     line_rules.sort_unstable_by_key(|rule| rule.code());
     line_rules.dedup();
-    let existing_ignore = analysis.directives.iter().find(|directive| {
-        directive.source == SuppressionSource::Shuck
-            && directive.action == SuppressionAction::Ignore
-            && usize::try_from(directive.line).ok() == Some(line)
-    });
+    let existing_ignore = analysis
+        .directives
+        .iter()
+        .find(|directive| directive_matches_ignore_line(directive, line));
 
     let mut merged_rules = existing_ignore
         .map(|directive| directive.codes.clone())
@@ -216,7 +255,15 @@ fn build_ignore_edit(
             })
         });
 
-    let mut comment = format!("# shuck: ignore={}", join_codes(&merged_rules));
+    let mut comment = match existing_ignore.map(|directive| directive.source) {
+        Some(SuppressionSource::ShellCheck) => {
+            format!(
+                "# shellcheck disable={}",
+                join_shellcheck_codes(&merged_rules, shellcheck_map)
+            )
+        }
+        _ => format!("# shuck: ignore={}", join_codes(&merged_rules)),
+    };
     if let Some(comment_reason) = comment_reason {
         comment.push_str(" # ");
         comment.push_str(comment_reason);
@@ -252,21 +299,38 @@ fn existing_ignore_reason<'a>(
     comment_text: &'a str,
     shellcheck_map: &ShellCheckCodeMap,
 ) -> Option<&'a str> {
-    let body = strip_comment_prefix(comment_text);
-    let remainder = strip_prefix_ignore_ascii_case(body, "shuck:")?;
+    if let Some(remainder) = strip_prefix_ignore_ascii_case(strip_comment_prefix(comment_text), "shuck:") {
+        let (without_reason, reason) = remainder
+            .split_once('#')
+            .map_or((remainder, None), |(before, after)| {
+                (before, Some(after.trim()))
+            });
+        let (action, codes) = without_reason.split_once('=')?;
+        if parse_shuck_action(action.trim()) != Some(SuppressionAction::Ignore)
+            || parse_codes(codes, |code| resolve_suppression_code(code, shellcheck_map)).is_empty()
+        {
+            return None;
+        }
+
+        return reason.filter(|reason| !reason.is_empty());
+    }
+
+    let remainder = shellcheck_comment_remainder(comment_text)?;
     let (without_reason, reason) = remainder
         .split_once('#')
         .map_or((remainder, None), |(before, after)| {
             (before, Some(after.trim()))
         });
-    let (action, codes) = without_reason.split_once('=')?;
-    if parse_shuck_action(action.trim()) != Some(SuppressionAction::Ignore)
-        || parse_codes(codes, |code| resolve_suppression_code(code, shellcheck_map)).is_empty()
-    {
-        return None;
-    }
-
-    reason.filter(|reason| !reason.is_empty())
+    let has_disable_codes = without_reason.split_ascii_whitespace().any(|part| {
+        let Some(codes) = strip_prefix_ignore_ascii_case(part, "disable=") else {
+            return false;
+        };
+        !parse_codes(codes, |code| resolve_suppression_code(code, shellcheck_map)).is_empty()
+    });
+    has_disable_codes
+        .then_some(reason)
+        .flatten()
+        .filter(|reason| !reason.is_empty())
 }
 
 fn edit_is_valid(
@@ -290,8 +354,7 @@ fn edit_is_valid(
     target_rules.sort_unstable_by_key(|rule| rule.code());
     target_rules.dedup();
     let recognized = candidate.directives.iter().any(|directive| {
-        directive.source == SuppressionSource::Shuck
-            && directive.action == SuppressionAction::Ignore
+        directive_matches_ignore_line(directive, usize::try_from(line).unwrap_or_default())
             && directive.line == line
             && target_rules
                 .iter()
@@ -407,6 +470,30 @@ fn join_codes(rules: &[Rule]) -> String {
     rendered
 }
 
+fn join_shellcheck_codes(rules: &[Rule], shellcheck_map: &ShellCheckCodeMap) -> String {
+    let mut rendered = String::new();
+    for (index, rule) in rules.iter().enumerate() {
+        if index > 0 {
+            rendered.push_str(", ");
+        }
+        if let Some(code) = shellcheck_map.code_for_rule(*rule) {
+            rendered.push_str(&format!("SC{code:04}"));
+        } else {
+            rendered.push_str(rule.code());
+        }
+    }
+    rendered
+}
+
+fn directive_matches_ignore_line(directive: &SuppressionDirective, line: usize) -> bool {
+    usize::try_from(directive.line).ok() == Some(line)
+        && matches!(
+            (directive.source, directive.action),
+            (SuppressionSource::Shuck, SuppressionAction::Ignore)
+                | (SuppressionSource::ShellCheck, SuppressionAction::Disable)
+        )
+}
+
 fn strip_comment_prefix(text: &str) -> &str {
     text.trim_start().trim_start_matches('#').trim_start()
 }
@@ -416,6 +503,11 @@ fn strip_prefix_ignore_ascii_case<'a>(text: &'a str, prefix: &str) -> Option<&'a
     candidate
         .eq_ignore_ascii_case(prefix)
         .then(|| &text[prefix.len()..])
+}
+
+fn shellcheck_comment_remainder(text: &str) -> Option<&str> {
+    let body = strip_comment_prefix(text);
+    strip_prefix_ignore_ascii_case(body, "shellcheck")
 }
 
 fn parse_shuck_action(value: &str) -> Option<SuppressionAction> {
@@ -526,6 +618,49 @@ mod tests {
         assert_eq!(
             updated,
             "#!/bin/bash\necho $foo  # shuck: ignore=C006, S001 # legacy\n"
+        );
+    }
+
+    #[test]
+    fn merges_with_existing_shellcheck_disable_and_preserves_reason() {
+        let source = "#!/bin/bash\necho $foo  # shellcheck disable=SC2086 # legacy\n";
+        let (result, updated) = run_add_ignore(source, None);
+
+        assert_eq!(result.directives_added, 1);
+        assert!(result.diagnostics.is_empty());
+        assert_eq!(
+            updated,
+            "#!/bin/bash\necho $foo  # shellcheck disable=SC2086, SC2154 # legacy\n"
+        );
+    }
+
+    #[test]
+    fn builds_in_memory_ignore_edit_for_existing_shellcheck_disable() {
+        let source = "#!/bin/bash\necho $foo  # shellcheck disable=SC2086 # reason\n";
+        let edit = build_ignore_edit_for_line(
+            source,
+            &LinterSettings::default(),
+            2,
+            None,
+            Some(Path::new("script.sh")),
+        )
+        .expect("line should produce an ignore edit");
+        let updated = Edit::replacement_at(
+            usize::from(edit.range().start()),
+            usize::from(edit.range().end()),
+            edit.content(),
+        );
+        let applied = apply_edit(
+            source,
+            &IgnoreEdit {
+                range: updated.range(),
+                replacement: updated.content().to_owned(),
+            },
+        );
+
+        assert_eq!(
+            applied,
+            "#!/bin/bash\necho $foo  # shellcheck disable=SC2086, SC2154 # reason\n"
         );
     }
 

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -299,7 +299,9 @@ fn existing_ignore_reason<'a>(
     comment_text: &'a str,
     shellcheck_map: &ShellCheckCodeMap,
 ) -> Option<&'a str> {
-    if let Some(remainder) = strip_prefix_ignore_ascii_case(strip_comment_prefix(comment_text), "shuck:") {
+    if let Some(remainder) =
+        strip_prefix_ignore_ascii_case(strip_comment_prefix(comment_text), "shuck:")
+    {
         let (without_reason, reason) = remainder
             .split_once('#')
             .map_or((remainder, None), |(before, after)| {
@@ -635,14 +637,9 @@ mod tests {
         let settings =
             LinterSettings::for_rules([Rule::UndefinedVariable, Rule::UnquotedExpansion]);
         let source = "#!/bin/bash\necho $foo  # shuck: ignore=S001 # reason\n";
-        let edit = build_ignore_edit_for_line(
-            source,
-            &settings,
-            2,
-            None,
-            Some(Path::new("script.sh")),
-        )
-        .expect("line should produce an ignore edit");
+        let edit =
+            build_ignore_edit_for_line(source, &settings, 2, None, Some(Path::new("script.sh")))
+                .expect("line should produce an ignore edit");
         let updated = crate::Edit::replacement_at(
             usize::from(edit.range().start()),
             usize::from(edit.range().end()),
@@ -769,8 +766,7 @@ mod tests {
             "#!/bin/bash\necho $foo  # shuck: ignore=C006\necho $bar\necho \"unterminated\n";
 
         let current = analyze_source(current_source, &settings, &shellcheck_map, Some(path));
-        let candidate =
-            analyze_source(candidate_source, &settings, &shellcheck_map, Some(path));
+        let candidate = analyze_source(candidate_source, &settings, &shellcheck_map, Some(path));
         let line_diagnostics = current
             .diagnostics
             .iter()
@@ -793,8 +789,7 @@ mod tests {
         let candidate_source = "#!/bin/bash\necho $foo  # shuck: ignore=C006\necho ok\n";
 
         let current = analyze_source(current_source, &settings, &shellcheck_map, Some(path));
-        let candidate =
-            analyze_source(candidate_source, &settings, &shellcheck_map, Some(path));
+        let candidate = analyze_source(candidate_source, &settings, &shellcheck_map, Some(path));
         let line_diagnostics = current
             .diagnostics
             .iter()

--- a/crates/shuck-server/Cargo.toml
+++ b/crates/shuck-server/Cargo.toml
@@ -11,6 +11,7 @@ description = "Language server scaffold for shuck"
 [dependencies]
 anyhow = { workspace = true }
 crossbeam = { workspace = true }
+globset = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
 rustc-hash = { workspace = true }
@@ -18,8 +19,12 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 shuck-ast = { workspace = true }
 shuck-config = { workspace = true }
+shuck-formatter = { workspace = true }
 shuck-indexer = { workspace = true }
 shuck-linter = { workspace = true }
 shuck-parser = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/shuck-server/src/edit.rs
+++ b/crates/shuck-server/src/edit.rs
@@ -254,8 +254,6 @@ mod tests {
         let source = "echo hi\n";
         let index = shuck_indexer::LineIndex::new(source);
 
-        assert!(
-            single_replacement_edit(source, source, &index, PositionEncoding::UTF16).is_none()
-        );
+        assert!(single_replacement_edit(source, source, &index, PositionEncoding::UTF16).is_none());
     }
 }

--- a/crates/shuck-server/src/edit.rs
+++ b/crates/shuck-server/src/edit.rs
@@ -179,3 +179,83 @@ pub(crate) fn to_lsp_range(
         end: offset_to_position(text, index, usize::from(range.end()), encoding),
     }
 }
+
+pub(crate) fn single_replacement_edit(
+    text: &str,
+    replacement: &str,
+    index: &shuck_indexer::LineIndex,
+    encoding: PositionEncoding,
+) -> Option<lsp_types::TextEdit> {
+    if text == replacement {
+        return None;
+    }
+
+    let prefix_len = common_prefix_len(text, replacement);
+    let suffix_len = common_suffix_len(&text[prefix_len..], &replacement[prefix_len..]);
+    let original_end = text.len().saturating_sub(suffix_len);
+    let replacement_end = replacement.len().saturating_sub(suffix_len);
+
+    Some(lsp_types::TextEdit {
+        range: to_lsp_range(
+            TextRange::new(
+                shuck_ast::TextSize::new(prefix_len as u32),
+                shuck_ast::TextSize::new(original_end as u32),
+            ),
+            text,
+            index,
+            encoding,
+        ),
+        new_text: replacement[prefix_len..replacement_end].to_owned(),
+    })
+}
+
+fn common_prefix_len(left: &str, right: &str) -> usize {
+    left.chars()
+        .zip(right.chars())
+        .take_while(|(left, right)| left == right)
+        .map(|(ch, _)| ch.len_utf8())
+        .sum()
+}
+
+fn common_suffix_len(left: &str, right: &str) -> usize {
+    left.chars()
+        .rev()
+        .zip(right.chars().rev())
+        .take_while(|(left, right)| left == right)
+        .map(|(ch, _)| ch.len_utf8())
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_replacement_edit_keeps_shared_prefix_and_suffix() {
+        let source = "echo old value\n";
+        let replacement = "echo new value\n";
+        let index = shuck_indexer::LineIndex::new(source);
+
+        let edit = single_replacement_edit(source, replacement, &index, PositionEncoding::UTF16)
+            .expect("edit should be present");
+
+        assert_eq!(
+            edit.range,
+            lsp_types::Range {
+                start: lsp_types::Position::new(0, 5),
+                end: lsp_types::Position::new(0, 8),
+            }
+        );
+        assert_eq!(edit.new_text, "new");
+    }
+
+    #[test]
+    fn single_replacement_edit_returns_none_for_identical_text() {
+        let source = "echo hi\n";
+        let index = shuck_indexer::LineIndex::new(source);
+
+        assert!(
+            single_replacement_edit(source, source, &index, PositionEncoding::UTF16).is_none()
+        );
+    }
+}

--- a/crates/shuck-server/src/fix.rs
+++ b/crates/shuck-server/src/fix.rs
@@ -26,9 +26,9 @@ pub(crate) fn code_actions(
             };
 
             if should_offer_fix(&snapshot, &data) {
-                actions.push(types::CodeActionOrCommand::CodeAction(diagnostic_fix_action(
-                    &snapshot, &diagnostic, &data,
-                )));
+                actions.push(types::CodeActionOrCommand::CodeAction(
+                    diagnostic_fix_action(&snapshot, &diagnostic, &data),
+                ));
             }
 
             if let Some(edit) = data.directive_edit.clone() {
@@ -231,12 +231,14 @@ fn fix_all_action(
         .resolved_client_capabilities()
         .code_action_deferred_edit_resolution
     {
-        action.data = Some(serde_json::to_value(ResolveCodeActionData {
-            kind: ResolveCodeActionKind::FixAll,
-            uri: snapshot.query().file_url().clone(),
-            include_unsafe: snapshot.client_settings().unsafe_fixes(),
-        })
-        .map_err(anyhow::Error::new)?);
+        action.data = Some(
+            serde_json::to_value(ResolveCodeActionData {
+                kind: ResolveCodeActionKind::FixAll,
+                uri: snapshot.query().file_url().clone(),
+                include_unsafe: snapshot.client_settings().unsafe_fixes(),
+            })
+            .map_err(anyhow::Error::new)?,
+        );
     } else {
         action.edit = Some(workspace_edit_for_document(snapshot, edits));
     }
@@ -299,7 +301,9 @@ fn apply_workspace_edit(
             if !response.applied {
                 tracing::warn!(
                     "Client rejected workspace edit: {}",
-                    response.failure_reason.unwrap_or_else(|| "unknown reason".to_owned())
+                    response
+                        .failure_reason
+                        .unwrap_or_else(|| "unknown reason".to_owned())
                 );
             }
         },
@@ -396,16 +400,14 @@ mod tests {
     use crossbeam::channel;
     use lsp_server::Message;
     use lsp_types::{
-        CodeActionContext, CodeActionParams, ClientCapabilities, PartialResultParams, Position,
-        Range, TextDocumentContentChangeEvent, TextDocumentIdentifier, Url,
-        WorkDoneProgressParams,
+        ClientCapabilities, CodeActionContext, CodeActionParams, PartialResultParams, Position,
+        Range, TextDocumentContentChangeEvent, TextDocumentIdentifier, Url, WorkDoneProgressParams,
     };
 
     use super::*;
     use crate::{
         ClientOptions, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace,
-        Workspaces,
-        lint::generate_diagnostics,
+        Workspaces, lint::generate_diagnostics,
     };
 
     fn make_session(
@@ -413,12 +415,7 @@ mod tests {
         source: &str,
         language_id: &str,
         file_name: &str,
-    ) -> (
-        Session,
-        Client,
-        channel::Receiver<Message>,
-        lsp_types::Url,
-    ) {
+    ) -> (Session, Client, channel::Receiver<Message>, lsp_types::Url) {
         let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
         let (client_sender, client_receiver) = channel::unbounded();
         let client = Client::new(main_loop_sender, client_sender);
@@ -450,9 +447,7 @@ mod tests {
         (session, client, client_receiver, uri)
     }
 
-    fn extract_actions(
-        response: types::CodeActionResponse,
-    ) -> Vec<types::CodeAction> {
+    fn extract_actions(response: types::CodeActionResponse) -> Vec<types::CodeAction> {
         response
             .into_iter()
             .map(|entry| match entry {
@@ -534,8 +529,16 @@ mod tests {
 
         let actions = extract_actions(response);
 
-        assert!(actions.iter().any(|action| action.title.contains("rename the unused assignment target")));
-        assert!(actions.iter().any(|action| action.title.contains("Disable for this line")));
+        assert!(
+            actions
+                .iter()
+                .any(|action| action.title.contains("rename the unused assignment target"))
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|action| action.title.contains("Disable for this line"))
+        );
         let fix_all = actions
             .iter()
             .find(|action| action.kind == Some(crate::SOURCE_FIX_ALL_SHUCK))
@@ -599,7 +602,11 @@ mod tests {
         )
         .expect("fix-all action request should succeed")
         .expect("fix-all action should be present");
-        let action = match response.into_iter().next().expect("fix-all action expected") {
+        let action = match response
+            .into_iter()
+            .next()
+            .expect("fix-all action expected")
+        {
             types::CodeActionOrCommand::CodeAction(action) => action,
             types::CodeActionOrCommand::Command(_) => panic!("expected a code action"),
         };
@@ -611,9 +618,11 @@ mod tests {
             fix_all_document_edits(&expected_snapshot, shuck_linter::Applicability::Unsafe),
         );
 
-        let resolved = resolve_code_action(&session, &client, action)
-            .expect("resolve request should succeed");
-        let edit = resolved.edit.expect("resolved action should include an edit");
+        let resolved =
+            resolve_code_action(&session, &client, action).expect("resolve request should succeed");
+        let edit = resolved
+            .edit
+            .expect("resolved action should include an edit");
         assert_eq!(edit, expected_edit);
     }
 
@@ -705,15 +714,21 @@ mod tests {
 
         let actions = extract_actions(response);
 
-        assert!(actions
-            .iter()
-            .any(|action| action.title.contains("Disable for this line")));
-        assert!(!actions
-            .iter()
-            .any(|action| action.title.contains("rename the unused assignment target")));
-        assert!(!actions
-            .iter()
-            .any(|action| action.kind == Some(crate::SOURCE_FIX_ALL_SHUCK)));
+        assert!(
+            actions
+                .iter()
+                .any(|action| action.title.contains("Disable for this line"))
+        );
+        assert!(
+            !actions
+                .iter()
+                .any(|action| action.title.contains("rename the unused assignment target"))
+        );
+        assert!(
+            !actions
+                .iter()
+                .any(|action| action.kind == Some(crate::SOURCE_FIX_ALL_SHUCK))
+        );
     }
 
     #[test]
@@ -816,9 +831,11 @@ mod tests {
             .expect("fix-all action should be returned for parent kind filters");
 
             let actions = extract_actions(response);
-            assert!(actions
-                .iter()
-                .any(|action| action.kind == Some(crate::SOURCE_FIX_ALL_SHUCK)));
+            assert!(
+                actions
+                    .iter()
+                    .any(|action| action.kind == Some(crate::SOURCE_FIX_ALL_SHUCK))
+            );
         }
     }
 }

--- a/crates/shuck-server/src/fix.rs
+++ b/crates/shuck-server/src/fix.rs
@@ -1,28 +1,585 @@
-#![allow(dead_code)]
-
+use anyhow::{Context, anyhow};
+use lsp_server::ErrorCode;
 use lsp_types as types;
+use serde::{Deserialize, Serialize};
 
+use crate::lint::{
+    AssociatedDiagnosticData, associated_diagnostic_data, directive_edit_for_line,
+    fix_all_document_edits,
+};
 use crate::session::{Client, DocumentSnapshot, Session};
 
 pub(crate) fn code_actions(
-    _snapshot: DocumentSnapshot,
+    snapshot: DocumentSnapshot,
     _client: &Client,
-    _params: types::CodeActionParams,
+    params: types::CodeActionParams,
 ) -> crate::server::Result<Option<types::CodeActionResponse>> {
-    unimplemented!("shuck LSP code actions are not implemented yet")
+    let mut actions = Vec::new();
+    let only = params.context.only.as_ref();
+    let include_quickfix = wants_kind(only, &types::CodeActionKind::QUICKFIX);
+    let include_fix_all = wants_kind(only, &crate::SOURCE_FIX_ALL_SHUCK);
+
+    if include_quickfix {
+        for diagnostic in params.context.diagnostics {
+            let Some(data) = associated_diagnostic_data(&snapshot, &diagnostic) else {
+                continue;
+            };
+
+            if should_offer_fix(&snapshot, &data) {
+                actions.push(types::CodeActionOrCommand::CodeAction(diagnostic_fix_action(
+                    &snapshot, &diagnostic, &data,
+                )));
+            }
+
+            if let Some(edit) = data.directive_edit.clone() {
+                actions.push(types::CodeActionOrCommand::CodeAction(
+                    diagnostic_directive_action(&snapshot, &diagnostic, &data, edit),
+                ));
+            }
+        }
+    }
+
+    if include_fix_all && snapshot.client_settings().fix_all() {
+        let edits = fix_all_document_edits(
+            &snapshot,
+            if snapshot.client_settings().unsafe_fixes() {
+                shuck_linter::Applicability::Unsafe
+            } else {
+                shuck_linter::Applicability::Safe
+            },
+        );
+        if !edits.is_empty() {
+            actions.push(types::CodeActionOrCommand::CodeAction(fix_all_action(
+                &snapshot, edits,
+            )?));
+        }
+    }
+
+    Ok((!actions.is_empty()).then_some(actions))
 }
 
 pub(crate) fn resolve_code_action(
+    session: &Session,
     _client: &Client,
-    _action: types::CodeAction,
+    mut action: types::CodeAction,
 ) -> crate::server::Result<types::CodeAction> {
-    unimplemented!("shuck LSP code action resolution is not implemented yet")
+    if action.edit.is_some() {
+        return Ok(action);
+    }
+
+    let Some(data) = action.data.clone() else {
+        return Ok(action);
+    };
+    let resolved: ResolveCodeActionData =
+        serde_json::from_value(data).context("deserialize code action resolve payload")?;
+    let Some(snapshot) = session.take_snapshot(resolved.uri.clone()) else {
+        return Ok(action);
+    };
+
+    let edits = match resolved.kind {
+        ResolveCodeActionKind::FixAll => fix_all_document_edits(
+            &snapshot,
+            if resolved.include_unsafe {
+                shuck_linter::Applicability::Unsafe
+            } else {
+                shuck_linter::Applicability::Safe
+            },
+        ),
+    };
+    if !edits.is_empty() {
+        action.edit = Some(workspace_edit_for_document(&snapshot, edits));
+    }
+    Ok(action)
 }
 
 pub(crate) fn execute_command(
-    _session: &mut Session,
-    _client: &Client,
-    _params: types::ExecuteCommandParams,
+    session: &mut Session,
+    client: &Client,
+    params: types::ExecuteCommandParams,
 ) -> crate::server::Result<Option<serde_json::Value>> {
-    unimplemented!("shuck LSP executeCommand is not implemented yet")
+    match params.command.as_str() {
+        "shuck.applyAutofix" => {
+            let uri = command_uri(&params.arguments)?;
+            let Some(snapshot) = session.take_snapshot(uri) else {
+                return Ok(None);
+            };
+            let edits = fix_all_document_edits(
+                &snapshot,
+                if snapshot.client_settings().unsafe_fixes() {
+                    shuck_linter::Applicability::Unsafe
+                } else {
+                    shuck_linter::Applicability::Safe
+                },
+            );
+            apply_workspace_edit(session, client, "Shuck: apply autofix", &snapshot, edits)?;
+            Ok(None)
+        }
+        "shuck.applyDirective" => {
+            let args: ApplyDirectiveCommand = command_args(&params.arguments)?;
+            let Some(snapshot) = session.take_snapshot(args.uri.clone()) else {
+                return Ok(None);
+            };
+            let Some(edit) = directive_edit_for_line(&snapshot, args.line) else {
+                return Ok(None);
+            };
+            apply_workspace_edit(
+                session,
+                client,
+                "Shuck: disable for this line",
+                &snapshot,
+                vec![edit],
+            )?;
+            Ok(None)
+        }
+        "shuck.applyFormat" => {
+            let uri = command_uri(&params.arguments)?;
+            let Some(snapshot) = session.take_snapshot(uri) else {
+                return Ok(None);
+            };
+            let edits = crate::format::format_document(
+                snapshot.clone(),
+                client,
+                types::DocumentFormattingParams {
+                    text_document: types::TextDocumentIdentifier {
+                        uri: snapshot.query().file_url().clone(),
+                    },
+                    options: types::FormattingOptions {
+                        tab_size: 8,
+                        insert_spaces: false,
+                        ..types::FormattingOptions::default()
+                    },
+                    work_done_progress_params: types::WorkDoneProgressParams::default(),
+                },
+            )?
+            .unwrap_or_default();
+            apply_workspace_edit(session, client, "Shuck: apply format", &snapshot, edits)?;
+            Ok(None)
+        }
+        "shuck.printDebugInformation" => {
+            tracing::info!(
+                "shuck server state: open_documents={} workspace_roots={:?}",
+                session.open_document_count(),
+                session.workspace_roots()
+            );
+            Ok(None)
+        }
+        other => Err(crate::server::Error::new(
+            anyhow!("unsupported executeCommand request: {other}"),
+            ErrorCode::MethodNotFound,
+        )),
+    }
+}
+
+fn should_offer_fix(snapshot: &DocumentSnapshot, data: &AssociatedDiagnosticData) -> bool {
+    !data.edits.is_empty()
+        && (snapshot.client_settings().unsafe_fixes()
+            || data.applicability == crate::lint::DiagnosticApplicability::Safe)
+}
+
+fn diagnostic_fix_action(
+    snapshot: &DocumentSnapshot,
+    diagnostic: &types::Diagnostic,
+    data: &AssociatedDiagnosticData,
+) -> types::CodeAction {
+    types::CodeAction {
+        title: format!("Shuck ({}): {}", data.code, data.title),
+        kind: Some(types::CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(workspace_edit_for_document(snapshot, data.edits.clone())),
+        command: None,
+        is_preferred: Some(true),
+        disabled: None,
+        data: None,
+    }
+}
+
+fn diagnostic_directive_action(
+    snapshot: &DocumentSnapshot,
+    diagnostic: &types::Diagnostic,
+    data: &AssociatedDiagnosticData,
+    edit: types::TextEdit,
+) -> types::CodeAction {
+    types::CodeAction {
+        title: format!("Shuck ({}): Disable for this line", data.code),
+        kind: Some(types::CodeActionKind::QUICKFIX),
+        diagnostics: Some(vec![diagnostic.clone()]),
+        edit: Some(workspace_edit_for_document(snapshot, vec![edit])),
+        command: None,
+        is_preferred: Some(false),
+        disabled: None,
+        data: None,
+    }
+}
+
+fn fix_all_action(
+    snapshot: &DocumentSnapshot,
+    edits: Vec<types::TextEdit>,
+) -> crate::server::Result<types::CodeAction> {
+    let mut action = types::CodeAction {
+        title: "Shuck: Fix all auto-fixable issues".to_owned(),
+        kind: Some(crate::SOURCE_FIX_ALL_SHUCK),
+        diagnostics: None,
+        edit: None,
+        command: None,
+        is_preferred: Some(true),
+        disabled: None,
+        data: None,
+    };
+    if snapshot
+        .resolved_client_capabilities()
+        .code_action_deferred_edit_resolution
+    {
+        action.data = Some(serde_json::to_value(ResolveCodeActionData {
+            kind: ResolveCodeActionKind::FixAll,
+            uri: snapshot.query().file_url().clone(),
+            include_unsafe: snapshot.client_settings().unsafe_fixes(),
+        })
+        .map_err(anyhow::Error::new)?);
+    } else {
+        action.edit = Some(workspace_edit_for_document(snapshot, edits));
+    }
+    Ok(action)
+}
+
+fn workspace_edit_for_document(
+    snapshot: &DocumentSnapshot,
+    edits: Vec<types::TextEdit>,
+) -> types::WorkspaceEdit {
+    if snapshot.resolved_client_capabilities().document_changes {
+        return types::WorkspaceEdit {
+            changes: None,
+            document_changes: Some(types::DocumentChanges::Edits(vec![
+                types::TextDocumentEdit {
+                    text_document: types::OptionalVersionedTextDocumentIdentifier {
+                        uri: snapshot.query().file_url().clone(),
+                        version: Some(snapshot.query().document().version()),
+                    },
+                    edits: edits.into_iter().map(types::OneOf::Left).collect(),
+                },
+            ])),
+            change_annotations: None,
+        };
+    }
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(snapshot.query().file_url().clone(), edits);
+    types::WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+        change_annotations: None,
+    }
+}
+
+fn apply_workspace_edit(
+    session: &Session,
+    client: &Client,
+    label: &str,
+    snapshot: &DocumentSnapshot,
+    edits: Vec<types::TextEdit>,
+) -> crate::server::Result<()> {
+    if edits.is_empty() {
+        return Ok(());
+    }
+    if !snapshot.resolved_client_capabilities().apply_edit {
+        return Err(crate::server::Error::new(
+            anyhow!("LSP client does not advertise workspace/applyEdit support"),
+            ErrorCode::InvalidRequest,
+        ));
+    }
+
+    client.send_request::<types::request::ApplyWorkspaceEdit>(
+        session,
+        types::ApplyWorkspaceEditParams {
+            label: Some(label.to_owned()),
+            edit: workspace_edit_for_document(snapshot, edits),
+        },
+        |_, response| {
+            if !response.applied {
+                tracing::warn!(
+                    "Client rejected workspace edit: {}",
+                    response.failure_reason.unwrap_or_else(|| "unknown reason".to_owned())
+                );
+            }
+        },
+    )?;
+    Ok(())
+}
+
+fn wants_kind(only: Option<&Vec<types::CodeActionKind>>, expected: &types::CodeActionKind) -> bool {
+    only.is_none_or(|kinds| kinds.iter().any(|kind| kind == expected))
+}
+
+fn command_uri(arguments: &[serde_json::Value]) -> crate::server::Result<lsp_types::Url> {
+    if let Some(uri) = arguments
+        .first()
+        .and_then(|value| value.as_str())
+        .and_then(|value| lsp_types::Url::parse(value).ok())
+    {
+        return Ok(uri);
+    }
+
+    #[derive(Deserialize)]
+    struct UriArg {
+        uri: lsp_types::Url,
+    }
+
+    let arg = arguments
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow!("missing executeCommand argument"))?;
+    Ok(serde_json::from_value::<UriArg>(arg)
+        .map_err(anyhow::Error::new)?
+        .uri)
+}
+
+fn command_args<T: for<'de> Deserialize<'de>>(
+    arguments: &[serde_json::Value],
+) -> crate::server::Result<T> {
+    let value = arguments
+        .first()
+        .cloned()
+        .ok_or_else(|| anyhow!("missing executeCommand argument"))?;
+    Ok(serde_json::from_value(value).map_err(anyhow::Error::new)?)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum ResolveCodeActionKind {
+    FixAll,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ResolveCodeActionData {
+    kind: ResolveCodeActionKind,
+    uri: lsp_types::Url,
+    include_unsafe: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplyDirectiveCommand {
+    uri: lsp_types::Url,
+    line: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam::channel;
+    use lsp_server::Message;
+    use lsp_types::{
+        CodeActionContext, CodeActionParams, ClientCapabilities, PartialResultParams, Position,
+        Range, TextDocumentIdentifier, Url, WorkDoneProgressParams,
+    };
+
+    use super::*;
+    use crate::{
+        ClientOptions, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace,
+        Workspaces,
+        lint::generate_diagnostics,
+    };
+
+    fn make_session(
+        client_capabilities: ClientCapabilities,
+        source: &str,
+        language_id: &str,
+        file_name: &str,
+    ) -> (
+        Session,
+        Client,
+        channel::Receiver<Message>,
+        lsp_types::Url,
+    ) {
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_root = std::env::temp_dir().join("shuck-server-fix-tests");
+        let workspace_uri =
+            Url::from_file_path(&workspace_root).expect("workspace path should convert to a URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &client_capabilities,
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+        session.update_client_options(ClientOptions {
+            unsafe_fixes: Some(true),
+            ..ClientOptions::default()
+        });
+
+        let path = workspace_root.join(file_name);
+        let uri = Url::from_file_path(path).expect("test path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new(source.to_owned(), 1).with_language_id(language_id),
+        );
+
+        (session, client, client_receiver, uri)
+    }
+
+    fn deferred_capabilities() -> ClientCapabilities {
+        serde_json::from_value(serde_json::json!({
+            "textDocument": {
+                "codeAction": {
+                    "dataSupport": true,
+                    "resolveSupport": { "properties": ["edit"] }
+                }
+            },
+            "workspace": {
+                "applyEdit": true,
+                "workspaceEdit": {
+                    "documentChanges": true
+                }
+            }
+        }))
+        .expect("test client capabilities should deserialize")
+    }
+
+    #[test]
+    fn code_actions_include_quickfix_disable_and_fix_all() {
+        let capabilities = deferred_capabilities();
+        let (session, client, _client_receiver, uri) =
+            make_session(capabilities, "foo=1\n", "shellscript", "script.sh");
+        let snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        let diagnostics = generate_diagnostics(&snapshot);
+
+        let response = code_actions(
+            snapshot,
+            &client,
+            CodeActionParams {
+                text_document: TextDocumentIdentifier { uri: uri.clone() },
+                range: Range::new(Position::new(0, 0), Position::new(0, 3)),
+                context: CodeActionContext {
+                    diagnostics,
+                    only: None,
+                    trigger_kind: None,
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("code action request should succeed")
+        .expect("violating document should produce actions");
+
+        let actions = response
+            .into_iter()
+            .map(|entry| match entry {
+                types::CodeActionOrCommand::CodeAction(action) => action,
+                types::CodeActionOrCommand::Command(command) => {
+                    panic!("unexpected command response: {}", command.title)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        assert!(actions.iter().any(|action| action.title.contains("rename the unused assignment target")));
+        assert!(actions.iter().any(|action| action.title.contains("Disable for this line")));
+        let fix_all = actions
+            .iter()
+            .find(|action| action.kind == Some(crate::SOURCE_FIX_ALL_SHUCK))
+            .expect("fix-all action should be present");
+        assert!(fix_all.edit.is_none());
+        assert!(fix_all.data.is_some());
+    }
+
+    #[test]
+    fn code_actions_return_none_for_non_shell_documents() {
+        let capabilities = deferred_capabilities();
+        let (session, client, _client_receiver, uri) =
+            make_session(capabilities, "# heading\n", "markdown", "README.md");
+        let snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+
+        let response = code_actions(
+            snapshot,
+            &client,
+            CodeActionParams {
+                text_document: TextDocumentIdentifier { uri },
+                range: Range::new(Position::new(0, 0), Position::new(0, 3)),
+                context: CodeActionContext {
+                    diagnostics: Vec::new(),
+                    only: None,
+                    trigger_kind: None,
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("code action request should succeed");
+
+        assert!(response.is_none());
+    }
+
+    #[test]
+    fn code_action_resolve_materializes_deferred_fix_all_edit() {
+        let capabilities = deferred_capabilities();
+        let (session, client, _client_receiver, uri) =
+            make_session(capabilities, "foo=1\n", "shellscript", "script.sh");
+        let snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        let diagnostics = generate_diagnostics(&snapshot);
+        let response = code_actions(
+            snapshot,
+            &client,
+            CodeActionParams {
+                text_document: TextDocumentIdentifier { uri: uri.clone() },
+                range: Range::new(Position::new(0, 0), Position::new(0, 3)),
+                context: CodeActionContext {
+                    diagnostics,
+                    only: Some(vec![crate::SOURCE_FIX_ALL_SHUCK]),
+                    trigger_kind: None,
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("fix-all action request should succeed")
+        .expect("fix-all action should be present");
+        let action = match response.into_iter().next().expect("fix-all action expected") {
+            types::CodeActionOrCommand::CodeAction(action) => action,
+            types::CodeActionOrCommand::Command(_) => panic!("expected a code action"),
+        };
+        let expected_snapshot = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot");
+        let expected_edit = workspace_edit_for_document(
+            &expected_snapshot,
+            fix_all_document_edits(&expected_snapshot, shuck_linter::Applicability::Unsafe),
+        );
+
+        let resolved = resolve_code_action(&session, &client, action)
+            .expect("resolve request should succeed");
+        let edit = resolved.edit.expect("resolved action should include an edit");
+        assert_eq!(edit, expected_edit);
+    }
+
+    #[test]
+    fn apply_autofix_command_dispatches_workspace_edit_request() {
+        let capabilities = deferred_capabilities();
+        let (mut session, client, client_receiver, uri) =
+            make_session(capabilities, "foo=1\n", "shellscript", "script.sh");
+
+        execute_command(
+            &mut session,
+            &client,
+            types::ExecuteCommandParams {
+                command: "shuck.applyAutofix".to_owned(),
+                arguments: vec![serde_json::Value::String(uri.to_string())],
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("applyAutofix should succeed");
+
+        let message = client_receiver
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("applyAutofix should send a workspace/applyEdit request");
+        let Message::Request(request) = message else {
+            panic!("expected a client request");
+        };
+        assert_eq!(request.method, "workspace/applyEdit");
+    }
 }

--- a/crates/shuck-server/src/fix.rs
+++ b/crates/shuck-server/src/fix.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::lint::{
     AssociatedDiagnosticData, associated_diagnostic_data, directive_edit_for_line,
-    fix_all_document_edits,
+    fix_all_document_edits, generate_diagnostics,
 };
 use crate::session::{Client, DocumentSnapshot, Session};
 
@@ -20,7 +20,7 @@ pub(crate) fn code_actions(
     let include_fix_all = wants_kind(only, &crate::SOURCE_FIX_ALL_SHUCK);
 
     if include_quickfix {
-        for diagnostic in params.context.diagnostics {
+        for diagnostic in diagnostics_for_range(&snapshot, &params.range) {
             let Some(data) = associated_diagnostic_data(&snapshot, &diagnostic) else {
                 continue;
             };
@@ -308,7 +308,36 @@ fn apply_workspace_edit(
 }
 
 fn wants_kind(only: Option<&Vec<types::CodeActionKind>>, expected: &types::CodeActionKind) -> bool {
-    only.is_none_or(|kinds| kinds.iter().any(|kind| kind == expected))
+    only.is_none_or(|kinds| kinds.iter().any(|kind| action_kind_matches(kind, expected)))
+}
+
+fn diagnostics_for_range(
+    snapshot: &DocumentSnapshot,
+    requested_range: &types::Range,
+) -> Vec<types::Diagnostic> {
+    generate_diagnostics(snapshot)
+        .into_iter()
+        .filter(|diagnostic| ranges_overlap(&diagnostic.range, requested_range))
+        .collect()
+}
+
+fn action_kind_matches(
+    requested: &types::CodeActionKind,
+    provided: &types::CodeActionKind,
+) -> bool {
+    provided.as_str() == requested.as_str()
+        || provided
+            .as_str()
+            .strip_prefix(requested.as_str())
+            .is_some_and(|suffix| suffix.starts_with('.'))
+}
+
+fn ranges_overlap(left: &types::Range, right: &types::Range) -> bool {
+    position_leq(left.start, right.end) && position_leq(right.start, left.end)
+}
+
+fn position_leq(left: types::Position, right: types::Position) -> bool {
+    (left.line, left.character) <= (right.line, right.character)
 }
 
 fn command_uri(arguments: &[serde_json::Value]) -> crate::server::Result<lsp_types::Url> {
@@ -368,7 +397,8 @@ mod tests {
     use lsp_server::Message;
     use lsp_types::{
         CodeActionContext, CodeActionParams, ClientCapabilities, PartialResultParams, Position,
-        Range, TextDocumentIdentifier, Url, WorkDoneProgressParams,
+        Range, TextDocumentContentChangeEvent, TextDocumentIdentifier, Url,
+        WorkDoneProgressParams,
     };
 
     use super::*;
@@ -420,6 +450,42 @@ mod tests {
         (session, client, client_receiver, uri)
     }
 
+    fn extract_actions(
+        response: types::CodeActionResponse,
+    ) -> Vec<types::CodeAction> {
+        response
+            .into_iter()
+            .map(|entry| match entry {
+                types::CodeActionOrCommand::CodeAction(action) => action,
+                types::CodeActionOrCommand::Command(command) => {
+                    panic!("unexpected command response: {}", command.title)
+                }
+            })
+            .collect()
+    }
+
+    fn first_edit_range(action: &types::CodeAction) -> Range {
+        let edit = action
+            .edit
+            .as_ref()
+            .expect("code action should include an edit");
+        let document_changes = edit
+            .document_changes
+            .as_ref()
+            .expect("workspace edit should use document changes");
+        let types::DocumentChanges::Edits(edits) = document_changes else {
+            panic!("workspace edit should contain document edits");
+        };
+        let text_edit = edits[0]
+            .edits
+            .first()
+            .expect("workspace edit should contain at least one text edit");
+        let types::OneOf::Left(text_edit) = text_edit else {
+            panic!("workspace edit should contain plain text edits");
+        };
+        text_edit.range
+    }
+
     fn deferred_capabilities() -> ClientCapabilities {
         serde_json::from_value(serde_json::json!({
             "textDocument": {
@@ -466,15 +532,7 @@ mod tests {
         .expect("code action request should succeed")
         .expect("violating document should produce actions");
 
-        let actions = response
-            .into_iter()
-            .map(|entry| match entry {
-                types::CodeActionOrCommand::CodeAction(action) => action,
-                types::CodeActionOrCommand::Command(command) => {
-                    panic!("unexpected command response: {}", command.title)
-                }
-            })
-            .collect::<Vec<_>>();
+        let actions = extract_actions(response);
 
         assert!(actions.iter().any(|action| action.title.contains("rename the unused assignment target")));
         assert!(actions.iter().any(|action| action.title.contains("Disable for this line")));
@@ -645,15 +703,7 @@ mod tests {
         .expect("code action request should succeed")
         .expect("violating document should still produce a disable action");
 
-        let actions = response
-            .into_iter()
-            .map(|entry| match entry {
-                types::CodeActionOrCommand::CodeAction(action) => action,
-                types::CodeActionOrCommand::Command(command) => {
-                    panic!("unexpected command response: {}", command.title)
-                }
-            })
-            .collect::<Vec<_>>();
+        let actions = extract_actions(response);
 
         assert!(actions
             .iter()
@@ -664,5 +714,111 @@ mod tests {
         assert!(!actions
             .iter()
             .any(|action| action.kind == Some(crate::SOURCE_FIX_ALL_SHUCK)));
+    }
+
+    #[test]
+    fn code_actions_recompute_live_quickfix_and_disable_edits() {
+        let capabilities = deferred_capabilities();
+        let (mut session, client, _client_receiver, uri) =
+            make_session(capabilities, "foo=1\n", "shellscript", "script.sh");
+        let stale_snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        let stale_diagnostics = generate_diagnostics(&stale_snapshot);
+
+        let key = session.key_from_url(uri.clone());
+        session
+            .update_text_document(
+                &key,
+                vec![TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "\nfoo=1\n".to_owned(),
+                }],
+                2,
+            )
+            .expect("text document update should succeed");
+
+        let live_snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("updated document should produce a snapshot");
+        let response = code_actions(
+            live_snapshot,
+            &client,
+            CodeActionParams {
+                text_document: TextDocumentIdentifier { uri },
+                range: Range::new(Position::new(1, 0), Position::new(1, 3)),
+                context: CodeActionContext {
+                    diagnostics: stale_diagnostics,
+                    only: Some(vec![types::CodeActionKind::QUICKFIX]),
+                    trigger_kind: None,
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("code action request should succeed")
+        .expect("live diagnostic should still produce actions");
+
+        let actions = extract_actions(response);
+        let quickfix = actions
+            .iter()
+            .find(|action| action.title.contains("rename the unused assignment target"))
+            .expect("quickfix action should be present");
+        let disable = actions
+            .iter()
+            .find(|action| action.title.contains("Disable for this line"))
+            .expect("disable action should be present");
+
+        assert_eq!(first_edit_range(quickfix).start.line, 1);
+        assert_eq!(first_edit_range(disable).start.line, 1);
+        assert_eq!(
+            quickfix
+                .diagnostics
+                .as_ref()
+                .expect("quickfix should preserve associated diagnostic")[0]
+                .range
+                .start
+                .line,
+            1
+        );
+    }
+
+    #[test]
+    fn code_actions_match_parent_fix_all_kinds() {
+        let capabilities = deferred_capabilities();
+        let (session, client, _client_receiver, uri) =
+            make_session(capabilities, "foo=1\n", "shellscript", "script.sh");
+
+        for only in [
+            types::CodeActionKind::SOURCE_FIX_ALL,
+            types::CodeActionKind::SOURCE,
+        ] {
+            let snapshot = session
+                .take_snapshot(uri.clone())
+                .expect("test document should produce a snapshot");
+            let response = code_actions(
+                snapshot,
+                &client,
+                CodeActionParams {
+                    text_document: TextDocumentIdentifier { uri: uri.clone() },
+                    range: Range::new(Position::new(0, 0), Position::new(0, 3)),
+                    context: CodeActionContext {
+                        diagnostics: Vec::new(),
+                        only: Some(vec![only]),
+                        trigger_kind: None,
+                    },
+                    work_done_progress_params: WorkDoneProgressParams::default(),
+                    partial_result_params: PartialResultParams::default(),
+                },
+            )
+            .expect("code action request should succeed")
+            .expect("fix-all action should be returned for parent kind filters");
+
+            let actions = extract_actions(response);
+            assert!(actions
+                .iter()
+                .any(|action| action.kind == Some(crate::SOURCE_FIX_ALL_SHUCK)));
+        }
     }
 }

--- a/crates/shuck-server/src/fix.rs
+++ b/crates/shuck-server/src/fix.rs
@@ -337,11 +337,34 @@ fn action_kind_matches(
 }
 
 fn ranges_overlap(left: &types::Range, right: &types::Range) -> bool {
-    position_leq(left.start, right.end) && position_leq(right.start, left.end)
+    if range_is_empty(left) {
+        return range_contains(right, left.start);
+    }
+    if range_is_empty(right) {
+        return range_contains(left, right.start);
+    }
+
+    position_lt(left.start, right.end) && position_lt(right.start, left.end)
+}
+
+fn range_contains(range: &types::Range, position: types::Position) -> bool {
+    if range_is_empty(range) {
+        return range.start == position;
+    }
+
+    position_leq(range.start, position) && position_lt(position, range.end)
+}
+
+fn range_is_empty(range: &types::Range) -> bool {
+    range.start == range.end
 }
 
 fn position_leq(left: types::Position, right: types::Position) -> bool {
     (left.line, left.character) <= (right.line, right.character)
+}
+
+fn position_lt(left: types::Position, right: types::Position) -> bool {
+    (left.line, left.character) < (right.line, right.character)
 }
 
 fn command_uri(arguments: &[serde_json::Value]) -> crate::server::Result<lsp_types::Url> {
@@ -545,6 +568,30 @@ mod tests {
             .expect("fix-all action should be present");
         assert!(fix_all.edit.is_none());
         assert!(fix_all.data.is_some());
+    }
+
+    #[test]
+    fn adjacent_ranges_do_not_overlap() {
+        let left = Range::new(Position::new(0, 0), Position::new(0, 3));
+        let right = Range::new(Position::new(0, 3), Position::new(0, 5));
+
+        assert!(!ranges_overlap(&left, &right));
+    }
+
+    #[test]
+    fn empty_requested_range_overlaps_when_inside_diagnostic() {
+        let diagnostic = Range::new(Position::new(0, 0), Position::new(0, 3));
+        let cursor = Range::new(Position::new(0, 2), Position::new(0, 2));
+
+        assert!(ranges_overlap(&diagnostic, &cursor));
+    }
+
+    #[test]
+    fn empty_requested_range_at_diagnostic_end_does_not_overlap() {
+        let diagnostic = Range::new(Position::new(0, 0), Position::new(0, 3));
+        let cursor = Range::new(Position::new(0, 3), Position::new(0, 3));
+
+        assert!(!ranges_overlap(&diagnostic, &cursor));
     }
 
     #[test]

--- a/crates/shuck-server/src/fix.rs
+++ b/crates/shuck-server/src/fix.rs
@@ -172,6 +172,8 @@ pub(crate) fn execute_command(
 
 fn should_offer_fix(snapshot: &DocumentSnapshot, data: &AssociatedDiagnosticData) -> bool {
     !data.edits.is_empty()
+        && shuck_linter::code_to_rule(&data.code)
+            .is_some_and(|rule| snapshot.shuck_settings().fixable_rules().contains(rule))
         && (snapshot.client_settings().unsafe_fixes()
             || data.applicability == crate::lint::DiagnosticApplicability::Safe)
 }
@@ -581,5 +583,86 @@ mod tests {
             panic!("expected a client request");
         };
         assert_eq!(request.method, "workspace/applyEdit");
+    }
+
+    #[test]
+    fn code_actions_skip_rules_marked_unfixable_in_project_config() {
+        let capabilities = deferred_capabilities();
+        let workspace_root = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            workspace_root.path().join(".shuck.toml"),
+            "[lint]\nunfixable = ['C001']\n",
+        )
+        .expect("config should be written");
+        let script_path = workspace_root.path().join("script.sh");
+        std::fs::write(&script_path, "foo=1\n").expect("source should be written");
+
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_uri = Url::from_file_path(workspace_root.path())
+            .expect("workspace path should convert to a URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &capabilities,
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+        session.update_client_options(ClientOptions {
+            unsafe_fixes: Some(true),
+            ..ClientOptions::default()
+        });
+
+        let uri = Url::from_file_path(&script_path).expect("test path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+        let snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        let diagnostics = generate_diagnostics(&snapshot);
+
+        let response = code_actions(
+            snapshot,
+            &client,
+            CodeActionParams {
+                text_document: TextDocumentIdentifier { uri },
+                range: Range::new(Position::new(0, 0), Position::new(0, 3)),
+                context: CodeActionContext {
+                    diagnostics,
+                    only: None,
+                    trigger_kind: None,
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            },
+        )
+        .expect("code action request should succeed")
+        .expect("violating document should still produce a disable action");
+
+        let actions = response
+            .into_iter()
+            .map(|entry| match entry {
+                types::CodeActionOrCommand::CodeAction(action) => action,
+                types::CodeActionOrCommand::Command(command) => {
+                    panic!("unexpected command response: {}", command.title)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        assert!(actions
+            .iter()
+            .any(|action| action.title.contains("Disable for this line")));
+        assert!(!actions
+            .iter()
+            .any(|action| action.title.contains("rename the unused assignment target")));
+        assert!(!actions
+            .iter()
+            .any(|action| action.kind == Some(crate::SOURCE_FIX_ALL_SHUCK)));
     }
 }

--- a/crates/shuck-server/src/format.rs
+++ b/crates/shuck-server/src/format.rs
@@ -61,7 +61,9 @@ mod tests {
     use lsp_types::{ClientCapabilities, PositionEncodingKind, Url};
 
     use super::*;
-    use crate::{Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces};
+    use crate::{
+        Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces,
+    };
 
     #[test]
     fn range_formatting_returns_empty_edits_for_already_formatted_buffer() {
@@ -103,10 +105,7 @@ mod tests {
             &client,
             types::DocumentRangeFormattingParams {
                 text_document: types::TextDocumentIdentifier { uri },
-                range: types::Range::new(
-                    types::Position::new(0, 0),
-                    types::Position::new(0, 7),
-                ),
+                range: types::Range::new(types::Position::new(0, 0), types::Position::new(0, 7)),
                 options: types::FormattingOptions::default(),
                 work_done_progress_params: types::WorkDoneProgressParams::default(),
             },

--- a/crates/shuck-server/src/format.rs
+++ b/crates/shuck-server/src/format.rs
@@ -1,23 +1,119 @@
-#![allow(dead_code)]
-
+use anyhow::Error;
 use lsp_types as types;
+use shuck_formatter::FormattedSource;
 
 use crate::session::{Client, DocumentSnapshot};
 
 pub(crate) type FormatResponse = Option<Vec<types::TextEdit>>;
 
 pub(crate) fn format_document(
-    _snapshot: DocumentSnapshot,
+    snapshot: DocumentSnapshot,
     _client: &Client,
     _params: types::DocumentFormattingParams,
 ) -> crate::server::Result<FormatResponse> {
-    unimplemented!("shuck LSP document formatting is not implemented yet")
+    let query = snapshot.query();
+    let source = query.document().contents();
+    let formatted = shuck_formatter::format_source(
+        source,
+        query.file_path().as_deref(),
+        snapshot.shuck_settings().formatter(),
+    )
+    .map_err(Error::new)?;
+
+    Ok(Some(match formatted {
+        FormattedSource::Unchanged => Vec::new(),
+        FormattedSource::Formatted(code) => crate::edit::single_replacement_edit(
+            source,
+            &code,
+            query.document().index(),
+            snapshot.encoding(),
+        )
+        .into_iter()
+        .collect(),
+    }))
 }
 
 pub(crate) fn format_range(
-    _snapshot: DocumentSnapshot,
-    _client: &Client,
+    snapshot: DocumentSnapshot,
+    client: &Client,
     _params: types::DocumentRangeFormattingParams,
 ) -> crate::server::Result<FormatResponse> {
-    unimplemented!("shuck LSP range formatting is not implemented yet")
+    format_document(
+        snapshot,
+        client,
+        types::DocumentFormattingParams {
+            text_document: types::TextDocumentIdentifier {
+                uri: lsp_types::Url::parse("file:///dev/null").expect("static URI should parse"),
+            },
+            options: types::FormattingOptions {
+                tab_size: 8,
+                insert_spaces: false,
+                ..types::FormattingOptions::default()
+            },
+            work_done_progress_params: types::WorkDoneProgressParams::default(),
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam::channel;
+    use lsp_types::{ClientCapabilities, PositionEncodingKind, Url};
+
+    use super::*;
+    use crate::{Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces};
+
+    #[test]
+    fn range_formatting_returns_empty_edits_for_already_formatted_buffer() {
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_root = std::env::temp_dir().join("shuck-server-format-tests");
+        let workspace_uri =
+            Url::from_file_path(&workspace_root).expect("workspace path should convert to a URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities {
+                general: Some(lsp_types::GeneralClientCapabilities {
+                    position_encodings: Some(vec![PositionEncodingKind::UTF16]),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+
+        let uri = Url::from_file_path(workspace_root.join("script.sh"))
+            .expect("script path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("echo hi\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+        let snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+
+        let edits = format_range(
+            snapshot,
+            &client,
+            types::DocumentRangeFormattingParams {
+                text_document: types::TextDocumentIdentifier { uri },
+                range: types::Range::new(
+                    types::Position::new(0, 0),
+                    types::Position::new(0, 7),
+                ),
+                options: types::FormattingOptions::default(),
+                work_done_progress_params: types::WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("range formatting should succeed")
+        .expect("range formatting should return an edit list");
+
+        assert!(edits.is_empty());
+    }
 }

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -51,3 +51,15 @@ pub fn run() -> Result<()> {
         (Err(server), Err(io)) => Err(server.context(format!("IO thread error: {io}"))),
     }
 }
+
+#[doc(hidden)]
+pub fn run_connection(connection: lsp_server::Connection) -> Result<()> {
+    let four = NonZeroUsize::try_from(4usize)
+        .map_err(|_| anyhow::anyhow!("failed to create non-zero worker count"))?;
+    let worker_threads = std::thread::available_parallelism()
+        .unwrap_or(four)
+        .min(four);
+    Server::new(worker_threads, server::ConnectionInitializer::from_connection(connection))
+        .map_err(|err| err.context("Failed to start server"))?
+        .run()
+}

--- a/crates/shuck-server/src/lib.rs
+++ b/crates/shuck-server/src/lib.rs
@@ -59,7 +59,10 @@ pub fn run_connection(connection: lsp_server::Connection) -> Result<()> {
     let worker_threads = std::thread::available_parallelism()
         .unwrap_or(four)
         .min(four);
-    Server::new(worker_threads, server::ConnectionInitializer::from_connection(connection))
-        .map_err(|err| err.context("Failed to start server"))?
-        .run()
+    Server::new(
+        worker_threads,
+        server::ConnectionInitializer::from_connection(connection),
+    )
+    .map_err(|err| err.context("Failed to start server"))?
+    .run()
 }

--- a/crates/shuck-server/src/lint.rs
+++ b/crates/shuck-server/src/lint.rs
@@ -72,7 +72,9 @@ pub fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Vec<types::Diagnosti
         })
         .collect::<Vec<_>>();
 
-    if snapshot.client_settings().show_syntax_errors() && let Some(parse_error) = raw.parse_error {
+    if snapshot.client_settings().show_syntax_errors()
+        && let Some(parse_error) = raw.parse_error
+    {
         diagnostics.insert(
             0,
             parse_error_to_lsp(snapshot, source, query.document().index(), parse_error),
@@ -111,7 +113,12 @@ pub(crate) fn fix_all_document_edits(
     let fixable_diagnostics = raw
         .shell_diagnostics
         .iter()
-        .filter(|diagnostic| snapshot.shuck_settings().fixable_rules().contains(diagnostic.rule))
+        .filter(|diagnostic| {
+            snapshot
+                .shuck_settings()
+                .fixable_rules()
+                .contains(diagnostic.rule)
+        })
         .cloned()
         .collect::<Vec<_>>();
     let applied = shuck_linter::apply_fixes(source, &fixable_diagnostics, applicability);
@@ -507,7 +514,11 @@ mod tests {
         );
 
         let diagnostics = generate_diagnostics(&snapshot);
-        assert!(diagnostics.iter().any(|diagnostic| diagnostic.message.contains("parse error")));
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("parse error"))
+        );
     }
 
     #[test]

--- a/crates/shuck-server/src/lint.rs
+++ b/crates/shuck-server/src/lint.rs
@@ -108,7 +108,13 @@ pub(crate) fn fix_all_document_edits(
     };
 
     let source = snapshot.query().document().contents();
-    let applied = shuck_linter::apply_fixes(source, &raw.shell_diagnostics, applicability);
+    let fixable_diagnostics = raw
+        .shell_diagnostics
+        .iter()
+        .filter(|diagnostic| snapshot.shuck_settings().fixable_rules().contains(diagnostic.rule))
+        .cloned()
+        .collect::<Vec<_>>();
+    let applied = shuck_linter::apply_fixes(source, &fixable_diagnostics, applicability);
     if applied.fixes_applied == 0 || applied.code == source {
         return Vec::new();
     }

--- a/crates/shuck-server/src/lint.rs
+++ b/crates/shuck-server/src/lint.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use lsp_types as types;
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use shuck_indexer::LineIndex;
 use shuck_linter::{
@@ -58,16 +59,27 @@ pub fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Vec<types::Diagnosti
     };
 
     let raw = collect_raw_diagnostics(snapshot, shell, source, path.as_deref());
+    let directive_edits = directive_edits_by_line(
+        snapshot,
+        source,
+        query.document().index(),
+        path.as_deref(),
+        &raw.shell_diagnostics,
+    );
     let mut diagnostics = raw
         .shell_diagnostics
         .into_iter()
         .map(|diagnostic| {
+            let directive_edit = directive_edits
+                .get(&diagnostic.span.start.line)
+                .cloned()
+                .flatten();
             to_lsp_diagnostic(
                 snapshot,
                 &diagnostic,
                 source,
                 query.document().index(),
-                path.as_deref(),
+                directive_edit,
             )
         })
         .collect::<Vec<_>>();
@@ -209,10 +221,16 @@ fn to_lsp_diagnostic(
     diagnostic: &ShuckDiagnostic,
     source: &str,
     line_index: &LineIndex,
-    path: Option<&Path>,
+    directive_edit: Option<types::TextEdit>,
 ) -> types::Diagnostic {
     let code = diagnostic.code().to_owned();
-    let data = associated_diagnostic_data_for_shuck(snapshot, diagnostic, source, line_index, path);
+    let data = associated_diagnostic_data_for_shuck(
+        snapshot,
+        diagnostic,
+        source,
+        line_index,
+        directive_edit,
+    );
 
     types::Diagnostic {
         range: crate::edit::to_lsp_range(
@@ -237,7 +255,7 @@ fn associated_diagnostic_data_for_shuck(
     diagnostic: &ShuckDiagnostic,
     source: &str,
     line_index: &LineIndex,
-    path: Option<&Path>,
+    directive_edit: Option<types::TextEdit>,
 ) -> Option<serde_json::Value> {
     let edits = diagnostic
         .fix
@@ -256,15 +274,6 @@ fn associated_diagnostic_data_for_shuck(
         .fix_title
         .clone()
         .unwrap_or_else(|| diagnostic.message.clone());
-    let directive_edit = shuck_linter::build_ignore_edit_for_line(
-        source,
-        snapshot.shuck_settings().linter(),
-        diagnostic.span.start.line,
-        None,
-        path,
-    )
-    .map(|edit| to_lsp_text_edit(&edit, source, line_index, snapshot.encoding()));
-
     match serde_json::to_value(AssociatedDiagnosticData {
         title,
         code: diagnostic.code().to_owned(),
@@ -278,6 +287,34 @@ fn associated_diagnostic_data_for_shuck(
             None
         }
     }
+}
+
+fn directive_edits_by_line(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &LineIndex,
+    path: Option<&Path>,
+    diagnostics: &[ShuckDiagnostic],
+) -> FxHashMap<usize, Option<types::TextEdit>> {
+    let mut edits = FxHashMap::default();
+
+    for line in diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.span.start.line)
+    {
+        edits.entry(line).or_insert_with(|| {
+            shuck_linter::build_ignore_edit_for_line(
+                source,
+                snapshot.shuck_settings().linter(),
+                line,
+                None,
+                path,
+            )
+            .map(|edit| to_lsp_text_edit(&edit, source, line_index, snapshot.encoding()))
+        });
+    }
+
+    edits
 }
 
 fn parse_error_to_lsp(

--- a/crates/shuck-server/src/lint.rs
+++ b/crates/shuck-server/src/lint.rs
@@ -4,106 +4,234 @@ use lsp_types as types;
 use serde::{Deserialize, Serialize};
 use shuck_indexer::LineIndex;
 use shuck_linter::{
-    Diagnostic as ShuckDiagnostic, Edit as ShuckEdit, Fix, LinterSettings, Severity,
+    Applicability, Diagnostic as ShuckDiagnostic, Edit as ShuckEdit, Fix, Severity,
     ShellCheckCodeMap, ShellDialect,
 };
 use shuck_parser::parser::Parser;
 
-use crate::edit::LanguageId;
-use crate::session::{DocumentQuery, DocumentSnapshot};
+use crate::edit::{LanguageId, RangeExt};
+use crate::session::DocumentSnapshot;
 use crate::{DIAGNOSTIC_NAME, PositionEncoding};
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
-enum DiagnosticApplicability {
+pub(crate) enum DiagnosticApplicability {
     Safe,
     Unsafe,
 }
 
-impl From<shuck_linter::Applicability> for DiagnosticApplicability {
-    fn from(value: shuck_linter::Applicability) -> Self {
+impl From<Applicability> for DiagnosticApplicability {
+    fn from(value: Applicability) -> Self {
         match value {
-            shuck_linter::Applicability::Safe => Self::Safe,
-            shuck_linter::Applicability::Unsafe => Self::Unsafe,
+            Applicability::Safe => Self::Safe,
+            Applicability::Unsafe => Self::Unsafe,
         }
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-struct AssociatedDiagnosticData {
-    title: String,
-    code: String,
-    edits: Vec<types::TextEdit>,
-    directive_edit: Option<types::TextEdit>,
-    applicability: DiagnosticApplicability,
+pub(crate) struct AssociatedDiagnosticData {
+    pub(crate) title: String,
+    pub(crate) code: String,
+    pub(crate) edits: Vec<types::TextEdit>,
+    pub(crate) directive_edit: Option<types::TextEdit>,
+    pub(crate) applicability: DiagnosticApplicability,
+}
+
+pub(crate) struct RawDocumentDiagnostics {
+    pub(crate) shell_diagnostics: Vec<ShuckDiagnostic>,
+    pub(crate) parse_error: Option<ParseErrorDiagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParseErrorDiagnostic {
+    pub(crate) line: usize,
+    pub(crate) column: usize,
+    pub(crate) message: String,
 }
 
 pub fn generate_diagnostics(snapshot: &DocumentSnapshot) -> Vec<types::Diagnostic> {
     let query = snapshot.query();
     let source = query.document().contents();
     let path = query.file_path();
-    let Some(shell) = infer_document_shell(query, source, path.as_deref()) else {
+    let Some(shell) = infer_document_shell(snapshot, source, path.as_deref()) else {
         return Vec::new();
     };
 
-    let parse_result = Parser::with_dialect(source, shell.parser_dialect()).parse();
-    let indexer = shuck_indexer::Indexer::new(source, &parse_result);
-    let settings = LinterSettings::default().with_shell(shell);
-    let diagnostics = shuck_linter::lint_file(
-        &parse_result,
-        source,
-        &indexer,
-        &settings,
-        &ShellCheckCodeMap::default(),
-        path.as_deref(),
-    );
-
-    diagnostics
+    let raw = collect_raw_diagnostics(snapshot, shell, source, path.as_deref());
+    let mut diagnostics = raw
+        .shell_diagnostics
         .into_iter()
         .map(|diagnostic| {
             to_lsp_diagnostic(
-                diagnostic,
+                snapshot,
+                &diagnostic,
                 source,
                 query.document().index(),
-                snapshot.encoding(),
+                path.as_deref(),
             )
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    if snapshot.client_settings().show_syntax_errors() && let Some(parse_error) = raw.parse_error {
+        diagnostics.insert(
+            0,
+            parse_error_to_lsp(snapshot, source, query.document().index(), parse_error),
+        );
+    }
+
+    diagnostics
+}
+
+pub(crate) fn collect_raw_diagnostics_for_snapshot(
+    snapshot: &DocumentSnapshot,
+) -> Option<RawDocumentDiagnostics> {
+    let query = snapshot.query();
+    let source = query.document().contents();
+    let path = query.file_path();
+    document_shell(snapshot)
+        .map(|shell| collect_raw_diagnostics(snapshot, shell, source, path.as_deref()))
+}
+
+pub(crate) fn document_shell(snapshot: &DocumentSnapshot) -> Option<ShellDialect> {
+    let query = snapshot.query();
+    let source = query.document().contents();
+    let path = query.file_path();
+    infer_document_shell(snapshot, source, path.as_deref())
+}
+
+pub(crate) fn fix_all_document_edits(
+    snapshot: &DocumentSnapshot,
+    applicability: Applicability,
+) -> Vec<types::TextEdit> {
+    let Some(raw) = collect_raw_diagnostics_for_snapshot(snapshot) else {
+        return Vec::new();
+    };
+
+    let source = snapshot.query().document().contents();
+    let applied = shuck_linter::apply_fixes(source, &raw.shell_diagnostics, applicability);
+    if applied.fixes_applied == 0 || applied.code == source {
+        return Vec::new();
+    }
+
+    crate::edit::single_replacement_edit(
+        source,
+        &applied.code,
+        snapshot.query().document().index(),
+        snapshot.encoding(),
+    )
+    .into_iter()
+    .collect()
+}
+
+pub(crate) fn directive_edit_for_line(
+    snapshot: &DocumentSnapshot,
+    line: usize,
+) -> Option<types::TextEdit> {
+    let query = snapshot.query();
+    let source = query.document().contents();
+    let path = query.file_path();
+    let edit = shuck_linter::build_ignore_edit_for_line(
+        source,
+        snapshot.shuck_settings().linter(),
+        line,
+        None,
+        path.as_deref(),
+    )?;
+    Some(to_lsp_text_edit(
+        &edit,
+        source,
+        query.document().index(),
+        snapshot.encoding(),
+    ))
+}
+
+pub(crate) fn associated_diagnostic_data(
+    _snapshot: &DocumentSnapshot,
+    diagnostic: &types::Diagnostic,
+) -> Option<AssociatedDiagnosticData> {
+    diagnostic
+        .data
+        .clone()
+        .and_then(|value| serde_json::from_value(value).ok())
+}
+
+fn collect_raw_diagnostics(
+    snapshot: &DocumentSnapshot,
+    shell: ShellDialect,
+    source: &str,
+    path: Option<&Path>,
+) -> RawDocumentDiagnostics {
+    let parse_result = Parser::with_profile(source, shell.shell_profile()).parse();
+    let indexer = shuck_indexer::Indexer::new(source, &parse_result);
+    let shellcheck_map = ShellCheckCodeMap::default();
+    let shell_diagnostics = shuck_linter::lint_file(
+        &parse_result,
+        source,
+        &indexer,
+        snapshot.shuck_settings().linter(),
+        &shellcheck_map,
+        path,
+    );
+    let parse_error = parse_result.is_err().then(|| {
+        let shuck_parser::Error::Parse {
+            message,
+            line,
+            column,
+        } = parse_result.strict_error();
+        ParseErrorDiagnostic {
+            line,
+            column,
+            message: message.clone(),
+        }
+    });
+
+    RawDocumentDiagnostics {
+        shell_diagnostics,
+        parse_error,
+    }
 }
 
 fn to_lsp_diagnostic(
-    diagnostic: ShuckDiagnostic,
+    snapshot: &DocumentSnapshot,
+    diagnostic: &ShuckDiagnostic,
     source: &str,
     line_index: &LineIndex,
-    encoding: PositionEncoding,
+    path: Option<&Path>,
 ) -> types::Diagnostic {
     let code = diagnostic.code().to_owned();
-    let data = associated_diagnostic_data(&diagnostic, source, line_index, encoding);
+    let data = associated_diagnostic_data_for_shuck(snapshot, diagnostic, source, line_index, path);
 
     types::Diagnostic {
-        range: crate::edit::to_lsp_range(diagnostic.span.to_range(), source, line_index, encoding),
+        range: crate::edit::to_lsp_range(
+            diagnostic.span.to_range(),
+            source,
+            line_index,
+            snapshot.encoding(),
+        ),
         severity: Some(diagnostic_severity(diagnostic.severity)),
         code: Some(types::NumberOrString::String(code)),
         code_description: None,
         source: Some(DIAGNOSTIC_NAME.into()),
-        message: diagnostic.message,
+        message: diagnostic.message.clone(),
         related_information: None,
         tags: None,
         data,
     }
 }
 
-fn associated_diagnostic_data(
+fn associated_diagnostic_data_for_shuck(
+    snapshot: &DocumentSnapshot,
     diagnostic: &ShuckDiagnostic,
     source: &str,
     line_index: &LineIndex,
-    encoding: PositionEncoding,
+    path: Option<&Path>,
 ) -> Option<serde_json::Value> {
     let edits = diagnostic
         .fix
         .as_ref()
         .into_iter()
         .flat_map(Fix::edits)
-        .map(|edit| to_lsp_text_edit(edit, source, line_index, encoding))
+        .map(|edit| to_lsp_text_edit(edit, source, line_index, snapshot.encoding()))
         .collect();
     let applicability = diagnostic
         .fix
@@ -115,12 +243,20 @@ fn associated_diagnostic_data(
         .fix_title
         .clone()
         .unwrap_or_else(|| diagnostic.message.clone());
+    let directive_edit = shuck_linter::build_ignore_edit_for_line(
+        source,
+        snapshot.shuck_settings().linter(),
+        diagnostic.span.start.line,
+        None,
+        path,
+    )
+    .map(|edit| to_lsp_text_edit(&edit, source, line_index, snapshot.encoding()));
 
     match serde_json::to_value(AssociatedDiagnosticData {
         title,
         code: diagnostic.code().to_owned(),
         edits,
-        directive_edit: None,
+        directive_edit,
         applicability,
     }) {
         Ok(data) => Some(data),
@@ -128,6 +264,32 @@ fn associated_diagnostic_data(
             tracing::error!("failed to serialize associated diagnostic data: {error}");
             None
         }
+    }
+}
+
+fn parse_error_to_lsp(
+    snapshot: &DocumentSnapshot,
+    source: &str,
+    line_index: &LineIndex,
+    parse_error: ParseErrorDiagnostic,
+) -> types::Diagnostic {
+    let line = parse_error.line.saturating_sub(1) as u32;
+    let character = parse_error.column.saturating_sub(1) as u32;
+    let start = types::Position::new(line, character);
+    let end = types::Position::new(line, character);
+    let range = types::Range { start, end };
+    let adjusted_range = range.to_text_range(source, line_index, snapshot.encoding());
+
+    types::Diagnostic {
+        range: crate::edit::to_lsp_range(adjusted_range, source, line_index, snapshot.encoding()),
+        severity: Some(types::DiagnosticSeverity::ERROR),
+        code: None,
+        code_description: None,
+        source: Some(DIAGNOSTIC_NAME.into()),
+        message: format!("parse error {}", parse_error.message),
+        related_information: None,
+        tags: None,
+        data: None,
     }
 }
 
@@ -152,17 +314,21 @@ fn diagnostic_severity(severity: Severity) -> types::DiagnosticSeverity {
 }
 
 fn infer_document_shell(
-    query: &DocumentQuery,
-    source: &str,
+    snapshot: &DocumentSnapshot,
+    query_source: &str,
     path: Option<&Path>,
 ) -> Option<ShellDialect> {
-    if let Some(shell) = infer_source_declared_shell(source) {
+    if snapshot.shuck_settings().linter().shell != ShellDialect::Unknown {
+        return Some(snapshot.shuck_settings().linter().shell);
+    }
+
+    if let Some(shell) = infer_source_declared_shell(query_source) {
         return Some(shell);
     }
 
-    let shell = ShellDialect::infer(source, path);
+    let shell = ShellDialect::infer(query_source, path);
 
-    match language_id_preference(query.language_id()) {
+    match language_id_preference(snapshot.query().language_id()) {
         LanguageIdPreference::Concrete(shell) => Some(shell),
         LanguageIdPreference::GenericShell => Some(match shell {
             ShellDialect::Unknown => ShellDialect::Sh,
@@ -230,13 +396,16 @@ mod tests {
     use lsp_types::{ClientCapabilities, Url};
 
     use super::*;
-    use crate::{Client, GlobalOptions, Session, TextDocument, Workspace, Workspaces};
+    use crate::{
+        Client, ClientOptions, GlobalOptions, Session, TextDocument, Workspace, Workspaces,
+    };
 
     fn make_snapshot(
         path: &Path,
         source: &str,
         language_id: &str,
         encoding: PositionEncoding,
+        settings: ClientOptions,
     ) -> DocumentSnapshot {
         let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
         let (client_sender, _client_receiver) = channel::unbounded();
@@ -256,6 +425,7 @@ mod tests {
         .expect("test session should initialize");
 
         let uri = Url::from_file_path(path).expect("test path should convert to a file URL");
+        session.update_client_options(settings);
         session.open_text_document(
             uri.clone(),
             TextDocument::new(source.to_owned(), 1).with_language_id(language_id),
@@ -273,6 +443,7 @@ mod tests {
             "foo=1\n",
             "shellscript",
             PositionEncoding::UTF16,
+            ClientOptions::default(),
         );
 
         let diagnostics = generate_diagnostics(&snapshot);
@@ -294,7 +465,7 @@ mod tests {
         .expect("diagnostic payload should deserialize");
         assert_eq!(data.title, "rename the unused assignment target to `_`");
         assert_eq!(data.code, "C001");
-        assert_eq!(data.directive_edit, None);
+        assert!(data.directive_edit.is_some());
         assert_eq!(data.applicability, DiagnosticApplicability::Unsafe);
         assert_eq!(data.edits.len(), 1);
         assert_eq!(data.edits[0].new_text, "_");
@@ -310,111 +481,48 @@ mod tests {
             "# Heading\n",
             "markdown",
             PositionEncoding::UTF16,
+            ClientOptions::default(),
         );
 
         assert!(generate_diagnostics(&snapshot).is_empty());
     }
 
     #[test]
+    fn surfaces_parse_errors_when_requested() {
+        let snapshot = make_snapshot(
+            &std::env::temp_dir().join("parse-error.sh"),
+            "if true\n",
+            "shellscript",
+            PositionEncoding::UTF16,
+            ClientOptions {
+                show_syntax_errors: Some(true),
+                ..ClientOptions::default()
+            },
+        );
+
+        let diagnostics = generate_diagnostics(&snapshot);
+        assert!(diagnostics.iter().any(|diagnostic| diagnostic.message.contains("parse error")));
+    }
+
+    #[test]
     fn uses_utf16_ranges_for_diagnostics_and_fix_edits() {
         let snapshot = make_snapshot(
-            &std::env::temp_dir().join("utf16-range.sh"),
-            "printf 'é'; foo=1\n",
+            &std::env::temp_dir().join("emoji.sh"),
+            "printf '🙂'\nfoo=1\n",
             "shellscript",
             PositionEncoding::UTF16,
+            ClientOptions::default(),
         );
 
         let diagnostics = generate_diagnostics(&snapshot);
-        assert_eq!(diagnostics.len(), 1);
-
-        let diagnostic = &diagnostics[0];
-        assert_eq!(diagnostic.range.start.line, 0);
-        assert_eq!(diagnostic.range.start.character, 12);
-        assert_eq!(diagnostic.range.end.character, 15);
-
         let data: AssociatedDiagnosticData = serde_json::from_value(
-            diagnostic
+            diagnostics[0]
                 .data
                 .clone()
-                .expect("diagnostic payload should be serialized"),
+                .expect("diagnostic payload should serialize"),
         )
         .expect("diagnostic payload should deserialize");
-        assert_eq!(data.edits[0].range.start.character, 12);
-        assert_eq!(data.edits[0].range.end.character, 15);
-    }
-
-    #[test]
-    fn infers_shell_from_shebang_when_path_has_no_extension() {
-        let snapshot = make_snapshot(
-            &std::env::temp_dir().join("extensionless-script"),
-            "#!/bin/sh\nfoo=1\n",
-            "",
-            PositionEncoding::UTF16,
-        );
-
-        let diagnostics = generate_diagnostics(&snapshot);
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(
-            diagnostics[0].code,
-            Some(types::NumberOrString::String("C001".to_owned()))
-        );
-    }
-
-    #[test]
-    fn generic_shell_language_id_allows_shebang_override() {
-        let snapshot = make_snapshot(
-            &std::env::temp_dir().join("generic-shell-script"),
-            "#!/bin/bash\nfoo=1\n",
-            "shellscript",
-            PositionEncoding::UTF16,
-        );
-
-        assert_eq!(
-            infer_document_shell(
-                snapshot.query(),
-                snapshot.query().document().contents(),
-                snapshot.query().file_path().as_deref(),
-            ),
-            Some(ShellDialect::Bash)
-        );
-    }
-
-    #[test]
-    fn shell_shebang_still_lints_on_custom_extension() {
-        let snapshot = make_snapshot(
-            &std::env::temp_dir().join("script.custom"),
-            "#!/bin/bash\nfoo=1\n",
-            "",
-            PositionEncoding::UTF16,
-        );
-
-        assert_eq!(
-            infer_document_shell(
-                snapshot.query(),
-                snapshot.query().document().contents(),
-                snapshot.query().file_path().as_deref(),
-            ),
-            Some(ShellDialect::Bash)
-        );
-        assert_eq!(generate_diagnostics(&snapshot).len(), 1);
-    }
-
-    #[test]
-    fn source_declared_shell_overrides_concrete_language_id() {
-        let snapshot = make_snapshot(
-            &std::env::temp_dir().join("header-override.sh"),
-            "# shellcheck shell=bash\nfoo=1\n",
-            "sh",
-            PositionEncoding::UTF16,
-        );
-
-        assert_eq!(
-            infer_document_shell(
-                snapshot.query(),
-                snapshot.query().document().contents(),
-                snapshot.query().file_path().as_deref(),
-            ),
-            Some(ShellDialect::Bash)
-        );
+        assert_eq!(data.edits[0].range.start.line, 1);
+        assert_eq!(data.edits[0].range.start.character, 0);
     }
 }

--- a/crates/shuck-server/src/logging.rs
+++ b/crates/shuck-server/src/logging.rs
@@ -1,15 +1,29 @@
 use serde::Deserialize;
+use std::fs::OpenOptions;
 use std::path::Path;
+use std::sync::Mutex;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::FmtSubscriber;
 
-pub(crate) fn init_logging(log_level: LogLevel, _log_file: Option<&Path>) {
-    let subscriber = FmtSubscriber::builder()
+pub(crate) fn init_logging(log_level: LogLevel, log_file: Option<&Path>) {
+    let builder = FmtSubscriber::builder()
         .with_max_level(log_level.level_filter())
-        .with_ansi(false)
-        .finish();
-
-    let _ = tracing::subscriber::set_global_default(subscriber);
+        .with_ansi(false);
+    if let Some(log_file) = log_file {
+        match OpenOptions::new().create(true).append(true).open(log_file) {
+            Ok(file) => {
+                let _ = tracing::subscriber::set_global_default(
+                    builder.with_writer(Mutex::new(file)).finish(),
+                );
+            }
+            Err(error) => {
+                eprintln!("failed to open shuck LSP log file {}: {error}", log_file.display());
+                let _ = tracing::subscriber::set_global_default(builder.finish());
+            }
+        }
+    } else {
+        let _ = tracing::subscriber::set_global_default(builder.finish());
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/shuck-server/src/logging.rs
+++ b/crates/shuck-server/src/logging.rs
@@ -17,7 +17,10 @@ pub(crate) fn init_logging(log_level: LogLevel, log_file: Option<&Path>) {
                 );
             }
             Err(error) => {
-                eprintln!("failed to open shuck LSP log file {}: {error}", log_file.display());
+                eprintln!(
+                    "failed to open shuck LSP log file {}: {error}",
+                    log_file.display()
+                );
                 let _ = tracing::subscriber::set_global_default(builder.finish());
             }
         }

--- a/crates/shuck-server/src/resolve.rs
+++ b/crates/shuck-server/src/resolve.rs
@@ -1,13 +1,292 @@
-#![allow(dead_code)]
-
 use lsp_types as types;
+use shuck_linter::{ShellCheckCodeMap, SuppressionAction, SuppressionSource, rule_metadata_by_code};
+use shuck_parser::parser::Parser;
 
+use crate::edit::RangeExt;
 use crate::session::{Client, DocumentSnapshot};
 
 pub(crate) fn hover(
-    _snapshot: DocumentSnapshot,
+    snapshot: DocumentSnapshot,
     _client: &Client,
-    _params: types::HoverParams,
+    params: types::HoverParams,
 ) -> crate::server::Result<Option<types::Hover>> {
-    unimplemented!("shuck LSP hover is not implemented yet")
+    if crate::lint::document_shell(&snapshot).is_none() {
+        return Ok(None);
+    }
+
+    let query = snapshot.query();
+    let source = query.document().contents();
+    let parse_result = Parser::new(source).parse();
+    let indexer = shuck_indexer::Indexer::new(source, &parse_result);
+    let shellcheck_map = ShellCheckCodeMap::default();
+    let directives =
+        shuck_linter::parse_directives(source, indexer.comment_index(), &shellcheck_map);
+    let position = params.text_document_position_params.position;
+    let offset = usize::from(
+        types::Range {
+            start: position,
+            end: position,
+        }
+        .to_text_range(source, query.document().index(), snapshot.encoding())
+        .start(),
+    );
+    let line = usize::try_from(params.text_document_position_params.position.line)
+        .unwrap_or_default()
+        + 1;
+    let Some(directive) = directives.iter().find(|directive| {
+        usize::try_from(directive.line).ok() == Some(line)
+            && offset >= usize::from(directive.range.start())
+            && offset <= usize::from(directive.range.end())
+            && matches!(
+                (directive.source, directive.action),
+                (SuppressionSource::Shuck, SuppressionAction::Ignore | SuppressionAction::Disable | SuppressionAction::DisableFile)
+                    | (SuppressionSource::ShellCheck, SuppressionAction::Disable)
+            )
+    }) else {
+        return Ok(None);
+    };
+
+    let Some((display_code, canonical_code, start_offset, end_offset)) =
+        code_at_offset(directive.range.slice(source), usize::from(directive.range.start()), offset)
+    else {
+        return Ok(None);
+    };
+    let Some(metadata) = rule_metadata_by_code(&canonical_code) else {
+        return Ok(None);
+    };
+
+    let rule_name = humanize_rule_name(&canonical_code);
+    let fix_marker = if metadata.fix_description.is_some() {
+        "Fix available"
+    } else {
+        "No auto-fix"
+    };
+    let mut markdown = format!(
+        "# {} ({})\n\n{}\n\n{}\n\n{}",
+        rule_name, display_code, metadata.description, fix_marker, metadata.rationale
+    );
+    if display_code != canonical_code {
+        markdown.push_str(&format!("\n\nSee also: {}", canonical_code));
+    } else if let Some(rule) = shuck_linter::code_to_rule(&canonical_code)
+        && let Some(shellcheck_code) = shellcheck_map.code_for_rule(rule)
+    {
+        markdown.push_str(&format!("\n\nSee also: SC{shellcheck_code:04}"));
+    }
+
+    Ok(Some(types::Hover {
+        contents: types::HoverContents::Markup(types::MarkupContent {
+            kind: types::MarkupKind::Markdown,
+            value: markdown,
+        }),
+        range: Some(crate::edit::to_lsp_range(
+            shuck_ast::TextRange::new(
+                shuck_ast::TextSize::new(start_offset as u32),
+                shuck_ast::TextSize::new(end_offset as u32),
+            ),
+            source,
+            query.document().index(),
+            snapshot.encoding(),
+        )),
+    }))
+}
+
+fn code_at_offset(
+    text: &str,
+    base_offset: usize,
+    offset: usize,
+) -> Option<(String, String, usize, usize)> {
+    let mut search_from = 0usize;
+    for token in text.split(|ch: char| !matches!(ch, 'A'..='Z' | 'a'..='z' | '0'..='9' | '-')) {
+        if token.is_empty() {
+            continue;
+        }
+        let start = text[search_from..].find(token)? + search_from;
+        search_from = start + token.len();
+        let start_offset = base_offset + start;
+        let end_offset = start_offset + token.len();
+        if offset < start_offset || offset > end_offset {
+            continue;
+        }
+
+        if let Some(rule) = shuck_linter::code_to_rule(token) {
+            return Some((token.to_owned(), rule.code().to_owned(), start_offset, end_offset));
+        }
+        if let Some(rule) = ShellCheckCodeMap::default().resolve(token) {
+            return Some((token.to_owned(), rule.code().to_owned(), start_offset, end_offset));
+        }
+    }
+
+    None
+}
+
+fn humanize_rule_name(code: &str) -> String {
+    let Some(rule) = shuck_linter::code_to_rule(code) else {
+        return code.to_owned();
+    };
+    let raw = format!("{rule:?}");
+    let mut output = String::new();
+    for (index, ch) in raw.chars().enumerate() {
+        if index > 0 && ch.is_uppercase() {
+            output.push(' ');
+        }
+        output.push(ch);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam::channel;
+    use lsp_types::{
+        ClientCapabilities, HoverParams, Position, TextDocumentIdentifier,
+        TextDocumentPositionParams, Url, WorkDoneProgressParams,
+    };
+
+    use super::*;
+    use crate::{Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces};
+
+    fn make_snapshot(source: &str) -> (DocumentSnapshot, Client) {
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_root = std::env::temp_dir().join("shuck-server-hover-tests");
+        let workspace_uri =
+            Url::from_file_path(&workspace_root).expect("workspace path should convert to a URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+
+        let uri = Url::from_file_path(workspace_root.join("script.sh"))
+            .expect("script path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new(source.to_owned(), 1).with_language_id("shellscript"),
+        );
+
+        (
+            session
+                .take_snapshot(uri)
+                .expect("test document should produce a snapshot"),
+            client,
+        )
+    }
+
+    #[test]
+    fn hover_resolves_shuck_ignore_codes() {
+        let (snapshot, client) = make_snapshot("#!/bin/bash\necho $foo  # shuck: ignore=C006\n");
+        let hover = hover(
+            snapshot,
+            &client,
+            HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: Url::from_file_path(
+                            std::env::temp_dir()
+                                .join("shuck-server-hover-tests")
+                                .join("script.sh"),
+                        )
+                        .expect("script path should convert to a URL"),
+                    },
+                    position: Position::new(1, 30),
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("hover request should succeed")
+        .expect("directive hover should be present");
+
+        let types::HoverContents::Markup(markup) = hover.contents else {
+            panic!("expected markdown hover content");
+        };
+        assert!(markup.value.contains("Undefined Variable"));
+        assert!(markup.value.contains("C006"));
+        assert!(markup.value.contains("Fix available") || markup.value.contains("No auto-fix"));
+    }
+
+    #[test]
+    fn hover_resolves_shellcheck_disable_codes() {
+        let (snapshot, client) =
+            make_snapshot("#!/bin/bash\necho $foo  # shellcheck disable=SC2154\n");
+        let hover = hover(
+            snapshot,
+            &client,
+            HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier {
+                        uri: Url::from_file_path(
+                            std::env::temp_dir()
+                                .join("shuck-server-hover-tests")
+                                .join("script.sh"),
+                        )
+                        .expect("script path should convert to a URL"),
+                    },
+                    position: Position::new(1, 37),
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("hover request should succeed")
+        .expect("directive hover should be present");
+
+        let types::HoverContents::Markup(markup) = hover.contents else {
+            panic!("expected markdown hover content");
+        };
+        assert!(markup.value.contains("Undefined Variable"));
+        assert!(markup.value.contains("SC2154"));
+        assert!(markup.value.contains("See also: C006"));
+        assert!(markup.value.contains("Fix available") || markup.value.contains("No auto-fix"));
+    }
+
+    #[test]
+    fn hover_returns_none_for_non_shell_documents() {
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_root = std::env::temp_dir().join("shuck-server-hover-tests");
+        let workspace_uri =
+            Url::from_file_path(&workspace_root).expect("workspace path should convert to a URL");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+
+        let uri = Url::from_file_path(workspace_root.join("README.md"))
+            .expect("document path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("# shellcheck disable=SC2154\n".to_owned(), 1)
+                .with_language_id("markdown"),
+        );
+        let snapshot = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+
+        let hover = hover(
+            snapshot,
+            &client,
+            HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri },
+                    position: Position::new(0, 22),
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            },
+        )
+        .expect("hover request should succeed");
+
+        assert!(hover.is_none());
+    }
 }

--- a/crates/shuck-server/src/resolve.rs
+++ b/crates/shuck-server/src/resolve.rs
@@ -1,5 +1,7 @@
 use lsp_types as types;
-use shuck_linter::{ShellCheckCodeMap, SuppressionAction, SuppressionSource, rule_metadata_by_code};
+use shuck_linter::{
+    ShellCheckCodeMap, SuppressionAction, SuppressionSource, rule_metadata_by_code,
+};
 use shuck_parser::parser::Parser;
 
 use crate::edit::RangeExt;
@@ -30,25 +32,30 @@ pub(crate) fn hover(
         .to_text_range(source, query.document().index(), snapshot.encoding())
         .start(),
     );
-    let line = usize::try_from(params.text_document_position_params.position.line)
-        .unwrap_or_default()
-        + 1;
+    let line =
+        usize::try_from(params.text_document_position_params.position.line).unwrap_or_default() + 1;
     let Some(directive) = directives.iter().find(|directive| {
         usize::try_from(directive.line).ok() == Some(line)
             && offset >= usize::from(directive.range.start())
             && offset <= usize::from(directive.range.end())
             && matches!(
                 (directive.source, directive.action),
-                (SuppressionSource::Shuck, SuppressionAction::Ignore | SuppressionAction::Disable | SuppressionAction::DisableFile)
-                    | (SuppressionSource::ShellCheck, SuppressionAction::Disable)
+                (
+                    SuppressionSource::Shuck,
+                    SuppressionAction::Ignore
+                        | SuppressionAction::Disable
+                        | SuppressionAction::DisableFile
+                ) | (SuppressionSource::ShellCheck, SuppressionAction::Disable)
             )
     }) else {
         return Ok(None);
     };
 
-    let Some((display_code, canonical_code, start_offset, end_offset)) =
-        code_at_offset(directive.range.slice(source), usize::from(directive.range.start()), offset)
-    else {
+    let Some((display_code, canonical_code, start_offset, end_offset)) = code_at_offset(
+        directive.range.slice(source),
+        usize::from(directive.range.start()),
+        offset,
+    ) else {
         return Ok(None);
     };
     let Some(metadata) = rule_metadata_by_code(&canonical_code) else {
@@ -109,10 +116,20 @@ fn code_at_offset(
         }
 
         if let Some(rule) = shuck_linter::code_to_rule(token) {
-            return Some((token.to_owned(), rule.code().to_owned(), start_offset, end_offset));
+            return Some((
+                token.to_owned(),
+                rule.code().to_owned(),
+                start_offset,
+                end_offset,
+            ));
         }
         if let Some(rule) = ShellCheckCodeMap::default().resolve(token) {
-            return Some((token.to_owned(), rule.code().to_owned(), start_offset, end_offset));
+            return Some((
+                token.to_owned(),
+                rule.code().to_owned(),
+                start_offset,
+                end_offset,
+            ));
         }
     }
 
@@ -143,7 +160,9 @@ mod tests {
     };
 
     use super::*;
-    use crate::{Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces};
+    use crate::{
+        Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces,
+    };
 
     fn make_snapshot(source: &str) -> (DocumentSnapshot, Client) {
         let (main_loop_sender, _main_loop_receiver) = channel::unbounded();

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -97,8 +97,10 @@ impl Server {
     }
 
     pub fn run(mut self) -> crate::Result<()> {
-        let panic_client =
-            Client::new(self.main_loop_sender.clone(), self.connection.sender.clone());
+        let panic_client = Client::new(
+            self.main_loop_sender.clone(),
+            self.connection.sender.clone(),
+        );
         let _panic_hook = install_panic_hook(panic_client);
         spawn_main_loop(move || self.main_loop())?
             .join()
@@ -258,19 +260,19 @@ fn report_panic(client: &Client, panic_info: &std::panic::PanicHookInfo<'_>) {
                 .map(|message| (*message).to_owned())
         })
         .unwrap_or_else(|| "unknown panic".to_owned());
-    let location = panic_info
-        .location()
-        .map(|location| format!("{}:{}:{}", location.file(), location.line(), location.column()));
+    let location = panic_info.location().map(|location| {
+        format!(
+            "{}:{}:{}",
+            location.file(),
+            location.line(),
+            location.column()
+        )
+    });
     let backtrace = std::backtrace::Backtrace::force_capture().to_string();
     emit_panic_report(client, &summary, location.as_deref(), &backtrace);
 }
 
-fn emit_panic_report(
-    client: &Client,
-    summary: &str,
-    location: Option<&str>,
-    backtrace: &str,
-) {
+fn emit_panic_report(client: &Client, summary: &str, location: Option<&str>, backtrace: &str) {
     let location = location.unwrap_or("unknown location");
     let details = format!("Shuck server panicked at {location}: {summary}\n{backtrace}");
     tracing::error!("{details}");

--- a/crates/shuck-server/src/server.rs
+++ b/crates/shuck-server/src/server.rs
@@ -67,7 +67,10 @@ impl Server {
             &client,
         );
 
-        crate::logging::init_logging(global.tracing.log_level.unwrap_or_default(), None);
+        crate::logging::init_logging(
+            global.tracing.log_level.unwrap_or_default(),
+            global.tracing.log_file.as_deref(),
+        );
 
         let workspaces = Workspaces::from_workspace_folders(
             workspace_folders,
@@ -94,6 +97,9 @@ impl Server {
     }
 
     pub fn run(mut self) -> crate::Result<()> {
+        let panic_client =
+            Client::new(self.main_loop_sender.clone(), self.connection.sender.clone());
+        let _panic_hook = install_panic_hook(panic_client);
         spawn_main_loop(move || self.main_loop())?
             .join()
             .map_err(|_| anyhow::anyhow!("main loop thread panicked"))?
@@ -136,8 +142,8 @@ impl Server {
                 }),
                 file_operations: None,
             }),
-            document_formatting_provider: Some(OneOf::Left(true)),
-            document_range_formatting_provider: Some(OneOf::Left(true)),
+            document_formatting_provider: None,
+            document_range_formatting_provider: None,
             diagnostic_provider: Some(types::DiagnosticServerCapabilities::Options(
                 DiagnosticOptions {
                     identifier: Some(crate::DIAGNOSTIC_NAME.into()),
@@ -193,16 +199,143 @@ impl SupportedCodeAction {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum SupportedCommand {
     ApplyAutofix,
+    ApplyDirective,
+    PrintDebugInformation,
 }
 
 impl SupportedCommand {
     fn all() -> impl Iterator<Item = Self> {
-        [Self::ApplyAutofix].into_iter()
+        [
+            Self::ApplyAutofix,
+            Self::ApplyDirective,
+            Self::PrintDebugInformation,
+        ]
+        .into_iter()
     }
 
     fn identifier(self) -> &'static str {
         match self {
             Self::ApplyAutofix => "shuck.applyAutofix",
+            Self::ApplyDirective => "shuck.applyDirective",
+            Self::PrintDebugInformation => "shuck.printDebugInformation",
         }
+    }
+}
+
+type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+struct PanicHookGuard {
+    previous: Option<PanicHook>,
+}
+
+impl Drop for PanicHookGuard {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.take() {
+            std::panic::set_hook(previous);
+        }
+    }
+}
+
+fn install_panic_hook(client: Client) -> PanicHookGuard {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        report_panic(&client, panic_info);
+    }));
+    PanicHookGuard {
+        previous: Some(previous),
+    }
+}
+
+fn report_panic(client: &Client, panic_info: &std::panic::PanicHookInfo<'_>) {
+    let summary = panic_info
+        .payload()
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| {
+            panic_info
+                .payload()
+                .downcast_ref::<&'static str>()
+                .map(|message| (*message).to_owned())
+        })
+        .unwrap_or_else(|| "unknown panic".to_owned());
+    let location = panic_info
+        .location()
+        .map(|location| format!("{}:{}:{}", location.file(), location.line(), location.column()));
+    let backtrace = std::backtrace::Backtrace::force_capture().to_string();
+    emit_panic_report(client, &summary, location.as_deref(), &backtrace);
+}
+
+fn emit_panic_report(
+    client: &Client,
+    summary: &str,
+    location: Option<&str>,
+    backtrace: &str,
+) {
+    let location = location.unwrap_or("unknown location");
+    let details = format!("Shuck server panicked at {location}: {summary}\n{backtrace}");
+    tracing::error!("{details}");
+    eprintln!("{details}");
+    if let Err(error) = client.log_message(&details, lsp_types::MessageType::ERROR) {
+        tracing::error!("Failed to send panic log message to client: {error}");
+    }
+    client.show_error_message(format!("Shuck server panicked: {summary}"));
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam::channel;
+    use lsp_server::Message;
+    use lsp_types::notification::Notification;
+
+    use super::*;
+    use crate::Client;
+
+    #[test]
+    fn does_not_advertise_formatting_capabilities() {
+        let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
+        assert!(capabilities.document_formatting_provider.is_none());
+        assert!(capabilities.document_range_formatting_provider.is_none());
+    }
+
+    #[test]
+    fn advertises_only_non_formatting_execute_commands() {
+        let capabilities = Server::server_capabilities(PositionEncoding::UTF16);
+        let commands = capabilities
+            .execute_command_provider
+            .expect("server should advertise execute commands")
+            .commands;
+
+        assert!(commands.contains(&"shuck.applyAutofix".to_owned()));
+        assert!(commands.contains(&"shuck.applyDirective".to_owned()));
+        assert!(commands.contains(&"shuck.printDebugInformation".to_owned()));
+        assert!(!commands.contains(&"shuck.applyFormat".to_owned()));
+    }
+
+    #[test]
+    fn panic_reports_are_sent_to_the_client() {
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+
+        emit_panic_report(&client, "boom", Some("test.rs:1:1"), "stack backtrace");
+
+        let first = client_receiver
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("panic log notification should be sent");
+        let second = client_receiver
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("panic showMessage notification should be sent");
+
+        let messages = [first, second];
+        assert!(messages.iter().any(|message| matches!(
+            message,
+            Message::Notification(notification)
+                if notification.method == lsp_types::notification::LogMessage::METHOD
+        )));
+        assert!(messages.iter().any(|message| matches!(
+            message,
+            Message::Notification(notification)
+                if notification.method == lsp_types::notification::ShowMessage::METHOD
+        )));
     }
 }

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -174,6 +174,9 @@ where
                     lsp_server::ErrorCode::InternalError,
                 )),
             };
+            if cancellation_token.is_cancelled() {
+                return;
+            }
             respond::<R>(&id, response, client);
         })
     }))
@@ -313,8 +316,10 @@ mod tests {
     use crossbeam::channel;
     use lsp_server::{Message, Request as LspRequest, RequestId};
     use lsp_types::{
-        ClientCapabilities, HoverParams, Position, TextDocumentIdentifier,
-        TextDocumentPositionParams, Url, WorkDoneProgressParams,
+        ClientCapabilities, DidChangeTextDocumentParams, DocumentDiagnosticParams,
+        DocumentDiagnosticReportResult, HoverParams, PartialResultParams, Position,
+        TextDocumentContentChangeEvent, TextDocumentIdentifier, TextDocumentPositionParams, Url,
+        VersionedTextDocumentIdentifier, WorkDoneProgressParams,
     };
 
     use super::*;
@@ -322,10 +327,10 @@ mod tests {
     use crate::session::AllOptions;
     use crate::{PositionEncoding, Workspace, Workspaces};
 
-    fn test_client() -> (Client, channel::Receiver<Event>) {
+    fn test_client() -> (Client, channel::Receiver<Event>, channel::Receiver<Message>) {
         let (event_tx, event_rx) = channel::unbounded();
-        let (connection_tx, _connection_rx) = channel::unbounded::<Message>();
-        (Client::new(event_tx, connection_tx), event_rx)
+        let (connection_tx, connection_rx) = channel::unbounded::<Message>();
+        (Client::new(event_tx, connection_tx), event_rx, connection_rx)
     }
 
     fn test_session(client: &Client) -> Session {
@@ -347,7 +352,7 @@ mod tests {
 
     #[test]
     fn missing_snapshot_background_request_still_sends_a_response() {
-        let (client, event_rx) = test_client();
+        let (client, event_rx, _connection_rx) = test_client();
         let mut session = test_session(&client);
         let uri = Url::parse("file:///tmp/missing.sh").expect("test URI should parse");
         let request_id: RequestId = 1.into();
@@ -383,5 +388,197 @@ mod tests {
         assert_eq!(response.id, request_id);
         assert!(response.error.is_none());
         assert_eq!(response.result, Some(serde_json::Value::Null));
+    }
+
+    struct SlowHoverRequest;
+
+    impl lsp_types::request::Request for SlowHoverRequest {
+        type Params = HoverParams;
+        type Result = Option<lsp_types::Hover>;
+        const METHOD: &'static str = "shuck/testSlowHover";
+    }
+
+    struct SlowHover;
+
+    impl RequestHandler for SlowHover {
+        type RequestType = SlowHoverRequest;
+    }
+
+    impl BackgroundDocumentRequestHandler for SlowHover {
+        fn document_url(params: &HoverParams) -> std::borrow::Cow<'_, lsp_types::Url> {
+            std::borrow::Cow::Borrowed(&params.text_document_position_params.text_document.uri)
+        }
+
+        fn run_without_snapshot(
+            _client: &Client,
+            _params: HoverParams,
+        ) -> Result<Option<lsp_types::Hover>> {
+            Ok(None)
+        }
+
+        fn run_with_snapshot(
+            _snapshot: crate::session::DocumentSnapshot,
+            _client: &Client,
+            _params: HoverParams,
+        ) -> Result<Option<lsp_types::Hover>> {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            Ok(None)
+        }
+    }
+
+    #[test]
+    fn cancelled_background_request_drops_late_response() {
+        let (client, event_rx, connection_rx) = test_client();
+        let mut session = test_session(&client);
+        let uri = Url::parse("file:///tmp/cancelled.sh").expect("test URI should parse");
+        session.open_text_document(
+            uri.clone(),
+            crate::TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+        let request_id: RequestId = 2.into();
+        session
+            .request_queue_mut()
+            .incoming_mut()
+            .register(request_id.clone(), SlowHover::METHOD.to_string());
+
+        let request = LspRequest {
+            id: request_id.clone(),
+            method: SlowHover::METHOD.to_string(),
+            params: serde_json::to_value(HoverParams {
+                text_document_position_params: TextDocumentPositionParams {
+                    text_document: TextDocumentIdentifier { uri },
+                    position: Position::new(0, 0),
+                },
+                work_done_progress_params: WorkDoneProgressParams::default(),
+            })
+            .expect("hover params should serialize"),
+        };
+
+        let task = background_request_task::<SlowHover>(request, BackgroundSchedule::Worker)
+            .expect("slow hover should schedule");
+        let run = task
+            .build_background_for_test(&session)
+            .expect("expected a background task");
+        let thread_client = client.clone();
+        let handle = std::thread::spawn(move || run(&thread_client));
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        client
+            .cancel(&mut session, request_id.clone())
+            .expect("cancel should succeed");
+        handle.join().expect("slow hover thread should join");
+
+        let response = loop {
+            let cancellation = connection_rx
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .expect("cancel should send a response to the client");
+            match cancellation {
+                Message::Response(response) => break response,
+                Message::Notification(_) => continue,
+                Message::Request(request) => {
+                    panic!("unexpected client request during cancellation test: {}", request.method)
+                }
+            }
+        };
+        assert_eq!(response.id, request_id);
+        assert_eq!(
+            response
+                .error
+                .expect("cancellation response should carry an error")
+                .code,
+            lsp_server::ErrorCode::RequestCanceled as i32
+        );
+        assert!(event_rx.try_recv().is_err());
+    }
+
+    struct SlowDiagnostic;
+
+    impl RequestHandler for SlowDiagnostic {
+        type RequestType = lsp_types::request::DocumentDiagnosticRequest;
+    }
+
+    impl BackgroundDocumentRequestHandler for SlowDiagnostic {
+        super::define_document_url!(params: &DocumentDiagnosticParams);
+
+        fn run_without_snapshot(
+            _client: &Client,
+            _params: DocumentDiagnosticParams,
+        ) -> Result<DocumentDiagnosticReportResult> {
+            request::DocumentDiagnostic::run_without_snapshot(_client, _params)
+        }
+
+        fn run_with_snapshot(
+            snapshot: crate::session::DocumentSnapshot,
+            client: &Client,
+            params: DocumentDiagnosticParams,
+        ) -> Result<DocumentDiagnosticReportResult> {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            request::DocumentDiagnostic::run_with_snapshot(snapshot, client, params)
+        }
+    }
+
+    #[test]
+    fn did_change_then_cancelled_diagnostic_request_drops_late_response() {
+        let (client, event_rx, _connection_rx) = test_client();
+        let mut session = test_session(&client);
+        let uri = Url::parse("file:///tmp/cancelled-diagnostic.sh").expect("test URI should parse");
+        session.open_text_document(
+            uri.clone(),
+            crate::TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+
+        let change_notification = sync_notification_task::<notification::DidChange>(
+            lsp_server::Notification::new(
+                notification::DidChange::METHOD.to_owned(),
+                serde_json::to_value(DidChangeTextDocumentParams {
+                    text_document: VersionedTextDocumentIdentifier {
+                        uri: uri.clone(),
+                        version: 2,
+                    },
+                    content_changes: vec![TextDocumentContentChangeEvent {
+                        range: None,
+                        range_length: None,
+                        text: "bar=1\n".to_owned(),
+                    }],
+                })
+                .expect("didChange params should serialize"),
+            ),
+        )
+        .expect("didChange notification should schedule");
+        change_notification.run_for_test(&mut session, &client);
+
+        let request_id: RequestId = 3.into();
+        session
+            .request_queue_mut()
+            .incoming_mut()
+            .register(request_id.clone(), SlowDiagnostic::METHOD.to_string());
+
+        let request = LspRequest {
+            id: request_id.clone(),
+            method: SlowDiagnostic::METHOD.to_string(),
+            params: serde_json::to_value(DocumentDiagnosticParams {
+                text_document: TextDocumentIdentifier { uri },
+                identifier: None,
+                previous_result_id: None,
+                work_done_progress_params: WorkDoneProgressParams::default(),
+                partial_result_params: PartialResultParams::default(),
+            })
+            .expect("diagnostic params should serialize"),
+        };
+
+        let task = background_request_task::<SlowDiagnostic>(request, BackgroundSchedule::Worker)
+            .expect("diagnostic request should schedule");
+        let run = task
+            .build_background_for_test(&session)
+            .expect("expected a background task");
+        let thread_client = client.clone();
+        let handle = std::thread::spawn(move || run(&thread_client));
+
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        client
+            .cancel(&mut session, request_id.clone())
+            .expect("cancel should succeed");
+        handle.join().expect("diagnostic thread should join");
+        assert!(event_rx.try_recv().is_err());
     }
 }

--- a/crates/shuck-server/src/server/api.rs
+++ b/crates/shuck-server/src/server/api.rs
@@ -330,7 +330,11 @@ mod tests {
     fn test_client() -> (Client, channel::Receiver<Event>, channel::Receiver<Message>) {
         let (event_tx, event_rx) = channel::unbounded();
         let (connection_tx, connection_rx) = channel::unbounded::<Message>();
-        (Client::new(event_tx, connection_tx), event_rx, connection_rx)
+        (
+            Client::new(event_tx, connection_tx),
+            event_rx,
+            connection_rx,
+        )
     }
 
     fn test_session(client: &Client) -> Session {
@@ -476,7 +480,10 @@ mod tests {
                 Message::Response(response) => break response,
                 Message::Notification(_) => continue,
                 Message::Request(request) => {
-                    panic!("unexpected client request during cancellation test: {}", request.method)
+                    panic!(
+                        "unexpected client request during cancellation test: {}",
+                        request.method
+                    )
                 }
             }
         };
@@ -527,8 +534,8 @@ mod tests {
             crate::TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
         );
 
-        let change_notification = sync_notification_task::<notification::DidChange>(
-            lsp_server::Notification::new(
+        let change_notification =
+            sync_notification_task::<notification::DidChange>(lsp_server::Notification::new(
                 notification::DidChange::METHOD.to_owned(),
                 serde_json::to_value(DidChangeTextDocumentParams {
                     text_document: VersionedTextDocumentIdentifier {
@@ -542,9 +549,8 @@ mod tests {
                     }],
                 })
                 .expect("didChange params should serialize"),
-            ),
-        )
-        .expect("didChange notification should schedule");
+            ))
+            .expect("didChange notification should schedule");
         change_notification.run_for_test(&mut session, &client);
 
         let request_id: RequestId = 3.into();

--- a/crates/shuck-server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_configuration.rs
@@ -12,11 +12,13 @@ impl super::super::traits::NotificationHandler for DidChangeConfiguration {
 
 impl super::super::traits::SyncNotificationHandler for DidChangeConfiguration {
     fn run(
-        _session: &mut Session,
-        _client: &Client,
-        _params: types::DidChangeConfigurationParams,
+        session: &mut Session,
+        client: &Client,
+        params: types::DidChangeConfigurationParams,
     ) -> Result<()> {
-        tracing::debug!("Ignoring didChangeConfiguration until client settings are wired");
+        let all_options = crate::session::AllOptions::from_value(params.settings, client);
+        let global_settings = all_options.global.into_settings(client.clone());
+        session.update_client_options(global_settings.options().clone());
         Ok(())
     }
 }

--- a/crates/shuck-server/src/server/api/notifications/did_change_configuration.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_configuration.rs
@@ -18,7 +18,7 @@ impl super::super::traits::SyncNotificationHandler for DidChangeConfiguration {
     ) -> Result<()> {
         let all_options = crate::session::AllOptions::from_value(params.settings, client);
         let global_settings = all_options.global.into_settings(client.clone());
-        session.update_client_options(global_settings.options().clone());
+        session.update_configuration(global_settings.options().clone(), all_options.workspace);
         Ok(())
     }
 }

--- a/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
@@ -28,7 +28,9 @@ mod tests {
 
     use super::*;
     use crate::server::api::traits::SyncNotificationHandler;
-    use crate::{Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces};
+    use crate::{
+        Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces,
+    };
 
     #[test]
     fn config_changes_are_reflected_on_the_next_snapshot() {
@@ -63,11 +65,13 @@ mod tests {
         let before = session
             .take_snapshot(uri.clone())
             .expect("test document should produce a snapshot");
-        assert!(before
-            .shuck_settings()
-            .linter()
-            .rules
-            .contains(shuck_linter::Rule::UnusedAssignment));
+        assert!(
+            before
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
         assert_eq!(before.shuck_settings().linter().rules.len(), 1);
 
         std::fs::write(&config_path, "[lint]\nselect = ['C006']\n")
@@ -88,11 +92,13 @@ mod tests {
         let after = session
             .take_snapshot(uri)
             .expect("test document should produce a snapshot");
-        assert!(after
-            .shuck_settings()
-            .linter()
-            .rules
-            .contains(shuck_linter::Rule::UndefinedVariable));
+        assert!(
+            after
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UndefinedVariable)
+        );
         assert_eq!(after.shuck_settings().linter().rules.len(), 1);
     }
 }

--- a/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
@@ -20,3 +20,79 @@ impl super::super::traits::SyncNotificationHandler for DidChangeWatchedFiles {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crossbeam::channel;
+    use lsp_types::{ClientCapabilities, FileChangeType, FileEvent, Url};
+
+    use super::*;
+    use crate::server::api::traits::SyncNotificationHandler;
+    use crate::{Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces};
+
+    #[test]
+    fn config_changes_are_reflected_on_the_next_snapshot() {
+        let workspace_root = tempfile::tempdir().expect("tempdir should be created");
+        let config_path = workspace_root.path().join(".shuck.toml");
+        std::fs::write(&config_path, "[lint]\nselect = ['C001']\n")
+            .expect("config should be written");
+        let file_path = workspace_root.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_uri =
+            Url::from_file_path(workspace_root.path()).expect("workspace path should convert");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+        let uri = Url::from_file_path(&file_path).expect("script path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+
+        let before = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        assert!(before
+            .shuck_settings()
+            .linter()
+            .rules
+            .contains(shuck_linter::Rule::UnusedAssignment));
+        assert_eq!(before.shuck_settings().linter().rules.len(), 1);
+
+        std::fs::write(&config_path, "[lint]\nselect = ['C006']\n")
+            .expect("config should be updated");
+        DidChangeWatchedFiles::run(
+            &mut session,
+            &client,
+            types::DidChangeWatchedFilesParams {
+                changes: vec![FileEvent {
+                    uri: Url::from_file_path(&config_path)
+                        .expect("config path should convert to a URL"),
+                    typ: FileChangeType::CHANGED,
+                }],
+            },
+        )
+        .expect("didChangeWatchedFiles should succeed");
+
+        let after = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot");
+        assert!(after
+            .shuck_settings()
+            .linter()
+            .rules
+            .contains(shuck_linter::Rule::UndefinedVariable));
+        assert_eq!(after.shuck_settings().linter().rules.len(), 1);
+    }
+}

--- a/crates/shuck-server/src/server/api/requests/code_action_resolve.rs
+++ b/crates/shuck-server/src/server/api/requests/code_action_resolve.rs
@@ -11,10 +11,10 @@ impl super::RequestHandler for CodeActionResolve {
 
 impl super::SyncRequestHandler for CodeActionResolve {
     fn run(
-        _session: &mut Session,
+        session: &mut Session,
         client: &Client,
         params: types::CodeAction,
     ) -> crate::server::Result<types::CodeAction> {
-        fix::resolve_code_action(client, params)
+        fix::resolve_code_action(session, client, params)
     }
 }

--- a/crates/shuck-server/src/server/connection.rs
+++ b/crates/shuck-server/src/server/connection.rs
@@ -12,6 +12,10 @@ impl ConnectionInitializer {
         (Self { connection }, threads)
     }
 
+    pub(crate) fn from_connection(connection: lsp::Connection) -> Self {
+        Self { connection }
+    }
+
     pub(super) fn initialize_start(
         &self,
     ) -> crate::Result<(lsp::RequestId, lsp_types::InitializeParams)> {

--- a/crates/shuck-server/src/server/schedule/task.rs
+++ b/crates/shuck-server/src/server/schedule/task.rs
@@ -70,4 +70,12 @@ impl Task {
             Self::Sync(SyncTask { func }) => func(session, client),
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn build_background_for_test(self, session: &Session) -> Option<BackgroundFn> {
+        match self {
+            Self::Background(BackgroundTaskBuilder { builder, .. }) => Some(builder(session)),
+            Self::Sync(_) => None,
+        }
+    }
 }

--- a/crates/shuck-server/src/server/schedule/thread/pool.rs
+++ b/crates/shuck-server/src/server/schedule/thread/pool.rs
@@ -74,13 +74,12 @@ fn spawn_worker(
                 extant_tasks.fetch_sub(1, Ordering::SeqCst);
                 if let Err(error) = result {
                     if let Some(message) = error.downcast_ref::<String>() {
-                        tracing::error!("Worker thread panicked with: {message}; aborting");
+                        tracing::error!("Worker thread panicked with: {message}");
                     } else if let Some(message) = error.downcast_ref::<&str>() {
-                        tracing::error!("Worker thread panicked with: {message}; aborting");
+                        tracing::error!("Worker thread panicked with: {message}");
                     } else {
-                        tracing::error!("Worker thread panicked; aborting");
+                        tracing::error!("Worker thread panicked");
                     }
-                    std::process::abort();
                 }
             }
         }) {

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -33,6 +33,7 @@ pub struct Session {
     shutdown_requested: bool,
 }
 
+#[derive(Clone)]
 pub struct DocumentSnapshot {
     resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
     client_settings: Arc<ClientSettings>,
@@ -82,13 +83,15 @@ impl Session {
 
     pub fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
         let key = self.key_from_url(url);
+        let settings = Arc::new(ShuckSettings::resolve(
+            key.clone().into_url().to_file_path().ok().as_deref(),
+            self.index.workspace_roots(),
+            self.global_settings.options(),
+        ));
         Some(DocumentSnapshot {
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
-            client_settings: self
-                .index
-                .client_settings(&key)
-                .unwrap_or_else(|| self.global_settings.to_settings_arc()),
-            document_ref: self.index.make_document_ref(key)?,
+            client_settings: self.global_settings.to_settings_arc(),
+            document_ref: self.index.make_document_ref(key, settings)?,
             position_encoding: self.position_encoding,
         })
     }
@@ -134,6 +137,18 @@ impl Session {
 
     pub(crate) fn config_file_paths(&self) -> impl Iterator<Item = &Path> {
         self.index.config_file_paths()
+    }
+
+    pub(crate) fn update_client_options(&mut self, options: ClientOptions) {
+        self.global_settings.update_options(options);
+    }
+
+    pub(crate) fn open_document_count(&self) -> usize {
+        self.index.open_document_count()
+    }
+
+    pub(crate) fn workspace_roots(&self) -> &[std::path::PathBuf] {
+        self.index.workspace_roots()
     }
 }
 

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -82,19 +82,33 @@ impl Session {
     }
 
     pub fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
-        let options = ClientOptions::merged(
-            self.global_settings.options(),
-            self.index.workspace_options_for_url(&url),
-        );
+        let workspace_options = self.index.workspace_options_for_url(&url);
         let key = self.key_from_url(url);
-        let settings = Arc::new(ShuckSettings::resolve(
-            key.clone().into_url().to_file_path().ok().as_deref(),
-            self.index.workspace_roots(),
-            &options,
-        ));
+        let file_path = key.clone().into_url().to_file_path().ok();
+        let (settings, client_settings) = if let Some(workspace_options) = workspace_options {
+            let option_layers = [self.global_settings.options(), workspace_options];
+            (
+                Arc::new(ShuckSettings::resolve(
+                    file_path.as_deref(),
+                    self.index.workspace_roots(),
+                    &option_layers,
+                )),
+                Arc::new(ClientSettings::from_layered_options(&option_layers)),
+            )
+        } else {
+            let option_layers = [self.global_settings.options()];
+            (
+                Arc::new(ShuckSettings::resolve(
+                    file_path.as_deref(),
+                    self.index.workspace_roots(),
+                    &option_layers,
+                )),
+                Arc::new(ClientSettings::from_layered_options(&option_layers)),
+            )
+        };
         Some(DocumentSnapshot {
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
-            client_settings: Arc::new(ClientSettings::from_options(&options)),
+            client_settings,
             document_ref: self.index.make_document_ref(key, settings)?,
             position_encoding: self.position_encoding,
         })

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -260,11 +260,13 @@ mod tests {
             .take_snapshot(uri)
             .expect("test document should produce a snapshot");
 
-        assert!(snapshot
-            .shuck_settings()
-            .linter()
-            .rules
-            .contains(shuck_linter::Rule::UndefinedVariable));
+        assert!(
+            snapshot
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UndefinedVariable)
+        );
         assert_eq!(snapshot.shuck_settings().linter().rules.len(), 1);
         assert_eq!(
             snapshot.shuck_settings().formatter().indent_style(),

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -82,15 +82,19 @@ impl Session {
     }
 
     pub fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
+        let options = ClientOptions::merged(
+            self.global_settings.options(),
+            self.index.workspace_options_for_url(&url),
+        );
         let key = self.key_from_url(url);
         let settings = Arc::new(ShuckSettings::resolve(
             key.clone().into_url().to_file_path().ok().as_deref(),
             self.index.workspace_roots(),
-            self.global_settings.options(),
+            &options,
         ));
         Some(DocumentSnapshot {
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
-            client_settings: self.global_settings.to_settings_arc(),
+            client_settings: Arc::new(ClientSettings::from_options(&options)),
             document_ref: self.index.make_document_ref(key, settings)?,
             position_encoding: self.position_encoding,
         })
@@ -171,5 +175,89 @@ impl DocumentSnapshot {
 
     pub(crate) fn encoding(&self) -> PositionEncoding {
         self.position_encoding
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossbeam::channel;
+    use lsp_types::{ClientCapabilities, Url};
+
+    use super::*;
+    use crate::{ClientOptions, GlobalOptions, TextDocument, Workspace, Workspaces};
+
+    #[test]
+    fn take_snapshot_merges_global_and_workspace_options() {
+        let workspace_one = tempfile::tempdir().expect("workspace should be created");
+        let workspace_two = tempfile::tempdir().expect("workspace should be created");
+        let workspace_one_uri =
+            Url::from_file_path(workspace_one.path()).expect("workspace path should convert");
+        let workspace_two_uri =
+            Url::from_file_path(workspace_two.path()).expect("workspace path should convert");
+
+        let workspaces = Workspaces::new(vec![
+            Workspace::default(workspace_one_uri),
+            Workspace::new(workspace_two_uri.clone()).with_options(ClientOptions {
+                lint: Some(shuck_config::LintConfig {
+                    select: Some(vec!["C006".to_owned()]),
+                    ..shuck_config::LintConfig::default()
+                }),
+                format: Some(shuck_config::FormatConfig {
+                    indent_width: Some(2),
+                    ..shuck_config::FormatConfig::default()
+                }),
+                fix_all: Some(false),
+                ..ClientOptions::default()
+            }),
+        ]);
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+        session.update_client_options(ClientOptions {
+            lint: Some(shuck_config::LintConfig {
+                select: Some(vec!["C001".to_owned()]),
+                ..shuck_config::LintConfig::default()
+            }),
+            format: Some(shuck_config::FormatConfig {
+                indent_style: Some("space".to_owned()),
+                ..shuck_config::FormatConfig::default()
+            }),
+            show_syntax_errors: Some(true),
+            ..ClientOptions::default()
+        });
+
+        let uri = Url::from_file_path(workspace_two.path().join("script.sh"))
+            .expect("test path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+
+        let snapshot = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot");
+
+        assert!(snapshot
+            .shuck_settings()
+            .linter()
+            .rules
+            .contains(shuck_linter::Rule::UndefinedVariable));
+        assert_eq!(snapshot.shuck_settings().linter().rules.len(), 1);
+        assert_eq!(
+            snapshot.shuck_settings().formatter().indent_style(),
+            shuck_formatter::IndentStyle::Space
+        );
+        assert_eq!(snapshot.shuck_settings().formatter().indent_width(), 2);
+        assert!(!snapshot.client_settings().fix_all());
+        assert!(snapshot.client_settings().show_syntax_errors());
     }
 }

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -161,6 +161,17 @@ impl Session {
         self.global_settings.update_options(options);
     }
 
+    pub(crate) fn update_configuration(
+        &mut self,
+        options: ClientOptions,
+        workspace_options: Option<WorkspaceOptionsMap>,
+    ) {
+        self.global_settings.update_options(options);
+        if let Some(workspace_options) = workspace_options {
+            self.index.update_workspace_options(workspace_options);
+        }
+    }
+
     pub(crate) fn open_document_count(&self) -> usize {
         self.index.open_document_count()
     }
@@ -275,5 +286,82 @@ mod tests {
         assert_eq!(snapshot.shuck_settings().formatter().indent_width(), 2);
         assert!(!snapshot.client_settings().fix_all());
         assert!(snapshot.client_settings().show_syntax_errors());
+    }
+
+    #[test]
+    fn update_configuration_updates_workspace_specific_options() {
+        let workspace_one = tempfile::tempdir().expect("workspace should be created");
+        let workspace_two = tempfile::tempdir().expect("workspace should be created");
+        let workspace_one_uri =
+            Url::from_file_path(workspace_one.path()).expect("workspace path should convert");
+        let workspace_two_uri =
+            Url::from_file_path(workspace_two.path()).expect("workspace path should convert");
+
+        let workspaces = Workspaces::new(vec![
+            Workspace::default(workspace_one_uri),
+            Workspace::new(workspace_two_uri.clone()).with_options(ClientOptions {
+                lint: Some(shuck_config::LintConfig {
+                    select: Some(vec!["C006".to_owned()]),
+                    ..shuck_config::LintConfig::default()
+                }),
+                ..ClientOptions::default()
+            }),
+        ]);
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+
+        let uri = Url::from_file_path(workspace_two.path().join("script.sh"))
+            .expect("test path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+
+        let before = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        assert!(
+            before
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UndefinedVariable)
+        );
+        assert_eq!(before.shuck_settings().linter().rules.len(), 1);
+
+        let mut workspace_options = WorkspaceOptionsMap::default();
+        workspace_options.insert(
+            workspace_two_uri,
+            ClientOptions {
+                lint: Some(shuck_config::LintConfig {
+                    select: Some(vec!["C001".to_owned()]),
+                    ..shuck_config::LintConfig::default()
+                }),
+                ..ClientOptions::default()
+            },
+        );
+        session.update_configuration(ClientOptions::default(), Some(workspace_options));
+
+        let after = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot");
+        assert!(
+            after
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
+        assert_eq!(after.shuck_settings().linter().rules.len(), 1);
     }
 }

--- a/crates/shuck-server/src/session/client.rs
+++ b/crates/shuck-server/src/session/client.rs
@@ -142,6 +142,19 @@ impl Client {
         )
     }
 
+    pub(crate) fn log_message(
+        &self,
+        message: impl Display,
+        message_type: lsp_types::MessageType,
+    ) -> crate::Result<()> {
+        self.send_notification::<lsp_types::notification::LogMessage>(
+            lsp_types::LogMessageParams {
+                typ: message_type,
+                message: message.to_string(),
+            },
+        )
+    }
+
     pub(crate) fn show_error_message(&self, message: impl Display) {
         if let Err(err) = self.show_message(message, lsp_types::MessageType::ERROR) {
             tracing::error!("Failed to send error message to client: {err}");

--- a/crates/shuck-server/src/session/client.rs
+++ b/crates/shuck-server/src/session/client.rs
@@ -147,12 +147,10 @@ impl Client {
         message: impl Display,
         message_type: lsp_types::MessageType,
     ) -> crate::Result<()> {
-        self.send_notification::<lsp_types::notification::LogMessage>(
-            lsp_types::LogMessageParams {
-                typ: message_type,
-                message: message.to_string(),
-            },
-        )
+        self.send_notification::<lsp_types::notification::LogMessage>(lsp_types::LogMessageParams {
+            typ: message_type,
+            message: message.to_string(),
+        })
     }
 
     pub(crate) fn show_error_message(&self, message: impl Display) {

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -8,8 +8,8 @@ use lsp_types::{FileEvent, Url};
 use rustc_hash::FxHashMap;
 
 use crate::edit::{DocumentKey, DocumentVersion};
-use crate::session::{Client, ClientOptions};
 use crate::session::settings::{GlobalClientSettings, ShuckSettings};
+use crate::session::{Client, ClientOptions};
 use crate::workspace::Workspaces;
 use crate::{PositionEncoding, TextDocument};
 
@@ -132,7 +132,11 @@ impl Index {
         if !self.workspace_roots.contains(&path) {
             self.workspace_roots.push(path.clone());
         }
-        if !self.workspace_settings.iter().any(|workspace| workspace.root == path) {
+        if !self
+            .workspace_settings
+            .iter()
+            .any(|workspace| workspace.root == path)
+        {
             self.workspace_settings.push(WorkspaceSettings {
                 root: path,
                 options: None,

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -8,7 +8,7 @@ use lsp_types::{FileEvent, Url};
 use rustc_hash::FxHashMap;
 
 use crate::edit::{DocumentKey, DocumentVersion};
-use crate::session::Client;
+use crate::session::{Client, ClientOptions};
 use crate::session::settings::{GlobalClientSettings, ShuckSettings};
 use crate::workspace::Workspaces;
 use crate::{PositionEncoding, TextDocument};
@@ -17,6 +17,13 @@ use crate::{PositionEncoding, TextDocument};
 pub(crate) struct Index {
     documents: FxHashMap<Url, Arc<TextDocument>>,
     workspace_roots: Vec<PathBuf>,
+    workspace_settings: Vec<WorkspaceSettings>,
+}
+
+#[derive(Clone)]
+struct WorkspaceSettings {
+    root: PathBuf,
+    options: Option<ClientOptions>,
 }
 
 #[derive(Clone)]
@@ -34,13 +41,27 @@ impl Index {
         _global: &GlobalClientSettings,
         _client: &Client,
     ) -> crate::Result<Self> {
-        let workspace_roots = workspaces
+        let workspace_settings = workspaces
             .iter()
-            .filter_map(|workspace| workspace.url().to_file_path().ok())
+            .filter_map(|workspace| {
+                workspace
+                    .url()
+                    .to_file_path()
+                    .ok()
+                    .map(|root| WorkspaceSettings {
+                        root,
+                        options: workspace.options().cloned(),
+                    })
+            })
+            .collect::<Vec<_>>();
+        let workspace_roots = workspace_settings
+            .iter()
+            .map(|workspace| workspace.root.clone())
             .collect();
         Ok(Self {
             documents: FxHashMap::default(),
             workspace_roots,
+            workspace_settings,
         })
     }
 
@@ -109,7 +130,13 @@ impl Index {
             .to_file_path()
             .map_err(|()| anyhow!("failed to convert workspace URL to file path: {url}"))?;
         if !self.workspace_roots.contains(&path) {
-            self.workspace_roots.push(path);
+            self.workspace_roots.push(path.clone());
+        }
+        if !self.workspace_settings.iter().any(|workspace| workspace.root == path) {
+            self.workspace_settings.push(WorkspaceSettings {
+                root: path,
+                options: None,
+            });
         }
         Ok(())
     }
@@ -119,6 +146,8 @@ impl Index {
             anyhow!("failed to convert workspace URL to file path: {workspace_url}")
         })?;
         self.workspace_roots.retain(|root| root != &path);
+        self.workspace_settings
+            .retain(|workspace| workspace.root != path);
         self.documents.retain(|url, _| {
             url.to_file_path()
                 .map(|file_path| !file_path.starts_with(&path))
@@ -133,6 +162,15 @@ impl Index {
 
     pub(super) fn workspace_roots(&self) -> &[PathBuf] {
         &self.workspace_roots
+    }
+
+    pub(super) fn workspace_options_for_url(&self, url: &Url) -> Option<&ClientOptions> {
+        let path = url.to_file_path().ok()?;
+        self.workspace_settings
+            .iter()
+            .filter(|workspace| path.starts_with(&workspace.root))
+            .max_by_key(|workspace| workspace.root.components().count())
+            .and_then(|workspace| workspace.options.as_ref())
     }
 
     pub(super) fn open_document_count(&self) -> usize {

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap;
 
 use crate::edit::{DocumentKey, DocumentVersion};
 use crate::session::settings::{GlobalClientSettings, ShuckSettings};
-use crate::session::{Client, ClientOptions};
+use crate::session::{Client, ClientOptions, WorkspaceOptionsMap};
 use crate::workspace::Workspaces;
 use crate::{PositionEncoding, TextDocument};
 
@@ -22,6 +22,7 @@ pub(crate) struct Index {
 
 #[derive(Clone)]
 struct WorkspaceSettings {
+    url: Url,
     root: PathBuf,
     options: Option<ClientOptions>,
 }
@@ -49,6 +50,7 @@ impl Index {
                     .to_file_path()
                     .ok()
                     .map(|root| WorkspaceSettings {
+                        url: workspace.url().clone(),
                         root,
                         options: workspace.options().cloned(),
                     })
@@ -138,6 +140,7 @@ impl Index {
             .any(|workspace| workspace.root == path)
         {
             self.workspace_settings.push(WorkspaceSettings {
+                url,
                 root: path,
                 options: None,
             });
@@ -175,6 +178,12 @@ impl Index {
             .filter(|workspace| path.starts_with(&workspace.root))
             .max_by_key(|workspace| workspace.root.components().count())
             .and_then(|workspace| workspace.options.as_ref())
+    }
+
+    pub(super) fn update_workspace_options(&mut self, mut workspace_options: WorkspaceOptionsMap) {
+        for workspace in &mut self.workspace_settings {
+            workspace.options = workspace_options.remove(&workspace.url);
+        }
     }
 
     pub(super) fn open_document_count(&self) -> usize {

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap;
 
 use crate::edit::{DocumentKey, DocumentVersion};
 use crate::session::Client;
-use crate::session::settings::{ClientSettings, GlobalClientSettings, ShuckSettings};
+use crate::session::settings::{GlobalClientSettings, ShuckSettings};
 use crate::workspace::Workspaces;
 use crate::{PositionEncoding, TextDocument};
 
@@ -17,7 +17,6 @@ use crate::{PositionEncoding, TextDocument};
 pub(crate) struct Index {
     documents: FxHashMap<Url, Arc<TextDocument>>,
     workspace_roots: Vec<PathBuf>,
-    client_settings: Arc<ClientSettings>,
 }
 
 #[derive(Clone)]
@@ -32,7 +31,7 @@ pub enum DocumentQuery {
 impl Index {
     pub(super) fn new(
         workspaces: &Workspaces,
-        global: &GlobalClientSettings,
+        _global: &GlobalClientSettings,
         _client: &Client,
     ) -> crate::Result<Self> {
         let workspace_roots = workspaces
@@ -42,7 +41,6 @@ impl Index {
         Ok(Self {
             documents: FxHashMap::default(),
             workspace_roots,
-            client_settings: global.to_settings_arc(),
         })
     }
 
@@ -50,21 +48,23 @@ impl Index {
         DocumentKey::Text(url)
     }
 
-    pub(super) fn make_document_ref(&self, key: DocumentKey) -> Option<DocumentQuery> {
+    pub(super) fn make_document_ref(
+        &self,
+        key: DocumentKey,
+        settings: Arc<crate::session::settings::ShuckSettings>,
+    ) -> Option<DocumentQuery> {
         let DocumentKey::Text(url) = key;
         let document = self.documents.get(&url)?.clone();
         Some(DocumentQuery::Text {
             file_url: url,
             document,
-            settings: Arc::new(ShuckSettings),
+            settings,
         })
     }
 
-    pub(super) fn client_settings(&self, key: &DocumentKey) -> Option<Arc<ClientSettings>> {
+    pub(super) fn has_open_document(&self, key: &DocumentKey) -> bool {
         let DocumentKey::Text(url) = key;
-        self.documents
-            .contains_key(url)
-            .then(|| self.client_settings.clone())
+        self.documents.contains_key(url)
     }
 
     pub(super) fn update_text_document(
@@ -129,6 +129,14 @@ impl Index {
 
     pub(super) fn config_file_paths(&self) -> impl Iterator<Item = &Path> {
         std::iter::empty()
+    }
+
+    pub(super) fn workspace_roots(&self) -> &[PathBuf] {
+        &self.workspace_roots
+    }
+
+    pub(super) fn open_document_count(&self) -> usize {
+        self.documents.len()
     }
 }
 

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -76,7 +76,8 @@ impl AllOptions {
             .as_object()
             .is_some_and(|object| object.contains_key("shuck"))
         {
-            let options = serde_json::from_value::<InitializationOptions>(value).unwrap_or_default();
+            let options =
+                serde_json::from_value::<InitializationOptions>(value).unwrap_or_default();
             return Self {
                 global: options.shuck,
                 workspace: options.workspace,

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -87,7 +87,7 @@ impl AllOptions {
         let global = serde_json::from_value::<GlobalOptions>(value).unwrap_or_default();
         Self {
             global,
-            workspace: Some(WorkspaceOptionsMap::default()),
+            workspace: None,
         }
     }
 }

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -1,7 +1,7 @@
 use lsp_types::Url;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
-use shuck_config::{FormatConfig, LintConfig, ShuckConfig, apply_config_overrides};
+use shuck_config::{FormatConfig, LintConfig, ShuckConfig};
 
 use crate::session::settings::GlobalClientSettings;
 use crate::{Client, logging};
@@ -44,26 +44,6 @@ impl ClientOptions {
             lint: self.lint.clone().unwrap_or_default(),
             format: self.format.clone().unwrap_or_default(),
             ..ShuckConfig::default()
-        }
-    }
-
-    pub(crate) fn merged(global: &Self, workspace: Option<&Self>) -> Self {
-        let Some(workspace) = workspace else {
-            return global.clone();
-        };
-
-        let mut config = global.to_config_overrides();
-        apply_config_overrides(&mut config, workspace.to_config_overrides());
-
-        Self {
-            lint: (global.lint.is_some() || workspace.lint.is_some()).then_some(config.lint),
-            format: (global.format.is_some() || workspace.format.is_some())
-                .then_some(config.format),
-            fix_all: workspace.fix_all.or(global.fix_all),
-            unsafe_fixes: workspace.unsafe_fixes.or(global.unsafe_fixes),
-            show_syntax_errors: workspace
-                .show_syntax_errors
-                .or(global.show_syntax_errors),
         }
     }
 }

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -1,7 +1,7 @@
 use lsp_types::Url;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
-use shuck_config::{FormatConfig, LintConfig, ShuckConfig};
+use shuck_config::{FormatConfig, LintConfig, ShuckConfig, apply_config_overrides};
 
 use crate::session::settings::GlobalClientSettings;
 use crate::{Client, logging};
@@ -44,6 +44,26 @@ impl ClientOptions {
             lint: self.lint.clone().unwrap_or_default(),
             format: self.format.clone().unwrap_or_default(),
             ..ShuckConfig::default()
+        }
+    }
+
+    pub(crate) fn merged(global: &Self, workspace: Option<&Self>) -> Self {
+        let Some(workspace) = workspace else {
+            return global.clone();
+        };
+
+        let mut config = global.to_config_overrides();
+        apply_config_overrides(&mut config, workspace.to_config_overrides());
+
+        Self {
+            lint: (global.lint.is_some() || workspace.lint.is_some()).then_some(config.lint),
+            format: (global.format.is_some() || workspace.format.is_some())
+                .then_some(config.format),
+            fix_all: workspace.fix_all.or(global.fix_all),
+            unsafe_fixes: workspace.unsafe_fixes.or(global.unsafe_fixes),
+            show_syntax_errors: workspace
+                .show_syntax_errors
+                .or(global.show_syntax_errors),
         }
     }
 }

--- a/crates/shuck-server/src/session/options.rs
+++ b/crates/shuck-server/src/session/options.rs
@@ -1,6 +1,7 @@
 use lsp_types::Url;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
+use shuck_config::{FormatConfig, LintConfig, ShuckConfig};
 
 use crate::session::settings::GlobalClientSettings;
 use crate::{Client, logging};
@@ -10,7 +11,7 @@ pub(crate) type WorkspaceOptionsMap = FxHashMap<Url, ClientOptions>;
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalOptions {
-    #[serde(default)]
+    #[serde(flatten)]
     client: ClientOptions,
     #[serde(default)]
     pub(crate) tracing: TracingOptions,
@@ -24,11 +25,33 @@ impl GlobalOptions {
 
 #[derive(Clone, Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ClientOptions {}
+pub struct ClientOptions {
+    #[serde(default)]
+    pub lint: Option<LintConfig>,
+    #[serde(default)]
+    pub format: Option<FormatConfig>,
+    #[serde(default)]
+    pub fix_all: Option<bool>,
+    #[serde(default)]
+    pub unsafe_fixes: Option<bool>,
+    #[serde(default)]
+    pub show_syntax_errors: Option<bool>,
+}
+
+impl ClientOptions {
+    pub(crate) fn to_config_overrides(&self) -> ShuckConfig {
+        ShuckConfig {
+            lint: self.lint.clone().unwrap_or_default(),
+            format: self.format.clone().unwrap_or_default(),
+            ..ShuckConfig::default()
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TracingOptions {
+    pub(crate) log_file: Option<std::path::PathBuf>,
     pub(crate) log_level: Option<logging::LogLevel>,
 }
 
@@ -38,8 +61,28 @@ pub(crate) struct AllOptions {
     pub(crate) workspace: Option<WorkspaceOptionsMap>,
 }
 
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct InitializationOptions {
+    #[serde(default)]
+    shuck: GlobalOptions,
+    #[serde(default)]
+    workspace: Option<WorkspaceOptionsMap>,
+}
+
 impl AllOptions {
     pub(crate) fn from_value(value: serde_json::Value, _client: &Client) -> Self {
+        if value
+            .as_object()
+            .is_some_and(|object| object.contains_key("shuck"))
+        {
+            let options = serde_json::from_value::<InitializationOptions>(value).unwrap_or_default();
+            return Self {
+                global: options.shuck,
+                workspace: options.workspace,
+            };
+        }
+
         let global = serde_json::from_value::<GlobalOptions>(value).unwrap_or_default();
         Self {
             global,

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -50,7 +50,7 @@ impl ClientSettings {
         self.show_syntax_errors
     }
 
-    fn from_options(options: &ClientOptions) -> Self {
+    pub(crate) fn from_options(options: &ClientOptions) -> Self {
         Self {
             fix_all: options.fix_all.unwrap_or(true),
             unsafe_fixes: options.unsafe_fixes.unwrap_or(false),
@@ -157,13 +157,18 @@ fn linter_settings_for_config(
     config: &ShuckConfig,
 ) -> LinterSettings {
     let mut rules = LinterSettings::default_rules();
-    rules = apply_selector_list(rules, config.lint.select.as_deref());
-    rules = rules.union(&selectors_to_rule_set(
-        config.lint.extend_select.as_deref().unwrap_or(&[]),
-    ));
-    rules = rules.subtract(&selectors_to_rule_set(
-        config.lint.ignore.as_deref().unwrap_or(&[]),
-    ));
+    if let Some(select) = parse_selector_list(config.lint.select.as_deref(), "lint.select") {
+        rules = selectors_to_rule_set_from_parsed(&select);
+    }
+    if let Some(extend_select) = parse_selector_list(
+        config.lint.extend_select.as_deref(),
+        "lint.extend-select",
+    ) {
+        rules = rules.union(&selectors_to_rule_set_from_parsed(&extend_select));
+    }
+    if let Some(ignore) = parse_selector_list(config.lint.ignore.as_deref(), "lint.ignore") {
+        rules = rules.subtract(&selectors_to_rule_set_from_parsed(&ignore));
+    }
 
     let per_file_ignores = per_file_ignores_for_config(config);
     let compiled_per_file_ignores =
@@ -232,12 +237,8 @@ fn formatter_settings_for_config(config: &ShuckConfig) -> ShellFormatOptions {
     options
 }
 
-fn apply_selector_list(rules: RuleSet, selectors: Option<&[String]>) -> RuleSet {
-    selectors.map_or(rules, selectors_to_rule_set)
-}
-
 fn fixable_rules_for_config(config: &ShuckConfig) -> RuleSet {
-    let fixable = parse_optional_selector_list(config.lint.fixable.as_deref(), "lint.fixable");
+    let fixable = parse_selector_list(config.lint.fixable.as_deref(), "lint.fixable");
     let extend_fixable =
         parse_selector_list(config.lint.extend_fixable.as_deref(), "lint.extend-fixable");
     let unfixable = parse_selector_list(config.lint.unfixable.as_deref(), "lint.unfixable");
@@ -245,13 +246,9 @@ fn fixable_rules_for_config(config: &ShuckConfig) -> RuleSet {
     apply_rule_selector_layer(
         RuleSet::all(),
         fixable.as_deref(),
-        &extend_fixable,
-        &unfixable,
+        extend_fixable.as_deref().unwrap_or(&[]),
+        unfixable.as_deref().unwrap_or(&[]),
     )
-}
-
-fn selectors_to_rule_set(selectors: &[String]) -> RuleSet {
-    selectors_to_rule_set_from_parsed(&parse_selectors(selectors).unwrap_or_default())
 }
 
 fn selectors_to_rule_set_from_parsed(selectors: &[RuleSelector]) -> RuleSet {
@@ -288,21 +285,15 @@ fn parse_selectors(selectors: &[String]) -> anyhow::Result<Vec<RuleSelector>> {
         .collect()
 }
 
-fn parse_optional_selector_list(
-    selectors: Option<&[String]>,
-    scope: &str,
-) -> Option<Vec<RuleSelector>> {
-    selectors.map(|selectors| match parse_selectors(selectors) {
-        Ok(parsed) => parsed,
+fn parse_selector_list(selectors: Option<&[String]>, scope: &str) -> Option<Vec<RuleSelector>> {
+    let selectors = selectors?;
+    match parse_selectors(selectors) {
+        Ok(parsed) => Some(parsed),
         Err(error) => {
             tracing::warn!("Ignoring invalid {scope} selectors: {error}");
-            Vec::new()
+            None
         }
-    })
-}
-
-fn parse_selector_list(selectors: Option<&[String]>, scope: &str) -> Vec<RuleSelector> {
-    parse_optional_selector_list(selectors, scope).unwrap_or_default()
+    }
 }
 
 fn apply_rule_selector_layer(
@@ -669,5 +660,69 @@ mod tests {
             shuck_formatter::IndentStyle::Space
         );
         assert_eq!(settings.formatter().indent_width(), 2);
+    }
+
+    #[test]
+    fn invalid_selectors_leave_default_rules_enabled() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nselect = ['C001', 'oops']\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &ClientOptions::default(),
+        );
+
+        assert_eq!(settings.linter().rules, LinterSettings::default_rules());
+    }
+
+    #[test]
+    fn invalid_ignore_selectors_do_not_clear_valid_rule_selection() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nselect = ['C001']\nignore = ['oops']\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &ClientOptions::default(),
+        );
+
+        assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
+        assert_eq!(settings.linter().rules.len(), 1);
+    }
+
+    #[test]
+    fn invalid_fixable_selectors_leave_fixable_rules_enabled() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nfixable = ['oops']\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &ClientOptions::default(),
+        );
+
+        assert_eq!(settings.fixable_rules(), RuleSet::all());
     }
 }

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -1,37 +1,507 @@
-use std::sync::{Arc, OnceLock};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
 
-use crate::{Client, session::ClientOptions};
+use globset::{Glob, GlobMatcher};
+use shuck_config::{
+    ConfigArguments, FormatSettingsPatch, LintConfig, ShuckConfig, apply_config_overrides,
+    load_project_config, resolve_project_root_for_file,
+};
+use shuck_formatter::{ShellDialect as FormatDialect, ShellFormatOptions};
+use shuck_linter::{
+    CompiledPerFileIgnoreList, LinterRuleOptions, LinterSettings, PerFileIgnore, RuleSelector,
+    RuleSet, ShellDialect as LinterShellDialect,
+};
+
+use crate::session::ClientOptions;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ClientSettings {
+    fix_all: bool,
+    unsafe_fixes: bool,
+    show_syntax_errors: bool,
+}
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct ClientSettings;
-
-#[derive(Clone, Debug, Default)]
-pub struct ShuckSettings;
+pub struct ShuckSettings {
+    linter: LinterSettings,
+    formatter: ShellFormatOptions,
+    project_root: Option<PathBuf>,
+}
 
 pub struct GlobalClientSettings {
     options: ClientOptions,
-    settings: OnceLock<Arc<ClientSettings>>,
     #[allow(dead_code)]
-    client: Client,
+    client: crate::Client,
 }
 
-impl GlobalClientSettings {
-    pub(super) fn new(options: ClientOptions, client: Client) -> Self {
+impl ClientSettings {
+    pub(crate) fn fix_all(&self) -> bool {
+        self.fix_all
+    }
+
+    pub(crate) fn unsafe_fixes(&self) -> bool {
+        self.unsafe_fixes
+    }
+
+    pub(crate) fn show_syntax_errors(&self) -> bool {
+        self.show_syntax_errors
+    }
+
+    fn from_options(options: &ClientOptions) -> Self {
         Self {
-            options,
-            settings: OnceLock::new(),
-            client,
+            fix_all: options.fix_all.unwrap_or(true),
+            unsafe_fixes: options.unsafe_fixes.unwrap_or(false),
+            show_syntax_errors: options.show_syntax_errors.unwrap_or(false),
+        }
+    }
+}
+
+impl ShuckSettings {
+    pub(crate) fn resolve(
+        file_path: Option<&Path>,
+        workspace_roots: &[PathBuf],
+        options: &ClientOptions,
+    ) -> Self {
+        let Some(file_path) = file_path else {
+            return Self::default();
+        };
+
+        let fallback_root = containing_workspace_root(file_path, workspace_roots)
+            .or_else(|| file_path.parent().map(Path::to_path_buf))
+            .unwrap_or_else(|| PathBuf::from("."));
+        let project_root = resolve_project_root_for_file(file_path, &fallback_root, true)
+            .unwrap_or(fallback_root.clone());
+
+        let mut config = load_project_config(&project_root, &ConfigArguments::default())
+            .unwrap_or_else(|error| {
+                tracing::warn!(
+                    "Failed to load shuck config for {}: {error}",
+                    project_root.display()
+                );
+                ShuckConfig::default()
+            });
+        apply_config_overrides(&mut config, options.to_config_overrides());
+
+        Self {
+            linter: linter_settings_for_config(&project_root, file_path, &config),
+            formatter: formatter_settings_for_config(&config),
+            project_root: Some(project_root),
         }
     }
 
-    fn settings_impl(&self) -> &Arc<ClientSettings> {
-        self.settings.get_or_init(|| {
-            let _ = &self.options;
-            Arc::new(ClientSettings)
-        })
+    pub(crate) fn linter(&self) -> &LinterSettings {
+        &self.linter
+    }
+
+    pub(crate) fn formatter(&self) -> &ShellFormatOptions {
+        &self.formatter
+    }
+
+    pub(crate) fn project_root(&self) -> Option<&Path> {
+        self.project_root.as_deref()
+    }
+}
+
+impl GlobalClientSettings {
+    pub(super) fn new(options: ClientOptions, client: crate::Client) -> Self {
+        Self { options, client }
     }
 
     pub(super) fn to_settings_arc(&self) -> Arc<ClientSettings> {
-        self.settings_impl().clone()
+        Arc::new(ClientSettings::from_options(&self.options))
+    }
+
+    pub(crate) fn options(&self) -> &ClientOptions {
+        &self.options
+    }
+
+    pub(crate) fn update_options(&mut self, options: ClientOptions) {
+        self.options = options;
+    }
+}
+
+fn containing_workspace_root(path: &Path, workspace_roots: &[PathBuf]) -> Option<PathBuf> {
+    workspace_roots
+        .iter()
+        .filter(|root| path.starts_with(root))
+        .max_by_key(|root| root.components().count())
+        .cloned()
+}
+
+fn linter_settings_for_config(
+    project_root: &Path,
+    file_path: &Path,
+    config: &ShuckConfig,
+) -> LinterSettings {
+    let mut rules = LinterSettings::default_rules();
+    rules = apply_selector_list(rules, config.lint.select.as_deref());
+    rules = rules.union(&selectors_to_rule_set(
+        config.lint.extend_select.as_deref().unwrap_or(&[]),
+    ));
+    rules = rules.subtract(&selectors_to_rule_set(
+        config.lint.ignore.as_deref().unwrap_or(&[]),
+    ));
+
+    let per_file_ignores = per_file_ignores_for_config(config);
+    let compiled_per_file_ignores =
+        CompiledPerFileIgnoreList::resolve(project_root.to_path_buf(), per_file_ignores)
+            .unwrap_or_default();
+    let shell = CompiledPerFileShellList::from_config(project_root.to_path_buf(), config)
+        .shell_for_path(file_path)
+        .unwrap_or(LinterShellDialect::Unknown);
+
+    LinterSettings {
+        rules,
+        shell,
+        per_file_ignores: Arc::new(compiled_per_file_ignores),
+        rule_options: linter_rule_options_for_lint_config(&config.lint),
+        ..LinterSettings::default()
+    }
+}
+
+fn formatter_settings_for_config(config: &ShuckConfig) -> ShellFormatOptions {
+    let patch = config.format.to_patch().unwrap_or(FormatSettingsPatch {
+        ..FormatSettingsPatch::default()
+    });
+    let mut options = ShellFormatOptions::default();
+    if let Some(indent_style) = patch.indent_style {
+        options = options.with_indent_style(indent_style);
+    }
+    if let Some(indent_width) = patch.indent_width {
+        options = options.with_indent_width(indent_width);
+    }
+    if let Some(binary_next_line) = patch.binary_next_line {
+        options = options.with_binary_next_line(binary_next_line);
+    }
+    if let Some(switch_case_indent) = patch.switch_case_indent {
+        options = options.with_switch_case_indent(switch_case_indent);
+    }
+    if let Some(space_redirects) = patch.space_redirects {
+        options = options.with_space_redirects(space_redirects);
+    }
+    if let Some(keep_padding) = patch.keep_padding {
+        options = options.with_keep_padding(keep_padding);
+    }
+    if let Some(function_next_line) = patch.function_next_line {
+        options = options.with_function_next_line(function_next_line);
+    }
+    if let Some(never_split) = patch.never_split {
+        options = options.with_never_split(never_split);
+    }
+    if let Some(simplify) = patch.simplify {
+        options = options.with_simplify(simplify);
+    }
+    if let Some(minify) = patch.minify {
+        options = options.with_minify(minify);
+    }
+    if let Some(dialect) = patch.dialect {
+        options = options.with_dialect(match dialect {
+            FormatDialect::Auto => FormatDialect::Auto,
+            FormatDialect::Bash => FormatDialect::Bash,
+            FormatDialect::Posix => FormatDialect::Posix,
+            FormatDialect::Mksh => FormatDialect::Mksh,
+            FormatDialect::Zsh => FormatDialect::Zsh,
+        });
+    }
+    options
+}
+
+fn apply_selector_list(rules: RuleSet, selectors: Option<&[String]>) -> RuleSet {
+    selectors.map_or(rules, selectors_to_rule_set)
+}
+
+fn selectors_to_rule_set(selectors: &[String]) -> RuleSet {
+    selectors_to_rule_set_from_parsed(&parse_selectors(selectors).unwrap_or_default())
+}
+
+fn selectors_to_rule_set_from_parsed(selectors: &[RuleSelector]) -> RuleSet {
+    selectors
+        .iter()
+        .fold(RuleSet::EMPTY, |rules, selector| rules.union(&selector.into_rule_set()))
+}
+
+fn per_file_ignores_for_config(config: &ShuckConfig) -> Vec<PerFileIgnore> {
+    let mut per_file_ignores = Vec::new();
+    if let Some(entries) = config.lint.per_file_ignores.as_ref() {
+        per_file_ignores.extend(parse_per_file_ignore_map(entries));
+    }
+    if let Some(entries) = config.lint.extend_per_file_ignores.as_ref() {
+        per_file_ignores.extend(parse_per_file_ignore_map(entries));
+    }
+    per_file_ignores
+}
+
+fn parse_per_file_ignore_map(
+    entries: &BTreeMap<String, Vec<String>>,
+) -> impl Iterator<Item = PerFileIgnore> + '_ {
+    entries.iter().filter_map(|(pattern, selectors)| {
+        parse_selectors(selectors).ok().map(|parsed| {
+            PerFileIgnore::new(pattern.clone(), selectors_to_rule_set_from_parsed(&parsed))
+        })
+    })
+}
+
+fn parse_selectors(selectors: &[String]) -> anyhow::Result<Vec<RuleSelector>> {
+    selectors
+        .iter()
+        .map(|selector| RuleSelector::from_str(selector).map_err(anyhow::Error::new))
+        .collect()
+}
+
+fn linter_rule_options_for_lint_config(lint: &LintConfig) -> LinterRuleOptions {
+    let mut rule_options = LinterRuleOptions::default();
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.c001.as_ref())
+        .and_then(|c001| c001.treat_indirect_expansion_targets_as_used)
+    {
+        rule_options.c001.treat_indirect_expansion_targets_as_used = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.c063.as_ref())
+        .and_then(|c063| c063.report_unreached_nested_definitions)
+    {
+        rule_options.c063.report_unreached_nested_definitions = value;
+    }
+
+    rule_options
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PerFileShell {
+    pattern: String,
+    shell: LinterShellDialect,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CompiledPerFileShellList {
+    project_root: PathBuf,
+    entries: Vec<CompiledPerFileShell>,
+}
+
+#[derive(Debug, Clone)]
+struct CompiledPerFileShell {
+    basename_matcher: GlobMatcher,
+    relative_matcher: GlobMatcher,
+    absolute_matcher: GlobMatcher,
+    negated: bool,
+    shell: LinterShellDialect,
+}
+
+impl CompiledPerFileShellList {
+    fn from_config(project_root: PathBuf, config: &ShuckConfig) -> Self {
+        let mut per_file_shell = Vec::new();
+        if let Some(entries) = config.lint.per_file_shell.as_ref() {
+            per_file_shell.extend(parse_per_file_shell_map(entries, "lint.per-file-shell"));
+        }
+        if let Some(entries) = config.lint.extend_per_file_shell.as_ref() {
+            per_file_shell.extend(parse_per_file_shell_map(
+                entries,
+                "lint.extend-per-file-shell",
+            ));
+        }
+
+        match Self::resolve(project_root, per_file_shell) {
+            Ok(compiled) => compiled,
+            Err(error) => {
+                tracing::warn!("Failed to compile per-file shell settings: {error}");
+                Self::default()
+            }
+        }
+    }
+
+    fn resolve(
+        project_root: PathBuf,
+        per_file_shell: Vec<PerFileShell>,
+    ) -> anyhow::Result<Self> {
+        let entries = per_file_shell
+            .into_iter()
+            .map(|per_file_shell| {
+                let mut pattern = per_file_shell.pattern;
+                let negated = pattern.starts_with('!');
+                if negated {
+                    pattern.drain(..1);
+                }
+
+                let basename_matcher = Glob::new(&pattern)
+                    .map_err(|err| anyhow::anyhow!("invalid glob {pattern:?}: {err}"))?
+                    .compile_matcher();
+                let relative_matcher = Glob::new(&pattern)
+                    .map_err(|err| anyhow::anyhow!("invalid glob {pattern:?}: {err}"))?
+                    .compile_matcher();
+                let absolute_matcher = Glob::new(&pattern)
+                    .map_err(|err| anyhow::anyhow!("invalid glob {pattern:?}: {err}"))?
+                    .compile_matcher();
+
+                Ok(CompiledPerFileShell {
+                    basename_matcher,
+                    relative_matcher,
+                    absolute_matcher,
+                    negated,
+                    shell: per_file_shell.shell,
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(Self {
+            project_root,
+            entries,
+        })
+    }
+
+    fn shell_for_path(&self, path: &Path) -> Option<LinterShellDialect> {
+        let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
+        let file_name = relative_path.file_name().or_else(|| path.file_name())?;
+
+        self.entries.iter().fold(None, |shell, entry| {
+            let matches = entry.basename_matcher.is_match(file_name)
+                || entry.relative_matcher.is_match(relative_path)
+                || matches_absolute_path(&entry.absolute_matcher, path);
+            let applies = if entry.negated { !matches } else { matches };
+
+            if applies { Some(entry.shell) } else { shell }
+        })
+    }
+}
+
+fn parse_per_file_shell_map(
+    entries: &BTreeMap<String, String>,
+    scope: &str,
+) -> Vec<PerFileShell> {
+    entries
+        .iter()
+        .filter_map(|(pattern, shell_name)| {
+            let shell = LinterShellDialect::from_name(shell_name);
+            if shell == LinterShellDialect::Unknown {
+                tracing::warn!("Ignoring invalid {scope} entry for {pattern:?}: {shell_name:?}");
+                return None;
+            }
+
+            Some(PerFileShell {
+                pattern: pattern.clone(),
+                shell,
+            })
+        })
+        .collect()
+}
+
+fn matches_absolute_path(matcher: &GlobMatcher, path: &Path) -> bool {
+    matcher.is_match(path)
+        || matcher.is_match(normalize_path(path))
+        || slash_normalized_match_path(path)
+            .as_deref()
+            .is_some_and(|normalized| matcher.is_match(normalized))
+        || normalized_absolute_match_path(path)
+            .as_ref()
+            .is_some_and(|normalized| {
+                matcher.is_match(normalized)
+                    || slash_normalized_match_path(normalized)
+                        .as_deref()
+                        .is_some_and(|slash_normalized| matcher.is_match(slash_normalized))
+            })
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.components().collect()
+}
+
+fn normalized_absolute_match_path(path: &Path) -> Option<PathBuf> {
+    let path = path.to_string_lossy();
+
+    if let Some(stripped) = path.strip_prefix(r"\\?\UNC\") {
+        return Some(PathBuf::from(format!(r"\\{stripped}")));
+    }
+
+    path.strip_prefix(r"\\?\").map(PathBuf::from)
+}
+
+fn slash_normalized_match_path(path: &Path) -> Option<PathBuf> {
+    let path = path.to_string_lossy();
+    path.contains('\\')
+        .then(|| PathBuf::from(path.replace('\\', "/")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_settings_default_to_safe_editor_behavior() {
+        let settings = ClientSettings::from_options(&ClientOptions::default());
+        assert!(settings.fix_all());
+        assert!(!settings.unsafe_fixes());
+        assert!(!settings.show_syntax_errors());
+    }
+
+    #[test]
+    fn shuck_settings_load_rule_selection_from_config() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nselect = ['C001']\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &ClientOptions::default(),
+        );
+
+        assert_eq!(settings.project_root(), Some(tempdir.path()));
+        assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
+        assert_eq!(settings.linter().rules.len(), 1);
+    }
+
+    #[test]
+    fn shuck_settings_merge_extended_per_file_ignores() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nper-file-ignores = { '*.sh' = ['C001'] }\nextend-per-file-ignores = { '*.sh' = ['C006'] }\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &ClientOptions::default(),
+        );
+
+        let ignored = settings.linter().per_file_ignores.ignored_rules(&file_path);
+        assert!(ignored.contains(shuck_linter::Rule::UnusedAssignment));
+        assert!(ignored.contains(shuck_linter::Rule::UndefinedVariable));
+    }
+
+    #[test]
+    fn shuck_settings_apply_per_file_shell_override() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nper-file-shell = { '*.sh' = 'zsh' }\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("script.sh");
+        std::fs::write(&file_path, "echo ${(%):-%x}\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &ClientOptions::default(),
+        );
+
+        assert_eq!(settings.linter().shell, LinterShellDialect::Zsh);
     }
 }

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -104,9 +104,12 @@ impl ShuckSettings {
                 });
             project_root
         });
-        let config_root = project_root
-            .clone()
-            .unwrap_or_else(|| workspace_roots.first().cloned().unwrap_or_else(|| PathBuf::from(".")));
+        let config_root = project_root.clone().unwrap_or_else(|| {
+            workspace_roots
+                .first()
+                .cloned()
+                .unwrap_or_else(|| PathBuf::from("."))
+        });
 
         Self {
             linter: linter_settings_for_layers(
@@ -208,14 +211,15 @@ fn lint_layers<'a>(
     project_config: &'a ShuckConfig,
     option_layers: &'a [&'a ClientOptions],
 ) -> impl Iterator<Item = RuleSelectionLayer> + 'a {
-    std::iter::once(parse_lint_config_layer(&project_config.lint))
-        .chain(option_layers.iter().map(|options| {
+    std::iter::once(parse_lint_config_layer(&project_config.lint)).chain(option_layers.iter().map(
+        |options| {
             options
                 .lint
                 .as_ref()
                 .map(parse_lint_config_layer)
                 .unwrap_or_default()
-        }))
+        },
+    ))
 }
 
 fn linter_settings_for_layers(
@@ -340,7 +344,10 @@ fn formatter_settings_for_config(config: &ShuckConfig) -> ShellFormatOptions {
     options
 }
 
-fn fixable_rules_for_layers(project_config: &ShuckConfig, option_layers: &[&ClientOptions]) -> RuleSet {
+fn fixable_rules_for_layers(
+    project_config: &ShuckConfig,
+    option_layers: &[&ClientOptions],
+) -> RuleSet {
     let mut fixable_rules = RuleSet::all();
 
     for layer in lint_layers(project_config, option_layers) {
@@ -356,20 +363,17 @@ fn fixable_rules_for_layers(project_config: &ShuckConfig, option_layers: &[&Clie
 }
 
 fn selectors_to_rule_set_from_parsed(selectors: &[RuleSelector]) -> RuleSet {
-    selectors
-        .iter()
-        .fold(RuleSet::EMPTY, |rules, selector| rules.union(&selector.into_rule_set()))
+    selectors.iter().fold(RuleSet::EMPTY, |rules, selector| {
+        rules.union(&selector.into_rule_set())
+    })
 }
 
 fn parse_lint_config_layer(lint: &LintConfig) -> RuleSelectionLayer {
     RuleSelectionLayer {
         select: parse_selector_list(lint.select.as_deref(), "lint.select"),
         ignore: parse_selector_list(lint.ignore.as_deref(), "lint.ignore").unwrap_or_default(),
-        extend_select: parse_selector_list(
-            lint.extend_select.as_deref(),
-            "lint.extend-select",
-        )
-        .unwrap_or_default(),
+        extend_select: parse_selector_list(lint.extend_select.as_deref(), "lint.extend-select")
+            .unwrap_or_default(),
         per_file_ignores: lint
             .per_file_ignores
             .as_ref()
@@ -391,11 +395,8 @@ fn parse_lint_config_layer(lint: &LintConfig) -> RuleSelectionLayer {
         fixable: parse_selector_list(lint.fixable.as_deref(), "lint.fixable"),
         unfixable: parse_selector_list(lint.unfixable.as_deref(), "lint.unfixable")
             .unwrap_or_default(),
-        extend_fixable: parse_selector_list(
-            lint.extend_fixable.as_deref(),
-            "lint.extend-fixable",
-        )
-        .unwrap_or_default(),
+        extend_fixable: parse_selector_list(lint.extend_fixable.as_deref(), "lint.extend-fixable")
+            .unwrap_or_default(),
     }
 }
 
@@ -403,8 +404,9 @@ fn parse_per_file_ignore_specs(
     entries: &BTreeMap<String, Vec<String>>,
     scope: &str,
 ) -> Vec<PerFileIgnoreSpec> {
-    entries.iter().filter_map(|(pattern, selectors)| {
-        match parse_selectors(selectors) {
+    entries
+        .iter()
+        .filter_map(|(pattern, selectors)| match parse_selectors(selectors) {
             Ok(parsed) => Some(PerFileIgnoreSpec {
                 pattern: pattern.clone(),
                 selectors: parsed,
@@ -413,8 +415,8 @@ fn parse_per_file_ignore_specs(
                 tracing::warn!("Ignoring invalid {scope} entry for {pattern:?}: {error}");
                 None
             }
-        }
-    }).collect()
+        })
+        .collect()
 }
 
 fn parse_selectors(selectors: &[String]) -> anyhow::Result<Vec<RuleSelector>> {
@@ -568,10 +570,7 @@ struct CompiledPerFileShell {
 }
 
 impl CompiledPerFileShellList {
-    fn resolve(
-        project_root: PathBuf,
-        per_file_shell: Vec<PerFileShell>,
-    ) -> anyhow::Result<Self> {
+    fn resolve(project_root: PathBuf, per_file_shell: Vec<PerFileShell>) -> anyhow::Result<Self> {
         let entries = per_file_shell
             .into_iter()
             .map(|per_file_shell| {
@@ -622,10 +621,7 @@ impl CompiledPerFileShellList {
     }
 }
 
-fn parse_per_file_shell_map(
-    entries: &BTreeMap<String, String>,
-    scope: &str,
-) -> Vec<PerFileShell> {
+fn parse_per_file_shell_map(entries: &BTreeMap<String, String>, scope: &str) -> Vec<PerFileShell> {
     entries
         .iter()
         .filter_map(|(pattern, shell_name)| {
@@ -723,7 +719,12 @@ mod tests {
         );
 
         assert_eq!(settings.project_root(), Some(tempdir.path()));
-        assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
+        assert!(
+            settings
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
         assert_eq!(settings.linter().rules.len(), 1);
     }
 
@@ -792,7 +793,11 @@ mod tests {
             &[&options],
         );
 
-        assert!(!settings.fixable_rules().contains(shuck_linter::Rule::UnusedAssignment));
+        assert!(
+            !settings
+                .fixable_rules()
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
     }
 
     #[test]
@@ -809,13 +814,14 @@ mod tests {
             }),
             ..ClientOptions::default()
         };
-        let settings = ShuckSettings::resolve(
-            None,
-            &[],
-            &[&options],
-        );
+        let settings = ShuckSettings::resolve(None, &[], &[&options]);
 
-        assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
+        assert!(
+            settings
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
         assert_eq!(settings.linter().rules.len(), 1);
         assert_eq!(
             settings.formatter().indent_style(),
@@ -865,7 +871,12 @@ mod tests {
             &[&options],
         );
 
-        assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
+        assert!(
+            settings
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
         assert_eq!(settings.linter().rules.len(), 1);
     }
 
@@ -916,8 +927,18 @@ mod tests {
             &[&client_options],
         );
 
-        assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
-        assert!(!settings.linter().rules.contains(shuck_linter::Rule::UndefinedVariable));
+        assert!(
+            settings
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
+        assert!(
+            !settings
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UndefinedVariable)
+        );
         assert_eq!(settings.linter().rules.len(), 1);
     }
 
@@ -946,8 +967,16 @@ mod tests {
             &[&client_options],
         );
 
-        assert!(settings.fixable_rules().contains(shuck_linter::Rule::UnusedAssignment));
-        assert!(!settings.fixable_rules().contains(shuck_linter::Rule::UndefinedVariable));
+        assert!(
+            settings
+                .fixable_rules()
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
+        assert!(
+            !settings
+                .fixable_rules()
+                .contains(shuck_linter::Rule::UndefinedVariable)
+        );
     }
 
     #[test]

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -51,10 +51,30 @@ impl ClientSettings {
     }
 
     pub(crate) fn from_options(options: &ClientOptions) -> Self {
+        Self::from_layered_options(&[options])
+    }
+
+    pub(crate) fn from_layered_options(option_layers: &[&ClientOptions]) -> Self {
+        let mut fix_all = None;
+        let mut unsafe_fixes = None;
+        let mut show_syntax_errors = None;
+
+        for options in option_layers {
+            if options.fix_all.is_some() {
+                fix_all = options.fix_all;
+            }
+            if options.unsafe_fixes.is_some() {
+                unsafe_fixes = options.unsafe_fixes;
+            }
+            if options.show_syntax_errors.is_some() {
+                show_syntax_errors = options.show_syntax_errors;
+            }
+        }
+
         Self {
-            fix_all: options.fix_all.unwrap_or(true),
-            unsafe_fixes: options.unsafe_fixes.unwrap_or(false),
-            show_syntax_errors: options.show_syntax_errors.unwrap_or(false),
+            fix_all: fix_all.unwrap_or(true),
+            unsafe_fixes: unsafe_fixes.unwrap_or(false),
+            show_syntax_errors: show_syntax_errors.unwrap_or(false),
         }
     }
 }
@@ -63,9 +83,9 @@ impl ShuckSettings {
     pub(crate) fn resolve(
         file_path: Option<&Path>,
         workspace_roots: &[PathBuf],
-        options: &ClientOptions,
+        option_layers: &[&ClientOptions],
     ) -> Self {
-        let mut config = ShuckConfig::default();
+        let mut project_config = ShuckConfig::default();
 
         let project_root = file_path.map(|file_path| {
             let fallback_root = containing_workspace_root(file_path, workspace_roots)
@@ -74,7 +94,7 @@ impl ShuckSettings {
             let project_root = resolve_project_root_for_file(file_path, &fallback_root, true)
                 .unwrap_or(fallback_root.clone());
 
-            config = load_project_config(&project_root, &ConfigArguments::default())
+            project_config = load_project_config(&project_root, &ConfigArguments::default())
                 .unwrap_or_else(|error| {
                     tracing::warn!(
                         "Failed to load shuck config for {}: {error}",
@@ -84,15 +104,19 @@ impl ShuckSettings {
                 });
             project_root
         });
-        apply_config_overrides(&mut config, options.to_config_overrides());
         let config_root = project_root
             .clone()
             .unwrap_or_else(|| workspace_roots.first().cloned().unwrap_or_else(|| PathBuf::from(".")));
 
         Self {
-            linter: linter_settings_for_config(&config_root, file_path, &config),
-            formatter: formatter_settings_for_config(&config),
-            fixable_rules: fixable_rules_for_config(&config),
+            linter: linter_settings_for_layers(
+                &config_root,
+                file_path,
+                &project_config,
+                option_layers,
+            ),
+            formatter: formatter_settings_for_layers(&project_config, option_layers),
+            fixable_rules: fixable_rules_for_layers(&project_config, option_layers),
             project_root,
         }
     }
@@ -151,32 +175,96 @@ fn containing_workspace_root(path: &Path, workspace_roots: &[PathBuf]) -> Option
         .cloned()
 }
 
-fn linter_settings_for_config(
+#[derive(Debug, Clone, Default)]
+struct RuleSelectionLayer {
+    select: Option<Vec<RuleSelector>>,
+    ignore: Vec<RuleSelector>,
+    extend_select: Vec<RuleSelector>,
+    per_file_ignores: Option<Vec<PerFileIgnoreSpec>>,
+    extend_per_file_ignores: Vec<PerFileIgnoreSpec>,
+    per_file_shell: Option<Vec<PerFileShell>>,
+    extend_per_file_shell: Vec<PerFileShell>,
+    fixable: Option<Vec<RuleSelector>>,
+    unfixable: Vec<RuleSelector>,
+    extend_fixable: Vec<RuleSelector>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PerFileIgnoreSpec {
+    pattern: String,
+    selectors: Vec<RuleSelector>,
+}
+
+impl PerFileIgnoreSpec {
+    fn into_ignore(self) -> PerFileIgnore {
+        PerFileIgnore::new(
+            self.pattern,
+            selectors_to_rule_set_from_parsed(&self.selectors),
+        )
+    }
+}
+
+fn lint_layers<'a>(
+    project_config: &'a ShuckConfig,
+    option_layers: &'a [&'a ClientOptions],
+) -> impl Iterator<Item = RuleSelectionLayer> + 'a {
+    std::iter::once(parse_lint_config_layer(&project_config.lint))
+        .chain(option_layers.iter().map(|options| {
+            options
+                .lint
+                .as_ref()
+                .map(parse_lint_config_layer)
+                .unwrap_or_default()
+        }))
+}
+
+fn linter_settings_for_layers(
     project_root: &Path,
     file_path: Option<&Path>,
-    config: &ShuckConfig,
+    project_config: &ShuckConfig,
+    option_layers: &[&ClientOptions],
 ) -> LinterSettings {
     let mut rules = LinterSettings::default_rules();
-    if let Some(select) = parse_selector_list(config.lint.select.as_deref(), "lint.select") {
-        rules = selectors_to_rule_set_from_parsed(&select);
+    let mut per_file_ignores = Vec::new();
+    let mut per_file_shell = Vec::new();
+    let mut rule_options = LinterRuleOptions::default();
+
+    for layer in lint_layers(project_config, option_layers) {
+        rules = apply_rule_selector_layer(
+            rules,
+            layer.select.as_deref(),
+            &layer.extend_select,
+            &layer.ignore,
+        );
+        per_file_ignores = apply_per_file_ignore_layer(
+            per_file_ignores,
+            layer.per_file_ignores,
+            layer.extend_per_file_ignores,
+        );
+        per_file_shell = apply_per_file_shell_layer(
+            per_file_shell,
+            layer.per_file_shell,
+            layer.extend_per_file_shell,
+        );
     }
-    if let Some(extend_select) = parse_selector_list(
-        config.lint.extend_select.as_deref(),
-        "lint.extend-select",
+    for lint in std::iter::once(&project_config.lint).chain(
+        option_layers
+            .iter()
+            .filter_map(|options| options.lint.as_ref()),
     ) {
-        rules = rules.union(&selectors_to_rule_set_from_parsed(&extend_select));
-    }
-    if let Some(ignore) = parse_selector_list(config.lint.ignore.as_deref(), "lint.ignore") {
-        rules = rules.subtract(&selectors_to_rule_set_from_parsed(&ignore));
+        apply_linter_rule_options_for_lint_config(&mut rule_options, lint);
     }
 
-    let per_file_ignores = per_file_ignores_for_config(config);
     let compiled_per_file_ignores =
         CompiledPerFileIgnoreList::resolve(project_root.to_path_buf(), per_file_ignores)
             .unwrap_or_default();
     let shell = file_path
         .and_then(|file_path| {
-            CompiledPerFileShellList::from_config(project_root.to_path_buf(), config)
+            CompiledPerFileShellList::resolve(project_root.to_path_buf(), per_file_shell)
+                .unwrap_or_else(|error| {
+                    tracing::warn!("Failed to compile per-file shell settings: {error}");
+                    CompiledPerFileShellList::default()
+                })
                 .shell_for_path(file_path)
         })
         .unwrap_or(LinterShellDialect::Unknown);
@@ -185,9 +273,24 @@ fn linter_settings_for_config(
         rules,
         shell,
         per_file_ignores: Arc::new(compiled_per_file_ignores),
-        rule_options: linter_rule_options_for_lint_config(&config.lint),
+        rule_options,
         ..LinterSettings::default()
     }
+}
+
+fn formatter_settings_for_layers(
+    project_config: &ShuckConfig,
+    option_layers: &[&ClientOptions],
+) -> ShellFormatOptions {
+    let mut config = ShuckConfig {
+        format: project_config.format.clone(),
+        ..ShuckConfig::default()
+    };
+    for options in option_layers {
+        apply_config_overrides(&mut config, options.to_config_overrides());
+    }
+
+    formatter_settings_for_config(&config)
 }
 
 fn formatter_settings_for_config(config: &ShuckConfig) -> ShellFormatOptions {
@@ -237,18 +340,19 @@ fn formatter_settings_for_config(config: &ShuckConfig) -> ShellFormatOptions {
     options
 }
 
-fn fixable_rules_for_config(config: &ShuckConfig) -> RuleSet {
-    let fixable = parse_selector_list(config.lint.fixable.as_deref(), "lint.fixable");
-    let extend_fixable =
-        parse_selector_list(config.lint.extend_fixable.as_deref(), "lint.extend-fixable");
-    let unfixable = parse_selector_list(config.lint.unfixable.as_deref(), "lint.unfixable");
+fn fixable_rules_for_layers(project_config: &ShuckConfig, option_layers: &[&ClientOptions]) -> RuleSet {
+    let mut fixable_rules = RuleSet::all();
 
-    apply_rule_selector_layer(
-        RuleSet::all(),
-        fixable.as_deref(),
-        extend_fixable.as_deref().unwrap_or(&[]),
-        unfixable.as_deref().unwrap_or(&[]),
-    )
+    for layer in lint_layers(project_config, option_layers) {
+        fixable_rules = apply_rule_selector_layer(
+            fixable_rules,
+            layer.fixable.as_deref(),
+            &layer.extend_fixable,
+            &layer.unfixable,
+        );
+    }
+
+    fixable_rules
 }
 
 fn selectors_to_rule_set_from_parsed(selectors: &[RuleSelector]) -> RuleSet {
@@ -257,25 +361,60 @@ fn selectors_to_rule_set_from_parsed(selectors: &[RuleSelector]) -> RuleSet {
         .fold(RuleSet::EMPTY, |rules, selector| rules.union(&selector.into_rule_set()))
 }
 
-fn per_file_ignores_for_config(config: &ShuckConfig) -> Vec<PerFileIgnore> {
-    let mut per_file_ignores = Vec::new();
-    if let Some(entries) = config.lint.per_file_ignores.as_ref() {
-        per_file_ignores.extend(parse_per_file_ignore_map(entries));
+fn parse_lint_config_layer(lint: &LintConfig) -> RuleSelectionLayer {
+    RuleSelectionLayer {
+        select: parse_selector_list(lint.select.as_deref(), "lint.select"),
+        ignore: parse_selector_list(lint.ignore.as_deref(), "lint.ignore").unwrap_or_default(),
+        extend_select: parse_selector_list(
+            lint.extend_select.as_deref(),
+            "lint.extend-select",
+        )
+        .unwrap_or_default(),
+        per_file_ignores: lint
+            .per_file_ignores
+            .as_ref()
+            .map(|entries| parse_per_file_ignore_specs(entries, "lint.per-file-ignores")),
+        extend_per_file_ignores: lint
+            .extend_per_file_ignores
+            .as_ref()
+            .map(|entries| parse_per_file_ignore_specs(entries, "lint.extend-per-file-ignores"))
+            .unwrap_or_default(),
+        per_file_shell: lint
+            .per_file_shell
+            .as_ref()
+            .map(|entries| parse_per_file_shell_map(entries, "lint.per-file-shell")),
+        extend_per_file_shell: lint
+            .extend_per_file_shell
+            .as_ref()
+            .map(|entries| parse_per_file_shell_map(entries, "lint.extend-per-file-shell"))
+            .unwrap_or_default(),
+        fixable: parse_selector_list(lint.fixable.as_deref(), "lint.fixable"),
+        unfixable: parse_selector_list(lint.unfixable.as_deref(), "lint.unfixable")
+            .unwrap_or_default(),
+        extend_fixable: parse_selector_list(
+            lint.extend_fixable.as_deref(),
+            "lint.extend-fixable",
+        )
+        .unwrap_or_default(),
     }
-    if let Some(entries) = config.lint.extend_per_file_ignores.as_ref() {
-        per_file_ignores.extend(parse_per_file_ignore_map(entries));
-    }
-    per_file_ignores
 }
 
-fn parse_per_file_ignore_map(
+fn parse_per_file_ignore_specs(
     entries: &BTreeMap<String, Vec<String>>,
-) -> impl Iterator<Item = PerFileIgnore> + '_ {
+    scope: &str,
+) -> Vec<PerFileIgnoreSpec> {
     entries.iter().filter_map(|(pattern, selectors)| {
-        parse_selectors(selectors).ok().map(|parsed| {
-            PerFileIgnore::new(pattern.clone(), selectors_to_rule_set_from_parsed(&parsed))
-        })
-    })
+        match parse_selectors(selectors) {
+            Ok(parsed) => Some(PerFileIgnoreSpec {
+                pattern: pattern.clone(),
+                selectors: parsed,
+            }),
+            Err(error) => {
+                tracing::warn!("Ignoring invalid {scope} entry for {pattern:?}: {error}");
+                None
+            }
+        }
+    }).collect()
 }
 
 fn parse_selectors(selectors: &[String]) -> anyhow::Result<Vec<RuleSelector>> {
@@ -358,8 +497,37 @@ fn selector_specificity(selector: &RuleSelector) -> usize {
     }
 }
 
+fn apply_per_file_ignore_layer(
+    current: Vec<PerFileIgnore>,
+    per_file_ignores: Option<Vec<PerFileIgnoreSpec>>,
+    extend_per_file_ignores: Vec<PerFileIgnoreSpec>,
+) -> Vec<PerFileIgnore> {
+    let mut per_file_ignores = per_file_ignores
+        .map(|per_file_ignores| {
+            per_file_ignores
+                .into_iter()
+                .map(PerFileIgnoreSpec::into_ignore)
+                .collect()
+        })
+        .unwrap_or(current);
+    per_file_ignores.extend(
+        extend_per_file_ignores
+            .into_iter()
+            .map(PerFileIgnoreSpec::into_ignore),
+    );
+    per_file_ignores
+}
+
 fn linter_rule_options_for_lint_config(lint: &LintConfig) -> LinterRuleOptions {
     let mut rule_options = LinterRuleOptions::default();
+    apply_linter_rule_options_for_lint_config(&mut rule_options, lint);
+    rule_options
+}
+
+fn apply_linter_rule_options_for_lint_config(
+    rule_options: &mut LinterRuleOptions,
+    lint: &LintConfig,
+) {
     if let Some(value) = lint
         .rule_options
         .as_ref()
@@ -376,8 +544,6 @@ fn linter_rule_options_for_lint_config(lint: &LintConfig) -> LinterRuleOptions {
     {
         rule_options.c063.report_unreached_nested_definitions = value;
     }
-
-    rule_options
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -402,27 +568,6 @@ struct CompiledPerFileShell {
 }
 
 impl CompiledPerFileShellList {
-    fn from_config(project_root: PathBuf, config: &ShuckConfig) -> Self {
-        let mut per_file_shell = Vec::new();
-        if let Some(entries) = config.lint.per_file_shell.as_ref() {
-            per_file_shell.extend(parse_per_file_shell_map(entries, "lint.per-file-shell"));
-        }
-        if let Some(entries) = config.lint.extend_per_file_shell.as_ref() {
-            per_file_shell.extend(parse_per_file_shell_map(
-                entries,
-                "lint.extend-per-file-shell",
-            ));
-        }
-
-        match Self::resolve(project_root, per_file_shell) {
-            Ok(compiled) => compiled,
-            Err(error) => {
-                tracing::warn!("Failed to compile per-file shell settings: {error}");
-                Self::default()
-            }
-        }
-    }
-
     fn resolve(
         project_root: PathBuf,
         per_file_shell: Vec<PerFileShell>,
@@ -498,6 +643,16 @@ fn parse_per_file_shell_map(
         .collect()
 }
 
+fn apply_per_file_shell_layer(
+    current: Vec<PerFileShell>,
+    per_file_shell: Option<Vec<PerFileShell>>,
+    extend_per_file_shell: Vec<PerFileShell>,
+) -> Vec<PerFileShell> {
+    let mut per_file_shell = per_file_shell.unwrap_or(current);
+    per_file_shell.extend(extend_per_file_shell);
+    per_file_shell
+}
+
 fn matches_absolute_path(matcher: &GlobMatcher, path: &Path) -> bool {
     matcher.is_match(path)
         || matcher.is_match(normalize_path(path))
@@ -536,6 +691,8 @@ fn slash_normalized_match_path(path: &Path) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
 
     #[test]
@@ -548,6 +705,7 @@ mod tests {
 
     #[test]
     fn shuck_settings_load_rule_selection_from_config() {
+        let options = ClientOptions::default();
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
         std::fs::write(
             tempdir.path().join(".shuck.toml"),
@@ -561,7 +719,7 @@ mod tests {
         let settings = ShuckSettings::resolve(
             Some(&file_path),
             &[tempdir.path().to_path_buf()],
-            &ClientOptions::default(),
+            &[&options],
         );
 
         assert_eq!(settings.project_root(), Some(tempdir.path()));
@@ -571,6 +729,7 @@ mod tests {
 
     #[test]
     fn shuck_settings_merge_extended_per_file_ignores() {
+        let options = ClientOptions::default();
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
         std::fs::write(
             tempdir.path().join(".shuck.toml"),
@@ -584,7 +743,7 @@ mod tests {
         let settings = ShuckSettings::resolve(
             Some(&file_path),
             &[tempdir.path().to_path_buf()],
-            &ClientOptions::default(),
+            &[&options],
         );
 
         let ignored = settings.linter().per_file_ignores.ignored_rules(&file_path);
@@ -594,6 +753,7 @@ mod tests {
 
     #[test]
     fn shuck_settings_apply_per_file_shell_override() {
+        let options = ClientOptions::default();
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
         std::fs::write(
             tempdir.path().join(".shuck.toml"),
@@ -607,7 +767,7 @@ mod tests {
         let settings = ShuckSettings::resolve(
             Some(&file_path),
             &[tempdir.path().to_path_buf()],
-            &ClientOptions::default(),
+            &[&options],
         );
 
         assert_eq!(settings.linter().shell, LinterShellDialect::Zsh);
@@ -615,6 +775,7 @@ mod tests {
 
     #[test]
     fn shuck_settings_honor_unfixable_rule_config() {
+        let options = ClientOptions::default();
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
         std::fs::write(
             tempdir.path().join(".shuck.toml"),
@@ -628,7 +789,7 @@ mod tests {
         let settings = ShuckSettings::resolve(
             Some(&file_path),
             &[tempdir.path().to_path_buf()],
-            &ClientOptions::default(),
+            &[&options],
         );
 
         assert!(!settings.fixable_rules().contains(shuck_linter::Rule::UnusedAssignment));
@@ -636,21 +797,22 @@ mod tests {
 
     #[test]
     fn shuck_settings_apply_client_overrides_without_a_file_path() {
+        let options = ClientOptions {
+            lint: Some(shuck_config::LintConfig {
+                select: Some(vec!["C001".to_owned()]),
+                ..shuck_config::LintConfig::default()
+            }),
+            format: Some(shuck_config::FormatConfig {
+                indent_style: Some("space".to_owned()),
+                indent_width: Some(2),
+                ..shuck_config::FormatConfig::default()
+            }),
+            ..ClientOptions::default()
+        };
         let settings = ShuckSettings::resolve(
             None,
             &[],
-            &ClientOptions {
-                lint: Some(shuck_config::LintConfig {
-                    select: Some(vec!["C001".to_owned()]),
-                    ..shuck_config::LintConfig::default()
-                }),
-                format: Some(shuck_config::FormatConfig {
-                    indent_style: Some("space".to_owned()),
-                    indent_width: Some(2),
-                    ..shuck_config::FormatConfig::default()
-                }),
-                ..ClientOptions::default()
-            },
+            &[&options],
         );
 
         assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
@@ -664,6 +826,7 @@ mod tests {
 
     #[test]
     fn invalid_selectors_leave_default_rules_enabled() {
+        let options = ClientOptions::default();
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
         std::fs::write(
             tempdir.path().join(".shuck.toml"),
@@ -677,7 +840,7 @@ mod tests {
         let settings = ShuckSettings::resolve(
             Some(&file_path),
             &[tempdir.path().to_path_buf()],
-            &ClientOptions::default(),
+            &[&options],
         );
 
         assert_eq!(settings.linter().rules, LinterSettings::default_rules());
@@ -685,6 +848,7 @@ mod tests {
 
     #[test]
     fn invalid_ignore_selectors_do_not_clear_valid_rule_selection() {
+        let options = ClientOptions::default();
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
         std::fs::write(
             tempdir.path().join(".shuck.toml"),
@@ -698,7 +862,7 @@ mod tests {
         let settings = ShuckSettings::resolve(
             Some(&file_path),
             &[tempdir.path().to_path_buf()],
-            &ClientOptions::default(),
+            &[&options],
         );
 
         assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
@@ -707,6 +871,7 @@ mod tests {
 
     #[test]
     fn invalid_fixable_selectors_leave_fixable_rules_enabled() {
+        let options = ClientOptions::default();
         let tempdir = tempfile::tempdir().expect("tempdir should be created");
         std::fs::write(
             tempdir.path().join(".shuck.toml"),
@@ -720,9 +885,156 @@ mod tests {
         let settings = ShuckSettings::resolve(
             Some(&file_path),
             &[tempdir.path().to_path_buf()],
-            &ClientOptions::default(),
+            &[&options],
         );
 
         assert_eq!(settings.fixable_rules(), RuleSet::all());
+    }
+
+    #[test]
+    fn later_select_replaces_earlier_extend_select() {
+        let client_options = ClientOptions {
+            lint: Some(shuck_config::LintConfig {
+                select: Some(vec!["C001".to_owned()]),
+                ..shuck_config::LintConfig::default()
+            }),
+            ..ClientOptions::default()
+        };
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nextend-select = ['C006']\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &[&client_options],
+        );
+
+        assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
+        assert!(!settings.linter().rules.contains(shuck_linter::Rule::UndefinedVariable));
+        assert_eq!(settings.linter().rules.len(), 1);
+    }
+
+    #[test]
+    fn later_fixable_replaces_earlier_extend_fixable() {
+        let client_options = ClientOptions {
+            lint: Some(shuck_config::LintConfig {
+                fixable: Some(vec!["C001".to_owned()]),
+                ..shuck_config::LintConfig::default()
+            }),
+            ..ClientOptions::default()
+        };
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nextend-fixable = ['C006']\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &[&client_options],
+        );
+
+        assert!(settings.fixable_rules().contains(shuck_linter::Rule::UnusedAssignment));
+        assert!(!settings.fixable_rules().contains(shuck_linter::Rule::UndefinedVariable));
+    }
+
+    #[test]
+    fn later_per_file_shell_replaces_earlier_extend_per_file_shell() {
+        let client_options = ClientOptions {
+            lint: Some(shuck_config::LintConfig {
+                per_file_shell: Some(BTreeMap::from([(
+                    "portable.sh".to_owned(),
+                    "sh".to_owned(),
+                )])),
+                ..shuck_config::LintConfig::default()
+            }),
+            ..ClientOptions::default()
+        };
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nextend-per-file-shell = { '*.sh' = 'bash' }\n",
+        )
+        .expect("config should be written");
+
+        let portable_path = tempdir.path().join("portable.sh");
+        let other_path = tempdir.path().join("other.sh");
+        std::fs::write(&portable_path, "source helper.sh\n").expect("source should be written");
+        std::fs::write(&other_path, "source helper.sh\n").expect("source should be written");
+
+        let portable_settings = ShuckSettings::resolve(
+            Some(&portable_path),
+            &[tempdir.path().to_path_buf()],
+            &[&client_options],
+        );
+        let other_settings = ShuckSettings::resolve(
+            Some(&other_path),
+            &[tempdir.path().to_path_buf()],
+            &[&client_options],
+        );
+
+        assert_eq!(portable_settings.linter().shell, LinterShellDialect::Sh);
+        assert_eq!(other_settings.linter().shell, LinterShellDialect::Unknown);
+    }
+
+    #[test]
+    fn later_per_file_ignores_replace_earlier_extend_per_file_ignores() {
+        let client_options = ClientOptions {
+            lint: Some(shuck_config::LintConfig {
+                per_file_ignores: Some(BTreeMap::from([(
+                    "portable.sh".to_owned(),
+                    vec!["C006".to_owned()],
+                )])),
+                ..shuck_config::LintConfig::default()
+            }),
+            ..ClientOptions::default()
+        };
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nextend-per-file-ignores = { '*.sh' = ['C001'] }\n",
+        )
+        .expect("config should be written");
+
+        let portable_path = tempdir.path().join("portable.sh");
+        let other_path = tempdir.path().join("other.sh");
+        std::fs::write(&portable_path, "foo=1\n").expect("source should be written");
+        std::fs::write(&other_path, "foo=1\n").expect("source should be written");
+
+        let portable_settings = ShuckSettings::resolve(
+            Some(&portable_path),
+            &[tempdir.path().to_path_buf()],
+            &[&client_options],
+        );
+        let other_settings = ShuckSettings::resolve(
+            Some(&other_path),
+            &[tempdir.path().to_path_buf()],
+            &[&client_options],
+        );
+
+        let portable_ignored = portable_settings
+            .linter()
+            .per_file_ignores
+            .ignored_rules(&portable_path);
+        let other_ignored = other_settings
+            .linter()
+            .per_file_ignores
+            .ignored_rules(&other_path);
+
+        assert!(portable_ignored.contains(shuck_linter::Rule::UndefinedVariable));
+        assert!(!portable_ignored.contains(shuck_linter::Rule::UnusedAssignment));
+        assert!(other_ignored.is_empty());
     }
 }

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -23,10 +23,11 @@ pub(crate) struct ClientSettings {
     show_syntax_errors: bool,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ShuckSettings {
     linter: LinterSettings,
     formatter: ShellFormatOptions,
+    fixable_rules: RuleSet,
     project_root: Option<PathBuf>,
 }
 
@@ -64,30 +65,35 @@ impl ShuckSettings {
         workspace_roots: &[PathBuf],
         options: &ClientOptions,
     ) -> Self {
-        let Some(file_path) = file_path else {
-            return Self::default();
-        };
+        let mut config = ShuckConfig::default();
 
-        let fallback_root = containing_workspace_root(file_path, workspace_roots)
-            .or_else(|| file_path.parent().map(Path::to_path_buf))
-            .unwrap_or_else(|| PathBuf::from("."));
-        let project_root = resolve_project_root_for_file(file_path, &fallback_root, true)
-            .unwrap_or(fallback_root.clone());
+        let project_root = file_path.map(|file_path| {
+            let fallback_root = containing_workspace_root(file_path, workspace_roots)
+                .or_else(|| file_path.parent().map(Path::to_path_buf))
+                .unwrap_or_else(|| PathBuf::from("."));
+            let project_root = resolve_project_root_for_file(file_path, &fallback_root, true)
+                .unwrap_or(fallback_root.clone());
 
-        let mut config = load_project_config(&project_root, &ConfigArguments::default())
-            .unwrap_or_else(|error| {
-                tracing::warn!(
-                    "Failed to load shuck config for {}: {error}",
-                    project_root.display()
-                );
-                ShuckConfig::default()
-            });
+            config = load_project_config(&project_root, &ConfigArguments::default())
+                .unwrap_or_else(|error| {
+                    tracing::warn!(
+                        "Failed to load shuck config for {}: {error}",
+                        project_root.display()
+                    );
+                    ShuckConfig::default()
+                });
+            project_root
+        });
         apply_config_overrides(&mut config, options.to_config_overrides());
+        let config_root = project_root
+            .clone()
+            .unwrap_or_else(|| workspace_roots.first().cloned().unwrap_or_else(|| PathBuf::from(".")));
 
         Self {
-            linter: linter_settings_for_config(&project_root, file_path, &config),
+            linter: linter_settings_for_config(&config_root, file_path, &config),
             formatter: formatter_settings_for_config(&config),
-            project_root: Some(project_root),
+            fixable_rules: fixable_rules_for_config(&config),
+            project_root,
         }
     }
 
@@ -99,8 +105,23 @@ impl ShuckSettings {
         &self.formatter
     }
 
+    pub(crate) fn fixable_rules(&self) -> RuleSet {
+        self.fixable_rules
+    }
+
     pub(crate) fn project_root(&self) -> Option<&Path> {
         self.project_root.as_deref()
+    }
+}
+
+impl Default for ShuckSettings {
+    fn default() -> Self {
+        Self {
+            linter: LinterSettings::default(),
+            formatter: ShellFormatOptions::default(),
+            fixable_rules: RuleSet::all(),
+            project_root: None,
+        }
     }
 }
 
@@ -132,7 +153,7 @@ fn containing_workspace_root(path: &Path, workspace_roots: &[PathBuf]) -> Option
 
 fn linter_settings_for_config(
     project_root: &Path,
-    file_path: &Path,
+    file_path: Option<&Path>,
     config: &ShuckConfig,
 ) -> LinterSettings {
     let mut rules = LinterSettings::default_rules();
@@ -148,8 +169,11 @@ fn linter_settings_for_config(
     let compiled_per_file_ignores =
         CompiledPerFileIgnoreList::resolve(project_root.to_path_buf(), per_file_ignores)
             .unwrap_or_default();
-    let shell = CompiledPerFileShellList::from_config(project_root.to_path_buf(), config)
-        .shell_for_path(file_path)
+    let shell = file_path
+        .and_then(|file_path| {
+            CompiledPerFileShellList::from_config(project_root.to_path_buf(), config)
+                .shell_for_path(file_path)
+        })
         .unwrap_or(LinterShellDialect::Unknown);
 
     LinterSettings {
@@ -212,6 +236,20 @@ fn apply_selector_list(rules: RuleSet, selectors: Option<&[String]>) -> RuleSet 
     selectors.map_or(rules, selectors_to_rule_set)
 }
 
+fn fixable_rules_for_config(config: &ShuckConfig) -> RuleSet {
+    let fixable = parse_optional_selector_list(config.lint.fixable.as_deref(), "lint.fixable");
+    let extend_fixable =
+        parse_selector_list(config.lint.extend_fixable.as_deref(), "lint.extend-fixable");
+    let unfixable = parse_selector_list(config.lint.unfixable.as_deref(), "lint.unfixable");
+
+    apply_rule_selector_layer(
+        RuleSet::all(),
+        fixable.as_deref(),
+        &extend_fixable,
+        &unfixable,
+    )
+}
+
 fn selectors_to_rule_set(selectors: &[String]) -> RuleSet {
     selectors_to_rule_set_from_parsed(&parse_selectors(selectors).unwrap_or_default())
 }
@@ -248,6 +286,85 @@ fn parse_selectors(selectors: &[String]) -> anyhow::Result<Vec<RuleSelector>> {
         .iter()
         .map(|selector| RuleSelector::from_str(selector).map_err(anyhow::Error::new))
         .collect()
+}
+
+fn parse_optional_selector_list(
+    selectors: Option<&[String]>,
+    scope: &str,
+) -> Option<Vec<RuleSelector>> {
+    selectors.map(|selectors| match parse_selectors(selectors) {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            tracing::warn!("Ignoring invalid {scope} selectors: {error}");
+            Vec::new()
+        }
+    })
+}
+
+fn parse_selector_list(selectors: Option<&[String]>, scope: &str) -> Vec<RuleSelector> {
+    parse_optional_selector_list(selectors, scope).unwrap_or_default()
+}
+
+fn apply_rule_selector_layer(
+    current: RuleSet,
+    select: Option<&[RuleSelector]>,
+    extend_select: &[RuleSelector],
+    ignore: &[RuleSelector],
+) -> RuleSet {
+    let mut specificities = select
+        .into_iter()
+        .flatten()
+        .chain(extend_select.iter())
+        .chain(ignore.iter())
+        .map(selector_specificity)
+        .collect::<Vec<_>>();
+    specificities.sort_unstable();
+    specificities.dedup();
+
+    let mut updates = std::collections::HashMap::<shuck_linter::Rule, bool>::new();
+    for specificity in specificities {
+        for selector in select
+            .into_iter()
+            .flatten()
+            .chain(extend_select.iter())
+            .filter(|selector| selector_specificity(selector) == specificity)
+        {
+            for rule in selector.into_rule_set().iter() {
+                updates.insert(rule, true);
+            }
+        }
+        for selector in ignore
+            .iter()
+            .filter(|selector| selector_specificity(selector) == specificity)
+        {
+            for rule in selector.into_rule_set().iter() {
+                updates.insert(rule, false);
+            }
+        }
+    }
+
+    if select.is_some() {
+        updates
+            .into_iter()
+            .filter_map(|(rule, enabled)| enabled.then_some(rule))
+            .collect()
+    } else {
+        let mut rules = current;
+        for (rule, enabled) in updates {
+            rules.set(rule, enabled);
+        }
+        rules
+    }
+}
+
+fn selector_specificity(selector: &RuleSelector) -> usize {
+    match selector {
+        RuleSelector::All => 0,
+        RuleSelector::Category(_) => 1,
+        RuleSelector::Named(_) => 1,
+        RuleSelector::Prefix(prefix) => 2 + prefix.len(),
+        RuleSelector::Rule(_) => usize::MAX,
+    }
 }
 
 fn linter_rule_options_for_lint_config(lint: &LintConfig) -> LinterRuleOptions {
@@ -503,5 +620,54 @@ mod tests {
         );
 
         assert_eq!(settings.linter().shell, LinterShellDialect::Zsh);
+    }
+
+    #[test]
+    fn shuck_settings_honor_unfixable_rule_config() {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        std::fs::write(
+            tempdir.path().join(".shuck.toml"),
+            "[lint]\nunfixable = ['C001']\n",
+        )
+        .expect("config should be written");
+
+        let file_path = tempdir.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let settings = ShuckSettings::resolve(
+            Some(&file_path),
+            &[tempdir.path().to_path_buf()],
+            &ClientOptions::default(),
+        );
+
+        assert!(!settings.fixable_rules().contains(shuck_linter::Rule::UnusedAssignment));
+    }
+
+    #[test]
+    fn shuck_settings_apply_client_overrides_without_a_file_path() {
+        let settings = ShuckSettings::resolve(
+            None,
+            &[],
+            &ClientOptions {
+                lint: Some(shuck_config::LintConfig {
+                    select: Some(vec!["C001".to_owned()]),
+                    ..shuck_config::LintConfig::default()
+                }),
+                format: Some(shuck_config::FormatConfig {
+                    indent_style: Some("space".to_owned()),
+                    indent_width: Some(2),
+                    ..shuck_config::FormatConfig::default()
+                }),
+                ..ClientOptions::default()
+            },
+        );
+
+        assert!(settings.linter().rules.contains(shuck_linter::Rule::UnusedAssignment));
+        assert_eq!(settings.linter().rules.len(), 1);
+        assert_eq!(
+            settings.formatter().indent_style(),
+            shuck_formatter::IndentStyle::Space
+        );
+        assert_eq!(settings.formatter().indent_width(), 2);
     }
 }

--- a/crates/shuck-server/tests/diagnostics.rs
+++ b/crates/shuck-server/tests/diagnostics.rs
@@ -70,7 +70,7 @@ fn shell_document_snapshot_reports_native_shuck_diagnostic() {
         .clone()
         .expect("diagnostic payload should be present");
     assert_eq!(data["code"], "C001");
-    assert_eq!(data["directive_edit"], serde_json::Value::Null);
+    assert!(data["directive_edit"].is_object());
     assert_eq!(data["applicability"], "Unsafe");
     assert_eq!(data["edits"][0]["newText"], "_");
 }

--- a/crates/shuck-server/tests/latency.rs
+++ b/crates/shuck-server/tests/latency.rs
@@ -27,14 +27,21 @@ fn recv_response(connection: &Connection, id: i32) -> serde_json::Value {
             .expect("server should respond");
         match message {
             Message::Response(response) if response.id == RequestId::from(id) => {
-                assert!(response.error.is_none(), "unexpected LSP error: {:?}", response.error);
+                assert!(
+                    response.error.is_none(),
+                    "unexpected LSP error: {:?}",
+                    response.error
+                );
                 return response
                     .result
                     .expect("successful response should carry a result");
             }
             Message::Notification(_) => continue,
             Message::Request(request) => {
-                panic!("unexpected server request during latency test: {}", request.method)
+                panic!(
+                    "unexpected server request during latency test: {}",
+                    request.method
+                )
             }
             Message::Response(_) => continue,
         }
@@ -75,7 +82,8 @@ fn measure_pull_diagnostics_round_trip() {
 
     let workspace_root = tempfile::tempdir().expect("tempdir should be created");
     let script_path = workspace_root.path().join("latency.sh");
-    let script_uri = Url::from_file_path(&script_path).expect("script path should convert to a URL");
+    let script_uri =
+        Url::from_file_path(&script_path).expect("script path should convert to a URL");
     let source = shell_source_of_size(5 * 1024);
 
     send_request(

--- a/crates/shuck-server/tests/latency.rs
+++ b/crates/shuck-server/tests/latency.rs
@@ -1,0 +1,163 @@
+use std::thread;
+use std::time::{Duration, Instant};
+
+use lsp_server::{Connection, Message, Notification, Request, RequestId};
+use lsp_types::{
+    ClientCapabilities, DocumentDiagnosticParams, DocumentDiagnosticReport,
+    DocumentDiagnosticReportResult, PartialResultParams, TextDocumentIdentifier, Url,
+    WorkDoneProgressParams,
+};
+
+fn send_request(connection: &Connection, id: i32, method: &str, params: serde_json::Value) {
+    connection
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(id),
+            method: method.to_owned(),
+            params,
+        }))
+        .expect("request should send");
+}
+
+fn recv_response(connection: &Connection, id: i32) -> serde_json::Value {
+    loop {
+        let message = connection
+            .receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("server should respond");
+        match message {
+            Message::Response(response) if response.id == RequestId::from(id) => {
+                assert!(response.error.is_none(), "unexpected LSP error: {:?}", response.error);
+                return response
+                    .result
+                    .expect("successful response should carry a result");
+            }
+            Message::Notification(_) => continue,
+            Message::Request(request) => {
+                panic!("unexpected server request during latency test: {}", request.method)
+            }
+            Message::Response(_) => continue,
+        }
+    }
+}
+
+fn replay_capabilities() -> ClientCapabilities {
+    serde_json::from_value(serde_json::json!({
+        "general": {
+            "positionEncodings": ["utf-16"]
+        },
+        "textDocument": {
+            "diagnostic": {
+                "dynamicRegistration": false,
+                "relatedDocumentSupport": false
+            }
+        },
+        "workspace": {
+            "workspaceFolders": true
+        }
+    }))
+    .expect("test client capabilities should deserialize")
+}
+
+fn shell_source_of_size(target_bytes: usize) -> String {
+    let mut source = String::from("#!/bin/bash\n");
+    while source.len() < target_bytes {
+        source.push_str("value=1\n");
+    }
+    source
+}
+
+#[test]
+#[ignore = "manual performance measurement"]
+fn measure_pull_diagnostics_round_trip() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace_root = tempfile::tempdir().expect("tempdir should be created");
+    let script_path = workspace_root.path().join("latency.sh");
+    let script_uri = Url::from_file_path(&script_path).expect("script path should convert to a URL");
+    let source = shell_source_of_size(5 * 1024);
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "rootUri": Url::from_file_path(workspace_root.path())
+                .expect("workspace path should convert to a URL"),
+        }),
+    );
+    let _ = recv_response(&client_connection, 1);
+
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized notification should send");
+
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "textDocument/didOpen".to_owned(),
+            serde_json::json!({
+                "textDocument": {
+                    "uri": script_uri,
+                    "languageId": "shellscript",
+                    "version": 1,
+                    "text": source,
+                }
+            }),
+        )))
+        .expect("didOpen notification should send");
+
+    let start = Instant::now();
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/diagnostic",
+        serde_json::to_value(DocumentDiagnosticParams {
+            text_document: TextDocumentIdentifier {
+                uri: script_uri.clone(),
+            },
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        })
+        .expect("diagnostic params should serialize"),
+    );
+    let diagnostic_report: DocumentDiagnosticReportResult =
+        serde_json::from_value(recv_response(&client_connection, 2))
+            .expect("diagnostic response should deserialize");
+    let elapsed = start.elapsed();
+    let DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(report)) =
+        diagnostic_report
+    else {
+        panic!("expected a full diagnostic report");
+    };
+
+    println!(
+        "pull diagnostics round-trip: {:.3} ms for {} bytes ({} diagnostics)",
+        elapsed.as_secs_f64() * 1000.0,
+        5 * 1024,
+        report.full_document_diagnostic_report.items.len()
+    );
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -1,0 +1,237 @@
+use std::thread;
+use std::time::Duration;
+
+use lsp_server::{Connection, Message, Notification, Request, RequestId};
+use lsp_types::{
+    ClientCapabilities, CodeAction, CodeActionContext, CodeActionParams,
+    DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
+    HoverParams, PartialResultParams, Position, Range, TextDocumentIdentifier,
+    TextDocumentPositionParams, Url, WorkDoneProgressParams,
+};
+
+fn send_request(connection: &Connection, id: i32, method: &str, params: serde_json::Value) {
+    connection
+        .sender
+        .send(Message::Request(Request {
+            id: RequestId::from(id),
+            method: method.to_owned(),
+            params,
+        }))
+        .expect("request should send");
+}
+
+fn recv_response(connection: &Connection, id: i32) -> serde_json::Value {
+    loop {
+        let message = connection
+            .receiver
+            .recv_timeout(Duration::from_secs(2))
+            .expect("server should respond");
+        match message {
+            Message::Response(response) if response.id == RequestId::from(id) => {
+                assert!(response.error.is_none(), "unexpected LSP error: {:?}", response.error);
+                return response
+                    .result
+                    .expect("successful response should carry a result");
+            }
+            Message::Notification(_) => continue,
+            Message::Request(request) => panic!("unexpected server request during replay: {}", request.method),
+            Message::Response(_) => continue,
+        }
+    }
+}
+
+fn replay_capabilities() -> ClientCapabilities {
+    serde_json::from_value(serde_json::json!({
+        "general": {
+            "positionEncodings": ["utf-16"]
+        },
+        "textDocument": {
+            "diagnostic": {
+                "dynamicRegistration": false,
+                "relatedDocumentSupport": false
+            },
+            "codeAction": {
+                "dataSupport": true,
+                "resolveSupport": { "properties": ["edit"] }
+            },
+            "hover": {
+                "contentFormat": ["markdown"]
+            }
+        },
+        "workspace": {
+            "applyEdit": true,
+            "workspaceEdit": {
+                "documentChanges": true
+            },
+            "workspaceFolders": true,
+            "configuration": false
+        }
+    }))
+    .expect("test client capabilities should deserialize")
+}
+
+#[test]
+fn replays_a_small_lsp_session() {
+    let (server_connection, client_connection) = Connection::memory();
+    let server_thread = thread::spawn(move || shuck_server::run_connection(server_connection));
+
+    let workspace_root = tempfile::tempdir().expect("tempdir should be created");
+    let script_path = workspace_root.path().join("script.sh");
+    let script_uri = Url::from_file_path(&script_path).expect("script path should convert to a URL");
+
+    send_request(
+        &client_connection,
+        1,
+        "initialize",
+        serde_json::json!({
+            "capabilities": replay_capabilities(),
+            "rootUri": Url::from_file_path(workspace_root.path())
+                .expect("workspace path should convert to a URL"),
+            "initializationOptions": { "shuck": { "fixAll": true, "unsafeFixes": true } }
+        }),
+    );
+    let initialize = recv_response(&client_connection, 1);
+    assert!(initialize["capabilities"]["documentFormattingProvider"].is_null());
+    assert!(initialize["capabilities"]["documentRangeFormattingProvider"].is_null());
+
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "initialized".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("initialized notification should send");
+
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "textDocument/didOpen".to_owned(),
+            serde_json::json!({
+                "textDocument": {
+                    "uri": script_uri,
+                    "languageId": "shellscript",
+                    "version": 1,
+                    "text": "foo=1\n",
+                }
+            }),
+        )))
+        .expect("didOpen notification should send");
+
+    send_request(
+        &client_connection,
+        2,
+        "textDocument/diagnostic",
+        serde_json::to_value(DocumentDiagnosticParams {
+            text_document: TextDocumentIdentifier {
+                uri: script_uri.clone(),
+            },
+            identifier: None,
+            previous_result_id: None,
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        })
+        .expect("diagnostic params should serialize"),
+    );
+    let diagnostic_report: DocumentDiagnosticReportResult = serde_json::from_value(recv_response(&client_connection, 2))
+        .expect("diagnostic response should deserialize");
+    let DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(report)) =
+        diagnostic_report
+    else {
+        panic!("expected a full diagnostic report");
+    };
+    assert_eq!(report.full_document_diagnostic_report.items.len(), 1);
+    let diagnostics = report.full_document_diagnostic_report.items;
+
+    send_request(
+        &client_connection,
+        3,
+        "textDocument/codeAction",
+        serde_json::to_value(CodeActionParams {
+            text_document: TextDocumentIdentifier {
+                uri: script_uri.clone(),
+            },
+            range: Range::new(Position::new(0, 0), Position::new(0, 3)),
+            context: CodeActionContext {
+                diagnostics: diagnostics.clone(),
+                only: None,
+                trigger_kind: None,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        })
+        .expect("code action params should serialize"),
+    );
+    let actions: Vec<lsp_types::CodeActionOrCommand> = serde_json::from_value(recv_response(&client_connection, 3))
+        .expect("code action response should deserialize");
+    let fix_all = actions
+        .into_iter()
+        .filter_map(|entry| match entry {
+            lsp_types::CodeActionOrCommand::CodeAction(action) => Some(action),
+            lsp_types::CodeActionOrCommand::Command(_) => None,
+        })
+        .find(|action| {
+            action
+                .kind
+                .as_ref()
+                .is_some_and(|kind| kind.as_str() == "source.fixAll.shuck")
+        })
+        .expect("fix-all action should be present");
+    assert!(fix_all.edit.is_none());
+    assert!(fix_all.data.is_some());
+
+    send_request(
+        &client_connection,
+        4,
+        "codeAction/resolve",
+        serde_json::to_value(fix_all).expect("code action should serialize"),
+    );
+    let resolved: CodeAction = serde_json::from_value(recv_response(&client_connection, 4))
+        .expect("resolved code action should deserialize");
+    assert!(resolved.edit.is_some());
+
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "textDocument/didChange".to_owned(),
+            serde_json::json!({
+                "textDocument": { "uri": script_uri, "version": 2 },
+                "contentChanges": [{ "text": "#!/bin/bash\necho $foo  # shellcheck disable=SC2154\n" }],
+            }),
+        )))
+        .expect("didChange notification should send");
+
+    send_request(
+        &client_connection,
+        5,
+        "textDocument/hover",
+        serde_json::to_value(HoverParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: script_uri.clone(),
+                },
+                position: Position::new(1, 37),
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        })
+        .expect("hover params should serialize"),
+    );
+    let hover = recv_response(&client_connection, 5);
+    assert!(hover["contents"]["value"]
+        .as_str()
+        .is_some_and(|value| value.contains("Undefined Variable")));
+
+    send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
+    let _ = recv_response(&client_connection, 99);
+    client_connection
+        .sender
+        .send(Message::Notification(Notification::new(
+            "exit".to_owned(),
+            serde_json::json!({}),
+        )))
+        .expect("exit notification should send");
+
+    server_thread
+        .join()
+        .expect("server thread should join")
+        .expect("server should exit cleanly");
+}

--- a/crates/shuck-server/tests/manual.rs
+++ b/crates/shuck-server/tests/manual.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 
 use lsp_server::{Connection, Message, Notification, Request, RequestId};
 use lsp_types::{
-    ClientCapabilities, CodeAction, CodeActionContext, CodeActionParams,
-    DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
-    HoverParams, PartialResultParams, Position, Range, TextDocumentIdentifier,
-    TextDocumentPositionParams, Url, WorkDoneProgressParams,
+    ClientCapabilities, CodeAction, CodeActionContext, CodeActionParams, DocumentDiagnosticParams,
+    DocumentDiagnosticReport, DocumentDiagnosticReportResult, HoverParams, PartialResultParams,
+    Position, Range, TextDocumentIdentifier, TextDocumentPositionParams, Url,
+    WorkDoneProgressParams,
 };
 
 fn send_request(connection: &Connection, id: i32, method: &str, params: serde_json::Value) {
@@ -28,13 +28,20 @@ fn recv_response(connection: &Connection, id: i32) -> serde_json::Value {
             .expect("server should respond");
         match message {
             Message::Response(response) if response.id == RequestId::from(id) => {
-                assert!(response.error.is_none(), "unexpected LSP error: {:?}", response.error);
+                assert!(
+                    response.error.is_none(),
+                    "unexpected LSP error: {:?}",
+                    response.error
+                );
                 return response
                     .result
                     .expect("successful response should carry a result");
             }
             Message::Notification(_) => continue,
-            Message::Request(request) => panic!("unexpected server request during replay: {}", request.method),
+            Message::Request(request) => panic!(
+                "unexpected server request during replay: {}",
+                request.method
+            ),
             Message::Response(_) => continue,
         }
     }
@@ -77,7 +84,8 @@ fn replays_a_small_lsp_session() {
 
     let workspace_root = tempfile::tempdir().expect("tempdir should be created");
     let script_path = workspace_root.path().join("script.sh");
-    let script_uri = Url::from_file_path(&script_path).expect("script path should convert to a URL");
+    let script_uri =
+        Url::from_file_path(&script_path).expect("script path should convert to a URL");
 
     send_request(
         &client_connection,
@@ -132,8 +140,9 @@ fn replays_a_small_lsp_session() {
         })
         .expect("diagnostic params should serialize"),
     );
-    let diagnostic_report: DocumentDiagnosticReportResult = serde_json::from_value(recv_response(&client_connection, 2))
-        .expect("diagnostic response should deserialize");
+    let diagnostic_report: DocumentDiagnosticReportResult =
+        serde_json::from_value(recv_response(&client_connection, 2))
+            .expect("diagnostic response should deserialize");
     let DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(report)) =
         diagnostic_report
     else {
@@ -161,8 +170,9 @@ fn replays_a_small_lsp_session() {
         })
         .expect("code action params should serialize"),
     );
-    let actions: Vec<lsp_types::CodeActionOrCommand> = serde_json::from_value(recv_response(&client_connection, 3))
-        .expect("code action response should deserialize");
+    let actions: Vec<lsp_types::CodeActionOrCommand> =
+        serde_json::from_value(recv_response(&client_connection, 3))
+            .expect("code action response should deserialize");
     let fix_all = actions
         .into_iter()
         .filter_map(|entry| match entry {
@@ -216,9 +226,11 @@ fn replays_a_small_lsp_session() {
         .expect("hover params should serialize"),
     );
     let hover = recv_response(&client_connection, 5);
-    assert!(hover["contents"]["value"]
-        .as_str()
-        .is_some_and(|value| value.contains("Undefined Variable")));
+    assert!(
+        hover["contents"]["value"]
+            .as_str()
+            .is_some_and(|value| value.contains("Undefined Variable"))
+    );
 
     send_request(&client_connection, 99, "shutdown", serde_json::json!(null));
     let _ = recv_response(&client_connection, 99);

--- a/crates/shuck-server/tests/perf.md
+++ b/crates/shuck-server/tests/perf.md
@@ -1,0 +1,29 @@
+# shuck-server perf notes
+
+Recorded on 2026-05-03 from `/Users/ewhauser/working/shuck-lsp`.
+
+## Benchmark gate
+
+Command:
+
+```bash
+cargo bench -p shuck-benchmark --bench check_command
+```
+
+Result:
+
+- Completed successfully.
+- Representative `check_command_full/all` sample: `444.64 ms .. 446.03 ms`
+- Representative `check_command_concise/all` sample: `444.40 ms .. 448.09 ms`
+
+## Pull diagnostics latency
+
+Command:
+
+```bash
+cargo test -p shuck-server --release --test latency measure_pull_diagnostics_round_trip -- --ignored --nocapture
+```
+
+Result:
+
+- `pull diagnostics round-trip: 18.143 ms for 5120 bytes (1 diagnostics)`


### PR DESCRIPTION
## Summary
- complete the remaining shuck-server LSP behavior from `specs/018-lsp.md`, including diagnostics, code actions, execute-command handling, hover, config-backed settings resolution, panic surfacing, and the manual replay harness
- keep formatter support implemented but not advertised, and tighten quick-fix and fix-all behavior so edits are recomputed from the live snapshot and filtered through resolved fixable settings
- preserve CLI-style layered precedence for project, global client, and workspace client lint settings, including `select`/`extend-select`, `fixable`/`extend-fixable`, and per-file shell and ignore overrides

## Testing
- `cargo test -p shuck-linter`
- `cargo test -p shuck-server`
- `cargo clippy -p shuck-linter -p shuck-server --all-targets -- -D warnings`
- `cargo test -p shuck-config -p shuck-server`
- `cargo build -p shuck-config -p shuck-server -p shuck-cli`
- `cargo clippy -p shuck-config -p shuck-server --all-targets -- -D warnings`
- `cargo test -p shuck-server --release --test latency measure_pull_diagnostics_round_trip -- --ignored --nocapture`
- `cargo bench -p shuck-benchmark --bench check_command`