### PR TITLE
fix(linter): partition indexed array facts by behavior

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -674,10 +674,13 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 .copied(),
         );
         for fragment in &mut indexed_array_references {
-            let behavior = self
-                .semantic
-                .shell_behavior_at(fragment.span().start.offset)
-                .subscript_indexing();
+            let span = match fragment {
+                IndexedArrayReferenceFragmentFact::OneBased(fragment)
+                | IndexedArrayReferenceFragmentFact::ZeroBased(fragment)
+                | IndexedArrayReferenceFragmentFact::OneBasedWithZeroAlias(fragment)
+                | IndexedArrayReferenceFragmentFact::Ambiguous(fragment) => fragment.span(),
+            };
+            let behavior = self.semantic.shell_behavior_at(span.start.offset).subscript_indexing();
             *fragment = (*fragment).with_subscript_index_behavior(behavior);
         }
         let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -31,12 +31,12 @@ use self::{
     presence::{PresenceTestNameFact, PresenceTestReferenceFact, build_presence_tested_names},
     surface::{
         CaseModificationFragmentFact, CasePatternExpansionFact, DollarDoubleQuotedFragmentFact,
-        IndexedArrayReferenceFragmentFact, IndirectExpansionFragmentFact,
-        NestedParameterExpansionFragmentFact, OpenDoubleQuoteFragmentFact,
-        ParameterPatternSpecialTargetFragmentFact, PositionalParameterTrimFragmentFact,
-        ReplacementExpansionFragmentFact, SubstringExpansionFragmentFact, SurfaceFragmentFacts,
-        SurfaceFragmentSink, SurfaceScanContext, SuspectClosingQuoteFragmentFact,
-        ZshParameterIndexFlagFragmentFact, build_subscript_later_suppression_reference_spans,
+        IndirectExpansionFragmentFact, NestedParameterExpansionFragmentFact,
+        OpenDoubleQuoteFragmentFact, ParameterPatternSpecialTargetFragmentFact,
+        PositionalParameterTrimFragmentFact, ReplacementExpansionFragmentFact,
+        SubstringExpansionFragmentFact, SurfaceFragmentFacts, SurfaceFragmentSink,
+        SurfaceScanContext, SuspectClosingQuoteFragmentFact, ZshParameterIndexFlagFragmentFact,
+        build_subscript_later_suppression_reference_spans,
         build_suppressed_subscript_reference_spans, rewrite_pattern_as_single_double_quoted_string,
         rewrite_word_as_single_double_quoted_string,
     },
@@ -98,7 +98,8 @@ pub use self::normalized_commands::{
 };
 pub use self::surface::{
     AmbiguousArrayReference, ArithmeticLiteralFact, BacktickFragmentFact,
-    LegacyArithmeticFragmentFact, NativeZshScalarArrayReference, PlainUnindexedArrayReferenceFact,
+    IndexedArrayReferenceFragment, IndexedArrayReferenceFragmentFact, LegacyArithmeticFragmentFact,
+    NativeZshScalarArrayReference, PlainUnindexedArrayReferenceFact,
     PositionalParameterFragmentFact, SelectorRequiredArrayReference, SingleQuotedFragmentFact,
 };
 

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -218,31 +218,58 @@ impl IndirectExpansionFragmentFact {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct IndexedArrayReferenceFragmentFact {
-    span: Span,
-    plain: bool,
-    subscript_index_behavior: SubscriptIndexBehavior,
+pub enum IndexedArrayReferenceFragmentFact {
+    OneBased(IndexedArrayReferenceFragment),
+    ZeroBased(IndexedArrayReferenceFragment),
+    OneBasedWithZeroAlias(IndexedArrayReferenceFragment),
+    Ambiguous(IndexedArrayReferenceFragment),
 }
 
 impl IndexedArrayReferenceFragmentFact {
+    pub(super) fn new(span: Span, plain: bool) -> Self {
+        Self::Ambiguous(IndexedArrayReferenceFragment { span, plain })
+    }
+
+    pub(super) fn with_plain(mut self, plain: bool) -> Self {
+        match &mut self {
+            Self::OneBased(fragment)
+            | Self::ZeroBased(fragment)
+            | Self::OneBasedWithZeroAlias(fragment)
+            | Self::Ambiguous(fragment) => fragment.plain |= plain,
+        }
+        self
+    }
+
+    pub(super) fn with_subscript_index_behavior(self, behavior: SubscriptIndexBehavior) -> Self {
+        let fragment = match self {
+            Self::OneBased(fragment)
+            | Self::ZeroBased(fragment)
+            | Self::OneBasedWithZeroAlias(fragment)
+            | Self::Ambiguous(fragment) => fragment,
+        };
+
+        match behavior {
+            SubscriptIndexBehavior::OneBased => Self::OneBased(fragment),
+            SubscriptIndexBehavior::ZeroBased => Self::ZeroBased(fragment),
+            SubscriptIndexBehavior::OneBasedWithZeroAlias => Self::OneBasedWithZeroAlias(fragment),
+            SubscriptIndexBehavior::Ambiguous => Self::Ambiguous(fragment),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct IndexedArrayReferenceFragment {
+    span: Span,
+    plain: bool,
+}
+
+impl IndexedArrayReferenceFragment {
     pub fn span(&self) -> Span {
         self.span
     }
 
     pub fn is_plain(&self) -> bool {
         self.plain
-    }
-
-    pub fn subscript_index_behavior(&self) -> SubscriptIndexBehavior {
-        self.subscript_index_behavior
-    }
-
-    pub(super) fn with_subscript_index_behavior(
-        mut self,
-        behavior: SubscriptIndexBehavior,
-    ) -> Self {
-        self.subscript_index_behavior = behavior;
-        self
     }
 }
 
@@ -563,18 +590,19 @@ impl<'a> SurfaceFragmentSink<'a> {
             .facts
             .indexed_array_references
             .iter_mut()
-            .find(|fragment| fragment.span() == span)
+            .find(|fragment| match fragment {
+                IndexedArrayReferenceFragmentFact::OneBased(fragment)
+                | IndexedArrayReferenceFragmentFact::ZeroBased(fragment)
+                | IndexedArrayReferenceFragmentFact::OneBasedWithZeroAlias(fragment)
+                | IndexedArrayReferenceFragmentFact::Ambiguous(fragment) => fragment.span() == span,
+            })
         {
-            fragment.plain |= plain;
+            *fragment = fragment.with_plain(plain);
             return;
         }
         self.facts
             .indexed_array_references
-            .push(IndexedArrayReferenceFragmentFact {
-                span,
-                plain,
-                subscript_index_behavior: SubscriptIndexBehavior::Ambiguous,
-            });
+            .push(IndexedArrayReferenceFragmentFact::new(span, plain));
     }
 
     fn record_plain_unindexed_reference(&mut self, span: Span) {

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1,8 +1,37 @@
 use super::*;
 use crate::{
-    FieldSplittingBehavior, GlobDotBehavior, GlobFailureBehavior, PathnameExpansionBehavior,
-    PatternOperatorBehavior, PlainUnindexedArrayReferenceFact, SubscriptIndexBehavior,
+    FieldSplittingBehavior, GlobDotBehavior, GlobFailureBehavior,
+    IndexedArrayReferenceFragmentFact, PathnameExpansionBehavior, PatternOperatorBehavior,
+    PlainUnindexedArrayReferenceFact, SubscriptIndexBehavior,
 };
+
+fn indexed_array_reference_parts<'a>(
+    fragment: &IndexedArrayReferenceFragmentFact,
+    source: &'a str,
+) -> (&'a str, bool, SubscriptIndexBehavior) {
+    match fragment {
+        IndexedArrayReferenceFragmentFact::OneBased(fragment) => (
+            fragment.span().slice(source),
+            fragment.is_plain(),
+            SubscriptIndexBehavior::OneBased,
+        ),
+        IndexedArrayReferenceFragmentFact::ZeroBased(fragment) => (
+            fragment.span().slice(source),
+            fragment.is_plain(),
+            SubscriptIndexBehavior::ZeroBased,
+        ),
+        IndexedArrayReferenceFragmentFact::OneBasedWithZeroAlias(fragment) => (
+            fragment.span().slice(source),
+            fragment.is_plain(),
+            SubscriptIndexBehavior::OneBasedWithZeroAlias,
+        ),
+        IndexedArrayReferenceFragmentFact::Ambiguous(fragment) => (
+            fragment.span().slice(source),
+            fragment.is_plain(),
+            SubscriptIndexBehavior::Ambiguous,
+        ),
+    }
+}
 
 #[test]
 fn builds_surface_fragment_facts_and_static_utility_names() {
@@ -216,7 +245,10 @@ if [[ \"$@\" =~ x ]]; then :; fi
             facts
                 .indexed_array_reference_fragments()
                 .iter()
-                .map(|fragment| (fragment.span().slice(source), fragment.is_plain()))
+                .map(|fragment| {
+                    let (span, plain, _) = indexed_array_reference_parts(fragment, source);
+                    (span, plain)
+                })
                 .collect::<Vec<_>>(),
             vec![
                 ("${!arr[*]}", false),
@@ -3502,7 +3534,10 @@ printf '%s\\n' \"${items[@]#$prefix/}\" \"${items[i]%$suffix}\"
             facts
                 .indexed_array_reference_fragments()
                 .iter()
-                .map(|fragment| (fragment.span().slice(source), fragment.is_plain()))
+                .map(|fragment| {
+                    let (span, plain, _) = indexed_array_reference_parts(fragment, source);
+                    (span, plain)
+                })
                 .collect::<Vec<_>>(),
             vec![
                 ("${items[@]#$prefix/}", false),
@@ -3534,12 +3569,9 @@ printf '%s\\n' ${arr[0]}
             facts
                 .indexed_array_reference_fragments()
                 .iter()
-                .filter(|fragment| fragment.is_plain())
-                .map(|fragment| {
-                    (
-                        fragment.span().slice(source),
-                        fragment.subscript_index_behavior(),
-                    )
+                .filter_map(|fragment| {
+                    let (span, plain, behavior) = indexed_array_reference_parts(fragment, source);
+                    plain.then_some((span, behavior))
                 })
                 .collect::<Vec<_>>(),
             vec![
@@ -3565,12 +3597,9 @@ printf '%s\\n' ${arr[0]}
             facts
                 .indexed_array_reference_fragments()
                 .iter()
-                .filter(|fragment| fragment.is_plain())
-                .map(|fragment| {
-                    (
-                        fragment.span().slice(source),
-                        fragment.subscript_index_behavior(),
-                    )
+                .filter_map(|fragment| {
+                    let (span, plain, behavior) = indexed_array_reference_parts(fragment, source);
+                    plain.then_some((span, behavior))
                 })
                 .collect::<Vec<_>>(),
             vec![("${arr[0]}", SubscriptIndexBehavior::ZeroBased)]

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -66,14 +66,14 @@ pub use facts::{
     CommandFactRef, CommandFacts, ConditionalBareWordFact, ConditionalBinaryFact, ConditionalFact,
     ConditionalMixedLogicalOperatorFact, ConditionalNodeFact, ConditionalOperandFact,
     ConditionalOperatorFamily, ConditionalPortabilityFacts, ConditionalUnaryFact, ForHeaderFact,
-    FunctionCallArityFacts, FunctionHeaderFact, LegacyArithmeticFragmentFact, ListFact,
-    ListOperatorFact, LoopHeaderWordFact, NativeZshScalarArrayReference, PipelineFact,
-    PipelineOperatorFact, PipelineSegmentFact, PlainUnindexedArrayReferenceFact,
-    PositionalParameterFragmentFact, RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis,
-    RedirectTargetKind, SelectHeaderFact, SelectorRequiredArrayReference, SimpleTestFact,
-    SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax, SingleQuotedFragmentFact,
-    StatementFact, SubstitutionFact, SubstitutionHostKind, SubstitutionOutputIntent,
-    SudoFamilyInvoker,
+    FunctionCallArityFacts, FunctionHeaderFact, IndexedArrayReferenceFragment,
+    IndexedArrayReferenceFragmentFact, LegacyArithmeticFragmentFact, ListFact, ListOperatorFact,
+    LoopHeaderWordFact, NativeZshScalarArrayReference, PipelineFact, PipelineOperatorFact,
+    PipelineSegmentFact, PlainUnindexedArrayReferenceFact, PositionalParameterFragmentFact,
+    RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis, RedirectTargetKind,
+    SelectHeaderFact, SelectorRequiredArrayReference, SimpleTestFact, SimpleTestOperatorFamily,
+    SimpleTestShape, SimpleTestSyntax, SingleQuotedFragmentFact, StatementFact, SubstitutionFact,
+    SubstitutionHostKind, SubstitutionOutputIntent, SudoFamilyInvoker,
 };
 /// Fact collection types and stable identifiers into those collections.
 pub use facts::{

--- a/crates/shuck-linter/src/rules/portability/array_reference.rs
+++ b/crates/shuck-linter/src/rules/portability/array_reference.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, IndexedArrayReferenceFragmentFact, Rule, ShellDialect, Violation};
 
 pub struct ArrayReference;
 
@@ -21,8 +21,14 @@ pub fn array_reference(checker: &mut Checker) {
         .facts()
         .indexed_array_reference_fragments()
         .iter()
-        .filter(|fragment| fragment.is_plain())
-        .map(|fragment| fragment.span())
+        .filter_map(|fragment| match fragment {
+            IndexedArrayReferenceFragmentFact::OneBased(fragment)
+            | IndexedArrayReferenceFragmentFact::ZeroBased(fragment)
+            | IndexedArrayReferenceFragmentFact::OneBasedWithZeroAlias(fragment)
+            | IndexedArrayReferenceFragmentFact::Ambiguous(fragment) => {
+                fragment.is_plain().then(|| fragment.span())
+            }
+        })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || ArrayReference);


### PR DESCRIPTION
## Summary

- Make indexed array reference facts behavior-partitioned by subscript indexing mode instead of exposing behavior as an ignorable side field.
- Keep the `ksh_arrays` / subscript-indexing decision in semantic/fact construction via `shell_behavior_at(...).subscript_indexing()`.
- Update the X019 array-reference portability rule to match fact variants before accessing report spans.

## Why

The `ksh_arrays` C100 follow-up noted that broader array/indexing fact consumers still were not mapped as enforced rule support. This change moves that enforcement into the fact shape so rule consumers cannot accidentally ignore the option-sensitive indexing behavior.

## Validation

- `cargo test -p shuck-linter indexed_array_reference_fragments --lib`
- `cargo test -p shuck-linter array_reference --lib`
- `cargo test -p shuck-linter quoted_bash_source --lib`
- `cargo test -p shuck-linter --lib`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C100`