### PR TITLE
test(zsh): add remaining upstream regression coverage

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -2024,6 +2024,86 @@ coproc {
   read -r reply
   print -r -- $reply
 }
+
+while getopts ":wtfvh-:" opt; do
+  case "$opt" in
+    -)
+      case "${OPTARG}" in
+        wait)
+          WAIT=1
+          ;;
+        help|version)
+          REDIRECT_STDERR=1
+          EXPECT_OUTPUT=1
+          ;;
+        foreground|benchmark|benchmark-test|test)
+          EXPECT_OUTPUT=1
+          ;;
+      esac
+      ;;
+    w)
+      WAIT=1
+      ;;
+    h|v)
+      REDIRECT_STDERR=1
+      EXPECT_OUTPUT=1
+      ;;
+    f|t)
+      EXPECT_OUTPUT=1
+      ;;
+  esac
+done
+
+filelist=()
+fid=0
+find "$prefix/$folder" -type l | while read file; do
+  target=`$readlink $file | grep '/\.npm/'`
+  if [ "x$target" != "x" ]; then
+    filelist[$fid]="$file"
+    let 'fid++'
+    base=`basename "$file"`
+    find "`dirname $file`" -type l -name "$base"'*' \
+      | while read link; do
+          filelist[$fid]="$link"
+          let 'fid++'
+        done
+  fi
+done
+
+args=()
+if [[ -n $verbose ]]; then
+  args+=("--reporter=spec")
+else
+  args+=("--reporter=singleline")
+fi
+
+case ${mode} in
+  valgrind)
+    valgrind                                     \
+      --suppressions=./script/util/valgrind.supp \
+      --dsymutil=yes                             \
+      --leak-check=${leak_check}                 \
+      $cmd "${args[@]}" 2>&1 |                   \
+      grep --color -E '\w+_tests?.cc:\d+|$'
+    ;;
+  SVG)
+    $cmd "${args[@]}" 2> >(grep -v 'Assertion failed' | dot -Tsvg >> index.html)
+    ;;
+esac
+
+html_replace_tokens () {
+  local url=$1
+  sed "s|@NAME@|$name|g" \
+    | sed "s|@URL@|$url|g" \
+    | perl -p -e 's/<h1([^>]*)>(.*?)<\/h1>/<h1>\2<\/h1>/g' \
+    | (if [ $(basename $(dirname $dest)) == "doc" ]; then
+        perl -p -e 's/ href="\.\.\// href="/g'
+      else
+        cat
+      fi)
+}
+
+0=${(%):-%N}
 "#
     }
 

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1078,8 +1078,17 @@ impl<'a> Lexer<'a> {
         start: Position,
         capture: &Option<String>,
     ) -> bool {
-        let text = self.current_word_text(start, capture).to_string();
-        self.looks_like_zsh_glob_modifier_suffix(&text)
+        if self.current_zsh_options().is_none() || self.peek_char() != Some('(') {
+            return false;
+        }
+
+        let text = self.current_word_text(start, capture);
+        if !text.contains('/') {
+            return false;
+        }
+
+        let mut chars = self.lookahead_chars();
+        matches!((chars.next(), chars.next()), (Some('('), Some(':')))
     }
 
     /// Get the next source-backed token from the input, skipping line comments.

--- a/crates/shuck-parser/src/parser/lexer.rs
+++ b/crates/shuck-parser/src/parser/lexer.rs
@@ -1073,6 +1073,15 @@ impl<'a> Lexer<'a> {
             .is_some_and(|ch| matches!(ch, '@' | '?' | '*' | '+' | '!'))
     }
 
+    fn current_word_surface_can_take_zsh_glob_modifier_suffix(
+        &mut self,
+        start: Position,
+        capture: &Option<String>,
+    ) -> bool {
+        let text = self.current_word_text(start, capture).to_string();
+        self.looks_like_zsh_glob_modifier_suffix(&text)
+    }
+
     /// Get the next source-backed token from the input, skipping line comments.
     ///
     /// Returned tokens expose their [`TokenKind`] and source [`Span`]. Comments
