### PR TITLE
refactor(linter): finish option-sensitive glob behavior migration

### DIFF
--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -66,10 +66,11 @@ use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::Parser;
 use shuck_semantic::{
     Binding, BindingAttributes, BindingId, BindingKind, CaseCliDispatch, Declaration,
-    DeclarationBuiltin, DeclarationOperand as SemanticDeclarationOperand,
-    NonpersistentAssignmentAnalysisContext, NonpersistentAssignmentAnalysisOptions,
-    NonpersistentAssignmentCommandContext, NonpersistentAssignmentExtraRead, OptionValue,
-    Reference, ReferenceId, ReferenceKind, ScopeId, SemanticAnalysis, SemanticModel,
+    DeclarationBuiltin, DeclarationOperand as SemanticDeclarationOperand, FieldSplittingBehavior,
+    GlobFailureBehavior, NonpersistentAssignmentAnalysisContext,
+    NonpersistentAssignmentAnalysisOptions, NonpersistentAssignmentCommandContext,
+    NonpersistentAssignmentExtraRead, OptionValue, PathnameExpansionBehavior, Reference,
+    ReferenceId, ReferenceKind, ScopeId, SemanticAnalysis, SemanticModel,
     SemanticPipelineOperatorKind, ZshOptionState,
 };
 use smallvec::SmallVec;

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::PlainUnindexedArrayReferenceFact;
+use crate::{
+    FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior,
+    PlainUnindexedArrayReferenceFact,
+};
 
 #[test]
 fn builds_surface_fragment_facts_and_static_utility_names() {
@@ -1993,6 +1996,112 @@ fn builds_word_facts_for_zsh_qualified_globs() {
 
             assert!(glob.classification().is_expanded());
             assert!(glob.analysis().hazards.pathname_matching);
+        },
+    );
+}
+
+#[test]
+fn builds_option_sensitive_word_behaviors_for_zsh_words() {
+    let source = "\
+#!/usr/bin/env zsh
+setopt sh_word_split
+print $name
+noglob rm *
+print ${~~name}
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            let split = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source) == "$name")
+                .expect("expected split-sensitive fact");
+            let wrapped_glob = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source) == "*")
+                .expect("expected wrapped glob fact");
+            let double_tilde = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source) == "${~~name}")
+                .expect("expected double-tilde fact");
+
+            assert_eq!(
+                split.analysis().field_splitting_behavior,
+                FieldSplittingBehavior::UnquotedOnly
+            );
+            assert_eq!(
+                wrapped_glob.runtime_literal().pathname_expansion_behavior,
+                PathnameExpansionBehavior::Disabled
+            );
+            assert_eq!(
+                double_tilde.analysis().pathname_expansion_behavior,
+                PathnameExpansionBehavior::LiteralGlobsOnly
+            );
+        },
+    );
+}
+
+#[test]
+fn builds_ambiguous_pathname_behaviors_for_dynamic_zsh_words() {
+    let source = "\
+#!/usr/bin/env zsh
+opt=glob_subst
+setopt \"$opt\"
+print $name
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            let ambiguous = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source) == "$name")
+                .expect("expected ambiguous scalar fact");
+
+            assert_eq!(
+                ambiguous.analysis().pathname_expansion_behavior,
+                PathnameExpansionBehavior::Ambiguous
+            );
+            assert!(ambiguous.analysis().hazards.pathname_matching);
+        },
+    );
+}
+
+#[test]
+fn builds_glob_failure_behaviors_for_zsh_globs() {
+    let source = "\
+#!/usr/bin/env zsh
+setopt null_glob csh_null_glob
+rm *
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            let glob = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source) == "*")
+                .expect("expected glob fact");
+
+            assert!(
+                glob.runtime_literal()
+                    .pathname_expansion_behavior
+                    .literal_globs_can_expand()
+            );
+            assert_eq!(
+                glob.runtime_literal().glob_failure_behavior,
+                GlobFailureBehavior::CshNullGlob
+            );
         },
     );
 }

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -2075,6 +2075,50 @@ print $name
 }
 
 #[test]
