### PR TITLE
fix(linter): honor zsh split state in split facts

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -1048,6 +1048,7 @@ fn build_word_occurrence_index(
                 runtime_literal: RuntimeLiteralAnalysis::default(),
                 operand_class: None,
                 enclosing_expansion_context: Some(pending.enclosing_expansion_context),
+                split_sensitive_unquoted_command_substitution_spans: IdRange::empty(),
                 array_assignment_split_scalar_expansion_spans: IdRange::empty(),
             }),
     );

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1349,16 +1349,21 @@ fn collect_array_assignment_split_scalar_expansion_spans(
     let fact = &word_occurrences[id.index()];
     let word = occurrence_word(word_nodes, fact);
     let derived = word_node_derived(&word_nodes[fact.node_id.index()]);
-    split_sensitive_spans.extend(
-        fact_store
-            .word_spans(derived.unquoted_scalar_expansion_spans)
-            .iter()
-            .copied(),
-    );
+    if word_nodes[fact.node_id.index()]
+        .analysis
+        .can_expand_to_multiple_fields
+    {
+        split_sensitive_spans.extend(
+            fact_store
+                .word_spans(derived.unquoted_scalar_expansion_spans)
+                .iter()
+                .copied(),
+        );
+    }
 
     let fact_span = occurrence_span(word_nodes, fact);
     let unquoted_command_substitution_spans =
-        fact_store.word_spans(derived.unquoted_command_substitution_spans);
+        fact_store.word_spans(fact.split_sensitive_unquoted_command_substitution_spans);
 
     if !unquoted_command_substitution_spans.is_empty() {
         // commands is sorted by start offset (compare_command_facts_by_offset),

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -2272,6 +2272,15 @@ fn builds_word_facts_for_filename_builder_command_substitutions() {
             "parts: {:?}",
             fact.word().parts
         );
+        assert_eq!(
+            fact.split_sensitive_unquoted_command_substitution_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(echo ${KERNEL} | tr '-' '_')"],
+            "parts: {:?}",
+            fact.word().parts
+        );
     });
 }
 

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -38,6 +38,7 @@ pub struct WordOccurrence {
     pub(super) runtime_literal: RuntimeLiteralAnalysis,
     pub(super) operand_class: Option<TestOperandClass>,
     pub(super) enclosing_expansion_context: Option<ExpansionContext>,
+    pub(super) split_sensitive_unquoted_command_substitution_spans: IdRange<Span>,
     pub(super) array_assignment_split_scalar_expansion_spans: IdRange<Span>,
 }
 
@@ -388,6 +389,12 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.facts
             .fact_store
             .word_spans(self.derived().unquoted_command_substitution_spans)
+    }
+
+    pub fn split_sensitive_unquoted_command_substitution_spans(self) -> &'facts [Span] {
+        self.facts
+            .fact_store
+            .word_spans(self.occurrence().split_sensitive_unquoted_command_substitution_spans)
     }
 
     pub fn unquoted_dollar_paren_command_substitution_spans(self) -> &'facts [Span] {
@@ -1261,6 +1268,31 @@ pub(super) fn simple_command_word_at(command: &SimpleCommand, index: usize) -> &
         &command.name
     } else {
         &command.args[index - 1]
+    }
+}
+
+fn collect_split_sensitive_unquoted_command_substitution_spans(
+    parts: &[WordPartNode],
+    quoted: bool,
+    options: Option<&ZshOptionState>,
+    spans: &mut Vec<Span>,
+) {
+    for part in parts {
+        match &part.kind {
+            WordPart::SingleQuoted { .. } => {}
+            WordPart::DoubleQuoted { parts, .. } => {
+                collect_split_sensitive_unquoted_command_substitution_spans(
+                    parts, true, options, spans,
+                );
+            }
+            WordPart::CommandSubstitution { .. }
+                if !quoted
+                    && analyze_part(&part.kind, quoted, options).can_expand_to_multiple_fields =>
+            {
+                spans.push(part.span);
+            }
+            _ => {}
+        }
     }
 }
 
@@ -2252,6 +2284,15 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             | WordFactContext::CaseSubject
             | WordFactContext::ArithmeticCommand => None,
         };
