### PR TITLE
fix(linter): account for zsh glob_subst in loop facts

### DIFF
--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -2075,6 +2075,47 @@ print $name
 }
 
 #[test]
+fn builds_glob_subst_for_list_fanout_facts_for_zsh_words() {
+    let source = "\
+#!/usr/bin/env zsh
+setopt glob_subst
+for item in $name; do :; done
+setopt no_glob
+for item in $literal; do :; done
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            let glob_subst = facts
+                .expansion_word_facts(ExpansionContext::ForList)
+                .find(|fact| fact.span().slice(source) == "$name")
+                .expect("expected glob_subst for-list fact");
+            let no_glob = facts
+                .expansion_word_facts(ExpansionContext::ForList)
+                .find(|fact| fact.span().slice(source) == "$literal")
+                .expect("expected no_glob for-list fact");
+
+            assert_eq!(
+                glob_subst.analysis().pathname_expansion_behavior,
+                PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted
+            );
+            assert!(glob_subst.analysis().hazards.pathname_matching);
+            assert!(glob_subst.analysis().can_expand_to_multiple_fields);
+            assert_eq!(
+                no_glob.analysis().pathname_expansion_behavior,
+                PathnameExpansionBehavior::Disabled
+            );
+            assert!(!no_glob.analysis().hazards.pathname_matching);
+            assert!(!no_glob.analysis().can_expand_to_multiple_fields);
+        },
+    );
+}
+
+#[test]
 fn builds_flow_merged_literal_only_pathname_behaviors_for_zsh_words() {
     let source = "\
 #!/usr/bin/env zsh

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -259,6 +259,35 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.node().analysis
     }
 
+    pub fn can_expand_to_multiple_fields_at_runtime(self, locator: Locator<'_>) -> bool {
+        let analysis = self.analysis();
+        let runtime_hazards = self.runtime_literal().hazards;
+
+        runtime_hazards.pathname_matching
+            || runtime_hazards.brace_fanout
+            || analysis.hazards.pathname_matching
+            || analysis.hazards.brace_fanout
+            || analysis.array_valued
+            || analysis.can_expand_to_multiple_fields
+            || self.has_direct_all_elements_array_expansion_in_source(locator)
+    }
+
+    pub fn is_single_for_list_item(self, locator: Locator<'_>) -> bool {
+        if self.context() != WordFactContext::Expansion(ExpansionContext::ForList) {
+            return false;
+        }
+
+        let analysis = self.analysis();
+        if analysis.quote == WordQuote::FullyQuoted
+            && analysis.literalness == WordLiteralness::Expanded
+            && self.double_quoted_scalar_affix_span().is_none()
+        {
+            return false;
+        }
+
+        !self.can_expand_to_multiple_fields_at_runtime(locator)
+    }
+
     pub fn runtime_literal(self) -> RuntimeLiteralAnalysis {
         self.occurrence().runtime_literal
     }

--- a/crates/shuck-linter/src/rules/style/single_iteration_loop.rs
+++ b/crates/shuck-linter/src/rules/style/single_iteration_loop.rs
@@ -1,6 +1,4 @@
-use crate::{
-    Checker, ExpansionContext, Rule, Violation, WordFactContext, WordLiteralness, WordQuote,
-};
+use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext};
 
 pub struct SingleIterationLoop;
 
@@ -30,29 +28,7 @@ pub fn single_iteration_loop(checker: &mut Checker) {
                 word.span(),
                 WordFactContext::Expansion(ExpansionContext::ForList),
             )?;
-            let analysis = fact.analysis();
-            if analysis.quote == WordQuote::FullyQuoted
-                && analysis.literalness == WordLiteralness::Expanded
-                && fact.double_quoted_scalar_affix_span().is_none()
-            {
-                return None;
-            }
-            if fact.has_direct_all_elements_array_expansion_in_source(locator) {
-                return None;
-            }
-            let runtime_hazards = fact.runtime_literal().hazards;
-            let hazards = analysis.hazards;
-            if runtime_hazards.pathname_matching
-                || runtime_hazards.brace_fanout
-                || hazards.pathname_matching
-                || hazards.brace_fanout
-                || analysis.array_valued
-                || analysis.can_expand_to_multiple_fields
-            {
-                return None;
-            }
-
-            Some(word.span())
+            fact.is_single_for_list_item(locator).then_some(word.span())
         })
         .collect::<Vec<_>>();
 
@@ -62,7 +38,7 @@ pub fn single_iteration_loop(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_only_single_literal_for_list_items() {
@@ -127,6 +103,61 @@ done
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["a", "\"${dir}\"/x.patch", "\"$(printf /tmp)\"/x.patch", "~"]
+        );
+    }
+
+    #[test]
+    fn skips_zsh_for_list_scalars_when_glob_subst_can_fan_out() {
+        let source = "\
+setopt glob_subst
+for item in $name; do
+\tprint -r -- \"$item\"
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SingleIterationLoop).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn skips_zsh_for_list_scalars_when_dynamic_glob_subst_is_ambiguous() {
+        let source = "\
+opt=glob_subst
+setopt \"$opt\"
+for item in $name; do
+\tprint -r -- \"$item\"
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SingleIterationLoop).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_for_list_scalars_when_no_glob_masks_glob_subst() {
+        let source = "\
+setopt glob_subst no_glob
+for item in $name; do
+\tprint -r -- \"$item\"
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SingleIterationLoop).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$name"]
         );
     }
 }


### PR DESCRIPTION
## Summary
- Move S020's for-list fanout decision behind reusable word-fact helpers.
- Treat zsh `glob_subst` substitution-result globbing as runtime fanout for single-iteration loop detection.
- Add fact-layer and S020 regressions for `glob_subst`, dynamic option state, and `no_glob` masking.

## Validation
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S001,S020`
- `cargo fmt --check`
- `git diff --check`