### PR TITLE
fix(linter): respect zsh equals in assignment facts

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -240,7 +240,7 @@ fn bare_command_name_assignment_span<'a>(
     }
 
     let text = occurrence_static_text(word_nodes, fact, source)?;
-    if !is_bare_command_name_assignment_value(&text) {
+    if !is_bare_command_name_assignment_value(&text, command.zsh_options()) {
         return None;
     }
 
@@ -295,7 +295,8 @@ fn assignment_target_span(assignment: &Assignment) -> Span {
     )
 }
 
-fn is_bare_command_name_assignment_value(text: &str) -> bool {
+fn is_bare_command_name_assignment_value(text: &str, zsh_options: Option<&ZshOptionState>) -> bool {
+    let text = zsh_literal_assignment_value_for_command_name_check(text, zsh_options);
     matches!(
         text,
         "admin"
@@ -402,6 +403,22 @@ fn is_bare_command_name_assignment_value(text: &str) -> bool {
             | "xargs"
             | "zcat"
     )
+}
+
+fn zsh_literal_assignment_value_for_command_name_check<'a>(
+    text: &'a str,
+    zsh_options: Option<&ZshOptionState>,
+) -> &'a str {
+    let Some(candidate) = text.strip_prefix('=') else {
+        return text;
+    };
+    let Some(options) = zsh_options else {
+        return text;
+    };
+    if !options.equals.is_definitely_off() {
+        return text;
+    }
+    candidate
 }
 
 #[derive(Debug, Default)]

--- a/crates/shuck-linter/src/facts/tests/assignments.rs
+++ b/crates/shuck-linter/src/facts/tests/assignments.rs
@@ -302,6 +302,40 @@ name+=still_ok
 }
 
 #[test]
+fn bare_command_name_assignments_respect_zsh_equals_option() {
+    let source = "\
+#!/bin/zsh
+unsetopt equals
+tool==grep run
+setopt magic_equal_subst
+magic_literal==grep run
+setopt equals
+path==grep run
+if cond; then
+  unsetopt equals
+fi
+maybe==grep run
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            assert_eq!(
+                facts
+                    .bare_command_name_assignment_spans()
+                    .iter()
+                    .map(|span| span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec!["tool==grep run", "magic_literal==grep run"]
+            );
+        },
+    );
+}
+
+#[test]
 fn ignores_assignment_like_text_after_literal_arrow_prefix() {
     let source = r#"#!/bin/bash
 rvm_info="

--- a/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
+++ b/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
@@ -78,4 +78,31 @@ f() {
 
         assert!(diagnostics.is_empty());
     }
+
+    #[test]
+    fn respects_zsh_equals_path_expansion_for_assignment_values() {
+        let source = "\
+#!/bin/zsh
+unsetopt equals
+tool==grep run
+setopt magic_equal_subst
+magic_literal==grep run
+setopt equals
+path==grep run
+setopt magic_equal_subst
+magic==grep run
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::BareCommandNameAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["tool==grep run", "magic_literal==grep run"]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Teach the bare command-name assignment fact builder to account for zsh `equals` option state when evaluating literal assignment values like `=grep`.
- Keep `magic_equal_subst` covered in regression cases so it does not mask literal values when `equals` is disabled.
- Add fact-level and rule-level tests for the zsh option-sensitive behavior.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-linter`