### PR TITLE
refactor(linter): add remaining option-sensitive facts

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -450,6 +450,20 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         arithmetic_update_operator_spans
             .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
         arithmetic_update_operator_spans.dedup();
+        base_prefix_arithmetic_spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+        base_prefix_arithmetic_spans.dedup();
+        let arithmetic_literal_facts = base_prefix_arithmetic_spans
+            .iter()
+            .copied()
+            .map(|span| {
+                ArithmeticLiteralFact::new(
+                    span,
+                    self.semantic
+                        .shell_behavior_at(span.start.offset)
+                        .arithmetic_literals(),
+                )
+            })
+            .collect::<Vec<_>>();
 
         let mut fact_store = FactStore::empty();
         fact_store.redirect_facts = redirect_fact_store;
@@ -641,7 +655,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             nested_pattern_charclass_spans,
             nested_parameter_expansions,
             indirect_expansions,
-            indexed_array_references,
+            mut indexed_array_references,
             plain_unindexed_references,
             parameter_pattern_special_targets,
             zsh_parameter_index_flags,
@@ -659,6 +673,13 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 .iter()
                 .copied(),
         );
+        for fragment in &mut indexed_array_references {
+            let behavior = self
+                .semantic
+                .shell_behavior_at(fragment.span().start.offset)
+                .subscript_indexing();
+            *fragment = (*fragment).with_subscript_index_behavior(behavior);
+        }
         let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(
             self.semantic,
             &commands,
@@ -983,6 +1004,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             double_paren_grouping_spans,
             arithmetic_update_operator_spans,
             base_prefix_arithmetic_spans,
+            arithmetic_literal_facts,
             escape_scan_matches,
             echo_backslash_escape_word_spans,
             echo_to_sed_substitution_spans,

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -65,13 +65,14 @@ use shuck_indexer::{Indexer, LineIndex};
 #[cfg(test)]
 use shuck_parser::parser::Parser;
 use shuck_semantic::{
-    Binding, BindingAttributes, BindingId, BindingKind, CaseCliDispatch, Declaration,
-    DeclarationBuiltin, DeclarationOperand as SemanticDeclarationOperand, FieldSplittingBehavior,
-    GlobFailureBehavior, NonpersistentAssignmentAnalysisContext,
-    NonpersistentAssignmentAnalysisOptions, NonpersistentAssignmentCommandContext,
-    NonpersistentAssignmentExtraRead, OptionValue, PathnameExpansionBehavior, Reference,
-    ReferenceId, ReferenceKind, ScopeId, SemanticAnalysis, SemanticModel,
-    SemanticPipelineOperatorKind, ZshOptionState,
+    ArithmeticLiteralBehavior, Binding, BindingAttributes, BindingId, BindingKind, CaseCliDispatch,
+    Declaration, DeclarationBuiltin, DeclarationOperand as SemanticDeclarationOperand,
+    FieldSplittingBehavior, GlobDotBehavior, GlobFailureBehavior, GlobPatternBehavior,
+    NonpersistentAssignmentAnalysisContext, NonpersistentAssignmentAnalysisOptions,
+    NonpersistentAssignmentCommandContext, NonpersistentAssignmentExtraRead, OptionValue,
+    PathnameExpansionBehavior, PatternOperatorBehavior, Reference, ReferenceId, ReferenceKind,
+    ScopeId, SemanticAnalysis, SemanticModel, SemanticPipelineOperatorKind, SubscriptIndexBehavior,
+    ZshOptionState,
 };
 use smallvec::SmallVec;
 use std::{borrow::Cow, ops::ControlFlow, sync::OnceLock};
@@ -96,8 +97,8 @@ pub use self::normalized_commands::{
     DeclarationKind, NormalizedCommand, NormalizedDeclaration, WrapperKind,
 };
 pub use self::surface::{
-    AmbiguousArrayReference, BacktickFragmentFact, LegacyArithmeticFragmentFact,
-    NativeZshScalarArrayReference, PlainUnindexedArrayReferenceFact,
+    AmbiguousArrayReference, ArithmeticLiteralFact, BacktickFragmentFact,
+    LegacyArithmeticFragmentFact, NativeZshScalarArrayReference, PlainUnindexedArrayReferenceFact,
     PositionalParameterFragmentFact, SelectorRequiredArrayReference, SingleQuotedFragmentFact,
 };
 

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -120,6 +120,7 @@ pub struct LinterFacts<'a> {
     double_paren_grouping_spans: Vec<Span>,
     arithmetic_update_operator_spans: Vec<Span>,
     base_prefix_arithmetic_spans: Vec<Span>,
+    arithmetic_literal_facts: Vec<ArithmeticLiteralFact>,
     escape_scan_matches: Vec<EscapeScanMatch>,
     echo_backslash_escape_word_spans: Vec<Span>,
     echo_to_sed_substitution_spans: Vec<Span>,
@@ -934,6 +935,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn base_prefix_arithmetic_spans(&self) -> &[Span] {
         &self.base_prefix_arithmetic_spans
+    }
+
+    pub fn arithmetic_literal_facts(&self) -> &[ArithmeticLiteralFact] {
+        &self.arithmetic_literal_facts
     }
 
     pub(crate) fn escape_scan_matches(&self) -> &[EscapeScanMatch] {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -139,6 +139,26 @@ impl LegacyArithmeticFragmentFact {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ArithmeticLiteralFact {
+    span: Span,
+    behavior: ArithmeticLiteralBehavior,
+}
+
+impl ArithmeticLiteralFact {
+    pub(super) fn new(span: Span, behavior: ArithmeticLiteralBehavior) -> Self {
+        Self { span, behavior }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn behavior(&self) -> ArithmeticLiteralBehavior {
+        self.behavior
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PositionalParameterFragmentKind {
     AboveNine,
@@ -201,6 +221,7 @@ impl IndirectExpansionFragmentFact {
 pub struct IndexedArrayReferenceFragmentFact {
     span: Span,
     plain: bool,
+    subscript_index_behavior: SubscriptIndexBehavior,
 }
 
 impl IndexedArrayReferenceFragmentFact {
@@ -210,6 +231,18 @@ impl IndexedArrayReferenceFragmentFact {
 
     pub fn is_plain(&self) -> bool {
         self.plain
+    }
+
+    pub fn subscript_index_behavior(&self) -> SubscriptIndexBehavior {
+        self.subscript_index_behavior
+    }
+
+    pub(super) fn with_subscript_index_behavior(
+        mut self,
+        behavior: SubscriptIndexBehavior,
+    ) -> Self {
+        self.subscript_index_behavior = behavior;
+        self
     }
 }
 
@@ -537,7 +570,11 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
         self.facts
             .indexed_array_references
-            .push(IndexedArrayReferenceFragmentFact { span, plain });
+            .push(IndexedArrayReferenceFragmentFact {
+                span,
+                plain,
+                subscript_index_behavior: SubscriptIndexBehavior::Ambiguous,
+            });
     }
 
     fn record_plain_unindexed_reference(&mut self, span: Span) {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1815,11 +1815,16 @@ fn base_prefix_arithmetic_literals_record_arithmetic_literal_behavior() {
     let source = "\
 #!/bin/zsh
 echo $((10#1))
-setopt c_bases octal_zeroes
+setopt c_bases
 echo $((10#2))
+unsetopt c_bases
+setopt octal_zeroes
+echo $((10#3))
+setopt c_bases
+echo $((10#4))
 opt=c_bases
 unsetopt \"$opt\"
-echo $((10#3))
+echo $((10#5))
 ";
     let output = Parser::with_dialect(source, shuck_parser::parser::ShellDialect::Zsh)
         .parse()
@@ -1836,9 +1841,32 @@ echo $((10#3))
             .collect::<Vec<_>>(),
         vec![
             ("10#1", ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,),
-            ("10#2", ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal,),
-            ("10#3", ArithmeticLiteralBehavior::Ambiguous),
+            ("10#2", ArithmeticLiteralBehavior::CStyleBasePrefixes),
+            ("10#3", ArithmeticLiteralBehavior::LeadingZeroOctal),
+            ("10#4", ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal),
+            ("10#5", ArithmeticLiteralBehavior::Ambiguous),
         ]
+    );
+}
+
+#[test]
+fn base_prefix_arithmetic_literals_record_bash_arithmetic_literal_behavior() {
+    let source = "\
+#!/bin/bash
+echo $((10#1))
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+
+    assert_eq!(
+        facts
+            .arithmetic_literal_facts()
+            .iter()
+            .map(|literal| (literal.span().slice(source), literal.behavior()))
+            .collect::<Vec<_>>(),
+        vec![("10#1", ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal,)]
     );
 }
 

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1822,9 +1822,11 @@ setopt octal_zeroes
 echo $((10#3))
 setopt c_bases
 echo $((10#4))
-opt=c_bases
-unsetopt \"$opt\"
+unsetopt c_bases
 echo $((10#5))
+opt=octal_zeroes
+unsetopt \"$opt\"
+echo $((10#6))
 ";
     let output = Parser::with_dialect(source, shuck_parser::parser::ShellDialect::Zsh)
         .parse()
@@ -1841,10 +1843,11 @@ echo $((10#5))
             .collect::<Vec<_>>(),
         vec![
             ("10#1", ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,),
-            ("10#2", ArithmeticLiteralBehavior::CStyleBasePrefixes),
+            ("10#2", ArithmeticLiteralBehavior::DecimalUnlessExplicitBase),
             ("10#3", ArithmeticLiteralBehavior::LeadingZeroOctal),
-            ("10#4", ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal),
-            ("10#5", ArithmeticLiteralBehavior::Ambiguous),
+            ("10#4", ArithmeticLiteralBehavior::LeadingZeroOctal),
+            ("10#5", ArithmeticLiteralBehavior::LeadingZeroOctal),
+            ("10#6", ArithmeticLiteralBehavior::Ambiguous),
         ]
     );
 }

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1811,6 +1811,38 @@ echo ${foo:-$((10#1))}
 }
 
 #[test]
+fn base_prefix_arithmetic_literals_record_arithmetic_literal_behavior() {
+    let source = "\
+#!/bin/zsh
+echo $((10#1))
+setopt c_bases octal_zeroes
+echo $((10#2))
+opt=c_bases
+unsetopt \"$opt\"
+echo $((10#3))
+";
+    let output = Parser::with_dialect(source, shuck_parser::parser::ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+
+    assert_eq!(
+        facts
+            .arithmetic_literal_facts()
+            .iter()
+            .map(|literal| (literal.span().slice(source), literal.behavior()))
+            .collect::<Vec<_>>(),
+        vec![
+            ("10#1", ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,),
+            ("10#2", ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal,),
+            ("10#3", ArithmeticLiteralBehavior::Ambiguous),
+        ]
+    );
+}
+
+#[test]
 fn collects_base_prefix_arithmetic_spans_from_semantic_nested_command_visits() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/mod.rs
+++ b/crates/shuck-linter/src/facts/tests/mod.rs
@@ -15,7 +15,7 @@ use super::{
 };
 use crate::WrapperKind;
 use crate::facts::surface::PositionalParameterFragmentKind;
-use crate::{LinterFacts, LinterSemanticArtifacts, ShellDialect};
+use crate::{ArithmeticLiteralBehavior, LinterFacts, LinterSemanticArtifacts, ShellDialect};
 
 mod assignments;
 mod braces;

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
-    FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior,
-    PlainUnindexedArrayReferenceFact, SubscriptIndexBehavior,
+    FieldSplittingBehavior, GlobDotBehavior, GlobFailureBehavior, PathnameExpansionBehavior,
+    PatternOperatorBehavior, PlainUnindexedArrayReferenceFact, SubscriptIndexBehavior,
 };
 
 #[test]
@@ -2151,6 +2151,82 @@ rm *
 }
 
 #[test]
+fn builds_glob_dot_and_pattern_behaviors_for_zsh_globs() {
+    let source = "\
+#!/usr/bin/env zsh
+rm *
+setopt glob_dots extended_glob
+rm *
+setopt ksh_glob sh_glob
+rm *
+unsetopt extended_glob ksh_glob sh_glob
+rm *
+opt=glob_dots
+unsetopt \"$opt\"
+rm *
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            let glob_behaviors = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .filter(|fact| fact.span().slice(source) == "*")
+                .map(|fact| {
+                    let literal = fact.runtime_literal();
+                    let pattern = literal.glob_pattern_behavior;
+                    (
+                        literal.glob_dot_behavior,
+                        pattern.extended_glob(),
+                        pattern.ksh_glob(),
+                        pattern.sh_glob(),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                glob_behaviors,
+                vec![
+                    (
+                        GlobDotBehavior::ExplicitDotRequired,
+                        PatternOperatorBehavior::Disabled,
+                        PatternOperatorBehavior::Disabled,
+                        PatternOperatorBehavior::Disabled,
+                    ),
+                    (
+                        GlobDotBehavior::DotfilesIncluded,
+                        PatternOperatorBehavior::Enabled,
+                        PatternOperatorBehavior::Disabled,
+                        PatternOperatorBehavior::Disabled,
+                    ),
+                    (
+                        GlobDotBehavior::DotfilesIncluded,
+                        PatternOperatorBehavior::Enabled,
+                        PatternOperatorBehavior::Enabled,
+                        PatternOperatorBehavior::Enabled,
+                    ),
+                    (
+                        GlobDotBehavior::DotfilesIncluded,
+                        PatternOperatorBehavior::Disabled,
+                        PatternOperatorBehavior::Disabled,
+                        PatternOperatorBehavior::Disabled,
+                    ),
+                    (
+                        GlobDotBehavior::Ambiguous,
+                        PatternOperatorBehavior::Ambiguous,
+                        PatternOperatorBehavior::Ambiguous,
+                        PatternOperatorBehavior::Ambiguous,
+                    ),
+                ]
+            );
+        },
+    );
+}
+
+#[test]
 fn builds_word_facts_for_special_parameter_arguments() {
     let source = "\
 #!/bin/bash
@@ -3405,6 +3481,9 @@ printf '%s\\n' ${arr[1]}
 unsetopt ksh_arrays
 setopt ksh_zero_subscript
 printf '%s\\n' ${arr[0]}
+opt=ksh_zero_subscript
+unsetopt \"$opt\"
+printf '%s\\n' ${arr[0]}
 ";
 
     with_facts(source, None, |_, facts| {
@@ -3424,7 +3503,33 @@ printf '%s\\n' ${arr[0]}
                 ("${arr[1]}", SubscriptIndexBehavior::OneBased),
                 ("${arr[1]}", SubscriptIndexBehavior::ZeroBased),
                 ("${arr[0]}", SubscriptIndexBehavior::OneBasedWithZeroAlias,),
+                ("${arr[0]}", SubscriptIndexBehavior::Ambiguous),
             ]
+        );
+    });
+}
+
+#[test]
+fn indexed_array_reference_fragments_record_bash_subscript_index_behavior() {
+    let source = "\
+#!/bin/bash
+printf '%s\\n' ${arr[0]}
+";
+
+    with_facts(source, None, |_, facts| {
+        assert_eq!(
+            facts
+                .indexed_array_reference_fragments()
+                .iter()
+                .filter(|fragment| fragment.is_plain())
+                .map(|fragment| {
+                    (
+                        fragment.span().slice(source),
+                        fragment.subscript_index_behavior(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![("${arr[0]}", SubscriptIndexBehavior::ZeroBased)]
         );
     });
 }

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -3478,6 +3478,8 @@ fn indexed_array_reference_fragments_record_subscript_index_behavior() {
 printf '%s\\n' ${arr[1]}
 setopt ksh_arrays
 printf '%s\\n' ${arr[1]}
+if cond; then setopt ksh_zero_subscript; fi
+printf '%s\\n' ${arr[1]}
 unsetopt ksh_arrays
 setopt ksh_zero_subscript
 printf '%s\\n' ${arr[0]}
@@ -3501,6 +3503,7 @@ printf '%s\\n' ${arr[0]}
                 .collect::<Vec<_>>(),
             vec![
                 ("${arr[1]}", SubscriptIndexBehavior::OneBased),
+                ("${arr[1]}", SubscriptIndexBehavior::ZeroBased),
                 ("${arr[1]}", SubscriptIndexBehavior::ZeroBased),
                 ("${arr[0]}", SubscriptIndexBehavior::OneBasedWithZeroAlias,),
                 ("${arr[0]}", SubscriptIndexBehavior::Ambiguous),

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior,
-    PlainUnindexedArrayReferenceFact,
+    PlainUnindexedArrayReferenceFact, SubscriptIndexBehavior,
 };
 
 #[test]
@@ -3390,6 +3390,40 @@ printf '%s\\n' \"${items[@]#$prefix/}\" \"${items[i]%$suffix}\"
             vec![
                 ("${items[@]#$prefix/}", false),
                 ("${items[i]%$suffix}", false),
+            ]
+        );
+    });
+}
+
+#[test]
+fn indexed_array_reference_fragments_record_subscript_index_behavior() {
+    let source = "\
+#!/bin/zsh
+printf '%s\\n' ${arr[1]}
+setopt ksh_arrays
+printf '%s\\n' ${arr[1]}
+unsetopt ksh_arrays
+setopt ksh_zero_subscript
+printf '%s\\n' ${arr[0]}
+";
+
+    with_facts(source, None, |_, facts| {
+        assert_eq!(
+            facts
+                .indexed_array_reference_fragments()
+                .iter()
+                .filter(|fragment| fragment.is_plain())
+                .map(|fragment| {
+                    (
+                        fragment.span().slice(source),
+                        fragment.subscript_index_behavior(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                ("${arr[1]}", SubscriptIndexBehavior::OneBased),
+                ("${arr[1]}", SubscriptIndexBehavior::ZeroBased),
+                ("${arr[0]}", SubscriptIndexBehavior::OneBasedWithZeroAlias,),
             ]
         );
     });

--- a/crates/shuck-linter/src/facts/words/expansion.rs
+++ b/crates/shuck-linter/src/facts/words/expansion.rs
@@ -102,6 +102,8 @@ pub struct RuntimeLiteralAnalysis {
     pub runtime_sensitive: bool,
     pub pathname_expansion_behavior: PathnameExpansionBehavior,
     pub glob_failure_behavior: GlobFailureBehavior,
+    pub glob_dot_behavior: GlobDotBehavior,
+    pub glob_pattern_behavior: GlobPatternBehavior,
     pub hazards: ExpansionHazards,
 }
 
@@ -111,6 +113,8 @@ impl Default for RuntimeLiteralAnalysis {
             runtime_sensitive: false,
             pathname_expansion_behavior: PathnameExpansionBehavior::Disabled,
             glob_failure_behavior: GlobFailureBehavior::KeepLiteralOnNoMatch,
+            glob_dot_behavior: GlobDotBehavior::ExplicitDotRequired,
+            glob_pattern_behavior: default_glob_pattern_behavior(),
             hazards: ExpansionHazards::default(),
         }
     }
@@ -357,6 +361,57 @@ pub(super) fn glob_failure_behavior_for_options(
     }
 }
 
+pub(super) fn glob_dot_behavior_for_options(options: Option<&ZshOptionState>) -> GlobDotBehavior {
+    match options {
+        Some(options) => match options.glob_dots {
+            OptionValue::Off => GlobDotBehavior::ExplicitDotRequired,
+            OptionValue::On => GlobDotBehavior::DotfilesIncluded,
+            OptionValue::Unknown => GlobDotBehavior::Ambiguous,
+        },
+        None => GlobDotBehavior::ExplicitDotRequired,
+    }
+}
+
+pub(super) fn glob_pattern_behavior_for_options(
+    options: Option<&ZshOptionState>,
+) -> GlobPatternBehavior {
+    options.map_or_else(default_glob_pattern_behavior, |options| {
+        semantic_glob_pattern_behavior(
+            pattern_operator_behavior_for_options(options.extended_glob),
+            pattern_operator_behavior_for_options(options.ksh_glob),
+            pattern_operator_behavior_for_options(options.sh_glob),
+        )
+    })
+}
+
+fn default_glob_pattern_behavior() -> GlobPatternBehavior {
+    semantic_glob_pattern_behavior(
+        PatternOperatorBehavior::Disabled,
+        PatternOperatorBehavior::Disabled,
+        PatternOperatorBehavior::Disabled,
+    )
+}
+
+fn semantic_glob_pattern_behavior(
+    extended_glob: PatternOperatorBehavior,
+    ksh_glob: PatternOperatorBehavior,
+    sh_glob: PatternOperatorBehavior,
+) -> GlobPatternBehavior {
+    GlobPatternBehavior::from_parts(
+        extended_glob,
+        ksh_glob,
+        sh_glob,
+    )
+}
+
+fn pattern_operator_behavior_for_options(value: OptionValue) -> PatternOperatorBehavior {
+    match value {
+        OptionValue::Off => PatternOperatorBehavior::Disabled,
+        OptionValue::On => PatternOperatorBehavior::Enabled,
+        OptionValue::Unknown => PatternOperatorBehavior::Ambiguous,
+    }
+}
+
 fn merge_field_splitting_behavior(
     current: Option<FieldSplittingBehavior>,
     next: FieldSplittingBehavior,
@@ -490,6 +545,8 @@ pub(crate) fn analyze_literal_runtime(
     let mut analysis = RuntimeLiteralAnalysis {
         pathname_expansion_behavior: pathname_expansion_behavior_for_options(options),
         glob_failure_behavior: glob_failure_behavior_for_options(options),
+        glob_dot_behavior: glob_dot_behavior_for_options(options),
+        glob_pattern_behavior: glob_pattern_behavior_for_options(options),
         ..RuntimeLiteralAnalysis::default()
     };
     let mut state = RuntimeLiteralState::default();

--- a/crates/shuck-linter/src/facts/words/tests.rs
+++ b/crates/shuck-linter/src/facts/words/tests.rs
@@ -221,7 +221,10 @@ mod expansion_analysis_tests {
         ExpansionValueShape, RedirectDevNullStatus, WordLiteralness, WordQuote,
         analyze_literal_runtime, analyze_redirect_target, analyze_word, comparable_path,
     };
-    use crate::{FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior};
+    use crate::{
+        FieldSplittingBehavior, GlobDotBehavior, GlobFailureBehavior, PathnameExpansionBehavior,
+        PatternOperatorBehavior,
+    };
 
     fn parse_argument_words(source: &str) -> Vec<shuck_ast::Word> {
         let file = Parser::new(source).parse().unwrap().file;
@@ -626,6 +629,41 @@ mod expansion_analysis_tests {
             GlobFailureBehavior::CshNullGlob
         );
         assert!(csh_null_glob.hazards.pathname_matching);
+    }
+
+    #[test]
+    fn analyze_literal_runtime_records_glob_pattern_behaviors() {
+        let source = "print *.jpg\n";
+        let words = parse_argument_words(source);
+        let analysis = analyze_literal_runtime(
+            &words[0],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&shuck_semantic::ZshOptionState {
+                glob_dots: shuck_semantic::OptionValue::On,
+                extended_glob: shuck_semantic::OptionValue::On,
+                ksh_glob: shuck_semantic::OptionValue::Unknown,
+                sh_glob: shuck_semantic::OptionValue::On,
+                ..shuck_semantic::ZshOptionState::zsh_default()
+            }),
+        );
+
+        assert_eq!(
+            analysis.glob_dot_behavior,
+            GlobDotBehavior::DotfilesIncluded
+        );
+        assert_eq!(
+            analysis.glob_pattern_behavior.extended_glob(),
+            PatternOperatorBehavior::Enabled
+        );
+        assert_eq!(
+            analysis.glob_pattern_behavior.ksh_glob(),
+            PatternOperatorBehavior::Ambiguous
+        );
+        assert_eq!(
+            analysis.glob_pattern_behavior.sh_glob(),
+            PatternOperatorBehavior::Enabled
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -62,8 +62,8 @@ pub use facts::words::{
 };
 /// Extracted structural facts available to rules and callers.
 pub use facts::{
-    AmbiguousArrayReference, BacktickFragmentFact, CommandFact, CommandFactRef, CommandFacts,
-    ConditionalBareWordFact, ConditionalBinaryFact, ConditionalFact,
+    AmbiguousArrayReference, ArithmeticLiteralFact, BacktickFragmentFact, CommandFact,
+    CommandFactRef, CommandFacts, ConditionalBareWordFact, ConditionalBinaryFact, ConditionalFact,
     ConditionalMixedLogicalOperatorFact, ConditionalNodeFact, ConditionalOperandFact,
     ConditionalOperatorFamily, ConditionalPortabilityFacts, ConditionalUnaryFact, ForHeaderFact,
     FunctionCallArityFacts, FunctionHeaderFact, LegacyArithmeticFragmentFact, ListFact,
@@ -106,7 +106,11 @@ pub use settings::{
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;
 /// Option-sensitive shell behavior enums reused by linter facts and rules.
-pub use shuck_semantic::{FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior};
+pub use shuck_semantic::{
+    ArithmeticLiteralBehavior, FieldSplittingBehavior, GlobDotBehavior, GlobFailureBehavior,
+    GlobPatternBehavior, PathnameExpansionBehavior, PatternOperatorBehavior,
+    SubscriptIndexBehavior,
+};
 /// Suppression directives, shellcheck mappings, and rewrite helpers.
 pub use suppression::{
     AddIgnoreParseError, AddIgnoreResult, ShellCheckCodeMap, SuppressionAction,

--- a/crates/shuck-semantic/src/glob.rs
+++ b/crates/shuck-semantic/src/glob.rs
@@ -309,6 +309,14 @@ mod tests {
             behavior.glob_failure(),
             GlobFailureBehavior::KeepLiteralOnNoMatch
         );
+        assert_eq!(
+            behavior.glob_dot_matching(),
+            GlobDotBehavior::ExplicitDotRequired
+        );
+        let pattern = behavior.glob_pattern();
+        assert_eq!(pattern.extended_glob(), PatternOperatorBehavior::Disabled);
+        assert_eq!(pattern.ksh_glob(), PatternOperatorBehavior::Disabled);
+        assert_eq!(pattern.sh_glob(), PatternOperatorBehavior::Disabled);
     }
 
     #[test]
@@ -488,6 +496,10 @@ print $name
                 GlobDotBehavior::DotfilesIncluded,
             ),
             (
+                "setopt glob_dots\nunsetopt glob_dots\nprint *\n",
+                GlobDotBehavior::ExplicitDotRequired,
+            ),
+            (
                 "opt=glob_dots\nsetopt \"$opt\"\nprint *\n",
                 GlobDotBehavior::Ambiguous,
             ),
@@ -509,6 +521,12 @@ print $name
 print *
 setopt extended_glob ksh_glob sh_glob
 print *
+unsetopt extended_glob
+print *
+unsetopt ksh_glob
+print *
+unsetopt sh_glob
+print *
 opt=extended_glob
 unsetopt \"$opt\"
 print *
@@ -529,6 +547,33 @@ print *
         assert_eq!(enabled.extended_glob(), PatternOperatorBehavior::Enabled);
         assert_eq!(enabled.ksh_glob(), PatternOperatorBehavior::Enabled);
         assert_eq!(enabled.sh_glob(), PatternOperatorBehavior::Enabled);
+
+        let only_ksh_and_sh = model
+            .shell_behavior_at(print_offsets.next().expect("expected partial print"))
+            .glob_pattern();
+        assert_eq!(
+            only_ksh_and_sh.extended_glob(),
+            PatternOperatorBehavior::Disabled
+        );
+        assert_eq!(only_ksh_and_sh.ksh_glob(), PatternOperatorBehavior::Enabled);
+        assert_eq!(only_ksh_and_sh.sh_glob(), PatternOperatorBehavior::Enabled);
+
+        let only_sh = model
+            .shell_behavior_at(print_offsets.next().expect("expected sh print"))
+            .glob_pattern();
+        assert_eq!(only_sh.extended_glob(), PatternOperatorBehavior::Disabled);
+        assert_eq!(only_sh.ksh_glob(), PatternOperatorBehavior::Disabled);
+        assert_eq!(only_sh.sh_glob(), PatternOperatorBehavior::Enabled);
+
+        let disabled_again = model
+            .shell_behavior_at(print_offsets.next().expect("expected disabled print"))
+            .glob_pattern();
+        assert_eq!(
+            disabled_again.extended_glob(),
+            PatternOperatorBehavior::Disabled
+        );
+        assert_eq!(disabled_again.ksh_glob(), PatternOperatorBehavior::Disabled);
+        assert_eq!(disabled_again.sh_glob(), PatternOperatorBehavior::Disabled);
 
         let ambiguous = model
             .shell_behavior_at(print_offsets.next().expect("expected ambiguous print"))

--- a/crates/shuck-semantic/src/glob.rs
+++ b/crates/shuck-semantic/src/glob.rs
@@ -63,6 +63,66 @@ pub enum GlobFailureBehavior {
     Ambiguous,
 }
 
+/// Whether glob patterns match dot-prefixed path segments without an explicit dot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlobDotBehavior {
+    /// Dot-prefixed names require an explicit dot in the pattern.
+    ExplicitDotRequired,
+    /// Dot-prefixed names may be matched by ordinary glob metacharacters.
+    DotfilesIncluded,
+    /// Runtime option state may select either behavior.
+    Ambiguous,
+}
+
+/// Whether a zsh pattern-operator family is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PatternOperatorBehavior {
+    /// The operator family is disabled.
+    Disabled,
+    /// The operator family is enabled.
+    Enabled,
+    /// Runtime option state may select either behavior.
+    Ambiguous,
+}
+
+/// Option-sensitive pattern operators available to glob and shell-pattern facts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GlobPatternBehavior {
+    extended_glob: PatternOperatorBehavior,
+    ksh_glob: PatternOperatorBehavior,
+    sh_glob: PatternOperatorBehavior,
+}
+
+impl GlobPatternBehavior {
+    /// Creates a pattern behavior from its operator-family states.
+    pub const fn from_parts(
+        extended_glob: PatternOperatorBehavior,
+        ksh_glob: PatternOperatorBehavior,
+        sh_glob: PatternOperatorBehavior,
+    ) -> Self {
+        Self {
+            extended_glob,
+            ksh_glob,
+            sh_glob,
+        }
+    }
+
+    /// Returns whether zsh extended glob operators such as `#`, `~`, and `^` are active.
+    pub fn extended_glob(self) -> PatternOperatorBehavior {
+        self.extended_glob
+    }
+
+    /// Returns whether ksh-style glob operators such as `@(...)` are active.
+    pub fn ksh_glob(self) -> PatternOperatorBehavior {
+        self.ksh_glob
+    }
+
+    /// Returns whether sh-compatible glob parsing is active.
+    pub fn sh_glob(self) -> PatternOperatorBehavior {
+        self.sh_glob
+    }
+}
+
 impl ShellBehaviorAt<'_> {
     /// Returns the field-splitting behavior implied by the shell and runtime option state.
     pub fn field_splitting(&self) -> FieldSplittingBehavior {
@@ -131,6 +191,55 @@ impl ShellBehaviorAt<'_> {
                 },
             },
         }
+    }
+
+    /// Returns how glob patterns treat dot-prefixed path segments.
+    pub fn glob_dot_matching(&self) -> GlobDotBehavior {
+        if self.shell != ShellDialect::Zsh {
+            return GlobDotBehavior::ExplicitDotRequired;
+        }
+
+        match self
+            .effective_zsh_options()
+            .map(|options| options.glob_dots)
+        {
+            Some(OptionValue::On) => GlobDotBehavior::DotfilesIncluded,
+            Some(OptionValue::Unknown) => GlobDotBehavior::Ambiguous,
+            Some(OptionValue::Off) | None => GlobDotBehavior::ExplicitDotRequired,
+        }
+    }
+
+    /// Returns the option-sensitive glob/pattern operator families available at this offset.
+    pub fn glob_pattern(&self) -> GlobPatternBehavior {
+        if self.shell != ShellDialect::Zsh {
+            return GlobPatternBehavior::from_parts(
+                PatternOperatorBehavior::Disabled,
+                PatternOperatorBehavior::Disabled,
+                PatternOperatorBehavior::Disabled,
+            );
+        }
+
+        let Some(options) = self.effective_zsh_options() else {
+            return GlobPatternBehavior::from_parts(
+                PatternOperatorBehavior::Disabled,
+                PatternOperatorBehavior::Disabled,
+                PatternOperatorBehavior::Disabled,
+            );
+        };
+
+        GlobPatternBehavior::from_parts(
+            pattern_operator_behavior(options.extended_glob),
+            pattern_operator_behavior(options.ksh_glob),
+            pattern_operator_behavior(options.sh_glob),
+        )
+    }
+}
+
+fn pattern_operator_behavior(value: OptionValue) -> PatternOperatorBehavior {
+    match value {
+        OptionValue::Off => PatternOperatorBehavior::Disabled,
+        OptionValue::On => PatternOperatorBehavior::Enabled,
+        OptionValue::Unknown => PatternOperatorBehavior::Ambiguous,
     }
 }
 
@@ -368,5 +477,67 @@ print $name
                 "{source}"
             );
         }
+    }
+
+    #[test]
+    fn tracks_glob_dot_matching_by_offset() {
+        for (source, expected) in [
+            ("print *\n", GlobDotBehavior::ExplicitDotRequired),
+            (
+                "setopt glob_dots\nprint *\n",
+                GlobDotBehavior::DotfilesIncluded,
+            ),
+            (
+                "opt=glob_dots\nsetopt \"$opt\"\nprint *\n",
+                GlobDotBehavior::Ambiguous,
+            ),
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let offset = source.find("print").expect("expected print offset");
+
+            assert_eq!(
+                model.shell_behavior_at(offset).glob_dot_matching(),
+                expected,
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn tracks_glob_pattern_operator_families_by_offset() {
+        let source = "\
+print *
+setopt extended_glob ksh_glob sh_glob
+print *
+opt=extended_glob
+unsetopt \"$opt\"
+print *
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let mut print_offsets = source.match_indices("print").map(|(offset, _)| offset);
+
+        let native = model
+            .shell_behavior_at(print_offsets.next().expect("expected native print"))
+            .glob_pattern();
+        assert_eq!(native.extended_glob(), PatternOperatorBehavior::Disabled);
+        assert_eq!(native.ksh_glob(), PatternOperatorBehavior::Disabled);
+        assert_eq!(native.sh_glob(), PatternOperatorBehavior::Disabled);
+
+        let enabled = model
+            .shell_behavior_at(print_offsets.next().expect("expected enabled print"))
+            .glob_pattern();
+        assert_eq!(enabled.extended_glob(), PatternOperatorBehavior::Enabled);
+        assert_eq!(enabled.ksh_glob(), PatternOperatorBehavior::Enabled);
+        assert_eq!(enabled.sh_glob(), PatternOperatorBehavior::Enabled);
+
+        let ambiguous = model
+            .shell_behavior_at(print_offsets.next().expect("expected ambiguous print"))
+            .glob_pattern();
+        assert_eq!(
+            ambiguous.extended_glob(),
+            PatternOperatorBehavior::Ambiguous
+        );
+        assert_eq!(ambiguous.ksh_glob(), PatternOperatorBehavior::Ambiguous);
+        assert_eq!(ambiguous.sh_glob(), PatternOperatorBehavior::Ambiguous);
     }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -62,7 +62,10 @@ pub use function_call_reachability::{
     FunctionCallPersistence,
 };
 /// Option-sensitive globbing and expansion behavior queries.
-pub use glob::{FieldSplittingBehavior, GlobFailureBehavior, PathnameExpansionBehavior};
+pub use glob::{
+    FieldSplittingBehavior, GlobDotBehavior, GlobFailureBehavior, GlobPatternBehavior,
+    PathnameExpansionBehavior, PatternOperatorBehavior,
+};
 /// Nonpersistent assignment effects, such as assignments made in subshells and read later outside.
 pub use nonpersistent::{
     NonpersistentAssignmentAnalysis, NonpersistentAssignmentAnalysisContext,
@@ -88,6 +91,34 @@ pub enum ArrayReferencePolicy {
     /// Native zsh treats an unindexed array reference as a scalar first-element read.
     NativeZshScalar,
     /// Runtime option state may select either policy.
+    Ambiguous,
+}
+
+/// How indexed array subscripts are interpreted at a source offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubscriptIndexBehavior {
+    /// Subscript `1` names the first array element.
+    OneBased,
+    /// Subscript `0` names the first array element.
+    ZeroBased,
+    /// Subscript `1` names the first element, but `0` is accepted as an alias.
+    OneBasedWithZeroAlias,
+    /// Runtime option state may select more than one indexing policy.
+    Ambiguous,
+}
+
+/// How arithmetic number literals are interpreted at a source offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArithmeticLiteralBehavior {
+    /// Decimal literals are used unless an explicit shell arithmetic base is present.
+    DecimalUnlessExplicitBase,
+    /// C-style numeric base prefixes such as `0x` are active.
+    CStyleBasePrefixes,
+    /// Leading zeroes denote octal literals.
+    LeadingZeroOctal,
+    /// Both C-style base prefixes and leading-zero octal literals are active.
+    CStyleAndLeadingZeroOctal,
+    /// Runtime option state may select more than one literal policy.
     Ambiguous,
 }
 
@@ -117,6 +148,51 @@ impl ShellBehaviorAt<'_> {
             Some(OptionValue::Off) => ArrayReferencePolicy::NativeZshScalar,
             Some(OptionValue::Unknown) => ArrayReferencePolicy::Ambiguous,
             Some(OptionValue::On) | None => ArrayReferencePolicy::RequiresExplicitSelector,
+        }
+    }
+
+    /// Returns how array subscript indexes are interpreted.
+    pub fn subscript_indexing(&self) -> SubscriptIndexBehavior {
+        if self.shell != ShellDialect::Zsh {
+            return SubscriptIndexBehavior::ZeroBased;
+        }
+
+        let Some(options) = self.effective_zsh_options() else {
+            return SubscriptIndexBehavior::OneBased;
+        };
+
+        match (options.ksh_arrays, options.ksh_zero_subscript) {
+            (OptionValue::Unknown, _) | (_, OptionValue::Unknown) => {
+                SubscriptIndexBehavior::Ambiguous
+            }
+            (OptionValue::On, _) => SubscriptIndexBehavior::ZeroBased,
+            (OptionValue::Off, OptionValue::On) => SubscriptIndexBehavior::OneBasedWithZeroAlias,
+            (OptionValue::Off, OptionValue::Off) => SubscriptIndexBehavior::OneBased,
+        }
+    }
+
+    /// Returns how arithmetic numeric literals are interpreted.
+    pub fn arithmetic_literals(&self) -> ArithmeticLiteralBehavior {
+        if self.shell != ShellDialect::Zsh {
+            return ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal;
+        }
+
+        let Some(options) = self.effective_zsh_options() else {
+            return ArithmeticLiteralBehavior::DecimalUnlessExplicitBase;
+        };
+
+        match (options.c_bases, options.octal_zeroes) {
+            (OptionValue::Unknown, _) | (_, OptionValue::Unknown) => {
+                ArithmeticLiteralBehavior::Ambiguous
+            }
+            (OptionValue::Off, OptionValue::Off) => {
+                ArithmeticLiteralBehavior::DecimalUnlessExplicitBase
+            }
+            (OptionValue::On, OptionValue::Off) => ArithmeticLiteralBehavior::CStyleBasePrefixes,
+            (OptionValue::Off, OptionValue::On) => ArithmeticLiteralBehavior::LeadingZeroOctal,
+            (OptionValue::On, OptionValue::On) => {
+                ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal
+            }
         }
     }
 }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -162,10 +162,10 @@ impl ShellBehaviorAt<'_> {
         };
 
         match (options.ksh_arrays, options.ksh_zero_subscript) {
-            (OptionValue::Unknown, _) | (_, OptionValue::Unknown) => {
+            (OptionValue::On, _) => SubscriptIndexBehavior::ZeroBased,
+            (OptionValue::Unknown, _) | (OptionValue::Off, OptionValue::Unknown) => {
                 SubscriptIndexBehavior::Ambiguous
             }
-            (OptionValue::On, _) => SubscriptIndexBehavior::ZeroBased,
             (OptionValue::Off, OptionValue::On) => SubscriptIndexBehavior::OneBasedWithZeroAlias,
             (OptionValue::Off, OptionValue::Off) => SubscriptIndexBehavior::OneBased,
         }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -112,8 +112,6 @@ pub enum SubscriptIndexBehavior {
 pub enum ArithmeticLiteralBehavior {
     /// Decimal literals are used unless an explicit shell arithmetic base is present.
     DecimalUnlessExplicitBase,
-    /// C-style numeric base prefixes such as `0x` are active.
-    CStyleBasePrefixes,
     /// Leading zeroes denote octal literals.
     LeadingZeroOctal,
     /// Both C-style base prefixes and leading-zero octal literals are active.
@@ -181,18 +179,10 @@ impl ShellBehaviorAt<'_> {
             return ArithmeticLiteralBehavior::DecimalUnlessExplicitBase;
         };
 
-        match (options.c_bases, options.octal_zeroes) {
-            (OptionValue::Unknown, _) | (_, OptionValue::Unknown) => {
-                ArithmeticLiteralBehavior::Ambiguous
-            }
-            (OptionValue::Off, OptionValue::Off) => {
-                ArithmeticLiteralBehavior::DecimalUnlessExplicitBase
-            }
-            (OptionValue::On, OptionValue::Off) => ArithmeticLiteralBehavior::CStyleBasePrefixes,
-            (OptionValue::Off, OptionValue::On) => ArithmeticLiteralBehavior::LeadingZeroOctal,
-            (OptionValue::On, OptionValue::On) => {
-                ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal
-            }
+        match options.octal_zeroes {
+            OptionValue::Off => ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
+            OptionValue::On => ArithmeticLiteralBehavior::LeadingZeroOctal,
+            OptionValue::Unknown => ArithmeticLiteralBehavior::Ambiguous,
         }
     }
 }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9790,6 +9790,69 @@ fn array_reference_policy_at(model: &SemanticModel, offset: usize) -> ArrayRefer
 }
 
 #[test]
+fn semantic_behavior_tracks_subscript_indexing_options() {
+    for (source, expected) in [
+        ("print ${arr[1]}\n", SubscriptIndexBehavior::OneBased),
+        (
+            "setopt ksh_arrays\nprint ${arr[1]}\n",
+            SubscriptIndexBehavior::ZeroBased,
+        ),
+        (
+            "setopt ksh_zero_subscript\nprint ${arr[0]}\n",
+            SubscriptIndexBehavior::OneBasedWithZeroAlias,
+        ),
+        (
+            "opt=ksh_zero_subscript\nsetopt \"$opt\"\nprint ${arr[0]}\n",
+            SubscriptIndexBehavior::Ambiguous,
+        ),
+    ] {
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let offset = source.find("print").unwrap();
+
+        assert_eq!(
+            model.shell_behavior_at(offset).subscript_indexing(),
+            expected,
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn semantic_behavior_tracks_arithmetic_literal_options() {
+    for (source, expected) in [
+        (
+            "print $(( 010 + 0x10 ))\n",
+            ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
+        ),
+        (
+            "setopt c_bases\nprint $(( 010 + 0x10 ))\n",
+            ArithmeticLiteralBehavior::CStyleBasePrefixes,
+        ),
+        (
+            "setopt octal_zeroes\nprint $(( 010 + 0x10 ))\n",
+            ArithmeticLiteralBehavior::LeadingZeroOctal,
+        ),
+        (
+            "setopt c_bases octal_zeroes\nprint $(( 010 + 0x10 ))\n",
+            ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal,
+        ),
+        (
+            "opt=c_bases\nsetopt \"$opt\"\nprint $(( 010 + 0x10 ))\n",
+            ArithmeticLiteralBehavior::Ambiguous,
+        ),
+    ] {
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let offset = source.find("print").unwrap();
+
+        assert_eq!(
+            model.shell_behavior_at(offset).arithmetic_literals(),
+            expected,
+            "{source}"
+        );
+    }
+}
+
+#[test]
 fn semantic_behavior_detects_real_ksh_array_enables() {
     for source in [
         "setopt ksh_arrays\nprint $name\n",

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9858,7 +9858,7 @@ fn semantic_behavior_tracks_arithmetic_literal_options() {
         ),
         (
             "setopt c_bases\nprint $(( 010 + 0x10 ))\n",
-            ArithmeticLiteralBehavior::CStyleBasePrefixes,
+            ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
         ),
         (
             "setopt octal_zeroes\nprint $(( 010 + 0x10 ))\n",
@@ -9866,10 +9866,10 @@ fn semantic_behavior_tracks_arithmetic_literal_options() {
         ),
         (
             "setopt c_bases octal_zeroes\nprint $(( 010 + 0x10 ))\n",
-            ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal,
+            ArithmeticLiteralBehavior::LeadingZeroOctal,
         ),
         (
-            "opt=c_bases\nsetopt \"$opt\"\nprint $(( 010 + 0x10 ))\n",
+            "opt=octal_zeroes\nsetopt \"$opt\"\nprint $(( 010 + 0x10 ))\n",
             ArithmeticLiteralBehavior::Ambiguous,
         ),
     ] {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9791,11 +9791,29 @@ fn array_reference_policy_at(model: &SemanticModel, offset: usize) -> ArrayRefer
 
 #[test]
 fn semantic_behavior_tracks_subscript_indexing_options() {
+    let bash_source = "print ${arr[0]}\n";
+    let bash_model = model_with_profile(bash_source, ShellProfile::native(ShellDialect::Bash));
+    let bash_offset = bash_source.find("print").unwrap();
+    assert_eq!(
+        bash_model
+            .shell_behavior_at(bash_offset)
+            .subscript_indexing(),
+        SubscriptIndexBehavior::ZeroBased,
+    );
+
     for (source, expected) in [
         ("print ${arr[1]}\n", SubscriptIndexBehavior::OneBased),
         (
             "setopt ksh_arrays\nprint ${arr[1]}\n",
             SubscriptIndexBehavior::ZeroBased,
+        ),
+        (
+            "setopt ksh_arrays ksh_zero_subscript\nprint ${arr[0]}\n",
+            SubscriptIndexBehavior::ZeroBased,
+        ),
+        (
+            "setopt ksh_arrays\nunsetopt ksh_arrays\nprint ${arr[1]}\n",
+            SubscriptIndexBehavior::OneBased,
         ),
         (
             "setopt ksh_zero_subscript\nprint ${arr[0]}\n",
@@ -9819,6 +9837,16 @@ fn semantic_behavior_tracks_subscript_indexing_options() {
 
 #[test]
 fn semantic_behavior_tracks_arithmetic_literal_options() {
+    let bash_source = "print $(( 010 + 0x10 ))\n";
+    let bash_model = model_with_profile(bash_source, ShellProfile::native(ShellDialect::Bash));
+    let bash_offset = bash_source.find("print").unwrap();
+    assert_eq!(
+        bash_model
+            .shell_behavior_at(bash_offset)
+            .arithmetic_literals(),
+        ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal,
+    );
+
     for (source, expected) in [
         (
             "print $(( 010 + 0x10 ))\n",

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9812,6 +9812,10 @@ fn semantic_behavior_tracks_subscript_indexing_options() {
             SubscriptIndexBehavior::ZeroBased,
         ),
         (
+            "setopt ksh_arrays\nif cond; then setopt ksh_zero_subscript; fi\nprint ${arr[1]}\n",
+            SubscriptIndexBehavior::ZeroBased,
+        ),
+        (
             "setopt ksh_arrays\nunsetopt ksh_arrays\nprint ${arr[1]}\n",
             SubscriptIndexBehavior::OneBased,
         ),

--- a/specs/014-zsh-option-state.md
+++ b/specs/014-zsh-option-state.md
@@ -107,7 +107,7 @@ The following tracked options now have behavior-backed semantic queries and lint
 - `NOMATCH`, `NULL_GLOB`, and `CSH_NULL_GLOB` feed unmatched-glob behavior.
 - `GLOB_DOTS`, `EXTENDED_GLOB`, `KSH_GLOB`, and `SH_GLOB` feed glob/pattern behavior facts.
 - `KSH_ARRAYS` and `KSH_ZERO_SUBSCRIPT` feed array-reference and subscript-indexing behavior.
-- `C_BASES` and `OCTAL_ZEROES` feed arithmetic-literal behavior.
+- `OCTAL_ZEROES` feeds arithmetic-literal input behavior; `C_BASES` remains tracked for arithmetic output formatting.
 
 The remaining options in this inventory are still tracked for parser, syntax, or future fact
 support unless a later section states otherwise.

--- a/specs/014-zsh-option-state.md
+++ b/specs/014-zsh-option-state.md
@@ -99,6 +99,19 @@ The following zsh options are analysis-relevant. They are grouped by which syste
 | `C_BASES` | off | Arithmetic output uses `0x`/`0` prefixes. |
 | `OCTAL_ZEROES` | off | Leading `0` in arithmetic is octal. |
 
+#### Behavior-Backed Inventory Status
+
+The following tracked options now have behavior-backed semantic queries and linter facts:
+
+- `SH_WORD_SPLIT`, `GLOB_SUBST`, and `GLOB` feed field-splitting and pathname-expansion behavior.
+- `NOMATCH`, `NULL_GLOB`, and `CSH_NULL_GLOB` feed unmatched-glob behavior.
+- `GLOB_DOTS`, `EXTENDED_GLOB`, `KSH_GLOB`, and `SH_GLOB` feed glob/pattern behavior facts.
+- `KSH_ARRAYS` and `KSH_ZERO_SUBSCRIPT` feed array-reference and subscript-indexing behavior.
+- `C_BASES` and `OCTAL_ZEROES` feed arithmetic-literal behavior.
+
+The remaining options in this inventory are still tracked for parser, syntax, or future fact
+support unless a later section states otherwise.
+
 #### Emulation Modes
 
 `emulate` presets a constellation of options to match another shell's behavior:

--- a/specs/019-option-sensitive-facts.md
+++ b/specs/019-option-sensitive-facts.md
@@ -326,7 +326,6 @@ pub enum SubscriptIndexBehavior {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ArithmeticLiteralBehavior {
     DecimalUnlessExplicitBase,
-    CStyleBasePrefixes,
     LeadingZeroOctal,
     CStyleAndLeadingZeroOctal,
     Ambiguous,
@@ -406,7 +405,7 @@ This means new rule files should not add direct AST walks or raw option queries.
 
 - Add fact behavior for `NULL_GLOB`, `CSH_NULL_GLOB`, `GLOB_DOTS`, `EXTENDED_GLOB`, `KSH_GLOB`, and `SH_GLOB` in glob/pattern facts.
 - Add `SubscriptIndexBehavior` for `KSH_ARRAYS` and `KSH_ZERO_SUBSCRIPT`.
-- Add `ArithmeticLiteralBehavior` for `C_BASES` and `OCTAL_ZEROES`.
+- Add `ArithmeticLiteralBehavior` for arithmetic input behavior. `OCTAL_ZEROES` changes literal interpretation; `C_BASES` remains tracked for arithmetic output formatting rather than widening input-literal facts.
 - Update the zsh option support inventory as each option moves from tracked-only to behavior-backed.
 
 ## Alternatives Considered


### PR DESCRIPTION
## Summary

Completes Phase 4 of `specs/019-option-sensitive-facts.md` by moving the remaining stateful zsh option behavior into semantic behavior queries and linter facts.

- Adds behavior-backed glob dot and pattern-operator state for `GLOB_DOTS`, `EXTENDED_GLOB`, `KSH_GLOB`, and `SH_GLOB`.
- Adds `SubscriptIndexBehavior` for `KSH_ARRAYS` / `KSH_ZERO_SUBSCRIPT` and exposes it on indexed array reference facts.
- Adds `ArithmeticLiteralBehavior` for `C_BASES` / `OCTAL_ZEROES` and exposes arithmetic literal facts.
- Updates the zsh option inventory to record which options now have behavior-backed fact support.

## Validation

- `cargo fmt`
- `cargo test -p shuck-linter quoted_bash_source --lib`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C100`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`