### PR TITLE
fix(linter): centralize active glob behavior in facts

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1364,7 +1364,7 @@ fn build_declaration_assignment_probes<'a>(
     normalized: &NormalizedCommand<'a>,
     semantic: &SemanticModel,
     source: &str,
-    zsh_options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
 ) -> Vec<DeclarationAssignmentProbe> {
     if let Some(declaration) = normalized.declaration.as_ref() {
         return declaration
@@ -1383,7 +1383,7 @@ fn build_declaration_assignment_probes<'a>(
                     has_command_substitution: word_has_command_substitution(
                         word,
                         source,
-                        zsh_options,
+                        behavior,
                     ),
                     status_capture: word_is_standalone_status_capture(word),
                 })
@@ -1530,9 +1530,9 @@ fn part_is_standalone_status_or_pid_capture(part: &WordPart) -> bool {
 fn word_has_command_substitution(
     word: &Word,
     source: &str,
-    zsh_options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
 ) -> bool {
-    word_classification_from_analysis(analyze_word(word, source, zsh_options))
+    word_classification_from_analysis(analyze_word(word, source, Some(behavior)))
         .has_command_substitution()
 }
 

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -240,7 +240,7 @@ fn bare_command_name_assignment_span<'a>(
     }
 
     let text = occurrence_static_text(word_nodes, fact, source)?;
-    if !is_bare_command_name_assignment_value(&text, command.zsh_options()) {
+    if !is_bare_command_name_assignment_value(&text, command.shell_behavior().zsh_options()) {
         return None;
     }
 

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -194,7 +194,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 let normalized = command::normalize_command(visit.command, self.source);
                 let command_start_offset = command_span(visit.command).start.offset;
                 let scope = context.scope();
-                let command_zsh_options = effective_command_zsh_options(
+                let command_shell_behavior = effective_command_shell_behavior(
                     self.semantic,
                     command_start_offset,
                     &normalized,
@@ -214,7 +214,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                         scope,
                     },
                     &normalized,
-                    command_zsh_options.clone(),
+                    command_shell_behavior.clone(),
                     WordFactOutputs {
                         word_nodes: &mut word_nodes,
                         word_spans: &mut word_spans,
@@ -285,7 +285,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     visit.redirects,
                     Some(self.semantic_artifacts),
                     locator,
-                    command_zsh_options.as_ref(),
+                    &command_shell_behavior,
                 );
                 let redirect_fact_range = redirect_fact_store.push_many(redirect_facts);
                 let options = CommandOptionFacts::build(
@@ -293,13 +293,14 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     &normalized,
                     self.semantic_artifacts,
                     self.source,
+                    &command_shell_behavior,
                 );
                 let declaration_assignment_probes = build_declaration_assignment_probes(
                     visit.command,
                     &normalized,
                     self.semantic,
                     self.source,
-                    command_zsh_options.as_ref(),
+                    &command_shell_behavior,
                 );
                 let declaration_assignment_probe_range =
                     declaration_assignment_probe_store.push_many(declaration_assignment_probes);
@@ -320,7 +321,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     nested_word_command,
                     scope,
                     normalized,
-                    zsh_options: command_zsh_options,
+                    shell_behavior: command_shell_behavior,
                     redirect_facts: redirect_fact_range,
                     substitution_facts: IdRange::empty(),
                     options,

--- a/crates/shuck-linter/src/facts/case_patterns.rs
+++ b/crates/shuck-linter/src/facts/case_patterns.rs
@@ -304,8 +304,12 @@ struct ReachableCasePattern {
 }
 
 impl StaticCasePatternMatcher {
-    fn from_pattern(pattern: &Pattern, source: &str) -> Option<Self> {
-        ensure_case_pattern_is_statically_analyzable(pattern, source)?;
+    fn from_pattern(
+        pattern: &Pattern,
+        source: &str,
+        behavior: &ShellBehaviorAt<'_>,
+    ) -> Option<Self> {
+        ensure_case_pattern_is_statically_analyzable(pattern, source, behavior)?;
 
         let mut tokens = Vec::new();
         collect_static_case_pattern_tokens(pattern.span.slice(source), &mut tokens)?;
@@ -923,7 +927,11 @@ fn merged_case_pattern_symbols(left: &[char], right: &[char]) -> Vec<CasePattern
     symbols
 }
 
-fn ensure_case_pattern_is_statically_analyzable(pattern: &Pattern, source: &str) -> Option<()> {
+fn ensure_case_pattern_is_statically_analyzable(
+    pattern: &Pattern,
+    source: &str,
+    behavior: &ShellBehaviorAt<'_>,
+) -> Option<()> {
     for (part, _) in pattern.parts_with_spans() {
         match part {
             PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => {}
@@ -934,7 +942,50 @@ fn ensure_case_pattern_is_statically_analyzable(pattern: &Pattern, source: &str)
         }
     }
 
+    if behavior.shell_dialect() == shuck_semantic::ShellDialect::Zsh
+        && pattern_operator_may_be_active(behavior.glob_pattern().extended_glob())
+        && text_has_unquoted_zsh_extended_glob_operator(pattern.span.slice(source))
+    {
+        return None;
+    }
+
     Some(())
+}
+
+fn pattern_operator_may_be_active(behavior: shuck_semantic::PatternOperatorBehavior) -> bool {
+    !matches!(
+        behavior,
+        shuck_semantic::PatternOperatorBehavior::Disabled
+    )
+}
+
+fn text_has_unquoted_zsh_extended_glob_operator(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\\' {
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+
+        match bytes[index] {
+            b'\'' if !in_double_quotes => {
+                in_single_quotes = !in_single_quotes;
+            }
+            b'"' if !in_single_quotes => {
+                in_double_quotes = !in_double_quotes;
+            }
+            b'#' | b'~' | b'^' if !in_single_quotes && !in_double_quotes => return true,
+            _ => {}
+        }
+
+        index += 1;
+    }
+
+    false
 }
 
 fn collect_static_case_pattern_tokens(
@@ -1077,7 +1128,9 @@ fn build_case_pattern_shadow_facts(
             let mut same_item_patterns = Vec::<ReachableCasePattern>::new();
 
             for pattern in &item.patterns {
-                let Some(matcher) = StaticCasePatternMatcher::from_pattern(pattern, source) else {
+                let Some(matcher) =
+                    StaticCasePatternMatcher::from_pattern(pattern, source, fact.shell_behavior())
+                else {
                     continue;
                 };
 
@@ -1140,7 +1193,8 @@ fn build_case_pattern_impossible_spans(commands: &[CommandFact<'_>], source: &st
 
         for item in &command.cases {
             for pattern in &item.patterns {
-                let Some(pattern_matcher) = StaticCasePatternMatcher::from_pattern(pattern, source)
+                let Some(pattern_matcher) =
+                    StaticCasePatternMatcher::from_pattern(pattern, source, fact.shell_behavior())
                 else {
                     continue;
                 };
@@ -1449,7 +1503,8 @@ fn getopts_case_pattern_is_fallback(pattern: &Pattern, source: &str) -> bool {
 }
 
 fn static_case_pattern_text(pattern: &Pattern, source: &str) -> Option<String> {
-    ensure_case_pattern_is_statically_analyzable(pattern, source)?;
+    let behavior = ShellBehaviorAt::for_dialect(shuck_semantic::ShellDialect::Bash);
+    ensure_case_pattern_is_statically_analyzable(pattern, source, &behavior)?;
 
     let mut tokens = Vec::new();
     collect_static_case_pattern_tokens(pattern.span.slice(source), &mut tokens)?;

--- a/crates/shuck-linter/src/facts/command_options/find.rs
+++ b/crates/shuck-linter/src/facts/command_options/find.rs
@@ -188,6 +188,7 @@ where
 pub(super) fn parse_find_command<'a>(
     args: impl IntoIterator<Item = &'a Word>,
     source: &str,
+    behavior: &ShellBehaviorAt<'_>,
 ) -> FindCommandFacts {
     let mut has_print0 = false;
     let mut has_formatted_output_action = false;
@@ -200,7 +201,13 @@ pub(super) fn parse_find_command<'a>(
         let Some(text) = static_word_text(word, source) else {
             if let Some(state) = pending_argument {
                 if state.expects_pattern_operand()
-                    && !word_spans::word_unquoted_glob_pattern_spans(word, source).is_empty()
+                    && !word_spans::word_active_glob_pattern_spans(
+                        word,
+                        source,
+                        behavior.pathname_expansion(),
+                        behavior.glob_pattern(),
+                    )
+                    .is_empty()
                 {
                     glob_pattern_operand_spans.push(word.span);
                 }
@@ -211,7 +218,13 @@ pub(super) fn parse_find_command<'a>(
 
         if let Some(state) = pending_argument {
             if state.expects_pattern_operand()
-                && !word_spans::word_unquoted_glob_pattern_spans(word, source).is_empty()
+                && !word_spans::word_active_glob_pattern_spans(
+                    word,
+                    source,
+                    behavior.pathname_expansion(),
+                    behavior.glob_pattern(),
+                )
+                .is_empty()
             {
                 glob_pattern_operand_spans.push(word.span);
             }

--- a/crates/shuck-linter/src/facts/command_options/mod.rs
+++ b/crates/shuck-linter/src/facts/command_options/mod.rs
@@ -35,12 +35,12 @@ impl<'a> PathWordFact<'a> {
         word: &'a Word,
         context: ExpansionContext,
         source: &str,
-        zsh_options: Option<&ZshOptionState>,
+        behavior: &ShellBehaviorAt<'_>,
     ) -> Self {
         Self {
             word,
             context,
-            comparable_path: comparable_path(word, source, context, zsh_options),
+            comparable_path: comparable_path(word, source, context, Some(behavior)),
         }
     }
 
@@ -728,6 +728,7 @@ impl<'a> CommandOptionFacts<'a> {
         normalized: &NormalizedCommand<'a>,
         semantic: &LinterSemanticArtifacts<'a>,
         source: &str,
+        behavior: &ShellBehaviorAt<'_>,
     ) -> Self {
         Self {
             rm: normalized
@@ -780,7 +781,13 @@ impl<'a> CommandOptionFacts<'a> {
                 .then(|| parse_unset_command(normalized.body_args(), source)),
             find: (normalized.effective_name_is("find")
                 || normalized.literal_name.as_deref() == Some("find"))
-            .then(|| parse_find_command(find_command_args(command, normalized, source), source)),
+            .then(|| {
+                parse_find_command(
+                    find_command_args(command, normalized, source),
+                    source,
+                    behavior,
+                )
+            }),
             find_exec: (normalized.has_wrapper(WrapperKind::FindExec)
                 || normalized.has_wrapper(WrapperKind::FindExecDir))
             .then(|| FindExecCommandFacts {

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -6,7 +6,7 @@ pub struct CommandFact<'a> {
     nested_word_command: bool,
     scope: ScopeId,
     normalized: NormalizedCommand<'a>,
-    zsh_options: Option<ZshOptionState>,
+    shell_behavior: ShellBehaviorAt<'a>,
     redirect_facts: IdRange<RedirectFact<'a>>,
     substitution_facts: IdRange<SubstitutionFact>,
     options: CommandOptionFacts<'a>,
@@ -76,8 +76,8 @@ impl<'a> CommandFact<'a> {
         self.visit.redirects
     }
 
-    pub fn zsh_options(&self) -> Option<&ZshOptionState> {
-        self.zsh_options.as_ref()
+    pub(crate) fn shell_behavior(&self) -> &ShellBehaviorAt<'a> {
+        &self.shell_behavior
     }
 
     pub fn normalized(&self) -> &NormalizedCommand<'a> {
@@ -245,8 +245,12 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         self.fact.redirects()
     }
 
-    pub fn zsh_options(self) -> Option<&'facts ZshOptionState> {
-        self.fact.zsh_options.as_ref()
+    pub(crate) fn shell_behavior(self) -> &'facts ShellBehaviorAt<'a> {
+        &self.fact.shell_behavior
+    }
+
+    pub fn zsh_options(self) -> Option<&'facts shuck_semantic::ZshOptionState> {
+        self.fact.shell_behavior.zsh_options()
     }
 
     pub fn redirect_facts(self) -> &'facts [RedirectFact<'a>] {
@@ -444,18 +448,18 @@ fn command_span_with_redirects_and_shellcheck_tail(
     ))
 }
 
-fn effective_command_zsh_options(
-    semantic: &SemanticModel,
+fn effective_command_shell_behavior<'a>(
+    semantic: &'a SemanticModel,
     offset: usize,
     normalized: &NormalizedCommand<'_>,
-) -> Option<ZshOptionState> {
-    let mut options = semantic.zsh_options_at(offset).cloned();
-    if normalized.has_wrapper(WrapperKind::Noglob)
-        && let Some(options) = options.as_mut()
-    {
-        options.glob = shuck_semantic::OptionValue::Off;
+) -> ShellBehaviorAt<'a> {
+    let behavior = semantic.shell_behavior_at(offset);
+    if normalized.has_wrapper(WrapperKind::Noglob) {
+        return behavior.with_zsh_option_overlay(|options| {
+            options.glob = shuck_semantic::OptionValue::Off;
+        });
     }
-    options
+    behavior
 }
 
 fn contains_template_placeholder_text(text: &str) -> bool {
@@ -1008,7 +1012,7 @@ fn collect_own_scope_read_source_words<'a>(
                 word,
                 ExpansionContext::CommandArgument,
                 source,
-                command.zsh_options(),
+                command.shell_behavior(),
             )
         })
     );
@@ -1203,7 +1207,7 @@ fn collect_command_redirect_read_source_words<'a>(
             word,
             context,
             source,
-            command.zsh_options(),
+            command.shell_behavior(),
         ));
     }
 }
@@ -1225,7 +1229,7 @@ fn collect_command_simple_test_path_words<'a>(
                 word,
                 ExpansionContext::StringTestOperand,
                 source,
-                command.zsh_options(),
+                command.shell_behavior(),
             )
         }));
 }
@@ -1246,7 +1250,7 @@ fn collect_command_conditional_path_words<'a>(
                             word,
                             ExpansionContext::StringTestOperand,
                             source,
-                            command.zsh_options(),
+                            command.shell_behavior(),
                         ));
                     }
                     if let Some(word) = binary.right().word() {
@@ -1254,7 +1258,7 @@ fn collect_command_conditional_path_words<'a>(
                             word,
                             ExpansionContext::StringTestOperand,
                             source,
-                            command.zsh_options(),
+                            command.shell_behavior(),
                         ));
                     }
                 }

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -70,9 +70,9 @@ use shuck_semantic::{
     FieldSplittingBehavior, FileExpansionOrderBehavior, GlobDotBehavior, GlobFailureBehavior,
     GlobPatternBehavior, NonpersistentAssignmentAnalysisContext,
     NonpersistentAssignmentAnalysisOptions, NonpersistentAssignmentCommandContext,
-    NonpersistentAssignmentExtraRead, OptionValue, PathnameExpansionBehavior,
-    PatternOperatorBehavior, Reference, ReferenceId, ReferenceKind, ScopeId, SemanticAnalysis,
-    SemanticModel, SemanticPipelineOperatorKind, SubscriptIndexBehavior, ZshOptionState,
+    NonpersistentAssignmentExtraRead, OptionValue, PathnameExpansionBehavior, Reference,
+    ReferenceId, ReferenceKind, ScopeId, SemanticAnalysis, SemanticModel,
+    SemanticPipelineOperatorKind, ShellBehaviorAt, SubscriptIndexBehavior, ZshOptionState,
 };
 use smallvec::SmallVec;
 use std::{borrow::Cow, ops::ControlFlow, sync::OnceLock};

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -326,6 +326,13 @@ impl<'a> LinterFacts<'a> {
             .map(|id| self.command(id))
     }
 
