### PR TITLE
docs(website): add editor integration guide

### DIFF
--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import { flattenNav, docsNavigation } from "@/app/lib/docs-navigation";
 // Map of slug paths to their MDX imports
 const pages: Record<string, () => Promise<{ default: React.ComponentType; metadata?: { title?: string; description?: string } }>> = {
   "getting-started": () => import("@/content/getting-started/index.mdx"),
+  "editors": () => import("@/content/editors/index.mdx"),
   "run": () => import("@/content/run/index.mdx"),
   "embedded-scripts": () => import("@/content/embedded-scripts/index.mdx"),
   "configuration": () => import("@/content/configuration/index.mdx"),

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -9,8 +9,9 @@ export const docsNavigation: NavItem[] = [
     title: "Getting Started",
     items: [
       { title: "Overview", href: "/docs/getting-started" },
-      { title: "Managed Runtime", href: "/docs/run" },
       { title: "Configuration", href: "/docs/configuration" },
+      { title: "Managed Runtime", href: "/docs/run" },
+      { title: "Editor Integration", href: "/docs/editors" },
       { title: "Suppression", href: "/docs/suppression" },
       { title: "Settings Reference", href: "/docs/settings" },
       { title: "ShellCheck Compatibility", href: "/docs/shellcheck-compat" },

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -23,7 +23,8 @@ export default function Home() {
             />
             <p className="text-base text-fg-secondary leading-relaxed mb-6">
               A fast shell script linter, built in Rust. Checks for
-              correctness, portability, and style issues in your shell scripts.
+              correctness, portability, and style issues in your shell scripts,
+              with a built-in LSP server for editor integration.
             </p>
 
             {/* Install */}
@@ -40,6 +41,12 @@ export default function Home() {
                   shuck check .
                 </pre>
               </div>
+              <div>
+                <p className="text-xs text-fg-dim mb-1 font-medium">Editor LSP</p>
+                <pre className="rounded-md bg-bg-secondary border border-fg-dim/20 px-3 py-2 text-sm font-mono text-fg-primary overflow-x-auto">
+                  shuck server
+                </pre>
+              </div>
             </div>
 
             {/* Links */}
@@ -49,6 +56,12 @@ export default function Home() {
                 className="text-accent hover:underline"
               >
                 Docs
+              </Link>
+              <Link
+                href="/docs/editors"
+                className="text-accent hover:underline"
+              >
+                Editor Setup
               </Link>
               <Link
                 href="/docs/performance/benchmarks"
@@ -134,7 +147,7 @@ export default function Home() {
           <FeatureCard
             icon={<Plug className="h-5 w-5" />}
             title="Integrated"
-            description="Works with your editor, CI pipeline, and pre-commit hooks. One binary, zero dependencies."
+            description="Works with your editor through the built-in LSP server, plus CI pipelines and pre-commit hooks. One binary, zero dependencies."
           />
         </div>
       </section>

--- a/website/content/editors/index.mdx
+++ b/website/content/editors/index.mdx
@@ -1,0 +1,131 @@
+# Editor Integration
+
+Shuck ships with a first-party Language Server Protocol server in the main CLI. Start it with `shuck server` and point your editor at that command over stdio.
+
+That gives editor diagnostics from the current in-memory buffer instead of rerunning `shuck check` from scratch on every save.
+
+## Current scope
+
+The current server already covers the core editor feedback loop:
+
+- Real-time diagnostics for open shell buffers
+- Incremental document sync over LSP
+- Dialect inference from the buffer `languageId`, shebang, and file path
+- Quick fixes, disable-this-line actions, and `source.fixAll.shuck` code actions
+- Hover help for suppression codes in `# shuck:` and `# shellcheck` directives
+
+Formatting is not advertised to editors yet, so it is still best to keep your existing shell formatter setup alongside Shuck for now.
+
+## Before you start
+
+Make sure `shuck` is installed and available on your `PATH`:
+
+```bash
+shuck --version
+shuck server
+```
+
+If `shuck server` starts successfully, your editor only needs to launch that command over stdio.
+
+Shuck also resolves `.shuck.toml` or `shuck.toml` from the workspace and layers any LSP-provided Shuck settings on top when the client supports them.
+
+## Neovim
+
+Neovim 0.11+ can use the built-in LSP client directly through [`vim.lsp`](https://neovim.io/doc/user/lsp/):
+
+```lua
+vim.lsp.config("shuck", {
+  cmd = { "shuck", "server" },
+  filetypes = { "sh", "bash", "zsh", "ksh" },
+  root_markers = { ".shuck.toml", "shuck.toml", ".git" },
+})
+
+vim.lsp.enable("shuck")
+```
+
+If your setup normalizes shell buffers to `sh`, leaving only `sh` in `filetypes` is fine too.
+
+## Vim
+
+With [`vim-lsp`](https://github.com/prabirshrestha/vim-lsp), register Shuck in your `.vimrc`:
+
+```vim
+if executable('shuck')
+    augroup shuck_lsp
+        au!
+        au User lsp_setup call lsp#register_server({
+            \ 'name': 'shuck',
+            \ 'cmd': {server_info->['shuck', 'server']},
+            \ 'allowlist': ['sh'],
+            \ })
+    augroup END
+endif
+```
+
+Most Vim setups detect shell scripts as `sh`. If yours uses dedicated `bash`, `zsh`, or `ksh` filetypes, add them to the allowlist as well.
+
+## Emacs
+
+[`Eglot`](https://www.gnu.org/software/emacs/manual/html_mono/eglot.html) can launch `shuck server` for shell buffers by extending `eglot-server-programs`:
+
+```elisp
+(with-eval-after-load 'eglot
+  (add-to-list 'eglot-server-programs
+               '(sh-mode . ("shuck" "server"))))
+```
+
+Then open a shell script and run `M-x eglot`.
+
+If you use additional shell major modes, add them to the same entry or register a second one for those modes.
+
+## Zed
+
+Zed currently routes language servers through extensions rather than letting you point a language directly at an arbitrary stdio command from settings alone. The practical route today is a small dev extension that launches `shuck server` for `Shell Script` buffers.
+
+In `extension.toml`, register a shell language server:
+
+```toml
+id = "shuck"
+name = "Shuck"
+version = "0.0.1"
+schema_version = 1
+
+[language_servers.shuck]
+name = "Shuck"
+languages = ["Shell Script"]
+
+[language_servers.shuck.language_ids]
+"Shell Script" = "shellscript"
+```
+
+Then implement `language_server_command` in the extension's Rust entrypoint, following the [Zed language extension docs](https://zed.dev/docs/extensions/languages):
+
+```rust
+fn language_server_command(
+    &mut self,
+    _language_server_id: &zed::LanguageServerId,
+    _worktree: &zed::Worktree,
+) -> Result<zed::Command> {
+    Ok(zed::Command {
+        command: "shuck".into(),
+        args: vec!["server".into()],
+        env: Default::default(),
+    })
+}
+```
+
+Once the extension is installed, prefer it for shell files in your Zed settings:
+
+```json
+{
+  "languages": {
+    "Shell Script": {
+      "language_servers": ["shuck", "..."]
+    }
+  }
+}
+```
+
+## Related docs
+
+For project-wide lint configuration, see [Configuration](/docs/configuration) and [Settings Reference](/docs/settings).

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -45,6 +45,16 @@ echo 'echo $foo' | shuck check -
 shuck check --fix .
 ```
 
+## Editor integration
+
+Shuck also ships with a first-party LSP server over stdio:
+
+```bash
+shuck server
+```
+
+See the dedicated [Editor Integration guide](/docs/editors) for setup examples in Neovim, Vim, Emacs, and Zed.
+
 ## Managed runtime
 
 Shuck can also run scripts with managed shell interpreters instead of whatever version happens to be installed on your machine.


### PR DESCRIPTION
## Summary
- add a new website editor integration guide for Neovim, Vim, Emacs, and Zed
- link the new guide from getting started and add it to the docs sidebar in the requested order
- describe the current Shuck LSP surface in terms that match the rebased server on `main`

## Why
Shuck did not yet have a dedicated website page for editor integration, and the PR needed to be rebased onto the newer `main` branch before it could merge cleanly.

## Validation
- npm exec --yes pnpm@10.33.0 -- test
- npm exec --yes pnpm@10.33.0 -- build