@@ -1532,7 +1541,8 @@ impl<'a> Lexer<'a> {
                 );
                 let continues = continues
                     || (self.peek_char() == Some('(')
-                        && self.looks_like_zsh_alternative_glob_suffix(chunk));
+                        && (self.looks_like_zsh_alternative_glob_suffix(chunk)
+                            || self.looks_like_zsh_glob_modifier_suffix(chunk)));
 
                 if !continues {
                     let end = self.current_position();
@@ -1546,7 +1556,8 @@ impl<'a> Lexer<'a> {
                 if self.peek_char() == Some('(')
                     && (chunk.ends_with('=')
                         || Self::word_can_take_parenthesized_suffix(chunk)
-                        || self.looks_like_zsh_alternative_glob_suffix(chunk))
+                        || self.looks_like_zsh_alternative_glob_suffix(chunk)
+                        || self.looks_like_zsh_glob_modifier_suffix(chunk))
                 {
                     return self.read_complex_word(start);
                 }
@@ -1790,10 +1801,12 @@ impl<'a> Lexer<'a> {
                         _ => {}
                     }
                 }
-            } else if ch == '(' && self.current_word_surface_ends_with_extglob_prefix(start, &word)
+            } else if ch == '('
+                && (self.current_word_surface_ends_with_extglob_prefix(start, &word)
+                    || self.current_word_surface_can_take_zsh_glob_modifier_suffix(start, &word))
             {
-                // Extglob: @(...), ?(...), *(...), +(...), !(...)
-                // Consume through matching ) including nested parens
+                // Extglob and zsh glob modifiers consume through matching )
+                // including nested parens.
                 Self::push_capture_char(&mut word, ch);
                 self.advance();
                 let mut depth = 1;
@@ -2181,7 +2194,8 @@ impl<'a> Lexer<'a> {
                 }
                 Some('(')
                     if Self::lexed_word_can_take_parenthesized_suffix(word)
-                        || self.looks_like_zsh_alternative_glob_suffix(&word.joined_text()) =>
+                        || self.looks_like_zsh_alternative_glob_suffix(&word.joined_text())
+                        || self.looks_like_zsh_glob_modifier_suffix(&word.joined_text()) =>
                 {
                     let Some(segment) = self.read_parenthesized_word_suffix_segment() else {
                         unreachable!("peeked '(' should produce a suffix segment");
@@ -3878,6 +3892,18 @@ impl<'a> Lexer<'a> {
         }
 
         false
+    }
+
+    fn looks_like_zsh_glob_modifier_suffix(&mut self, prefix: &str) -> bool {
+        if self.current_zsh_options().is_none()
+            || self.peek_char() != Some('(')
+            || !prefix.contains('/')
+        {
+            return false;
+        }
+
+        let mut chars = self.lookahead_chars();
+        matches!((chars.next(), chars.next()), (Some('('), Some(':')))
     }
 
     fn lexed_word_can_take_parenthesized_suffix(word: &LexedWord<'_>) -> bool {
@@ -6458,6 +6484,23 @@ ac_top_builddir_sub=`$as_echo \"$ac_dir_suffix\" | sed 's|/[^\\\\/]*|/..|g;s|/||
         assert_eq!(token.kind, TokenKind::Word);
         assert_eq!(token.span.slice(source), source);
         assert!(lexer.next_lexed_token().is_none());
+    }
+
+    #[test]
+    fn test_zsh_path_glob_modifier_keeps_suffix_group() {
+        let source = "/path/file(:h)";
+        let profile = ShellProfile::native(crate::parser::ShellDialect::Zsh);
+        let mut lexer = Lexer::with_profile(source, &profile);
+
+        let token = lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::Word);
+        assert_eq!(token.span.slice(source), source);
+        assert!(lexer.next_lexed_token().is_none());
+
+        let mut default_lexer = Lexer::new(source);
+        let token = default_lexer.next_lexed_token().unwrap();
+        assert_eq!(token.kind, TokenKind::Word);
+        assert_eq!(token.span.slice(source), "/path/file");
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/tests/commands.rs
+++ b/crates/shuck-parser/src/parser/tests/commands.rs
@@ -3204,6 +3204,92 @@ fn test_parse_zsh_conditional_pattern_rhs_accepts_negated_hash_q_glob_qualifier(
 }
 
 #[test]
+fn test_parse_zsh_remaining_upstream_conditionals_and_control_flow_examples() {
+    for input in [
+        "[[ ( a == b ) || ( c == d ) ]]\n",
+        "[[ ! -f file ]]\n",
+        "[[ -f file1 && ( -r file1 || -w file1 ) ]]\n",
+        "case $var in\n    *.txt) echo \"text file\" ;;\n    *.sh) echo \"shell script\" ;;\n    *) echo \"other\" ;;\nesac\n",
+        "if [[ $a -eq $b ]]; then\n    echo \"equal\"\nfi\n",
+        "if [[ $a -gt 5 ]]; then\n    echo \"greater\"\nelif [[ $a -lt 0 ]]; then\n    echo \"less\"\nelse\n    echo \"between\"\nfi\n",
+        "until [[ $count -ge 10 ]]; do\n    echo $count\n    ((count++))\ndone\n",
+        "while true; do\n    if [[ $done ]]; then\n        break\n    fi\n    echo \"working\"\ndone\n",
+    ] {
+        Parser::with_dialect(input, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+    }
+}
+
+#[test]
+fn test_parse_zsh_remaining_upstream_advanced_command_examples() {
+    for input in [
+        "cat file.txt | grep pattern | sort | uniq\n",
+        "sleep 10 &\n",
+        "sleep 10 &!\n",
+        "sleep 10 &|\n",
+    ] {
+        Parser::with_dialect(input, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+    }
+}
+
+#[test]
+fn test_parse_zsh_newer_than_conditional_from_upstream() {
+    let input = "[[ file1 -nt file2 ]]\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    assert_eq!(binary.op, ConditionalBinaryOp::NewerThan);
+}
+
+#[test]
+fn test_parse_zsh_ansi_c_string_regex_match_expression_from_upstream() {
+    let input = "[[ \"$x\" =~ \"^foo\"$'\\t'\"bar\" ]]\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let (compound, _) = expect_compound(&script.body[0]);
+    let AstCompoundCommand::Conditional(command) = compound else {
+        panic!("expected conditional compound command");
+    };
+    let ConditionalExpr::Binary(binary) = &command.expression else {
+        panic!("expected binary conditional");
+    };
+    assert_eq!(binary.op, ConditionalBinaryOp::RegexMatch);
+
+    let ConditionalExpr::Regex(word) = binary.right.as_ref() else {
+        panic!("expected regex rhs");
+    };
+    assert_eq!(word.span.slice(input), "\"^foo\"$'\\t'\"bar\"");
+}
+
+#[test]
+fn test_parse_zsh_remaining_upstream_conditional_glob_examples() {
+    for input in [
+        "[[ $file == *.txt ]]\n",
+        "[[ $name != (#i)*.TMP ]]\n",
+        "[[ -f *.log(.) ]]\n",
+    ] {
+        parse_zsh_with_options(input, |options| {
+            options.extended_glob = OptionValue::On;
+        });
+    }
+}
+
+#[test]
 fn test_parse_zsh_if_with_defaulting_subscript_and_or_condition() {
     let input = "if [[ $zsyh_user_options[ignorebraces] == on || ${zsyh_user_options[ignoreclosebraces]:-off} == on ]]; then\n  print ok\nfi\n";
     Parser::with_dialect(input, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/tests/redirects.rs
+++ b/crates/shuck-parser/src/parser/tests/redirects.rs
@@ -116,6 +116,25 @@ fn test_parse_named_fd_redirect_read_write() {
 }
 
 #[test]
+fn test_parse_zsh_output_append_redirect_from_upstream() {
+    let input = "command >> output.txt\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+    let stmt = &script.body[0];
+    let command = expect_simple(stmt);
+
+    assert_eq!(command.name.render(input), "command");
+    assert_eq!(stmt.redirects.len(), 1);
+    assert_eq!(stmt.redirects[0].kind, RedirectKind::Append);
+    assert_eq!(
+        redirect_word_target(&stmt.redirects[0]).render(input),
+        "output.txt"
+    );
+}
+
+#[test]
 fn test_parse_zsh_here_string_examples_from_upstream() {
     for (input, expected_name) in [
         ("cat <<< \"hello\"\n", "cat"),

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -6683,6 +6683,78 @@ fn test_zsh_additional_upstream_glob_examples_parse_as_single_arguments() {
 }
 
 #[test]
+fn test_zsh_remaining_upstream_glob_qualifier_examples_parse_as_single_arguments() {
+    for (command_name, syntax) in [
+        ("print", "*(/)"),
+        ("print", "*(*)"),
+        ("print", "*(%)"),
+        ("print", "*(:t)"),
+        ("print", "*(:r)"),
+        ("echo", "*(Lk+100)"),
+        ("echo", "*(Lm-1)"),
+        ("echo", "*(Lg2)"),
+        ("echo", "*(mh-1)"),
+        ("echo", "*(mm+30)"),
+        ("echo", "*(ms-3600)"),
+        ("echo", "*(cD-1)"),
+        ("echo", "*(om)"),
+        ("echo", "*(On)"),
+        ("echo", "*(oL)"),
+        ("echo", "*(oc)"),
+        ("echo", "*.txt(:r)"),
+        ("echo", "*.tar.gz(:r:r)"),
+        ("echo", "/path/file(:h)"),
+        ("echo", "/path/file(:t)"),
+        ("ls", "**/*.py(mh-24.L+1k)"),
+    ] {
+        let source = format!("{command_name} {syntax}\n");
+        let output = Parser::with_dialect(&source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
+        let command = expect_simple(&output.file.body[0]);
+
+        assert_eq!(command.args.len(), 1, "expected one arg for {syntax:?}");
+        assert_eq!(command.args[0].span.slice(&source), syntax);
+    }
+}
+
+#[test]
+fn test_zsh_remaining_upstream_extended_glob_examples_parse_as_single_arguments() {
+    for syntax in [
+        "(#a1)approx*",
+        "(#a3)vague*",
+        "(#i)*.TXT",
+        "(#b)(*).backup~$match[1]",
+        "*.txt(#qN.)",
+        "(#i)*.txt(.)",
+        "(#q)test*(N)",
+        "(#l)FILE*(.om)",
+    ] {
+        let source = format!("echo {syntax}\n");
+        let output = parse_zsh_with_options(&source, |options| {
+            options.extended_glob = OptionValue::On;
+        });
+        let command = expect_simple(&output.file.body[0]);
+
+        assert_eq!(command.args.len(), 1, "expected one arg for {syntax:?}");
+        assert_eq!(command.args[0].span.slice(&source), syntax);
+    }
+}
+
+#[test]
+fn test_zsh_remaining_upstream_complex_glob_examples_parse() {
+    for source in [
+        "print glob.tmp/**/*~*/dir3(/*|(#e))(/)\n",
+        "find . -name \"*.c\" -o -name \"*.h\" | grep -v test\n",
+        "echo ${files[@]:#*.tmp}\n",
+    ] {
+        parse_zsh_with_options(source, |options| {
+            options.extended_glob = OptionValue::On;
+        });
+    }
+}
+
+#[test]
 fn test_zsh_upstream_alternative_glob_examples_parse() {
     for source in ["echo file.(txt|doc|pdf)\n", "echo file.{txt,doc,pdf}\n"] {
         Parser::with_dialect(source, ShellDialect::Zsh)
@@ -7507,9 +7579,11 @@ fn test_zsh_additional_upstream_pattern_removal_examples_parse() {
 #[test]
 fn test_zsh_additional_upstream_declaration_examples_parse() {
     for source in [
+        "array=(one two three)\n",
         "integer count=42\n",
         "float pi=3.14\n",
         "typeset -A hash\nhash=(key1 value1 key2 value2)\n",
+        "local -a array\n",
         "0=${(%):-%N}\n",
     ] {
         Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/tests/testdata/oils/zsh-obscure-syntax.test.sh
+++ b/crates/shuck-parser/tests/testdata/oils/zsh-obscure-syntax.test.sh
@@ -123,3 +123,112 @@ coproc {
   read -r reply
   print -r -- $reply
 }
+
+#### tree-sitter-zsh example getopts with nested case dispatch
+
+while getopts ":wtfvh-:" opt; do
+  case "$opt" in
+    -)
+      case "${OPTARG}" in
+        wait)
+          WAIT=1
+          ;;
+        help|version)
+          REDIRECT_STDERR=1
+          EXPECT_OUTPUT=1
+          ;;
+        foreground|benchmark|benchmark-test|test)
+          EXPECT_OUTPUT=1
+          ;;
+      esac
+      ;;
+    w)
+      WAIT=1
+      ;;
+    h|v)
+      REDIRECT_STDERR=1
+      EXPECT_OUTPUT=1
+      ;;
+    f|t)
+      EXPECT_OUTPUT=1
+      ;;
+  esac
+done
+
+#### tree-sitter-zsh example array accumulation in pipeline loops
+
+filelist=()
+fid=0
+
+find "$prefix/$folder" -type l | while read file; do
+  target=`$readlink $file | grep '/\.npm/'`
+  if [ "x$target" != "x" ]; then
+    filelist[$fid]="$file"
+    let 'fid++'
+    base=`basename "$file"`
+    find "`dirname $file`" -type l -name "$base"'*' \
+      | while read link; do
+          filelist[$fid]="$link"
+          let 'fid++'
+        done
+  fi
+done
+
+if [ "${#filelist[@]}" -gt 0 ]; then
+  for item in "${filelist[@]}"; do
+    print -r -- "$item"
+  done
+fi
+
+#### tree-sitter-zsh example mode dispatch with process substitution
+
+args=()
+if [[ -n $verbose ]]; then
+  args+=("--reporter=spec")
+else
+  args+=("--reporter=singleline")
+fi
+
+case ${mode} in
+  valgrind)
+    valgrind                                     \
+      --suppressions=./script/util/valgrind.supp \
+      --dsymutil=yes                             \
+      --leak-check=${leak_check}                 \
+      $cmd "${args[@]}" 2>&1 |                   \
+      grep --color -E '\w+_tests?.cc:\d+|$'
+    ;;
+
+  SVG)
+    $cmd "${args[@]}" 2> >(grep -v 'Assertion failed' | dot -Tsvg >> index.html)
+    ;;
+esac
+
+#### tree-sitter-zsh example filter function inside destination case
+
+html_replace_tokens () {
+  local url=$1
+  sed "s|@NAME@|$name|g" \
+    | sed "s|@URL@|$url|g" \
+    | perl -p -e 's/<h1([^>]*)>(.*?)<\/h1>/<h1>\2<\/h1>/g' \
+    | (if [ $(basename $(dirname $dest)) == "doc" ]; then
+        perl -p -e 's/ href="\.\.\// href="/g'
+      else
+        cat
+      fi)
+}
+
+case $dest in
+  *.[1357])
+    marked-man --roff $src | man_replace_tokens > $dest
+    exit $?
+    ;;
+  *.html)
+    (cat html/dochead.html && cat $src | marked && cat html/docfoot.html) \
+      | html_replace_tokens $url > $dest
+    ;;
+esac
+
+#### tree-sitter-zsh clean-core special parameter assignment
+
+0=${(%):-%N}


### PR DESCRIPTION
## Summary
- add the remaining tree-sitter-zsh example-shaped cases to the zsh obscure parser fixture
- mirror those cases into the `.zsh` linter stress source so path-based dialect inference is exercised too
- keep the precise upstream unit coverage and the lexer fix for path-style glob modifiers like `/path/file(:h)`

## Why
The earlier unit-test import pass was useful and surfaced three parser bugs. The cases left in the matrix were broader script-shaped examples rather than tight AST assertions, so this PR layers them into regression fixtures where they belong.

## Validation
- `cargo fmt`
- `cargo test -p shuck-parser`
- `cargo test -p shuck-linter`
