### PR TITLE
fix(linter): account for zsh file expansion order

### DIFF
--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -67,12 +67,12 @@ use shuck_parser::parser::Parser;
 use shuck_semantic::{
     ArithmeticLiteralBehavior, Binding, BindingAttributes, BindingId, BindingKind, CaseCliDispatch,
     Declaration, DeclarationBuiltin, DeclarationOperand as SemanticDeclarationOperand,
-    FieldSplittingBehavior, GlobDotBehavior, GlobFailureBehavior, GlobPatternBehavior,
-    NonpersistentAssignmentAnalysisContext, NonpersistentAssignmentAnalysisOptions,
-    NonpersistentAssignmentCommandContext, NonpersistentAssignmentExtraRead, OptionValue,
-    PathnameExpansionBehavior, PatternOperatorBehavior, Reference, ReferenceId, ReferenceKind,
-    ScopeId, SemanticAnalysis, SemanticModel, SemanticPipelineOperatorKind, SubscriptIndexBehavior,
-    ZshOptionState,
+    FieldSplittingBehavior, FileExpansionOrderBehavior, GlobDotBehavior, GlobFailureBehavior,
+    GlobPatternBehavior, NonpersistentAssignmentAnalysisContext,
+    NonpersistentAssignmentAnalysisOptions, NonpersistentAssignmentCommandContext,
+    NonpersistentAssignmentExtraRead, OptionValue, PathnameExpansionBehavior,
+    PatternOperatorBehavior, Reference, ReferenceId, ReferenceKind, ScopeId, SemanticAnalysis,
+    SemanticModel, SemanticPipelineOperatorKind, SubscriptIndexBehavior, ZshOptionState,
 };
 use smallvec::SmallVec;
 use std::{borrow::Cow, ops::ControlFlow, sync::OnceLock};

--- a/crates/shuck-linter/src/facts/words/expansion.rs
+++ b/crates/shuck-linter/src/facts/words/expansion.rs
@@ -336,6 +336,19 @@ pub(super) fn pathname_expansion_behavior_for_options(
     }
 }
 
+pub(super) fn file_expansion_order_for_options(
+    options: Option<&ZshOptionState>,
+) -> FileExpansionOrderBehavior {
+    match options {
+        Some(options) => match options.sh_file_expansion {
+            OptionValue::Off => FileExpansionOrderBehavior::AfterParameterExpansion,
+            OptionValue::On => FileExpansionOrderBehavior::BeforeParameterExpansion,
+            OptionValue::Unknown => FileExpansionOrderBehavior::Ambiguous,
+        },
+        None => FileExpansionOrderBehavior::BeforeParameterExpansion,
+    }
+}
+
 pub(super) fn glob_failure_behavior_for_options(
     options: Option<&ZshOptionState>,
 ) -> GlobFailureBehavior {
@@ -567,6 +580,7 @@ pub(crate) fn analyze_literal_runtime(
 pub(super) struct RuntimeLiteralState {
     seen_text: bool,
     last_unquoted_char: Option<char>,
+    deferred_tilde: bool,
 }
 
 pub(super) fn analyze_literal_runtime_parts(
@@ -589,34 +603,40 @@ pub(super) fn analyze_literal_runtime_parts(
                 );
             }
             WordPart::SingleQuoted { value, .. } => {
+                cancel_deferred_tilde(state);
                 if !value.slice(source).is_empty() {
                     state.seen_text = true;
                     state.last_unquoted_char = None;
                 }
             }
             WordPart::DoubleQuoted { parts, .. } => {
+                cancel_deferred_tilde(state);
                 if !parts.is_empty() {
                     state.seen_text = true;
                     state.last_unquoted_char = None;
                 }
             }
-            _ => {}
+            _ => cancel_deferred_tilde(state),
         }
     }
