### PR TITLE
fix(zsh): recognize integer declarations

### DIFF
--- a/crates/shuck-ast/src/command_resolution.rs
+++ b/crates/shuck-ast/src/command_resolution.rs
@@ -230,21 +230,23 @@ fn declaration_kind(raw_kind: &str) -> DeclarationKind {
         "export" => DeclarationKind::Export,
         "local" => DeclarationKind::Local,
         "declare" => DeclarationKind::Declare,
-        "typeset" => DeclarationKind::Typeset,
+        "typeset" | "integer" => DeclarationKind::Typeset,
         _ => DeclarationKind::Other(raw_kind.to_owned()),
     }
 }
 
 fn declaration_has_readonly_flag(command: &DeclClause, source: &str) -> bool {
-    matches!(command.variant.as_ref(), "local" | "declare" | "typeset")
-        && command.operands.iter().any(|operand| {
-            let DeclOperand::Flag(word) = operand else {
-                return false;
-            };
+    matches!(
+        command.variant.as_ref(),
+        "local" | "declare" | "typeset" | "integer"
+    ) && command.operands.iter().any(|operand| {
+        let DeclOperand::Flag(word) = operand else {
+            return false;
+        };
 
-            static_word_text(word, source)
-                .is_some_and(|text| text.starts_with('-') && text.contains('r'))
-        })
+        static_word_text(word, source)
+            .is_some_and(|text| text.starts_with('-') && text.contains('r'))
+    })
 }
 
 fn declaration_head_span(command: &DeclClause) -> Span {

--- a/crates/shuck-linter/src/facts/normalized_commands.rs
+++ b/crates/shuck-linter/src/facts/normalized_commands.rs
@@ -4,12 +4,19 @@ pub(crate) use shuck_ast::{normalize_command, normalize_command_words};
 #[cfg(test)]
 mod tests {
     use shuck_ast::Command;
-    use shuck_parser::parser::Parser;
+    use shuck_parser::parser::{Parser, ShellDialect};
 
     use super::{DeclarationKind, WrapperKind, normalize_command};
 
     fn parse_first_command(source: &str) -> Command {
         let output = Parser::new(source).parse().unwrap();
+        output.file.body.stmts.into_iter().next().unwrap().command
+    }
+
+    fn parse_first_zsh_command(source: &str) -> Command {
+        let output = Parser::with_dialect(source, ShellDialect::Zsh)
+            .parse()
+            .unwrap();
         output.file.body.stmts.into_iter().next().unwrap().command
     }
 
@@ -304,6 +311,25 @@ mod tests {
                 assignment_names
             );
         }
+    }
+
+    #[test]
+    fn normalize_command_treats_zsh_integer_as_typeset_declaration() {
+        let source = "integer -r foo=$(date) bar\n";
+        let command = parse_first_zsh_command(source);
+        let normalized = normalize_command(&command, source);
+        let declaration = normalized.declaration.expect("expected declaration");
+
+        assert_eq!(declaration.kind, DeclarationKind::Typeset);
+        assert!(declaration.readonly_flag);
+        assert_eq!(
+            declaration
+                .assignment_operands
+                .iter()
+                .map(|assignment| assignment.target.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["foo"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/export_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/export_command_substitution.rs
@@ -80,7 +80,7 @@ fn should_report_s010_declaration(
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_declaration_assignment_names() {
@@ -162,6 +162,28 @@ typeset -r n_version=\"$(./bin/n --version)\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["archive_dir_create", "n_version"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_integer_declarations_with_command_substitution() {
+        let source = "\
+#!/bin/zsh
+integer generated=$(date)
+integer -r readonly_generated=$(date)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ExportCommandSubstitution)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["generated", "readonly_generated"]
         );
     }
 

--- a/crates/shuck-parser/src/parser/commands.rs
+++ b/crates/shuck-parser/src/parser/commands.rs
@@ -498,6 +498,7 @@ impl<'a> Parser<'a> {
         let name = self.single_literal_word_text(word)?;
         match name {
             "declare" | "local" | "export" | "readonly" | "typeset" => Some(Name::from(name)),
+            "integer" if self.dialect == ShellDialect::Zsh => Some(Name::from(name)),
             _ => None,
         }
     }

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -5281,6 +5281,44 @@ fn test_parse_typeset_clause_classifies_flags_and_assignments() {
 }
 
 #[test]
+fn test_parse_zsh_integer_clause_classifies_assignment() {
+    let input = "integer -g count=0 other\n";
+    let script = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap()
+        .file;
+
+    let AstCommand::Decl(command) = &script.body[0].command else {
+        panic!("expected declaration clause");
+    };
+
+    assert_eq!(command.variant, "integer");
+    assert_eq!(command.operands.len(), 3);
+    assert!(matches!(command.operands[0], DeclOperand::Flag(_)));
+
+    let DeclOperand::Assignment(assignment) = &command.operands[1] else {
+        panic!("expected assignment operand");
+    };
+    assert_eq!(assignment.target.name, "count");
+
+    let DeclOperand::Name(name) = &command.operands[2] else {
+        panic!("expected bare name operand");
+    };
+    assert_eq!(name.name, "other");
+}
+
+#[test]
+fn test_parse_integer_stays_simple_command_outside_zsh() {
+    let input = "integer count=0\n";
+    let script = Parser::with_dialect(input, ShellDialect::Bash)
+        .parse()
+        .unwrap()
+        .file;
+
+    assert!(matches!(script.body[0].command, AstCommand::Simple(_)));
+}
+
+#[test]
 fn test_parse_assignment_word_handles_process_substitution_subscript() {
     let input = "\\declare -A arr[<(printf \"]\")]=$(date)\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -347,14 +347,24 @@ fn apply_implicit_declaration_flags(command_name: &str, flags: &mut FxHashSet<ch
     }
 }
 
-fn declaration_flags(operands: &[DeclOperand], source: &str) -> FxHashSet<char> {
+fn declaration_flags(
+    command_name: &str,
+    operands: &[DeclOperand],
+    source: &str,
+) -> FxHashSet<char> {
     let mut flags = FxHashSet::default();
+    apply_implicit_declaration_flags(command_name, &mut flags);
     for operand in operands {
         if let DeclOperand::Flag(word) = operand
             && let Some(text) = static_word_text(word, source)
         {
+            let enabled_for_operand = text.starts_with('-');
             for flag in text.chars().skip(1) {
-                flags.insert(flag);
+                if enabled_for_operand {
+                    flags.insert(flag);
+                } else {
+                    flags.remove(&flag);
+                }
             }
         }
     }

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -325,7 +325,7 @@ fn declaration_builtin(name: &Name) -> DeclarationBuiltin {
         "local" => DeclarationBuiltin::Local,
         "export" => DeclarationBuiltin::Export,
         "readonly" => DeclarationBuiltin::Readonly,
-        "typeset" => DeclarationBuiltin::Typeset,
+        "typeset" | "integer" => DeclarationBuiltin::Typeset,
         _ => DeclarationBuiltin::Declare,
     }
 }
@@ -336,8 +336,14 @@ fn declaration_builtin_name(name: &str) -> Option<DeclarationBuiltin> {
         "local" => Some(DeclarationBuiltin::Local),
         "export" => Some(DeclarationBuiltin::Export),
         "readonly" => Some(DeclarationBuiltin::Readonly),
-        "typeset" => Some(DeclarationBuiltin::Typeset),
+        "typeset" | "integer" => Some(DeclarationBuiltin::Typeset),
         _ => None,
+    }
+}
+
+fn apply_implicit_declaration_flags(command_name: &str, flags: &mut FxHashSet<char>) {
+    if command_name == "integer" {
+        flags.insert('i');
     }
 }
 

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -128,6 +128,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 }
             }
             "unset" => self.record_unset_variable_targets(args, flow),
