### PR TITLE
fix(linter): account for zsh array fanout in word facts

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-option-state/rc-expand-param.toml
+++ b/crates/shuck-cli/tests/testdata/zsh-option-state/rc-expand-param.toml
@@ -1,0 +1,80 @@
+name = "rc_expand_param array fanout"
+source = '''
+arr=(a b)
+__shuck_probe_options native rcexpandparam ksharrays
+__shuck_probe_fields native $arr
+__shuck_probe_fields native_affix ${arr}x
+setopt rc_expand_param
+__shuck_probe_options rc_on rcexpandparam
+__shuck_probe_fields rc_affix ${arr}x
+__shuck_probe_fields force_rc ${^arr}x
+__shuck_probe_fields force_rc_off ${^^arr}x
+setopt ksh_arrays
+__shuck_probe_options ksh_arrays rcexpandparam ksharrays
+__shuck_probe_fields ksh_affix ${arr}x
+'''
+
+[option_probes.native]
+rcexpandparam = "off"
+ksharrays = "off"
+
+[option_probes.rc_on]
+rcexpandparam = "on"
+
+[option_probes.ksh_arrays]
+rcexpandparam = "on"
+ksharrays = "on"
+
+[field_probes.native]
+count = 2
+values = ["a", "b"]
+
+[field_probes.native.shuck]
+multi = true
+field_splitting = false
+pathname_matching = false
+
+[field_probes.native_affix]
+count = 2
+values = ["a", "bx"]
+
+[field_probes.native_affix.shuck]
+multi = true
+field_splitting = false
+pathname_matching = false
+
+[field_probes.rc_affix]
+count = 2
+values = ["ax", "bx"]
+
+[field_probes.rc_affix.shuck]
+multi = true
+field_splitting = false
+pathname_matching = false
+
+[field_probes.force_rc]
+count = 2
+values = ["ax", "bx"]
+
+[field_probes.force_rc.shuck]
+multi = true
+field_splitting = false
+pathname_matching = false
+
+[field_probes.force_rc_off]
+count = 2
+values = ["a", "bx"]
+
+[field_probes.force_rc_off.shuck]
+multi = true
+field_splitting = false
+pathname_matching = false
+
+[field_probes.ksh_affix]
+count = 1
+values = ["ax"]
+
+[field_probes.ksh_affix.shuck]
+multi = false
+field_splitting = false
+pathname_matching = false

--- a/crates/shuck-cli/tests/testdata/zsh-option-state/scope-and-arrays.toml
+++ b/crates/shuck-cli/tests/testdata/zsh-option-state/scope-and-arrays.toml
@@ -51,6 +51,16 @@ shwordsplit = "on"
 count = 2
 values = ["one", "two"]
 
+[field_probes.array_native.shuck]
+multi = true
+field_splitting = false
+pathname_matching = false
+
 [field_probes.array_ksh]
 count = 1
 values = ["one"]
+
+[field_probes.array_ksh.shuck]
+multi = false
+field_splitting = false
+pathname_matching = false

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -57,9 +57,9 @@ use shuck_ast::{
     Position, PrefixMatchKind, Redirect, RedirectKind, SelectCommand, SimpleCommand, SourceText,
     Span, StaticCommandWrapperTarget, Stmt, StmtSeq, StmtTerminator, Subscript, SubscriptSelector,
     TextRange, TextSize, VarRef, WhileCommand, Word, WordPart, WordPartNode, ZshExpansionOperation,
-    ZshExpansionTarget, ZshGlobSegment, ZshQualifiedGlob, is_shell_variable_name,
-    static_command_name_text, static_command_wrapper_target_index, static_word_text,
-    word_is_standalone_status_capture,
+    ZshExpansionTarget, ZshGlobSegment, ZshParameterExpansion, ZshQualifiedGlob,
+    is_shell_variable_name, static_command_name_text, static_command_wrapper_target_index,
+    static_word_text, word_is_standalone_status_capture,
 };
 use shuck_indexer::{Indexer, LineIndex};
 #[cfg(test)]

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -908,6 +908,119 @@ pub(super) fn build_unquoted_command_argument_use_offsets(
     offsets_by_name
 }
 
