### PR TITLE
test(linter): cover ksh zero subscript facts

### DIFF
--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -3516,12 +3516,14 @@ printf '%s\\n' \"${items[@]#$prefix/}\" \"${items[i]%$suffix}\"
 fn indexed_array_reference_fragments_record_subscript_index_behavior() {
     let source = "\
 #!/bin/zsh
-printf '%s\\n' ${arr[1]}
+printf '%s\\n' ${arr[0]}
 setopt ksh_arrays
 printf '%s\\n' ${arr[1]}
 if cond; then setopt ksh_zero_subscript; fi
 printf '%s\\n' ${arr[1]}
 unsetopt ksh_arrays
+unsetopt ksh_zero_subscript
+printf '%s\\n' ${arr[0]}
 setopt ksh_zero_subscript
 printf '%s\\n' ${arr[0]}
 opt=ksh_zero_subscript
@@ -3543,9 +3545,10 @@ printf '%s\\n' ${arr[0]}
                 })
                 .collect::<Vec<_>>(),
             vec![
-                ("${arr[1]}", SubscriptIndexBehavior::OneBased),
+                ("${arr[0]}", SubscriptIndexBehavior::OneBased),
                 ("${arr[1]}", SubscriptIndexBehavior::ZeroBased),
                 ("${arr[1]}", SubscriptIndexBehavior::ZeroBased),
+                ("${arr[0]}", SubscriptIndexBehavior::OneBased),
                 ("${arr[0]}", SubscriptIndexBehavior::OneBasedWithZeroAlias,),
                 ("${arr[0]}", SubscriptIndexBehavior::Ambiguous),
             ]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9802,7 +9802,7 @@ fn semantic_behavior_tracks_subscript_indexing_options() {
     );
 
     for (source, expected) in [
-        ("print ${arr[1]}\n", SubscriptIndexBehavior::OneBased),
+        ("print ${arr[0]}\n", SubscriptIndexBehavior::OneBased),
         (
             "setopt ksh_arrays\nprint ${arr[1]}\n",
             SubscriptIndexBehavior::ZeroBased,
@@ -9817,6 +9817,10 @@ fn semantic_behavior_tracks_subscript_indexing_options() {
         ),
         (
             "setopt ksh_arrays\nunsetopt ksh_arrays\nprint ${arr[1]}\n",
+            SubscriptIndexBehavior::OneBased,
+        ),
+        (
+            "setopt ksh_zero_subscript\nunsetopt ksh_zero_subscript\nprint ${arr[0]}\n",
             SubscriptIndexBehavior::OneBased,
         ),
         (


### PR DESCRIPTION
## Summary

- Clarify semantic behavior coverage for zsh `${arr[0]}` when `KSH_ZERO_SUBSCRIPT` is off, unset, on, ambiguous, or dominated by `KSH_ARRAYS`.
- Extend linter fact tests so indexed array reference fragments record the same behavior for `${arr[0]}`.

## Validation

- `cargo test -p shuck-semantic semantic_behavior_tracks_subscript_indexing_options --lib`
- `cargo test -p shuck-linter subscript_index_behavior --lib`
- `cargo fmt`