+            "integer" if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh => {
+                self.visit_simple_declaration_command(name.as_str(), args, command_span, flow);
+            }
             "export" | "local" | "declare" | "typeset" | "readonly" => {
                 self.visit_simple_declaration_command(name.as_str(), args, command_span, flow);
             }
@@ -182,6 +185,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         };
 
         let mut flags = FxHashSet::default();
+        apply_implicit_declaration_flags(command_name, &mut flags);
         let mut global_flag_enabled = false;
         let mut name_operands_are_function_names = false;
         let mut parsing_options = true;

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -293,8 +293,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
 
         let builtin = declaration_builtin(&command.variant);
-        let mut flags = declaration_flags(&command.operands, self.source);
-        apply_implicit_declaration_flags(command.variant.as_str(), &mut flags);
+        let flags = declaration_flags(command.variant.as_str(), &command.operands, self.source);
         let global_flag_enabled =
             declaration_flag_is_enabled(&command.operands, self.source, 'g').unwrap_or(false);
         self.declarations.push(Declaration {

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -293,7 +293,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         }
 
         let builtin = declaration_builtin(&command.variant);
-        let flags = declaration_flags(&command.operands, self.source);
+        let mut flags = declaration_flags(&command.operands, self.source);
+        apply_implicit_declaration_flags(command.variant.as_str(), &mut flags);
         let global_flag_enabled =
             declaration_flag_is_enabled(&command.operands, self.source, 'g').unwrap_or(false);
         self.declarations.push(Declaration {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -962,8 +962,9 @@ f() {
   typeset -i implicit_local_integer=6
   typeset -g promoted=7
   integer integer_local=8
+  integer +i string_local=9
   print $local_count $implicit_local $implicit_local_integer
-  print $promoted $integer_local
+  print $promoted $integer_local $string_local
 }
 f
 print $promoted
@@ -1016,6 +1017,11 @@ print $promoted
                 | BindingAttributes::LOCAL
                 | BindingAttributes::INTEGER,
             BindingAttributes::READONLY,
+        ),
+        (
+            "string_local",
+            BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::LOCAL,
+            BindingAttributes::INTEGER | BindingAttributes::READONLY,
         ),
     ];
 

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -949,6 +949,123 @@ fn escaped_declarations_create_name_bindings() {
 }
 
 #[test]
+fn zsh_declaration_builtins_with_options_create_initialized_bindings() {
+    let source = "\
+#!/bin/zsh
+typeset -g global_count=1
+typeset -gr readonly_global=2
+typeset -gi integer_global=3
+print $global_count $readonly_global $integer_global
+f() {
+  local -i local_count=4
+  typeset implicit_local=5
+  typeset -i implicit_local_integer=6
+  typeset -g promoted=7
+  integer integer_local=8
+  print $local_count $implicit_local $implicit_local_integer
+  print $promoted $integer_local
+}
+f
+print $promoted
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let cases = [
+        (
+            "global_count",
+            BindingAttributes::DECLARATION_INITIALIZED,
+            BindingAttributes::LOCAL | BindingAttributes::INTEGER | BindingAttributes::READONLY,
+        ),
+        (
+            "readonly_global",
+            BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::READONLY,
+            BindingAttributes::LOCAL | BindingAttributes::INTEGER,
+        ),
+        (
+            "integer_global",
+            BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
+            BindingAttributes::LOCAL | BindingAttributes::READONLY,
+        ),
+        (
+            "local_count",
+            BindingAttributes::DECLARATION_INITIALIZED
+                | BindingAttributes::LOCAL
+                | BindingAttributes::INTEGER,
+            BindingAttributes::READONLY,
+        ),
+        (
+            "implicit_local",
+            BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::LOCAL,
+            BindingAttributes::INTEGER | BindingAttributes::READONLY,
+        ),
+        (
+            "implicit_local_integer",
+            BindingAttributes::DECLARATION_INITIALIZED
+                | BindingAttributes::LOCAL
+                | BindingAttributes::INTEGER,
+            BindingAttributes::READONLY,
+        ),
+        (
+            "promoted",
+            BindingAttributes::DECLARATION_INITIALIZED,
+            BindingAttributes::LOCAL | BindingAttributes::INTEGER | BindingAttributes::READONLY,
+        ),
+        (
+            "integer_local",
+            BindingAttributes::DECLARATION_INITIALIZED
+                | BindingAttributes::LOCAL
+                | BindingAttributes::INTEGER,
+            BindingAttributes::READONLY,
+        ),
+    ];
+
+    let declaration_names = cases.map(|(name, _, _)| name);
+
+    for (name, required, forbidden) in cases {
+        let binding = binding_for_name(&model, name);
+        assert!(
+            matches!(
+                binding.kind,
+                BindingKind::Declaration(DeclarationBuiltin::Typeset)
+                    | BindingKind::Declaration(DeclarationBuiltin::Local)
+            ),
+            "expected declaration binding for {name}, got {:?}",
+            binding.kind
+        );
+        assert!(
+            binding.attributes.contains(required),
+            "expected {name} to contain {required:?}, got {:?}",
+            binding.attributes
+        );
+        assert!(
+            !binding.attributes.intersects(forbidden),
+            "expected {name} not to contain {forbidden:?}, got {:?}",
+            binding.attributes
+        );
+        assert!(!binding.references.is_empty(), "expected {name} to be read");
+    }
+
+    let uninitialized = uninitialized_names(&model);
+    assert!(
+        declaration_names
+            .iter()
+            .filter(|name| **name != "promoted")
+            .all(|name| !uninitialized
+                .iter()
+                .any(|uninitialized| uninitialized == name)),
+        "zsh declaration reads should resolve, got {uninitialized:?}"
+    );
+
+    let unused = binding_names(&model, model.analysis().unused_assignments());
+    assert!(
+        declaration_names
+            .iter()
+            .all(|name| !unused.iter().any(|unused| unused == name)),
+        "zsh declaration assignments should be live, got {unused:?}"
+    );
+}
+
+#[test]
 fn escaped_exported_declarations_keep_exported_attributes() {
     let source = "\\typeset -x rvm_hook\nrvm_hook=after_update\n";
     let model = model(source);


### PR DESCRIPTION
## Summary
- Parse zsh `integer` commands as declaration clauses while leaving non-zsh shells unchanged.
- Model `integer` through the existing `typeset` declaration path with implicit integer attributes.
- Add parser and semantic regression coverage for zsh declaration option combinations including `typeset -g`, `typeset -gr`, `typeset -gi`, `local -i`, and `integer`.

## Root Cause
Zsh `integer` declarations were falling through as ordinary simple commands, so inline declaration assignments like `integer value=0` did not create initialized declaration bindings. That could surface as false C001/C006 findings in zsh-heavy scripts.

## Validation
- `cargo fmt`
- `cargo test -p shuck-parser integer`
- `cargo test -p shuck-semantic zsh_declaration_builtins_with_options_create_initialized_bindings`
- `cargo run -q -p shuck-cli -- check --select C001,C006 /tmp/shuck-zsh-decl-matrix.zsh`
- `make test`