+fn builds_flow_merged_literal_only_pathname_behaviors_for_zsh_words() {
+    let source = "\
+#!/usr/bin/env zsh
+if cond; then
+  setopt no_glob
+fi
+print $name
+rm *
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            let scalar = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source) == "$name")
+                .expect("expected scalar fact");
+            let glob = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .find(|fact| fact.span().slice(source) == "*")
+                .expect("expected glob fact");
+
+            assert_eq!(
+                scalar.analysis().pathname_expansion_behavior,
+                PathnameExpansionBehavior::LiteralGlobsOnlyOrDisabled
+            );
+            assert!(!scalar.analysis().hazards.pathname_matching);
+            assert_eq!(
+                glob.runtime_literal().pathname_expansion_behavior,
+                PathnameExpansionBehavior::LiteralGlobsOnlyOrDisabled
+            );
+            assert!(
+                glob.runtime_literal()
+                    .pathname_expansion_behavior
+                    .literal_globs_can_expand()
+            );
+        },
+    );
+}
+
+#[test]
 fn builds_glob_failure_behaviors_for_zsh_globs() {
     let source = "\
 #!/usr/bin/env zsh

--- a/crates/shuck-linter/src/facts/words/expansion.rs
+++ b/crates/shuck-linter/src/facts/words/expansion.rs
@@ -90,15 +90,30 @@ pub struct ExpansionAnalysis {
     pub literalness: WordLiteralness,
     pub value_shape: ExpansionValueShape,
     pub substitution_shape: WordSubstitutionShape,
+    pub field_splitting_behavior: FieldSplittingBehavior,
+    pub pathname_expansion_behavior: PathnameExpansionBehavior,
     pub hazards: ExpansionHazards,
     pub array_valued: bool,
     pub can_expand_to_multiple_fields: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RuntimeLiteralAnalysis {
     pub runtime_sensitive: bool,
+    pub pathname_expansion_behavior: PathnameExpansionBehavior,
+    pub glob_failure_behavior: GlobFailureBehavior,
     pub hazards: ExpansionHazards,
+}
+
+impl Default for RuntimeLiteralAnalysis {
+    fn default() -> Self {
+        Self {
+            runtime_sensitive: false,
+            pathname_expansion_behavior: PathnameExpansionBehavior::Disabled,
+            glob_failure_behavior: GlobFailureBehavior::KeepLiteralOnNoMatch,
+            hazards: ExpansionHazards::default(),
+        }
+    }
 }
 
 impl RuntimeLiteralAnalysis {
@@ -284,6 +299,83 @@ pub(super) fn classify_pattern_operand(pattern: &Pattern, source: &str) -> TestO
     TestOperandClass::FixedLiteral
 }
 
+pub(super) fn field_splitting_behavior_for_options(
+    options: Option<&ZshOptionState>,
+) -> FieldSplittingBehavior {
+    match options {
+        Some(options) => match options.sh_word_split {
+            OptionValue::Off => FieldSplittingBehavior::Never,
+            OptionValue::On => FieldSplittingBehavior::UnquotedOnly,
+            OptionValue::Unknown => FieldSplittingBehavior::Ambiguous,
+        },
+        None => FieldSplittingBehavior::UnquotedOnly,
+    }
+}
+
+pub(super) fn pathname_expansion_behavior_for_options(
+    options: Option<&ZshOptionState>,
+) -> PathnameExpansionBehavior {
+    match options {
+        Some(options) => match options.glob {
+            OptionValue::Off => PathnameExpansionBehavior::Disabled,
+            OptionValue::On => match options.glob_subst {
+                OptionValue::Off => PathnameExpansionBehavior::LiteralGlobsOnly,
+                OptionValue::On => PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
+                OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
+            },
+            OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
+        },
+        None => PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
+    }
+}
+
+pub(super) fn glob_failure_behavior_for_options(
+    options: Option<&ZshOptionState>,
+) -> GlobFailureBehavior {
+    match options {
+        Some(options) => match options.glob {
+            OptionValue::Off => GlobFailureBehavior::KeepLiteralOnNoMatch,
+            OptionValue::On => match options.csh_null_glob {
+                OptionValue::On => GlobFailureBehavior::CshNullGlob,
+                OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
+                OptionValue::Off => match options.null_glob {
+                    OptionValue::On => GlobFailureBehavior::DropUnmatchedPattern,
+                    OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
+                    OptionValue::Off => match options.nomatch {
+                        OptionValue::On => GlobFailureBehavior::ErrorOnNoMatch,
+                        OptionValue::Off => GlobFailureBehavior::KeepLiteralOnNoMatch,
+                        OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
+                    },
+                },
+            },
+            OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
+        },
+        None => GlobFailureBehavior::KeepLiteralOnNoMatch,
+    }
+}
+
+fn merge_field_splitting_behavior(
+    current: Option<FieldSplittingBehavior>,
+    next: FieldSplittingBehavior,
+) -> Option<FieldSplittingBehavior> {
+    Some(match current {
+        None => next,
+        Some(existing) if existing == next => existing,
+        Some(_) => FieldSplittingBehavior::Ambiguous,
+    })
+}
+
+fn merge_pathname_expansion_behavior(
+    current: Option<PathnameExpansionBehavior>,
+    next: PathnameExpansionBehavior,
+) -> Option<PathnameExpansionBehavior> {
+    Some(match current {
+        None => next,
+        Some(existing) if existing == next => existing,
+        Some(_) => PathnameExpansionBehavior::Ambiguous,
+    })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum PartValueShape {
     Scalar,
@@ -296,6 +388,8 @@ pub(super) struct PartAnalysis {
     value_shape: PartValueShape,
     array_valued: bool,
     can_expand_to_multiple_fields: bool,
+    field_splitting_behavior: FieldSplittingBehavior,
+    pathname_expansion_behavior: PathnameExpansionBehavior,
     hazards: ExpansionHazards,
     command_substitution: bool,
     process_substitution: bool,
@@ -308,6 +402,8 @@ pub(super) struct AnalysisSummary {
     has_array_value: bool,
     has_unknown_value: bool,
     can_expand_to_multiple_fields: bool,
+    field_splitting_behavior: Option<FieldSplittingBehavior>,
+    pathname_expansion_behavior: Option<PathnameExpansionBehavior>,
     hazards: ExpansionHazards,
     command_substitution_count: usize,
     has_process_substitution: bool,
@@ -320,6 +416,8 @@ pub(super) fn analyze_word(
 ) -> ExpansionAnalysis {
     let mut summary = AnalysisSummary::default();
     analyze_parts(&word.parts, false, options, &mut summary);
+    let default_field_splitting_behavior = field_splitting_behavior_for_options(options);
+    let default_pathname_expansion_behavior = pathname_expansion_behavior_for_options(options);
 
     ExpansionAnalysis {
         quote: if is_fully_quoted(word) {
@@ -352,6 +450,12 @@ pub(super) fn analyze_word(
         } else {
             WordSubstitutionShape::Mixed
         },
+        field_splitting_behavior: summary
+            .field_splitting_behavior
+            .unwrap_or(default_field_splitting_behavior),
+        pathname_expansion_behavior: summary
+            .pathname_expansion_behavior
+            .unwrap_or(default_pathname_expansion_behavior),
         hazards: summary.hazards,
         array_valued: summary.has_array_value,
         can_expand_to_multiple_fields: summary.can_expand_to_multiple_fields,
@@ -364,7 +468,11 @@ pub(crate) fn analyze_literal_runtime(
     context: ExpansionContext,
     options: Option<&ZshOptionState>,
 ) -> RuntimeLiteralAnalysis {
-    let mut analysis = RuntimeLiteralAnalysis::default();
+    let mut analysis = RuntimeLiteralAnalysis {
+        pathname_expansion_behavior: pathname_expansion_behavior_for_options(options),
+        glob_failure_behavior: glob_failure_behavior_for_options(options),
+        ..RuntimeLiteralAnalysis::default()
+    };
     let mut state = RuntimeLiteralState::default();
 
     analyze_literal_runtime_parts(
@@ -424,7 +532,7 @@ pub(super) fn analyze_literal_runtime_parts(
 pub(super) fn scan_literal_runtime_text(
     text: &str,
     context: ExpansionContext,
-    options: Option<&ZshOptionState>,
+    _options: Option<&ZshOptionState>,
     state: &mut RuntimeLiteralState,
     analysis: &mut RuntimeLiteralAnalysis,
 ) {
@@ -451,7 +559,9 @@ pub(super) fn scan_literal_runtime_text(
         }
 
         if context_allows_pathname_matching(context)
-            && glob_is_effectively_enabled(options)
+            && analysis
+                .pathname_expansion_behavior
+                .literal_globs_can_expand()
             && matches!(ch, '*' | '?' | '[')
         {
             analysis.runtime_sensitive = true;
@@ -542,6 +652,14 @@ pub(super) fn analyze_parts(
                 summary.has_array_value |= analysis.array_valued;
                 summary.has_unknown_value |= analysis.value_shape == PartValueShape::Unknown;
                 summary.can_expand_to_multiple_fields |= analysis.can_expand_to_multiple_fields;
+                summary.field_splitting_behavior = merge_field_splitting_behavior(
+                    summary.field_splitting_behavior,
+                    analysis.field_splitting_behavior,
+                );
+                summary.pathname_expansion_behavior = merge_pathname_expansion_behavior(
+                    summary.pathname_expansion_behavior,
+                    analysis.pathname_expansion_behavior,
+                );
                 summary.hazards.field_splitting |= analysis.hazards.field_splitting;
                 summary.hazards.pathname_matching |= analysis.hazards.pathname_matching;
                 summary.hazards.tilde_expansion |= analysis.hazards.tilde_expansion;
@@ -562,14 +680,20 @@ pub(super) fn analyze_part(
     in_double_quotes: bool,
     options: Option<&ZshOptionState>,
 ) -> PartAnalysis {
+    let field_splitting_behavior = field_splitting_behavior_for_options(options);
+    let pathname_expansion_behavior = pathname_expansion_behavior_for_options(options);
+
     match part {
         WordPart::ZshQualifiedGlob(_) => PartAnalysis {
             value_shape: PartValueShape::Unknown,
             array_valued: false,
             can_expand_to_multiple_fields: !in_double_quotes
-                && glob_is_effectively_enabled(options),
+                && pathname_expansion_behavior.literal_globs_can_expand(),
+            field_splitting_behavior,
+            pathname_expansion_behavior,
             hazards: ExpansionHazards {
-                pathname_matching: !in_double_quotes && glob_is_effectively_enabled(options),
+                pathname_matching: !in_double_quotes
+                    && pathname_expansion_behavior.literal_globs_can_expand(),
                 ..ExpansionHazards::default()
             },
             command_substitution: false,
@@ -580,6 +704,8 @@ pub(super) fn analyze_part(
         }
         WordPart::CommandSubstitution { .. } => scalar_part(
             substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+            field_splitting_behavior,
+            pathname_expansion_behavior,
             ExpansionHazards {
                 field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                 pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
@@ -591,6 +717,8 @@ pub(super) fn analyze_part(
         ),
         WordPart::ProcessSubstitution { .. } => scalar_part(
             false,
+            field_splitting_behavior,
+            pathname_expansion_behavior,
             ExpansionHazards {
                 command_or_process_substitution: true,
                 ..ExpansionHazards::default()
@@ -599,10 +727,24 @@ pub(super) fn analyze_part(
             true,
         ),
         WordPart::Variable(name) if matches!(name.as_str(), "@") => {
-            array_part(true, false, false, false)
+            array_part(
+                true,
+                field_splitting_behavior,
+                pathname_expansion_behavior,
+                false,
+                false,
+                false,
+            )
         }
         WordPart::Variable(name) if matches!(name.as_str(), "*") => {
-            array_part(!in_double_quotes, !in_double_quotes, false, false)
+            array_part(
+                !in_double_quotes,
+                field_splitting_behavior,
+                pathname_expansion_behavior,
+                !in_double_quotes,
+                false,
+                false,
+            )
         }
         WordPart::Variable(_)
         | WordPart::ArithmeticExpansion { .. }
@@ -610,6 +752,8 @@ pub(super) fn analyze_part(
         | WordPart::ArrayLength(_)
         | WordPart::Substring { .. } => scalar_part(
             substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+            field_splitting_behavior,
+            pathname_expansion_behavior,
             ExpansionHazards {
                 field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                 pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
@@ -620,10 +764,19 @@ pub(super) fn analyze_part(
             false,
         ),
         WordPart::Transformation { .. } => {
-            scalar_part(false, ExpansionHazards::default(), false, false)
+            scalar_part(
+                false,
+                field_splitting_behavior,
+                pathname_expansion_behavior,
+                ExpansionHazards::default(),
+                false,
+                false,
+            )
         }
         WordPart::ParameterExpansion { operator, .. } => scalar_part(
             substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+            field_splitting_behavior,
+            pathname_expansion_behavior,
             ExpansionHazards {
                 field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                 pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
@@ -638,12 +791,28 @@ pub(super) fn analyze_part(
             .as_ref()
             .and_then(|subscript| subscript.selector())
         {
-            Some(SubscriptSelector::At) => array_part(true, false, false, false),
+            Some(SubscriptSelector::At) => array_part(
+                true,
+                field_splitting_behavior,
+                pathname_expansion_behavior,
+                false,
+                false,
+                false,
+            ),
             Some(SubscriptSelector::Star) => {
-                array_part(!in_double_quotes, !in_double_quotes, false, false)
+                array_part(
+                    !in_double_quotes,
+                    field_splitting_behavior,
+                    pathname_expansion_behavior,
+                    !in_double_quotes,
+                    false,
+                    false,
+                )
             }
             None => scalar_part(
                 substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                field_splitting_behavior,
+                pathname_expansion_behavior,
                 ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                     pathname_matching: substitution_pathname_matching_hazard(
@@ -657,7 +826,14 @@ pub(super) fn analyze_part(
             ),
         },
         WordPart::ArraySlice { .. } | WordPart::ArrayIndices(_) => {
-            array_part(true, false, false, false)
+            array_part(
+                true,
+                field_splitting_behavior,
+                pathname_expansion_behavior,
+                false,
+                false,
+                false,
+            )
         }
         WordPart::PrefixMatch { kind, .. } => {
             let multi_field = prefix_match_can_expand_to_multiple_fields(*kind, in_double_quotes);
@@ -669,6 +845,8 @@ pub(super) fn analyze_part(
                 },
                 array_valued: false,
                 can_expand_to_multiple_fields: multi_field,
+                field_splitting_behavior,
+                pathname_expansion_behavior,
                 hazards: ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                     pathname_matching: substitution_pathname_matching_hazard(
@@ -688,6 +866,8 @@ pub(super) fn analyze_part(
                 in_double_quotes,
                 options,
             ),
+            field_splitting_behavior,
+            pathname_expansion_behavior,
             hazards: ExpansionHazards {
                 field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                 pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
@@ -710,6 +890,9 @@ pub(super) fn analyze_parameter_part(
     in_double_quotes: bool,
     options: Option<&ZshOptionState>,
 ) -> PartAnalysis {
+    let field_splitting_behavior = field_splitting_behavior_for_options(options);
+    let pathname_expansion_behavior = pathname_expansion_behavior_for_options(options);
+
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(syntax) => match syntax {
             BourneParameterExpansion::Access { reference } => match reference
@@ -717,12 +900,28 @@ pub(super) fn analyze_parameter_part(
                 .as_ref()
                 .and_then(|subscript| subscript.selector())
             {
-                Some(SubscriptSelector::At) => array_part(true, false, false, false),
+                Some(SubscriptSelector::At) => array_part(
+                    true,
+                    field_splitting_behavior,
+                    pathname_expansion_behavior,
+                    false,
+                    false,
+                    false,
+                ),
                 Some(SubscriptSelector::Star) => {
-                    array_part(!in_double_quotes, !in_double_quotes, false, false)
+                    array_part(
+                        !in_double_quotes,
+                        field_splitting_behavior,
+                        pathname_expansion_behavior,
+                        !in_double_quotes,
+                        false,
+                        false,
+                    )
                 }
                 None => scalar_part(
                     substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                    field_splitting_behavior,
+                    pathname_expansion_behavior,
                     ExpansionHazards {
                         field_splitting: substitution_field_splitting_hazard(
                             in_double_quotes,
@@ -740,6 +939,8 @@ pub(super) fn analyze_parameter_part(
             },
             BourneParameterExpansion::Length { .. } => scalar_part(
                 substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                field_splitting_behavior,
+                pathname_expansion_behavior,
                 ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                     pathname_matching: substitution_pathname_matching_hazard(
@@ -751,7 +952,14 @@ pub(super) fn analyze_parameter_part(
                 false,
                 false,
             ),
-            BourneParameterExpansion::Indices { .. } => array_part(true, false, false, false),
+            BourneParameterExpansion::Indices { .. } => array_part(
+                true,
+                field_splitting_behavior,
+                pathname_expansion_behavior,
+                false,
+                false,
+                false,
+            ),
             BourneParameterExpansion::Indirect { operator, .. } => PartAnalysis {
                 value_shape: PartValueShape::Unknown,
                 array_valued: false,
@@ -759,6 +967,8 @@ pub(super) fn analyze_parameter_part(
                     in_double_quotes,
                     options,
                 ),
+                field_splitting_behavior,
+                pathname_expansion_behavior,
                 hazards: ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                     pathname_matching: substitution_pathname_matching_hazard(
@@ -780,13 +990,15 @@ pub(super) fn analyze_parameter_part(
                     value_shape: if multi_field {
                         PartValueShape::Scalar
                     } else {
-                        PartValueShape::Unknown
-                    },
-                    array_valued: false,
-                    can_expand_to_multiple_fields: multi_field,
-                    hazards: ExpansionHazards {
-                        field_splitting: substitution_field_splitting_hazard(
-                            in_double_quotes,
+                    PartValueShape::Unknown
+                },
+                array_valued: false,
+                can_expand_to_multiple_fields: multi_field,
+                field_splitting_behavior,
+                pathname_expansion_behavior,
+                hazards: ExpansionHazards {
+                    field_splitting: substitution_field_splitting_hazard(
+                        in_double_quotes,
                             options,
                         ),
                         pathname_matching: substitution_pathname_matching_hazard(
@@ -801,10 +1013,19 @@ pub(super) fn analyze_parameter_part(
             }
             BourneParameterExpansion::Slice { reference, .. } => {
                 if reference.has_array_selector() {
-                    array_part(true, false, false, false)
+                    array_part(
+                        true,
+                        field_splitting_behavior,
+                        pathname_expansion_behavior,
+                        false,
+                        false,
+                        false,
+                    )
                 } else {
                     scalar_part(
                         substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                        field_splitting_behavior,
+                        pathname_expansion_behavior,
                         ExpansionHazards {
                             field_splitting: substitution_field_splitting_hazard(
                                 in_double_quotes,
@@ -823,6 +1044,8 @@ pub(super) fn analyze_parameter_part(
             }
             BourneParameterExpansion::Operation { operator, .. } => scalar_part(
                 substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                field_splitting_behavior,
+                pathname_expansion_behavior,
                 ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                     pathname_matching: substitution_pathname_matching_hazard(
@@ -837,6 +1060,8 @@ pub(super) fn analyze_parameter_part(
             ),
             BourneParameterExpansion::Transformation { .. } => scalar_part(
                 substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                field_splitting_behavior,
+                pathname_expansion_behavior,
                 ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
                     pathname_matching: substitution_pathname_matching_hazard(
@@ -851,6 +1076,10 @@ pub(super) fn analyze_parameter_part(
         },
         ParameterExpansionSyntax::Zsh(syntax) => {
             let effective_options = overlay_zsh_modifier_overrides(options, syntax);
+            let field_splitting_behavior =
+                field_splitting_behavior_for_options(effective_options.as_ref());
+            let pathname_expansion_behavior =
+                pathname_expansion_behavior_for_options(effective_options.as_ref());
             PartAnalysis {
                 value_shape: PartValueShape::Unknown,
                 array_valued: false,
@@ -858,6 +1087,8 @@ pub(super) fn analyze_parameter_part(
                     in_double_quotes,
                     effective_options.as_ref(),
                 ),
+                field_splitting_behavior,
+                pathname_expansion_behavior,
                 hazards: ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(
                         in_double_quotes,
@@ -885,41 +1116,25 @@ pub(super) fn substitution_can_expand_to_multiple_fields(
     options: Option<&ZshOptionState>,
 ) -> bool {
     !in_double_quotes
-        && (substitution_field_splitting_hazard(false, options)
-            || substitution_pathname_matching_hazard(false, options)
-            || options.is_none())
+        && (field_splitting_behavior_for_options(options).unquoted_results_can_split()
+            || pathname_expansion_behavior_for_options(options)
+                .unquoted_substitution_results_can_glob())
 }
 
 pub(super) fn substitution_field_splitting_hazard(
     in_double_quotes: bool,
     options: Option<&ZshOptionState>,
 ) -> bool {
-    if in_double_quotes {
-        return false;
-    }
-
-    match options {
-        Some(options) => !matches!(options.sh_word_split, OptionValue::Off),
-        None => true,
-    }
+    !in_double_quotes && field_splitting_behavior_for_options(options).unquoted_results_can_split()
 }
 
 pub(super) fn substitution_pathname_matching_hazard(
     in_double_quotes: bool,
     options: Option<&ZshOptionState>,
 ) -> bool {
-    if in_double_quotes || !glob_is_effectively_enabled(options) {
-        return false;
-    }
-
-    match options {
-        Some(options) => !matches!(options.glob_subst, OptionValue::Off),
-        None => true,
-    }
-}
-
-pub(super) fn glob_is_effectively_enabled(options: Option<&ZshOptionState>) -> bool {
-    !matches!(options.map(|options| options.glob), Some(OptionValue::Off))
+    !in_double_quotes
+        && pathname_expansion_behavior_for_options(options)
+            .unquoted_substitution_results_can_glob()
 }
 
 pub(super) fn overlay_zsh_modifier_overrides(
@@ -968,6 +1183,8 @@ pub(super) fn apply_toggle_override(value: &mut OptionValue, count: usize) {
 
 pub(super) fn scalar_part(
     can_expand_to_multiple_fields: bool,
+    field_splitting_behavior: FieldSplittingBehavior,
+    pathname_expansion_behavior: PathnameExpansionBehavior,
     hazards: ExpansionHazards,
     command_substitution: bool,
     process_substitution: bool,
@@ -976,6 +1193,8 @@ pub(super) fn scalar_part(
         value_shape: PartValueShape::Scalar,
         array_valued: false,
         can_expand_to_multiple_fields,
+        field_splitting_behavior,
+        pathname_expansion_behavior,
         hazards,
         command_substitution,
         process_substitution,
@@ -984,6 +1203,8 @@ pub(super) fn scalar_part(
 
 pub(super) fn array_part(
     can_expand_to_multiple_fields: bool,
+    field_splitting_behavior: FieldSplittingBehavior,
+    pathname_expansion_behavior: PathnameExpansionBehavior,
     field_splitting: bool,
     pathname_matching: bool,
     runtime_pattern: bool,
@@ -992,6 +1213,8 @@ pub(super) fn array_part(
         value_shape: PartValueShape::Array,
         array_valued: true,
         can_expand_to_multiple_fields,
+        field_splitting_behavior,
+        pathname_expansion_behavior,
         hazards: ExpansionHazards {
             field_splitting,
             pathname_matching,

--- a/crates/shuck-linter/src/facts/words/expansion.rs
+++ b/crates/shuck-linter/src/facts/words/expansion.rs
@@ -323,7 +323,10 @@ pub(super) fn pathname_expansion_behavior_for_options(
                 OptionValue::On => PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
                 OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
             },
-            OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
+            OptionValue::Unknown => match options.glob_subst {
+                OptionValue::Off => PathnameExpansionBehavior::LiteralGlobsOnlyOrDisabled,
+                OptionValue::On | OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
+            },
         },
         None => PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
     }
@@ -369,10 +372,26 @@ fn merge_pathname_expansion_behavior(
     current: Option<PathnameExpansionBehavior>,
     next: PathnameExpansionBehavior,
 ) -> Option<PathnameExpansionBehavior> {
+    use PathnameExpansionBehavior::{
+        Ambiguous, Disabled, LiteralGlobsOnly, LiteralGlobsOnlyOrDisabled,
+    };
+
     Some(match current {
         None => next,
         Some(existing) if existing == next => existing,
-        Some(_) => PathnameExpansionBehavior::Ambiguous,
+        Some(Ambiguous) | Some(_) if next == Ambiguous => Ambiguous,
+        Some(Disabled) if next == LiteralGlobsOnly => LiteralGlobsOnlyOrDisabled,
+        Some(LiteralGlobsOnly) if next == Disabled => LiteralGlobsOnlyOrDisabled,
+        Some(LiteralGlobsOnlyOrDisabled)
+            if matches!(next, Disabled | LiteralGlobsOnly | LiteralGlobsOnlyOrDisabled) =>
+        {
+            LiteralGlobsOnlyOrDisabled
+        }
+        Some(Disabled) if next == LiteralGlobsOnlyOrDisabled => LiteralGlobsOnlyOrDisabled,
+        Some(LiteralGlobsOnly) if next == LiteralGlobsOnlyOrDisabled => {
+            LiteralGlobsOnlyOrDisabled
+        }
+        Some(_) => Ambiguous,
     })
 }
 

--- a/crates/shuck-linter/src/facts/words/tests.rs
+++ b/crates/shuck-linter/src/facts/words/tests.rs
@@ -221,6 +221,7 @@ mod expansion_analysis_tests {
         ExpansionValueShape, RedirectDevNullStatus, WordLiteralness, WordQuote,
         analyze_literal_runtime, analyze_redirect_target, analyze_word, comparable_path,
     };
+    use crate::{FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior};
 
     fn parse_argument_words(source: &str) -> Vec<shuck_ast::Word> {
         let file = Parser::new(source).parse().unwrap().file;
@@ -364,6 +365,117 @@ mod expansion_analysis_tests {
     }
 
     #[test]
+    fn analyze_word_records_option_sensitive_expansion_behaviors() {
+        let source = "print $name\n";
+        let file = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
+        let Command::Simple(command) = &file.body[0].command else {
+            panic!("expected simple command");
+        };
+        let native = analyze_word(
+            &command.args[0],
+            source,
+            Some(&shuck_semantic::ZshOptionState::zsh_default()),
+        );
+        let split_options = shuck_semantic::ZshOptionState {
+            sh_word_split: shuck_semantic::OptionValue::On,
+            ..shuck_semantic::ZshOptionState::zsh_default()
+        };
+        let split = analyze_word(&command.args[0], source, Some(&split_options));
+        let no_glob_options = shuck_semantic::ZshOptionState {
+            glob: shuck_semantic::OptionValue::Off,
+            ..shuck_semantic::ZshOptionState::zsh_default()
+        };
+        let no_glob = analyze_word(&command.args[0], source, Some(&no_glob_options));
+
+        assert_eq!(
+            native.field_splitting_behavior,
+            FieldSplittingBehavior::Never
+        );
+        assert_eq!(
+            native.pathname_expansion_behavior,
+            PathnameExpansionBehavior::LiteralGlobsOnly
+        );
+        assert_eq!(
+            split.field_splitting_behavior,
+            FieldSplittingBehavior::UnquotedOnly
+        );
+        assert!(split.hazards.field_splitting);
+        assert_eq!(
+            no_glob.pathname_expansion_behavior,
+            PathnameExpansionBehavior::Disabled
+        );
+        assert!(!no_glob.hazards.pathname_matching);
+    }
+
+    #[test]
+    fn analyze_word_treats_unknown_option_state_as_ambiguous_behavior() {
+        let source = "print $name\n";
+        let file = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
+        let Command::Simple(command) = &file.body[0].command else {
+            panic!("expected simple command");
+        };
+        let analysis = analyze_word(
+            &command.args[0],
+            source,
+            Some(&shuck_semantic::ZshOptionState {
+                sh_word_split: shuck_semantic::OptionValue::Unknown,
+                glob: shuck_semantic::OptionValue::Unknown,
+                ..shuck_semantic::ZshOptionState::zsh_default()
+            }),
+        );
+
+        assert_eq!(
+            analysis.field_splitting_behavior,
+            FieldSplittingBehavior::Ambiguous
+        );
+        assert_eq!(
+            analysis.pathname_expansion_behavior,
+            PathnameExpansionBehavior::Ambiguous
+        );
+        assert!(analysis.hazards.field_splitting);
+        assert!(analysis.hazards.pathname_matching);
+        assert!(analysis.can_expand_to_multiple_fields);
+    }
+
+    #[test]
+    fn analyze_word_applies_zsh_modifier_overrides_to_behaviors() {
+        let source = "print ${=name} ${~name} ${~~name}\n";
+        let file = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
+        let Command::Simple(command) = &file.body[0].command else {
+            panic!("expected simple command");
+        };
+        let options = shuck_semantic::ZshOptionState::zsh_default();
+        let split = analyze_word(&command.args[0], source, Some(&options));
+        let glob = analyze_word(&command.args[1], source, Some(&options));
+        let no_glob_subst = analyze_word(&command.args[2], source, Some(&options));
+
+        assert_eq!(
+            split.field_splitting_behavior,
+            FieldSplittingBehavior::UnquotedOnly
+        );
+        assert!(split.hazards.field_splitting);
+        assert_eq!(
+            glob.pathname_expansion_behavior,
+            PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted
+        );
+        assert!(glob.hazards.pathname_matching);
+        assert_eq!(
+            no_glob_subst.pathname_expansion_behavior,
+            PathnameExpansionBehavior::LiteralGlobsOnly
+        );
+        assert!(!no_glob_subst.hazards.pathname_matching);
+    }
+
+    #[test]
     fn analyze_literal_runtime_tracks_globs_in_mixed_words() {
         let source =
             "printf '%s\\n' \"$basedir/\"* \"$(dirname \"$0\")\"/../docs/usage/distrobox*\n";
@@ -375,6 +487,116 @@ mod expansion_analysis_tests {
         assert!(first.is_runtime_sensitive());
         assert!(second.hazards.pathname_matching);
         assert!(second.is_runtime_sensitive());
+    }
+
+    #[test]
+    fn analyze_literal_runtime_records_glob_failure_behavior() {
+        let source = "print *.jpg\n";
+        let words = parse_argument_words(source);
+        let native = analyze_literal_runtime(
+            &words[0],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&shuck_semantic::ZshOptionState::zsh_default()),
+        );
+        let null_glob = analyze_literal_runtime(
+            &words[0],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&shuck_semantic::ZshOptionState {
+                null_glob: shuck_semantic::OptionValue::On,
+                ..shuck_semantic::ZshOptionState::zsh_default()
+            }),
+        );
+        let no_glob = analyze_literal_runtime(
+            &words[0],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&shuck_semantic::ZshOptionState {
+                glob: shuck_semantic::OptionValue::Off,
+                ..shuck_semantic::ZshOptionState::zsh_default()
+            }),
+        );
+
+        assert_eq!(
+            native.glob_failure_behavior,
+            GlobFailureBehavior::ErrorOnNoMatch
+        );
+        assert_eq!(
+            null_glob.glob_failure_behavior,
+            GlobFailureBehavior::DropUnmatchedPattern
+        );
+        assert_eq!(
+            no_glob.pathname_expansion_behavior,
+            PathnameExpansionBehavior::Disabled
+        );
+        assert_eq!(
+            no_glob.glob_failure_behavior,
+            GlobFailureBehavior::KeepLiteralOnNoMatch
+        );
+    }
+
+    #[test]
+    fn analyze_literal_runtime_respects_no_glob_precedence_over_failure_modes() {
+        let source = "print *.jpg\n";
+        let words = parse_argument_words(source);
+        let analysis = analyze_literal_runtime(
+            &words[0],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&shuck_semantic::ZshOptionState {
+                glob: shuck_semantic::OptionValue::Off,
+                null_glob: shuck_semantic::OptionValue::On,
+                csh_null_glob: shuck_semantic::OptionValue::On,
+                nomatch: shuck_semantic::OptionValue::On,
+                ..shuck_semantic::ZshOptionState::zsh_default()
+            }),
+        );
+
+        assert_eq!(
+            analysis.pathname_expansion_behavior,
+            PathnameExpansionBehavior::Disabled
+        );
+        assert_eq!(
+            analysis.glob_failure_behavior,
+            GlobFailureBehavior::KeepLiteralOnNoMatch
+        );
+        assert!(!analysis.hazards.pathname_matching);
+        assert!(!analysis.is_runtime_sensitive());
+    }
+
+    #[test]
+    fn analyze_literal_runtime_distinguishes_nomatch_and_csh_null_glob() {
+        let source = "print *.jpg\n";
+        let words = parse_argument_words(source);
+        let keep_literal = analyze_literal_runtime(
+            &words[0],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&shuck_semantic::ZshOptionState {
+                nomatch: shuck_semantic::OptionValue::Off,
+                ..shuck_semantic::ZshOptionState::zsh_default()
+            }),
+        );
+        let csh_null_glob = analyze_literal_runtime(
+            &words[0],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&shuck_semantic::ZshOptionState {
+                csh_null_glob: shuck_semantic::OptionValue::On,
+                ..shuck_semantic::ZshOptionState::zsh_default()
+            }),
+        );
+
+        assert_eq!(
+            keep_literal.glob_failure_behavior,
+            GlobFailureBehavior::KeepLiteralOnNoMatch
+        );
+        assert_eq!(
+            csh_null_glob.glob_failure_behavior,
+            GlobFailureBehavior::CshNullGlob
+        );
+        assert!(csh_null_glob.hazards.pathname_matching);
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/words/tests.rs
+++ b/crates/shuck-linter/src/facts/words/tests.rs
@@ -426,6 +426,7 @@ mod expansion_analysis_tests {
             Some(&shuck_semantic::ZshOptionState {
                 sh_word_split: shuck_semantic::OptionValue::Unknown,
                 glob: shuck_semantic::OptionValue::Unknown,
+                glob_subst: shuck_semantic::OptionValue::Unknown,
                 ..shuck_semantic::ZshOptionState::zsh_default()
             }),
         );
@@ -441,6 +442,34 @@ mod expansion_analysis_tests {
         assert!(analysis.hazards.field_splitting);
         assert!(analysis.hazards.pathname_matching);
         assert!(analysis.can_expand_to_multiple_fields);
+    }
+
+    #[test]
+    fn analyze_word_keeps_glob_subst_off_when_glob_state_is_unknown() {
+        let source = "print $name\n";
+        let file = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
+        let Command::Simple(command) = &file.body[0].command else {
+            panic!("expected simple command");
+        };
+        let analysis = analyze_word(
+            &command.args[0],
+            source,
+            Some(&shuck_semantic::ZshOptionState {
+                glob: shuck_semantic::OptionValue::Unknown,
+                glob_subst: shuck_semantic::OptionValue::Off,
+                ..shuck_semantic::ZshOptionState::zsh_default()
+            }),
+        );
+
+        assert_eq!(
+            analysis.pathname_expansion_behavior,
+            PathnameExpansionBehavior::LiteralGlobsOnlyOrDisabled
+        );
+        assert!(!analysis.hazards.pathname_matching);
+        assert!(!analysis.can_expand_to_multiple_fields);
     }
 
     #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -105,6 +105,9 @@ pub use settings::{
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;
+/// Option-sensitive shell behavior enums reused by linter facts and rules.
+pub use shuck_semantic::{FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior};
+pub(crate) use suppression::parse_directives;
 /// Suppression directives, shellcheck mappings, and rewrite helpers.
 pub use suppression::{
     AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -107,7 +107,6 @@ pub use settings::{
 pub use shell::ShellDialect;
 /// Option-sensitive shell behavior enums reused by linter facts and rules.
 pub use shuck_semantic::{FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior};
-pub(crate) use suppression::parse_directives;
 /// Suppression directives, shellcheck mappings, and rewrite helpers.
 pub use suppression::{
     AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -323,6 +323,24 @@ printf '%s\\n' *
     }
 
     #[test]
+    fn still_reports_when_glob_is_flow_merged_in_zsh() {
+        let source = "if cond; then setopt no_glob; fi\nrm *\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*"]
+        );
+    }
+
+    #[test]
     fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
         let result = test_path_with_fix(
             Path::new("correctness").join("C012.sh").as_path(),

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -41,11 +41,10 @@ fn reportable_glob_diagnostic(
     if command_exempts_glob_warning(command.effective_name()) {
         return None;
     }
-    if checker
-        .facts()
-        .command(fact.command_id())
-        .zsh_options()
-        .is_some_and(|options| options.glob.is_definitely_off())
+    if !fact
+        .runtime_literal()
+        .pathname_expansion_behavior
+        .literal_globs_can_expand()
     {
         return None;
     }
@@ -248,6 +247,72 @@ printf '%s\\n' *
     #[test]
     fn ignores_noglob_wrapped_commands_in_zsh() {
         let source = "noglob rm *\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn still_reports_when_no_nomatch_keeps_unmatched_globs_literal() {
+        let source = "setopt no_nomatch\nrm *\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*"]
+        );
+    }
+
+    #[test]
+    fn still_reports_when_null_glob_drops_unmatched_patterns() {
+        let source = "setopt null_glob\nrm *\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*"]
+        );
+    }
+
+    #[test]
+    fn still_reports_when_glob_failure_options_do_not_disable_globbing() {
+        let source = "setopt null_glob csh_null_glob\nrm *\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["*"]
+        );
+    }
+
+    #[test]
+    fn ignores_when_no_glob_overrides_glob_failure_options_in_zsh() {
+        let source = "setopt no_glob null_glob csh_null_glob\nrm *\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::LeadingGlobArgument)

--- a/crates/shuck-linter/src/rules/mod.rs
+++ b/crates/shuck-linter/src/rules/mod.rs
@@ -136,4 +136,56 @@ mod architecture_tests {
             violations.join("\n"),
         );
     }
+
+    #[test]
+    fn c012_rule_avoids_raw_zsh_option_state_queries() {
+        let rule_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/rules/correctness/leading_glob_argument.rs");
+        let source = fs::read_to_string(&rule_path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", rule_path.display()));
+        let forbidden_tokens = [
+            "zsh_options_at",
+            "zsh_options()",
+            "ZshOptionState",
+            "OptionValue",
+            "shell_behavior_at",
+        ];
+        let violations = forbidden_tokens
+            .iter()
+            .copied()
+            .filter(|token| source.contains(token))
+            .collect::<Vec<_>>();
+
+        assert!(
+            violations.is_empty(),
+            "C012 should consume behavior-partitioned facts instead of raw zsh option state:\n{}",
+            violations.join("\n"),
+        );
+    }
+
+    #[test]
+    fn k001_rule_avoids_raw_zsh_option_state_queries() {
+        let rule_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src/rules/security/rm_glob_on_variable_path.rs");
+        let source = fs::read_to_string(&rule_path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", rule_path.display()));
+        let forbidden_tokens = [
+            "zsh_options_at",
+            "zsh_options()",
+            "ZshOptionState",
+            "OptionValue",
+            "shell_behavior_at",
+        ];
+        let violations = forbidden_tokens
+            .iter()
+            .copied()
+            .filter(|token| source.contains(token))
+            .collect::<Vec<_>>();
+
+        assert!(
+            violations.is_empty(),
+            "K001 should consume behavior-partitioned facts instead of raw zsh option state:\n{}",
+            violations.join("\n"),
+        );
+    }
 }

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -1,4 +1,6 @@
-use crate::{Checker, Rule, Violation};
+use rustc_hash::FxHashSet;
+
+use crate::{Checker, ExpansionContext, FactSpan, Rule, Violation, WordFactHostKind};
 
 pub struct RmGlobOnVariablePath;
 
@@ -13,17 +15,35 @@ impl Violation for RmGlobOnVariablePath {
 }
 
 pub fn rm_glob_on_variable_path(checker: &mut Checker) {
+    let source = checker.source();
+    let reportable_word_spans = checker
+        .facts()
+        .expansion_word_facts(ExpansionContext::CommandArgument)
+        .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
+        .filter(|fact| {
+            fact.unquoted_glob_pattern_spans(source).is_empty()
+                || fact
+                    .runtime_literal()
+                    .pathname_expansion_behavior
+                    .literal_globs_can_expand()
+        })
+        .map(|fact| (fact.command_id(), FactSpan::new(fact.span())))
+        .collect::<FxHashSet<_>>();
+    let reportable_word_spans = &reportable_word_spans;
+
     let spans = checker
         .facts()
         .structural_commands()
         .filter(|fact| fact.effective_name_is("rm"))
-        .filter(|fact| {
-            !fact
-                .zsh_options()
-                .is_some_and(|options| options.glob.is_definitely_off())
+        .filter_map(|fact| fact.options().rm().map(|rm| (fact.id(), rm)))
+        .flat_map(|(command_id, rm)| {
+            rm.dangerous_path_spans()
+                .iter()
+                .copied()
+                .filter(move |span| {
+                    reportable_word_spans.contains(&(command_id, FactSpan::new(*span)))
+                })
         })
-        .filter_map(|fact| fact.options().rm())
-        .flat_map(|rm| rm.dangerous_path_spans().iter().copied())
         .collect::<Vec<_>>();
 
     checker.report_all(spans, || RmGlobOnVariablePath);
@@ -195,5 +215,66 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_glob_driven_rm_paths_when_no_glob_is_active_in_zsh() {
+        let source = "#!/usr/bin/env zsh\nsetopt no_glob\ndir=/tmp\nrm -rf \"$dir\"/*\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RmGlobOnVariablePath)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_noglob_wrapped_globbed_rm_paths_in_zsh() {
+        let source = "#!/usr/bin/env zsh\ndir=/tmp\nnoglob rm -rf \"$dir\"/*\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RmGlobOnVariablePath)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn still_reports_non_glob_rm_paths_when_no_glob_is_active_in_zsh() {
+        let source = "#!/usr/bin/env zsh\nsetopt no_glob\nDESTDIR=/dest\nrm -rf \"$DESTDIR\"/usr\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RmGlobOnVariablePath)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"$DESTDIR\"/usr"]
+        );
+    }
+
+    #[test]
+    fn still_reports_globbed_rm_paths_when_glob_failure_options_do_not_disable_globbing() {
+        let source =
+            "#!/usr/bin/env zsh\nsetopt null_glob csh_null_glob\ndir=/tmp\nrm -rf \"$dir\"/*\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::RmGlobOnVariablePath)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["\"$dir\"/*"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -337,6 +337,7 @@ fn report_word_expansions<F>(
         backtick_escaped_parameter_spans,
         part_filter,
     } = options;
+    let star_spans = fact.unquoted_star_parameter_spans();
 
     let analysis = fact.analysis();
     if !analysis
@@ -345,6 +346,7 @@ fn report_word_expansions<F>(
         && !analysis
             .pathname_expansion_behavior
             .unquoted_substitution_results_can_glob()
+        && star_spans.is_empty()
     {
         return;
     }
@@ -356,7 +358,6 @@ fn report_word_expansions<F>(
         Default::default()
     };
     let use_replacement_spans = fact.use_replacement_spans();
-    let star_spans = fact.unquoted_star_parameter_spans();
     if scalar_spans.is_empty() && star_spans.is_empty() {
         return;
     }
@@ -1634,6 +1635,23 @@ rsync ${RSYNC_OPTIONS[*]} src dst
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${RSYNC_OPTIONS[*]}"]
+        );
+    }
+
+    #[test]
+    fn reports_unquoted_star_parameter_in_native_zsh_mode() {
+        let source = "print $*\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$*"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -5417,6 +5417,17 @@ printf '%s\\n' ${!dynamic}
     }
 
     #[test]
+    fn skips_unquoted_scalars_when_glob_is_flow_merged_but_glob_subst_is_off_in_zsh() {
+        let source = "if cond; then setopt no_glob; fi\nprint $name\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_unquoted_scalars_when_sh_word_split_is_set_even_with_no_glob_in_zsh() {
         let source = "setopt sh_word_split no_glob\nprint $name\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -338,7 +338,14 @@ fn report_word_expansions<F>(
         part_filter,
     } = options;
 
-    if !fact.analysis().hazards.field_splitting && !fact.analysis().hazards.pathname_matching {
+    let analysis = fact.analysis();
+    if !analysis
+        .field_splitting_behavior
+        .unquoted_results_can_split()
+        && !analysis
+            .pathname_expansion_behavior
+            .unquoted_substitution_results_can_glob()
+    {
         return;
     }
 
@@ -5365,6 +5372,68 @@ printf '%s\\n' ${!dynamic}
     }
 
     #[test]
+    fn reports_unquoted_scalars_after_setopt_glob_subst_in_zsh() {
+        let source = "setopt glob_subst\nprint $name\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$name"]
+        );
+    }
+
+    #[test]
+    fn reports_unquoted_scalars_after_dynamic_glob_subst_in_zsh() {
+        let source = "opt=glob_subst\nsetopt \"$opt\"\nprint $name\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$name"]
+        );
+    }
+
+    #[test]
+    fn skips_unquoted_scalars_when_no_glob_masks_glob_subst_in_zsh() {
+        let source = "setopt glob_subst no_glob\nprint $name\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_unquoted_scalars_when_sh_word_split_is_set_even_with_no_glob_in_zsh() {
+        let source = "setopt sh_word_split no_glob\nprint $name\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$name"]
+        );
+    }
+
+    #[test]
     fn reports_zsh_force_split_modifier_even_without_sh_word_split() {
         let source = "print ${=name}\n";
         let diagnostics = test_snippet(
@@ -5378,6 +5447,23 @@ printf '%s\\n' ${!dynamic}
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${=name}"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_force_glob_modifier_even_without_glob_subst() {
+        let source = "print ${~name}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedExpansion).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${~name}"]
         );
     }
 

--- a/crates/shuck-semantic/src/glob.rs
+++ b/crates/shuck-semantic/src/glob.rs
@@ -25,6 +25,8 @@ pub enum PathnameExpansionBehavior {
     Disabled,
     /// Literal glob characters are active, but substitution results are not globbed.
     LiteralGlobsOnly,
+    /// Runtime option state may enable literal glob expansion, but substitution results stay plain.
+    LiteralGlobsOnlyOrDisabled,
     /// Unquoted substitution results can also trigger pathname expansion.
     SubstitutionResultsWhenUnquoted,
     /// Runtime option state may select either behavior family.
@@ -90,7 +92,10 @@ impl ShellBehaviorAt<'_> {
 
         match options.glob {
             OptionValue::Off => PathnameExpansionBehavior::Disabled,
-            OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
+            OptionValue::Unknown => match options.glob_subst {
+                OptionValue::Off => PathnameExpansionBehavior::LiteralGlobsOnlyOrDisabled,
+                OptionValue::On | OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
+            },
             OptionValue::On => match options.glob_subst {
                 OptionValue::Off => PathnameExpansionBehavior::LiteralGlobsOnly,
                 OptionValue::On => PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
@@ -213,6 +218,10 @@ mod tests {
                 "opt=glob_subst\nsetopt \"$opt\"\nprint $name\n",
                 PathnameExpansionBehavior::Ambiguous,
             ),
+            (
+                "if cond; then setopt no_glob; fi\nprint $name\n",
+                PathnameExpansionBehavior::LiteralGlobsOnlyOrDisabled,
+            ),
         ] {
             let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
             let offset = source.find("print").expect("expected print offset");
@@ -250,6 +259,26 @@ mod tests {
                 "{source}"
             );
         }
+    }
+
+    #[test]
+    fn pathname_expansion_keeps_glob_subst_off_when_glob_is_flow_merged() {
+        let source = "\
+if cond; then
+  setopt no_glob
+fi
+print $name
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let offset = source.find("print").expect("expected print offset");
+        let behavior = model.shell_behavior_at(offset).pathname_expansion();
+
+        assert_eq!(
+            behavior,
+            PathnameExpansionBehavior::LiteralGlobsOnlyOrDisabled
+        );
+        assert!(behavior.literal_globs_can_expand());
+        assert!(!behavior.unquoted_substitution_results_can_glob());
     }
 
     #[test]

--- a/crates/shuck-semantic/src/glob.rs
+++ b/crates/shuck-semantic/src/glob.rs
@@ -1,0 +1,343 @@
+use crate::{OptionValue, ShellBehaviorAt, ShellDialect};
+
+/// Whether unquoted expansion results are subject to field splitting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldSplittingBehavior {
+    /// Field splitting does not apply.
+    Never,
+    /// Field splitting applies only when the expansion is unquoted.
+    UnquotedOnly,
+    /// Runtime option state may select either behavior.
+    Ambiguous,
+}
+
+impl FieldSplittingBehavior {
+    /// Returns whether an unquoted expansion result may be split into fields.
+    pub fn unquoted_results_can_split(self) -> bool {
+        matches!(self, Self::UnquotedOnly | Self::Ambiguous)
+    }
+}
+
+/// Whether pathname expansion applies to literal globs and substitution results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathnameExpansionBehavior {
+    /// Pathname expansion does not apply.
+    Disabled,
+    /// Literal glob characters are active, but substitution results are not globbed.
+    LiteralGlobsOnly,
+    /// Unquoted substitution results can also trigger pathname expansion.
+    SubstitutionResultsWhenUnquoted,
+    /// Runtime option state may select either behavior family.
+    Ambiguous,
+}
+
+impl PathnameExpansionBehavior {
+    /// Returns whether literal glob characters may trigger pathname expansion.
+    pub fn literal_globs_can_expand(self) -> bool {
+        !matches!(self, Self::Disabled)
+    }
+
+    /// Returns whether unquoted substitution results may be interpreted as globs.
+    pub fn unquoted_substitution_results_can_glob(self) -> bool {
+        matches!(
+            self,
+            Self::SubstitutionResultsWhenUnquoted | Self::Ambiguous
+        )
+    }
+}
+
+/// How unmatched glob patterns behave.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobFailureBehavior {
+    /// An unmatched glob produces an error.
+    ErrorOnNoMatch,
+    /// An unmatched glob stays literal in argv.
+    KeepLiteralOnNoMatch,
+    /// An unmatched glob is removed from argv.
+    DropUnmatchedPattern,
+    /// Unmatched globs are removed unless every glob in the command misses.
+    CshNullGlob,
+    /// Runtime option state may select either behavior.
+    Ambiguous,
+}
+
+impl ShellBehaviorAt<'_> {
+    /// Returns the field-splitting behavior implied by the shell and runtime option state.
+    pub fn field_splitting(&self) -> FieldSplittingBehavior {
+        if self.shell != ShellDialect::Zsh {
+            return FieldSplittingBehavior::UnquotedOnly;
+        }
+
+        match self
+            .effective_zsh_options()
+            .map(|options| options.sh_word_split)
+        {
+            Some(OptionValue::Off) => FieldSplittingBehavior::Never,
+            Some(OptionValue::Unknown) => FieldSplittingBehavior::Ambiguous,
+            Some(OptionValue::On) | None => FieldSplittingBehavior::UnquotedOnly,
+        }
+    }
+
+    /// Returns the pathname-expansion behavior implied by the shell and runtime option state.
+    pub fn pathname_expansion(&self) -> PathnameExpansionBehavior {
+        if self.shell != ShellDialect::Zsh {
+            return PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted;
+        }
+
+        let Some(options) = self.effective_zsh_options() else {
+            return PathnameExpansionBehavior::LiteralGlobsOnly;
+        };
+
+        match options.glob {
+            OptionValue::Off => PathnameExpansionBehavior::Disabled,
+            OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
+            OptionValue::On => match options.glob_subst {
+                OptionValue::Off => PathnameExpansionBehavior::LiteralGlobsOnly,
+                OptionValue::On => PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
+                OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
+            },
+        }
+    }
+
+    /// Returns the unmatched-glob behavior implied by the shell and runtime option state.
+    pub fn glob_failure(&self) -> GlobFailureBehavior {
+        if self.shell != ShellDialect::Zsh {
+            return GlobFailureBehavior::KeepLiteralOnNoMatch;
+        }
+
+        let Some(options) = self.effective_zsh_options() else {
+            return GlobFailureBehavior::ErrorOnNoMatch;
+        };
+
+        match options.glob {
+            OptionValue::Off => GlobFailureBehavior::KeepLiteralOnNoMatch,
+            OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
+            OptionValue::On => match options.csh_null_glob {
+                OptionValue::On => GlobFailureBehavior::CshNullGlob,
+                OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
+                OptionValue::Off => match options.null_glob {
+                    OptionValue::On => GlobFailureBehavior::DropUnmatchedPattern,
+                    OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
+                    OptionValue::Off => match options.nomatch {
+                        OptionValue::On => GlobFailureBehavior::ErrorOnNoMatch,
+                        OptionValue::Off => GlobFailureBehavior::KeepLiteralOnNoMatch,
+                        OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
+                    },
+                },
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SemanticBuildOptions, SemanticModel, ShellProfile};
+    use shuck_indexer::Indexer;
+    use shuck_parser::parser::Parser;
+
+    fn model_with_profile(source: &str, profile: ShellProfile) -> SemanticModel {
+        let output = Parser::with_profile(source, profile.clone())
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(source, &output);
+        SemanticModel::build_with_options(
+            &output.file,
+            source,
+            &indexer,
+            SemanticBuildOptions {
+                shell_profile: Some(profile),
+                ..SemanticBuildOptions::default()
+            },
+        )
+    }
+
+    #[test]
+    fn tracks_field_splitting_by_offset() {
+        for (source, expected) in [
+            ("print $name\n", FieldSplittingBehavior::Never),
+            (
+                "setopt sh_word_split\nprint $name\n",
+                FieldSplittingBehavior::UnquotedOnly,
+            ),
+            (
+                "opt=sh_word_split\nsetopt \"$opt\"\nprint $name\n",
+                FieldSplittingBehavior::Ambiguous,
+            ),
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let offset = source.find("print").expect("expected print offset");
+
+            assert_eq!(
+                model.shell_behavior_at(offset).field_splitting(),
+                expected,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn uses_non_zsh_default_behaviors() {
+        let source = "printf '%s\\n' $name *.txt\n";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Bash));
+        let offset = source.find("printf").expect("expected printf offset");
+        let behavior = model.shell_behavior_at(offset);
+
+        assert_eq!(
+            behavior.field_splitting(),
+            FieldSplittingBehavior::UnquotedOnly
+        );
+        assert_eq!(
+            behavior.pathname_expansion(),
+            PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted
+        );
+        assert_eq!(
+            behavior.glob_failure(),
+            GlobFailureBehavior::KeepLiteralOnNoMatch
+        );
+    }
+
+    #[test]
+    fn tracks_pathname_expansion_by_offset() {
+        for (source, expected) in [
+            ("print $name\n", PathnameExpansionBehavior::LiteralGlobsOnly),
+            (
+                "setopt glob_subst\nprint $name\n",
+                PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
+            ),
+            (
+                "setopt no_glob\nprint $name\n",
+                PathnameExpansionBehavior::Disabled,
+            ),
+            (
+                "opt=glob_subst\nsetopt \"$opt\"\nprint $name\n",
+                PathnameExpansionBehavior::Ambiguous,
+            ),
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let offset = source.find("print").expect("expected print offset");
+
+            assert_eq!(
+                model.shell_behavior_at(offset).pathname_expansion(),
+                expected,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn pathname_expansion_respects_no_glob_precedence() {
+        for (source, expected) in [
+            (
+                "setopt no_glob glob_subst\nprint $name\n",
+                PathnameExpansionBehavior::Disabled,
+            ),
+            (
+                "setopt glob_subst\nprint $name\n",
+                PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
+            ),
+            (
+                "unsetopt glob_subst\nprint $name\n",
+                PathnameExpansionBehavior::LiteralGlobsOnly,
+            ),
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let offset = source.find("print").expect("expected print offset");
+
+            assert_eq!(
+                model.shell_behavior_at(offset).pathname_expansion(),
+                expected,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn tracks_function_leaked_option_effects_by_offset() {
+        let source = "\
+fn() {
+  setopt sh_word_split glob_subst
+}
+fn
+print $name
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let offset = source.rfind("print").expect("expected print offset");
+
+        assert_eq!(
+            model.shell_behavior_at(offset).field_splitting(),
+            FieldSplittingBehavior::UnquotedOnly
+        );
+        assert_eq!(
+            model.shell_behavior_at(offset).pathname_expansion(),
+            PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted
+        );
+        assert_eq!(
+            model.shell_behavior_at(offset).glob_failure(),
+            GlobFailureBehavior::ErrorOnNoMatch
+        );
+    }
+
+    #[test]
+    fn tracks_glob_failure_modes_by_offset() {
+        for (source, expected) in [
+            ("print *\n", GlobFailureBehavior::ErrorOnNoMatch),
+            (
+                "setopt no_nomatch\nprint *\n",
+                GlobFailureBehavior::KeepLiteralOnNoMatch,
+            ),
+            (
+                "setopt null_glob\nprint *\n",
+                GlobFailureBehavior::DropUnmatchedPattern,
+            ),
+            (
+                "setopt csh_null_glob\nprint *\n",
+                GlobFailureBehavior::CshNullGlob,
+            ),
+            (
+                "opt=no_nomatch\nsetopt \"$opt\"\nprint *\n",
+                GlobFailureBehavior::Ambiguous,
+            ),
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let offset = source.find("print").expect("expected print offset");
+
+            assert_eq!(
+                model.shell_behavior_at(offset).glob_failure(),
+                expected,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn glob_failure_respects_option_precedence() {
+        for (source, expected) in [
+            (
+                "setopt no_glob null_glob csh_null_glob\nprint *\n",
+                GlobFailureBehavior::KeepLiteralOnNoMatch,
+            ),
+            (
+                "setopt null_glob csh_null_glob\nprint *\n",
+                GlobFailureBehavior::CshNullGlob,
+            ),
+            (
+                "setopt null_glob\nunsetopt csh_null_glob\nprint *\n",
+                GlobFailureBehavior::DropUnmatchedPattern,
+            ),
+            (
+                "setopt no_nomatch null_glob csh_null_glob\nprint *\n",
+                GlobFailureBehavior::CshNullGlob,
+            ),
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let offset = source.find("print").expect("expected print offset");
+
+            assert_eq!(
+                model.shell_behavior_at(offset).glob_failure(),
+                expected,
+                "{source}"
+            );
+        }
+    }
+}

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -16,6 +16,7 @@ mod declaration;
 mod dense_bit_set;
 mod function_call_reachability;
 mod function_resolution;
+mod glob;
 mod nonpersistent;
 mod reachability;
 mod reference;
@@ -60,6 +61,8 @@ pub use function_call_reachability::{
     DirectFunctionCallReachability, DirectFunctionCallWindow, FunctionCallCandidate,
     FunctionCallPersistence,
 };
+/// Option-sensitive globbing and expansion behavior queries.
+pub use glob::{FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior};
 /// Nonpersistent assignment effects, such as assignments made in subshells and read later outside.
 pub use nonpersistent::{
     NonpersistentAssignmentAnalysis, NonpersistentAssignmentAnalysisContext,


### PR DESCRIPTION
## Summary

- finish the Phase 3 option-sensitive glob behavior migration across the semantic and linter fact APIs
- switch S001, C012, and K001 to the behavior-partitioned fact surface instead of raw zsh option queries
- preserve glob_subst=off when glob state is flow-merged and add regression coverage for the zsh false-positive case

## Why

This completes the option-sensitive glob behavior migration while keeping literal-glob ambiguity separate from substitution-globbing ambiguity in zsh.

## Validation

- cargo test
- cargo test -p shuck-linter
- cargo clippy --all-targets -- -D warnings
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001,C012,K001,K003

Large corpus summary: blocking=0, implementation_diffs=0.