+
+    flush_deferred_tilde(state, analysis);
 }
 
 pub(super) fn scan_literal_runtime_text(
     text: &str,
     context: ExpansionContext,
-    _options: Option<&ZshOptionState>,
+    options: Option<&ZshOptionState>,
     state: &mut RuntimeLiteralState,
     analysis: &mut RuntimeLiteralAnalysis,
 ) {
     let mut escaped = false;
     let mut brace_candidate: Option<usize> = None;
+    let file_expansion_order = file_expansion_order_for_options(options);
 
     for (idx, ch) in text.char_indices() {
         if escaped {
+            cancel_deferred_tilde(state);
             escaped = false;
             state.seen_text = true;
             state.last_unquoted_char = Some(ch);
@@ -624,14 +644,25 @@ pub(super) fn scan_literal_runtime_text(
         }
 
         if ch == '\\' {
+            cancel_deferred_tilde(state);
             escaped = true;
             state.seen_text = true;
             continue;
         }
 
         if context_allows_tilde(context) && ch == '~' && tilde_is_runtime_sensitive(state) {
-            analysis.runtime_sensitive = true;
-            analysis.hazards.tilde_expansion = true;
+            match file_expansion_order {
+                FileExpansionOrderBehavior::BeforeParameterExpansion => {
+                    state.deferred_tilde = true;
+                }
+                FileExpansionOrderBehavior::AfterParameterExpansion
+                | FileExpansionOrderBehavior::Ambiguous => {
+                    analysis.runtime_sensitive = true;
+                    analysis.hazards.tilde_expansion = true;
+                }
+            }
+        } else if state.deferred_tilde && ch == '/' {
+            flush_deferred_tilde(state, analysis);
         }
 
         if context_allows_pathname_matching(context)
@@ -659,6 +690,21 @@ pub(super) fn scan_literal_runtime_text(
         state.seen_text = true;
         state.last_unquoted_char = Some(ch);
     }
+}
+
+fn flush_deferred_tilde(
+    state: &mut RuntimeLiteralState,
+    analysis: &mut RuntimeLiteralAnalysis,
+) {
+    if state.deferred_tilde {
+        analysis.runtime_sensitive = true;
+        analysis.hazards.tilde_expansion = true;
+        state.deferred_tilde = false;
+    }
+}
+
+fn cancel_deferred_tilde(state: &mut RuntimeLiteralState) {
+    state.deferred_tilde = false;
 }
 
 pub(super) fn tilde_is_runtime_sensitive(state: &RuntimeLiteralState) -> bool {

--- a/crates/shuck-linter/src/facts/words/tests.rs
+++ b/crates/shuck-linter/src/facts/words/tests.rs
@@ -522,6 +522,63 @@ mod expansion_analysis_tests {
     }
 
     #[test]
+    fn analyze_literal_runtime_respects_sh_file_expansion_tilde_order() {
+        let source = "print ~$USER ~root/$USER ~/\"$USER\" ~$USER/x\n";
+        let words = parse_argument_words(source);
+        let native_options = shuck_semantic::ZshOptionState::zsh_default();
+        let sh_file_options = shuck_semantic::ZshOptionState {
+            sh_file_expansion: shuck_semantic::OptionValue::On,
+            ..shuck_semantic::ZshOptionState::zsh_default()
+        };
+        let unknown_options = shuck_semantic::ZshOptionState {
+            sh_file_expansion: shuck_semantic::OptionValue::Unknown,
+            ..shuck_semantic::ZshOptionState::zsh_default()
+        };
+
+        let native_dynamic_user = analyze_literal_runtime(
+            &words[0],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&native_options),
+        );
+        let sh_file_dynamic_user = analyze_literal_runtime(
+            &words[0],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&sh_file_options),
+        );
+        let sh_file_literal_user = analyze_literal_runtime(
+            &words[1],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&sh_file_options),
+        );
+        let sh_file_home = analyze_literal_runtime(
+            &words[2],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&sh_file_options),
+        );
+        let unknown_dynamic_user = analyze_literal_runtime(
+            &words[3],
+            source,
+            ExpansionContext::CommandArgument,
+            Some(&unknown_options),
+        );
+        let default_dynamic_user =
+            analyze_literal_runtime(&words[0], source, ExpansionContext::CommandArgument, None);
+
+        assert!(!default_dynamic_user.hazards.tilde_expansion);
+        assert!(!default_dynamic_user.is_runtime_sensitive());
+        assert!(native_dynamic_user.hazards.tilde_expansion);
+        assert!(!sh_file_dynamic_user.is_runtime_sensitive());
+        assert!(!sh_file_dynamic_user.hazards.tilde_expansion);
+        assert!(sh_file_literal_user.hazards.tilde_expansion);
+        assert!(sh_file_home.hazards.tilde_expansion);
+        assert!(unknown_dynamic_user.hazards.tilde_expansion);
+    }
+
+    #[test]
     fn analyze_literal_runtime_records_glob_failure_behavior() {
         let source = "print *.jpg\n";
         let words = parse_argument_words(source);

--- a/crates/shuck-semantic/src/glob.rs
+++ b/crates/shuck-semantic/src/glob.rs
@@ -48,6 +48,17 @@ impl PathnameExpansionBehavior {
     }
 }
 
