### PR TITLE
fix(linter): handle zsh brace_ccl in facts

### DIFF
--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -357,6 +357,23 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         self.fact.body_name_word()
     }
 
+    pub fn suspicious_body_name_bracket_glob_spans(self, source: &str) -> Vec<Span> {
+        let Some(word) = self.body_name_word() else {
+            return Vec::new();
+        };
+
+        let mut spans = word_spans::word_suspicious_bracket_glob_spans(word, source);
+        if self
+            .zsh_options()
+            .is_some_and(|options| !options.brace_ccl.is_definitely_off())
+        {
+            spans.extend(word_spans::word_suspicious_brace_character_class_spans(
+                word, source,
+            ));
+        }
+        spans
+    }
+
     pub fn body_word_span(self) -> Option<Span> {
         self.fact.body_word_span()
     }

--- a/crates/shuck-linter/src/facts/word_spans/globs.rs
+++ b/crates/shuck-linter/src/facts/word_spans/globs.rs
@@ -40,6 +40,28 @@ pub fn word_suspicious_bracket_glob_spans(word: &Word, source: &str) -> Vec<Span
         .collect()
 }
 
+pub fn word_suspicious_brace_character_class_spans(word: &Word, source: &str) -> Vec<Span> {
+    let mut spans = word
+        .brace_syntax()
+        .iter()
+        .copied()
+        .filter(|brace| {
+            matches!(
+                brace.kind,
+                shuck_ast::BraceSyntaxKind::Expansion(
+                    shuck_ast::BraceExpansionKind::CharacterClass
+                ) | shuck_ast::BraceSyntaxKind::Literal
+            ) && matches!(brace.quote_context, shuck_ast::BraceQuoteContext::Unquoted)
+                && suspicious_brace_character_class_text(brace.span.slice(source))
+        })
+        .map(|brace| brace.span)
+        .collect::<Vec<_>>();
+    collect_literal_suspicious_brace_character_class_spans(word, source, &mut spans);
+    spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+    spans.dedup();
+    spans
+}
+
 pub fn word_unbraced_variable_before_bracket_spans(word: &Word, source: &str) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_unbraced_variable_before_bracket_spans(&word.parts, source, &mut spans);
@@ -426,6 +448,58 @@ pub(crate) fn suspicious_bracket_glob_text(text: &str) -> bool {
     }
 
     false
