### PR TITLE
fix(semantic): ignore zsh existence probe reads

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -93,7 +93,7 @@ pub fn undefined_variable(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn prior_defaulting_parameter_operands_suppress_later_plain_uses() {
@@ -273,9 +273,49 @@ f() {
   (( quiet ))
 }
 ";
-        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UndefinedVariable));
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn suppresses_zsh_existence_test_fake_variable_references() {
+        let source = "\
+#!/bin/zsh
+if (( $+commands[git] )); then
+  :
+fi
+if (( ${+functions[zdot_warn]} )); then
+  :
+fi
+if (( $+ZINIT_CNORM )); then
+  :
+fi
+if (( $+commands[$cmd] )); then
+  :
+fi
+if (( ${+functions[$fn]} )); then
+  :
+fi
+if (( $+arr[i+1] )); then
+  :
+fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$cmd", "$fn", "i"]
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -259,13 +259,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             subscript.interpretation,
             shuck_ast::SubscriptInterpretation::Associative
         ) || owner_name.is_some_and(|name| {
-            self.resolve_reference(name, self.current_scope(), subscript.span().start.offset)
-                .map(|binding_id| {
-                    self.bindings[binding_id.index()]
-                        .attributes
-                        .contains(BindingAttributes::ASSOC)
-                })
-                .unwrap_or(false)
+            (self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+                && zsh_runtime_array_uses_associative_subscript(name))
+                || self.visible_binding_is_assoc(name, subscript.span().start.offset)
         });
         if !uses_associative_word_semantics
             && let Some(expression) = subscript.arithmetic_ast.as_ref()
