### PR TITLE
fix(parser): handle zsh associative and numeric assignments

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
@@ -1,6 +1,6 @@
 use shuck_ast::{DeclOperand, Position, Span};
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct AssignmentToNumericVariable;
 
@@ -15,6 +15,10 @@ impl Violation for AssignmentToNumericVariable {
 }
 
 pub fn assignment_to_numeric_variable(checker: &mut Checker) {
+    if checker.shell() == ShellDialect::Zsh {
+        return;
+    }
+
     let source = checker.source();
     let spans = checker
         .facts()
@@ -74,7 +78,7 @@ fn numeric_assignment_target_span(text: &str, start: Position) -> Option<Span> {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_numeric_assignment_targets() {
@@ -115,5 +119,22 @@ a2=1
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_zsh_numeric_parameter_assignments() {
+        let source = "\
+#!/bin/zsh
+0=${(%):-%N}
+1=value
+2+=more
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentToNumericVariable)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -22,7 +22,7 @@ pub fn plus_prefix_in_assignment(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_assignment_like_words_with_a_leading_plus() {
@@ -99,5 +99,21 @@ rvm_info="
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_zsh_numeric_parameter_assignments() {
+        let source = "\
+#!/bin/zsh
+0=${(%):-%N}
+1=value
+2+=more
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PlusPrefixInAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -304,6 +304,24 @@ fi
     }
 
     #[test]
+    fn suppresses_zsh_associative_key_fake_variable_references() {
+        let source = "\
+#!/bin/zsh
+typeset -A ZINIT ICE
+ZINIT[ice-list]=x
+ICE[ps-on-update]=x
+functions[iterm2_precmd]=x
+print -r -- ${functions[iterm2_precmd]}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn subscript_suppression_hides_later_same_name_uses() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -93,7 +93,7 @@ pub fn undefined_variable(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn prior_defaulting_parameter_operands_suppress_later_plain_uses() {
@@ -273,7 +273,32 @@ f() {
   (( quiet ))
 }
 ";
-        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UndefinedVariable));
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn suppresses_zsh_existence_test_fake_variable_references() {
+        let source = "\
+#!/bin/zsh
+if (( $+commands[git] )); then
+  :
+fi
+if (( ${+functions[zdot_warn]} )); then
+  :
+fi
+if (( $+ZINIT_CNORM )); then
+  :
+fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -381,7 +381,7 @@ mod tests {
     use std::path::Path;
 
     use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
-    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn anchors_on_variable_name_span_and_attaches_fix_metadata() {
@@ -514,6 +514,29 @@ done
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn zsh_associative_key_literals_do_not_count_as_assignment_reads() {
+        let source = "\
+#!/bin/zsh
+ice=1
+iterm2_precmd=1
+typeset -A ZINIT
+ZINIT[ice-list]=x
+functions[iterm2_precmd]=x
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        let names = diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.span.slice(source))
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"ice"), "{diagnostics:#?}");
+        assert!(names.contains(&"iterm2_precmd"), "{diagnostics:#?}");
     }
 
     #[test]

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -4440,8 +4440,11 @@ impl<'a> Parser<'a> {
                     let is_literal = kind == TokenKind::LiteralWord;
                     let word_text =
                         self.current_source_like_word_text_or_error("simple command word")?;
-                    let assignment_shape = (!is_literal && words.is_empty())
-                        .then(|| Self::is_assignment(word_text.as_ref()));
+                    let allow_zsh_numeric_assignments =
+                        self.dialect.features().zsh_parameter_modifiers;
+                    let assignment_shape = (!is_literal && words.is_empty()).then(|| {
+                        Self::is_assignment(word_text.as_ref(), allow_zsh_numeric_assignments)
+                    });
                     let assignment_shape = assignment_shape.flatten();
 
                     // Check for assignment (only before the command name, not for literal words)

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -7682,6 +7682,30 @@ fn test_zsh_additional_upstream_declaration_examples_parse() {
 }
 
 #[test]
+fn test_zsh_numeric_parameter_assignments_parse_as_assignments() {
+    let source = "0=${(%):-%N}\n1=value\n2+=more\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let targets = output
+        .file
+        .body
+        .iter()
+        .map(|stmt| {
+            let command = expect_simple(stmt);
+            assert_eq!(command.name.render(source), "");
+            assert_eq!(command.assignments.len(), 1);
+            command.assignments[0].target.name.as_str()
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(targets, vec!["0", "1", "2"]);
+    assert!(!expect_simple(&output.file.body[0]).assignments[0].append);
+    assert!(expect_simple(&output.file.body[2]).assignments[0].append);
+}
+
+#[test]
 fn test_parse_zsh_array_assignment_with_word_target_and_glob_qualifier() {
     let source = "dirs=( /proc/${^$(pidof zsh):#$$}/cwd(N:A) )\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -981,7 +981,10 @@ impl<'a> Parser<'a> {
 
         Some(())
     }
-    pub(super) fn is_assignment(word: &str) -> Option<(&str, Option<&str>, &str, bool)> {
+    pub(super) fn is_assignment(
+        word: &str,
+        allow_zsh_numeric_assignments: bool,
+    ) -> Option<(&str, Option<&str>, &str, bool)> {
         if !word.contains('=') {
             return None;
         }
@@ -989,15 +992,29 @@ impl<'a> Parser<'a> {
         let mut ident_end = 0;
         let mut chars = word.char_indices();
         let (_, first) = chars.next()?;
-        if !first.is_ascii_alphabetic() && first != '_' {
-            return None;
-        }
-        ident_end += first.len_utf8();
-        for (index, ch) in chars {
-            if ch.is_ascii_alphanumeric() || ch == '_' {
-                ident_end = index + ch.len_utf8();
-            } else {
-                break;
+        if first.is_ascii_digit() {
+            if !allow_zsh_numeric_assignments {
+                return None;
+            }
+            ident_end += first.len_utf8();
+            for (index, ch) in chars {
+                if ch.is_ascii_digit() {
+                    ident_end = index + ch.len_utf8();
+                } else {
+                    break;
+                }
+            }
+        } else {
+            if !first.is_ascii_alphabetic() && first != '_' {
+                return None;
+            }
+            ident_end += first.len_utf8();
+            for (index, ch) in chars {
+                if ch.is_ascii_alphanumeric() || ch == '_' {
+                    ident_end = index + ch.len_utf8();
+                } else {
+                    break;
+                }
             }
         }
 
@@ -2851,13 +2868,27 @@ impl<'a> Parser<'a> {
         };
         let first_text = first_literal.as_str(self.input, first_part.span);
         let mut name_end = 0;
-        for (offset, ch) in first_text.char_indices() {
-            if (offset == 0 && (ch.is_ascii_alphabetic() || ch == '_'))
-                || (offset > 0 && (ch.is_ascii_alphanumeric() || ch == '_'))
-            {
-                name_end = offset + ch.len_utf8();
+        let mut first_chars = first_text.char_indices();
+        if let Some((_, first)) = first_chars.next() {
+            if first.is_ascii_digit() && self.dialect.features().zsh_parameter_modifiers {
+                name_end = first.len_utf8();
+                for (offset, ch) in first_chars {
+                    if ch.is_ascii_digit() {
+                        name_end = offset + ch.len_utf8();
+                    } else {
+                        break;
+                    }
+                }
             } else {
-                break;
+                for (offset, ch) in first_text.char_indices() {
+                    if (offset == 0 && (ch.is_ascii_alphabetic() || ch == '_'))
+                        || (offset > 0 && (ch.is_ascii_alphanumeric() || ch == '_'))
+                    {
+                        name_end = offset + ch.len_utf8();
+                    } else {
+                        break;
+                    }
+                }
             }
         }
         if name_end == 0 {

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -281,7 +281,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         owner_name: &Name,
         offset: usize,
     ) -> bool {
-        self.visible_binding_is_assoc(owner_name, offset)
+        self.name_uses_associative_word_semantics(owner_name, offset)
+    }
+
+    pub(super) fn name_uses_associative_word_semantics(&self, name: &Name, offset: usize) -> bool {
+        self.visible_binding_is_assoc(name, offset)
+            || self.runtime.is_preinitialized_associative_array(name)
     }
 
     pub(super) fn visible_binding_is_assoc(&self, name: &Name, offset: usize) -> bool {

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -215,6 +215,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.visit_arithmetic_expr_into(expression, flow, nested_regions);
             }
             ArithmeticExpr::Unary { op, expr: inner } => {
+                if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+                    && *op == ArithmeticUnaryOp::Plus
+                    && arithmetic_expr_is_zsh_parameter_existence_test(expr, self.source)
+                {
+                    return;
+                }
                 if matches!(
                     op,
                     ArithmeticUnaryOp::PreIncrement | ArithmeticUnaryOp::PreDecrement
@@ -476,6 +482,42 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
         }
     }
+}
+
+fn arithmetic_expr_is_zsh_parameter_existence_test(
+    expr: &ArithmeticExprNode,
+    source: &str,
+) -> bool {
+    let text = expr.span.slice(source);
+    let tail = text.strip_prefix("$+").or_else(|| {
+        text.strip_prefix('+').filter(|_| {
+            expr.span.start.offset > 0 && source[..expr.span.start.offset].ends_with('$')
+        })
+    });
+    let Some(tail) = tail else {
+        return false;
+    };
+
+    let name_end = tail
+        .char_indices()
+        .find_map(|(index, ch)| (!is_shell_name_char(ch)).then_some(index))
+        .unwrap_or(tail.len());
+    name_end > 0
+        && is_shell_identifier(&tail[..name_end])
+        && tail[name_end..].chars().next().is_none_or(|ch| ch == '[')
+}
+
+fn is_shell_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars.next().is_some_and(is_shell_name_start) && chars.all(is_shell_name_char)
+}
+
+fn is_shell_name_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
+}
+
+fn is_shell_name_char(ch: char) -> bool {
+    is_shell_name_start(ch) || ch.is_ascii_digit()
 }
 
 fn conditional_expr_is_logical_binary(expression: &ConditionalExpr) -> bool {

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -326,6 +326,11 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.visit_word_part_nodes(parts, span, kind, flow, nested_regions);
             }
             WordPart::Variable(name) => {
+                if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+                    && is_zsh_parameter_existence_name(name)
+                {
+                    return;
+                }
                 self.add_reference(
                     name,
                     self.word_reference_kind_override
@@ -411,6 +416,11 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 );
             }
             WordPart::ArrayAccess(reference) => {
+                if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+                    && is_zsh_parameter_existence_name(&reference.name)
+                {
+                    return;
+                }
                 self.visit_var_ref_reference(
                     reference,
                     reference_kind_for_word_visit(kind, ReferenceKind::ArrayAccess),
@@ -579,6 +589,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         nested_regions: &mut Vec<IsolatedRegion>,
         span: Span,
     ) {
+        if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh
+            && zsh_parameter_expansion_is_existence_test(parameter, self.source)
+        {
+            return;
+        }
+
         match &parameter.syntax {
             ParameterExpansionSyntax::Bourne(syntax) => match syntax {
                 BourneParameterExpansion::Access { reference } => {
@@ -917,4 +933,38 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             | PatternPart::CharClass(_) => {}
         }
     }
+}
+
+fn is_zsh_parameter_existence_name(name: &Name) -> bool {
+    name.as_str()
+        .strip_prefix('+')
+        .is_some_and(is_shell_identifier)
+}
+
+fn zsh_parameter_expansion_is_existence_test(parameter: &ParameterExpansion, source: &str) -> bool {
+    parameter.raw_body.is_source_backed()
+        && zsh_parameter_body_is_existence_test(parameter.raw_body.slice(source))
+}
+
+fn zsh_parameter_body_is_existence_test(body: &str) -> bool {
+    body.strip_prefix('+').is_some_and(|body| {
+        let name_end = body
+            .char_indices()
+            .find_map(|(index, ch)| (!is_shell_name_char(ch)).then_some(index))
+            .unwrap_or(body.len());
+        name_end > 0 && is_shell_identifier(&body[..name_end])
+    })
+}
+
+fn is_shell_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars.next().is_some_and(is_shell_name_start) && chars.all(is_shell_name_char)
+}
+
+fn is_shell_name_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
+}
+
+fn is_shell_name_char(ch: char) -> bool {
+    is_shell_name_start(ch) || ch.is_ascii_digit()
 }

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -259,13 +259,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             subscript.interpretation,
             shuck_ast::SubscriptInterpretation::Associative
         ) || owner_name.is_some_and(|name| {
-            self.resolve_reference(name, self.current_scope(), subscript.span().start.offset)
-                .map(|binding_id| {
-                    self.bindings[binding_id.index()]
-                        .attributes
-                        .contains(BindingAttributes::ASSOC)
-                })
-                .unwrap_or(false)
+            self.name_uses_associative_word_semantics(name, subscript.span().start.offset)
         });
         if !uses_associative_word_semantics
             && let Some(expression) = subscript.arithmetic_ast.as_ref()

--- a/crates/shuck-semantic/src/runtime.rs
+++ b/crates/shuck-semantic/src/runtime.rs
@@ -214,6 +214,20 @@ const ZSH_PREINITIALIZED_ARRAYS: &[&str] = &[
     "zsh_eval_context",
 ];
 
+const ZSH_PREINITIALIZED_ASSOCIATIVE_ARRAYS: &[&str] = &[
+    "aliases",
+    "commands",
+    "functions",
+    "jobdirs",
+    "jobstates",
+    "jobtexts",
+    "options",
+    "parameters",
+    "termcap",
+    "terminfo",
+    "widgets",
+];
+
 const ALWAYS_USED_BINDINGS: &[&str] = &["IFS", "PATH", "CDPATH", "COMPREPLY", "FLAGS_PARENT"];
 const BASH_ALWAYS_USED_BINDINGS: &[&str] = &["COMPREPLY"];
 const EMPTY_IMPLICIT_READS: &[&str] = &[];
@@ -267,6 +281,11 @@ impl RuntimePrelude {
         (self.bash_enabled && contains_name(BASH_PREINITIALIZED_ARRAYS, name))
             || (self.shell_dialect == ShellDialect::Zsh
                 && contains_name(ZSH_PREINITIALIZED_ARRAYS, name))
+    }
+
+    pub(crate) fn is_preinitialized_associative_array(&self, name: &Name) -> bool {
+        self.shell_dialect == ShellDialect::Zsh
+            && contains_name(ZSH_PREINITIALIZED_ASSOCIATIVE_ARRAYS, name)
     }
 
     pub(crate) fn is_always_used_binding(&self, name: &Name) -> bool {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -7171,6 +7171,64 @@ printf '%s\\n' \"${path[1]}\" \"${options[xtrace]}\" \"${pipestatus[1]}\" \"$ZSH
 }
 
 #[test]
+fn zsh_existence_tests_do_not_register_fake_variable_reads() {
+    let source = "\
+#!/bin/zsh
+if (( $+commands[git] )); then
+  :
+fi
+if (( ${+functions[zdot_warn]} )); then
+  :
+fi
+if (( $+ZINIT_CNORM )); then
+  :
+fi
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let unresolved = unresolved_names(&model);
+    let uninitialized = uninitialized_names(&model);
+    let unresolved_details = model
+        .unresolved_references()
+        .iter()
+        .map(|id| {
+            let reference = model.reference(*id);
+            (reference.name.to_string(), reference.span.slice(source))
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        unresolved_details.is_empty(),
+        "unexpected unresolved refs: {unresolved_details:?}"
+    );
+    assert_names_absent(
+        &[
+            "+commands",
+            "git",
+            "commands",
+            "+functions",
+            "zdot_warn",
+            "functions",
+            "+ZINIT_CNORM",
+            "ZINIT_CNORM",
+        ],
+        &unresolved,
+    );
+    assert_names_absent(
+        &[
+            "+commands",
+            "git",
+            "commands",
+            "+functions",
+            "zdot_warn",
+            "functions",
+            "+ZINIT_CNORM",
+            "ZINIT_CNORM",
+        ],
+        &uninitialized,
+    );
+}
+
+#[test]
 fn bash_runtime_vars_remain_unresolved_in_non_bash_scripts() {
     let source = bash_runtime_source("#!/bin/sh");
     let model = model(&source);

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9124,6 +9124,25 @@ printf '%s\\n' \"$((box[m_width]))\" \"$((box[$dynamic_key]))\"
 }
 
 #[test]
+fn zsh_associative_key_literals_do_not_register_variable_reads() {
+    let source = "\
+#!/bin/zsh
+typeset -A ZINIT ICE
+ZINIT[ice-list]=x
+ICE[ps-on-update]=x
+functions[iterm2_precmd]=x
+print -r -- ${functions[iterm2_precmd]}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let unresolved = unresolved_names(&model);
+
+    assert_names_absent(
+        &["ice", "list", "ps", "on", "update", "iterm2_precmd"],
+        &unresolved,
+    );
+}
+
+#[test]
 fn arithmetic_indexed_writes_preserve_associative_attributes() {
     let source = "\
 #!/bin/bash


### PR DESCRIPTION
Superseded by the scoped bug #3 PR: https://github.com/ewhauser/shuck/pull/851