### PR TITLE
fix(semantic): model zsh always cleanup reachability

### DIFF
--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -5605,6 +5605,26 @@ printf '%s\\n' two
     }
 
     #[test]
+    fn unreachable_after_exit_treats_zsh_always_cleanup_as_reachable() {
+        let source = "\
+#!/bin/zsh
+{
+  return
+} always {
+  printf '%s\\n' cleanup
+}
+printf '%s\\n' after
+";
+        let diagnostics = crate::test::test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnreachableAfterExit).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        assert_eq!(diagnostics[0].span.slice(source), "printf '%s\\n' after");
+    }
+
+    #[test]
     fn unreachable_after_exit_reports_after_script_terminating_function_calls() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -748,14 +748,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     in_block: true,
                     ..flow
                 };
-                let mut body = Vec::with_capacity(command.body.len() + command.always_body.len());
-                self.visit_stmt_seq_into(&command.body, block_flow, &mut body);
-                self.visit_stmt_seq_into(&command.always_body, block_flow, &mut body);
-                let body = self.recorded_program.push_command_ids(body);
+                let body = self.visit_stmt_seq(&command.body, block_flow);
+                let always_body = self.visit_stmt_seq(&command.always_body, block_flow);
                 self.record_command(
                     command.span,
                     Vec::new(),
-                    RecordedCommandKind::BraceGroup { body },
+                    RecordedCommandKind::Always { body, always_body },
                 )
             }
             CompoundCommand::Arithmetic(command) => {
@@ -973,6 +971,14 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             | RecordedCommandKind::BraceGroup { body }
             | RecordedCommandKind::Subshell { body } => {
                 for &command in self.recorded_program.commands_in(body) {
+                    regions.extend(self.flatten_recorded_regions(command));
+                }
+            }
+            RecordedCommandKind::Always { body, always_body } => {
+                for &command in self.recorded_program.commands_in(body) {
+                    regions.extend(self.flatten_recorded_regions(command));
+                }
+                for &command in self.recorded_program.commands_in(always_body) {
                     regions.extend(self.flatten_recorded_regions(command));
                 }
             }

--- a/crates/shuck-semantic/src/cfg.rs
+++ b/crates/shuck-semantic/src/cfg.rs
@@ -496,6 +496,10 @@ pub(crate) enum RecordedCommandKind {
     BraceGroup {
         body: RecordedCommandRange,
     },
+    Always {
+        body: RecordedCommandRange,
+        always_body: RecordedCommandRange,
+    },
     Subshell {
         body: RecordedCommandRange,
     },
@@ -860,6 +864,10 @@ fn command_can_return_before(
         | RecordedCommandKind::ArithmeticFor { body } => {
             command_range_can_return_before(program, body, before_offset)
         }
+        RecordedCommandKind::Always { body, always_body } => {
+            command_range_can_return_before(program, body, before_offset)
+                || command_range_can_return_before(program, always_body, before_offset)
+        }
         RecordedCommandKind::While { condition, body }
         | RecordedCommandKind::Until { condition, body } => {
             command_range_can_return_before(program, condition, before_offset)
@@ -1026,6 +1034,9 @@ fn command_exit_effect(
         RecordedCommandKind::BraceGroup { body } => {
             sequence_exit_effect(program, body, terminating_call_spans)
         }
+        RecordedCommandKind::Always { body, always_body } => {
+            always_exit_effect(program, body, always_body, terminating_call_spans)
+        }
         RecordedCommandKind::While { condition, body }
         | RecordedCommandKind::Until { condition, body } => {
             loop_exit_effect(program, condition, body, terminating_call_spans)
@@ -1183,6 +1194,29 @@ fn case_exit_effect(
             arm.commands,
             terminating_call_spans,
         ));
+    }
+
+    effect
+}
+
+fn always_exit_effect(
+    program: &RecordedProgram,
+    body: RecordedCommandRange,
+    always_body: RecordedCommandRange,
+    terminating_call_spans: &FxHashSet<SpanKey>,
+) -> ExitEffect {
+    let body_effect = sequence_exit_effect(program, body, terminating_call_spans);
+    let always_effect = sequence_exit_effect(program, always_body, terminating_call_spans);
+    let mut effect = ExitEffect::default();
+
+    if body_effect.may_continue {
+        effect.combine_alternative(always_effect);
+    }
+    if body_effect.may_return {
+        effect.may_return = true;
+    }
+    if body_effect.may_exit {
+        effect.may_exit = true;
     }
 
     effect
@@ -1499,6 +1533,9 @@ impl<'a> GraphBuilder<'a> {
                     force_command_header,
                 )
             }
+            RecordedCommandKind::Always { body, always_body } => {
+                self.build_always(command_id, *body, *always_body, loops, force_command_header)
+            }
             RecordedCommandKind::Subshell { body, .. } => {
                 let block = self.command_block(command.span);
                 self.attach_nested_regions(block, command.nested_regions, loops);
@@ -1531,6 +1568,67 @@ impl<'a> GraphBuilder<'a> {
                 }
             }
         }
+    }
+
+    fn build_always(
+        &mut self,
+        command_id: CommandId,
+        body: RecordedCommandRange,
+        always_body: RecordedCommandRange,
+        loops: &[LoopTarget],
+        force_command_header: bool,
+    ) -> SequenceResult {
+        let body_start = self.blocks.len();
+        let body_sequence = self.build_sequence(body, loops);
+        let body_end = self.blocks.len();
+        let always_sequence = self.build_sequence(always_body, loops);
+
+        if let Some(always_entry) = always_sequence.entry {
+            if body_sequence.exits.is_empty() {
+                let terminal_blocks = self.terminal_leaf_blocks(body_start, body_end);
+                for block in terminal_blocks {
+                    self.add_edge(block, always_entry, EdgeKind::Sequential);
+                }
+            } else {
+                for block in &body_sequence.exits {
+                    self.add_edge(*block, always_entry, EdgeKind::Sequential);
+                }
+            }
+        }
+
+        let exits = if body_sequence.exits.is_empty() {
+            SmallVec::new()
+        } else {
+            always_sequence.exits
+        };
+        let terminal_cause = if exits.is_empty() {
+            if body_sequence.exits.is_empty() {
+                body_sequence.terminal_cause
+            } else {
+                always_sequence.terminal_cause
+            }
+        } else {
+            None
+        };
+        let entry = body_sequence.entry.or(always_sequence.entry);
+        self.wrap_sequence_with_command_header(
+            command_id,
+            SequenceResult {
+                entry,
+                exits,
+                terminal_cause,
+            },
+            loops,
+            force_command_header,
+        )
+    }
+
+    fn terminal_leaf_blocks(&self, start: usize, end: usize) -> SmallVec<[BlockId; 2]> {
+        self.blocks[start..end]
+            .iter()
+            .filter(|block| self.successors[block.id.index()].is_empty())
+            .map(|block| block.id)
+            .collect()
     }
 
     fn wrap_sequence_with_command_header(

--- a/crates/shuck-semantic/src/function_resolution.rs
+++ b/crates/shuck-semantic/src/function_resolution.rs
@@ -193,6 +193,22 @@ fn collect_command_function_bindings(
             bindings,
             unconditional,
         ),
+        RecordedCommandKind::Always { body, always_body } => {
+            collect_sequence_function_bindings(
+                program,
+                body,
+                command_bindings,
+                bindings,
+                unconditional,
+            );
+            collect_sequence_function_bindings(
+                program,
+                always_body,
+                command_bindings,
+                bindings,
+                unconditional,
+            );
+        }
         RecordedCommandKind::Linear
         | RecordedCommandKind::Break { .. }
         | RecordedCommandKind::Continue { .. }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2840,6 +2840,7 @@ fn record_command_condition_starts(
         | RecordedCommandKind::ArithmeticFor { .. }
         | RecordedCommandKind::Case { .. }
         | RecordedCommandKind::BraceGroup { .. }
+        | RecordedCommandKind::Always { .. }
         | RecordedCommandKind::Subshell { .. }
         | RecordedCommandKind::Pipeline { .. } => {}
     }
@@ -3098,6 +3099,10 @@ fn record_command_children(
         | RecordedCommandKind::Subshell { body } => {
             assign_range_parent(program, parent, body, parent_ids, child_ids);
         }
+        RecordedCommandKind::Always { body, always_body } => {
+            assign_range_parent(program, parent, body, parent_ids, child_ids);
+            assign_range_parent(program, parent, always_body, parent_ids, child_ids);
+        }
         RecordedCommandKind::Case { arms } => {
             for arm in program.case_arms(arms) {
                 assign_range_parent(program, parent, arm.commands, parent_ids, child_ids);
@@ -3238,6 +3243,10 @@ fn command_descendants(program: &RecordedProgram, command: CommandId) -> Vec<Com
         | RecordedCommandKind::BraceGroup { body }
         | RecordedCommandKind::Subshell { body } => {
             descendants.extend(commands_in_range_recursive(program, body));
+        }
+        RecordedCommandKind::Always { body, always_body } => {
+            descendants.extend(commands_in_range_recursive(program, body));
+            descendants.extend(commands_in_range_recursive(program, always_body));
         }
         RecordedCommandKind::Case { arms } => {
             for arm in program.case_arms(arms) {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -6413,6 +6413,36 @@ fn detects_dead_code_after_exit() {
 }
 
 #[test]
+fn zsh_always_cleanup_after_return_is_reachable() {
+    let source = "\
+#!/bin/zsh
+{
+  return
+} always {
+  printf '%s\\n' cleanup
+}
+printf '%s\\n' after
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let unreachable = model
+        .analysis()
+        .dead_code()
+        .iter()
+        .flat_map(|entry| entry.unreachable.iter())
+        .map(|span| span.slice(source).trim_end().to_owned())
+        .collect::<Vec<_>>();
+
+    assert!(
+        !unreachable.contains(&"printf '%s\\n' cleanup".to_owned()),
+        "unreachable spans: {unreachable:?}"
+    );
+    assert!(
+        unreachable.contains(&"printf '%s\\n' after".to_owned()),
+        "unreachable spans: {unreachable:?}"
+    );
+}
+
+#[test]
 fn loop_control_condition_keeps_unreachable_if_tree_causes() {
     let source = "\
 while true; do

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -686,6 +686,10 @@ impl<'a> Analyzer<'a> {
             RecordedCommandKind::BraceGroup { body } => {
                 self.analyze_sequence(scope, *body, state, leak)
             }
+            RecordedCommandKind::Always { body, always_body } => {
+                let after_body = self.analyze_sequence(scope, *body, state, leak);
+                self.analyze_sequence(scope, *always_body, after_body, leak)
+            }
             RecordedCommandKind::Case { arms } => self.analyze_case(scope, &state, *arms, leak),
             RecordedCommandKind::Subshell { body } => {
                 self.analyze_sequence(


### PR DESCRIPTION
## Summary
- keep zsh `always` body and cleanup ranges distinct in semantic command recording
- route CFG terminal paths through cleanup without making following code reachable
- add semantic and C124 regression coverage for cleanup after `return`

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p shuck-semantic zsh_`
- `cargo test -p shuck-linter unreachable_after_exit`
- `make test`