### PR TITLE
fix(parser): support upstream zsh function and glob forms

### DIFF
--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -4192,6 +4192,9 @@ impl<'a> Parser<'a> {
         if self.dialect == ShellDialect::Zsh {
             let mut entries = Vec::new();
             while self.current_token_kind.is_some_and(TokenKind::is_word_like) {
+                if !entries.is_empty() && self.current_token_is_compact_zsh_brace_body() {
+                    break;
+                }
                 entries.push(self.parse_function_header_entry()?);
                 if self.at(TokenKind::LeftParen) {
                     break;

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1530,6 +1530,9 @@ impl<'a> Lexer<'a> {
                                 && (chunk.ends_with('=')
                                     || Self::word_can_take_parenthesized_suffix(chunk)))
                 );
+                let continues = continues
+                    || (self.peek_char() == Some('(')
+                        && self.looks_like_zsh_alternative_glob_suffix(chunk));
 
                 if !continues {
                     let end = self.current_position();
@@ -1541,7 +1544,9 @@ impl<'a> Lexer<'a> {
                 }
 
                 if self.peek_char() == Some('(')
-                    && (chunk.ends_with('=') || Self::word_can_take_parenthesized_suffix(chunk))
+                    && (chunk.ends_with('=')
+                        || Self::word_can_take_parenthesized_suffix(chunk)
+                        || self.looks_like_zsh_alternative_glob_suffix(chunk))
                 {
                     return self.read_complex_word(start);
                 }
@@ -2174,7 +2179,10 @@ impl<'a> Lexer<'a> {
                 Some('$') if self.second_char() == Some('"') => {
                     word.push_segment(self.read_dollar_double_quoted_segment()?);
                 }
-                Some('(') if Self::lexed_word_can_take_parenthesized_suffix(word) => {
+                Some('(')
+                    if Self::lexed_word_can_take_parenthesized_suffix(word)
+                        || self.looks_like_zsh_alternative_glob_suffix(&word.joined_text()) =>
+                {
                     let Some(segment) = self.read_parenthesized_word_suffix_segment() else {
                         unreachable!("peeked '(' should produce a suffix segment");
                     };
@@ -3828,6 +3836,48 @@ impl<'a> Lexer<'a> {
 
     fn word_can_take_parenthesized_suffix(text: &str) -> bool {
         text.ends_with(['@', '?', '*', '+', '!']) || Self::looks_like_zsh_glob_qualifier_base(text)
+    }
+
+    fn looks_like_zsh_alternative_glob_suffix(&mut self, prefix: &str) -> bool {
+        if self.current_zsh_options().is_none()
+            || self.peek_char() != Some('(')
+            || !prefix.ends_with('.')
+        {
+            return false;
+        }
+
+        let mut chars = self.lookahead_chars();
+        if chars.next() != Some('(') {
+            return false;
+        }
+
+        let mut depth = 1usize;
+        let mut escaped = false;
+        let mut saw_glob_marker = false;
+
+        for ch in chars {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            match ch {
+                '\\' => escaped = true,
+                '(' => depth += 1,
+                ')' => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        return saw_glob_marker;
+                    }
+                }
+                '|' if depth == 1 => {
+                    saw_glob_marker = true;
+                }
+                _ => {}
+            }
+        }
+
+        false
     }
 
     fn lexed_word_can_take_parenthesized_suffix(word: &LexedWord<'_>) -> bool {
@@ -6391,6 +6441,18 @@ ac_top_builddir_sub=`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||
     fn test_extglob_after_escaped_literal_keeps_suffix_group() {
         let source = r#"foo\_bar@(baz|qux)"#;
         let mut lexer = Lexer::new(source);
+
+        let token = lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::Word);
+        assert_eq!(token.span.slice(source), source);
+        assert!(lexer.next_lexed_token().is_none());
+    }
+
+    #[test]
+    fn test_zsh_alternative_glob_after_dot_keeps_suffix_group() {
+        let source = "file.(txt|doc|pdf)";
+        let profile = ShellProfile::native(crate::parser::ShellDialect::Zsh);
+        let mut lexer = Lexer::with_profile(source, &profile);
 
         let token = lexer.next_lexed_token().unwrap();
         assert_eq!(token.kind, TokenKind::Word);

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -799,6 +799,32 @@ fn test_zsh_function_keyword_preserves_multi_name_backslash_newline_brace_body()
 }
 
 #[test]
+fn test_zsh_function_keyword_preserves_multi_name_compact_empty_brace_body() {
+    let input = "function foo bar {}\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let function = expect_function(&script.body[0]);
+    assert_eq!(
+        function
+            .header
+            .static_names()
+            .map(Name::as_str)
+            .collect::<Vec<_>>(),
+        vec!["foo", "bar"]
+    );
+
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    assert!(body.is_empty());
+}
+
+#[test]
 fn test_zsh_function_keyword_allows_nameless_anonymous_function_command() {
     let input = "function { local x=1; print -- anon:$#; } a b\n";
     let script = Parser::with_dialect(input, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -771,6 +771,34 @@ fn test_zsh_function_keyword_preserves_multi_name_stub_body() {
 }
 
 #[test]
+fn test_zsh_function_keyword_preserves_multi_name_backslash_newline_brace_body() {
+    let input = "function foo \\\n    bar \\\n{ \n    echo hi\n}\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let function = expect_function(&script.body[0]);
+    assert_eq!(
+        function
+            .header
+            .static_names()
+            .map(Name::as_str)
+            .collect::<Vec<_>>(),
+        vec!["foo", "bar"]
+    );
+
+    let (compound, redirects) = expect_compound(function.body.as_ref());
+    let AstCompoundCommand::BraceGroup(body) = compound else {
+        panic!("expected brace-group function body");
+    };
+    assert!(redirects.is_empty());
+    assert_eq!(body.len(), 1);
+    assert_eq!(expect_simple(&body[0]).name.render(input), "echo");
+    assert_eq!(expect_simple(&body[0]).args[0].render(input), "hi");
+}
+
+#[test]
 fn test_zsh_function_keyword_allows_nameless_anonymous_function_command() {
     let input = "function { local x=1; print -- anon:$#; } a b\n";
     let script = Parser::with_dialect(input, ShellDialect::Zsh)
@@ -3102,11 +3130,73 @@ fn test_zsh_setopt_ksh_glob_changes_following_conditional_pattern_parse() {
 }
 
 #[test]
+fn test_parse_zsh_conditional_pattern_rhs_accepts_hash_q_glob_qualifier() {
+    let input = "[[ foo.txt == *.txt(#qN) ]]\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    assert_eq!(binary.op, ConditionalBinaryOp::PatternEq);
+
+    let ConditionalExpr::Pattern(pattern) = binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert_eq!(pattern.render(input), "*.txt(#qN)");
+}
+
+#[test]
+fn test_parse_zsh_conditional_pattern_rhs_accepts_negated_hash_q_glob_qualifier() {
+    let input = "[[ $file != *.tmp(#qN) ]]\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    assert_eq!(binary.op, ConditionalBinaryOp::PatternNe);
+
+    let ConditionalExpr::Pattern(pattern) = binary.right.as_ref() else {
+        panic!("expected pattern rhs");
+    };
+    assert_eq!(pattern.render(input), "*.tmp(#qN)");
+}
+
+#[test]
 fn test_parse_zsh_if_with_defaulting_subscript_and_or_condition() {
     let input = "if [[ $zsyh_user_options[ignorebraces] == on || ${zsyh_user_options[ignoreclosebraces]:-off} == on ]]; then\n  print ok\nfi\n";
     Parser::with_dialect(input, ShellDialect::Zsh)
         .parse()
         .unwrap();
+}
+
+#[test]
+fn test_parse_zsh_job_spec_commands_preserve_percent_arguments() {
+    for input in ["fg %1\n", "bg %2\n"] {
+        let script = Parser::with_dialect(input, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
+        let command = expect_simple(&script.body[0]);
+
+        assert_eq!(command.args.len(), 1);
+        assert!(command.args[0].span.slice(input).starts_with('%'));
+    }
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/redirects.rs
+++ b/crates/shuck-parser/src/parser/tests/redirects.rs
@@ -215,7 +215,10 @@ fn test_parse_redirect_with_descriptor_on_continuation_line_from_upstream() {
     assert_eq!(stmt.redirects.len(), 1);
     assert_eq!(stmt.redirects[0].fd, Some(2));
     assert_eq!(stmt.redirects[0].kind, RedirectKind::Output);
-    assert_eq!(redirect_word_target(&stmt.redirects[0]).render(input), "/dev/null");
+    assert_eq!(
+        redirect_word_target(&stmt.redirects[0]).render(input),
+        "/dev/null"
+    );
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/redirects.rs
+++ b/crates/shuck-parser/src/parser/tests/redirects.rs
@@ -116,6 +116,48 @@ fn test_parse_named_fd_redirect_read_write() {
 }
 
 #[test]
+fn test_parse_zsh_here_string_examples_from_upstream() {
+    for (input, expected_name) in [
+        ("cat <<< \"hello\"\n", "cat"),
+        ("grep pattern <<< \"$variable\"\n", "grep"),
+        ("cat 0<<< \"data\"\n", "cat"),
+    ] {
+        let script = Parser::with_dialect(input, ShellDialect::Zsh)
+            .parse()
+            .unwrap()
+            .file;
+        let stmt = &script.body[0];
+        let command = expect_simple(stmt);
+
+        assert_eq!(command.name.render(input), expected_name);
+        assert_eq!(stmt.redirects.len(), 1);
+        assert_eq!(stmt.redirects[0].kind, RedirectKind::HereString);
+    }
+}
+
+#[test]
+fn test_parse_zsh_here_string_pipeline_binds_to_left_command() {
+    let input = "command <<< \"input\" | other\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let stmt = &script.body[0];
+    let AstCommand::Binary(binary) = &stmt.command else {
+        panic!("expected pipeline command");
+    };
+    assert_eq!(binary.op, BinaryOp::Pipe);
+
+    let left = expect_simple(&binary.left);
+    assert_eq!(left.name.render(input), "command");
+    assert_eq!(binary.left.redirects.len(), 1);
+    assert_eq!(binary.left.redirects[0].kind, RedirectKind::HereString);
+
+    let right = expect_simple(&binary.right);
+    assert_eq!(right.name.render(input), "other");
+}
+
+#[test]
 fn test_parse_process_substitution_argument_with_here_string_inside_outer_process_substitution() {
     let input = "\
 readarray -t deps < <(
@@ -157,6 +199,23 @@ readarray -t deps < <(
     );
     assert_eq!(body[0].redirects.len(), 1);
     assert_eq!(body[0].redirects[0].kind, RedirectKind::HereString);
+}
+
+#[test]
+fn test_parse_redirect_with_descriptor_on_continuation_line_from_upstream() {
+    let input = "echo foo \\\n    2>/dev/null\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let stmt = &script.body[0];
+    let command = expect_simple(stmt);
+
+    assert_eq!(command.name.render(input), "echo");
+    assert_eq!(stmt.redirects.len(), 1);
+    assert_eq!(stmt.redirects[0].fd, Some(2));
+    assert_eq!(stmt.redirects[0].kind, RedirectKind::Output);
+    assert_eq!(redirect_word_target(&stmt.redirects[0]).render(input), "/dev/null");
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -6692,6 +6692,20 @@ fn test_zsh_upstream_alternative_glob_examples_parse() {
 }
 
 #[test]
+fn test_zsh_upstream_alternative_glob_examples_preserve_full_argument_spans() {
+    for syntax in ["file.(txt|doc|pdf)", "file.{txt,doc,pdf}"] {
+        let source = format!("echo {syntax}\n");
+        let output = Parser::with_dialect(&source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+        let command = expect_simple(&output.file.body[0]);
+
+        assert_eq!(command.args.len(), 1, "expected one arg for {syntax:?}");
+        assert_eq!(command.args[0].span.slice(&source), syntax);
+    }
+}
+
+#[test]
 fn test_zsh_numeric_glob_range_example_parses() {
     Parser::with_dialect("ls <1-100>.txt\n", ShellDialect::Zsh)
         .parse()

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -6650,6 +6650,94 @@ fn test_non_zsh_dialects_do_not_special_case_trailing_glob_qualifiers() {
 }
 
 #[test]
+fn test_zsh_additional_upstream_glob_examples_parse_as_single_arguments() {
+    for (command_name, syntax) in [
+        ("print", "*(@)"),
+        ("print", "*(=)"),
+        ("print", "*(/^F)"),
+        ("print", "*(Lk+10)"),
+        ("print", "*(.Lm+5)"),
+        ("print", "*(:h)"),
+        ("print", "*(:e)"),
+        ("print", "*(:u)"),
+        ("print", "*(:l)"),
+        ("print", "*(.)(:t)"),
+        ("ls", "glob.tmp/**(.)"),
+        ("echo", "file(#q.)"),
+        ("ls", "*.c~*foo*"),
+        ("ls", "^*.txt"),
+        ("echo", "(#a2)pattern"),
+        ("echo", "(#iq)*.txt"),
+        ("echo", "**/*(.N)"),
+        ("echo", "**/*(#qN.)~*test*"),
+    ] {
+        let source = format!("{command_name} {syntax}\n");
+        let output = Parser::with_dialect(&source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+        let command = expect_simple(&output.file.body[0]);
+
+        assert_eq!(command.args.len(), 1, "expected one arg for {syntax:?}");
+        assert_eq!(command.args[0].span.slice(&source), syntax);
+    }
+}
+
+#[test]
+fn test_zsh_upstream_alternative_glob_examples_parse() {
+    for source in ["echo file.(txt|doc|pdf)\n", "echo file.{txt,doc,pdf}\n"] {
+        Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+    }
+}
+
+#[test]
+fn test_zsh_numeric_glob_range_example_parses() {
+    Parser::with_dialect("ls <1-100>.txt\n", ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+}
+
+#[test]
+fn test_zsh_upstream_word_surface_examples_parse() {
+    for source in ["echo \\(foo\\)\n", "find . \\( -name \"*.zsh\" \\)\n"] {
+        Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+    }
+
+    let source = "diff =(sort file1) =(sort file2)\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    assert_eq!(command.name.render(source), "diff");
+    assert_eq!(command.args.len(), 2);
+    assert_eq!(command.args[0].span.slice(source), "=(sort file1)");
+    assert_eq!(command.args[1].span.slice(source), "=(sort file2)");
+}
+
+#[test]
+fn test_zsh_glob_qualifier_in_command_substitution_preserves_inner_argument() {
+    let source = "files=$(echo *(.))\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+    let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
+        panic!("expected scalar assignment");
+    };
+    let body = first_command_substitution_body(&word.parts)
+        .expect("expected command substitution body");
+    let inner = expect_simple(&body[0]);
+
+    assert_eq!(inner.name.render(source), "echo");
+    assert_eq!(inner.args.len(), 1);
+    assert_eq!(inner.args[0].span.slice(source), "*(.)");
+}
+
+#[test]
 fn test_zsh_repeat_do_done_preserves_structure_and_spans() {
     let source = "repeat 3; do echo hi; done\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)
@@ -6678,6 +6766,33 @@ fn test_zsh_repeat_do_done_preserves_structure_and_spans() {
     let body_command = expect_simple(&command.body[0]);
     assert_eq!(body_command.name.render(source), "echo");
     assert_eq!(body_command.args[0].render(source), "hi");
+}
+
+#[test]
+fn test_zsh_repeat_direct_preserves_structure_and_spans() {
+    let source = "repeat 3 echo test\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let (compound, redirects) = expect_compound(&output.file.body[0]);
+    let AstCompoundCommand::Repeat(command) = compound else {
+        panic!("expected repeat command");
+    };
+
+    assert!(redirects.is_empty());
+    assert_eq!(command.span.slice(source), source);
+    assert_eq!(command.count.span.slice(source), "3");
+    assert_eq!(command.body.len(), 1);
+
+    match command.syntax {
+        RepeatSyntax::Direct => {}
+        RepeatSyntax::Brace { .. } => panic!("expected direct repeat syntax"),
+        RepeatSyntax::DoDone { .. } => panic!("expected direct repeat syntax"),
+    }
+
+    let body_command = expect_simple(&command.body[0]);
+    assert_eq!(body_command.name.render(source), "echo");
+    assert_eq!(body_command.args[0].render(source), "test");
 }
 
 #[test]
@@ -7335,6 +7450,58 @@ fn test_zsh_plain_positional_parameters_preserve_bourne_references() {
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Length { reference })
             if reference.name.as_str() == "10"
     ));
+}
+
+#[test]
+fn test_zsh_additional_upstream_parameter_examples_parse() {
+    for source in [
+        "echo ${${var}:u}\n",
+        "echo ${var:-default}\n",
+        "echo ${var:=default}\n",
+        "echo ${var:-}\necho ${var:=}\n",
+        "echo \"${REPLY%%$'\\n'}\"\n",
+    ] {
+        Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+    }
+
+    let source = "echo ${array[(i)pattern]}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+    assert_eq!(command.args.len(), 1);
+    assert_eq!(command.args[0].render(source), "${array[(i)pattern]}");
+}
+
+#[test]
+fn test_zsh_additional_upstream_pattern_removal_examples_parse() {
+    for source in [
+        "echo \"${arr[@]:#pattern}\"\n",
+        "echo \"${arr[@]:%pattern}\"\n",
+        "filtered=(\"${(@)ingest:#--ingest=*}\")\n",
+        "basenames=(\"${(@)paths:##*/}\")\n",
+        "echo \"${arr[@]:# }\"\n",
+    ] {
+        Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+    }
+}
+
+#[test]
+fn test_zsh_additional_upstream_declaration_examples_parse() {
+    for source in [
+        "integer count=42\n",
+        "float pi=3.14\n",
+        "typeset -A hash\nhash=(key1 value1 key2 value2)\n",
+        "0=${(%):-%N}\n",
+    ] {
+        Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+    }
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -6728,8 +6728,8 @@ fn test_zsh_glob_qualifier_in_command_substitution_preserves_inner_argument() {
     let AssignmentValue::Scalar(word) = &command.assignments[0].value else {
         panic!("expected scalar assignment");
     };
-    let body = first_command_substitution_body(&word.parts)
-        .expect("expected command substitution body");
+    let body =
+        first_command_substitution_body(&word.parts).expect("expected command substitution body");
     let inner = expect_simple(&body[0]);
 
     assert_eq!(inner.name.render(source), "echo");


### PR DESCRIPTION
## Summary
- import focused zsh parser regressions from tree-sitter-zsh unit-sized cases
- support compact multi-name zsh `function` headers when the brace body arrives as a compact token
- preserve dotted zsh alternation-glob words like `file.(txt|doc|pdf)` as single arguments without widening other parenthesized tokenization paths

## Testing
- cargo test -p shuck-parser