+}
+
+fn suspicious_brace_character_class_text(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    if bytes.len() < 3 || bytes[0] != b'{' || *bytes.last().unwrap_or(&b'\0') != b'}' {
+        return false;
+    }
+
+    let mut bracket_text = String::with_capacity(text.len());
+    bracket_text.push('[');
+    bracket_text.push_str(&text[1..text.len() - 1]);
+    bracket_text.push(']');
+    suspicious_bracket_glob_text(&bracket_text)
+}
+
+fn collect_literal_suspicious_brace_character_class_spans(
+    word: &Word,
+    source: &str,
+    out: &mut Vec<Span>,
+) {
+    for part in &word.parts {
+        if !matches!(part.kind, WordPart::Literal(_)) {
+            continue;
+        }
+
+        let text = part.span.slice(source);
+        let bytes = text.as_bytes();
+        let mut index = 0usize;
+        while index < bytes.len() {
+            if bytes[index] != b'{' || byte_is_backslash_escaped(bytes, index) {
+                index += 1;
+                continue;
+            }
+
+            let mut close = index + 1;
+            while close < bytes.len() {
+                if bytes[close] == b'}' && !byte_is_backslash_escaped(bytes, close) {
+                    let span = span_within_literal(part.span, source, index, close + 1);
+                    if suspicious_brace_character_class_text(span.slice(source)) {
+                        out.push(span);
+                    }
+                    index = close + 1;
+                    break;
+                }
+                close += 1;
+            }
+
+            if close >= bytes.len() {
+                index += 1;
+            }
+        }
+    }
 }
 
 pub(crate) fn bracket_glob_is_named_class_without_outer_brackets(bytes: &[u8]) -> bool {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -530,7 +530,20 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     }
 
     pub fn suspicious_bracket_glob_spans(self, source: &str) -> Vec<Span> {
-        word_spans::word_suspicious_bracket_glob_spans(self.word(), source)
+        let mut spans = word_spans::word_suspicious_bracket_glob_spans(self.word(), source);
+        if self
+            .facts
+            .semantic
+            .shell_behavior_at(self.span().start.offset)
+            .brace_character_classes()
+            .can_expand()
+        {
+            spans.extend(word_spans::word_suspicious_brace_character_class_spans(
+                self.word(),
+                source,
+            ));
+        }
+        spans
     }
 
     pub fn standalone_literal_backslash_span(self, source: &str) -> Option<Span> {
@@ -599,9 +612,29 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
             .brace_syntax()
             .iter()
             .copied()
-            .filter(|brace| brace.expands())
+            .filter(|brace| self.brace_syntax_expands(*brace))
             .map(|brace| brace.span)
             .collect()
+    }
+
+    fn brace_syntax_expands(self, brace: shuck_ast::BraceSyntax) -> bool {
+        if !matches!(brace.quote_context, BraceQuoteContext::Unquoted) {
+            return false;
+        }
+
+        match brace.expansion_kind() {
+            Some(
+                shuck_ast::BraceExpansionKind::CommaList
+                | shuck_ast::BraceExpansionKind::Sequence,
+            ) => true,
+            Some(shuck_ast::BraceExpansionKind::CharacterClass) => self
+                .facts
+                .semantic
+                .shell_behavior_at(brace.span.start.offset)
+                .brace_character_classes()
+                .can_expand(),
+            None => false,
+        }
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
@@ -19,9 +19,11 @@ pub fn suspicious_bracket_glob(checker: &mut Checker) {
         .facts()
         .commands()
         .iter()
-        .filter_map(|fact| fact.body_name_word())
-        .filter(|word| !bare_bracket_test_name(word.span.slice(source)))
-        .flat_map(|word| word_spans::word_suspicious_bracket_glob_spans(word, source))
+        .filter(|fact| {
+            fact.body_name_word()
+                .is_none_or(|word| !bare_bracket_test_name(word.span.slice(source)))
+        })
+        .flat_map(|fact| fact.suspicious_body_name_bracket_glob_spans(source))
         .chain(checker.facts().case_items().iter().flat_map(|item| {
             word_spans::case_item_suspicious_bracket_glob_spans(item.item(), source)
         }))
@@ -76,7 +78,7 @@ fn bare_bracket_test_name(text: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_suspicious_bracket_globs_across_shell_contexts() {
@@ -144,5 +146,33 @@ if [ \"$ARCH\" = \"x86_64\" ]; then :; fi
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_zsh_brace_ccl_word_like_character_classes_from_facts() {
+        let source = "\
+setopt brace_ccl
+{appname} arg
+echo {appname}
+opt=brace_ccl
+setopt \"$opt\"
+{dynamicc} arg
+echo {dynamicc}
+unsetopt brace_ccl
+{appname} arg
+echo {appname}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SuspiciousBracketGlob).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["{appname}", "{appname}", "{dynamicc}", "{dynamicc}"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/mod.rs
+++ b/crates/shuck-linter/src/rules/mod.rs
@@ -188,4 +188,39 @@ mod architecture_tests {
             violations.join("\n"),
         );
     }
+
+    #[test]
+    fn brace_and_bracket_rules_avoid_raw_zsh_option_state_queries() {
+        let rule_paths = [
+            "src/rules/correctness/suspicious_bracket_glob.rs",
+            "src/rules/portability/brace_expansion.rs",
+        ];
+        let forbidden_tokens = [
+            "zsh_options_at",
+            "zsh_options()",
+            "ZshOptionState",
+            "OptionValue",
+            "shell_behavior_at",
+            "BraceCharacterClassBehavior",
+        ];
+        let mut violations = Vec::new();
+        for path in rule_paths {
+            let rule_path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
+            let source = fs::read_to_string(&rule_path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", rule_path.display()));
+            violations.extend(
+                forbidden_tokens
+                    .iter()
+                    .copied()
+                    .filter(|token| source.contains(token))
+                    .map(|token| format!("{path}: {token}")),
+            );
+        }
+
+        assert!(
+            violations.is_empty(),
+            "brace/glob rules should consume option-aware facts instead of raw zsh option state:\n{}",
+            violations.join("\n"),
+        );
+    }
 }

--- a/crates/shuck-semantic/src/glob.rs
+++ b/crates/shuck-semantic/src/glob.rs
@@ -96,6 +96,24 @@ pub enum PatternOperatorBehavior {
     Ambiguous,
 }
 
+/// Whether zsh brace character-class expansion is active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BraceCharacterClassBehavior {
+    /// Brace character classes are not expanded.
+    Disabled,
+    /// Brace character classes are expanded.
+    Enabled,
+    /// Runtime option state may select either behavior.
+    Ambiguous,
+}
+
+impl BraceCharacterClassBehavior {
+    /// Returns whether a brace character class may expand at runtime.
+    pub fn can_expand(self) -> bool {
+        matches!(self, Self::Enabled | Self::Ambiguous)
+    }
+}
+
 /// Option-sensitive pattern operators available to glob and shell-pattern facts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GlobPatternBehavior {
@@ -260,6 +278,22 @@ impl ShellBehaviorAt<'_> {
             pattern_operator_behavior(options.sh_glob),
         )
     }
+
+    /// Returns whether zsh brace character classes such as `{abc}` are active.
+    pub fn brace_character_classes(&self) -> BraceCharacterClassBehavior {
+        if self.shell != ShellDialect::Zsh {
+            return BraceCharacterClassBehavior::Disabled;
+        }
+
+        match self
+            .effective_zsh_options()
+            .map(|options| options.brace_ccl)
+        {
+            Some(OptionValue::On) => BraceCharacterClassBehavior::Enabled,
+            Some(OptionValue::Unknown) => BraceCharacterClassBehavior::Ambiguous,
+            Some(OptionValue::Off) | None => BraceCharacterClassBehavior::Disabled,
+        }
+    }
 }
 
 fn pattern_operator_behavior(value: OptionValue) -> PatternOperatorBehavior {
@@ -344,6 +378,38 @@ mod tests {
         assert_eq!(pattern.extended_glob(), PatternOperatorBehavior::Disabled);
         assert_eq!(pattern.ksh_glob(), PatternOperatorBehavior::Disabled);
         assert_eq!(pattern.sh_glob(), PatternOperatorBehavior::Disabled);
+        assert_eq!(
+            behavior.brace_character_classes(),
+            BraceCharacterClassBehavior::Disabled
+        );
+    }
+
+    #[test]
+    fn tracks_brace_character_classes_by_offset() {
+        for (source, expected) in [
+            ("print {app}\n", BraceCharacterClassBehavior::Disabled),
+            (
+                "setopt brace_ccl\nprint {app}\n",
+                BraceCharacterClassBehavior::Enabled,
+            ),
+            (
+                "setopt brace_ccl\nunsetopt brace_ccl\nprint {app}\n",
+                BraceCharacterClassBehavior::Disabled,
+            ),
+            (
+                "opt=brace_ccl\nsetopt \"$opt\"\nprint {app}\n",
+                BraceCharacterClassBehavior::Ambiguous,
+            ),
+        ] {
+            let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+            let offset = source.find("print").expect("expected print offset");
+
+            assert_eq!(
+                model.shell_behavior_at(offset).brace_character_classes(),
+                expected,
+                "{source}"
+            );
+        }
     }
 
     #[test]

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -63,8 +63,9 @@ pub use function_call_reachability::{
 };
 /// Option-sensitive globbing and expansion behavior queries.
 pub use glob::{
-    FieldSplittingBehavior, FileExpansionOrderBehavior, GlobDotBehavior, GlobFailureBehavior,
-    GlobPatternBehavior, PathnameExpansionBehavior, PatternOperatorBehavior,
+    BraceCharacterClassBehavior, FieldSplittingBehavior, FileExpansionOrderBehavior,
+    GlobDotBehavior, GlobFailureBehavior, GlobPatternBehavior, PathnameExpansionBehavior,
+    PatternOperatorBehavior,
 };
 /// Nonpersistent assignment effects, such as assignments made in subshells and read later outside.
 pub use nonpersistent::{


### PR DESCRIPTION
## Summary
- add semantic behavior for zsh `BRACE_CCL` state
- make linter word facts use that behavior for brace character-class expansion and C096 spans
- add regression and architecture coverage so X010/C096 keep option handling in facts instead of rule files

## Validation
- `cargo test -p shuck-semantic tracks_brace_character_classes_by_offset`
- `cargo test -p shuck-linter suspicious_bracket_glob`
- `cargo test -p shuck-linter brace_expansion`
- `cargo test -p shuck-linter brace_and_bracket_rules_avoid_raw_zsh_option_state_queries`
- `git diff --check`