@@ -326,6 +322,11 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.visit_word_part_nodes(parts, span, kind, flow, nested_regions);
             }
             WordPart::Variable(name) => {
+                if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+                    && is_zsh_parameter_existence_name(name)
+                {
+                    return;
+                }
                 self.add_reference(
                     name,
                     self.word_reference_kind_override
@@ -411,6 +412,25 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 );
             }
             WordPart::ArrayAccess(reference) => {
+                if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+                    && is_zsh_parameter_existence_name(&reference.name)
+                {
+                    let owner_name = Name::from(
+                        reference
+                            .name
+                            .as_str()
+                            .strip_prefix('+')
+                            .expect("zsh existence-test names start with plus"),
+                    );
+                    self.visit_zsh_existence_probe_subscript(
+                        &owner_name,
+                        reference.subscript.as_deref(),
+                        kind,
+                        flow,
+                        nested_regions,
+                    );
+                    return;
+                }
                 self.visit_var_ref_reference(
                     reference,
                     reference_kind_for_word_visit(kind, ReferenceKind::ArrayAccess),
@@ -579,6 +599,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         nested_regions: &mut Vec<IsolatedRegion>,
         span: Span,
     ) {
+        if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+            && zsh_parameter_expansion_is_existence_test(parameter, self.source)
+        {
+            self.visit_zsh_parameter_existence_probe_subscript(parameter, kind);
+            return;
+        }
+
         match &parameter.syntax {
             ParameterExpansionSyntax::Bourne(syntax) => match syntax {
                 BourneParameterExpansion::Access { reference } => {
@@ -806,6 +833,43 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
     }
 
+    fn visit_zsh_existence_probe_subscript(
+        &mut self,
+        owner_name: &Name,
+        subscript: Option<&'a Subscript>,
+        kind: WordVisitKind,
+        flow: FlowState,
+        nested_regions: &mut Vec<IsolatedRegion>,
+    ) {
+        self.visit_var_ref_subscript_words(Some(owner_name), subscript, kind, flow, nested_regions);
+    }
+
+    fn visit_zsh_parameter_existence_probe_subscript(
+        &mut self,
+        parameter: &ParameterExpansion,
+        kind: WordVisitKind,
+    ) {
+        let Some((subscript_text, subscript_span)) = zsh_parameter_existence_subscript_text(
+            parameter.raw_body.slice(self.source),
+            parameter,
+        ) else {
+            return;
+        };
+        let source_offsets = (0..subscript_text.len()).collect::<Vec<_>>();
+        for (name, span) in scan_parameter_reference_names(
+            subscript_text,
+            subscript_text,
+            &source_offsets,
+            subscript_span,
+        ) {
+            self.add_reference(
+                &name,
+                reference_kind_for_word_visit(kind, ReferenceKind::Expansion),
+                span,
+            );
+        }
+    }
+
     pub(super) fn visit_fragment_word(
         &mut self,
         word: Option<&'a Word>,
@@ -917,4 +981,97 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             | PatternPart::CharClass(_) => {}
         }
     }
+}
+
+fn is_zsh_parameter_existence_name(name: &Name) -> bool {
+    name.as_str()
+        .strip_prefix('+')
+        .is_some_and(is_shell_identifier)
+}
+
+fn zsh_runtime_array_uses_associative_subscript(name: &Name) -> bool {
+    matches!(
+        name.as_str(),
+        "aliases"
+            | "commands"
+            | "functions"
+            | "options"
+            | "parameters"
+            | "termcap"
+            | "terminfo"
+            | "widgets"
+    )
+}
+
+fn zsh_parameter_expansion_is_existence_test(parameter: &ParameterExpansion, source: &str) -> bool {
+    parameter.raw_body.is_source_backed()
+        && zsh_parameter_body_is_existence_test(parameter.raw_body.slice(source))
+}
+
+fn zsh_parameter_body_is_existence_test(body: &str) -> bool {
+    body.strip_prefix('+').is_some_and(|body| {
+        let name_end = body
+            .char_indices()
+            .find_map(|(index, ch)| (!is_shell_name_char(ch)).then_some(index))
+            .unwrap_or(body.len());
+        name_end > 0 && is_shell_identifier(&body[..name_end])
+    })
+}
+
+fn zsh_parameter_existence_subscript_text<'a>(
+    raw_body: &'a str,
+    parameter: &ParameterExpansion,
+) -> Option<(&'a str, Span)> {
+    let body = raw_body.strip_prefix('+')?;
+    let name_end = body
+        .char_indices()
+        .find_map(|(index, ch)| (!is_shell_name_char(ch)).then_some(index))
+        .unwrap_or(body.len());
+    if name_end == 0 || !is_shell_identifier(&body[..name_end]) {
+        return None;
+    }
+
+    let subscript_open = name_end;
+    if body.as_bytes().get(subscript_open) != Some(&b'[') {
+        return None;
+    }
+
+    let subscript_body_start = subscript_open + 1;
+    let mut depth = 1usize;
+    for (relative_index, ch) in body[subscript_body_start..].char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    let subscript_body_end = subscript_body_start + relative_index;
+                    let raw_body_span = parameter.raw_body.span();
+                    let start_offset = 1 + subscript_body_start;
+                    let end_offset = 1 + subscript_body_end;
+                    let start = raw_body_span.start.advanced_by(&raw_body[..start_offset]);
+                    let end = raw_body_span.start.advanced_by(&raw_body[..end_offset]);
+                    return Some((
+                        &body[subscript_body_start..subscript_body_end],
+                        Span::from_positions(start, end),
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn is_shell_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars.next().is_some_and(is_shell_name_start) && chars.all(is_shell_name_char)
+}
+
+fn is_shell_name_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
+}
+
+fn is_shell_name_char(ch: char) -> bool {
+    is_shell_name_start(ch) || ch.is_ascii_digit()
 }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -7171,6 +7171,87 @@ printf '%s\\n' \"${path[1]}\" \"${options[xtrace]}\" \"${pipestatus[1]}\" \"$ZSH
 }
 
 #[test]
+fn zsh_existence_tests_do_not_register_fake_variable_reads() {
+    let source = "\
+#!/bin/zsh
+if (( $+commands[git] )); then
+  :
+fi
+if (( ${+functions[zdot_warn]} )); then
+  :
+fi
+if (( $+ZINIT_CNORM )); then
+  :
+fi
+if (( $+commands[$cmd] )); then
+  :
+fi
+if (( ${+functions[$fn]} )); then
+  :
+fi
+if (( $+arr[i+1] )); then
+  :
+fi
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let unresolved = unresolved_names(&model);
+    let uninitialized = uninitialized_names(&model);
+    let unresolved_details = model
+        .unresolved_references()
+        .iter()
+        .map(|id| {
+            let reference = model.reference(*id);
+            (reference.name.to_string(), reference.span.slice(source))
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        unresolved_details,
+        vec![
+            ("cmd".into(), "$cmd"),
+            ("fn".into(), "$fn"),
+            ("i".into(), "i")
+        ]
+    );
+    assert_names_absent(
+        &[
+            "+commands",
+            "git",
+            "commands",
+            "+functions",
+            "zdot_warn",
+            "functions",
+            "+ZINIT_CNORM",
+            "ZINIT_CNORM",
+            "+cmd",
+            "+fn",
+            "+arr",
+            "arr",
+        ],
+        &unresolved,
+    );
+    assert_names_absent(
+        &[
+            "+commands",
+            "git",
+            "commands",
+            "+functions",
+            "zdot_warn",
+            "functions",
+            "+ZINIT_CNORM",
+            "ZINIT_CNORM",
+            "+cmd",
+            "+fn",
+            "+arr",
+            "arr",
+        ],
+        &uninitialized,
+    );
+    assert_names_present(&["cmd", "fn", "i"], &unresolved);
+    assert_names_present(&["cmd", "fn", "i"], &uninitialized);
+}
+
+#[test]
 fn bash_runtime_vars_remain_unresolved_in_non_bash_scripts() {
     let source = bash_runtime_source("#!/bin/sh");
     let model = model(&source);


### PR DESCRIPTION
## Summary

- Treat zsh `$+name` and `$+name[key]` probes as existence tests during semantic traversal instead of variable reads.
- Suppress bogus C006 reports for fake names like `+commands`, `+functions`, literal keys, and `$+ZINIT_CNORM` in zsh arithmetic contexts.
- Add semantic and undefined-variable regressions for the observed zsh probe shapes.

## Root Cause

Zsh existence probes were represented through ordinary word, array-access, and arithmetic traversal paths. Those paths registered the probe text and subscript keys as reads, so C006 reported names that are not real variable references.

## Validation

- `cargo test -p shuck-linter undefined_variable`
- `cargo test -p shuck-semantic zsh_`
- `make test`
- Spot-checked the original zsh files for the first tracker row and no longer saw the fake `+...` diagnostics or original example locations.