### PR TITLE
fix(semantic): cache zsh function option summaries

### DIFF
--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -10174,3 +10174,37 @@ run_dispatcher enable_ksh
         "{source}"
     );
 }
+
+#[test]
+fn semantic_runtime_zsh_option_analysis_reuses_dynamic_function_summaries() {
+    let mut source = String::from("#!/bin/zsh\n");
+    for index in 0..12 {
+        source.push_str(&format!(
+            "\
+f{index}() {{
+  $dispatcher
+}}
+"
+        ));
+    }
+    source.push_str(
+        "\
+enable_ksh() {
+  emulate ksh
+}
+run_dispatcher() {
+  $dispatcher
+  print $name
+}
+run_dispatcher
+",
+    );
+
+    let model = model_with_profile(&source, ShellProfile::native(ShellDialect::Zsh));
+    let offset = source.find("print $name").unwrap();
+
+    assert_eq!(
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::Ambiguous
+    );
+}

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -58,7 +58,7 @@ enum LeakBehavior {
     Never,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum EmulationState {
     Zsh,
     Sh,
@@ -86,7 +86,7 @@ impl EmulationState {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct InternalState {
     public: ZshOptionState,
     local_options: OptionValue,
@@ -269,6 +269,7 @@ pub(crate) fn analyze(
         scope_entries: FxHashMap::default(),
         snapshots: FxHashMap::default(),
         active_function_scopes: FxHashSet::default(),
+        function_summaries: FxHashMap::default(),
     };
 
     analyzer.analyze_sequence(
@@ -350,6 +351,7 @@ pub(crate) fn function_runtime_analysis_with_entry(
         scope_entries: FxHashMap::default(),
         snapshots: FxHashMap::default(),
         active_function_scopes: FxHashSet::default(),
+        function_summaries: FxHashMap::default(),
     };
     analyzer.analyze_function_scope(
         function_scope,
@@ -432,6 +434,7 @@ struct Analyzer<'a> {
     scope_entries: FxHashMap<ScopeId, ZshOptionState>,
     snapshots: FxHashMap<ScopeId, Vec<ZshOptionSnapshot>>,
     active_function_scopes: FxHashSet<ScopeId>,
+    function_summaries: FxHashMap<(ScopeId, InternalState), FunctionSummary>,
 }
 
 impl<'a> Analyzer<'a> {
@@ -864,6 +867,11 @@ impl<'a> Analyzer<'a> {
     }
 
     fn analyze_function_scope(&mut self, scope: ScopeId, entry: EvalState) -> FunctionSummary {
+        let cache_key = (scope, entry.current.clone());
+        if let Some(summary) = self.function_summaries.get(&cache_key) {
+            return summary.clone();
+        }
+
         if !self.active_function_scopes.insert(scope) {
             return FunctionSummary {
                 final_outward: entry.outward,
@@ -874,10 +882,12 @@ impl<'a> Analyzer<'a> {
         let body = self.recorded_program.function_body(scope);
         let result = self.analyze_sequence(scope, body, entry, LeakBehavior::Function);
         self.active_function_scopes.remove(&scope);
-        FunctionSummary {
+        let summary = FunctionSummary {
             final_outward: result.outward,
             outward_touched: result.outward_touched,
-        }
+        };
+        self.function_summaries.insert(cache_key, summary.clone());
+        summary
     }
 
     fn resolve_visible_function_scope(


### PR DESCRIPTION
## Summary

- Cache zsh runtime option function summaries by function scope and entry option state.
- Add a regression test for repeated dynamic function dispatch in zsh option analysis.

## Root Cause

Large zsh-heavy files with unresolved or dynamic dispatch could repeatedly re-analyze the same visible function bodies from the same entry option state. On `powerlevel10k` and `zinit`, that repeated summary work grew enough to look like a hang.

## Validation

- `cargo test -p shuck-semantic zsh_option_analysis -- --nocapture`
- `cargo test -p shuck-semantic semantic_runtime_ksh_arrays_state -- --nocapture`
- `make test`
- `git diff --check`
- Reran `shuck check` over all cloned `/tmp/zsh` repos with a 120s timeout; no timeouts after the fix.