### PR TITLE
fix(server): cache resolved project settings

### DIFF
--- a/crates/shuck-server/src/fix.rs
+++ b/crates/shuck-server/src/fix.rs
@@ -297,7 +297,7 @@ fn apply_workspace_edit(
             label: Some(label.to_owned()),
             edit: workspace_edit_for_document(snapshot, edits),
         },
-        |_, response| {
+        |_, _, response| {
             if !response.applied {
                 tracing::warn!(
                     "Client rejected workspace edit: {}",

--- a/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
@@ -76,6 +76,19 @@ mod tests {
 
         std::fs::write(&config_path, "[lint]\nselect = ['C006']\n")
             .expect("config should be updated");
+
+        let cached = session
+            .take_snapshot(uri.clone())
+            .expect("settings should stay cached until invalidated");
+        assert!(
+            cached
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
+        assert_eq!(cached.shuck_settings().linter().rules.len(), 1);
+
         DidChangeWatchedFiles::run(
             &mut session,
             &client,

--- a/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
@@ -24,13 +24,29 @@ impl super::super::traits::SyncNotificationHandler for DidChangeWatchedFiles {
 #[cfg(test)]
 mod tests {
     use crossbeam::channel;
-    use lsp_types::{ClientCapabilities, FileChangeType, FileEvent, Url};
+    use lsp_types::{
+        ClientCapabilities, DidChangeWatchedFilesClientCapabilities, FileChangeType, FileEvent,
+        Url, WorkspaceClientCapabilities,
+    };
 
     use super::*;
     use crate::server::api::traits::SyncNotificationHandler;
     use crate::{
         Client, GlobalOptions, PositionEncoding, Session, TextDocument, Workspace, Workspaces,
     };
+
+    fn client_capabilities_with_dynamic_watched_files() -> ClientCapabilities {
+        ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                    dynamic_registration: Some(true),
+                    relative_pattern_support: None,
+                }),
+                ..WorkspaceClientCapabilities::default()
+            }),
+            ..ClientCapabilities::default()
+        }
+    }
 
     #[test]
     fn config_changes_are_reflected_on_the_next_snapshot() {
@@ -49,7 +65,7 @@ mod tests {
         let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
         let global = GlobalOptions::default().into_settings(client.clone());
         let mut session = Session::new(
-            &ClientCapabilities::default(),
+            &client_capabilities_with_dynamic_watched_files(),
             PositionEncoding::UTF16,
             global,
             &workspaces,
@@ -101,6 +117,64 @@ mod tests {
             },
         )
         .expect("didChangeWatchedFiles should succeed");
+
+        let after = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot");
+        assert!(
+            after
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UndefinedVariable)
+        );
+        assert_eq!(after.shuck_settings().linter().rules.len(), 1);
+    }
+
+    #[test]
+    fn config_changes_refresh_without_dynamic_file_watch_support() {
+        let workspace_root = tempfile::tempdir().expect("tempdir should be created");
+        let config_path = workspace_root.path().join(".shuck.toml");
+        std::fs::write(&config_path, "[lint]\nselect = ['C001']\n")
+            .expect("config should be written");
+        let file_path = workspace_root.path().join("script.sh");
+        std::fs::write(&file_path, "foo=1\n").expect("source should be written");
+
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let workspace_uri =
+            Url::from_file_path(workspace_root.path()).expect("workspace path should convert");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+        let uri = Url::from_file_path(&file_path).expect("script path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+
+        let before = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        assert!(
+            before
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
+        assert_eq!(before.shuck_settings().linter().rules.len(), 1);
+
+        std::fs::write(&config_path, "[lint]\nselect = ['C006']\n")
+            .expect("config should be updated");
 
         let after = session
             .take_snapshot(uri)

--- a/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
+++ b/crates/shuck-server/src/server/api/notifications/did_change_watched_files.rs
@@ -72,6 +72,7 @@ mod tests {
             &client,
         )
         .expect("test session should initialize");
+        session.set_project_settings_cache_enabled(true);
         let uri = Url::from_file_path(&file_path).expect("script path should convert to a URL");
         session.open_text_document(
             uri.clone(),

--- a/crates/shuck-server/src/server/main_loop.rs
+++ b/crates/shuck-server/src/server/main_loop.rs
@@ -71,7 +71,7 @@ impl Server {
                                 .outgoing_mut()
                                 .complete(&response.id)
                             {
-                                handler(&client, response);
+                                handler(&client, &mut self.session, response);
                             } else {
                                 tracing::error!(
                                     "Received an unexpected response for request {}",
@@ -154,7 +154,8 @@ impl Server {
             }],
         };
 
-        let response_handler = |_: &Client, ()| {
+        let response_handler = |_: &Client, session: &mut crate::Session, ()| {
+            session.set_project_settings_cache_enabled(true);
             tracing::info!("Registered configuration file watcher");
         };
 

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -434,4 +434,73 @@ mod tests {
         );
         assert_eq!(after.shuck_settings().linter().rules.len(), 1);
     }
+
+    #[test]
+    fn nested_config_creation_switches_to_a_new_cache_key() {
+        let workspace = tempfile::tempdir().expect("workspace should be created");
+        std::fs::write(
+            workspace.path().join(".shuck.toml"),
+            "[lint]\nselect = ['C001']\n",
+        )
+        .expect("config should be written");
+        let nested = workspace.path().join("nested");
+        std::fs::create_dir_all(&nested).expect("nested dir should be created");
+        let workspace_uri =
+            Url::from_file_path(workspace.path()).expect("workspace path should convert");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &client_capabilities_with_dynamic_watched_files(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+        session.set_project_settings_cache_enabled(true);
+
+        let uri = Url::from_file_path(nested.join("script.sh"))
+            .expect("test path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+
+        let before = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        assert_eq!(
+            before.shuck_settings().project_root(),
+            Some(workspace.path())
+        );
+        assert!(
+            before
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
+
+        std::fs::write(nested.join(".shuck.toml"), "[lint]\nselect = ['C006']\n")
+            .expect("nested config should be written");
+
+        let after = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot");
+        assert_eq!(
+            after.shuck_settings().project_root(),
+            Some(nested.as_path())
+        );
+        assert!(
+            after
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UndefinedVariable)
+        );
+        assert_eq!(after.shuck_settings().linter().rules.len(), 1);
+    }
 }

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -82,30 +82,10 @@ impl Session {
     }
 
     pub fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
-        let workspace_options = self.index.workspace_options_for_url(&url);
+        let (settings, client_settings) = self
+            .index
+            .resolve_snapshot_settings(&url, self.global_settings.options());
         let key = self.key_from_url(url);
-        let file_path = key.clone().into_url().to_file_path().ok();
-        let (settings, client_settings) = if let Some(workspace_options) = workspace_options {
-            let option_layers = [self.global_settings.options(), workspace_options];
-            (
-                Arc::new(ShuckSettings::resolve(
-                    file_path.as_deref(),
-                    self.index.workspace_roots(),
-                    &option_layers,
-                )),
-                Arc::new(ClientSettings::from_layered_options(&option_layers)),
-            )
-        } else {
-            let option_layers = [self.global_settings.options()];
-            (
-                Arc::new(ShuckSettings::resolve(
-                    file_path.as_deref(),
-                    self.index.workspace_roots(),
-                    &option_layers,
-                )),
-                Arc::new(ClientSettings::from_layered_options(&option_layers)),
-            )
-        };
         Some(DocumentSnapshot {
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
             client_settings,
@@ -159,6 +139,7 @@ impl Session {
 
     pub(crate) fn update_client_options(&mut self, options: ClientOptions) {
         self.global_settings.update_options(options);
+        self.index.clear_project_settings_cache();
     }
 
     pub(crate) fn update_configuration(
@@ -169,6 +150,8 @@ impl Session {
         self.global_settings.update_options(options);
         if let Some(workspace_options) = workspace_options {
             self.index.update_workspace_options(workspace_options);
+        } else {
+            self.index.clear_project_settings_cache();
         }
     }
 
@@ -361,6 +344,70 @@ mod tests {
                 .linter()
                 .rules
                 .contains(shuck_linter::Rule::UnusedAssignment)
+        );
+        assert_eq!(after.shuck_settings().linter().rules.len(), 1);
+    }
+
+    #[test]
+    fn update_client_options_invalidates_cached_project_settings() {
+        let workspace = tempfile::tempdir().expect("workspace should be created");
+        std::fs::write(
+            workspace.path().join(".shuck.toml"),
+            "[lint]\nselect = ['C001']\n",
+        )
+        .expect("config should be written");
+        let workspace_uri =
+            Url::from_file_path(workspace.path()).expect("workspace path should convert");
+        let workspaces = Workspaces::new(vec![Workspace::default(workspace_uri)]);
+        let (main_loop_sender, _main_loop_receiver) = channel::unbounded();
+        let (client_sender, _client_receiver) = channel::unbounded();
+        let client = Client::new(main_loop_sender, client_sender);
+        let global = GlobalOptions::default().into_settings(client.clone());
+        let mut session = Session::new(
+            &ClientCapabilities::default(),
+            PositionEncoding::UTF16,
+            global,
+            &workspaces,
+            &client,
+        )
+        .expect("test session should initialize");
+
+        let uri = Url::from_file_path(workspace.path().join("script.sh"))
+            .expect("test path should convert to a URL");
+        session.open_text_document(
+            uri.clone(),
+            TextDocument::new("foo=1\n".to_owned(), 1).with_language_id("shellscript"),
+        );
+
+        let before = session
+            .take_snapshot(uri.clone())
+            .expect("test document should produce a snapshot");
+        assert!(
+            before
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UnusedAssignment)
+        );
+        assert_eq!(before.shuck_settings().linter().rules.len(), 1);
+
+        session.update_client_options(ClientOptions {
+            lint: Some(shuck_config::LintConfig {
+                select: Some(vec!["C006".to_owned()]),
+                ..shuck_config::LintConfig::default()
+            }),
+            ..ClientOptions::default()
+        });
+
+        let after = session
+            .take_snapshot(uri)
+            .expect("test document should produce a snapshot");
+        assert!(
+            after
+                .shuck_settings()
+                .linter()
+                .rules
+                .contains(shuck_linter::Rule::UndefinedVariable)
         );
         assert_eq!(after.shuck_settings().linter().rules.len(), 1);
     }

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -49,8 +49,9 @@ impl Session {
         workspaces: &Workspaces,
         client: &Client,
     ) -> crate::Result<Self> {
+        let cache_project_settings = supports_dynamic_watched_files(client_capabilities);
         Ok(Self {
-            index: index::Index::new(workspaces, &global, client)?,
+            index: index::Index::new(workspaces, cache_project_settings, &global, client)?,
             position_encoding,
             global_settings: global,
             resolved_client_capabilities: Arc::new(ResolvedClientCapabilities::new(
@@ -186,13 +187,38 @@ impl DocumentSnapshot {
     }
 }
 
+fn supports_dynamic_watched_files(client_capabilities: &ClientCapabilities) -> bool {
+    client_capabilities
+        .workspace
+        .as_ref()
+        .and_then(|workspace| workspace.did_change_watched_files)
+        .and_then(|watched_files| watched_files.dynamic_registration)
+        .unwrap_or_default()
+}
+
 #[cfg(test)]
 mod tests {
     use crossbeam::channel;
-    use lsp_types::{ClientCapabilities, Url};
+    use lsp_types::{
+        ClientCapabilities, DidChangeWatchedFilesClientCapabilities, Url,
+        WorkspaceClientCapabilities,
+    };
 
     use super::*;
     use crate::{ClientOptions, GlobalOptions, TextDocument, Workspace, Workspaces};
+
+    fn client_capabilities_with_dynamic_watched_files() -> ClientCapabilities {
+        ClientCapabilities {
+            workspace: Some(WorkspaceClientCapabilities {
+                did_change_watched_files: Some(DidChangeWatchedFilesClientCapabilities {
+                    dynamic_registration: Some(true),
+                    relative_pattern_support: None,
+                }),
+                ..WorkspaceClientCapabilities::default()
+            }),
+            ..ClientCapabilities::default()
+        }
+    }
 
     #[test]
     fn take_snapshot_merges_global_and_workspace_options() {
@@ -223,7 +249,7 @@ mod tests {
         let client = Client::new(main_loop_sender, client_sender);
         let global = GlobalOptions::default().into_settings(client.clone());
         let mut session = Session::new(
-            &ClientCapabilities::default(),
+            &client_capabilities_with_dynamic_watched_files(),
             PositionEncoding::UTF16,
             global,
             &workspaces,
@@ -295,7 +321,7 @@ mod tests {
         let client = Client::new(main_loop_sender, client_sender);
         let global = GlobalOptions::default().into_settings(client.clone());
         let mut session = Session::new(
-            &ClientCapabilities::default(),
+            &client_capabilities_with_dynamic_watched_files(),
             PositionEncoding::UTF16,
             global,
             &workspaces,
@@ -364,7 +390,7 @@ mod tests {
         let client = Client::new(main_loop_sender, client_sender);
         let global = GlobalOptions::default().into_settings(client.clone());
         let mut session = Session::new(
-            &ClientCapabilities::default(),
+            &client_capabilities_with_dynamic_watched_files(),
             PositionEncoding::UTF16,
             global,
             &workspaces,

--- a/crates/shuck-server/src/session.rs
+++ b/crates/shuck-server/src/session.rs
@@ -49,9 +49,8 @@ impl Session {
         workspaces: &Workspaces,
         client: &Client,
     ) -> crate::Result<Self> {
-        let cache_project_settings = supports_dynamic_watched_files(client_capabilities);
         Ok(Self {
-            index: index::Index::new(workspaces, cache_project_settings, &global, client)?,
+            index: index::Index::new(workspaces, &global, client)?,
             position_encoding,
             global_settings: global,
             resolved_client_capabilities: Arc::new(ResolvedClientCapabilities::new(
@@ -138,6 +137,10 @@ impl Session {
         self.index.config_file_paths()
     }
 
+    pub(crate) fn set_project_settings_cache_enabled(&mut self, enabled: bool) {
+        self.index.set_project_settings_cache_enabled(enabled);
+    }
+
     pub(crate) fn update_client_options(&mut self, options: ClientOptions) {
         self.global_settings.update_options(options);
         self.index.clear_project_settings_cache();
@@ -185,15 +188,6 @@ impl DocumentSnapshot {
     pub(crate) fn encoding(&self) -> PositionEncoding {
         self.position_encoding
     }
-}
-
-fn supports_dynamic_watched_files(client_capabilities: &ClientCapabilities) -> bool {
-    client_capabilities
-        .workspace
-        .as_ref()
-        .and_then(|workspace| workspace.did_change_watched_files)
-        .and_then(|watched_files| watched_files.dynamic_registration)
-        .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -256,6 +250,7 @@ mod tests {
             &client,
         )
         .expect("test session should initialize");
+        session.set_project_settings_cache_enabled(true);
         session.update_client_options(ClientOptions {
             lint: Some(shuck_config::LintConfig {
                 select: Some(vec!["C001".to_owned()]),
@@ -328,6 +323,7 @@ mod tests {
             &client,
         )
         .expect("test session should initialize");
+        session.set_project_settings_cache_enabled(true);
 
         let uri = Url::from_file_path(workspace_two.path().join("script.sh"))
             .expect("test path should convert to a URL");
@@ -397,6 +393,7 @@ mod tests {
             &client,
         )
         .expect("test session should initialize");
+        session.set_project_settings_cache_enabled(true);
 
         let uri = Url::from_file_path(workspace.path().join("script.sh"))
             .expect("test path should convert to a URL");

--- a/crates/shuck-server/src/session/client.rs
+++ b/crates/shuck-server/src/session/client.rs
@@ -8,7 +8,8 @@ use serde_json::Value;
 use crate::Session;
 use crate::server::{ConnectionSender, Event, MainLoopSender};
 
-pub(crate) type ClientResponseHandler = Box<dyn FnOnce(&Client, lsp_server::Response) + Send>;
+pub(crate) type ClientResponseHandler =
+    Box<dyn FnOnce(&Client, &mut Session, lsp_server::Response) + Send>;
 
 #[derive(Clone, Debug)]
 pub struct Client {
@@ -28,13 +29,16 @@ impl Client {
         &self,
         session: &Session,
         params: R::Params,
-        response_handler: impl FnOnce(&Client, R::Result) + Send + 'static,
+        response_handler: impl FnOnce(&Client, &mut Session, R::Result) + Send + 'static,
     ) -> crate::Result<()>
     where
         R: lsp_types::request::Request,
     {
-        let response_handler = Box::new(move |client: &Client, response: lsp_server::Response| {
-            match (response.error, response.result) {
+        let response_handler = Box::new(
+            move |client: &Client, session: &mut Session, response: lsp_server::Response| match (
+                response.error,
+                response.result,
+            ) {
                 (Some(err), _) => {
                     tracing::error!(
                         "Client request failed (method={} code={}): {}",
@@ -44,7 +48,7 @@ impl Client {
                     );
                 }
                 (None, Some(response)) => match serde_json::from_value(response) {
-                    Ok(response) => response_handler(client, response),
+                    Ok(response) => response_handler(client, session, response),
                     Err(error) => {
                         tracing::error!(
                             "Failed to deserialize client response for {}: {error}",
@@ -55,7 +59,7 @@ impl Client {
                 (None, None) => {
                     if TypeId::of::<R::Result>() == TypeId::of::<()>() {
                         match serde_json::from_value(Value::Null) {
-                            Ok(response) => response_handler(client, response),
+                            Ok(response) => response_handler(client, session, response),
                             Err(error) => {
                                 tracing::error!(
                                     "Failed to deserialize unit client response for {}: {error}",
@@ -70,8 +74,8 @@ impl Client {
                         );
                     }
                 }
-            }
-        });
+            },
+        );
 
         let id = session
             .request_queue()

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -1,14 +1,17 @@
 #![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use anyhow::anyhow;
 use lsp_types::{FileEvent, Url};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::edit::{DocumentKey, DocumentVersion};
-use crate::session::settings::{GlobalClientSettings, ShuckSettings};
+use crate::session::settings::{
+    ClientSettings, GlobalClientSettings, ResolvedProjectSettings, SettingsResolveContext,
+    ShuckSettings,
+};
 use crate::session::{Client, ClientOptions, WorkspaceOptionsMap};
 use crate::workspace::Workspaces;
 use crate::{PositionEncoding, TextDocument};
@@ -18,6 +21,8 @@ pub(crate) struct Index {
     documents: FxHashMap<Url, Arc<TextDocument>>,
     workspace_roots: Vec<PathBuf>,
     workspace_settings: Vec<WorkspaceSettings>,
+    project_settings_cache:
+        RwLock<FxHashMap<ProjectSettingsCacheKey, Arc<ResolvedProjectSettings>>>,
 }
 
 #[derive(Clone)]
@@ -25,6 +30,12 @@ struct WorkspaceSettings {
     url: Url,
     root: PathBuf,
     options: Option<ClientOptions>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ProjectSettingsCacheKey {
+    config_root: PathBuf,
+    workspace_root: Option<PathBuf>,
 }
 
 #[derive(Clone)]
@@ -64,6 +75,7 @@ impl Index {
             documents: FxHashMap::default(),
             workspace_roots,
             workspace_settings,
+            project_settings_cache: RwLock::new(FxHashMap::default()),
         })
     }
 
@@ -83,6 +95,39 @@ impl Index {
             document,
             settings,
         })
+    }
+
+    pub(super) fn resolve_snapshot_settings(
+        &self,
+        url: &Url,
+        global_options: &ClientOptions,
+    ) -> (Arc<ShuckSettings>, Arc<ClientSettings>) {
+        let file_path = url.to_file_path().ok();
+        let workspace_settings = self.workspace_settings_for_url(url);
+
+        if let Some(workspace_options) =
+            workspace_settings.and_then(|workspace| workspace.options.as_ref())
+        {
+            let option_layers = [global_options, workspace_options];
+            return (
+                self.resolve_shuck_settings(
+                    file_path.as_deref(),
+                    workspace_settings.map(|workspace| workspace.root.as_path()),
+                    &option_layers,
+                ),
+                Arc::new(ClientSettings::from_layered_options(&option_layers)),
+            );
+        }
+
+        let option_layers = [global_options];
+        (
+            self.resolve_shuck_settings(
+                file_path.as_deref(),
+                workspace_settings.map(|workspace| workspace.root.as_path()),
+                &option_layers,
+            ),
+            Arc::new(ClientSettings::from_layered_options(&option_layers)),
+        )
     }
 
     pub(super) fn has_open_document(&self, key: &DocumentKey) -> bool {
@@ -120,7 +165,27 @@ impl Index {
             .ok_or_else(|| anyhow!("document is not open: {url}"))
     }
 
-    pub(super) fn reload_settings(&mut self, _changes: &[FileEvent], _client: &Client) {}
+    pub(super) fn reload_settings(&mut self, changes: &[FileEvent], _client: &Client) {
+        let changed_roots = changes
+            .iter()
+            .filter_map(|change| change.uri.to_file_path().ok())
+            .filter(|path| {
+                matches!(
+                    path.file_name().and_then(|name| name.to_str()),
+                    Some(".shuck.toml" | "shuck.toml")
+                )
+            })
+            .filter_map(|path| path.parent().map(Path::to_path_buf))
+            .collect::<FxHashSet<_>>();
+        if changed_roots.is_empty() {
+            return;
+        }
+
+        self.project_settings_cache
+            .write()
+            .expect("settings cache lock should not be poisoned")
+            .retain(|cache_key, _| !changed_roots.contains(&cache_key.config_root));
+    }
 
     pub(super) fn open_workspace_folder(
         &mut self,
@@ -145,6 +210,7 @@ impl Index {
                 options: None,
             });
         }
+        self.clear_project_settings_cache();
         Ok(())
     }
 
@@ -160,6 +226,7 @@ impl Index {
                 .map(|file_path| !file_path.starts_with(&path))
                 .unwrap_or(true)
         });
+        self.clear_project_settings_cache();
         Ok(())
     }
 
@@ -172,18 +239,72 @@ impl Index {
     }
 
     pub(super) fn workspace_options_for_url(&self, url: &Url) -> Option<&ClientOptions> {
+        self.workspace_settings_for_url(url)
+            .and_then(|workspace| workspace.options.as_ref())
+    }
+
+    pub(super) fn clear_project_settings_cache(&self) {
+        self.project_settings_cache
+            .write()
+            .expect("settings cache lock should not be poisoned")
+            .clear();
+    }
+
+    fn workspace_settings_for_url(&self, url: &Url) -> Option<&WorkspaceSettings> {
         let path = url.to_file_path().ok()?;
         self.workspace_settings
             .iter()
             .filter(|workspace| path.starts_with(&workspace.root))
             .max_by_key(|workspace| workspace.root.components().count())
-            .and_then(|workspace| workspace.options.as_ref())
+    }
+
+    fn resolve_shuck_settings(
+        &self,
+        file_path: Option<&Path>,
+        workspace_root: Option<&Path>,
+        option_layers: &[&ClientOptions],
+    ) -> Arc<ShuckSettings> {
+        let Some(file_path) = file_path else {
+            return Arc::new(ShuckSettings::resolve(
+                None,
+                self.workspace_roots(),
+                option_layers,
+            ));
+        };
+
+        let context = SettingsResolveContext::for_file(file_path, self.workspace_roots());
+        let cache_key = ProjectSettingsCacheKey {
+            config_root: context.config_root().to_path_buf(),
+            workspace_root: workspace_root.map(Path::to_path_buf),
+        };
+
+        if let Some(cached) = self
+            .project_settings_cache
+            .read()
+            .expect("settings cache lock should not be poisoned")
+            .get(&cache_key)
+            .cloned()
+        {
+            return Arc::new(cached.for_file(Some(file_path)));
+        }
+
+        let resolved = Arc::new(ResolvedProjectSettings::resolve(&context, option_layers));
+        let cached = self
+            .project_settings_cache
+            .write()
+            .expect("settings cache lock should not be poisoned")
+            .entry(cache_key)
+            .or_insert_with(|| resolved.clone())
+            .clone();
+
+        Arc::new(cached.for_file(Some(file_path)))
     }
 
     pub(super) fn update_workspace_options(&mut self, mut workspace_options: WorkspaceOptionsMap) {
         for workspace in &mut self.workspace_settings {
             workspace.options = workspace_options.remove(&workspace.url);
         }
+        self.clear_project_settings_cache();
     }
 
     pub(super) fn open_document_count(&self) -> usize {

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -21,6 +21,7 @@ pub(crate) struct Index {
     documents: FxHashMap<Url, Arc<TextDocument>>,
     workspace_roots: Vec<PathBuf>,
     workspace_settings: Vec<WorkspaceSettings>,
+    cache_project_settings: bool,
     project_settings_cache:
         RwLock<FxHashMap<ProjectSettingsCacheKey, Arc<ResolvedProjectSettings>>>,
 }
@@ -50,6 +51,7 @@ pub enum DocumentQuery {
 impl Index {
     pub(super) fn new(
         workspaces: &Workspaces,
+        cache_project_settings: bool,
         _global: &GlobalClientSettings,
         _client: &Client,
     ) -> crate::Result<Self> {
@@ -75,6 +77,7 @@ impl Index {
             documents: FxHashMap::default(),
             workspace_roots,
             workspace_settings,
+            cache_project_settings,
             project_settings_cache: RwLock::new(FxHashMap::default()),
         })
     }
@@ -264,6 +267,14 @@ impl Index {
         workspace_root: Option<&Path>,
         option_layers: &[&ClientOptions],
     ) -> Arc<ShuckSettings> {
+        if !self.cache_project_settings {
+            return Arc::new(ShuckSettings::resolve(
+                file_path,
+                self.workspace_roots(),
+                option_layers,
+            ));
+        }
+
         let Some(file_path) = file_path else {
             return Arc::new(ShuckSettings::resolve(
                 None,

--- a/crates/shuck-server/src/session/index.rs
+++ b/crates/shuck-server/src/session/index.rs
@@ -51,7 +51,6 @@ pub enum DocumentQuery {
 impl Index {
     pub(super) fn new(
         workspaces: &Workspaces,
-        cache_project_settings: bool,
         _global: &GlobalClientSettings,
         _client: &Client,
     ) -> crate::Result<Self> {
@@ -77,7 +76,7 @@ impl Index {
             documents: FxHashMap::default(),
             workspace_roots,
             workspace_settings,
-            cache_project_settings,
+            cache_project_settings: false,
             project_settings_cache: RwLock::new(FxHashMap::default()),
         })
     }
@@ -251,6 +250,13 @@ impl Index {
             .write()
             .expect("settings cache lock should not be poisoned")
             .clear();
+    }
+
+    pub(super) fn set_project_settings_cache_enabled(&mut self, enabled: bool) {
+        self.cache_project_settings = enabled;
+        if !enabled {
+            self.clear_project_settings_cache();
+        }
     }
 
     fn workspace_settings_for_url(&self, url: &Url) -> Option<&WorkspaceSettings> {

--- a/crates/shuck-server/src/session/settings.rs
+++ b/crates/shuck-server/src/session/settings.rs
@@ -31,6 +31,26 @@ pub struct ShuckSettings {
     project_root: Option<PathBuf>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SettingsResolveContext {
+    config_root: PathBuf,
+    project_root: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedProjectSettings {
+    linter: ResolvedLinterSettings,
+    formatter: ShellFormatOptions,
+    fixable_rules: RuleSet,
+    project_root: Option<PathBuf>,
+}
+
+#[derive(Clone, Debug)]
+struct ResolvedLinterSettings {
+    base: LinterSettings,
+    per_file_shell: CompiledPerFileShellList,
+}
+
 pub struct GlobalClientSettings {
     options: ClientOptions,
     #[allow(dead_code)]
@@ -85,43 +105,10 @@ impl ShuckSettings {
         workspace_roots: &[PathBuf],
         option_layers: &[&ClientOptions],
     ) -> Self {
-        let mut project_config = ShuckConfig::default();
-
-        let project_root = file_path.map(|file_path| {
-            let fallback_root = containing_workspace_root(file_path, workspace_roots)
-                .or_else(|| file_path.parent().map(Path::to_path_buf))
-                .unwrap_or_else(|| PathBuf::from("."));
-            let project_root = resolve_project_root_for_file(file_path, &fallback_root, true)
-                .unwrap_or(fallback_root.clone());
-
-            project_config = load_project_config(&project_root, &ConfigArguments::default())
-                .unwrap_or_else(|error| {
-                    tracing::warn!(
-                        "Failed to load shuck config for {}: {error}",
-                        project_root.display()
-                    );
-                    ShuckConfig::default()
-                });
-            project_root
-        });
-        let config_root = project_root.clone().unwrap_or_else(|| {
-            workspace_roots
-                .first()
-                .cloned()
-                .unwrap_or_else(|| PathBuf::from("."))
-        });
-
-        Self {
-            linter: linter_settings_for_layers(
-                &config_root,
-                file_path,
-                &project_config,
-                option_layers,
-            ),
-            formatter: formatter_settings_for_layers(&project_config, option_layers),
-            fixable_rules: fixable_rules_for_layers(&project_config, option_layers),
-            project_root,
-        }
+        let context = file_path
+            .map(|file_path| SettingsResolveContext::for_file(file_path, workspace_roots))
+            .unwrap_or_else(|| SettingsResolveContext::without_file(workspace_roots));
+        ResolvedProjectSettings::resolve(&context, option_layers).for_file(file_path)
     }
 
     pub(crate) fn linter(&self) -> &LinterSettings {
@@ -149,6 +136,88 @@ impl Default for ShuckSettings {
             fixable_rules: RuleSet::all(),
             project_root: None,
         }
+    }
+}
+
+impl SettingsResolveContext {
+    pub(crate) fn for_file(file_path: &Path, workspace_roots: &[PathBuf]) -> Self {
+        let fallback_root = containing_workspace_root(file_path, workspace_roots)
+            .or_else(|| file_path.parent().map(Path::to_path_buf))
+            .unwrap_or_else(|| PathBuf::from("."));
+        let project_root = resolve_project_root_for_file(file_path, &fallback_root, true)
+            .unwrap_or(fallback_root.clone());
+
+        Self {
+            config_root: project_root.clone(),
+            project_root: Some(project_root),
+        }
+    }
+
+    pub(crate) fn without_file(workspace_roots: &[PathBuf]) -> Self {
+        Self {
+            config_root: workspace_roots
+                .first()
+                .cloned()
+                .unwrap_or_else(|| PathBuf::from(".")),
+            project_root: None,
+        }
+    }
+
+    pub(crate) fn config_root(&self) -> &Path {
+        &self.config_root
+    }
+}
+
+impl ResolvedProjectSettings {
+    pub(crate) fn resolve(
+        context: &SettingsResolveContext,
+        option_layers: &[&ClientOptions],
+    ) -> Self {
+        let project_config = context
+            .project_root
+            .as_ref()
+            .map(|project_root| {
+                load_project_config(project_root, &ConfigArguments::default()).unwrap_or_else(
+                    |error| {
+                        tracing::warn!(
+                            "Failed to load shuck config for {}: {error}",
+                            project_root.display()
+                        );
+                        ShuckConfig::default()
+                    },
+                )
+            })
+            .unwrap_or_default();
+
+        Self {
+            linter: resolved_linter_settings_for_layers(
+                context.config_root(),
+                &project_config,
+                option_layers,
+            ),
+            formatter: formatter_settings_for_layers(&project_config, option_layers),
+            fixable_rules: fixable_rules_for_layers(&project_config, option_layers),
+            project_root: context.project_root.clone(),
+        }
+    }
+
+    pub(crate) fn for_file(&self, file_path: Option<&Path>) -> ShuckSettings {
+        ShuckSettings {
+            linter: self.linter.for_file(file_path),
+            formatter: self.formatter.clone(),
+            fixable_rules: self.fixable_rules,
+            project_root: self.project_root.clone(),
+        }
+    }
+}
+
+impl ResolvedLinterSettings {
+    fn for_file(&self, file_path: Option<&Path>) -> LinterSettings {
+        let mut linter = self.base.clone();
+        linter.shell = file_path
+            .and_then(|file_path| self.per_file_shell.shell_for_path(file_path))
+            .unwrap_or(LinterShellDialect::Unknown);
+        linter
     }
 }
 
@@ -222,12 +291,11 @@ fn lint_layers<'a>(
     ))
 }
 
-fn linter_settings_for_layers(
+fn resolved_linter_settings_for_layers(
     project_root: &Path,
-    file_path: Option<&Path>,
     project_config: &ShuckConfig,
     option_layers: &[&ClientOptions],
-) -> LinterSettings {
+) -> ResolvedLinterSettings {
     let mut rules = LinterSettings::default_rules();
     let mut per_file_ignores = Vec::new();
     let mut per_file_shell = Vec::new();
@@ -262,23 +330,22 @@ fn linter_settings_for_layers(
     let compiled_per_file_ignores =
         CompiledPerFileIgnoreList::resolve(project_root.to_path_buf(), per_file_ignores)
             .unwrap_or_default();
-    let shell = file_path
-        .and_then(|file_path| {
-            CompiledPerFileShellList::resolve(project_root.to_path_buf(), per_file_shell)
-                .unwrap_or_else(|error| {
-                    tracing::warn!("Failed to compile per-file shell settings: {error}");
-                    CompiledPerFileShellList::default()
-                })
-                .shell_for_path(file_path)
-        })
-        .unwrap_or(LinterShellDialect::Unknown);
+    let compiled_per_file_shell =
+        CompiledPerFileShellList::resolve(project_root.to_path_buf(), per_file_shell)
+            .unwrap_or_else(|error| {
+                tracing::warn!("Failed to compile per-file shell settings: {error}");
+                CompiledPerFileShellList::default()
+            });
 
-    LinterSettings {
-        rules,
-        shell,
-        per_file_ignores: Arc::new(compiled_per_file_ignores),
-        rule_options,
-        ..LinterSettings::default()
+    ResolvedLinterSettings {
+        base: LinterSettings {
+            rules,
+            shell: LinterShellDialect::Unknown,
+            per_file_ignores: Arc::new(compiled_per_file_ignores),
+            rule_options,
+            ..LinterSettings::default()
+        },
+        per_file_shell: compiled_per_file_shell,
     }
 }
 


### PR DESCRIPTION
## Summary
- cache resolved project settings in the LSP session so repeated snapshots reuse project-scoped config state instead of reloading from disk on every request
- invalidate the settings cache when watched config files change, workspace configuration changes, or client options change
- add regression tests that prove cached settings stay stale until invalidation and then refresh on the next snapshot

## Why
The server was rebuilding `ShuckSettings` for each snapshot and always reloading project config from disk. That made hover, diagnostics, and code actions pay repeated config I/O and settings recomputation on active files.

## Validation
- cargo test -p shuck-server
- cargo clippy -p shuck-server --all-targets -- -D warnings