+    pub(crate) fn expansion_behavior_at(&self, offset: usize) -> ShellBehaviorAt<'a> {
+        self.innermost_command_at(offset).map_or_else(
+            || self.semantic.shell_behavior_at(offset),
+            |command| command.shell_behavior().clone(),
+        )
+    }
+
     pub fn innermost_command_id_at(&self, offset: usize) -> Option<CommandId> {
         precomputed_command_id_for_offset(&self.innermost_command_ids_by_offset, offset)
     }

--- a/crates/shuck-linter/src/facts/redirects.rs
+++ b/crates/shuck-linter/src/facts/redirects.rs
@@ -146,9 +146,9 @@ pub(crate) fn comparable_path(
     word: &Word,
     source: &str,
     context: ExpansionContext,
-    options: Option<&ZshOptionState>,
+    behavior: Option<&ShellBehaviorAt<'_>>,
 ) -> Option<ComparablePath> {
-    let analysis = analyze_word(word, source, options);
+    let analysis = analyze_word(word, source, behavior);
     if analysis.has_command_substitution()
         || analysis.hazards.command_or_process_substitution
         || analysis.has_array_expansion()
@@ -156,7 +156,7 @@ pub(crate) fn comparable_path(
         return None;
     }
 
-    let runtime_literal = analyze_literal_runtime(word, source, context, options);
+    let runtime_literal = analyze_literal_runtime(word, source, context, behavior);
     if runtime_literal.hazards.pathname_matching
         || runtime_literal.hazards.brace_fanout
         || runtime_literal.hazards.command_or_process_substitution
@@ -614,15 +614,15 @@ impl<'a> RedirectFact<'a> {
 pub(crate) fn analyze_redirect_target(
     redirect: &Redirect,
     source: &str,
-    options: Option<&ZshOptionState>,
+    behavior: Option<&ShellBehaviorAt<'_>>,
 ) -> Option<RedirectTargetAnalysis> {
     let target = redirect.word_target()?;
-    let expansion = analyze_word(target, source, options);
+    let expansion = analyze_word(target, source, behavior);
     let runtime_literal = analyze_literal_runtime(
         target,
         source,
         ExpansionContext::RedirectTarget(redirect.kind),
-        options,
+        behavior,
     );
 
     let (kind, dev_null_status, numeric_descriptor_target) = match redirect.kind {
@@ -667,7 +667,7 @@ fn build_redirect_facts<'a>(
     redirects: &'a [Redirect],
     semantic: Option<&LinterSemanticArtifacts<'a>>,
     locator: Locator<'_>,
-    zsh_options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
 ) -> Vec<RedirectFact<'a>> {
     let source = locator.source();
     redirects
@@ -692,10 +692,10 @@ fn build_redirect_facts<'a>(
                     spans
             })
             .into_boxed_slice(),
-            analysis: analyze_redirect_target(redirect, source, zsh_options),
+            analysis: analyze_redirect_target(redirect, source, Some(behavior)),
             comparable_path: redirect.word_target().and_then(|word| {
                 ExpansionContext::from_redirect_kind(redirect.kind)
-                    .and_then(|context| comparable_path(word, source, context, zsh_options))
+                    .and_then(|context| comparable_path(word, source, context, Some(behavior)))
             }),
             comparable_name_uses: comparable_redirect_name_uses(
                 redirect,

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -739,7 +739,8 @@ fn summarize_command_redirects<'a>(
     {
         summarize_redirect_facts(command_fact_ref(commands, id).redirect_facts(), source)
     } else {
-        let redirect_facts = build_redirect_facts(&stmt.redirects, None, locator, None);
+        let behavior = ShellBehaviorAt::for_dialect(shuck_semantic::ShellDialect::Bash);
+        let redirect_facts = build_redirect_facts(&stmt.redirects, None, locator, &behavior);
         summarize_redirect_facts(&redirect_facts, source)
     }
 }

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -2300,6 +2300,62 @@ rm *
 }
 
 #[test]
+fn builds_active_glob_spans_from_option_sensitive_zsh_behavior() {
+    let source = "\
+#!/usr/bin/env zsh
+rm *
+noglob rm *
+setopt extended_glob
+rm foo^bar
+unsetopt extended_glob
+rm foo^bar
+setopt ksh_glob
+rm ?(*.txt)
+unsetopt ksh_glob
+rm ?(*.txt)
+opt=ksh_glob
+setopt \"$opt\"
+rm ?(*.txt)
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            let active_spans = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .filter(|fact| matches!(fact.span().slice(source), "*" | "foo^bar" | "?(*.txt)"))
+                .map(|fact| {
+                    (
+                        fact.span().slice(source).to_owned(),
+                        fact.active_literal_glob_spans(source)
+                            .into_iter()
+                            .map(|span| span.slice(source).to_owned())
+                            .collect::<Vec<_>>(),
+                        fact.starts_with_active_glob_operator(source),
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                active_spans,
+                vec![
+                    ("*".to_owned(), vec!["*".to_owned()], false),
+                    ("*".to_owned(), Vec::<String>::new(), false),
+                    ("foo^bar".to_owned(), vec!["^".to_owned()], false),
+                    ("foo^bar".to_owned(), Vec::<String>::new(), false),
+                    ("?(*.txt)".to_owned(), vec!["?(*.txt)".to_owned()], true),
+                    ("?(*.txt)".to_owned(), vec!["?(*.txt)".to_owned()], false),
+                    ("?(*.txt)".to_owned(), vec!["?(*.txt)".to_owned()], true),
+                ]
+            );
+        },
+    );
+}
+
+#[test]
 fn builds_word_facts_for_special_parameter_arguments() {
     let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -2307,6 +2307,9 @@ rm *
 noglob rm *
 setopt extended_glob
 rm foo^bar
+rm foo~bar
+rm foo*~bar
+rm foo~bar*
 unsetopt extended_glob
 rm foo^bar
 setopt ksh_glob
@@ -2326,7 +2329,12 @@ rm ?(*.txt)
         |_, facts| {
             let active_spans = facts
                 .expansion_word_facts(ExpansionContext::CommandArgument)
-                .filter(|fact| matches!(fact.span().slice(source), "*" | "foo^bar" | "?(*.txt)"))
+                .filter(|fact| {
+                    matches!(
+                        fact.span().slice(source),
+                        "*" | "foo^bar" | "foo~bar" | "foo*~bar" | "foo~bar*" | "?(*.txt)"
+                    )
+                })
                 .map(|fact| {
                     (
                         fact.span().slice(source).to_owned(),
@@ -2345,10 +2353,50 @@ rm ?(*.txt)
                     ("*".to_owned(), vec!["*".to_owned()], false),
                     ("*".to_owned(), Vec::<String>::new(), false),
                     ("foo^bar".to_owned(), vec!["^".to_owned()], false),
+                    ("foo~bar".to_owned(), Vec::<String>::new(), false),
+                    (
+                        "foo*~bar".to_owned(),
+                        vec!["*".to_owned(), "~".to_owned()],
+                        false
+                    ),
+                    (
+                        "foo~bar*".to_owned(),
+                        vec!["~".to_owned(), "*".to_owned()],
+                        false
+                    ),
                     ("foo^bar".to_owned(), Vec::<String>::new(), false),
                     ("?(*.txt)".to_owned(), vec!["?(*.txt)".to_owned()], true),
-                    ("?(*.txt)".to_owned(), vec!["?(*.txt)".to_owned()], false),
+                    (
+                        "?(*.txt)".to_owned(),
+                        vec!["?".to_owned(), "*".to_owned()],
+                        false
+                    ),
                     ("?(*.txt)".to_owned(), vec!["?(*.txt)".to_owned()], true),
+                ]
+            );
+
+            let pathname_hazards = facts
+                .expansion_word_facts(ExpansionContext::CommandArgument)
+                .filter(|fact| {
+                    matches!(
+                        fact.span().slice(source),
+                        "foo~bar" | "foo*~bar" | "foo~bar*"
+                    )
+                })
+                .map(|fact| {
+                    (
+                        fact.span().slice(source).to_owned(),
+                        fact.analysis().hazards.pathname_matching,
+                    )
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                pathname_hazards,
+                vec![
+                    ("foo~bar".to_owned(), false),
+                    ("foo*~bar".to_owned(), true),
+                    ("foo~bar*".to_owned(), true),
                 ]
             );
         },

--- a/crates/shuck-linter/src/facts/word_spans/globs.rs
+++ b/crates/shuck-linter/src/facts/word_spans/globs.rs
@@ -6,6 +6,23 @@ pub fn word_unquoted_glob_pattern_spans(word: &Word, source: &str) -> Vec<Span> 
     spans
 }
 
+pub fn word_active_glob_pattern_spans(
+    word: &Word,
+    source: &str,
+    pathname_behavior: PathnameExpansionBehavior,
+    pattern_behavior: GlobPatternBehavior,
+) -> Vec<Span> {
+    if !pathname_behavior.literal_globs_can_expand() {
+        return Vec::new();
+    }
+
+    let mut spans = Vec::new();
+    collect_active_glob_pattern_spans(&word.parts, source, false, pattern_behavior, &mut spans);
+    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.dedup();
+    spans
+}
+
 pub fn word_unquoted_glob_pattern_spans_outside_brace_expansion(
     word: &Word,
     source: &str,
@@ -31,6 +48,54 @@ pub fn word_unquoted_glob_pattern_spans_outside_brace_expansion(
             })
         })
         .collect()
