### PR TITLE
fix(linter): model zsh octal arithmetic literals

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1073,6 +1073,11 @@ fn collect_leading_zero_integer_spans_in_text(
             continue;
         }
 
+        if matches!(bytes.get(match_end), Some(b'#')) {
+            index = match_end + 1;
+            continue;
+        }
+
         let start = span.start.advanced_by(&text[..index]);
         let end = start.advanced_by(&text[index..match_end]);
         spans.push((
@@ -1092,6 +1097,13 @@ fn contains_leading_zero_integer(text: &str) -> bool {
                 let previous = bytes[index - 1];
                 !previous.is_ascii_alphanumeric() && previous != b'_' && previous != b'#'
             })
+            && {
+                let mut match_end = index + 2;
+                while match_end < bytes.len() && bytes[match_end].is_ascii_digit() {
+                    match_end += 1;
+                }
+                !matches!(bytes.get(match_end), Some(b'#'))
+            }
     })
 }
 

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -325,7 +325,7 @@ fn zsh_option_map_subscript_key(owner_name: &str, text: &str) -> bool {
 fn collect_base_prefix_spans_in_command_parts(
     command: &Command,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     match command {
         Command::Simple(command) => {
@@ -469,7 +469,7 @@ fn collect_base_prefix_spans_in_command_parts(
 fn collect_base_prefix_spans_in_assignment(
     assignment: &Assignment,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     collect_base_prefix_spans_in_var_ref(&assignment.target, source, spans);
 
@@ -491,7 +491,7 @@ fn collect_base_prefix_spans_in_assignment(
     }
 }
 
-fn collect_base_prefix_spans_in_word(word: &Word, source: &str, spans: &mut Vec<Span>) {
+fn collect_base_prefix_spans_in_word(word: &Word, source: &str, spans: &mut Vec<(Span, ArithmeticLiteralKind)>) {
     for part in &word.parts {
         collect_base_prefix_spans_in_word_part(part, source, spans);
     }
@@ -500,7 +500,7 @@ fn collect_base_prefix_spans_in_word(word: &Word, source: &str, spans: &mut Vec<
 fn collect_base_prefix_spans_in_word_part(
     part: &WordPartNode,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     match &part.kind {
         WordPart::DoubleQuoted { parts, .. } => {
@@ -572,7 +572,7 @@ fn collect_base_prefix_spans_in_word_part(
 fn collect_base_prefix_spans_in_parameter_expansion(
     parameter: &shuck_ast::ParameterExpansion,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(syntax) => match syntax {
@@ -643,7 +643,7 @@ fn collect_base_prefix_spans_in_parameter_expansion(
 fn collect_base_prefix_spans_in_arithmetic_parameter_expansion(
     parameter: &shuck_ast::ParameterExpansion,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(syntax) => match syntax {
@@ -714,7 +714,7 @@ fn collect_base_prefix_spans_in_arithmetic_parameter_expansion(
 fn collect_base_prefix_spans_in_zsh_target(
     target: &shuck_ast::ZshExpansionTarget,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     match target {
         shuck_ast::ZshExpansionTarget::Reference(reference) => {
@@ -733,7 +733,7 @@ fn collect_base_prefix_spans_in_zsh_target(
 fn collect_base_prefix_spans_in_arithmetic_zsh_target(
     target: &shuck_ast::ZshExpansionTarget,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     match target {
         shuck_ast::ZshExpansionTarget::Reference(reference) => {
@@ -749,7 +749,7 @@ fn collect_base_prefix_spans_in_arithmetic_zsh_target(
     }
 }
 
-fn collect_base_prefix_spans_in_pattern(pattern: &Pattern, source: &str, spans: &mut Vec<Span>) {
+fn collect_base_prefix_spans_in_pattern(pattern: &Pattern, source: &str, spans: &mut Vec<(Span, ArithmeticLiteralKind)>) {
     for (part, _) in pattern.parts_with_spans() {
         match part {
             PatternPart::Group { patterns, .. } => {
@@ -766,14 +766,14 @@ fn collect_base_prefix_spans_in_pattern(pattern: &Pattern, source: &str, spans: 
     }
 }
 
-fn collect_base_prefix_spans_in_var_ref(reference: &VarRef, source: &str, spans: &mut Vec<Span>) {
+fn collect_base_prefix_spans_in_var_ref(reference: &VarRef, source: &str, spans: &mut Vec<(Span, ArithmeticLiteralKind)>) {
     collect_base_prefix_spans_in_subscript(reference.subscript.as_deref(), source, spans);
 }
 
 fn collect_base_prefix_spans_in_subscript(
     subscript: Option<&Subscript>,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     if let Some(expression) = subscript.and_then(|subscript| subscript.arithmetic_ast.as_ref()) {
         collect_base_prefix_spans_in_arithmetic(expression, source, spans);
@@ -783,11 +783,12 @@ fn collect_base_prefix_spans_in_subscript(
 fn collect_base_prefix_spans_in_arithmetic(
     expression: &ArithmeticExprNode,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     match &expression.kind {
         ArithmeticExpr::Number(number) => {
             collect_base_prefix_spans_in_text(number.span(), source, spans);
+            collect_leading_zero_integer_spans_in_text(number.span(), source, spans);
         }
         ArithmeticExpr::Variable(_) => {}
         ArithmeticExpr::Indexed { index, .. } => {
@@ -825,7 +826,7 @@ fn collect_base_prefix_spans_in_arithmetic(
 fn collect_base_prefix_spans_in_arithmetic_lvalue(
     target: &ArithmeticLvalue,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     match target {
         ArithmeticLvalue::Variable(_) => {}
@@ -835,7 +836,7 @@ fn collect_base_prefix_spans_in_arithmetic_lvalue(
     }
 }
 
-fn collect_base_prefix_spans_in_arithmetic_word(word: &Word, source: &str, spans: &mut Vec<Span>) {
+fn collect_base_prefix_spans_in_arithmetic_word(word: &Word, source: &str, spans: &mut Vec<(Span, ArithmeticLiteralKind)>) {
     for part in &word.parts {
         collect_base_prefix_spans_in_arithmetic_word_part(part, source, spans);
     }
@@ -844,11 +845,12 @@ fn collect_base_prefix_spans_in_arithmetic_word(word: &Word, source: &str, spans
 fn collect_base_prefix_spans_in_arithmetic_word_part(
     part: &WordPartNode,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     match &part.kind {
         WordPart::Literal(_) => {
             collect_base_prefix_spans_in_text(part.span, source, spans);
+            collect_leading_zero_integer_spans_in_text(part.span, source, spans);
         }
         WordPart::DoubleQuoted { parts, .. } => {
             for part in parts {
@@ -937,13 +939,13 @@ fn collect_base_prefix_spans_in_fragment(
     word: Option<&Word>,
     text: Option<&SourceText>,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     let Some(text) = text else {
         return;
     };
     let snippet = text.slice(source);
-    if !snippet.contains('#') {
+    if !snippet.contains('#') && !contains_leading_zero_integer(snippet) {
         return;
     }
 
@@ -952,6 +954,7 @@ fn collect_base_prefix_spans_in_fragment(
         "parser-backed fragment text should always carry a word AST"
     );
     let Some(word) = word else {
+        collect_leading_zero_integer_spans_in_text(text.span(), source, spans);
         return;
     };
     collect_base_prefix_spans_in_word(word, source, spans);
@@ -961,24 +964,29 @@ fn collect_base_prefix_spans_in_arithmetic_fragment(
     word: Option<&Word>,
     text: Option<&SourceText>,
     source: &str,
-    spans: &mut Vec<Span>,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
 ) {
     let Some(text) = text else {
         return;
     };
     let snippet = text.slice(source);
-    if !snippet.contains('#') {
+    if !snippet.contains('#') && !contains_leading_zero_integer(snippet) {
         return;
     }
 
     let Some(word) = word else {
         collect_base_prefix_spans_in_text(text.span(), source, spans);
+        collect_leading_zero_integer_spans_in_text(text.span(), source, spans);
         return;
     };
     collect_base_prefix_spans_in_arithmetic_word(word, source, spans);
 }
 
-fn collect_base_prefix_spans_in_text(span: Span, source: &str, spans: &mut Vec<Span>) {
+fn collect_base_prefix_spans_in_text(
+    span: Span,
+    source: &str,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
+) {
     let text = span.slice(source);
     let bytes = text.as_bytes();
     let mut index = 0usize;
@@ -1019,9 +1027,72 @@ fn collect_base_prefix_spans_in_text(span: Span, source: &str, spans: &mut Vec<S
 
         let start = span.start.advanced_by(&text[..index]);
         let end = start.advanced_by(&text[index..match_end]);
-        spans.push(Span::from_positions(start, end));
+        spans.push((
+            Span::from_positions(start, end),
+            ArithmeticLiteralKind::ExplicitBasePrefix,
+        ));
         index = match_end;
     }
+}
+
+fn collect_leading_zero_integer_spans_in_text(
+    span: Span,
+    source: &str,
+    spans: &mut Vec<(Span, ArithmeticLiteralKind)>,
+) {
+    let text = span.slice(source);
+    let bytes = text.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        if bytes[index] != b'0' {
+            index += 1;
+            continue;
+        }
+
+        if index > 0 {
+            let previous = bytes[index - 1];
+            if previous.is_ascii_alphanumeric() || previous == b'_' || previous == b'#' {
+                index += 1;
+                continue;
+            }
+        }
+
+        if matches!(bytes.get(index + 1), Some(b'x' | b'X')) {
+            index += 2;
+            continue;
+        }
+
+        let mut match_end = index + 1;
+        while match_end < bytes.len() && bytes[match_end].is_ascii_digit() {
+            match_end += 1;
+        }
+
+        if match_end == index + 1 {
+            index = match_end;
+            continue;
+        }
+
+        let start = span.start.advanced_by(&text[..index]);
+        let end = start.advanced_by(&text[index..match_end]);
+        spans.push((
+            Span::from_positions(start, end),
+            ArithmeticLiteralKind::LeadingZeroInteger,
+        ));
+        index = match_end;
+    }
+}
+
+fn contains_leading_zero_integer(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    bytes.windows(2).enumerate().any(|(index, window)| {
+        window[0] == b'0'
+            && window[1].is_ascii_digit()
+            && (index == 0 || {
+                let previous = bytes[index - 1];
+                !previous.is_ascii_alphanumeric() && previous != b'_' && previous != b'#'
+            })
+    })
 }
 
 fn build_double_paren_grouping_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -122,7 +122,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let mut precise_function_guard_suppressions = Vec::new();
         let mut command_substitution_command_spans = Vec::new();
         let mut arithmetic_update_operator_spans = Vec::new();
-        let mut base_prefix_arithmetic_spans = Vec::new();
+        let mut arithmetic_literal_spans = Vec::new();
 
         let mut command_contexts = self.semantic.command_contexts().collect::<Vec<_>>();
         command_contexts.sort_unstable_by(|left, right| {
@@ -246,7 +246,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 collect_base_prefix_spans_in_command_parts(
                     visit.command,
                     self.source,
-                    &mut base_prefix_arithmetic_spans,
+                    &mut arithmetic_literal_spans,
                 );
                 collect_arithmetic_update_operator_spans_in_command(
                     visit.command,
@@ -261,7 +261,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                         collect_base_prefix_spans_in_word(
                             word,
                             self.source,
-                            &mut base_prefix_arithmetic_spans,
+                            &mut arithmetic_literal_spans,
                         );
                         collect_arithmetic_update_operator_spans_in_word(
                             word,
@@ -450,14 +450,22 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         arithmetic_update_operator_spans
             .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
         arithmetic_update_operator_spans.dedup();
-        base_prefix_arithmetic_spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
-        base_prefix_arithmetic_spans.dedup();
-        let arithmetic_literal_facts = base_prefix_arithmetic_spans
+        arithmetic_literal_spans.sort_unstable_by_key(|(span, kind)| {
+            (span.start.offset, span.end.offset, *kind)
+        });
+        arithmetic_literal_spans.dedup();
+        let base_prefix_arithmetic_spans = arithmetic_literal_spans
             .iter()
-            .copied()
-            .map(|span| {
+            .filter_map(|(span, kind)| {
+                (*kind == ArithmeticLiteralKind::ExplicitBasePrefix).then_some(*span)
+            })
+            .collect::<Vec<_>>();
+        let arithmetic_literal_facts = arithmetic_literal_spans
+            .iter()
+            .map(|(span, kind)| {
                 ArithmeticLiteralFact::new(
-                    span,
+                    *span,
+                    *kind,
                     self.semantic
                         .shell_behavior_at(span.start.offset)
                         .arithmetic_literals(),

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -454,12 +454,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             (span.start.offset, span.end.offset, *kind)
         });
         arithmetic_literal_spans.dedup();
-        let base_prefix_arithmetic_spans = arithmetic_literal_spans
-            .iter()
-            .filter_map(|(span, kind)| {
-                (*kind == ArithmeticLiteralKind::ExplicitBasePrefix).then_some(*span)
-            })
-            .collect::<Vec<_>>();
         let arithmetic_literal_facts = arithmetic_literal_spans
             .iter()
             .map(|(span, kind)| {
@@ -1014,7 +1008,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             positional_parameter_operator_spans,
             double_paren_grouping_spans,
             arithmetic_update_operator_spans,
-            base_prefix_arithmetic_spans,
             arithmetic_literal_facts,
             escape_scan_matches,
             echo_backslash_escape_word_spans,

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -97,7 +97,7 @@ pub use self::normalized_commands::{
     DeclarationKind, NormalizedCommand, NormalizedDeclaration, WrapperKind,
 };
 pub use self::surface::{
-    AmbiguousArrayReference, ArithmeticLiteralFact, BacktickFragmentFact,
+    AmbiguousArrayReference, ArithmeticLiteralFact, ArithmeticLiteralKind, BacktickFragmentFact,
     IndexedArrayReferenceFragment, IndexedArrayReferenceFragmentFact, LegacyArithmeticFragmentFact,
     NativeZshScalarArrayReference, PlainUnindexedArrayReferenceFact,
     PositionalParameterFragmentFact, SelectorRequiredArrayReference, SingleQuotedFragmentFact,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -119,7 +119,6 @@ pub struct LinterFacts<'a> {
     positional_parameter_operator_spans: Vec<Span>,
     double_paren_grouping_spans: Vec<Span>,
     arithmetic_update_operator_spans: Vec<Span>,
-    base_prefix_arithmetic_spans: Vec<Span>,
     arithmetic_literal_facts: Vec<ArithmeticLiteralFact>,
     escape_scan_matches: Vec<EscapeScanMatch>,
     echo_backslash_escape_word_spans: Vec<Span>,
@@ -931,11 +930,6 @@ impl<'a> LinterFacts<'a> {
 
     pub fn arithmetic_update_operator_spans(&self) -> &[Span] {
         &self.arithmetic_update_operator_spans
-    }
-
-    #[cfg(test)]
-    pub(crate) fn base_prefix_arithmetic_spans(&self) -> &[Span] {
-        &self.base_prefix_arithmetic_spans
     }
 
     pub fn arithmetic_literal_facts(&self) -> &[ArithmeticLiteralFact] {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -933,7 +933,8 @@ impl<'a> LinterFacts<'a> {
         &self.arithmetic_update_operator_spans
     }
 
-    pub fn base_prefix_arithmetic_spans(&self) -> &[Span] {
+    #[cfg(test)]
+    pub(crate) fn base_prefix_arithmetic_spans(&self) -> &[Span] {
         &self.base_prefix_arithmetic_spans
     }
 

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -139,19 +139,38 @@ impl LegacyArithmeticFragmentFact {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ArithmeticLiteralKind {
+    ExplicitBasePrefix,
+    LeadingZeroInteger,
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct ArithmeticLiteralFact {
     span: Span,
+    kind: ArithmeticLiteralKind,
     behavior: ArithmeticLiteralBehavior,
 }
 
 impl ArithmeticLiteralFact {
-    pub(super) fn new(span: Span, behavior: ArithmeticLiteralBehavior) -> Self {
-        Self { span, behavior }
+    pub(super) fn new(
+        span: Span,
+        kind: ArithmeticLiteralKind,
+        behavior: ArithmeticLiteralBehavior,
+    ) -> Self {
+        Self {
+            span,
+            kind,
+            behavior,
+        }
     }
 
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    pub fn kind(&self) -> ArithmeticLiteralKind {
+        self.kind
     }
 
     pub fn behavior(&self) -> ArithmeticLiteralBehavior {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1815,11 +1815,13 @@ fn base_prefix_arithmetic_literals_record_arithmetic_literal_behavior() {
     let source = "\
 #!/bin/zsh
 echo $((10#1))
+echo $((010))
 setopt c_bases
 echo $((10#2))
 unsetopt c_bases
 setopt octal_zeroes
 echo $((10#3))
+echo $((010))
 setopt c_bases
 echo $((10#4))
 unsetopt c_bases
@@ -1839,15 +1841,55 @@ echo $((10#6))
         facts
             .arithmetic_literal_facts()
             .iter()
-            .map(|literal| (literal.span().slice(source), literal.behavior()))
+            .map(|literal| {
+                (
+                    literal.span().slice(source),
+                    literal.kind(),
+                    literal.behavior(),
+                )
+            })
             .collect::<Vec<_>>(),
         vec![
-            ("10#1", ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,),
-            ("10#2", ArithmeticLiteralBehavior::DecimalUnlessExplicitBase),
-            ("10#3", ArithmeticLiteralBehavior::LeadingZeroOctal),
-            ("10#4", ArithmeticLiteralBehavior::LeadingZeroOctal),
-            ("10#5", ArithmeticLiteralBehavior::LeadingZeroOctal),
-            ("10#6", ArithmeticLiteralBehavior::Ambiguous),
+            (
+                "10#1",
+                ArithmeticLiteralKind::ExplicitBasePrefix,
+                ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
+            ),
+            (
+                "010",
+                ArithmeticLiteralKind::LeadingZeroInteger,
+                ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
+            ),
+            (
+                "10#2",
+                ArithmeticLiteralKind::ExplicitBasePrefix,
+                ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
+            ),
+            (
+                "10#3",
+                ArithmeticLiteralKind::ExplicitBasePrefix,
+                ArithmeticLiteralBehavior::LeadingZeroOctal,
+            ),
+            (
+                "010",
+                ArithmeticLiteralKind::LeadingZeroInteger,
+                ArithmeticLiteralBehavior::LeadingZeroOctal,
+            ),
+            (
+                "10#4",
+                ArithmeticLiteralKind::ExplicitBasePrefix,
+                ArithmeticLiteralBehavior::LeadingZeroOctal,
+            ),
+            (
+                "10#5",
+                ArithmeticLiteralKind::ExplicitBasePrefix,
+                ArithmeticLiteralBehavior::LeadingZeroOctal,
+            ),
+            (
+                "10#6",
+                ArithmeticLiteralKind::ExplicitBasePrefix,
+                ArithmeticLiteralBehavior::Ambiguous,
+            ),
         ]
     );
 }
@@ -1857,6 +1899,7 @@ fn base_prefix_arithmetic_literals_record_bash_arithmetic_literal_behavior() {
     let source = "\
 #!/bin/bash
 echo $((10#1))
+echo $((010))
 ";
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
@@ -1867,9 +1910,67 @@ echo $((10#1))
         facts
             .arithmetic_literal_facts()
             .iter()
-            .map(|literal| (literal.span().slice(source), literal.behavior()))
+            .map(|literal| {
+                (
+                    literal.span().slice(source),
+                    literal.kind(),
+                    literal.behavior(),
+                )
+            })
             .collect::<Vec<_>>(),
-        vec![("10#1", ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal,)]
+        vec![
+            (
+                "10#1",
+                ArithmeticLiteralKind::ExplicitBasePrefix,
+                ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal,
+            ),
+            (
+                "010",
+                ArithmeticLiteralKind::LeadingZeroInteger,
+                ArithmeticLiteralBehavior::CStyleAndLeadingZeroOctal,
+            )
+        ]
+    );
+}
+
+#[test]
+fn arithmetic_literals_record_leading_zeroes_in_nested_arithmetic_fragments() {
+    let source = "\
+#!/bin/zsh
+echo ${value:010:1}
+echo ${value:-$((010))}
+";
+    let output = Parser::with_dialect(source, shuck_parser::parser::ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+
+    assert_eq!(
+        facts
+            .arithmetic_literal_facts()
+            .iter()
+            .map(|literal| {
+                (
+                    literal.span().slice(source),
+                    literal.kind(),
+                    literal.behavior(),
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                "010",
+                ArithmeticLiteralKind::LeadingZeroInteger,
+                ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
+            ),
+            (
+                "010",
+                ArithmeticLiteralKind::LeadingZeroInteger,
+                ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
+            ),
+        ]
     );
 }
 

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1802,8 +1802,10 @@ echo ${foo:-$((10#1))}
 
     assert_eq!(
         facts
-            .base_prefix_arithmetic_spans()
+            .arithmetic_literal_facts()
             .iter()
+            .filter(|literal| literal.kind() == ArithmeticLiteralKind::ExplicitBasePrefix)
+            .map(|literal| literal.span())
             .map(|span| span.slice(source))
             .collect::<Vec<_>>(),
         vec!["10#123", "10#1", "10#1", "10#1"]
@@ -1990,8 +1992,10 @@ esac
 
     assert_eq!(
         facts
-            .base_prefix_arithmetic_spans()
+            .arithmetic_literal_facts()
             .iter()
+            .filter(|literal| literal.kind() == ArithmeticLiteralKind::ExplicitBasePrefix)
+            .map(|literal| literal.span())
             .map(|span| span.slice(source))
             .collect::<Vec<_>>(),
         vec!["10#1", "10#2"]
@@ -2057,7 +2061,12 @@ echo ${foo:-${1##*/}}
     let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
-    assert!(facts.base_prefix_arithmetic_spans().is_empty());
+    assert!(
+        facts
+            .arithmetic_literal_facts()
+            .iter()
+            .all(|literal| literal.kind() != ArithmeticLiteralKind::ExplicitBasePrefix)
+    );
 }
 
 #[test]
@@ -2073,7 +2082,12 @@ echo $((42949 - ${1#-} / 100000))
     let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
     let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
 
-    assert!(facts.base_prefix_arithmetic_spans().is_empty());
+    assert!(
+        facts
+            .arithmetic_literal_facts()
+            .iter()
+            .all(|literal| literal.kind() != ArithmeticLiteralKind::ExplicitBasePrefix)
+    );
 }
 
 #[test]
@@ -2091,8 +2105,10 @@ echo $(( ${foo:-10#1} ))
 
     assert_eq!(
         facts
-            .base_prefix_arithmetic_spans()
+            .arithmetic_literal_facts()
             .iter()
+            .filter(|literal| literal.kind() == ArithmeticLiteralKind::ExplicitBasePrefix)
+            .map(|literal| literal.span())
             .map(|span| span.slice(source))
             .collect::<Vec<_>>(),
         vec!["10#1"]

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -1941,6 +1941,8 @@ fn arithmetic_literals_record_leading_zeroes_in_nested_arithmetic_fragments() {
 #!/bin/zsh
 echo ${value:010:1}
 echo ${value:-$((010))}
+echo ${value:010#7:1}
+echo ${value:-$((010#7))}
 ";
     let output = Parser::with_dialect(source, shuck_parser::parser::ShellDialect::Zsh)
         .parse()
@@ -1970,6 +1972,16 @@ echo ${value:-$((010))}
             (
                 "010",
                 ArithmeticLiteralKind::LeadingZeroInteger,
+                ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
+            ),
+            (
+                "010#7",
+                ArithmeticLiteralKind::ExplicitBasePrefix,
+                ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
+            ),
+            (
+                "010#7",
+                ArithmeticLiteralKind::ExplicitBasePrefix,
                 ArithmeticLiteralBehavior::DecimalUnlessExplicitBase,
             ),
         ]

--- a/crates/shuck-linter/src/facts/tests/mod.rs
+++ b/crates/shuck-linter/src/facts/tests/mod.rs
@@ -15,7 +15,10 @@ use super::{
 };
 use crate::WrapperKind;
 use crate::facts::surface::PositionalParameterFragmentKind;
-use crate::{ArithmeticLiteralBehavior, LinterFacts, LinterSemanticArtifacts, ShellDialect};
+use crate::{
+    ArithmeticLiteralBehavior, ArithmeticLiteralKind, LinterFacts, LinterSemanticArtifacts,
+    ShellDialect,
+};
 
 mod assignments;
 mod braces;

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -62,18 +62,19 @@ pub use facts::words::{
 };
 /// Extracted structural facts available to rules and callers.
 pub use facts::{
-    AmbiguousArrayReference, ArithmeticLiteralFact, BacktickFragmentFact, CommandFact,
-    CommandFactRef, CommandFacts, ConditionalBareWordFact, ConditionalBinaryFact, ConditionalFact,
-    ConditionalMixedLogicalOperatorFact, ConditionalNodeFact, ConditionalOperandFact,
-    ConditionalOperatorFamily, ConditionalPortabilityFacts, ConditionalUnaryFact, ForHeaderFact,
-    FunctionCallArityFacts, FunctionHeaderFact, IndexedArrayReferenceFragment,
-    IndexedArrayReferenceFragmentFact, LegacyArithmeticFragmentFact, ListFact, ListOperatorFact,
-    LoopHeaderWordFact, NativeZshScalarArrayReference, PipelineFact, PipelineOperatorFact,
-    PipelineSegmentFact, PlainUnindexedArrayReferenceFact, PositionalParameterFragmentFact,
-    RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis, RedirectTargetKind,
-    SelectHeaderFact, SelectorRequiredArrayReference, SimpleTestFact, SimpleTestOperatorFamily,
-    SimpleTestShape, SimpleTestSyntax, SingleQuotedFragmentFact, StatementFact, SubstitutionFact,
-    SubstitutionHostKind, SubstitutionOutputIntent, SudoFamilyInvoker,
+    AmbiguousArrayReference, ArithmeticLiteralFact, ArithmeticLiteralKind, BacktickFragmentFact,
+    CommandFact, CommandFactRef, CommandFacts, ConditionalBareWordFact, ConditionalBinaryFact,
+    ConditionalFact, ConditionalMixedLogicalOperatorFact, ConditionalNodeFact,
+    ConditionalOperandFact, ConditionalOperatorFamily, ConditionalPortabilityFacts,
+    ConditionalUnaryFact, ForHeaderFact, FunctionCallArityFacts, FunctionHeaderFact,
+    IndexedArrayReferenceFragment, IndexedArrayReferenceFragmentFact, LegacyArithmeticFragmentFact,
+    ListFact, ListOperatorFact, LoopHeaderWordFact, NativeZshScalarArrayReference, PipelineFact,
+    PipelineOperatorFact, PipelineSegmentFact, PlainUnindexedArrayReferenceFact,
+    PositionalParameterFragmentFact, RedirectDevNullStatus, RedirectFact, RedirectTargetAnalysis,
+    RedirectTargetKind, SelectHeaderFact, SelectorRequiredArrayReference, SimpleTestFact,
+    SimpleTestOperatorFamily, SimpleTestShape, SimpleTestSyntax, SingleQuotedFragmentFact,
+    StatementFact, SubstitutionFact, SubstitutionHostKind, SubstitutionOutputIntent,
+    SudoFamilyInvoker,
 };
 /// Fact collection types and stable identifiers into those collections.
 pub use facts::{

--- a/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
@@ -1,4 +1,4 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{ArithmeticLiteralKind, Checker, Rule, ShellDialect, Violation};
 
 pub struct BasePrefixInArithmetic;
 
@@ -17,10 +17,15 @@ pub fn base_prefix_in_arithmetic(checker: &mut Checker) {
         return;
     }
 
-    checker.report_fact_slice_dedup(
-        |facts| facts.base_prefix_arithmetic_spans(),
-        || BasePrefixInArithmetic,
-    );
+    let spans = checker
+        .facts()
+        .arithmetic_literal_facts()
+        .iter()
+        .filter_map(|fact| {
+            (fact.kind() == ArithmeticLiteralKind::ExplicitBasePrefix).then_some(fact.span())
+        })
+        .collect::<Vec<_>>();
+    checker.report_all_dedup(spans, || BasePrefixInArithmetic);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- add an arithmetic literal kind to linter facts so consumers distinguish explicit base prefixes from leading-zero integer literals
- record leading-zero arithmetic literals with semantic `ArithmeticLiteralBehavior`, including zsh `octal_zeroes` state
- update the base-prefix portability rule to consume the behavior-aware arithmetic literal fact surface instead of the raw span accessor

## Root Cause

Arithmetic literal facts carried semantic behavior, but the rule-facing surface still exposed a raw base-prefix span list. Leading-zero literals such as `010` were not represented in the shared fact layer, so future consumers would have needed to reinterpret numeric text locally.

## Validation

- `cargo test -p shuck-linter arithmetic_literal --lib`
- `cargo test -p shuck-linter --lib`
- `cargo test -p shuck-semantic semantic_behavior_tracks_arithmetic_literal_options --lib`
- source check: production rules have no raw `zsh_options_at`, `ZshOptionState`, or `OptionValue` hits