### PR TITLE
fix(parser): respect zsh glob option state

### DIFF
--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -2344,7 +2344,8 @@ impl<'a> Parser<'a> {
                     let has_ksh_group_prefix =
                         matches!(previous_char, Some('?' | '*' | '+' | '@' | '!'));
                     let ksh_group_start = features.ksh_groups && has_ksh_group_prefix;
-                    let bare_group_start = features.bare_groups && !has_ksh_group_prefix;
+                    let bare_group_start =
+                        features.bare_groups && (!has_ksh_group_prefix || !features.ksh_groups);
                     if bare_group_start || ksh_group_start {
                         state.paren_depth += 1;
                     }

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -2345,8 +2345,7 @@ impl<'a> Parser<'a> {
                         matches!(previous_char, Some('?' | '*' | '+' | '@' | '!'));
                     let ksh_group_start = features.ksh_groups && has_ksh_group_prefix;
                     let bare_group_start = features.bare_groups && !has_ksh_group_prefix;
-                    if bare_group_start || ksh_group_start
-                    {
+                    if bare_group_start || ksh_group_start {
                         state.paren_depth += 1;
                     }
                     Self::next_word_char_unwrap(&mut chars, &mut state.position);

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -2131,12 +2131,42 @@ impl<'a> Parser<'a> {
     }
 
     fn record_zsh_case_group_parts_from_current_case_header(&mut self) {
-        let Ok((pattern_spans, _)) = self.scan_zsh_case_pattern_spans() else {
+        let start = self.current_span.start;
+        let mut split_features = self.zsh_glob_parse_features_at(start.offset);
+        if self.dialect != ShellDialect::Zsh {
+            split_features.bare_groups = true;
+        }
+
+        let Some((pattern_spans, _)) = (if self.input[start.offset..].starts_with('(')
+            && let Some(wrapper_close) = self.scan_zsh_case_group_close(start)
+            && self.case_wrapper_close_is_arm_delimiter(wrapper_close)
+        {
+            let inner_start = start.advanced_by("(");
+            let inner_span = Span::from_positions(inner_start, wrapper_close.start);
+            self.split_zsh_case_pattern_alternatives_with_features(inner_span, split_features)
+                .map(|patterns| (patterns, wrapper_close))
+        } else if let Some(delimiter_span) = self.scan_zsh_case_arm_delimiter(start) {
+            let header_span = Span::from_positions(start, delimiter_span.start);
+            self.split_zsh_case_pattern_alternatives_with_features(header_span, split_features)
+                .map(|patterns| (patterns, delimiter_span))
+        } else {
+            None
+        }) else {
             return;
         };
 
         for span in pattern_spans {
-            let pattern = self.pattern_from_zsh_case_span(span);
+            let mut features = self.zsh_glob_parse_features_at(span.start.offset);
+            if self.dialect != ShellDialect::Zsh {
+                features.bare_groups = true;
+            }
+            let text = span.slice(self.input);
+            let word = if Self::source_text_needs_quote_preserving_decode(text) {
+                self.decode_fragment_word_text(text, span, span.start, true)
+            } else {
+                self.decode_word_text(text, span, span.start, true)
+            };
+            let pattern = self.pattern_from_zsh_case_word_with_features(&word, features);
             for (index, part) in pattern.parts.iter().enumerate() {
                 if matches!(
                     &part.kind,
@@ -2230,12 +2260,24 @@ impl<'a> Parser<'a> {
     }
 
     fn split_zsh_case_pattern_alternatives(&self, span: Span) -> Option<Vec<Span>> {
+        self.split_zsh_case_pattern_alternatives_with_features(
+            span,
+            self.zsh_glob_parse_features_at(span.start.offset),
+        )
+    }
+
+    fn split_zsh_case_pattern_alternatives_with_features(
+        &self,
+        span: Span,
+        features: ZshGlobParseFeatures,
+    ) -> Option<Vec<Span>> {
         let mut state = ZshCaseScanState::new(span.start);
         let mut chars = self.input[span.start.offset..span.end.offset]
             .chars()
             .peekable();
         let mut part_start = span.start;
         let mut parts = Vec::new();
+        let mut previous_char = None;
 
         while let Some(ch) = chars.peek().copied() {
             if state.escaped {
@@ -2299,7 +2341,14 @@ impl<'a> Parser<'a> {
                     && state.bracket_depth == 0
                     && state.brace_depth == 0 =>
                 {
-                    state.paren_depth += 1;
+                    let has_ksh_group_prefix =
+                        matches!(previous_char, Some('?' | '*' | '+' | '@' | '!'));
+                    let ksh_group_start = features.ksh_groups && has_ksh_group_prefix;
+                    let bare_group_start = features.bare_groups && !has_ksh_group_prefix;
+                    if bare_group_start || ksh_group_start
+                    {
+                        state.paren_depth += 1;
+                    }
                     Self::next_word_char_unwrap(&mut chars, &mut state.position);
                 }
                 ')' if !state.in_single
@@ -2330,6 +2379,8 @@ impl<'a> Parser<'a> {
                     Self::next_word_char_unwrap(&mut chars, &mut state.position);
                 }
             }
+
+            previous_char = Some(ch);
         }
 
         parts.push(

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -1603,11 +1603,9 @@ impl<'a> Parser<'a> {
                         &mut segments,
                         text,
                         span.start,
-                        pattern_start,
-                        index,
+                        (pattern_start, index),
                         source_backed,
                         features,
-                        &mut saw_glob_syntax,
                     );
                     segments.push(ZshGlobSegment::InlineControl(control));
                     saw_glob_syntax = true;
@@ -1626,11 +1624,9 @@ impl<'a> Parser<'a> {
                         &mut segments,
                         text,
                         span.start,
-                        pattern_start,
-                        index,
+                        (pattern_start, index),
                         source_backed,
                         features,
-                        &mut saw_glob_syntax,
                     );
                     qualifiers = Some(group);
                     saw_glob_syntax = true;
@@ -1652,11 +1648,9 @@ impl<'a> Parser<'a> {
                         &mut segments,
                         text,
                         span.start,
-                        pattern_start,
-                        index,
+                        (pattern_start, index),
                         source_backed,
                         features,
-                        &mut saw_glob_syntax,
                     );
                     qualifiers = Some(group);
                     saw_glob_syntax = true;
@@ -1669,15 +1663,13 @@ impl<'a> Parser<'a> {
             index += text[index..].chars().next()?.len_utf8();
         }
 
-        self.push_zsh_pattern_segment(
+        saw_glob_syntax |= self.push_zsh_pattern_segment(
             &mut segments,
             text,
             span.start,
-            pattern_start,
-            text.len(),
+            (pattern_start, text.len()),
             source_backed,
             features,
-            &mut saw_glob_syntax,
         );
 
         segments
@@ -1691,25 +1683,25 @@ impl<'a> Parser<'a> {
         segments: &mut Vec<ZshGlobSegment>,
         text: &str,
         base: Position,
-        start: usize,
-        end: usize,
+        bounds: (usize, usize),
         source_backed: bool,
         features: ZshGlobParseFeatures,
-        saw_glob_syntax: &mut bool,
-    ) {
+    ) -> bool {
+        let (start, end) = bounds;
         if start >= end {
-            return;
+            return false;
         }
 
-        let start_position = Self::text_position(base, text, start);
-        let end_position = Self::text_position(base, text, end);
-        let span = Span::from_positions(start_position, end_position);
+        let span = Span::from_positions(
+            Self::text_position(base, text, start),
+            Self::text_position(base, text, end),
+        );
         let pattern_word =
             self.decode_word_text(&text[start..end], span, span.start, source_backed);
         let pattern = self.pattern_from_word(&pattern_word);
-        *saw_glob_syntax |=
-            self.pattern_has_glob_syntax_with_features(&pattern, features);
+        let saw_glob_syntax = self.pattern_has_glob_syntax_with_features(&pattern, features);
         segments.push(ZshGlobSegment::Pattern(pattern));
+        saw_glob_syntax
     }
 
     fn parse_zsh_inline_glob_control(
@@ -1939,10 +1931,7 @@ impl<'a> Parser<'a> {
             PatternPart::Group { .. } => true,
             PatternPart::Word(word) => Self::pattern_has_glob_word(word),
             PatternPart::Literal(text) => {
-                Self::literal_text_has_zsh_glob_syntax(
-                    text.as_str(self.input, part.span),
-                    features,
-                )
+                Self::literal_text_has_zsh_glob_syntax(text.as_str(self.input, part.span), features)
             }
         })
     }
@@ -1969,7 +1958,9 @@ impl<'a> Parser<'a> {
         let mut index = 0usize;
 
         while index < bytes.len() {
-            let ch = text[index..].chars().next().unwrap();
+            let Some(ch) = text[index..].chars().next() else {
+                break;
+            };
 
             if escaped {
                 escaped = false;

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -67,6 +67,20 @@ use crate::error::{Error, Result};
 
 type WordPartBuffer = SmallVec<[WordPartNode; 2]>;
 
+#[derive(Debug, Clone, Copy, Default)]
+struct ZshGlobParseFeatures {
+    classic_qualifiers: bool,
+    extended_glob: bool,
+    ksh_groups: bool,
+    bare_groups: bool,
+}
+
+impl ZshGlobParseFeatures {
+    const fn zsh_word_parsing_enabled(self) -> bool {
+        self.classic_qualifiers || self.extended_glob || self.ksh_groups || self.bare_groups
+    }
+}
+
 /// Default maximum AST depth (matches ExecutionLimits default)
 const DEFAULT_MAX_AST_DEPTH: usize = 100;
 
@@ -442,12 +456,30 @@ impl<'a> Parser<'a> {
         self.zsh_brace_bodies_enabled()
     }
 
-    fn zsh_glob_qualifiers_enabled_at(&self, offset: usize) -> bool {
-        self.dialect.features().zsh_glob_qualifiers
-            && !self.zsh_options_at_offset(offset).is_some_and(|options| {
-                options.ignore_braces.is_definitely_on()
-                    || options.bare_glob_qual.is_definitely_off()
-            })
+    fn zsh_glob_parse_features_at(&self, offset: usize) -> ZshGlobParseFeatures {
+        let options = self.zsh_options_at_offset(offset);
+        let is_zsh = self.dialect == ShellDialect::Zsh;
+        ZshGlobParseFeatures {
+            classic_qualifiers: self.dialect.features().zsh_glob_qualifiers
+                && !options.is_some_and(|options| {
+                    options.ignore_braces.is_definitely_on()
+                        || options.bare_glob_qual.is_definitely_off()
+                }),
+            extended_glob: is_zsh
+                && !options.is_some_and(|options| options.extended_glob.is_definitely_off()),
+            // Preserve existing non-zsh pattern-group parsing behavior.
+            ksh_groups: !is_zsh
+                || !options.is_some_and(|options| options.ksh_glob.is_definitely_off()),
+            bare_groups: is_zsh
+                && !options.is_some_and(|options| options.sh_glob.is_definitely_on()),
+        }
+    }
+
+    fn zsh_glob_word_parsing_enabled_at(&self, offset: usize) -> bool {
+        self.dialect == ShellDialect::Zsh
+            && self
+                .zsh_glob_parse_features_at(offset)
+                .zsh_word_parsing_enabled()
     }
 
     fn brace_syntax_enabled_at(&self, offset: usize) -> bool {
@@ -1520,7 +1552,8 @@ impl<'a> Parser<'a> {
         span: Span,
         source_backed: bool,
     ) -> Option<Word> {
-        if !self.zsh_glob_qualifiers_enabled_at(span.start.offset)
+        let features = self.zsh_glob_parse_features_at(span.start.offset);
+        if !self.zsh_glob_word_parsing_enabled_at(span.start.offset)
             || text.is_empty()
             || text.contains('=')
             || text.contains(['\x00', '\\', '\'', '"', '$', '`'])
@@ -1529,14 +1562,9 @@ impl<'a> Parser<'a> {
             return None;
         }
 
-        let (segments, qualifiers) =
-            self.parse_zsh_qualified_glob_segments(text, span, source_backed)?;
-        if !segments.iter().any(|segment| {
-            matches!(
-                segment,
-                ZshGlobSegment::Pattern(pattern) if Self::pattern_has_glob_syntax(pattern)
-            )
-        }) {
+        let (segments, qualifiers, saw_glob_syntax) =
+            self.parse_zsh_qualified_glob_segments(text, span, source_backed, features)?;
+        if !saw_glob_syntax {
             return None;
         }
 
@@ -1558,14 +1586,16 @@ impl<'a> Parser<'a> {
         text: &str,
         span: Span,
         source_backed: bool,
-    ) -> Option<(Vec<ZshGlobSegment>, Option<ZshGlobQualifierGroup>)> {
+        features: ZshGlobParseFeatures,
+    ) -> Option<(Vec<ZshGlobSegment>, Option<ZshGlobQualifierGroup>, bool)> {
         let mut segments = Vec::new();
         let mut qualifiers = None;
+        let mut saw_glob_syntax = false;
         let mut pattern_start = 0usize;
         let mut index = 0usize;
 
         while index < text.len() {
-            if text[index..].starts_with("(#") {
+            if features.extended_glob && text[index..].starts_with("(#") {
                 if let Some((len, control)) =
                     self.parse_zsh_inline_glob_control(text, span.start, index)
                 {
@@ -1576,8 +1606,11 @@ impl<'a> Parser<'a> {
                         pattern_start,
                         index,
                         source_backed,
+                        features,
+                        &mut saw_glob_syntax,
                     );
                     segments.push(ZshGlobSegment::InlineControl(control));
+                    saw_glob_syntax = true;
                     index += len;
                     pattern_start = index;
                     continue;
@@ -1596,17 +1629,18 @@ impl<'a> Parser<'a> {
                         pattern_start,
                         index,
                         source_backed,
+                        features,
+                        &mut saw_glob_syntax,
                     );
                     qualifiers = Some(group);
+                    saw_glob_syntax = true;
                     index = text.len();
                     pattern_start = index;
                     break;
                 }
-
-                return None;
             }
 
-            if text[index..].starts_with('(') {
+            if features.classic_qualifiers && text[index..].starts_with('(') {
                 let suffix_start = Self::text_position(span.start, text, index);
                 if let Some(group) = self.parse_zsh_terminal_glob_qualifier_group(
                     &text[index..],
@@ -1621,8 +1655,11 @@ impl<'a> Parser<'a> {
                         pattern_start,
                         index,
                         source_backed,
+                        features,
+                        &mut saw_glob_syntax,
                     );
                     qualifiers = Some(group);
+                    saw_glob_syntax = true;
                     index = text.len();
                     pattern_start = index;
                     break;
@@ -1639,12 +1676,14 @@ impl<'a> Parser<'a> {
             pattern_start,
             text.len(),
             source_backed,
+            features,
+            &mut saw_glob_syntax,
         );
 
         segments
             .iter()
             .any(|segment| matches!(segment, ZshGlobSegment::Pattern(_)))
-            .then_some((segments, qualifiers))
+            .then_some((segments, qualifiers, saw_glob_syntax))
     }
 
     fn push_zsh_pattern_segment(
@@ -1655,6 +1694,8 @@ impl<'a> Parser<'a> {
         start: usize,
         end: usize,
         source_backed: bool,
+        features: ZshGlobParseFeatures,
+        saw_glob_syntax: &mut bool,
     ) {
         if start >= end {
             return;
@@ -1665,9 +1706,10 @@ impl<'a> Parser<'a> {
         let span = Span::from_positions(start_position, end_position);
         let pattern_word =
             self.decode_word_text(&text[start..end], span, span.start, source_backed);
-        segments.push(ZshGlobSegment::Pattern(
-            self.pattern_from_word(&pattern_word),
-        ));
+        let pattern = self.pattern_from_word(&pattern_word);
+        *saw_glob_syntax |=
+            self.pattern_has_glob_syntax_with_features(&pattern, features);
+        segments.push(ZshGlobSegment::Pattern(pattern));
     }
 
     fn parse_zsh_inline_glob_control(
@@ -1887,12 +1929,21 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn pattern_has_glob_syntax(pattern: &Pattern) -> bool {
+    fn pattern_has_glob_syntax_with_features(
+        &self,
+        pattern: &Pattern,
+        features: ZshGlobParseFeatures,
+    ) -> bool {
         pattern.parts.iter().any(|part| match &part.kind {
             PatternPart::AnyString | PatternPart::AnyChar | PatternPart::CharClass(_) => true,
             PatternPart::Group { .. } => true,
             PatternPart::Word(word) => Self::pattern_has_glob_word(word),
-            PatternPart::Literal(_) => false,
+            PatternPart::Literal(text) => {
+                Self::literal_text_has_zsh_glob_syntax(
+                    text.as_str(self.input, part.span),
+                    features,
+                )
+            }
         })
     }
 
@@ -1902,11 +1953,93 @@ impl<'a> Parser<'a> {
             .any(|part| !matches!(part.kind, WordPart::Literal(_)))
     }
 
+    fn literal_text_has_zsh_glob_syntax(text: &str, features: ZshGlobParseFeatures) -> bool {
+        if text.is_empty() {
+            return false;
+        }
+
+        if features.extended_glob && text.contains("(#") {
+            return true;
+        }
+
+        let bytes = text.as_bytes();
+        let mut escaped = false;
+        let mut bracket_depth = 0usize;
+        let mut previous_char = None;
+        let mut index = 0usize;
+
+        while index < bytes.len() {
+            let ch = text[index..].chars().next().unwrap();
+
+            if escaped {
+                escaped = false;
+                previous_char = Some(ch);
+                index += ch.len_utf8();
+                continue;
+            }
+
+            if ch == '\\' {
+                escaped = true;
+                previous_char = Some(ch);
+                index += ch.len_utf8();
+                continue;
+            }
+
+            if bracket_depth == 0 {
+                if features.extended_glob
+                    && (ch == '~'
+                        || ch == '#'
+                        || (ch == '^'
+                            && previous_char.is_none_or(|prev| prev == '(' || prev == '|')))
+                {
+                    return true;
+                }
+
+                if features.bare_groups
+                    && ch == '<'
+                    && Self::literal_text_has_numeric_range_suffix(&text[index..])
+                {
+                    return true;
+                }
+            }
+
+            match ch {
+                '[' => bracket_depth += 1,
+                ']' if bracket_depth > 0 => bracket_depth -= 1,
+                _ => {}
+            }
+
+            previous_char = Some(ch);
+            index += ch.len_utf8();
+        }
+
+        false
+    }
+
+    fn literal_text_has_numeric_range_suffix(text: &str) -> bool {
+        let Some(rest) = text.strip_prefix('<') else {
+            return false;
+        };
+
+        let mut saw_body = false;
+        for ch in rest.chars() {
+            if ch == '>' {
+                return saw_body;
+            }
+            if !matches!(ch, '0'..='9' | '-') {
+                return false;
+            }
+            saw_body = true;
+        }
+
+        false
+    }
+
     fn simple_word_from_token(&mut self, token: &LexedToken<'_>, span: Span) -> Option<Word> {
         let word = token.word()?;
         let source_backed = !token.flags.is_synthetic();
 
-        if self.zsh_glob_qualifiers_enabled_at(span.start.offset)
+        if self.zsh_glob_word_parsing_enabled_at(span.start.offset)
             && let Some(segment) = word.single_segment()
             && segment.kind() == LexedWordSegmentKind::Plain
             && let Some(word) = self.maybe_parse_zsh_qualified_glob_word(
@@ -2344,7 +2477,7 @@ impl<'a> Parser<'a> {
             return None;
         }
         let span = Span::from_positions(start, end);
-        if self.zsh_glob_qualifiers_enabled_at(span.start.offset)
+        if self.zsh_glob_word_parsing_enabled_at(span.start.offset)
             && let Some(word) = self.maybe_parse_zsh_qualified_glob_word(&text, span, true)
         {
             return Some(word);
@@ -5190,6 +5323,11 @@ impl<'a> Parser<'a> {
         }
 
         let span = text.span();
+        let nested_profile = self
+            .zsh_options_at_offset(span.start.offset)
+            .cloned()
+            .map(|options| ShellProfile::with_zsh_options(self.dialect, options))
+            .unwrap_or_else(|| self.shell_profile.clone());
         let remaining_depth = self.max_depth.saturating_sub(self.current_depth);
         if remaining_depth == 0 {
             return self.word_with_single_part(
@@ -5211,7 +5349,7 @@ impl<'a> Parser<'a> {
                     span,
                     reparse_depth,
                     self.fuel,
-                    self.shell_profile.clone(),
+                    nested_profile.clone(),
                 );
             }
         }
@@ -5222,7 +5360,7 @@ impl<'a> Parser<'a> {
             text.span(),
             reparse_depth,
             self.fuel,
-            self.shell_profile.clone(),
+            nested_profile,
         )
     }
 
@@ -5243,7 +5381,7 @@ impl<'a> Parser<'a> {
 
         if Self::word_text_needs_parse(raw)
             || raw.contains(['\'', '"', '\\'])
-            || self.zsh_glob_qualifiers_enabled_at(span.start.offset)
+            || self.zsh_glob_word_parsing_enabled_at(span.start.offset)
         {
             return None;
         }

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -2013,13 +2013,15 @@ impl<'a> Parser<'a> {
         };
 
         let mut saw_body = false;
+        let mut saw_hyphen = false;
         for ch in rest.chars() {
             if ch == '>' {
-                return saw_body;
+                return saw_body && saw_hyphen;
             }
             if !matches!(ch, '0'..='9' | '-') {
                 return false;
             }
+            saw_hyphen |= ch == '-';
             saw_body = true;
         }
 

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -2122,6 +2122,96 @@ fn test_zsh_case_accepts_optional_suffix_group_after_literal_url() {
 }
 
 #[test]
+fn test_zsh_case_bare_group_requires_sh_glob_off() {
+    let input = concat!(
+        "case \"$url\" in\n",
+        "  https://github.com/ohmyzsh/ohmyzsh(|.git)) print ok ;;\n",
+        "esac\n",
+    );
+
+    let default_script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let (default_compound, _) = expect_compound(&default_script.body[0]);
+    let AstCompoundCommand::Case(default_command) = default_compound else {
+        panic!("expected case command");
+    };
+    assert_eq!(default_command.cases[0].patterns.len(), 1);
+
+    let sh_glob_script = parse_zsh_with_options(input, |options| {
+        options.sh_glob = OptionValue::On;
+    })
+    .file;
+    let (sh_glob_compound, _) = expect_compound(&sh_glob_script.body[0]);
+    let AstCompoundCommand::Case(sh_glob_command) = sh_glob_compound else {
+        panic!("expected case command");
+    };
+    assert_eq!(
+        sh_glob_command.cases[0]
+            .patterns
+            .iter()
+            .map(|pattern| pattern.render_syntax(input))
+            .collect::<Vec<_>>(),
+        vec![
+            "https://github.com/ohmyzsh/ohmyzsh(",
+            ".git)",
+        ]
+    );
+}
+
+#[test]
+fn test_zsh_case_ksh_glob_requires_option() {
+    let input = concat!(
+        "case $mode in\n",
+        "  @(disable|enable)) print ok ;;\n",
+        "esac\n",
+    );
+
+    let default_script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let (default_compound, _) = expect_compound(&default_script.body[0]);
+    let AstCompoundCommand::Case(default_command) = default_compound else {
+        panic!("expected case command");
+    };
+    assert_eq!(
+        default_command.cases[0]
+            .patterns
+            .iter()
+            .map(|pattern| pattern.render_syntax(input))
+            .collect::<Vec<_>>(),
+        vec!["@(disable", "enable)"]
+    );
+
+    let script = parse_zsh_with_options(input, |options| {
+        options.ksh_glob = OptionValue::On;
+    })
+    .file;
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Case(command) = compound else {
+        panic!("expected case command");
+    };
+    assert_eq!(command.cases[0].patterns.len(), 1);
+    let pattern = &command.cases[0].patterns[0];
+    let [part] = pattern.parts.as_slice() else {
+        panic!("expected a single group part");
+    };
+    let PatternPart::Group { kind, patterns } = &part.kind else {
+        panic!("expected ksh glob group");
+    };
+    assert_eq!(*kind, PatternGroupKind::ExactlyOne);
+    assert_eq!(
+        patterns
+            .iter()
+            .map(|pattern| pattern.render_syntax(input))
+            .collect::<Vec<_>>(),
+        vec!["disable", "enable"]
+    );
+}
+
+#[test]
 fn test_zsh_case_accepts_wrapper_alternatives_with_empty_first_pattern() {
     let input = concat!(
         "case ${ICE[proto]} in\n",
@@ -2533,10 +2623,10 @@ fn test_parse_zsh_conditional_arithmetic_comparison_operand_with_subscripted_wor
 #[test]
 fn test_parse_zsh_conditional_pattern_rhs_with_backrefs_and_parameter_expansion() {
     let input = "[[ \"$buf\" == (#b)(*)(${~pat})* ]]\n";
-    let script = Parser::with_dialect(input, ShellDialect::Zsh)
-        .parse()
-        .unwrap()
-        .file;
+    let script = parse_zsh_with_options(input, |options| {
+        options.extended_glob = OptionValue::On;
+    })
+    .file;
 
     let (compound, _) = expect_compound(&script.body[0]);
     let AstCompoundCommand::Conditional(command) = compound else {
@@ -2557,10 +2647,10 @@ fn test_parse_zsh_conditional_pattern_rhs_with_backrefs_and_parameter_expansion(
 #[test]
 fn test_parse_zsh_conditional_pattern_rhs_with_inline_anchors() {
     let input = "[[ $buffer != (#s)[$'\\t -~']#(#e) ]]\n";
-    let script = Parser::with_dialect(input, ShellDialect::Zsh)
-        .parse()
-        .unwrap()
-        .file;
+    let script = parse_zsh_with_options(input, |options| {
+        options.extended_glob = OptionValue::On;
+    })
+    .file;
 
     let (compound, _) = expect_compound(&script.body[0]);
     let AstCompoundCommand::Conditional(command) = compound else {
@@ -2604,28 +2694,209 @@ fn test_parse_zsh_conditional_pattern_rhs_accepts_bare_alternation_groups() {
 }
 
 #[test]
+fn test_zsh_conditional_ksh_glob_requires_option() {
+    let input = "[[ $mode == @(disable|enable) ]]\n";
+
+    let default_script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let (default_compound, _) = expect_compound(&default_script.body[0]);
+    let AstCompoundCommand::Conditional(default_command) = default_compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(default_binary) = &default_command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(default_pattern) = default_binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert_eq!(default_pattern.render(input), "@(disable|enable)");
+    assert!(!matches!(
+        default_pattern.parts.as_slice(),
+        [PatternPartNode {
+            kind: PatternPart::Word(word),
+            ..
+        }] if matches!(
+            word.parts.as_slice(),
+            [WordPartNode {
+                kind: WordPart::ZshQualifiedGlob(_),
+                ..
+            }]
+        )
+    ));
+
+    let script = parse_zsh_with_options(input, |options| {
+        options.ksh_glob = OptionValue::On;
+    })
+    .file;
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(pattern) = binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    let [part] = pattern.parts.as_slice() else {
+        panic!("expected a single glob-aware word part");
+    };
+    let PatternPart::Word(word) = &part.kind else {
+        panic!("expected glob-aware word pattern part");
+    };
+    let glob = expect_zsh_qualified_glob(word);
+    let [segment] = glob.segments.as_slice() else {
+        panic!("expected a single pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(segment).render_syntax(input),
+        "@(disable|enable)"
+    );
+}
+
+#[test]
+fn test_zsh_conditional_extended_glob_backreference_requires_option() {
+    let input = "[[ $buf == (#b)(*) ]]\n";
+
+    let default_script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let (default_compound, _) = expect_compound(&default_script.body[0]);
+    let AstCompoundCommand::Conditional(default_command) = default_compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(default_binary) = &default_command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(default_pattern) = default_binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    let default_glob = expect_pattern_zsh_qualified_glob(default_pattern);
+    let [default_segment] = default_glob.segments.as_slice() else {
+        panic!("expected a single source-preserved pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(default_segment).render_syntax(input),
+        "(#b)(*)"
+    );
+
+    let script = parse_zsh_with_options(input, |options| {
+        options.extended_glob = OptionValue::On;
+    })
+    .file;
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(pattern) = binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    let glob = expect_pattern_zsh_qualified_glob(pattern);
+    let [control, segment] = glob.segments.as_slice() else {
+        panic!("expected inline control followed by pattern segment");
+    };
+    assert!(matches!(
+        control,
+        ZshGlobSegment::InlineControl(ZshInlineGlobControl::Backreferences { span })
+            if span.slice(input) == "(#b)"
+    ));
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(segment).render_syntax(input),
+        "(*)"
+    );
+}
+
+#[test]
+fn test_zsh_conditional_bare_group_requires_sh_glob_off() {
+    let input = "[[ $mode == (foo|bar) ]]\n";
+
+    let default_script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let (default_compound, _) = expect_compound(&default_script.body[0]);
+    let AstCompoundCommand::Conditional(default_command) = default_compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(default_binary) = &default_command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(default_pattern) = default_binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert!(matches!(
+        default_pattern.parts.as_slice(),
+        [PatternPartNode {
+            kind: PatternPart::Word(word),
+            ..
+        }] if matches!(
+            word.parts.as_slice(),
+            [WordPartNode {
+                kind: WordPart::ZshQualifiedGlob(_),
+                ..
+            }]
+        )
+    ));
+
+    let sh_glob_script = parse_zsh_with_options(input, |options| {
+        options.sh_glob = OptionValue::On;
+    })
+    .file;
+    let (sh_glob_compound, _) = expect_compound(&sh_glob_script.body[0]);
+    let AstCompoundCommand::Conditional(sh_glob_command) = sh_glob_compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(sh_glob_binary) = &sh_glob_command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(sh_glob_pattern) = sh_glob_binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert_eq!(sh_glob_pattern.render(input), "(foo|bar)");
+    assert!(!matches!(
+        sh_glob_pattern.parts.as_slice(),
+        [PatternPartNode {
+            kind: PatternPart::Word(word),
+            ..
+        }] if matches!(
+            word.parts.as_slice(),
+            [WordPartNode {
+                kind: WordPart::ZshQualifiedGlob(_),
+                ..
+            }]
+        )
+    ));
+}
+
+#[test]
 fn test_parse_zsh_if_with_pattern_capture_rhs() {
     let input = "if [[ \"$buf\" == (#b)(*)(${~pat})* ]]; then\n  print ok\nfi\n";
-    Parser::with_dialect(input, ShellDialect::Zsh)
-        .parse()
-        .unwrap();
+    parse_zsh_with_options(input, |options| {
+        options.extended_glob = OptionValue::On;
+    });
 }
 
 #[test]
 fn test_parse_zsh_if_else_with_inline_anchor_pattern_rhs() {
     let input =
         "if [[ $buffer != (#s)[$'\\t -~']#(#e) ]]; then\n  print ok\nelse\n  print alt\nfi\n";
-    Parser::with_dialect(input, ShellDialect::Zsh)
-        .parse()
-        .unwrap();
+    parse_zsh_with_options(input, |options| {
+        options.extended_glob = OptionValue::On;
+    });
 }
 
 #[test]
 fn test_parse_zsh_conditional_pattern_with_hash_repetition_after_char_class() {
     let input = "[[ $_p9k__ret == (#b)Python\\ ([[:digit:].]##)* ]]\n";
-    Parser::with_dialect(input, ShellDialect::Zsh)
-        .parse()
-        .unwrap();
+    parse_zsh_with_options(input, |options| {
+        options.extended_glob = OptionValue::On;
+    });
 }
 
 #[test]
@@ -2634,6 +2905,43 @@ fn test_parse_zsh_conditional_pattern_with_numeric_range_prefix_and_and_rhs() {
     Parser::with_dialect(input, ShellDialect::Zsh)
         .parse()
         .unwrap();
+}
+
+#[test]
+fn test_zsh_setopt_ksh_glob_changes_following_conditional_pattern_parse() {
+    let input = concat!(
+        "[[ $mode == @(disable|enable) ]]\n",
+        "setopt ksh_glob\n",
+        "[[ $mode == @(disable|enable) ]]\n",
+    );
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (first_compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(first_command) = first_compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(first_binary) = &first_command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(first_pattern) = first_binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert!(!pattern_has_zsh_qualified_glob(first_pattern));
+
+    let (second_compound, _) = expect_compound(&script.body[2]);
+    let AstCompoundCommand::Conditional(second_command) = second_compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(second_binary) = &second_command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(second_pattern) = second_binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert!(pattern_has_zsh_qualified_glob(second_pattern));
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -2905,6 +2905,51 @@ fn test_parse_zsh_conditional_pattern_with_numeric_range_prefix_and_and_rhs() {
 }
 
 #[test]
+fn test_zsh_conditional_numeric_range_requires_hyphen() {
+    let literal_input = "[[ $jobspec == jobspec:<123> ]]\n";
+    let literal_script = Parser::with_dialect(literal_input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let (literal_compound, _) = expect_compound(&literal_script.body[0]);
+    let AstCompoundCommand::Conditional(literal_command) = literal_compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(literal_binary) = &literal_command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(literal_pattern) = literal_binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert_eq!(literal_pattern.render(literal_input), "jobspec:<123>");
+    assert!(!pattern_has_zsh_qualified_glob(literal_pattern));
+
+    let range_input = "[[ $jobspec == jobspec:<1-9> ]]\n";
+    let range_script = Parser::with_dialect(range_input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let (range_compound, _) = expect_compound(&range_script.body[0]);
+    let AstCompoundCommand::Conditional(range_command) = range_compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(range_binary) = &range_command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(range_pattern) = range_binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    let glob = expect_pattern_zsh_qualified_glob(range_pattern);
+    let [segment] = glob.segments.as_slice() else {
+        panic!("expected a single pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(segment).render_syntax(range_input),
+        "jobspec:<1-9>"
+    );
+}
+
+#[test]
 fn test_zsh_setopt_ksh_glob_changes_following_conditional_pattern_parse() {
     let input = concat!(
         "[[ $mode == @(disable|enable) ]]\n",

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -2173,13 +2173,23 @@ fn test_zsh_case_ksh_glob_requires_option() {
     let AstCompoundCommand::Case(default_command) = default_compound else {
         panic!("expected case command");
     };
+    assert_eq!(default_command.cases[0].patterns.len(), 1);
+    let default_pattern = &default_command.cases[0].patterns[0];
+    assert_eq!(default_pattern.render_syntax(input), "@(disable|enable)");
+    assert!(matches!(
+        &default_pattern.parts[0].kind,
+        PatternPart::Literal(_)
+    ));
+    let PatternPart::Group { kind, patterns } = &default_pattern.parts[1].kind else {
+        panic!("expected bare zsh group after literal prefix");
+    };
+    assert_eq!(*kind, PatternGroupKind::ExactlyOne);
     assert_eq!(
-        default_command.cases[0]
-            .patterns
+        patterns
             .iter()
             .map(|pattern| pattern.render_syntax(input))
             .collect::<Vec<_>>(),
-        vec!["@(disable", "enable)"]
+        vec!["disable", "enable"]
     );
 
     let script = parse_zsh_with_options(input, |options| {
@@ -2708,20 +2718,22 @@ fn test_zsh_conditional_ksh_glob_requires_option() {
     let ConditionalExpr::Pattern(default_pattern) = default_binary.right.as_ref() else {
         panic!("expected pattern rhs");
     };
-    assert_eq!(default_pattern.render(input), "@(disable|enable)");
-    assert!(!matches!(
-        default_pattern.parts.as_slice(),
-        [PatternPartNode {
-            kind: PatternPart::Word(word),
-            ..
-        }] if matches!(
-            word.parts.as_slice(),
-            [WordPartNode {
-                kind: WordPart::ZshQualifiedGlob(_),
-                ..
-            }]
-        )
-    ));
+    assert_eq!(default_pattern.render_syntax(input), "@(disable|enable)");
+    let [prefix, group] = default_pattern.parts.as_slice() else {
+        panic!("expected literal prefix followed by bare zsh group");
+    };
+    assert!(matches!(&prefix.kind, PatternPart::Literal(_)));
+    let PatternPart::Group { kind, patterns } = &group.kind else {
+        panic!("expected bare zsh group after literal prefix");
+    };
+    assert_eq!(*kind, PatternGroupKind::ExactlyOne);
+    assert_eq!(
+        patterns
+            .iter()
+            .map(|pattern| pattern.render_syntax(input))
+            .collect::<Vec<_>>(),
+        vec!["disable", "enable"]
+    );
 
     let script = parse_zsh_with_options(input, |options| {
         options.ksh_glob = OptionValue::On;
@@ -2737,19 +2749,24 @@ fn test_zsh_conditional_ksh_glob_requires_option() {
     let ConditionalExpr::Pattern(pattern) = binary.right.as_ref() else {
         panic!("expected pattern rhs");
     };
-    let [part] = pattern.parts.as_slice() else {
-        panic!("expected a single glob-aware word part");
-    };
-    let PatternPart::Word(word) = &part.kind else {
-        panic!("expected glob-aware word pattern part");
-    };
-    let glob = expect_zsh_qualified_glob(word);
+    assert_eq!(pattern.render_syntax(input), "@(disable|enable)");
+    let glob = expect_pattern_zsh_qualified_glob(pattern);
     let [segment] = glob.segments.as_slice() else {
         panic!("expected a single pattern segment");
     };
+    let [part] = expect_zsh_glob_pattern_segment(segment).parts.as_slice() else {
+        panic!("expected a single group part");
+    };
+    let PatternPart::Group { kind, patterns } = &part.kind else {
+        panic!("expected ksh glob group");
+    };
+    assert_eq!(*kind, PatternGroupKind::ExactlyOne);
     assert_eq!(
-        expect_zsh_glob_pattern_segment(segment).render_syntax(input),
-        "@(disable|enable)"
+        patterns
+            .iter()
+            .map(|pattern| pattern.render_syntax(input))
+            .collect::<Vec<_>>(),
+        vec!["disable", "enable"]
     );
 }
 
@@ -2971,7 +2988,17 @@ fn test_zsh_setopt_ksh_glob_changes_following_conditional_pattern_parse() {
     let ConditionalExpr::Pattern(first_pattern) = first_binary.right.as_ref() else {
         panic!("expected pattern rhs");
     };
-    assert!(!pattern_has_zsh_qualified_glob(first_pattern));
+    let [first_prefix, first_group] = first_pattern.parts.as_slice() else {
+        panic!("expected literal prefix followed by bare zsh group");
+    };
+    assert!(matches!(&first_prefix.kind, PatternPart::Literal(_)));
+    assert!(matches!(
+        &first_group.kind,
+        PatternPart::Group {
+            kind: PatternGroupKind::ExactlyOne,
+            ..
+        }
+    ));
 
     let (second_compound, _) = expect_compound(&script.body[2]);
     let AstCompoundCommand::Conditional(second_command) = second_compound else {
@@ -2983,7 +3010,22 @@ fn test_zsh_setopt_ksh_glob_changes_following_conditional_pattern_parse() {
     let ConditionalExpr::Pattern(second_pattern) = second_binary.right.as_ref() else {
         panic!("expected pattern rhs");
     };
-    assert!(pattern_has_zsh_qualified_glob(second_pattern));
+    let second_glob = expect_pattern_zsh_qualified_glob(second_pattern);
+    let [second_segment] = second_glob.segments.as_slice() else {
+        panic!("expected a single pattern segment");
+    };
+    assert!(matches!(
+        expect_zsh_glob_pattern_segment(second_segment)
+            .parts
+            .as_slice(),
+        [PatternPartNode {
+            kind: PatternPart::Group {
+                kind: PatternGroupKind::ExactlyOne,
+                ..
+            },
+            ..
+        }]
+    ));
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -2153,10 +2153,7 @@ fn test_zsh_case_bare_group_requires_sh_glob_off() {
             .iter()
             .map(|pattern| pattern.render_syntax(input))
             .collect::<Vec<_>>(),
-        vec![
-            "https://github.com/ohmyzsh/ohmyzsh(",
-            ".git)",
-        ]
+        vec!["https://github.com/ohmyzsh/ohmyzsh(", ".git)",]
     );
 }
 

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -2771,6 +2771,79 @@ fn test_zsh_conditional_ksh_glob_requires_option() {
 }
 
 #[test]
+fn test_zsh_conditional_prefixed_bare_group_reparse_handles_single_glob_word() {
+    let input = "[[ $mode == *@(disable|enable) ]]\n";
+
+    let default_script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let (default_compound, _) = expect_compound(&default_script.body[0]);
+    let AstCompoundCommand::Conditional(default_command) = default_compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(default_binary) = &default_command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(default_pattern) = default_binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert_eq!(default_pattern.render_syntax(input), "*@(disable|enable)");
+    let [wildcard, prefix, group] = default_pattern.parts.as_slice() else {
+        panic!("expected wildcard, literal prefix, and bare zsh group");
+    };
+    assert!(matches!(&wildcard.kind, PatternPart::AnyString));
+    assert!(matches!(&prefix.kind, PatternPart::Literal(_)));
+    let PatternPart::Group { kind, patterns } = &group.kind else {
+        panic!("expected bare zsh group after literal prefix");
+    };
+    assert_eq!(*kind, PatternGroupKind::ExactlyOne);
+    assert_eq!(
+        patterns
+            .iter()
+            .map(|pattern| pattern.render_syntax(input))
+            .collect::<Vec<_>>(),
+        vec!["disable", "enable"]
+    );
+
+    let script = parse_zsh_with_options(input, |options| {
+        options.ksh_glob = OptionValue::On;
+    })
+    .file;
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    let ConditionalExpr::Pattern(pattern) = binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert_eq!(pattern.render_syntax(input), "*@(disable|enable)");
+    let glob = expect_pattern_zsh_qualified_glob(pattern);
+    let [segment] = glob.segments.as_slice() else {
+        panic!("expected a single pattern segment");
+    };
+    assert!(matches!(
+        expect_zsh_glob_pattern_segment(segment).parts.as_slice(),
+        [
+            PatternPartNode {
+                kind: PatternPart::AnyString,
+                ..
+            },
+            PatternPartNode {
+                kind: PatternPart::Group {
+                    kind: PatternGroupKind::ExactlyOne,
+                    ..
+                },
+                ..
+            }
+        ]
+    ));
+}
+
+#[test]
 fn test_zsh_conditional_extended_glob_backreference_requires_option() {
     let input = "[[ $buf == (#b)(*) ]]\n";
 

--- a/crates/shuck-parser/src/parser/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/tests/mod.rs
@@ -14,6 +14,18 @@ fn is_fully_quoted(word: &Word) -> bool {
     word.is_fully_quoted()
 }
 
+fn zsh_profile_with_options(update: impl FnOnce(&mut ZshOptionState)) -> ShellProfile {
+    let mut options = ZshOptionState::zsh_default();
+    update(&mut options);
+    ShellProfile::with_zsh_options(ShellDialect::Zsh, options)
+}
+
+fn parse_zsh_with_options(input: &str, update: impl FnOnce(&mut ZshOptionState)) -> ParseResult {
+    Parser::with_profile(input, zsh_profile_with_options(update))
+        .parse()
+        .unwrap()
+}
+
 fn heredoc_body_is_literal(body: &HeredocBody) -> bool {
     body.mode == HeredocBodyMode::Literal
 }
@@ -292,6 +304,32 @@ fn expect_zsh_glob_pattern_segment(segment: &ZshGlobSegment) -> &Pattern {
         panic!("expected pattern segment");
     };
     pattern
+}
+
+fn pattern_has_zsh_qualified_glob(pattern: &Pattern) -> bool {
+    pattern.parts.iter().any(|part| {
+        matches!(
+            &part.kind,
+            PatternPart::Word(word)
+                if matches!(
+                    word.parts.as_slice(),
+                    [WordPartNode {
+                        kind: WordPart::ZshQualifiedGlob(_),
+                        ..
+                    }]
+                )
+        )
+    })
+}
+
+fn expect_pattern_zsh_qualified_glob(pattern: &Pattern) -> &ZshQualifiedGlob {
+    let [part] = pattern.parts.as_slice() else {
+        panic!("expected single pattern word part");
+    };
+    let PatternPart::Word(word) = &part.kind else {
+        panic!("expected pattern word part, got {:?}", part.kind);
+    };
+    expect_zsh_qualified_glob(word)
 }
 
 fn expect_array_length_part(part: &WordPart) -> &VarRef {

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -6132,9 +6132,9 @@ fn test_zsh_trailing_glob_qualifier_parses_prefixed_glob_with_negation() {
 #[test]
 fn test_zsh_inline_glob_case_insensitive_control_preserves_segments() {
     let source = "print (#i)*.jpg\n";
-    let output = Parser::with_dialect(source, ShellDialect::Zsh)
-        .parse()
-        .unwrap();
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
     let AstCommand::Simple(command) = &output.file.body[0].command else {
         panic!("expected simple command");
     };
@@ -6160,9 +6160,9 @@ fn test_zsh_inline_glob_case_insensitive_control_preserves_segments() {
 #[test]
 fn test_zsh_inline_glob_backreference_control_preserves_segments() {
     let source = "print (#b)(*)\n";
-    let output = Parser::with_dialect(source, ShellDialect::Zsh)
-        .parse()
-        .unwrap();
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
     let AstCommand::Simple(command) = &output.file.body[0].command else {
         panic!("expected simple command");
     };
@@ -6183,6 +6183,43 @@ fn test_zsh_inline_glob_backreference_control_preserves_segments() {
         "(*)"
     );
     assert!(glob.qualifiers.is_none());
+}
+
+#[test]
+fn test_zsh_extended_glob_inline_backreference_word_requires_option() {
+    let source = "print (#b)(*)\n";
+
+    let default_output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let default_command = expect_simple(&default_output.file.body[0]);
+    let default_glob = expect_zsh_qualified_glob(&default_command.args[0]);
+    let [default_segment] = default_glob.segments.as_slice() else {
+        panic!("expected a single source-preserved pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(default_segment).render_syntax(source),
+        "(#b)(*)"
+    );
+    assert!(default_glob.qualifiers.is_none());
+
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
+    let command = expect_simple(&output.file.body[0]);
+    let glob = expect_zsh_qualified_glob(&command.args[0]);
+    let [control, segment] = glob.segments.as_slice() else {
+        panic!("expected inline control followed by pattern segment");
+    };
+    assert!(matches!(
+        control,
+        ZshGlobSegment::InlineControl(ZshInlineGlobControl::Backreferences { span })
+            if span.slice(source) == "(#b)"
+    ));
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(segment).render_syntax(source),
+        "(*)"
+    );
 }
 
 #[test]
@@ -6211,9 +6248,9 @@ fn test_zsh_inline_glob_anchor_controls_preserve_segments() {
 #[test]
 fn test_zsh_hash_q_glob_qualifier_parses_terminal_flag_group() {
     let source = "print *.log(#qN)\n";
-    let output = Parser::with_dialect(source, ShellDialect::Zsh)
-        .parse()
-        .unwrap();
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
     let AstCommand::Simple(command) = &output.file.body[0].command else {
         panic!("expected simple command");
     };
@@ -6237,11 +6274,39 @@ fn test_zsh_hash_q_glob_qualifier_parses_terminal_flag_group() {
 }
 
 #[test]
-fn test_zsh_hash_q_glob_qualifier_parses_recursive_pattern_with_letter_sequence_and_range() {
-    let source = "print **/*(#q.om[1,3])\n";
-    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+fn test_zsh_extended_glob_hash_q_qualifier_requires_option() {
+    let source = "print *.log(#qN)\n";
+
+    let default_output = Parser::with_dialect(source, ShellDialect::Zsh)
         .parse()
         .unwrap();
+    let default_command = expect_simple(&default_output.file.body[0]);
+    let default_glob = expect_zsh_qualified_glob(&default_command.args[0]);
+    let [default_segment] = default_glob.segments.as_slice() else {
+        panic!("expected a single source-preserved pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(default_segment).render_syntax(source),
+        "*.log(#qN)"
+    );
+    assert!(default_glob.qualifiers.is_none());
+
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
+    let command = expect_simple(&output.file.body[0]);
+    let glob = expect_zsh_qualified_glob(&command.args[0]);
+    let qualifiers = expect_zsh_glob_qualifiers(glob);
+    assert_eq!(qualifiers.kind, ZshGlobQualifierKind::HashQ);
+    assert_eq!(qualifiers.span.slice(source), "(#qN)");
+}
+
+#[test]
+fn test_zsh_hash_q_glob_qualifier_parses_recursive_pattern_with_letter_sequence_and_range() {
+    let source = "print **/*(#q.om[1,3])\n";
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
     let AstCommand::Simple(command) = &output.file.body[0].command else {
         panic!("expected simple command");
     };
@@ -6287,23 +6352,261 @@ fn test_zsh_hash_q_glob_qualifier_parses_recursive_pattern_with_letter_sequence_
 }
 
 #[test]
-fn test_zsh_glob_falls_back_for_unsupported_hash_control_group() {
+fn test_zsh_glob_preserves_unsupported_hash_control_group_as_source_backed_glob() {
     let source = "print *(#a)\n";
-    let output = Parser::with_dialect(source, ShellDialect::Zsh)
-        .parse()
-        .unwrap();
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
     let AstCommand::Simple(command) = &output.file.body[0].command else {
         panic!("expected simple command");
     };
 
-    assert_eq!(command.args[0].span.slice(source), "*(#a)");
+    let glob = expect_zsh_qualified_glob(&command.args[0]);
+    let [segment] = glob.segments.as_slice() else {
+        panic!("expected a single source-preserved pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(segment).render_syntax(source),
+        "*(#a)"
+    );
+}
+
+#[test]
+fn test_zsh_ksh_glob_word_requires_option() {
+    let source = "print @(foo|bar)\n";
+
+    let default_output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let default_command = expect_simple(&default_output.file.body[0]);
+    assert_eq!(default_command.args[0].span.slice(source), "@(foo|bar)");
     assert!(!matches!(
-        command.args[0].parts.as_slice(),
+        default_command.args[0].parts.as_slice(),
         [WordPartNode {
             kind: WordPart::ZshQualifiedGlob(_),
             ..
         }]
     ));
+
+    let output = parse_zsh_with_options(source, |options| {
+        options.ksh_glob = OptionValue::On;
+    });
+    let command = expect_simple(&output.file.body[0]);
+    let glob = expect_zsh_qualified_glob(&command.args[0]);
+    let [segment] = glob.segments.as_slice() else {
+        panic!("expected a single pattern segment");
+    };
+    let [part] = expect_zsh_glob_pattern_segment(segment).parts.as_slice() else {
+        panic!("expected a single group part");
+    };
+    let PatternPart::Group { kind, patterns } = &part.kind else {
+        panic!("expected ksh glob group");
+    };
+    assert_eq!(*kind, PatternGroupKind::ExactlyOne);
+    assert_eq!(
+        patterns
+            .iter()
+            .map(|pattern| pattern.render_syntax(source))
+            .collect::<Vec<_>>(),
+        vec!["foo", "bar"]
+    );
+}
+
+#[test]
+fn test_zsh_extended_glob_tilde_word_requires_option() {
+    let source = "print foo~bar\n";
+
+    let default_output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let default_command = expect_simple(&default_output.file.body[0]);
+    assert_eq!(default_command.args[0].span.slice(source), "foo~bar");
+    assert!(!matches!(
+        default_command.args[0].parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
+    let command = expect_simple(&output.file.body[0]);
+    let glob = expect_zsh_qualified_glob(&command.args[0]);
+    let [segment] = glob.segments.as_slice() else {
+        panic!("expected a single pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(segment).render_syntax(source),
+        "foo~bar"
+    );
+}
+
+#[test]
+fn test_zsh_extended_glob_hash_repetition_word_requires_option() {
+    let source = "print foo##\n";
+
+    let default_output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let default_command = expect_simple(&default_output.file.body[0]);
+    assert_eq!(default_command.args[0].span.slice(source), "foo##");
+    assert!(!matches!(
+        default_command.args[0].parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
+    let command = expect_simple(&output.file.body[0]);
+    let glob = expect_zsh_qualified_glob(&command.args[0]);
+    let [segment] = glob.segments.as_slice() else {
+        panic!("expected a single pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(segment).render_syntax(source),
+        "foo##"
+    );
+}
+
+#[test]
+fn test_zsh_sh_glob_disables_bare_optional_suffix_replacement_pattern_word() {
+    let source = "print ${(S)value//ohmyzsh(|.git)/X}\n";
+
+    let default_output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let default_command = expect_simple(&default_output.file.body[0]);
+    let default_parameter = expect_parameter(&default_command.args[0]);
+    let default_operation = match &default_parameter.syntax {
+        ParameterExpansionSyntax::Zsh(parameter) => parameter
+            .operation
+            .as_ref()
+            .expect("expected replacement operation"),
+        _ => panic!("expected zsh parameter syntax"),
+    };
+    let default_pattern = default_operation
+        .pattern_word_ast()
+        .expect("expected replacement pattern word");
+    let default_glob = expect_zsh_qualified_glob(default_pattern);
+    let [segment] = default_glob.segments.as_slice() else {
+        panic!("expected a single pattern segment");
+    };
+    let pattern = expect_zsh_glob_pattern_segment(segment);
+    assert_eq!(
+        pattern_part_slices(pattern, source),
+        vec!["ohmyzsh", "(|.git)"]
+    );
+    let part = &pattern.parts[1];
+    let PatternPart::Group { patterns, .. } = &part.kind else {
+        panic!("expected bare zsh group");
+    };
+    assert_eq!(
+        patterns
+            .iter()
+            .map(|pattern| pattern.render_syntax(source))
+            .collect::<Vec<_>>(),
+        vec!["", ".git"]
+    );
+
+    let sh_glob_output = parse_zsh_with_options(source, |options| {
+        options.sh_glob = OptionValue::On;
+    });
+    let sh_glob_command = expect_simple(&sh_glob_output.file.body[0]);
+    let sh_glob_parameter = expect_parameter(&sh_glob_command.args[0]);
+    let sh_glob_operation = match &sh_glob_parameter.syntax {
+        ParameterExpansionSyntax::Zsh(parameter) => parameter
+            .operation
+            .as_ref()
+            .expect("expected replacement operation"),
+        _ => panic!("expected zsh parameter syntax"),
+    };
+    let sh_glob_pattern = sh_glob_operation
+        .pattern_word_ast()
+        .expect("expected replacement pattern word");
+    assert_eq!(sh_glob_pattern.span.slice(source), "ohmyzsh(|.git)");
+    assert!(!matches!(
+        sh_glob_pattern.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+}
+
+#[test]
+fn test_zsh_sh_glob_disables_numeric_range_replacement_pattern_word() {
+    let source = "print ${(S)value//jobspec:<->/X}\n";
+
+    let default_output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let default_command = expect_simple(&default_output.file.body[0]);
+    let default_parameter = expect_parameter(&default_command.args[0]);
+    let default_operation = match &default_parameter.syntax {
+        ParameterExpansionSyntax::Zsh(parameter) => parameter
+            .operation
+            .as_ref()
+            .expect("expected replacement operation"),
+        _ => panic!("expected zsh parameter syntax"),
+    };
+    let default_word = default_operation
+        .pattern_word_ast()
+        .expect("expected replacement pattern word");
+    assert!(matches!(
+        default_word.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let sh_glob_output = parse_zsh_with_options(source, |options| {
+        options.sh_glob = OptionValue::On;
+    });
+    let sh_glob_command = expect_simple(&sh_glob_output.file.body[0]);
+    let sh_glob_parameter = expect_parameter(&sh_glob_command.args[0]);
+    let sh_glob_operation = match &sh_glob_parameter.syntax {
+        ParameterExpansionSyntax::Zsh(parameter) => parameter
+            .operation
+            .as_ref()
+            .expect("expected replacement operation"),
+        _ => panic!("expected zsh parameter syntax"),
+    };
+    let sh_glob_word = sh_glob_operation
+        .pattern_word_ast()
+        .expect("expected replacement pattern word");
+    assert_eq!(sh_glob_word.span.slice(source), "jobspec:<->");
+    assert!(!matches!(
+        sh_glob_word.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+}
+
+#[test]
+fn test_zsh_sh_glob_still_allows_ksh_groups_when_enabled() {
+    let source = "print @(foo|bar)\n";
+    let output = parse_zsh_with_options(source, |options| {
+        options.sh_glob = OptionValue::On;
+        options.ksh_glob = OptionValue::On;
+    });
+    let command = expect_simple(&output.file.body[0]);
+    let glob = expect_zsh_qualified_glob(&command.args[0]);
+    let [segment] = glob.segments.as_slice() else {
+        panic!("expected a single pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(segment).render_syntax(source),
+        "@(foo|bar)"
+    );
 }
 
 #[test]
@@ -7084,6 +7387,230 @@ fn test_parse_zsh_nested_join_modifier_inside_replacement_word() {
         array.span.slice(source),
         "(${(@)${:-{$#parts..1}}/(#m)*/$parent${(pj./.)parts[1,MATCH]}})"
     );
+}
+
+#[test]
+fn test_zsh_replacement_pattern_word_requires_extended_glob() {
+    let source = "print ${(S)value//(#m)o/X}\n";
+
+    let default_output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let default_command = expect_simple(&default_output.file.body[0]);
+    let default_parameter = expect_parameter(&default_command.args[0]);
+    let default_operation = match &default_parameter.syntax {
+        ParameterExpansionSyntax::Zsh(parameter) => parameter
+            .operation
+            .as_ref()
+            .expect("expected replacement operation"),
+        _ => panic!("expected zsh parameter syntax"),
+    };
+    let default_pattern = default_operation
+        .pattern_word_ast()
+        .expect("expected replacement pattern word");
+    assert!(!matches!(
+        default_pattern.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let output = parse_zsh_with_options(source, |options| {
+        options.extended_glob = OptionValue::On;
+    });
+    let command = expect_simple(&output.file.body[0]);
+    let parameter = expect_parameter(&command.args[0]);
+    let operation = match &parameter.syntax {
+        ParameterExpansionSyntax::Zsh(parameter) => parameter
+            .operation
+            .as_ref()
+            .expect("expected replacement operation"),
+        _ => panic!("expected zsh parameter syntax"),
+    };
+    let pattern = operation
+        .pattern_word_ast()
+        .expect("expected replacement pattern word");
+    let glob = expect_zsh_qualified_glob(pattern);
+    let [segment] = glob.segments.as_slice() else {
+        panic!("expected a single source-preserved pattern segment");
+    };
+    assert_eq!(
+        expect_zsh_glob_pattern_segment(segment).render_syntax(source),
+        "(#m)o"
+    );
+}
+
+#[test]
+fn test_zsh_setopt_and_unsetopt_change_following_word_parse() {
+    let source = concat!(
+        "print foo~bar\n",
+        "setopt extended_glob\n",
+        "print foo~bar\n",
+        "unsetopt extended_glob\n",
+        "print foo~bar\n",
+    );
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let first = expect_simple(&output.file.body[0]);
+    assert!(!matches!(
+        first.args[0].parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let second = expect_simple(&output.file.body[2]);
+    assert!(matches!(
+        second.args[0].parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let third = expect_simple(&output.file.body[4]);
+    assert!(!matches!(
+        third.args[0].parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+}
+
+#[test]
+fn test_zsh_setopt_and_unsetopt_sh_glob_change_following_replacement_pattern_parse() {
+    let source = concat!(
+        "print ${(S)value//jobspec:<->/X}\n",
+        "setopt sh_glob\n",
+        "print ${(S)value//jobspec:<->/X}\n",
+        "unsetopt sh_glob\n",
+        "print ${(S)value//jobspec:<->/X}\n",
+    );
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let first = expect_simple(&output.file.body[0]);
+    let first_parameter = expect_parameter(&first.args[0]);
+    let first_pattern = match &first_parameter.syntax {
+        ParameterExpansionSyntax::Zsh(parameter) => parameter
+            .operation
+            .as_ref()
+            .expect("expected replacement operation")
+            .pattern_word_ast()
+            .expect("expected replacement pattern word"),
+        _ => panic!("expected zsh parameter syntax"),
+    };
+    assert!(matches!(
+        first_pattern.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let second = expect_simple(&output.file.body[2]);
+    let second_parameter = expect_parameter(&second.args[0]);
+    let second_pattern = match &second_parameter.syntax {
+        ParameterExpansionSyntax::Zsh(parameter) => parameter
+            .operation
+            .as_ref()
+            .expect("expected replacement operation")
+            .pattern_word_ast()
+            .expect("expected replacement pattern word"),
+        _ => panic!("expected zsh parameter syntax"),
+    };
+    assert!(!matches!(
+        second_pattern.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let third = expect_simple(&output.file.body[4]);
+    let third_parameter = expect_parameter(&third.args[0]);
+    let third_pattern = match &third_parameter.syntax {
+        ParameterExpansionSyntax::Zsh(parameter) => parameter
+            .operation
+            .as_ref()
+            .expect("expected replacement operation")
+            .pattern_word_ast()
+            .expect("expected replacement pattern word"),
+        _ => panic!("expected zsh parameter syntax"),
+    };
+    assert!(matches!(
+        third_pattern.parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+}
+
+#[test]
+fn test_zsh_setopt_ksh_glob_changes_following_word_parse() {
+    let source = concat!(
+        "print @(foo|bar)\n",
+        "setopt ksh_glob\n",
+        "print @(foo|bar)\n",
+    );
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let first = expect_simple(&output.file.body[0]);
+    assert!(!matches!(
+        first.args[0].parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let second = expect_simple(&output.file.body[2]);
+    assert!(matches!(
+        second.args[0].parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+}
+
+#[test]
+fn test_zsh_emulate_extended_glob_changes_following_word_parse() {
+    let source = concat!(
+        "print foo##\n",
+        "emulate -L zsh -o extended_glob\n",
+        "print foo##\n",
+    );
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let first = expect_simple(&output.file.body[0]);
+    assert!(!matches!(
+        first.args[0].parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
+
+    let second = expect_simple(&output.file.body[2]);
+    assert!(matches!(
+        second.args[0].parts.as_slice(),
+        [WordPartNode {
+            kind: WordPart::ZshQualifiedGlob(_),
+            ..
+        }]
+    ));
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -13,18 +13,11 @@ enum PatternSegment<'a> {
     Word(&'a WordPartNode),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum PatternParseMode {
-    Standard,
-    ZshCase,
-    ZshConditional,
-}
-
 struct PatternParser<'a> {
     input: &'a str,
     segments: Vec<PatternSegment<'a>>,
     full_span: Span,
-    mode: PatternParseMode,
+    features: ZshGlobParseFeatures,
 }
 
 enum WordTargetBoundary {
@@ -64,23 +57,15 @@ impl<'a> PatternParser<'a> {
     const MAX_PATTERN_GROUP_DEPTH: usize = 8;
     const MAX_ZSH_CASE_GROUP_PRESCAN_BYTES: usize = 512;
 
-    fn new(input: &'a str, word: &'a Word) -> Self {
-        Self::from_word_parts_with_mode(input, &word.parts, word.span, PatternParseMode::Standard)
+    fn new(input: &'a str, word: &'a Word, features: ZshGlobParseFeatures) -> Self {
+        Self::from_word_parts(input, &word.parts, word.span, features)
     }
 
-    fn from_word_parts(input: &'a str, parts: &'a [WordPartNode], full_span: Span) -> Self {
-        Self::from_word_parts_with_mode(input, parts, full_span, PatternParseMode::Standard)
-    }
-
-    fn with_mode(input: &'a str, word: &'a Word, mode: PatternParseMode) -> Self {
-        Self::from_word_parts_with_mode(input, &word.parts, word.span, mode)
-    }
-
-    fn from_word_parts_with_mode(
+    fn from_word_parts(
         input: &'a str,
         parts: &'a [WordPartNode],
         full_span: Span,
-        mode: PatternParseMode,
+        features: ZshGlobParseFeatures,
     ) -> Self {
         let mut segments = Vec::with_capacity(parts.len());
 
@@ -98,7 +83,7 @@ impl<'a> PatternParser<'a> {
             input,
             segments,
             full_span,
-            mode,
+            features,
         }
     }
 
@@ -176,7 +161,7 @@ impl<'a> PatternParser<'a> {
 
                     if allow_groups
                         && let Some((group, next_cursor)) =
-                            self.try_parse_zsh_case_group(*cursor, group_depth)
+                            self.try_parse_bare_zsh_group(*cursor, group_depth)
                     {
                         self.flush_literal(
                             &mut parts,
@@ -269,15 +254,12 @@ impl<'a> PatternParser<'a> {
         }
     }
 
-    fn try_parse_zsh_case_group(
+    fn try_parse_bare_zsh_group(
         &self,
         cursor: PatternCursor,
         group_depth: usize,
     ) -> Option<(PatternPartNode, PatternCursor)> {
-        if !matches!(
-            self.mode,
-            PatternParseMode::ZshCase | PatternParseMode::ZshConditional
-        ) {
+        if !self.features.bare_groups {
             return None;
         }
 
@@ -285,7 +267,10 @@ impl<'a> PatternParser<'a> {
         if self.is_escaped(cursor) || opener != '(' {
             return None;
         }
-        if !self.has_zsh_case_group_separator(cursor) {
+        if self.is_immediately_preceded_by_ksh_group_operator(cursor) {
+            return None;
+        }
+        if !self.has_bare_zsh_group_separator(cursor) {
             return None;
         }
 
@@ -323,7 +308,7 @@ impl<'a> PatternParser<'a> {
         }
     }
 
-    fn has_zsh_case_group_separator(&self, cursor: PatternCursor) -> bool {
+    fn has_bare_zsh_group_separator(&self, cursor: PatternCursor) -> bool {
         let mut escaped = false;
         let mut paren_depth = 0usize;
         let mut scanned = 0usize;
@@ -385,16 +370,15 @@ impl<'a> PatternParser<'a> {
             return false;
         };
 
-        if matches!(
-            self.mode,
-            PatternParseMode::ZshCase | PatternParseMode::ZshConditional
-        ) && ch == '('
-            && self.has_zsh_case_group_separator(cursor)
+        if self.features.bare_groups
+            && ch == '('
+            && !self.is_immediately_preceded_by_ksh_group_operator(cursor)
+            && self.has_bare_zsh_group_separator(cursor)
         {
             return true;
         }
 
-        if !matches!(ch, '?' | '*' | '+' | '@' | '!') {
+        if !self.features.ksh_groups || !matches!(ch, '?' | '*' | '+' | '@' | '!') {
             return false;
         }
 
@@ -405,6 +389,21 @@ impl<'a> PatternParser<'a> {
         let next_offset = cursor.literal_offset + ch.len_utf8();
         text.get(next_offset..)
             .is_some_and(|rest| rest.starts_with('('))
+    }
+
+    fn is_immediately_preceded_by_ksh_group_operator(&self, cursor: PatternCursor) -> bool {
+        let Some(PatternSegment::Literal { text, .. }) = self.segments.get(cursor.segment_index)
+        else {
+            return false;
+        };
+        if cursor.literal_offset == 0 {
+            return false;
+        }
+
+        text[..cursor.literal_offset]
+            .chars()
+            .next_back()
+            .is_some_and(|ch| matches!(ch, '?' | '*' | '+' | '@' | '!'))
     }
 
     fn flush_literal(
@@ -485,7 +484,10 @@ impl<'a> PatternParser<'a> {
             return None;
         };
         let opener = self.peek_literal_char(cursor)?;
-        if self.is_escaped(cursor) || !matches!(opener, '?' | '*' | '+' | '@' | '!') {
+        if self.is_escaped(cursor)
+            || !self.features.ksh_groups
+            || !matches!(opener, '?' | '*' | '+' | '@' | '!')
+        {
             return None;
         }
         let mut chars = text[cursor.literal_offset..].chars();
@@ -667,16 +669,21 @@ impl<'a> PatternParser<'a> {
 
 impl<'a> Parser<'a> {
     pub(super) fn pattern_from_word(&self, word: &Word) -> Pattern {
-        PatternParser::new(self.input, word).parse()
+        PatternParser::new(
+            self.input,
+            word,
+            self.zsh_glob_parse_features_at(word.span.start.offset),
+        )
+        .parse()
     }
 
     pub(super) fn pattern_from_conditional_word(&self, word: &Word) -> Pattern {
-        let mode = if self.dialect == ShellDialect::Zsh {
-            PatternParseMode::ZshConditional
-        } else {
-            PatternParseMode::Standard
-        };
-        PatternParser::with_mode(self.input, word, mode).parse()
+        PatternParser::new(
+            self.input,
+            word,
+            self.zsh_glob_parse_features_at(word.span.start.offset),
+        )
+        .parse()
     }
 
     pub(super) fn pattern_from_zsh_case_span(&mut self, span: Span) -> Pattern {
@@ -686,7 +693,16 @@ impl<'a> Parser<'a> {
         } else {
             self.decode_word_text(text, span, span.start, true)
         };
-        PatternParser::with_mode(self.input, &word, PatternParseMode::ZshCase).parse()
+        let features = self.zsh_glob_parse_features_at(span.start.offset);
+        self.pattern_from_zsh_case_word_with_features(&word, features)
+    }
+
+    pub(super) fn pattern_from_zsh_case_word_with_features(
+        &self,
+        word: &Word,
+        features: ZshGlobParseFeatures,
+    ) -> Pattern {
+        PatternParser::new(self.input, word, features).parse()
     }
 
     pub(super) fn pattern_from_source_text(&mut self, text: &SourceText) -> Pattern {
@@ -719,7 +735,13 @@ impl<'a> Parser<'a> {
             },
             &mut parts,
         );
-        let pattern = PatternParser::from_word_parts(self.input, &parts, span).parse();
+        let pattern = PatternParser::from_word_parts(
+            self.input,
+            &parts,
+            span,
+            self.zsh_glob_parse_features_at(span.start.offset),
+        )
+        .parse();
         self.source_text_pattern_depth -= 1;
         pattern
     }

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -18,6 +18,7 @@ struct PatternParser<'a> {
     segments: Vec<PatternSegment<'a>>,
     full_span: Span,
     features: ZshGlobParseFeatures,
+    allow_prefixed_bare_groups_without_ksh: bool,
 }
 
 enum WordTargetBoundary {
@@ -58,7 +59,11 @@ impl<'a> PatternParser<'a> {
     const MAX_ZSH_CASE_GROUP_PRESCAN_BYTES: usize = 512;
 
     fn new(input: &'a str, word: &'a Word, features: ZshGlobParseFeatures) -> Self {
-        Self::from_word_parts(input, &word.parts, word.span, features)
+        Self::from_word_parts_with_options(input, &word.parts, word.span, features, false)
+    }
+
+    fn for_pattern_context(input: &'a str, word: &'a Word, features: ZshGlobParseFeatures) -> Self {
+        Self::from_word_parts_with_options(input, &word.parts, word.span, features, true)
     }
 
     fn from_word_parts(
@@ -66,6 +71,16 @@ impl<'a> PatternParser<'a> {
         parts: &'a [WordPartNode],
         full_span: Span,
         features: ZshGlobParseFeatures,
+    ) -> Self {
+        Self::from_word_parts_with_options(input, parts, full_span, features, false)
+    }
+
+    fn from_word_parts_with_options(
+        input: &'a str,
+        parts: &'a [WordPartNode],
+        full_span: Span,
+        features: ZshGlobParseFeatures,
+        allow_prefixed_bare_groups_without_ksh: bool,
     ) -> Self {
         let mut segments = Vec::with_capacity(parts.len());
 
@@ -84,6 +99,7 @@ impl<'a> PatternParser<'a> {
             segments,
             full_span,
             features,
+            allow_prefixed_bare_groups_without_ksh,
         }
     }
 
@@ -267,7 +283,7 @@ impl<'a> PatternParser<'a> {
         if self.is_escaped(cursor) || opener != '(' {
             return None;
         }
-        if self.is_immediately_preceded_by_ksh_group_operator(cursor) {
+        if self.prefix_reserves_group_for_ksh(cursor) {
             return None;
         }
         if !self.has_bare_zsh_group_separator(cursor) {
@@ -372,7 +388,7 @@ impl<'a> PatternParser<'a> {
 
         if self.features.bare_groups
             && ch == '('
-            && !self.is_immediately_preceded_by_ksh_group_operator(cursor)
+            && !self.prefix_reserves_group_for_ksh(cursor)
             && self.has_bare_zsh_group_separator(cursor)
         {
             return true;
@@ -389,6 +405,11 @@ impl<'a> PatternParser<'a> {
         let next_offset = cursor.literal_offset + ch.len_utf8();
         text.get(next_offset..)
             .is_some_and(|rest| rest.starts_with('('))
+    }
+
+    fn prefix_reserves_group_for_ksh(&self, cursor: PatternCursor) -> bool {
+        self.is_immediately_preceded_by_ksh_group_operator(cursor)
+            && (self.features.ksh_groups || !self.allow_prefixed_bare_groups_without_ksh)
     }
 
     fn is_immediately_preceded_by_ksh_group_operator(&self, cursor: PatternCursor) -> bool {
@@ -678,12 +699,52 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn pattern_from_conditional_word(&self, word: &Word) -> Pattern {
-        PatternParser::new(
-            self.input,
-            word,
-            self.zsh_glob_parse_features_at(word.span.start.offset),
-        )
-        .parse()
+        let features = self.zsh_glob_parse_features_at(word.span.start.offset);
+        let source_backed_word = self
+            .conditional_prefixed_bare_group_source_word(word, features)
+            .unwrap_or_else(|| word.clone());
+
+        PatternParser::for_pattern_context(self.input, &source_backed_word, features).parse()
+    }
+
+    fn conditional_prefixed_bare_group_source_word(
+        &self,
+        word: &Word,
+        features: ZshGlobParseFeatures,
+    ) -> Option<Word> {
+        if features.ksh_groups || !features.bare_groups {
+            return None;
+        }
+
+        let needs_reparse = word.parts.windows(2).any(|pair| {
+            let [left, right] = pair else {
+                return false;
+            };
+
+            let WordPart::Literal(text) = &left.kind else {
+                return false;
+            };
+            if !matches!(
+                text.as_str(self.input, left.span).chars().next_back(),
+                Some('?' | '*' | '+' | '@' | '!')
+            ) {
+                return false;
+            }
+
+            matches!(right.kind, WordPart::ZshQualifiedGlob(_))
+                && left.span.end.offset == right.span.start.offset
+                && right.span.slice(self.input).starts_with('(')
+        });
+
+        needs_reparse.then(|| {
+            self.word_with_parts(
+                vec![WordPartNode::new(
+                    WordPart::Literal(LiteralText::source()),
+                    word.span,
+                )],
+                word.span,
+            )
+        })
     }
 
     pub(super) fn pattern_from_zsh_case_span(&mut self, span: Span) -> Pattern {
@@ -702,7 +763,7 @@ impl<'a> Parser<'a> {
         word: &Word,
         features: ZshGlobParseFeatures,
     ) -> Pattern {
-        PatternParser::new(self.input, word, features).parse()
+        PatternParser::for_pattern_context(self.input, word, features).parse()
     }
 
     pub(super) fn pattern_from_source_text(&mut self, text: &SourceText) -> Pattern {

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -716,25 +716,8 @@ impl<'a> Parser<'a> {
             return None;
         }
 
-        let needs_reparse = word.parts.windows(2).any(|pair| {
-            let [left, right] = pair else {
-                return false;
-            };
-
-            let WordPart::Literal(text) = &left.kind else {
-                return false;
-            };
-            if !matches!(
-                text.as_str(self.input, left.span).chars().next_back(),
-                Some('?' | '*' | '+' | '@' | '!')
-            ) {
-                return false;
-            }
-
-            matches!(right.kind, WordPart::ZshQualifiedGlob(_))
-                && left.span.end.offset == right.span.start.offset
-                && right.span.slice(self.input).starts_with('(')
-        });
+        let needs_reparse = self.word_is_safe_for_prefixed_bare_group_reparse(word)
+            && Self::literal_text_has_prefixed_bare_group(word.span.slice(self.input));
 
         needs_reparse.then(|| {
             self.word_with_parts(
@@ -745,6 +728,107 @@ impl<'a> Parser<'a> {
                 word.span,
             )
         })
+    }
+
+    fn word_is_safe_for_prefixed_bare_group_reparse(&self, word: &Word) -> bool {
+        word.parts.iter().all(|part| match &part.kind {
+            WordPart::Literal(text) => text.is_source_backed(),
+            WordPart::ZshQualifiedGlob(glob) => {
+                Self::zsh_glob_is_safe_for_prefixed_bare_group_reparse(glob)
+            }
+            _ => false,
+        })
+    }
+
+    fn zsh_glob_is_safe_for_prefixed_bare_group_reparse(glob: &ZshQualifiedGlob) -> bool {
+        glob.segments
+            .iter()
+            .all(Self::zsh_glob_segment_is_safe_for_prefixed_bare_group_reparse)
+            && glob.qualifiers.is_none()
+    }
+
+    fn zsh_glob_segment_is_safe_for_prefixed_bare_group_reparse(segment: &ZshGlobSegment) -> bool {
+        match segment {
+            ZshGlobSegment::Pattern(pattern) => {
+                Self::pattern_is_safe_for_prefixed_bare_group_reparse(pattern)
+            }
+            ZshGlobSegment::InlineControl(_) => true,
+        }
+    }
+
+    fn pattern_is_safe_for_prefixed_bare_group_reparse(pattern: &Pattern) -> bool {
+        pattern.parts.iter().all(|part| match &part.kind {
+            PatternPart::Literal(text) => text.is_source_backed(),
+            PatternPart::AnyString | PatternPart::AnyChar => true,
+            PatternPart::CharClass(text) => text.is_source_backed(),
+            PatternPart::Group { patterns, .. } => patterns
+                .iter()
+                .all(Self::pattern_is_safe_for_prefixed_bare_group_reparse),
+            PatternPart::Word(_) => false,
+        })
+    }
+
+    fn literal_text_has_prefixed_bare_group(text: &str) -> bool {
+        let mut escaped = false;
+        let mut bracket_depth = 0usize;
+        let mut previous_char = None;
+
+        for (index, ch) in text.char_indices() {
+            if escaped {
+                escaped = false;
+                previous_char = Some(ch);
+                continue;
+            }
+
+            if ch == '\\' {
+                escaped = true;
+                previous_char = Some(ch);
+                continue;
+            }
+
+            match ch {
+                '[' => bracket_depth = bracket_depth.saturating_add(1),
+                ']' if bracket_depth > 0 => bracket_depth -= 1,
+                '(' if bracket_depth == 0
+                    && matches!(previous_char, Some('?' | '*' | '+' | '@' | '!'))
+                    && Self::literal_text_group_has_top_level_separator(text, index) =>
+                {
+                    return true;
+                }
+                _ => {}
+            }
+
+            previous_char = Some(ch);
+        }
+
+        false
+    }
+
+    fn literal_text_group_has_top_level_separator(text: &str, open_index: usize) -> bool {
+        let mut escaped = false;
+        let mut paren_depth = 0usize;
+
+        for ch in text[open_index + '('.len_utf8()..].chars() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+
+            match ch {
+                '(' => paren_depth = paren_depth.saturating_add(1),
+                ')' if paren_depth == 0 => return false,
+                ')' => paren_depth -= 1,
+                '|' if paren_depth == 0 => return true,
+                _ => {}
+            }
+        }
+
+        false
     }
 
     pub(super) fn pattern_from_zsh_case_span(&mut self, span: Span) -> Pattern {


### PR DESCRIPTION
## Summary
- make zsh glob parsing respect the active `extended_glob`, `ksh_glob`, and `sh_glob` state from both the parser profile and the in-file option timeline
- thread those feature gates through ordinary glob words, `case` patterns, `[[ ... == ... ]]`, and replacement-pattern reparses while preserving unsupported `(#...)` forms as source-backed zsh glob words
- add targeted parser tests for profile-seeded options plus mid-file `setopt`, `unsetopt`, and `emulate -L zsh -o ...` transitions

## Why
Several zsh glob forms were effectively treated as always-on, and nested source-text reparses were still using the initial profile instead of the active option snapshot at the source offset. That meant the parser could emit glob-aware nodes when the relevant zsh option was disabled, or miss them after an in-file option flip.

## Testing
- cargo test -p shuck-parser