+}
+
+pub fn word_active_glob_pattern_spans_outside_brace_expansion(
+    word: &Word,
+    source: &str,
+    pathname_behavior: PathnameExpansionBehavior,
+    pattern_behavior: GlobPatternBehavior,
+) -> Vec<Span> {
+    let active_brace_spans = word
+        .brace_syntax()
+        .iter()
+        .copied()
+        .filter(|brace| brace.expands())
+        .map(|brace| brace.span)
+        .collect::<Vec<_>>();
+
+    if active_brace_spans.is_empty() {
+        return word_active_glob_pattern_spans(word, source, pathname_behavior, pattern_behavior);
+    }
+
+    word_active_glob_pattern_spans(word, source, pathname_behavior, pattern_behavior)
+        .into_iter()
+        .filter(|glob_span| {
+            !active_brace_spans.iter().any(|brace_span| {
+                brace_span.start.offset <= glob_span.start.offset
+                    && glob_span.end.offset <= brace_span.end.offset
+            })
+        })
+        .collect()
+}
+
+pub fn word_starts_with_active_glob_group_operator(
+    word: &Word,
+    source: &str,
+    pathname_behavior: PathnameExpansionBehavior,
+    pattern_behavior: GlobPatternBehavior,
+) -> bool {
+    if !pathname_behavior.literal_globs_can_expand()
+        || !pattern_operator_may_be_active(pattern_behavior.ksh_glob())
+    {
+        return false;
+    }
+
+    let bytes = word.span.slice(source).as_bytes();
+    matches!(
+        find_ksh_glob_group_bounds(bytes).first().copied(),
+        Some((0, _))
+    )
 }
 
 pub fn word_suspicious_bracket_glob_spans(word: &Word, source: &str) -> Vec<Span> {
@@ -331,6 +396,78 @@ pub(crate) fn collect_unquoted_glob_pattern_spans(
     flush_literal_run(&mut literal_run_start, &mut literal_run_end, spans);
 }
 
+pub(crate) fn collect_active_glob_pattern_spans(
+    parts: &[WordPartNode],
+    source: &str,
+    in_double_quotes: bool,
+    pattern_behavior: GlobPatternBehavior,
+    spans: &mut Vec<Span>,
+) {
+    let mut literal_run_start = None::<usize>;
+    let mut literal_run_end = None::<usize>;
+
+    let flush_literal_run = |literal_run_start: &mut Option<usize>,
+                             literal_run_end: &mut Option<usize>,
+                             spans: &mut Vec<Span>| {
+        let Some(start_index) = literal_run_start.take() else {
+            return;
+        };
+        let Some(end_index) = literal_run_end.take() else {
+            return;
+        };
+        let start = parts[start_index].span.start;
+        let end = parts[end_index].span.end;
+        let combined_span = Span::from_positions(start, end);
+        spans.extend(active_literal_glob_pattern_spans(
+            combined_span,
+            source,
+            pattern_behavior,
+        ));
+    };
+
+    for (index, part) in parts.iter().enumerate() {
+        match &part.kind {
+            WordPart::DoubleQuoted { parts, .. } => {
+                flush_literal_run(&mut literal_run_start, &mut literal_run_end, spans);
+                collect_active_glob_pattern_spans(parts, source, true, pattern_behavior, spans)
+            }
+            WordPart::Literal(_)
+                if !in_double_quotes
+                    && !literal_part_is_parameter_operator_tail(parts, index, source) =>
+            {
+                literal_run_start.get_or_insert(index);
+                literal_run_end = Some(index);
+            }
+            WordPart::ZshQualifiedGlob(_) if !in_double_quotes => {
+                flush_literal_run(&mut literal_run_start, &mut literal_run_end, spans);
+                spans.push(part.span);
+            }
+            WordPart::Literal(_)
+            | WordPart::ZshQualifiedGlob(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::Transformation { .. } => {
+                flush_literal_run(&mut literal_run_start, &mut literal_run_end, spans);
+            }
+        }
+    }
+
+    flush_literal_run(&mut literal_run_start, &mut literal_run_end, spans);
+}
+
 pub(crate) fn literal_glob_pattern_spans(span: Span, source: &str) -> Vec<Span> {
     let text = span.slice(source);
     let bytes = text.as_bytes();
@@ -376,6 +513,101 @@ pub(crate) fn literal_glob_pattern_spans(span: Span, source: &str) -> Vec<Span> 
     }
 
     spans
+}
+
+pub(crate) fn active_literal_glob_pattern_spans(
+    span: Span,
+    source: &str,
+    pattern_behavior: GlobPatternBehavior,
+) -> Vec<Span> {
+    let text = span.slice(source);
+    let bytes = text.as_bytes();
+    let mut spans = Vec::new();
+    let mut covered = Vec::<(usize, usize)>::new();
+
+    if pattern_operator_may_be_active(pattern_behavior.ksh_glob()) {
+        for (start, end) in find_ksh_glob_group_bounds(bytes) {
+            spans.push(span_within_literal(span, source, start, end + 1));
+            covered.push((start, end));
+        }
+    }
+
+    if pattern_operator_may_be_active(pattern_behavior.extended_glob()) {
+        for (start, end) in find_zsh_extended_glob_operator_bounds(bytes) {
+            if covered
+                .iter()
+                .any(|(covered_start, covered_end)| *covered_start <= start && end <= *covered_end)
+            {
+                continue;
+            }
+            spans.push(span_within_literal(span, source, start, end + 1));
+            covered.push((start, end));
+        }
+    }
+
+    let basic_spans = literal_glob_pattern_spans(span, source)
+        .into_iter()
+        .filter(|glob_span| !span_is_within_any(*glob_span, &spans))
+        .collect::<Vec<_>>();
+    spans.extend(basic_spans);
+    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.dedup();
+    spans
+}
+
+pub(crate) fn find_ksh_glob_group_bounds(bytes: &[u8]) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut index = 0usize;
+
+    while index + 1 < bytes.len() {
+        if !is_extglob_operator(bytes[index])
+            || bytes[index + 1] != b'('
+            || byte_is_backslash_escaped(bytes, index)
+        {
+            index += 1;
+            continue;
+        }
+
+        if let Some(close) = matching_group_end(bytes, index + 1) {
+            spans.push((index, close));
+            index = close + 1;
+        } else {
+            index += 1;
+        }
+    }
+
+    spans
+}
+
+pub(crate) fn find_zsh_extended_glob_operator_bounds(bytes: &[u8]) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if byte_is_backslash_escaped(bytes, index) {
+            index += 1;
+            continue;
+        }
+
+        match bytes[index] {
+            b'#' | b'~' | b'^' => spans.push((index, index)),
+            _ => {}
+        }
+
+        index += 1;
+    }
+
+    spans
+}
+
+fn pattern_operator_may_be_active(behavior: PatternOperatorBehavior) -> bool {
+    !matches!(behavior, PatternOperatorBehavior::Disabled)
+}
+
+fn span_is_within_any(span: Span, hosts: &[Span]) -> bool {
+    hosts
+        .iter()
+        .any(|host| host.start.offset <= span.start.offset && span.end.offset <= host.end.offset)
 }
 
 pub(crate) fn suspicious_bracket_glob_text(text: &str) -> bool {

--- a/crates/shuck-linter/src/facts/word_spans/globs.rs
+++ b/crates/shuck-linter/src/facts/word_spans/globs.rs
@@ -438,9 +438,13 @@ pub(crate) fn collect_active_glob_pattern_spans(
                 literal_run_start.get_or_insert(index);
                 literal_run_end = Some(index);
             }
-            WordPart::ZshQualifiedGlob(_) if !in_double_quotes => {
+            WordPart::ZshQualifiedGlob(glob) if !in_double_quotes => {
                 flush_literal_run(&mut literal_run_start, &mut literal_run_end, spans);
-                spans.push(part.span);
+                spans.extend(zsh_qualified_glob_active_pattern_spans(
+                    glob,
+                    source,
+                    pattern_behavior,
+                ));
             }
             WordPart::Literal(_)
             | WordPart::ZshQualifiedGlob(_)
@@ -533,7 +537,7 @@ pub(crate) fn active_literal_glob_pattern_spans(
     }
 
     if pattern_operator_may_be_active(pattern_behavior.extended_glob()) {
-        for (start, end) in find_zsh_extended_glob_operator_bounds(bytes) {
+        for (start, end) in find_zsh_extended_glob_operator_bounds(bytes, &covered) {
             if covered
                 .iter()
                 .any(|(covered_start, covered_end)| *covered_start <= start && end <= *covered_end)
@@ -579,7 +583,10 @@ pub(crate) fn find_ksh_glob_group_bounds(bytes: &[u8]) -> Vec<(usize, usize)> {
     spans
 }
 
-pub(crate) fn find_zsh_extended_glob_operator_bounds(bytes: &[u8]) -> Vec<(usize, usize)> {
+pub(crate) fn find_zsh_extended_glob_operator_bounds(
+    bytes: &[u8],
+    active_group_bounds: &[(usize, usize)],
+) -> Vec<(usize, usize)> {
     let mut spans = Vec::new();
     let mut index = 0usize;
 
@@ -590,7 +597,15 @@ pub(crate) fn find_zsh_extended_glob_operator_bounds(bytes: &[u8]) -> Vec<(usize
         }
 
         match bytes[index] {
-            b'#' | b'~' | b'^' => spans.push((index, index)),
+            b'#' | b'^' => spans.push((index, index)),
+            b'~' if zsh_exclusion_operator_has_pattern_operand(
+                bytes,
+                index,
+                active_group_bounds,
+            ) =>
+            {
+                spans.push((index, index));
+            }
             _ => {}
         }
 
@@ -598,6 +613,87 @@ pub(crate) fn find_zsh_extended_glob_operator_bounds(bytes: &[u8]) -> Vec<(usize
     }
 
     spans
+}
+
+fn zsh_exclusion_operator_has_pattern_operand(
+    bytes: &[u8],
+    tilde_index: usize,
+    active_group_bounds: &[(usize, usize)],
+) -> bool {
+    literal_range_has_active_glob_syntax(bytes, 0, tilde_index, active_group_bounds)
+        || literal_range_has_active_glob_syntax(
+            bytes,
+            tilde_index + 1,
+            bytes.len(),
+            active_group_bounds,
+        )
+}
+
+pub(crate) fn zsh_qualified_glob_active_pattern_spans(
+    glob: &ZshQualifiedGlob,
+    source: &str,
+    pattern_behavior: GlobPatternBehavior,
+) -> Vec<Span> {
+    if zsh_qualified_glob_has_control_syntax(glob) {
+        vec![glob.span]
+    } else {
+        active_literal_glob_pattern_spans(glob.span, source, pattern_behavior)
+    }
+}
+
+pub(crate) fn zsh_qualified_glob_has_control_syntax(glob: &ZshQualifiedGlob) -> bool {
+    glob.qualifiers.is_some()
+        || glob
+            .segments
+            .iter()
+            .any(|segment| matches!(segment, ZshGlobSegment::InlineControl(_)))
+}
+
+fn literal_range_has_active_glob_syntax(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    active_group_bounds: &[(usize, usize)],
+) -> bool {
+    if active_group_bounds
+        .iter()
+        .any(|(group_start, group_end)| start <= *group_start && *group_end < end)
+    {
+        return true;
+    }
+
+    let mut index = start;
+    while index < end {
+        if byte_is_backslash_escaped(bytes, index) {
+            index += 1;
+            continue;
+        }
+
+        match bytes[index] {
+            b'*' | b'?' | b'#' | b'^' => return true,
+            b'[' => {
+                let mut close = index + 1;
+                while close < end {
+                    if let Some(named_end) = bracket_glob_named_class_end(bytes, close, end) {
+                        close = named_end;
+                        continue;
+                    }
+                    if bytes[close] == b'\\' {
+                        close = (close + 2).min(end);
+                        continue;
+                    }
+                    if bytes[close] == b']' {
+                        return true;
+                    }
+                    close += 1;
+                }
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    false
 }
 
 fn pattern_operator_may_be_active(behavior: PatternOperatorBehavior) -> bool {

--- a/crates/shuck-linter/src/facts/word_spans/mod.rs
+++ b/crates/shuck-linter/src/facts/word_spans/mod.rs
@@ -7,6 +7,7 @@ use shuck_ast::{
 
 use super::BacktickEscapedParameter;
 use crate::Locator;
+use shuck_semantic::{GlobPatternBehavior, PathnameExpansionBehavior, PatternOperatorBehavior};
 
 mod arrays;
 mod backticks;

--- a/crates/shuck-linter/src/facts/word_spans/mod.rs
+++ b/crates/shuck-linter/src/facts/word_spans/mod.rs
@@ -2,7 +2,7 @@ use shuck_ast::{
     ArithmeticExpr, BourneParameterExpansion, CaseItem, CommandSubstitutionSyntax, ConditionalExpr,
     ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position,
     PrefixMatchKind, Span, SubscriptSelector, VarRef, Word, WordPart, WordPartNode,
-    ZshExpansionTarget,
+    ZshExpansionTarget, ZshGlobSegment, ZshQualifiedGlob,
 };
 
 use super::BacktickEscapedParameter;

--- a/crates/shuck-linter/src/facts/words/expansion.rs
+++ b/crates/shuck-linter/src/facts/words/expansion.rs
@@ -384,7 +384,7 @@ pub(super) struct AnalysisSummary {
 
 pub(super) fn analyze_word(
     word: &Word,
-    _source: &str,
+    source: &str,
     behavior: Option<&ShellBehaviorAt<'_>>,
 ) -> ExpansionAnalysis {
     let default_behavior;
@@ -395,7 +395,7 @@ pub(super) fn analyze_word(
         &default_behavior
     };
     let mut summary = AnalysisSummary::default();
-    analyze_parts(&word.parts, false, behavior, &mut summary);
+    analyze_parts(&word.parts, source, false, behavior, &mut summary);
     let default_field_splitting_behavior = behavior.field_splitting();
     let default_pathname_expansion_behavior = behavior.pathname_expansion();
 
@@ -657,6 +657,7 @@ pub(super) fn context_allows_brace_fanout(context: ExpansionContext) -> bool {
 
 pub(super) fn analyze_parts(
     parts: &[WordPartNode],
+    source: &str,
     in_double_quotes: bool,
     behavior: &ShellBehaviorAt<'_>,
     summary: &mut AnalysisSummary,
@@ -665,10 +666,10 @@ pub(super) fn analyze_parts(
         match &part.kind {
             WordPart::Literal(_) | WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
-                analyze_parts(parts, true, behavior, summary);
+                analyze_parts(parts, source, true, behavior, summary);
             }
             kind => {
-                let analysis = analyze_part(kind, in_double_quotes, behavior);
+                let analysis = analyze_part(kind, source, in_double_quotes, behavior);
                 summary.has_non_literal = true;
                 summary.has_scalar_value |= analysis.value_shape == PartValueShape::Scalar;
                 summary.has_array_value |= analysis.array_valued;
@@ -699,6 +700,7 @@ pub(super) fn analyze_parts(
 
 pub(super) fn analyze_part(
     part: &WordPart,
+    source: &str,
     in_double_quotes: bool,
     behavior: &ShellBehaviorAt<'_>,
 ) -> PartAnalysis {
@@ -706,21 +708,30 @@ pub(super) fn analyze_part(
     let pathname_expansion_behavior = behavior.pathname_expansion();
 
     match part {
-        WordPart::ZshQualifiedGlob(_) => PartAnalysis {
-            value_shape: PartValueShape::Unknown,
-            array_valued: false,
-            can_expand_to_multiple_fields: !in_double_quotes
-                && pathname_expansion_behavior.literal_globs_can_expand(),
-            field_splitting_behavior,
-            pathname_expansion_behavior,
-            hazards: ExpansionHazards {
-                pathname_matching: !in_double_quotes
-                    && pathname_expansion_behavior.literal_globs_can_expand(),
-                ..ExpansionHazards::default()
-            },
-            command_substitution: false,
-            process_substitution: false,
-        },
+        WordPart::ZshQualifiedGlob(glob) => {
+            let pathname_matching = !in_double_quotes
+                && pathname_expansion_behavior.literal_globs_can_expand()
+                && !word_spans::zsh_qualified_glob_active_pattern_spans(
+                    glob,
+                    source,
+                    behavior.glob_pattern(),
+                )
+                .is_empty();
+
+            PartAnalysis {
+                value_shape: PartValueShape::Unknown,
+                array_valued: false,
+                can_expand_to_multiple_fields: pathname_matching,
+                field_splitting_behavior,
+                pathname_expansion_behavior,
+                hazards: ExpansionHazards {
+                    pathname_matching,
+                    ..ExpansionHazards::default()
+                },
+                command_substitution: false,
+                process_substitution: false,
+            }
+        }
         WordPart::Parameter(parameter) => {
             analyze_parameter_part(parameter, in_double_quotes, behavior)
         }

--- a/crates/shuck-linter/src/facts/words/expansion.rs
+++ b/crates/shuck-linter/src/facts/words/expansion.rs
@@ -303,126 +303,12 @@ pub(super) fn classify_pattern_operand(pattern: &Pattern, source: &str) -> TestO
     TestOperandClass::FixedLiteral
 }
 
-pub(super) fn field_splitting_behavior_for_options(
-    options: Option<&ZshOptionState>,
-) -> FieldSplittingBehavior {
-    match options {
-        Some(options) => match options.sh_word_split {
-            OptionValue::Off => FieldSplittingBehavior::Never,
-            OptionValue::On => FieldSplittingBehavior::UnquotedOnly,
-            OptionValue::Unknown => FieldSplittingBehavior::Ambiguous,
-        },
-        None => FieldSplittingBehavior::UnquotedOnly,
-    }
-}
-
-pub(super) fn pathname_expansion_behavior_for_options(
-    options: Option<&ZshOptionState>,
-) -> PathnameExpansionBehavior {
-    match options {
-        Some(options) => match options.glob {
-            OptionValue::Off => PathnameExpansionBehavior::Disabled,
-            OptionValue::On => match options.glob_subst {
-                OptionValue::Off => PathnameExpansionBehavior::LiteralGlobsOnly,
-                OptionValue::On => PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
-                OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
-            },
-            OptionValue::Unknown => match options.glob_subst {
-                OptionValue::Off => PathnameExpansionBehavior::LiteralGlobsOnlyOrDisabled,
-                OptionValue::On | OptionValue::Unknown => PathnameExpansionBehavior::Ambiguous,
-            },
-        },
-        None => PathnameExpansionBehavior::SubstitutionResultsWhenUnquoted,
-    }
-}
-
-pub(super) fn file_expansion_order_for_options(
-    options: Option<&ZshOptionState>,
-) -> FileExpansionOrderBehavior {
-    match options {
-        Some(options) => match options.sh_file_expansion {
-            OptionValue::Off => FileExpansionOrderBehavior::AfterParameterExpansion,
-            OptionValue::On => FileExpansionOrderBehavior::BeforeParameterExpansion,
-            OptionValue::Unknown => FileExpansionOrderBehavior::Ambiguous,
-        },
-        None => FileExpansionOrderBehavior::BeforeParameterExpansion,
-    }
-}
-
-pub(super) fn glob_failure_behavior_for_options(
-    options: Option<&ZshOptionState>,
-) -> GlobFailureBehavior {
-    match options {
-        Some(options) => match options.glob {
-            OptionValue::Off => GlobFailureBehavior::KeepLiteralOnNoMatch,
-            OptionValue::On => match options.csh_null_glob {
-                OptionValue::On => GlobFailureBehavior::CshNullGlob,
-                OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
-                OptionValue::Off => match options.null_glob {
-                    OptionValue::On => GlobFailureBehavior::DropUnmatchedPattern,
-                    OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
-                    OptionValue::Off => match options.nomatch {
-                        OptionValue::On => GlobFailureBehavior::ErrorOnNoMatch,
-                        OptionValue::Off => GlobFailureBehavior::KeepLiteralOnNoMatch,
-                        OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
-                    },
-                },
-            },
-            OptionValue::Unknown => GlobFailureBehavior::Ambiguous,
-        },
-        None => GlobFailureBehavior::KeepLiteralOnNoMatch,
-    }
-}
-
-pub(super) fn glob_dot_behavior_for_options(options: Option<&ZshOptionState>) -> GlobDotBehavior {
-    match options {
-        Some(options) => match options.glob_dots {
-            OptionValue::Off => GlobDotBehavior::ExplicitDotRequired,
-            OptionValue::On => GlobDotBehavior::DotfilesIncluded,
-            OptionValue::Unknown => GlobDotBehavior::Ambiguous,
-        },
-        None => GlobDotBehavior::ExplicitDotRequired,
-    }
-}
-
-pub(super) fn glob_pattern_behavior_for_options(
-    options: Option<&ZshOptionState>,
-) -> GlobPatternBehavior {
-    options.map_or_else(default_glob_pattern_behavior, |options| {
-        semantic_glob_pattern_behavior(
-            pattern_operator_behavior_for_options(options.extended_glob),
-            pattern_operator_behavior_for_options(options.ksh_glob),
-            pattern_operator_behavior_for_options(options.sh_glob),
-        )
-    })
-}
-
 fn default_glob_pattern_behavior() -> GlobPatternBehavior {
-    semantic_glob_pattern_behavior(
-        PatternOperatorBehavior::Disabled,
-        PatternOperatorBehavior::Disabled,
-        PatternOperatorBehavior::Disabled,
-    )
+    ShellBehaviorAt::for_dialect(shuck_semantic::ShellDialect::Bash).glob_pattern()
 }
 
-fn semantic_glob_pattern_behavior(
-    extended_glob: PatternOperatorBehavior,
-    ksh_glob: PatternOperatorBehavior,
-    sh_glob: PatternOperatorBehavior,
-) -> GlobPatternBehavior {
-    GlobPatternBehavior::from_parts(
-        extended_glob,
-        ksh_glob,
-        sh_glob,
-    )
-}
-
-fn pattern_operator_behavior_for_options(value: OptionValue) -> PatternOperatorBehavior {
-    match value {
-        OptionValue::Off => PatternOperatorBehavior::Disabled,
-        OptionValue::On => PatternOperatorBehavior::Enabled,
-        OptionValue::Unknown => PatternOperatorBehavior::Ambiguous,
-    }
+fn default_shell_behavior() -> ShellBehaviorAt<'static> {
+    ShellBehaviorAt::for_dialect(shuck_semantic::ShellDialect::Bash)
 }
 
 fn merge_field_splitting_behavior(
@@ -499,12 +385,19 @@ pub(super) struct AnalysisSummary {
 pub(super) fn analyze_word(
     word: &Word,
     _source: &str,
-    options: Option<&ZshOptionState>,
+    behavior: Option<&ShellBehaviorAt<'_>>,
 ) -> ExpansionAnalysis {
+    let default_behavior;
+    let behavior = if let Some(behavior) = behavior {
+        behavior
+    } else {
+        default_behavior = default_shell_behavior();
+        &default_behavior
+    };
     let mut summary = AnalysisSummary::default();
-    analyze_parts(&word.parts, false, options, &mut summary);
-    let default_field_splitting_behavior = field_splitting_behavior_for_options(options);
-    let default_pathname_expansion_behavior = pathname_expansion_behavior_for_options(options);
+    analyze_parts(&word.parts, false, behavior, &mut summary);
+    let default_field_splitting_behavior = behavior.field_splitting();
+    let default_pathname_expansion_behavior = behavior.pathname_expansion();
 
     ExpansionAnalysis {
         quote: if is_fully_quoted(word) {
@@ -553,13 +446,20 @@ pub(crate) fn analyze_literal_runtime(
     word: &Word,
     source: &str,
     context: ExpansionContext,
-    options: Option<&ZshOptionState>,
+    behavior: Option<&ShellBehaviorAt<'_>>,
 ) -> RuntimeLiteralAnalysis {
+    let default_behavior;
+    let behavior = if let Some(behavior) = behavior {
+        behavior
+    } else {
+        default_behavior = default_shell_behavior();
+        &default_behavior
+    };
     let mut analysis = RuntimeLiteralAnalysis {
-        pathname_expansion_behavior: pathname_expansion_behavior_for_options(options),
-        glob_failure_behavior: glob_failure_behavior_for_options(options),
-        glob_dot_behavior: glob_dot_behavior_for_options(options),
-        glob_pattern_behavior: glob_pattern_behavior_for_options(options),
+        pathname_expansion_behavior: behavior.pathname_expansion(),
+        glob_failure_behavior: behavior.glob_failure(),
+        glob_dot_behavior: behavior.glob_dot_matching(),
+        glob_pattern_behavior: behavior.glob_pattern(),
         ..RuntimeLiteralAnalysis::default()
     };
     let mut state = RuntimeLiteralState::default();
@@ -568,7 +468,7 @@ pub(crate) fn analyze_literal_runtime(
         &word.parts,
         source,
         context,
-        options,
+        behavior,
         &mut state,
         &mut analysis,
     );
@@ -587,7 +487,7 @@ pub(super) fn analyze_literal_runtime_parts(
     parts: &[WordPartNode],
     source: &str,
     context: ExpansionContext,
-    options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
     state: &mut RuntimeLiteralState,
     analysis: &mut RuntimeLiteralAnalysis,
 ) {
@@ -597,7 +497,7 @@ pub(super) fn analyze_literal_runtime_parts(
                 scan_literal_runtime_text(
                     part.span.slice(source),
                     context,
-                    options,
+                    behavior,
                     state,
                     analysis,
                 );
@@ -626,13 +526,13 @@ pub(super) fn analyze_literal_runtime_parts(
 pub(super) fn scan_literal_runtime_text(
     text: &str,
     context: ExpansionContext,
-    options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
     state: &mut RuntimeLiteralState,
     analysis: &mut RuntimeLiteralAnalysis,
 ) {
     let mut escaped = false;
     let mut brace_candidate: Option<usize> = None;
-    let file_expansion_order = file_expansion_order_for_options(options);
+    let file_expansion_order = behavior.file_expansion_order();
 
     for (idx, ch) in text.char_indices() {
         if escaped {
@@ -758,17 +658,17 @@ pub(super) fn context_allows_brace_fanout(context: ExpansionContext) -> bool {
 pub(super) fn analyze_parts(
     parts: &[WordPartNode],
     in_double_quotes: bool,
-    options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
     summary: &mut AnalysisSummary,
 ) {
     for part in parts {
         match &part.kind {
             WordPart::Literal(_) | WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
-                analyze_parts(parts, true, options, summary);
+                analyze_parts(parts, true, behavior, summary);
             }
             kind => {
-                let analysis = analyze_part(kind, in_double_quotes, options);
+                let analysis = analyze_part(kind, in_double_quotes, behavior);
                 summary.has_non_literal = true;
                 summary.has_scalar_value |= analysis.value_shape == PartValueShape::Scalar;
                 summary.has_array_value |= analysis.array_valued;
@@ -800,10 +700,10 @@ pub(super) fn analyze_parts(
 pub(super) fn analyze_part(
     part: &WordPart,
     in_double_quotes: bool,
-    options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
 ) -> PartAnalysis {
-    let field_splitting_behavior = field_splitting_behavior_for_options(options);
-    let pathname_expansion_behavior = pathname_expansion_behavior_for_options(options);
+    let field_splitting_behavior = behavior.field_splitting();
+    let pathname_expansion_behavior = behavior.pathname_expansion();
 
     match part {
         WordPart::ZshQualifiedGlob(_) => PartAnalysis {
@@ -822,15 +722,15 @@ pub(super) fn analyze_part(
             process_substitution: false,
         },
         WordPart::Parameter(parameter) => {
-            analyze_parameter_part(parameter, in_double_quotes, options)
+            analyze_parameter_part(parameter, in_double_quotes, behavior)
         }
         WordPart::CommandSubstitution { .. } => scalar_part(
-            substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+            substitution_can_expand_to_multiple_fields(in_double_quotes, behavior),
             field_splitting_behavior,
             pathname_expansion_behavior,
             ExpansionHazards {
-                field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
+                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, behavior),
                 command_or_process_substitution: true,
                 ..ExpansionHazards::default()
             },
@@ -873,12 +773,12 @@ pub(super) fn analyze_part(
         | WordPart::Length(_)
         | WordPart::ArrayLength(_)
         | WordPart::Substring { .. } => scalar_part(
-            substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+            substitution_can_expand_to_multiple_fields(in_double_quotes, behavior),
             field_splitting_behavior,
             pathname_expansion_behavior,
             ExpansionHazards {
-                field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
+                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, behavior),
                 arithmetic_expansion: matches!(part, WordPart::ArithmeticExpansion { .. }),
                 ..ExpansionHazards::default()
             },
@@ -896,12 +796,12 @@ pub(super) fn analyze_part(
             )
         }
         WordPart::ParameterExpansion { operator, .. } => scalar_part(
-            substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+            substitution_can_expand_to_multiple_fields(in_double_quotes, behavior),
             field_splitting_behavior,
             pathname_expansion_behavior,
             ExpansionHazards {
-                field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
+                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, behavior),
                 runtime_pattern: parameter_operator_uses_pattern(operator),
                 ..ExpansionHazards::default()
             },
@@ -932,14 +832,14 @@ pub(super) fn analyze_part(
                 )
             }
             None => scalar_part(
-                substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                substitution_can_expand_to_multiple_fields(in_double_quotes, behavior),
                 field_splitting_behavior,
                 pathname_expansion_behavior,
                 ExpansionHazards {
-                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
                     pathname_matching: substitution_pathname_matching_hazard(
                         in_double_quotes,
-                        options,
+                        behavior,
                     ),
                     ..ExpansionHazards::default()
                 },
@@ -970,10 +870,10 @@ pub(super) fn analyze_part(
                 field_splitting_behavior,
                 pathname_expansion_behavior,
                 hazards: ExpansionHazards {
-                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
                     pathname_matching: substitution_pathname_matching_hazard(
                         in_double_quotes,
-                        options,
+                        behavior,
                     ),
                     ..ExpansionHazards::default()
                 },
@@ -986,13 +886,13 @@ pub(super) fn analyze_part(
             array_valued: false,
             can_expand_to_multiple_fields: substitution_can_expand_to_multiple_fields(
                 in_double_quotes,
-                options,
+                behavior,
             ),
             field_splitting_behavior,
             pathname_expansion_behavior,
             hazards: ExpansionHazards {
-                field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
-                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, options),
+                field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
+                pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, behavior),
                 runtime_pattern: operator
                     .as_ref()
                     .is_some_and(parameter_operator_uses_pattern),
@@ -1010,10 +910,10 @@ pub(super) fn analyze_part(
 pub(super) fn analyze_parameter_part(
     parameter: &ParameterExpansion,
     in_double_quotes: bool,
-    options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
 ) -> PartAnalysis {
-    let field_splitting_behavior = field_splitting_behavior_for_options(options);
-    let pathname_expansion_behavior = pathname_expansion_behavior_for_options(options);
+    let field_splitting_behavior = behavior.field_splitting();
+    let pathname_expansion_behavior = behavior.pathname_expansion();
 
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(syntax) => match syntax {
@@ -1041,17 +941,17 @@ pub(super) fn analyze_parameter_part(
                     )
                 }
                 None => scalar_part(
-                    substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                    substitution_can_expand_to_multiple_fields(in_double_quotes, behavior),
                     field_splitting_behavior,
                     pathname_expansion_behavior,
                     ExpansionHazards {
                         field_splitting: substitution_field_splitting_hazard(
                             in_double_quotes,
-                            options,
+                            behavior,
                         ),
                         pathname_matching: substitution_pathname_matching_hazard(
                             in_double_quotes,
-                            options,
+                            behavior,
                         ),
                         ..ExpansionHazards::default()
                     },
@@ -1060,15 +960,15 @@ pub(super) fn analyze_parameter_part(
                 ),
             },
             BourneParameterExpansion::Length { .. } => scalar_part(
-                substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                substitution_can_expand_to_multiple_fields(in_double_quotes, behavior),
                 field_splitting_behavior,
                 pathname_expansion_behavior,
                 ExpansionHazards {
-                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
                     pathname_matching: substitution_pathname_matching_hazard(
                         in_double_quotes,
-                        options,
-                    ),
+                            behavior,
+                        ),
                     ..ExpansionHazards::default()
                 },
                 false,
@@ -1087,16 +987,16 @@ pub(super) fn analyze_parameter_part(
                 array_valued: false,
                 can_expand_to_multiple_fields: substitution_can_expand_to_multiple_fields(
                     in_double_quotes,
-                    options,
+                    behavior,
                 ),
                 field_splitting_behavior,
                 pathname_expansion_behavior,
                 hazards: ExpansionHazards {
-                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
                     pathname_matching: substitution_pathname_matching_hazard(
                         in_double_quotes,
-                        options,
-                    ),
+                            behavior,
+                        ),
                     runtime_pattern: operator
                         .as_ref()
                         .is_some_and(parameter_operator_uses_pattern),
@@ -1121,11 +1021,11 @@ pub(super) fn analyze_parameter_part(
                 hazards: ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(
                         in_double_quotes,
-                            options,
+                            behavior,
                         ),
                         pathname_matching: substitution_pathname_matching_hazard(
                             in_double_quotes,
-                            options,
+                            behavior,
                         ),
                         ..ExpansionHazards::default()
                     },
@@ -1145,18 +1045,18 @@ pub(super) fn analyze_parameter_part(
                     )
                 } else {
                     scalar_part(
-                        substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                        substitution_can_expand_to_multiple_fields(in_double_quotes, behavior),
                         field_splitting_behavior,
                         pathname_expansion_behavior,
                         ExpansionHazards {
                             field_splitting: substitution_field_splitting_hazard(
                                 in_double_quotes,
-                                options,
-                            ),
+                            behavior,
+                        ),
                             pathname_matching: substitution_pathname_matching_hazard(
                                 in_double_quotes,
-                                options,
-                            ),
+                            behavior,
+                        ),
                             ..ExpansionHazards::default()
                         },
                         false,
@@ -1165,15 +1065,15 @@ pub(super) fn analyze_parameter_part(
                 }
             }
             BourneParameterExpansion::Operation { operator, .. } => scalar_part(
-                substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                substitution_can_expand_to_multiple_fields(in_double_quotes, behavior),
                 field_splitting_behavior,
                 pathname_expansion_behavior,
                 ExpansionHazards {
-                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
                     pathname_matching: substitution_pathname_matching_hazard(
                         in_double_quotes,
-                        options,
-                    ),
+                            behavior,
+                        ),
                     runtime_pattern: parameter_operator_uses_pattern(operator),
                     ..ExpansionHazards::default()
                 },
@@ -1181,15 +1081,15 @@ pub(super) fn analyze_parameter_part(
                 false,
             ),
             BourneParameterExpansion::Transformation { .. } => scalar_part(
-                substitution_can_expand_to_multiple_fields(in_double_quotes, options),
+                substitution_can_expand_to_multiple_fields(in_double_quotes, behavior),
                 field_splitting_behavior,
                 pathname_expansion_behavior,
                 ExpansionHazards {
-                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, options),
+                    field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
                     pathname_matching: substitution_pathname_matching_hazard(
                         in_double_quotes,
-                        options,
-                    ),
+                            behavior,
+                        ),
                     ..ExpansionHazards::default()
                 },
                 false,
@@ -1197,28 +1097,26 @@ pub(super) fn analyze_parameter_part(
             ),
         },
         ParameterExpansionSyntax::Zsh(syntax) => {
-            let effective_options = overlay_zsh_modifier_overrides(options, syntax);
-            let field_splitting_behavior =
-                field_splitting_behavior_for_options(effective_options.as_ref());
-            let pathname_expansion_behavior =
-                pathname_expansion_behavior_for_options(effective_options.as_ref());
+            let effective_behavior = zsh_modifier_behavior(behavior, syntax);
+            let field_splitting_behavior = effective_behavior.field_splitting();
+            let pathname_expansion_behavior = effective_behavior.pathname_expansion();
             PartAnalysis {
                 value_shape: PartValueShape::Unknown,
                 array_valued: false,
                 can_expand_to_multiple_fields: substitution_can_expand_to_multiple_fields(
                     in_double_quotes,
-                    effective_options.as_ref(),
+                    &effective_behavior,
                 ),
                 field_splitting_behavior,
                 pathname_expansion_behavior,
                 hazards: ExpansionHazards {
                     field_splitting: substitution_field_splitting_hazard(
                         in_double_quotes,
-                        effective_options.as_ref(),
+                        &effective_behavior,
                     ),
                     pathname_matching: substitution_pathname_matching_hazard(
                         in_double_quotes,
-                        effective_options.as_ref(),
+                        &effective_behavior,
                     ),
                     runtime_pattern: syntax
                         .operation
@@ -1235,60 +1133,57 @@ pub(super) fn analyze_parameter_part(
 
 pub(super) fn substitution_can_expand_to_multiple_fields(
     in_double_quotes: bool,
-    options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
 ) -> bool {
     !in_double_quotes
-        && (field_splitting_behavior_for_options(options).unquoted_results_can_split()
-            || pathname_expansion_behavior_for_options(options)
+        && (behavior.field_splitting().unquoted_results_can_split()
+            || behavior
+                .pathname_expansion()
                 .unquoted_substitution_results_can_glob())
 }
 
 pub(super) fn substitution_field_splitting_hazard(
     in_double_quotes: bool,
-    options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
 ) -> bool {
-    !in_double_quotes && field_splitting_behavior_for_options(options).unquoted_results_can_split()
+    !in_double_quotes && behavior.field_splitting().unquoted_results_can_split()
 }
 
 pub(super) fn substitution_pathname_matching_hazard(
     in_double_quotes: bool,
-    options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
 ) -> bool {
     !in_double_quotes
-        && pathname_expansion_behavior_for_options(options)
+        && behavior
+            .pathname_expansion()
             .unquoted_substitution_results_can_glob()
 }
 
-pub(super) fn overlay_zsh_modifier_overrides(
-    options: Option<&ZshOptionState>,
+pub(super) fn zsh_modifier_behavior<'model>(
+    behavior: &ShellBehaviorAt<'model>,
     syntax: &shuck_ast::ZshParameterExpansion,
-) -> Option<ZshOptionState> {
-    let mut effective = options.cloned()?;
-    apply_toggle_override(
-        &mut effective.sh_word_split,
-        syntax
-            .modifiers
-            .iter()
-            .filter(|modifier| modifier.name == '=')
-            .count(),
-    );
-    apply_toggle_override(
-        &mut effective.glob_subst,
-        syntax
-            .modifiers
-            .iter()
-            .filter(|modifier| modifier.name == '~')
-            .count(),
-    );
-    apply_toggle_override(
-        &mut effective.rc_expand_param,
-        syntax
-            .modifiers
-            .iter()
-            .filter(|modifier| modifier.name == '^')
-            .count(),
-    );
-    Some(effective)
+) -> ShellBehaviorAt<'model> {
+    let field_split_toggles = syntax
+        .modifiers
+        .iter()
+        .filter(|modifier| modifier.name == '=')
+        .count();
+    let glob_subst_toggles = syntax
+        .modifiers
+        .iter()
+        .filter(|modifier| modifier.name == '~')
+        .count();
+    let rc_expand_toggles = syntax
+        .modifiers
+        .iter()
+        .filter(|modifier| modifier.name == '^')
+        .count();
+
+    behavior.clone().with_zsh_option_overlay(|options| {
+        apply_toggle_override(&mut options.sh_word_split, field_split_toggles);
+        apply_toggle_override(&mut options.glob_subst, glob_subst_toggles);
+        apply_toggle_override(&mut options.rc_expand_param, rc_expand_toggles);
+    })
 }
 
 pub(super) fn apply_toggle_override(value: &mut OptionValue, count: usize) {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -293,6 +293,18 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.occurrence().runtime_literal
     }
 
+    pub fn glob_failure_behavior(self) -> GlobFailureBehavior {
+        self.runtime_literal().glob_failure_behavior
+    }
+
+    pub fn glob_dot_behavior(self) -> GlobDotBehavior {
+        self.runtime_literal().glob_dot_behavior
+    }
+
+    pub fn glob_pattern_behavior(self) -> GlobPatternBehavior {
+        self.runtime_literal().glob_pattern_behavior
+    }
+
     pub fn classification(self) -> WordClassification {
         word_classification_from_analysis(self.analysis())
     }
@@ -525,8 +537,54 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         word_spans::word_unquoted_glob_pattern_spans(self.word(), source)
     }
 
+    pub fn has_literal_glob_syntax(self, source: &str) -> bool {
+        !self.unquoted_glob_pattern_spans(source).is_empty()
+            || self
+                .parts_with_spans()
+                .any(|(part, _)| matches!(part, WordPart::ZshQualifiedGlob(_)))
+    }
+
+    pub fn active_literal_glob_spans(self, source: &str) -> Vec<Span> {
+        let runtime = self.runtime_literal();
+        word_spans::word_active_glob_pattern_spans(
+            self.word(),
+            source,
+            runtime.pathname_expansion_behavior,
+            runtime.glob_pattern_behavior,
+        )
+    }
+
     pub fn unquoted_glob_pattern_spans_outside_brace_expansion(self, source: &str) -> Vec<Span> {
         word_spans::word_unquoted_glob_pattern_spans_outside_brace_expansion(self.word(), source)
+    }
+
+    pub fn active_glob_spans_outside_brace_expansion(self, source: &str) -> Vec<Span> {
+        let runtime = self.runtime_literal();
+        word_spans::word_active_glob_pattern_spans_outside_brace_expansion(
+            self.word(),
+            source,
+            runtime.pathname_expansion_behavior,
+            runtime.glob_pattern_behavior,
+        )
+    }
+
+    pub fn starts_with_active_glob_operator(self, source: &str) -> bool {
+        let runtime = self.runtime_literal();
+        if word_spans::word_starts_with_active_glob_group_operator(
+            self.word(),
+            source,
+            runtime.pathname_expansion_behavior,
+            runtime.glob_pattern_behavior,
+        ) {
+            return true;
+        }
+
+        self.facts
+            .command(self.command_id())
+            .shell_behavior()
+            .shell_dialect()
+            != shuck_semantic::ShellDialect::Zsh
+            && self.starts_with_extglob()
     }
 
     pub fn suspicious_bracket_glob_spans(self, source: &str) -> Vec<Span> {
@@ -1037,7 +1095,7 @@ pub(super) fn build_word_facts_for_command<'a>(
     semantic: &'a SemanticModel,
     context: WordFactCommandContext,
     normalized: &NormalizedCommand<'a>,
-    command_zsh_options: Option<ZshOptionState>,
+    command_shell_behavior: ShellBehaviorAt<'a>,
     outputs: WordFactOutputs<'_, 'a>,
 ) {
     let mut collector = WordFactCollector::new(
@@ -1048,7 +1106,7 @@ pub(super) fn build_word_facts_for_command<'a>(
         context.nested_word_command,
         context.scope,
         normalized,
-        command_zsh_options,
+        command_shell_behavior,
         outputs,
     );
     collector.collect_command(visit.command, visit.redirects);
@@ -1376,7 +1434,7 @@ pub(super) struct WordFactCollector<'out, 'a, 'norm> {
     command_scope: ScopeId,
     surface_command_name: Option<&'norm str>,
     surface_body_arg_start_offset: Option<usize>,
-    command_zsh_options: Option<ZshOptionState>,
+    command_shell_behavior: ShellBehaviorAt<'a>,
     word_nodes: &'out mut Vec<WordNode<'a>>,
     word_spans: &'out mut ListArena<Span>,
     word_span_scratch: &'out mut Vec<Span>,
@@ -1416,7 +1474,7 @@ pub(super) fn simple_command_word_at(command: &SimpleCommand, index: usize) -> &
 fn collect_split_sensitive_unquoted_command_substitution_spans(
     parts: &[WordPartNode],
     quoted: bool,
-    options: Option<&ZshOptionState>,
+    behavior: &ShellBehaviorAt<'_>,
     spans: &mut Vec<Span>,
 ) {
     for part in parts {
@@ -1424,12 +1482,12 @@ fn collect_split_sensitive_unquoted_command_substitution_spans(
             WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
                 collect_split_sensitive_unquoted_command_substitution_spans(
-                    parts, true, options, spans,
+                    parts, true, behavior, spans,
                 );
             }
             WordPart::CommandSubstitution { .. }
                 if !quoted
-                    && analyze_part(&part.kind, quoted, options).can_expand_to_multiple_fields =>
+                    && analyze_part(&part.kind, quoted, behavior).can_expand_to_multiple_fields =>
             {
                 spans.push(part.span);
             }
@@ -1448,7 +1506,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         nested_word_command: bool,
         command_scope: ScopeId,
         normalized: &'norm NormalizedCommand<'a>,
-        command_zsh_options: Option<ZshOptionState>,
+        command_shell_behavior: ShellBehaviorAt<'a>,
         outputs: WordFactOutputs<'out, 'a>,
     ) -> Self {
         Self {
@@ -1463,7 +1521,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 .body_args()
                 .first()
                 .map(|word| word.span.start.offset),
-            command_zsh_options,
+            command_shell_behavior,
             word_nodes: outputs.word_nodes,
             word_spans: outputs.word_spans,
             word_span_scratch: outputs.word_span_scratch,
@@ -2152,7 +2210,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             .filter_map(|part| match &part.kind {
                 PatternPart::Word(word) => {
                     let analysis =
-                        analyze_word(word, self.source, self.command_zsh_options.as_ref());
+                        analyze_word(word, self.source, Some(&self.command_shell_behavior));
                     (analysis.literalness == WordLiteralness::Expanded
                         && analysis.quote != WordQuote::FullyQuoted)
                         .then_some(word)
@@ -2366,12 +2424,12 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }
 
         let id = WordNodeId::new(self.word_nodes.len());
-        let mut analysis = analyze_word(word, self.source, self.command_zsh_options.as_ref());
+        let mut analysis = analyze_word(word, self.source, Some(&self.command_shell_behavior));
         apply_zsh_array_fanout(
             word,
             self.semantic,
             self.command_scope,
-            self.command_zsh_options.as_ref(),
+            self.command_shell_behavior.zsh_options(),
             &mut analysis,
         );
         let derived =
@@ -2411,7 +2469,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 word,
                 self.source,
                 context,
-                self.command_zsh_options.as_ref(),
+                Some(&self.command_shell_behavior),
             ),
             WordFactContext::CaseSubject | WordFactContext::ArithmeticCommand => {
                 RuntimeLiteralAnalysis::default()
@@ -2437,7 +2495,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         collect_split_sensitive_unquoted_command_substitution_spans(
             &word.parts,
             false,
-            self.command_zsh_options.as_ref(),
+            &self.command_shell_behavior,
             self.word_span_scratch,
         );
         word_spans::normalize_command_substitution_spans(self.word_span_scratch, self.locator);

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1473,6 +1473,7 @@ pub(super) fn simple_command_word_at(command: &SimpleCommand, index: usize) -> &
 
 fn collect_split_sensitive_unquoted_command_substitution_spans(
     parts: &[WordPartNode],
+    source: &str,
     quoted: bool,
     behavior: &ShellBehaviorAt<'_>,
     spans: &mut Vec<Span>,
@@ -1482,12 +1483,13 @@ fn collect_split_sensitive_unquoted_command_substitution_spans(
             WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
                 collect_split_sensitive_unquoted_command_substitution_spans(
-                    parts, true, behavior, spans,
+                    parts, source, true, behavior, spans,
                 );
             }
             WordPart::CommandSubstitution { .. }
                 if !quoted
-                    && analyze_part(&part.kind, quoted, behavior).can_expand_to_multiple_fields =>
+                    && analyze_part(&part.kind, source, quoted, behavior)
+                        .can_expand_to_multiple_fields =>
             {
                 spans.push(part.span);
             }
@@ -2494,6 +2496,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         self.word_span_scratch.clear();
         collect_split_sensitive_unquoted_command_substitution_spans(
             &word.parts,
+            self.source,
             false,
             &self.command_shell_behavior,
             self.word_span_scratch,

--- a/crates/shuck-linter/src/facts/words/tests.rs
+++ b/crates/shuck-linter/src/facts/words/tests.rs
@@ -522,45 +522,43 @@ mod expansion_analysis_tests {
     fn analyze_literal_runtime_respects_sh_file_expansion_tilde_order() {
         let source = "print ~$USER ~root/$USER ~/\"$USER\" ~$USER/x\n";
         let words = parse_argument_words(source);
-        let native_options = shuck_semantic::ZshOptionState::zsh_default();
-        let sh_file_options = shuck_semantic::ZshOptionState {
-            sh_file_expansion: shuck_semantic::OptionValue::On,
-            ..shuck_semantic::ZshOptionState::zsh_default()
-        };
-        let unknown_options = shuck_semantic::ZshOptionState {
-            sh_file_expansion: shuck_semantic::OptionValue::Unknown,
-            ..shuck_semantic::ZshOptionState::zsh_default()
-        };
+        let native_behavior = zsh_default_behavior();
+        let sh_file_behavior = zsh_behavior(|options| {
+            options.sh_file_expansion = shuck_semantic::OptionValue::On;
+        });
+        let unknown_behavior = zsh_behavior(|options| {
+            options.sh_file_expansion = shuck_semantic::OptionValue::Unknown;
+        });
 
         let native_dynamic_user = analyze_literal_runtime(
             &words[0],
             source,
             ExpansionContext::CommandArgument,
-            Some(&native_options),
+            Some(&native_behavior),
         );
         let sh_file_dynamic_user = analyze_literal_runtime(
             &words[0],
             source,
             ExpansionContext::CommandArgument,
-            Some(&sh_file_options),
+            Some(&sh_file_behavior),
         );
         let sh_file_literal_user = analyze_literal_runtime(
             &words[1],
             source,
             ExpansionContext::CommandArgument,
-            Some(&sh_file_options),
+            Some(&sh_file_behavior),
         );
         let sh_file_home = analyze_literal_runtime(
             &words[2],
             source,
             ExpansionContext::CommandArgument,
-            Some(&sh_file_options),
+            Some(&sh_file_behavior),
         );
         let unknown_dynamic_user = analyze_literal_runtime(
             &words[3],
             source,
             ExpansionContext::CommandArgument,
-            Some(&unknown_options),
+            Some(&unknown_behavior),
         );
         let default_dynamic_user =
             analyze_literal_runtime(&words[0], source, ExpansionContext::CommandArgument, None);

--- a/crates/shuck-linter/src/facts/words/tests.rs
+++ b/crates/shuck-linter/src/facts/words/tests.rs
@@ -234,6 +234,17 @@ mod expansion_analysis_tests {
         command.args.to_vec()
     }
 
+    fn zsh_behavior(
+        configure: impl FnOnce(&mut shuck_semantic::ZshOptionState),
+    ) -> shuck_semantic::ShellBehaviorAt<'static> {
+        shuck_semantic::ShellBehaviorAt::for_dialect(ShellDialect::Zsh)
+            .with_zsh_option_overlay(configure)
+    }
+
+    fn zsh_default_behavior() -> shuck_semantic::ShellBehaviorAt<'static> {
+        zsh_behavior(|_| {})
+    }
+
     fn analyze_argument_words(source: &str) -> Vec<ExpansionAnalysis> {
         parse_argument_words(source)
             .iter()
@@ -357,11 +368,10 @@ mod expansion_analysis_tests {
         let Command::Simple(command) = &file.body[0].command else {
             panic!("expected simple command");
         };
-        let options = shuck_semantic::ZshOptionState {
-            glob: shuck_semantic::OptionValue::Off,
-            ..shuck_semantic::ZshOptionState::zsh_default()
-        };
-        let analysis = analyze_word(&command.args[0], source, Some(&options));
+        let behavior = zsh_behavior(|options| {
+            options.glob = shuck_semantic::OptionValue::Off;
+        });
+        let analysis = analyze_word(&command.args[0], source, Some(&behavior));
 
         assert!(!analysis.hazards.pathname_matching);
         assert!(!analysis.can_expand_to_multiple_fields);
@@ -377,21 +387,16 @@ mod expansion_analysis_tests {
         let Command::Simple(command) = &file.body[0].command else {
             panic!("expected simple command");
         };
-        let native = analyze_word(
-            &command.args[0],
-            source,
-            Some(&shuck_semantic::ZshOptionState::zsh_default()),
-        );
-        let split_options = shuck_semantic::ZshOptionState {
-            sh_word_split: shuck_semantic::OptionValue::On,
-            ..shuck_semantic::ZshOptionState::zsh_default()
-        };
-        let split = analyze_word(&command.args[0], source, Some(&split_options));
-        let no_glob_options = shuck_semantic::ZshOptionState {
-            glob: shuck_semantic::OptionValue::Off,
-            ..shuck_semantic::ZshOptionState::zsh_default()
-        };
-        let no_glob = analyze_word(&command.args[0], source, Some(&no_glob_options));
+        let native_behavior = zsh_default_behavior();
+        let native = analyze_word(&command.args[0], source, Some(&native_behavior));
+        let split_behavior = zsh_behavior(|options| {
+            options.sh_word_split = shuck_semantic::OptionValue::On;
+        });
+        let split = analyze_word(&command.args[0], source, Some(&split_behavior));
+        let no_glob_behavior = zsh_behavior(|options| {
+            options.glob = shuck_semantic::OptionValue::Off;
+        });
+        let no_glob = analyze_word(&command.args[0], source, Some(&no_glob_behavior));
 
         assert_eq!(
             native.field_splitting_behavior,
@@ -423,16 +428,12 @@ mod expansion_analysis_tests {
         let Command::Simple(command) = &file.body[0].command else {
             panic!("expected simple command");
         };
-        let analysis = analyze_word(
-            &command.args[0],
-            source,
-            Some(&shuck_semantic::ZshOptionState {
-                sh_word_split: shuck_semantic::OptionValue::Unknown,
-                glob: shuck_semantic::OptionValue::Unknown,
-                glob_subst: shuck_semantic::OptionValue::Unknown,
-                ..shuck_semantic::ZshOptionState::zsh_default()
-            }),
-        );
+        let behavior = zsh_behavior(|options| {
+            options.sh_word_split = shuck_semantic::OptionValue::Unknown;
+            options.glob = shuck_semantic::OptionValue::Unknown;
+            options.glob_subst = shuck_semantic::OptionValue::Unknown;
+        });
+        let analysis = analyze_word(&command.args[0], source, Some(&behavior));
 
         assert_eq!(
             analysis.field_splitting_behavior,
@@ -457,15 +458,11 @@ mod expansion_analysis_tests {
         let Command::Simple(command) = &file.body[0].command else {
             panic!("expected simple command");
         };
-        let analysis = analyze_word(
-            &command.args[0],
-            source,
-            Some(&shuck_semantic::ZshOptionState {
-                glob: shuck_semantic::OptionValue::Unknown,
-                glob_subst: shuck_semantic::OptionValue::Off,
-                ..shuck_semantic::ZshOptionState::zsh_default()
-            }),
-        );
+        let behavior = zsh_behavior(|options| {
+            options.glob = shuck_semantic::OptionValue::Unknown;
+            options.glob_subst = shuck_semantic::OptionValue::Off;
+        });
+        let analysis = analyze_word(&command.args[0], source, Some(&behavior));
 
         assert_eq!(
             analysis.pathname_expansion_behavior,
@@ -485,10 +482,10 @@ mod expansion_analysis_tests {
         let Command::Simple(command) = &file.body[0].command else {
             panic!("expected simple command");
         };
-        let options = shuck_semantic::ZshOptionState::zsh_default();
-        let split = analyze_word(&command.args[0], source, Some(&options));
-        let glob = analyze_word(&command.args[1], source, Some(&options));
-        let no_glob_subst = analyze_word(&command.args[2], source, Some(&options));
+        let behavior = zsh_default_behavior();
+        let split = analyze_word(&command.args[0], source, Some(&behavior));
+        let glob = analyze_word(&command.args[1], source, Some(&behavior));
+        let no_glob_subst = analyze_word(&command.args[2], source, Some(&behavior));
 
         assert_eq!(
             split.field_splitting_behavior,
@@ -582,29 +579,30 @@ mod expansion_analysis_tests {
     fn analyze_literal_runtime_records_glob_failure_behavior() {
         let source = "print *.jpg\n";
         let words = parse_argument_words(source);
+        let native_behavior = zsh_default_behavior();
         let native = analyze_literal_runtime(
             &words[0],
             source,
             ExpansionContext::CommandArgument,
-            Some(&shuck_semantic::ZshOptionState::zsh_default()),
+            Some(&native_behavior),
         );
+        let null_glob_behavior = zsh_behavior(|options| {
+            options.null_glob = shuck_semantic::OptionValue::On;
+        });
         let null_glob = analyze_literal_runtime(
             &words[0],
             source,
             ExpansionContext::CommandArgument,
-            Some(&shuck_semantic::ZshOptionState {
-                null_glob: shuck_semantic::OptionValue::On,
-                ..shuck_semantic::ZshOptionState::zsh_default()
-            }),
+            Some(&null_glob_behavior),
         );
+        let no_glob_behavior = zsh_behavior(|options| {
+            options.glob = shuck_semantic::OptionValue::Off;
+        });
         let no_glob = analyze_literal_runtime(
             &words[0],
             source,
             ExpansionContext::CommandArgument,
-            Some(&shuck_semantic::ZshOptionState {
-                glob: shuck_semantic::OptionValue::Off,
-                ..shuck_semantic::ZshOptionState::zsh_default()
-            }),
+            Some(&no_glob_behavior),
         );
 
         assert_eq!(
@@ -629,17 +627,17 @@ mod expansion_analysis_tests {
     fn analyze_literal_runtime_respects_no_glob_precedence_over_failure_modes() {
         let source = "print *.jpg\n";
         let words = parse_argument_words(source);
+        let behavior = zsh_behavior(|options| {
+            options.glob = shuck_semantic::OptionValue::Off;
+            options.null_glob = shuck_semantic::OptionValue::On;
+            options.csh_null_glob = shuck_semantic::OptionValue::On;
+            options.nomatch = shuck_semantic::OptionValue::On;
+        });
         let analysis = analyze_literal_runtime(
             &words[0],
             source,
             ExpansionContext::CommandArgument,
-            Some(&shuck_semantic::ZshOptionState {
-                glob: shuck_semantic::OptionValue::Off,
-                null_glob: shuck_semantic::OptionValue::On,
-                csh_null_glob: shuck_semantic::OptionValue::On,
-                nomatch: shuck_semantic::OptionValue::On,
-                ..shuck_semantic::ZshOptionState::zsh_default()
-            }),
+            Some(&behavior),
         );
 
         assert_eq!(
@@ -658,23 +656,23 @@ mod expansion_analysis_tests {
     fn analyze_literal_runtime_distinguishes_nomatch_and_csh_null_glob() {
         let source = "print *.jpg\n";
         let words = parse_argument_words(source);
+        let keep_literal_behavior = zsh_behavior(|options| {
+            options.nomatch = shuck_semantic::OptionValue::Off;
+        });
         let keep_literal = analyze_literal_runtime(
             &words[0],
             source,
             ExpansionContext::CommandArgument,
-            Some(&shuck_semantic::ZshOptionState {
-                nomatch: shuck_semantic::OptionValue::Off,
-                ..shuck_semantic::ZshOptionState::zsh_default()
-            }),
+            Some(&keep_literal_behavior),
         );
+        let csh_null_glob_behavior = zsh_behavior(|options| {
+            options.csh_null_glob = shuck_semantic::OptionValue::On;
+        });
         let csh_null_glob = analyze_literal_runtime(
             &words[0],
             source,
             ExpansionContext::CommandArgument,
-            Some(&shuck_semantic::ZshOptionState {
-                csh_null_glob: shuck_semantic::OptionValue::On,
-                ..shuck_semantic::ZshOptionState::zsh_default()
-            }),
+            Some(&csh_null_glob_behavior),
         );
 
         assert_eq!(
@@ -692,17 +690,17 @@ mod expansion_analysis_tests {
     fn analyze_literal_runtime_records_glob_pattern_behaviors() {
         let source = "print *.jpg\n";
         let words = parse_argument_words(source);
+        let behavior = zsh_behavior(|options| {
+            options.glob_dots = shuck_semantic::OptionValue::On;
+            options.extended_glob = shuck_semantic::OptionValue::On;
+            options.ksh_glob = shuck_semantic::OptionValue::Unknown;
+            options.sh_glob = shuck_semantic::OptionValue::On;
+        });
         let analysis = analyze_literal_runtime(
             &words[0],
             source,
             ExpansionContext::CommandArgument,
-            Some(&shuck_semantic::ZshOptionState {
-                glob_dots: shuck_semantic::OptionValue::On,
-                extended_glob: shuck_semantic::OptionValue::On,
-                ksh_glob: shuck_semantic::OptionValue::Unknown,
-                sh_glob: shuck_semantic::OptionValue::On,
-                ..shuck_semantic::ZshOptionState::zsh_default()
-            }),
+            Some(&behavior),
         );
 
         assert_eq!(

--- a/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
@@ -78,6 +78,25 @@ esac
     }
 
     #[test]
+    fn ignores_zsh_extended_glob_patterns_when_reachability_is_uncertain() {
+        let source = "\
+#!/usr/bin/env zsh
+setopt extended_glob
+case \"$x\" in
+  foo^bar) : ;;
+  fooz) : ;;
+esac
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CaseDefaultBeforeGlob)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_literals_shadowed_by_suffix_globs() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
@@ -78,6 +78,25 @@ esac
     }
 
     #[test]
+    fn ignores_zsh_extended_glob_patterns_when_reachability_is_uncertain() {
+        let source = "\
+#!/usr/bin/env zsh
+setopt extended_glob
+case \"$x\" in
+  foo^bar) : ;;
+  fooz) : ;;
+esac
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CaseGlobReachability)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_static_quoted_pattern_fragments() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
@@ -208,6 +208,8 @@ setopt no_glob
 find ./ -name *.jar
 setopt glob extended_glob
 find ./ -name foo^bar
+find ./ -name foo~bar
+find ./ -name foo~bar*
 ";
         let diagnostics = test_snippet(
             source,
@@ -220,7 +222,7 @@ find ./ -name foo^bar
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["foo^bar"]
+            vec!["foo^bar", "foo~bar*"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_find_substitution.rs
@@ -201,6 +201,30 @@ command find ./ -name *.jar
     }
 
     #[test]
+    fn respects_zsh_glob_activation_for_find_pattern_operands() {
+        let source = "\
+#!/usr/bin/env zsh
+setopt no_glob
+find ./ -name *.jar
+setopt glob extended_glob
+find ./ -name foo^bar
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInFindSubstitution)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["foo^bar"]
+        );
+    }
+
+    #[test]
     fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
         let result = test_path_with_fix(
             Path::new("correctness").join("C083.sh").as_path(),

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
@@ -1,6 +1,6 @@
 use shuck_ast::static_word_text;
 
-use crate::{Checker, Rule, SimpleTestShape, SimpleTestSyntax, Violation};
+use crate::{Checker, LinterFacts, Rule, SimpleTestShape, SimpleTestSyntax, Violation};
 
 pub struct GlobInTestComparison;
 
@@ -20,13 +20,17 @@ pub fn glob_in_test_comparison(checker: &mut Checker) {
         .commands()
         .iter()
         .filter_map(|command| command.simple_test())
-        .filter_map(|simple_test| report_span(simple_test, checker.source()))
+        .filter_map(|simple_test| report_span(simple_test, checker.facts(), checker.source()))
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || GlobInTestComparison);
 }
 
-fn report_span(simple_test: &crate::SimpleTestFact<'_>, source: &str) -> Option<shuck_ast::Span> {
+fn report_span(
+    simple_test: &crate::SimpleTestFact<'_>,
+    facts: &LinterFacts<'_>,
+    source: &str,
+) -> Option<shuck_ast::Span> {
     if simple_test.syntax() != SimpleTestSyntax::Bracket
         || simple_test.effective_shape() != SimpleTestShape::Binary
     {
@@ -40,22 +44,12 @@ fn report_span(simple_test: &crate::SimpleTestFact<'_>, source: &str) -> Option<
 
     let rhs = *simple_test.effective_operands().get(2)?;
     let rhs_class = simple_test.effective_operand_class(2)?;
-    let rhs_text = static_word_text(rhs, source)?;
 
-    (!rhs_class.is_fixed_literal() && looks_like_glob_pattern(&rhs_text)).then_some(rhs.span)
-}
-
-fn looks_like_glob_pattern(text: &str) -> bool {
-    if text.chars().any(|ch| matches!(ch, '*' | '?')) {
-        return true;
-    }
-
-    text.char_indices().any(|(start, ch)| {
-        ch == '['
-            && text[start + ch.len_utf8()..]
-                .chars()
-                .any(|candidate| candidate == ']')
-    })
+    (!rhs_class.is_fixed_literal()
+        && facts
+            .any_word_fact(rhs.span)
+            .is_some_and(|fact| !fact.active_literal_glob_spans(source).is_empty()))
+    .then_some(rhs.span)
 }
 
 #[cfg(test)]
@@ -117,5 +111,29 @@ test \"$ARCH\" == i?86
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn respects_zsh_disabled_globbing_in_bracket_comparisons() {
+        let source = "\
+#!/usr/bin/env zsh
+setopt no_glob
+[ \"$ARCH\" == i?86 ]
+setopt glob
+[ \"$ARCH\" == i?86 ]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInTestComparison)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["i?86"]
+        );
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
@@ -1,8 +1,8 @@
 use shuck_ast::{ConditionalUnaryOp, Span, Word, static_word_text};
 
-use crate::facts::word_spans;
 use crate::{
-    Checker, ConditionalFact, ConditionalNodeFact, Rule, SimpleTestFact, SimpleTestShape, Violation,
+    Checker, ConditionalFact, ConditionalNodeFact, LinterFacts, Rule, SimpleTestFact,
+    SimpleTestShape, Violation,
 };
 
 pub struct GlobInTestDirectory;
@@ -26,10 +26,18 @@ pub fn glob_in_test_directory(checker: &mut Checker) {
         .flat_map(|fact| {
             let mut spans = Vec::new();
             if let Some(simple_test) = fact.simple_test() {
-                spans.extend(simple_test_file_test_spans(simple_test, source));
+                spans.extend(simple_test_file_test_spans(
+                    simple_test,
+                    checker.facts(),
+                    source,
+                ));
             }
             if let Some(conditional) = fact.conditional() {
-                spans.extend(conditional_file_test_spans(conditional, source));
+                spans.extend(conditional_file_test_spans(
+                    conditional,
+                    checker.facts(),
+                    source,
+                ));
             }
             spans
         })
@@ -38,19 +46,28 @@ pub fn glob_in_test_directory(checker: &mut Checker) {
     checker.report_all_dedup(spans, || GlobInTestDirectory);
 }
 
-fn simple_test_file_test_spans(simple_test: &SimpleTestFact<'_>, source: &str) -> Vec<Span> {
+fn simple_test_file_test_spans(
+    simple_test: &SimpleTestFact<'_>,
+    facts: &LinterFacts<'_>,
+    source: &str,
+) -> Vec<Span> {
     let mut spans = Vec::new();
-    if let Some(span) = simple_test_unary_file_test_span(simple_test, source) {
+    if let Some(span) = simple_test_unary_file_test_span(simple_test, facts, source) {
         spans.push(span);
     }
     spans.extend(collect_directory_operand_spans(
         simple_test.operands(),
+        facts,
         source,
     ));
     spans
 }
 
-fn conditional_file_test_spans(conditional: &ConditionalFact<'_>, source: &str) -> Vec<Span> {
+fn conditional_file_test_spans(
+    conditional: &ConditionalFact<'_>,
+    facts: &LinterFacts<'_>,
+    source: &str,
+) -> Vec<Span> {
     conditional
         .nodes()
         .iter()
@@ -58,7 +75,7 @@ fn conditional_file_test_spans(conditional: &ConditionalFact<'_>, source: &str) 
             ConditionalNodeFact::Unary(unary) if is_file_test_unary_op(unary.op()) => unary
                 .operand()
                 .word()
-                .and_then(|word| reportable_glob_span(word, source)),
+                .and_then(|word| reportable_glob_span(word, facts, source)),
             ConditionalNodeFact::BareWord(_)
             | ConditionalNodeFact::Unary(_)
             | ConditionalNodeFact::Binary(_)
@@ -91,7 +108,11 @@ fn is_file_test_unary_op(op: ConditionalUnaryOp) -> bool {
     )
 }
 
-fn collect_directory_operand_spans(operands: &[&Word], source: &str) -> Vec<Span> {
+fn collect_directory_operand_spans(
+    operands: &[&Word],
+    facts: &LinterFacts<'_>,
+    source: &str,
+) -> Vec<Span> {
     let operand_texts = operands
         .iter()
         .map(|word| static_word_text(word, source))
@@ -115,7 +136,7 @@ fn collect_directory_operand_spans(operands: &[&Word], source: &str) -> Vec<Span
 
         if is_file_test_operator(operand_texts[index].as_deref()) {
             if index + 1 < operands.len()
-                && let Some(span) = reportable_glob_span(operands[index + 1], source)
+                && let Some(span) = reportable_glob_span(operands[index + 1], facts, source)
             {
                 spans.push(span);
             }
@@ -131,6 +152,7 @@ fn collect_directory_operand_spans(operands: &[&Word], source: &str) -> Vec<Span
 
 fn simple_test_unary_file_test_span(
     simple_test: &SimpleTestFact<'_>,
+    facts: &LinterFacts<'_>,
     source: &str,
 ) -> Option<Span> {
     if simple_test.effective_shape() != SimpleTestShape::Unary {
@@ -149,11 +171,14 @@ fn simple_test_unary_file_test_span(
     simple_test
         .effective_operands()
         .get(1)
-        .and_then(|word| reportable_glob_span(word, source))
+        .and_then(|word| reportable_glob_span(word, facts, source))
 }
 
-fn reportable_glob_span(word: &Word, source: &str) -> Option<Span> {
-    (!word_spans::word_unquoted_glob_pattern_spans(word, source).is_empty()).then_some(word.span)
+fn reportable_glob_span(word: &Word, facts: &LinterFacts<'_>, source: &str) -> Option<Span> {
+    facts
+        .any_word_fact(word.span)
+        .is_some_and(|fact| !fact.active_literal_glob_spans(source).is_empty())
+        .then_some(word.span)
 }
 
 fn is_simple_test_separator(token: Option<&str>) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -20,7 +20,7 @@ pub fn glob_with_expansion_in_loop(checker: &mut Checker) {
         .expansion_word_facts(ExpansionContext::ForList)
         .filter(|fact| {
             !fact
-                .unquoted_glob_pattern_spans_outside_brace_expansion(source)
+                .active_glob_spans_outside_brace_expansion(source)
                 .is_empty()
         })
         .flat_map(unquoted_expansion_prefix_spans)

--- a/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
+++ b/crates/shuck-linter/src/rules/correctness/leading_glob_argument.rs
@@ -41,20 +41,16 @@ fn reportable_glob_diagnostic(
     if command_exempts_glob_warning(command.effective_name()) {
         return None;
     }
-    if !fact
-        .runtime_literal()
-        .pathname_expansion_behavior
-        .literal_globs_can_expand()
-    {
+    let active_globs = fact.active_literal_glob_spans(checker.source());
+    let first_glob = active_globs.first().copied()?;
+    if first_glob.start.offset != fact.span().start.offset {
         return None;
     }
-
-    let text = fact.span().slice(checker.source());
-    let prefix = text.chars().next()?;
+    let prefix = first_glob.slice(checker.source()).chars().next()?;
     if !matches!(prefix, '*' | '?') {
         return None;
     }
-    if fact.starts_with_extglob() {
+    if fact.starts_with_active_glob_operator(checker.source()) {
         return None;
     }
 
@@ -320,6 +316,29 @@ printf '%s\\n' *
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn treats_zsh_ksh_glob_groups_as_active_leading_operators() {
+        let source = "\
+setopt ksh_glob
+rm ?(*.txt)
+unsetopt ksh_glob
+rm ?(*.txt)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::LeadingGlobArgument)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["?"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
@@ -60,7 +60,7 @@ fn diagnostics_for_find_exec_argument(
     fact.unquoted_command_substitution_spans()
         .iter()
         .copied()
-        .chain(fact.unquoted_glob_pattern_spans(source))
+        .chain(fact.active_literal_glob_spans(source))
         .map(|span| {
             crate::Diagnostic::new(UnquotedGlobsInFind, span).with_fix(Fix::unsafe_edit(
                 Edit::replacement(replacement.clone(), word_span),
@@ -350,6 +350,30 @@ printf '*.txt'
         assert_eq!(result.fixes_applied, 0);
         assert_eq!(result.fixed_source, source);
         assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn respects_zsh_glob_activation_in_find_exec_arguments() {
+        let source = "\
+#!/usr/bin/env zsh
+setopt no_glob
+find . -exec echo *.txt {} +
+setopt glob ksh_glob
+find . -exec echo ?(*.txt) {} +
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedGlobsInFind)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["?(*.txt)"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_globs_in_find.rs
@@ -360,6 +360,9 @@ setopt no_glob
 find . -exec echo *.txt {} +
 setopt glob ksh_glob
 find . -exec echo ?(*.txt) {} +
+setopt extended_glob
+find . -exec echo foo~bar {} +
+find . -exec echo foo~bar* {} +
 ";
         let diagnostics = test_snippet(
             source,
@@ -372,7 +375,7 @@ find . -exec echo ?(*.txt) {} +
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["?(*.txt)"]
+            vec!["?(*.txt)", "~", "*"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -1,4 +1,3 @@
-use crate::facts::word_spans;
 use crate::{Checker, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct UnquotedGrepRegex;
@@ -29,7 +28,9 @@ pub fn unquoted_grep_regex(checker: &mut Checker) {
         .filter_map(|fact| fact.options().grep())
         .flat_map(|grep| grep.patterns().iter())
         .filter(|pattern| {
-            !word_spans::word_unquoted_glob_pattern_spans(pattern.word(), source).is_empty()
+            facts
+                .any_word_fact(pattern.word().span)
+                .is_some_and(|fact| !fact.active_literal_glob_spans(source).is_empty())
         })
         .map(|pattern| {
             let span = pattern.span();
@@ -229,6 +230,31 @@ done
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["[/$]"]
+        );
+    }
+
+    #[test]
+    fn respects_zsh_glob_activation_for_grep_patterns() {
+        let source = "\
+#!/usr/bin/env zsh
+setopt no_glob
+grep start* out.txt
+setopt glob extended_glob
+grep foo^bar out.txt
+unsetopt extended_glob
+grep foo^bar out.txt
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedGrepRegex).with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["foo^bar"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
+++ b/crates/shuck-linter/src/rules/correctness/unquoted_grep_regex.rs
@@ -241,6 +241,8 @@ setopt no_glob
 grep start* out.txt
 setopt glob extended_glob
 grep foo^bar out.txt
+grep foo~bar out.txt
+grep foo~bar* out.txt
 unsetopt extended_glob
 grep foo^bar out.txt
 ";
@@ -254,7 +256,7 @@ grep foo^bar out.txt
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["foo^bar"]
+            vec!["foo^bar", "foo~bar*"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/mod.rs
+++ b/crates/shuck-linter/src/rules/mod.rs
@@ -138,11 +138,25 @@ mod architecture_tests {
     }
 
     #[test]
-    fn c012_rule_avoids_raw_zsh_option_state_queries() {
-        let rule_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("src/rules/correctness/leading_glob_argument.rs");
-        let source = fs::read_to_string(&rule_path)
-            .unwrap_or_else(|error| panic!("failed to read {}: {error}", rule_path.display()));
+    fn glob_sensitive_rules_avoid_raw_zsh_option_state_queries() {
+        let rule_paths = [
+            ("C012", "correctness/leading_glob_argument.rs"),
+            ("K001", "security/rm_glob_on_variable_path.rs"),
+            ("S001", "style/unquoted_expansion.rs"),
+            ("S001", "style/unquoted_expansion/safe_value.rs"),
+            ("S020", "style/single_iteration_loop.rs"),
+            ("C055", "correctness/pattern_with_variable.rs"),
+            ("C059", "correctness/redirect_to_command_name.rs"),
+            ("C078", "correctness/unquoted_globs_in_find.rs"),
+            ("C083", "correctness/glob_in_find_substitution.rs"),
+            ("C084", "correctness/unquoted_grep_regex.rs"),
+            ("C090", "correctness/glob_in_test_comparison.rs"),
+            ("C094", "correctness/redirect_clobbers_input.rs"),
+            ("C102", "correctness/glob_in_test_directory.rs"),
+            ("C114", "correctness/glob_with_expansion_in_loop.rs"),
+            ("C128", "correctness/case_glob_reachability.rs"),
+            ("C129", "correctness/case_default_before_glob.rs"),
+        ];
         let forbidden_tokens = [
             "zsh_options_at",
             "zsh_options()",
@@ -150,41 +164,26 @@ mod architecture_tests {
             "OptionValue",
             "shell_behavior_at",
         ];
-        let violations = forbidden_tokens
-            .iter()
-            .copied()
-            .filter(|token| source.contains(token))
-            .collect::<Vec<_>>();
+        let mut violations = Vec::new();
+
+        for (rule, relative_path) in rule_paths {
+            let rule_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("src/rules")
+                .join(relative_path);
+            let source = fs::read_to_string(&rule_path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", rule_path.display()));
+            violations.extend(
+                forbidden_tokens
+                    .iter()
+                    .copied()
+                    .filter(|token| source.contains(token))
+                    .map(|token| format!("{rule} {} contains `{token}`", rule_path.display())),
+            );
+        }
 
         assert!(
             violations.is_empty(),
-            "C012 should consume behavior-partitioned facts instead of raw zsh option state:\n{}",
-            violations.join("\n"),
-        );
-    }
-
-    #[test]
-    fn k001_rule_avoids_raw_zsh_option_state_queries() {
-        let rule_path = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("src/rules/security/rm_glob_on_variable_path.rs");
-        let source = fs::read_to_string(&rule_path)
-            .unwrap_or_else(|error| panic!("failed to read {}: {error}", rule_path.display()));
-        let forbidden_tokens = [
-            "zsh_options_at",
-            "zsh_options()",
-            "ZshOptionState",
-            "OptionValue",
-            "shell_behavior_at",
-        ];
-        let violations = forbidden_tokens
-            .iter()
-            .copied()
-            .filter(|token| source.contains(token))
-            .collect::<Vec<_>>();
-
-        assert!(
-            violations.is_empty(),
-            "K001 should consume behavior-partitioned facts instead of raw zsh option state:\n{}",
+            "glob-sensitive rules should consume behavior-partitioned facts instead of raw zsh option state:\n{}",
             violations.join("\n"),
         );
     }

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -21,11 +21,8 @@ pub fn rm_glob_on_variable_path(checker: &mut Checker) {
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
         .filter(|fact| {
-            fact.unquoted_glob_pattern_spans(source).is_empty()
-                || fact
-                    .runtime_literal()
-                    .pathname_expansion_behavior
-                    .literal_globs_can_expand()
+            !fact.has_literal_glob_syntax(source)
+                || !fact.active_literal_glob_spans(source).is_empty()
         })
         .map(|fact| (fact.command_id(), FactSpan::new(fact.span())))
         .collect::<FxHashSet<_>>();

--- a/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
+++ b/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
@@ -25,7 +25,7 @@ pub fn glob_assigned_to_variable(checker: &mut Checker) {
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
         .filter(|fact| !checker.facts().is_compound_assignment_value_word(*fact))
         .filter(|fact| fact.classification().quote != WordQuote::FullyQuoted)
-        .filter(|fact| !fact.unquoted_glob_pattern_spans(source).is_empty())
+        .filter(|fact| !fact.active_literal_glob_spans(source).is_empty())
         .map(|fact| fact.span())
         .collect::<Vec<_>>();
 

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -601,7 +601,8 @@ impl<'a> SafeValueIndex<'a> {
         word: &Word,
         context: ExpansionContext,
     ) -> bool {
-        let runtime = analyze_literal_runtime(word, self.source, context, None);
+        let behavior = self.facts.expansion_behavior_at(word.span.start.offset);
+        let runtime = analyze_literal_runtime(word, self.source, context, Some(&behavior));
         if !runtime.is_runtime_sensitive() {
             return false;
         }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -121,7 +121,7 @@ pub enum ArithmeticLiteralBehavior {
 }
 
 /// Option-sensitive shell behavior visible at a source offset.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ShellBehaviorAt<'model> {
     shell: ShellDialect,
     zsh_options: Option<&'model ZshOptionState>,
@@ -131,6 +131,42 @@ pub struct ShellBehaviorAt<'model> {
 impl ShellBehaviorAt<'_> {
     fn effective_zsh_options(&self) -> Option<&ZshOptionState> {
         self.runtime_options.as_ref().or(self.zsh_options)
+    }
+
+    /// Returns the effective zsh option state when this behavior is for zsh.
+    pub fn zsh_options(&self) -> Option<&ZshOptionState> {
+        self.effective_zsh_options()
+    }
+
+    /// Returns the shell dialect this behavior was computed for.
+    pub fn shell_dialect(&self) -> ShellDialect {
+        self.shell
+    }
+
+    /// Creates behavior for a shell dialect without source-local option state.
+    pub fn for_dialect(shell: ShellDialect) -> Self {
+        Self {
+            shell,
+            zsh_options: None,
+            runtime_options: None,
+        }
+    }
+
+    /// Returns this behavior with a caller-provided zsh option overlay applied.
+    ///
+    /// Non-zsh behavior is returned unchanged. For zsh, the overlay starts with the
+    /// effective source-local option state, or the native zsh defaults when no
+    /// source-local state is available.
+    pub fn with_zsh_option_overlay(mut self, overlay: impl FnOnce(&mut ZshOptionState)) -> Self {
+        if self.shell == ShellDialect::Zsh {
+            let mut options = self
+                .effective_zsh_options()
+                .cloned()
+                .unwrap_or_else(ZshOptionState::zsh_default);
+            overlay(&mut options);
+            self.runtime_options = Some(options);
+        }
+        self
     }
 
     /// Returns the array-reference policy implied by the shell and runtime option state.


### PR DESCRIPTION
## Summary

- Move active glob interpretation behind semantic/fact-layer behavior instead of raw zsh option checks in rule files.
- Add active glob fact APIs for option-sensitive literal globs, zsh extended glob operators, ksh glob groups, and command-local behavior such as `noglob`.
- Migrate glob-sensitive rules to consume facts and avoid C128/C129 reachability proofs when zsh pattern semantics are uncertain.
- Fix zsh `~` exclusion handling so plain words such as `foo~bar` are not treated as pathname globs unless one side is itself an active glob pattern.

## Validation

- `cargo fmt --check`
- `cargo check -p shuck-linter`
- `cargo test -p shuck-linter`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C012,K001,S001,S020,C059,C094,C055,C078,C083,C084,C090,C102,C114,C128,C129`

Large corpus summary stayed clean: `implementation_diffs=0`, `mapping_issues=0`, `harness_failures=0`.