+        self.word_span_scratch.clear();
+        collect_split_sensitive_unquoted_command_substitution_spans(
+            &word.parts,
+            false,
+            self.command_zsh_options.as_ref(),
+            self.word_span_scratch,
+        );
+        let split_sensitive_unquoted_command_substitution_spans =
+            self.word_spans.push_many(self.word_span_scratch.drain(..));
         let id = WordOccurrenceId::new(self.word_occurrences.len());
         self.word_occurrences.push(WordOccurrence {
             node_id,
@@ -2262,6 +2303,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             runtime_literal,
             operand_class,
             enclosing_expansion_context: None,
+            split_sensitive_unquoted_command_substitution_spans,
             array_assignment_split_scalar_expansion_spans: IdRange::empty(),
         });
         if let WordFactContext::Expansion(enclosing_expansion_context) = context {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2291,6 +2291,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             self.command_zsh_options.as_ref(),
             self.word_span_scratch,
         );
+        word_spans::normalize_command_substitution_spans(self.word_span_scratch, self.locator);
         let split_sensitive_unquoted_command_substitution_spans =
             self.word_spans.push_many(self.word_span_scratch.drain(..));
         let id = WordOccurrenceId::new(self.word_occurrences.len());

--- a/crates/shuck-linter/src/rules/style/command_output_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/command_output_array_split.rs
@@ -16,7 +16,11 @@ pub fn command_output_array_split(checker: &mut Checker) {
     let spans = checker
         .facts()
         .array_assignment_split_word_facts()
-        .flat_map(|fact| fact.unquoted_command_substitution_spans().iter().copied())
+        .flat_map(|fact| {
+            fact.split_sensitive_unquoted_command_substitution_spans()
+                .iter()
+                .copied()
+        })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || CommandOutputArraySplit);
@@ -27,7 +31,7 @@ mod tests {
     use std::path::Path;
 
     use crate::test::{test_snippet, test_snippet_at_path};
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_unquoted_command_substitutions_in_array_assignments() {
@@ -152,6 +156,23 @@ check() {
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$(printf '%s\\n' 'Solarized (dark)' base16)"]
+        );
+    }
+
+    #[test]
+    fn skips_native_zsh_array_command_substitutions_without_split_behavior() {
+        let source = "arr=($(cmd))\nsetopt sh_word_split\narr=($(cmd))\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CommandOutputArraySplit).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(cmd)"]
         );
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
@@ -196,6 +196,23 @@ arr=(${flag:+-f} ${flag:+$fallback} ${name:+\"$name\" \"$regex\"} ${items[@]+\"$
     }
 
     #[test]
+    fn skips_native_zsh_scalar_array_elements_without_split_behavior() {
+        let source = "arr=($name)\nsetopt sh_word_split\narr=($name)\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedArraySplit).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$name"]
+        );
+    }
+
+    #[test]
     fn ignores_expansions_inside_brace_expansion_templates() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -45,7 +45,7 @@ pub fn unquoted_command_substitution(checker: &mut Checker) {
         .word_facts()
         .iter()
         .flat_map(|fact| {
-            fact.unquoted_command_substitution_spans()
+            fact.split_sensitive_unquoted_command_substitution_spans()
                 .iter()
                 .copied()
                 .filter(|span| {
@@ -460,6 +460,24 @@ kill $(cat \"$pidfile\")
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$(cat \"$pidfile\")"]
+        );
+    }
+
+    #[test]
+    fn skips_native_zsh_command_substitutions_without_split_behavior() {
+        let source = "print $(cmd)\nsetopt sh_word_split\nprint $(cmd)\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(cmd)"]
         );
     }
 


### PR DESCRIPTION
## Summary

- Add split-sensitive command substitution spans to word facts so split-oriented style rules can consume option-aware facts.
- Filter array assignment split scalar spans through the existing expansion analysis, so native zsh does not report split diagnostics unless `sh_word_split` or equivalent behavior is active.
- Add zsh regression coverage for `S004`, `S017`, and `S018`.

## Validation

- `cargo check -p shuck-linter`
- `cargo test -p shuck-linter unquoted_command_substitution --lib`
- `cargo test -p shuck-linter unquoted_array_split --lib`
- `cargo test -p shuck-linter command_output_array_split --lib`
- `cargo test -p shuck-linter --lib`
- `cargo test -p shuck-cli --lib`