+fn apply_zsh_array_fanout(
+    word: &Word,
+    semantic: &SemanticModel,
+    scope: ScopeId,
+    options: Option<&ZshOptionState>,
+    analysis: &mut ExpansionAnalysis,
+) {
+    if semantic.shell_profile().dialect != shuck_parser::parser::ShellDialect::Zsh
+        || zsh_unindexed_array_fanout_is_disabled(options)
+        || !word_has_unquoted_visible_array_reference(word, semantic, scope)
+    {
+        return;
+    }
+
+    analysis.array_valued = true;
+    analysis.can_expand_to_multiple_fields = true;
+    if !matches!(analysis.value_shape, ExpansionValueShape::Unknown) {
+        analysis.value_shape = ExpansionValueShape::MultiField;
+    }
+}
+
+fn zsh_unindexed_array_fanout_is_disabled(options: Option<&ZshOptionState>) -> bool {
+    matches!(options.map(|options| options.ksh_arrays), Some(OptionValue::On))
+}
+
+fn word_has_unquoted_visible_array_reference(
+    word: &Word,
+    semantic: &SemanticModel,
+    scope: ScopeId,
+) -> bool {
+    parts_have_unquoted_visible_array_reference(&word.parts, semantic, scope, false)
+}
+
+fn parts_have_unquoted_visible_array_reference(
+    parts: &[WordPartNode],
+    semantic: &SemanticModel,
+    scope: ScopeId,
+    in_double_quotes: bool,
+) -> bool {
+    for part in parts {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => {
+                if parts_have_unquoted_visible_array_reference(parts, semantic, scope, true) {
+                    return true;
+                }
+            }
+            WordPart::Variable(name) if !in_double_quotes => {
+                if visible_name_is_array_like(name, part.span, semantic, scope) {
+                    return true;
+                }
+            }
+            WordPart::Parameter(parameter) if !in_double_quotes => {
+                if zsh_parameter_targets_visible_array(parameter, semantic, scope) {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}
+
+fn zsh_parameter_targets_visible_array(
+    parameter: &ParameterExpansion,
+    semantic: &SemanticModel,
+    scope: ScopeId,
+) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+        | ParameterExpansionSyntax::Zsh(ZshParameterExpansion {
+            target: ZshExpansionTarget::Reference(reference),
+            length_prefix: None,
+            ..
+        }) if reference.subscript.is_none() => {
+            visible_name_is_array_like(&reference.name, reference.name_span, semantic, scope)
+        }
+        _ => false,
+    }
+}
+
+fn visible_name_is_array_like(
+    name: &Name,
+    span: Span,
+    semantic: &SemanticModel,
+    scope: ScopeId,
+) -> bool {
+    semantic
+        .analysis()
+        .value_flow()
+        .reaching_value_bindings_for_name_with_synthetic_use_block(
+            name,
+            span,
+            Some(
+                semantic
+                    .analysis()
+                    .flow_entry_block_for_binding_scopes(&[scope], span.start.offset),
+            ),
+        )
+        .into_iter()
+        .any(|binding_id| binding_is_array_like(semantic.binding(binding_id)))
+}
+
+fn binding_is_array_like(binding: &Binding) -> bool {
+    binding
+        .attributes
+        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+        || matches!(
+            binding.kind,
+            BindingKind::ArrayAssignment | BindingKind::MapfileTarget
+        )
+}
+
 #[cfg_attr(shuck_profiling, inline(never))]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn build_word_facts_for_command<'a>(
@@ -2221,7 +2334,14 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }
 
         let id = WordNodeId::new(self.word_nodes.len());
-        let analysis = analyze_word(word, self.source, self.command_zsh_options.as_ref());
+        let mut analysis = analyze_word(word, self.source, self.command_zsh_options.as_ref());
+        apply_zsh_array_fanout(
+            word,
+            self.semantic,
+            self.command_scope,
+            self.command_zsh_options.as_ref(),
+            &mut analysis,
+        );
         let derived =
             derive_word_fact_data(word, self.locator, self.word_spans, self.word_span_scratch);
         self.word_nodes.push(WordNode {

--- a/crates/shuck-linter/src/rules/style/single_iteration_loop.rs
+++ b/crates/shuck-linter/src/rules/style/single_iteration_loop.rs
@@ -160,4 +160,30 @@ done
             vec!["$name"]
         );
     }
+
+    #[test]
+    fn zsh_array_fanout_comes_from_word_facts() {
+        let source = "\
+arr=(a b)
+for item in ${arr}x; do
+\tprint -r -- $item
+done
+setopt ksh_arrays
+for item in ${arr}x; do
+\tprint -r -- $item
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SingleIterationLoop).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${arr}x"]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Mark unquoted zsh array references as array-valued and multi-field during word fact construction using semantic value-flow and option state.
- Keep S020 and other rules consuming the existing fact fields rather than checking zsh options directly.
- Add black-box zsh fixture coverage for native array fanout, `rc_expand_param`, `${^arr}`, `${^^arr}`, and `ksh_arrays`.

## Root Cause

The zsh option state was available in semantic/fact construction, but word expansion facts did not upgrade unquoted known-array references to multi-field fanout. Rules such as S020 therefore had no fact-level signal for those zsh array cases.

## Validation

- `cargo fmt`
- `cargo test -p shuck-cli zsh_option_state_fixtures_match_black_box_behavior -- --nocapture`
- `cargo test -p shuck-linter zsh_array_fanout_comes_from_word_facts -- --nocapture`
- `make test`