### PR TITLE
fix(semantic): handle zsh associative runtime keys

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -319,6 +319,24 @@ fi
     }
 
     #[test]
+    fn suppresses_zsh_associative_key_fake_variable_references() {
+        let source = "\
+#!/bin/zsh
+typeset -A ZINIT ICE
+ZINIT[ice-list]=x
+ICE[ps-on-update]=x
+functions[iterm2_precmd]=x
+print -r -- ${functions[iterm2_precmd]}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn subscript_suppression_hides_later_same_name_uses() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -381,7 +381,7 @@ mod tests {
     use std::path::Path;
 
     use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
-    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn anchors_on_variable_name_span_and_attaches_fix_metadata() {
@@ -514,6 +514,29 @@ done
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn zsh_associative_key_literals_do_not_count_as_assignment_reads() {
+        let source = "\
+#!/bin/zsh
+ice=1
+iterm2_precmd=1
+typeset -A ZINIT
+ZINIT[ice-list]=x
+functions[iterm2_precmd]=x
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        let names = diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.span.slice(source))
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"ice"), "{diagnostics:#?}");
+        assert!(names.contains(&"iterm2_precmd"), "{diagnostics:#?}");
     }
 
     #[test]

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -275,7 +275,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         owner_name: &Name,
         offset: usize,
     ) -> bool {
-        self.visible_binding_is_assoc(owner_name, offset)
+        self.name_uses_associative_word_semantics(owner_name, offset)
+    }
+
+    pub(super) fn name_uses_associative_word_semantics(&self, name: &Name, offset: usize) -> bool {
+        self.visible_binding_is_assoc(name, offset)
+            || self.runtime.is_preinitialized_associative_array(name)
     }
 
     pub(super) fn visible_binding_is_assoc(&self, name: &Name, offset: usize) -> bool {

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -259,9 +259,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             subscript.interpretation,
             shuck_ast::SubscriptInterpretation::Associative
         ) || owner_name.is_some_and(|name| {
-            (self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
-                && zsh_runtime_array_uses_associative_subscript(name))
-                || self.visible_binding_is_assoc(name, subscript.span().start.offset)
+            self.name_uses_associative_word_semantics(name, subscript.span().start.offset)
         });
         if !uses_associative_word_semantics
             && let Some(expression) = subscript.arithmetic_ast.as_ref()
@@ -987,20 +985,6 @@ fn is_zsh_parameter_existence_name(name: &Name) -> bool {
     name.as_str()
         .strip_prefix('+')
         .is_some_and(is_shell_identifier)
-}
-
-fn zsh_runtime_array_uses_associative_subscript(name: &Name) -> bool {
-    matches!(
-        name.as_str(),
-        "aliases"
-            | "commands"
-            | "functions"
-            | "options"
-            | "parameters"
-            | "termcap"
-            | "terminfo"
-            | "widgets"
-    )
 }
 
 fn zsh_parameter_expansion_is_existence_test(parameter: &ParameterExpansion, source: &str) -> bool {

--- a/crates/shuck-semantic/src/runtime.rs
+++ b/crates/shuck-semantic/src/runtime.rs
@@ -214,6 +214,20 @@ const ZSH_PREINITIALIZED_ARRAYS: &[&str] = &[
     "zsh_eval_context",
 ];
 
+const ZSH_PREINITIALIZED_ASSOCIATIVE_ARRAYS: &[&str] = &[
+    "aliases",
+    "commands",
+    "functions",
+    "jobdirs",
+    "jobstates",
+    "jobtexts",
+    "options",
+    "parameters",
+    "termcap",
+    "terminfo",
+    "widgets",
+];
+
 const ALWAYS_USED_BINDINGS: &[&str] = &["IFS", "PATH", "CDPATH", "COMPREPLY", "FLAGS_PARENT"];
 const BASH_ALWAYS_USED_BINDINGS: &[&str] = &["COMPREPLY"];
 const EMPTY_IMPLICIT_READS: &[&str] = &[];
@@ -267,6 +281,11 @@ impl RuntimePrelude {
         (self.bash_enabled && contains_name(BASH_PREINITIALIZED_ARRAYS, name))
             || (self.shell_dialect == ShellDialect::Zsh
                 && contains_name(ZSH_PREINITIALIZED_ARRAYS, name))
+    }
+
+    pub(crate) fn is_preinitialized_associative_array(&self, name: &Name) -> bool {
+        self.shell_dialect == ShellDialect::Zsh
+            && contains_name(ZSH_PREINITIALIZED_ASSOCIATIVE_ARRAYS, name)
     }
 
     pub(crate) fn is_always_used_binding(&self, name: &Name) -> bool {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9147,6 +9147,25 @@ printf '%s\\n' \"$((box[m_width]))\" \"$((box[$dynamic_key]))\"
 }
 
 #[test]
+fn zsh_associative_key_literals_do_not_register_variable_reads() {
+    let source = "\
+#!/bin/zsh
+typeset -A ZINIT ICE
+ZINIT[ice-list]=x
+ICE[ps-on-update]=x
+functions[iterm2_precmd]=x
+print -r -- ${functions[iterm2_precmd]}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let unresolved = unresolved_names(&model);
+
+    assert_names_absent(
+        &["ice", "list", "ps", "on", "update", "iterm2_precmd"],
+        &unresolved,
+    );
+}
+
+#[test]
 fn arithmetic_indexed_writes_preserve_associative_attributes() {
     let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary

- teach the semantic runtime prelude which zsh-provided parameters are associative hashes
- reuse that associative classification when deciding whether subscripts should be treated as literal keys instead of arithmetic/name reads
- add C006, C001, and semantic regressions for zsh associative keys such as `ZINIT[ice-list]`, `ICE[ps-on-update]`, and `functions[iterm2_precmd]`

## Root Cause

The semantic reference walker only used source-visible associative declarations to decide whether a subscript key should use word semantics. Zsh runtime hashes such as `functions`, `commands`, `options`, and related special parameters were known as runtime arrays, but not as associative arrays, so literal keys could be interpreted as variable reads.

## Validation

- `cargo test -p shuck-linter suppresses_zsh_associative_key_fake_variable_references -- --nocapture`
- `cargo test -p shuck-linter zsh_associative_key_literals_do_not_count_as_assignment_reads -- --nocapture`
- `cargo test -p shuck-semantic zsh_associative_key_literals_do_not_register_variable_reads -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `make test`