+/// Whether zsh filename expansion runs before or after parameter expansion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileExpansionOrderBehavior {
+    /// Filename expansion runs before parameter expansion.
+    BeforeParameterExpansion,
+    /// Filename expansion runs after parameter expansion.
+    AfterParameterExpansion,
+    /// Runtime option state may select either order.
+    Ambiguous,
+}
+
 /// How unmatched glob patterns behave.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GlobFailureBehavior {
@@ -161,6 +172,22 @@ impl ShellBehaviorAt<'_> {
                 OptionValue::On => PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
                 OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
             },
+        }
+    }
+
+    /// Returns the filename-expansion order implied by the shell and runtime option state.
+    pub fn file_expansion_order(&self) -> FileExpansionOrderBehavior {
+        if self.shell != ShellDialect::Zsh {
+            return FileExpansionOrderBehavior::BeforeParameterExpansion;
+        }
+
+        match self
+            .effective_zsh_options()
+            .map(|options| options.sh_file_expansion)
+        {
+            Some(OptionValue::On) => FileExpansionOrderBehavior::BeforeParameterExpansion,
+            Some(OptionValue::Unknown) => FileExpansionOrderBehavior::Ambiguous,
+            Some(OptionValue::Off) | None => FileExpansionOrderBehavior::AfterParameterExpansion,
         }
     }
 
@@ -376,6 +403,43 @@ mod tests {
                 "{source}"
             );
         }
+    }
+
+    #[test]
+    fn file_expansion_order_tracks_sh_file_expansion_by_offset() {
+        let source = "\
+print ~$USER
+setopt sh_file_expansion
+print ~$USER
+unsetopt sh_file_expansion
+print ~$USER
+opt=sh_file_expansion
+setopt \"$opt\"
+print ~$USER
+";
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+        let first = source.find("print ~$USER").unwrap();
+        let enabled = source.find("print ~$USER\nunsetopt").unwrap();
+        let disabled = source.find("print ~$USER\nopt=").unwrap();
+        let ambiguous = source.rfind("print ~$USER").unwrap();
+
+        assert_eq!(
+            model.shell_behavior_at(first).file_expansion_order(),
+            FileExpansionOrderBehavior::AfterParameterExpansion,
+        );
+        assert_eq!(
+            model.shell_behavior_at(enabled).file_expansion_order(),
+            FileExpansionOrderBehavior::BeforeParameterExpansion,
+        );
+        assert_eq!(
+            model.shell_behavior_at(disabled).file_expansion_order(),
+            FileExpansionOrderBehavior::AfterParameterExpansion,
+        );
+        assert_eq!(
+            model.shell_behavior_at(ambiguous).file_expansion_order(),
+            FileExpansionOrderBehavior::Ambiguous,
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -63,8 +63,8 @@ pub use function_call_reachability::{
 };
 /// Option-sensitive globbing and expansion behavior queries.
 pub use glob::{
-    FieldSplittingBehavior, GlobDotBehavior, GlobFailureBehavior, GlobPatternBehavior,
-    PathnameExpansionBehavior, PatternOperatorBehavior,
+    FieldSplittingBehavior, FileExpansionOrderBehavior, GlobDotBehavior, GlobFailureBehavior,
+    GlobPatternBehavior, PathnameExpansionBehavior, PatternOperatorBehavior,
 };
 /// Nonpersistent assignment effects, such as assignments made in subshells and read later outside.
 pub use nonpersistent::{


### PR DESCRIPTION
## Summary

- Add a shared semantic `FileExpansionOrderBehavior` for zsh `SH_FILE_EXPANSION` state.
- Thread that behavior into linter word expansion facts so tilde filename expansion respects whether filename expansion runs before or after parameter expansion.
- Add focused semantic and linter fact tests for `SH_FILE_EXPANSION` ordering, without adding raw zsh option reads to S001, C012, or K001 rule files.

## Validation

- `cargo fmt`
- `cargo test -p shuck-semantic --lib`
- `cargo test -p shuck-linter --lib`
- `cargo test -p shuck-linter zsh_option --lib`
- `git diff --check`