### PR TITLE
fix(parser): handle zsh numeric assignments

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
@@ -1,6 +1,6 @@
 use shuck_ast::{DeclOperand, Position, Span};
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct AssignmentToNumericVariable;
 
@@ -15,6 +15,10 @@ impl Violation for AssignmentToNumericVariable {
 }
 
 pub fn assignment_to_numeric_variable(checker: &mut Checker) {
+    if checker.shell() == ShellDialect::Zsh {
+        return;
+    }
+
     let source = checker.source();
     let spans = checker
         .facts()
@@ -74,7 +78,7 @@ fn numeric_assignment_target_span(text: &str, start: Position) -> Option<Span> {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_numeric_assignment_targets() {
@@ -115,5 +119,22 @@ a2=1
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_zsh_numeric_parameter_assignments() {
+        let source = "\
+#!/bin/zsh
+0=${(%):-%N}
+1=value
+2+=more
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentToNumericVariable)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -22,7 +22,7 @@ pub fn plus_prefix_in_assignment(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_assignment_like_words_with_a_leading_plus() {
@@ -99,5 +99,21 @@ rvm_info="
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_zsh_numeric_parameter_assignments() {
+        let source = "\
+#!/bin/zsh
+0=${(%):-%N}
+1=value
+2+=more
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PlusPrefixInAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 }

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -4440,8 +4440,11 @@ impl<'a> Parser<'a> {
                     let is_literal = kind == TokenKind::LiteralWord;
                     let word_text =
                         self.current_source_like_word_text_or_error("simple command word")?;
-                    let assignment_shape = (!is_literal && words.is_empty())
-                        .then(|| Self::is_assignment(word_text.as_ref()));
+                    let allow_zsh_numeric_assignments =
+                        self.dialect.features().zsh_parameter_modifiers;
+                    let assignment_shape = (!is_literal && words.is_empty()).then(|| {
+                        Self::is_assignment(word_text.as_ref(), allow_zsh_numeric_assignments)
+                    });
                     let assignment_shape = assignment_shape.flatten();
 
                     // Check for assignment (only before the command name, not for literal words)

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -7682,6 +7682,30 @@ fn test_zsh_additional_upstream_declaration_examples_parse() {
 }
 
 #[test]
+fn test_zsh_numeric_parameter_assignments_parse_as_assignments() {
+    let source = "0=${(%):-%N}\n1=value\n2+=more\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+
+    let targets = output
+        .file
+        .body
+        .iter()
+        .map(|stmt| {
+            let command = expect_simple(stmt);
+            assert_eq!(command.name.render(source), "");
+            assert_eq!(command.assignments.len(), 1);
+            command.assignments[0].target.name.as_str()
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(targets, vec!["0", "1", "2"]);
+    assert!(!expect_simple(&output.file.body[0]).assignments[0].append);
+    assert!(expect_simple(&output.file.body[2]).assignments[0].append);
+}
+
+#[test]
 fn test_parse_zsh_array_assignment_with_word_target_and_glob_qualifier() {
     let source = "dirs=( /proc/${^$(pidof zsh):#$$}/cwd(N:A) )\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -981,7 +981,10 @@ impl<'a> Parser<'a> {
 
         Some(())
     }
-    pub(super) fn is_assignment(word: &str) -> Option<(&str, Option<&str>, &str, bool)> {
+    pub(super) fn is_assignment(
+        word: &str,
+        allow_zsh_numeric_assignments: bool,
+    ) -> Option<(&str, Option<&str>, &str, bool)> {
         if !word.contains('=') {
             return None;
         }
@@ -989,15 +992,29 @@ impl<'a> Parser<'a> {
         let mut ident_end = 0;
         let mut chars = word.char_indices();
         let (_, first) = chars.next()?;
-        if !first.is_ascii_alphabetic() && first != '_' {
-            return None;
-        }
-        ident_end += first.len_utf8();
-        for (index, ch) in chars {
-            if ch.is_ascii_alphanumeric() || ch == '_' {
-                ident_end = index + ch.len_utf8();
-            } else {
-                break;
+        if first.is_ascii_digit() {
+            if !allow_zsh_numeric_assignments {
+                return None;
+            }
+            ident_end += first.len_utf8();
+            for (index, ch) in chars {
+                if ch.is_ascii_digit() {
+                    ident_end = index + ch.len_utf8();
+                } else {
+                    break;
+                }
+            }
+        } else {
+            if !first.is_ascii_alphabetic() && first != '_' {
+                return None;
+            }
+            ident_end += first.len_utf8();
+            for (index, ch) in chars {
+                if ch.is_ascii_alphanumeric() || ch == '_' {
+                    ident_end = index + ch.len_utf8();
+                } else {
+                    break;
+                }
             }
         }
 
@@ -2851,13 +2868,27 @@ impl<'a> Parser<'a> {
         };
         let first_text = first_literal.as_str(self.input, first_part.span);
         let mut name_end = 0;
-        for (offset, ch) in first_text.char_indices() {
-            if (offset == 0 && (ch.is_ascii_alphabetic() || ch == '_'))
-                || (offset > 0 && (ch.is_ascii_alphanumeric() || ch == '_'))
-            {
-                name_end = offset + ch.len_utf8();
+        let mut first_chars = first_text.char_indices();
+        if let Some((_, first)) = first_chars.next() {
+            if first.is_ascii_digit() && self.dialect.features().zsh_parameter_modifiers {
+                name_end = first.len_utf8();
+                for (offset, ch) in first_chars {
+                    if ch.is_ascii_digit() {
+                        name_end = offset + ch.len_utf8();
+                    } else {
+                        break;
+                    }
+                }
             } else {
-                break;
+                for (offset, ch) in first_text.char_indices() {
+                    if (offset == 0 && (ch.is_ascii_alphabetic() || ch == '_'))
+                        || (offset > 0 && (ch.is_ascii_alphanumeric() || ch == '_'))
+                    {
+                        name_end = offset + ch.len_utf8();
+                    } else {
+                        break;
+                    }
+                }
             }
         }
         if name_end == 0 {


### PR DESCRIPTION
## Summary

- Parse zsh numeric parameter assignments like `0=...`, `1=...`, and `2+=...` as assignment-only commands instead of command-like words.
- Suppress C116 for zsh so valid positional-parameter assignment idioms are not reported as invalid numeric targets.
- Add focused parser, C116, and C117 regressions while preserving non-zsh behavior.

## Validation

- `cargo test -p shuck-parser test_zsh_numeric_parameter_assignments_parse_as_assignments -- --nocapture`
- `cargo test -p shuck-linter assignment_to_numeric_variable`
- `cargo test -p shuck-linter plus_prefix_in_assignment`
- `cargo fmt --check`
- `git diff --cached --check`
- CLI spot-check: `shuck check --select C116,C117` on the zsh numeric assignment repro exits 0