### PR TITLE
fix(semantic): model zsh by-name helper operands

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -487,6 +487,108 @@ printf '%s\\n' \"$bar\" \"$foo\" \"$b\"
     }
 
     #[test]
+    fn zsh_zstyle_array_query_defines_named_target() {
+        let source = "\
+#!/bin/zsh
+zstyle -a ':prezto:load' pmodule-dirs user_pmodule_dirs
+print -r -- $user_pmodule_dirs $still_missing
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$still_missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_zstyle_array_query_preserves_associative_target_metadata() {
+        let source = "\
+#!/bin/zsh
+typeset -A style_map
+zstyle -a ':prezto:load' pmodule-dirs style_map
+print -r -- ${style_map[key]}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_zstyle_scalar_and_boolean_queries_define_named_targets() {
+        let source = "\
+#!/bin/zsh
+zstyle -s ':prezto:load' prompt prompt_theme
+zstyle -b ':prezto:load' verbose verbose_enabled
+print -r -- $prompt_theme $verbose_enabled $still_missing
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$still_missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_zstyle_listing_mode_does_not_define_named_target() {
+        let source = "\
+#!/bin/zsh
+zstyle -L -a ':prezto:load' pmodule-dirs user_pmodule_dirs
+print -r -- $user_pmodule_dirs
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$user_pmodule_dirs"]
+        );
+    }
+
+    #[test]
+    fn zsh_zstyle_other_modes_do_not_define_named_targets() {
+        for option in ["-g", "-d", "-m", "-t"] {
+            let source = format!(
+                "#!/bin/zsh\nzstyle {option} -a ':prezto:load' pmodule-dirs user_pmodule_dirs\nprint -r -- $user_pmodule_dirs\n"
+            );
+            let diagnostics = test_snippet(
+                &source,
+                &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+            );
+
+            assert_eq!(
+                diagnostics
+                    .iter()
+                    .map(|diagnostic| diagnostic.span.slice(&source))
+                    .collect::<Vec<_>>(),
+                vec!["$user_pmodule_dirs"],
+                "unexpected diagnostics for {option}"
+            );
+        }
+    }
+
+    #[test]
     fn subscript_suppression_hides_later_same_name_uses() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -645,7 +645,7 @@ unused=(other:'unused')
 #!/bin/zsh
 cmds=(git:'run git')
 other_cmds=(hg:'run hg')
-_describe -O expl 'external command' cmds
+_describe -O 'external command' cmds
 _describe -- 'other command' other_cmds
 unused=(other:'unused')
 ";

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -718,7 +718,8 @@ _describe \"$opts\" desc values
 #!/bin/zsh
 values=(git)
 more_values=(hg)
-_describe 'external command' values -- more_values
+more_descriptions=(hg:'run hg')
+_describe 'external command' values -- more_values more_descriptions
 unused=(other:'unused')
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -695,6 +695,24 @@ unused=(other:'unused')
     }
 
     #[test]
+    fn zsh_describe_does_not_consume_descriptor_after_dynamic_options() {
+        let source = "\
+#!/bin/zsh
+opts='-o'
+desc=(not:target)
+values=(git)
+_describe \"$opts\" desc values
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "desc");
+    }
+
+    #[test]
     fn zsh_describe_consumes_array_operand_after_group_separator() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -682,7 +682,8 @@ unused=(other:'unused')
 #!/bin/zsh
 desc='external command'
 values=(git)
-_describe \"$desc\" values
+descriptions=(git:'run git')
+_describe \"$desc\" values descriptions
 unused=(other:'unused')
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -695,6 +695,24 @@ unused=(other:'unused')
     }
 
     #[test]
+    fn zsh_describe_consumes_array_operand_after_group_separator() {
+        let source = "\
+#!/bin/zsh
+values=(git)
+more_values=(hg)
+_describe 'external command' values -- more_values
+unused=(other:'unused')
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "unused");
+    }
+
+    #[test]
     fn zsh_zstyle_named_target_counts_as_assignment() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -659,6 +659,24 @@ unused=(other:'unused')
     }
 
     #[test]
+    fn zsh_describe_consumes_optional_second_array_operand() {
+        let source = "\
+#!/bin/zsh
+values=(git)
+descriptions=(git:'run git')
+_describe 'external command' values descriptions
+unused=(other:'unused')
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "unused");
+    }
+
+    #[test]
     fn zsh_zstyle_named_target_counts_as_assignment() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -677,6 +677,24 @@ unused=(other:'unused')
     }
 
     #[test]
+    fn zsh_describe_consumes_array_operand_after_dynamic_description() {
+        let source = "\
+#!/bin/zsh
+desc='external command'
+values=(git)
+_describe \"$desc\" values
+unused=(other:'unused')
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "unused");
+    }
+
+    #[test]
     fn zsh_zstyle_named_target_counts_as_assignment() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -623,6 +623,57 @@ read -d '' -ra COMPREPLY < <(compgen -W \"one two\" -- \"$cur\")
     }
 
     #[test]
+    fn zsh_describe_named_array_operand_counts_as_use() {
+        let source = "\
+#!/bin/zsh
+cmds=(git:'run git')
+_describe -t commands 'external command' cmds
+unused=(other:'unused')
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "unused");
+    }
+
+    #[test]
+    fn zsh_describe_consumes_names_after_options_and_separator() {
+        let source = "\
+#!/bin/zsh
+cmds=(git:'run git')
+other_cmds=(hg:'run hg')
+_describe -O expl 'external command' cmds
+_describe -- 'other command' other_cmds
+unused=(other:'unused')
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "unused");
+    }
+
+    #[test]
+    fn zsh_zstyle_named_target_counts_as_assignment() {
+        let source = "\
+#!/bin/zsh
+zstyle -a ':prezto:load' pmodule-dirs user_pmodule_dirs
+print -r -- $user_pmodule_dirs
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn unreachable_assignments_are_still_checked() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -139,6 +139,8 @@ pub enum BuiltinBindingTargetKind {
     Getopts,
     /// `zparseopts`
     Zparseopts,
+    /// `zstyle -a`, `zstyle -s`, or `zstyle -b`
+    Zstyle,
 }
 
 /// High-level category for a semantic binding.

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -502,7 +502,7 @@ fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {
     let mut index = 0usize;
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
-            return Vec::new();
+            break;
         };
         if text == "--" {
             index += 1;

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -479,6 +479,7 @@ fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAtt
         };
         match text.as_ref() {
             "--" => return None,
+            "-L" => return None,
             "-a" | "-s" | "-b" => {
                 let attributes = if text == "-a" {
                     BindingAttributes::ARRAY

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -547,7 +547,7 @@ fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {
                     2 => (segment_start + 1, 1),
                     _ => (segment_start + 2, 2),
                 }
-            } else if first_group || segment_len > 1 {
+            } else if first_group {
                 (segment_start + 1, 2)
             } else {
                 (segment_start, 2)

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -473,29 +473,23 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
 fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAttributes)> {
     let index = 0usize;
-    while let Some(word) = args.get(index) {
-        let Some(text) = static_word_text(word, source) else {
-            return None;
-        };
-        match text.as_ref() {
-            "--" => return None,
-            "-a" | "-s" | "-b" => {
-                let attributes = if text == "-a" {
-                    BindingAttributes::ARRAY
-                } else {
-                    BindingAttributes::empty()
-                };
-                return args
-                    .get(index + 3)
-                    .and_then(|word| named_target_word(word, source))
-                    .map(|(name, span)| (name, span, attributes));
-            }
-            _ if text.starts_with('-') && text != "-" => return None,
-            _ => return None,
+    let word = args.get(index)?;
+    let text = static_word_text(word, source)?;
+    match text.as_ref() {
+        "--" => None,
+        "-a" | "-s" | "-b" => {
+            let attributes = if text == "-a" {
+                BindingAttributes::ARRAY
+            } else {
+                BindingAttributes::empty()
+            };
+            args.get(index + 3)
+                .and_then(|word| named_target_word(word, source))
+                .map(|(name, span)| (name, span, attributes))
         }
+        _ if text.starts_with('-') && text != "-" => None,
+        _ => None,
     }
-
-    None
 }
 
 fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -494,8 +494,10 @@ fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAtt
 
 fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {
     let mut index = 0usize;
+    let mut first_segment_starts_with_dynamic_option = false;
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
+            first_segment_starts_with_dynamic_option = true;
             break;
         };
         if text == "--" {
@@ -538,12 +540,19 @@ fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {
         }
 
         let segment_len = segment_end.saturating_sub(segment_start);
-        let target_start = if first_group || segment_len > 1 {
-            segment_start + 1
-        } else {
-            segment_start
-        };
-        for target_index in target_start..(target_start + 2).min(segment_end) {
+        let (target_start, target_count) =
+            if first_group && first_segment_starts_with_dynamic_option {
+                match segment_len {
+                    0 | 1 => (segment_end, 0),
+                    2 => (segment_start + 1, 1),
+                    _ => (segment_start + 2, 2),
+                }
+            } else if first_group || segment_len > 1 {
+                (segment_start + 1, 2)
+            } else {
+                (segment_start, 2)
+            };
+        for target_index in target_start..(target_start + target_count).min(segment_end) {
             if let Some(target) = args
                 .get(target_index)
                 .and_then(|word| named_target_word(word, source))

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -151,7 +151,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 }
             }
             "_describe" if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh => {
-                for (argument, span) in describe_array_names(args, self.source) {
+                for (argument, span) in describe_array_names(args, self.source, |word| {
+                    self.describe_dynamic_start(word)
+                }) {
                     self.add_reference_if_bound(&argument, ReferenceKind::ImplicitRead, span);
                 }
             }
@@ -469,6 +471,28 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 .push(argument.span.start.offset);
         }
     }
+
+    fn describe_dynamic_start(&self, word: &Word) -> DescribeDynamicStart {
+        let Some(name) = standalone_parameter_name(word) else {
+            return DescribeDynamicStart::Unknown;
+        };
+        let Some(binding_id) =
+            self.resolve_reference(&name, self.current_scope(), word.span.start.offset)
+        else {
+            return DescribeDynamicStart::Unknown;
+        };
+        let binding = &self.bindings[binding_id.index()];
+        let Some(value) = static_scalar_assignment_value(binding, self.source) else {
+            return DescribeDynamicStart::Unknown;
+        };
+
+        match value.as_str() {
+            "-t" => DescribeDynamicStart::OptionWithValue,
+            "-o" | "-O" => DescribeDynamicStart::OptionWithoutValue,
+            _ if value.starts_with('-') && value != "-" => DescribeDynamicStart::Unknown,
+            _ => DescribeDynamicStart::Descriptor,
+        }
+    }
 }
 
 fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAttributes)> {
@@ -492,12 +516,24 @@ fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAtt
     }
 }
 
-fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DescribeDynamicStart {
+    Descriptor,
+    OptionWithoutValue,
+    OptionWithValue,
+    Unknown,
+}
+
+fn describe_array_names(
+    args: &[&Word],
+    source: &str,
+    dynamic_start: impl Fn(&Word) -> DescribeDynamicStart,
+) -> Vec<(Name, Span)> {
     let mut index = 0usize;
-    let mut first_segment_starts_with_dynamic_option = false;
+    let mut first_segment_dynamic_start = None;
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
-            first_segment_starts_with_dynamic_option = true;
+            first_segment_dynamic_start = Some(dynamic_start(word));
             break;
         };
         if text == "--" {
@@ -541,11 +577,22 @@ fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {
 
         let segment_len = segment_end.saturating_sub(segment_start);
         let (target_start, target_count) =
-            if first_group && first_segment_starts_with_dynamic_option {
-                match segment_len {
-                    0 | 1 => (segment_end, 0),
-                    2 => (segment_start + 1, 1),
-                    _ => (segment_start + 2, 2),
+            if first_group && let Some(dynamic_start) = first_segment_dynamic_start {
+                match dynamic_start {
+                    DescribeDynamicStart::Descriptor => (segment_start + 1, 2),
+                    DescribeDynamicStart::OptionWithoutValue => match segment_len {
+                        0..=2 => (segment_end, 0),
+                        _ => (segment_start + 2, 2),
+                    },
+                    DescribeDynamicStart::OptionWithValue => match segment_len {
+                        0..=3 => (segment_end, 0),
+                        _ => (segment_start + 3, 2),
+                    },
+                    DescribeDynamicStart::Unknown => match segment_len {
+                        0 | 1 => (segment_end, 0),
+                        2 => (segment_start + 1, 1),
+                        _ => (segment_start + 2, 2),
+                    },
                 }
             } else if first_group {
                 (segment_start + 1, 2)
@@ -564,4 +611,68 @@ fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {
         first_group = false;
     }
     targets
+}
+
+fn standalone_parameter_name(word: &Word) -> Option<Name> {
+    standalone_parameter_name_from_parts(&word.parts)
+}
+
+fn standalone_parameter_name_from_parts(parts: &[WordPartNode]) -> Option<Name> {
+    let [part] = parts else {
+        return None;
+    };
+
+    match &part.kind {
+        WordPart::Variable(name) => Some(name.clone()),
+        WordPart::Parameter(parameter) => match parameter.bourne() {
+            Some(BourneParameterExpansion::Access { reference })
+                if reference.subscript.is_none() =>
+            {
+                Some(reference.name.clone())
+            }
+            _ => None,
+        },
+        WordPart::DoubleQuoted { parts, .. } => standalone_parameter_name_from_parts(parts),
+        _ => None,
+    }
+}
+
+fn static_scalar_assignment_value(binding: &Binding, source: &str) -> Option<String> {
+    if !matches!(
+        binding.origin,
+        BindingOrigin::Assignment {
+            value: AssignmentValueOrigin::StaticLiteral,
+            ..
+        }
+    ) {
+        return None;
+    }
+
+    let rest = source.get(binding.span.end.offset..)?;
+    let rest = rest.strip_prefix('=')?;
+    parse_static_assignment_literal(rest)
+}
+
+fn parse_static_assignment_literal(rest: &str) -> Option<String> {
+    let rest = rest.trim_start();
+    if let Some(rest) = rest.strip_prefix('\'') {
+        return rest.split_once('\'').map(|(value, _)| value.to_owned());
+    }
+    if let Some(rest) = rest.strip_prefix('"') {
+        let (value, _) = rest.split_once('"')?;
+        if value.contains(['$', '`', '\\']) {
+            return None;
+        }
+        return Some(value.to_owned());
+    }
+
+    let value = rest
+        .split(|ch: char| ch.is_whitespace() || ch == ';' || ch == '#')
+        .next()
+        .unwrap_or_default();
+    if value.is_empty() || value.starts_with('(') {
+        None
+    } else {
+        Some(value.to_owned())
+    }
 }

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -512,13 +512,47 @@ fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {
     }
 
     let mut targets = Vec::new();
-    for offset in [1, 2] {
-        if let Some(target) = args
-            .get(index + offset)
-            .and_then(|word| named_target_word(word, source))
+    let mut first_group = true;
+    while index < args.len() {
+        if args
+            .get(index)
+            .and_then(|word| static_word_text(word, source))
+            .as_deref()
+            == Some("--")
         {
-            targets.push(target);
+            index += 1;
+            first_group = false;
+            continue;
         }
+
+        let segment_start = index;
+        let mut segment_end = index;
+        while segment_end < args.len()
+            && args
+                .get(segment_end)
+                .and_then(|word| static_word_text(word, source))
+                .as_deref()
+                != Some("--")
+        {
+            segment_end += 1;
+        }
+
+        let segment_len = segment_end.saturating_sub(segment_start);
+        let target_start = if first_group || segment_len > 1 {
+            segment_start + 1
+        } else {
+            segment_start
+        };
+        for target_index in target_start..(target_start + 2).min(segment_end) {
+            if let Some(target) = args
+                .get(target_index)
+                .and_then(|word| named_target_word(word, source))
+            {
+                targets.push(target);
+            }
+        }
+        index = segment_end;
+        first_group = false;
     }
     targets
 }

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -119,6 +119,42 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     );
                 }
             }
+            "zstyle" if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh => {
+                if let Some((argument, span, mut attributes)) = zstyle_target(args, self.source) {
+                    if attributes.contains(BindingAttributes::ARRAY)
+                        && self
+                            .resolve_reference(&argument, self.current_scope(), span.start.offset)
+                            .map(|binding_id| {
+                                let binding = &self.bindings[binding_id.index()];
+                                binding.attributes.contains(BindingAttributes::ASSOC)
+                                    && !self.binding_was_cleared_before_lookup(
+                                        binding,
+                                        self.current_scope(),
+                                        span.start.offset,
+                                    )
+                            })
+                            .unwrap_or(false)
+                    {
+                        attributes |= BindingAttributes::ASSOC;
+                    }
+                    self.add_binding(
+                        &argument,
+                        BindingKind::ReadTarget,
+                        self.current_scope(),
+                        span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: span,
+                            kind: BuiltinBindingTargetKind::Zstyle,
+                        },
+                        attributes,
+                    );
+                }
+            }
+            "_describe" if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh => {
+                for (argument, span) in describe_array_names(args, self.source) {
+                    self.add_reference_if_bound(&argument, ReferenceKind::ImplicitRead, span);
+                }
+            }
             "let" => self.record_let_arithmetic_assignment_targets(args),
             "eval" => self.record_eval_argument_references(args),
             "trap" => self.record_trap_action_references(args),
@@ -433,4 +469,62 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 .push(argument.span.start.offset);
         }
     }
+}
+
+fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAttributes)> {
+    let index = 0usize;
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            return None;
+        };
+        match text.as_ref() {
+            "--" => return None,
+            "-a" | "-s" | "-b" => {
+                let attributes = if text == "-a" {
+                    BindingAttributes::ARRAY
+                } else {
+                    BindingAttributes::empty()
+                };
+                return args
+                    .get(index + 3)
+                    .and_then(|word| named_target_word(word, source))
+                    .map(|(name, span)| (name, span, attributes));
+            }
+            _ if text.starts_with('-') && text != "-" => return None,
+            _ => return None,
+        }
+    }
+
+    None
+}
+
+fn describe_array_names(args: &[&Word], source: &str) -> Vec<(Name, Span)> {
+    let mut index = 0usize;
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            return Vec::new();
+        };
+        if text == "--" {
+            index += 1;
+            break;
+        }
+        if !text.starts_with('-') || text == "-" {
+            break;
+        }
+        index += 1;
+        if text == "-t" {
+            index += 1;
+        }
+    }
+
+    let mut targets = Vec::new();
+    for offset in [1, 2] {
+        if let Some(target) = args
+            .get(index + offset)
+            .and_then(|word| named_target_word(word, source))
+        {
+            targets.push(target);
+        }
+    }
+    targets
 }

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -479,7 +479,6 @@ fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAtt
         };
         match text.as_ref() {
             "--" => return None,
-            "-L" => return None,
             "-a" | "-s" | "-b" => {
                 let attributes = if text == "-a" {
                     BindingAttributes::ARRAY

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1194,7 +1194,7 @@ fn zsh_describe_consumes_named_array_operand_after_options_and_separator() {
 #!/bin/zsh
 cmds=(git:'run git')
 other_cmds=(hg:'run hg')
-_describe -O expl 'external command' cmds
+_describe -O 'external command' cmds
 _describe -- 'other command' other_cmds
 ";
     let model = model_with_dialect(source, ShellDialect::Zsh);

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1178,6 +1178,24 @@ fn zsh_zstyle_listing_mode_does_not_create_named_target() {
 }
 
 #[test]
+fn zsh_zstyle_other_modes_do_not_create_named_targets() {
+    for option in ["-g", "-d", "-m", "-t"] {
+        let source = format!(
+            "#!/bin/zsh\nzstyle {option} -a ':prezto:load' pmodule-dirs user_pmodule_dirs\nprint $user_pmodule_dirs\n"
+        );
+        let model = model_with_dialect(&source, ShellDialect::Zsh);
+
+        assert!(
+            model
+                .bindings_for(&Name::from("user_pmodule_dirs"))
+                .is_empty(),
+            "unexpected target binding for {option}"
+        );
+        assert_eq!(unresolved_names(&model), vec!["user_pmodule_dirs"]);
+    }
+}
+
+#[test]
 fn zsh_zstyle_array_query_preserves_existing_associative_target() {
     let source = "\
 #!/bin/zsh
@@ -1207,6 +1225,26 @@ fn zsh_describe_consumes_named_array_operand() {
         model.reference(binding.references[0]).span.slice(source),
         "cmds"
     );
+}
+
+#[test]
+fn zsh_describe_consumes_optional_second_array_operand() {
+    let source = "\
+#!/bin/zsh
+values=(git)
+descriptions=(git:'run git')
+_describe 'external command' values descriptions
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    for name in ["values", "descriptions"] {
+        let binding = binding_for_name(&model, name);
+        assert_eq!(binding.references.len(), 1);
+        assert_eq!(
+            model.reference(binding.references[0]).span.slice(source),
+            name
+        );
+    }
 }
 
 #[test]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1121,6 +1121,95 @@ fn command_wrapped_printf_v_creates_target_binding() {
 }
 
 #[test]
+fn zsh_zstyle_query_creates_named_target_binding() {
+    let source = "#!/bin/zsh\nzstyle -a ':prezto:load' pmodule-dirs user_pmodule_dirs\nprint $user_pmodule_dirs\n";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let binding = binding_for_name(&model, "user_pmodule_dirs");
+
+    assert_eq!(binding.span.slice(source), "user_pmodule_dirs");
+    assert!(matches!(binding.kind, BindingKind::ReadTarget));
+    assert!(matches!(
+        binding.origin,
+        BindingOrigin::BuiltinTarget {
+            kind: BuiltinBindingTargetKind::Zstyle,
+            ..
+        }
+    ));
+    assert!(binding.attributes.contains(BindingAttributes::ARRAY));
+    assert_eq!(binding.references.len(), 1);
+}
+
+#[test]
+fn zsh_zstyle_scalar_and_boolean_queries_create_named_targets() {
+    let source = "\
+#!/bin/zsh
+zstyle -s ':prezto:load' prompt prompt_theme
+zstyle -b ':prezto:load' verbose verbose_enabled
+print $prompt_theme $verbose_enabled
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    for name in ["prompt_theme", "verbose_enabled"] {
+        let binding = binding_for_name(&model, name);
+        assert!(matches!(binding.kind, BindingKind::ReadTarget));
+        assert!(matches!(
+            binding.origin,
+            BindingOrigin::BuiltinTarget {
+                kind: BuiltinBindingTargetKind::Zstyle,
+                ..
+            }
+        ));
+        assert!(!binding.attributes.contains(BindingAttributes::ARRAY));
+        assert_eq!(binding.references.len(), 1);
+    }
+}
+
+#[test]
+fn zsh_zstyle_target_parser_skips_leading_options() {
+    let source = "#!/bin/zsh\nzstyle -L -a ':prezto:load' pmodule-dirs user_pmodule_dirs\nprint $user_pmodule_dirs\n";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let binding = binding_for_name(&model, "user_pmodule_dirs");
+
+    assert!(binding.attributes.contains(BindingAttributes::ARRAY));
+    assert_eq!(binding.references.len(), 1);
+}
+
+#[test]
+fn zsh_describe_consumes_named_array_operand() {
+    let source =
+        "#!/bin/zsh\ncmds=(git:'run git')\n_describe -t commands 'external command' cmds\n";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let binding = binding_for_name(&model, "cmds");
+
+    assert_eq!(binding.references.len(), 1);
+    assert_eq!(
+        model.reference(binding.references[0]).span.slice(source),
+        "cmds"
+    );
+}
+
+#[test]
+fn zsh_describe_consumes_named_array_operand_after_options_and_separator() {
+    let source = "\
+#!/bin/zsh
+cmds=(git:'run git')
+other_cmds=(hg:'run hg')
+_describe -O expl 'external command' cmds
+_describe -- 'other command' other_cmds
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    for name in ["cmds", "other_cmds"] {
+        let binding = binding_for_name(&model, name);
+        assert_eq!(binding.references.len(), 1);
+        assert_eq!(
+            model.reference(binding.references[0]).span.slice(source),
+            name
+        );
+    }
+}
+
+#[test]
 fn shflags_define_commands_create_flag_bindings() {
     let source = "DEFINE_boolean show_commands false 'show commands' s\n";
     let model = model(source);

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1266,6 +1266,26 @@ _describe \"$desc\" values
 }
 
 #[test]
+fn zsh_describe_consumes_array_operands_after_group_separator() {
+    let source = "\
+#!/bin/zsh
+values=(git)
+more_values=(hg)
+_describe 'external command' values -- more_values
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    for name in ["values", "more_values"] {
+        let binding = binding_for_name(&model, name);
+        assert_eq!(binding.references.len(), 1);
+        assert_eq!(
+            model.reference(binding.references[0]).span.slice(source),
+            name
+        );
+    }
+}
+
+#[test]
 fn zsh_describe_consumes_named_array_operand_after_options_and_separator() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1178,6 +1178,24 @@ fn zsh_zstyle_listing_mode_does_not_create_named_target() {
 }
 
 #[test]
+fn zsh_zstyle_array_query_preserves_existing_associative_target() {
+    let source = "\
+#!/bin/zsh
+typeset -A style_map
+zstyle -a ':prezto:load' pmodule-dirs style_map
+print -r -- ${style_map[key]}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let bindings = model.bindings_for(&Name::from("style_map"));
+    assert_eq!(bindings.len(), 2);
+    let binding = model.binding(*bindings.last().expect("zstyle target binding"));
+
+    assert!(binding.attributes.contains(BindingAttributes::ARRAY));
+    assert!(binding.attributes.contains(BindingAttributes::ASSOC));
+    assert_names_absent(&["key"], &unresolved_names(&model));
+}
+
+#[test]
 fn zsh_describe_consumes_named_array_operand() {
     let source =
         "#!/bin/zsh\ncmds=(git:'run git')\n_describe -t commands 'external command' cmds\n";

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1266,6 +1266,27 @@ _describe \"$desc\" values
 }
 
 #[test]
+fn zsh_describe_skips_descriptor_after_dynamic_options() {
+    let source = "\
+#!/bin/zsh
+opts='-o'
+desc=(not:target)
+values=(git)
+_describe \"$opts\" desc values
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    assert_eq!(binding_for_name(&model, "desc").references.len(), 0);
+
+    let binding = binding_for_name(&model, "values");
+    assert_eq!(binding.references.len(), 1);
+    assert_eq!(
+        model.reference(binding.references[0]).span.slice(source),
+        "values"
+    );
+}
+
+#[test]
 fn zsh_describe_consumes_array_operands_after_group_separator() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1248,6 +1248,24 @@ _describe 'external command' values descriptions
 }
 
 #[test]
+fn zsh_describe_consumes_array_operands_after_dynamic_description() {
+    let source = "\
+#!/bin/zsh
+desc='external command'
+values=(git)
+_describe \"$desc\" values
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let binding = binding_for_name(&model, "values");
+
+    assert_eq!(binding.references.len(), 1);
+    assert_eq!(
+        model.reference(binding.references[0]).span.slice(source),
+        "values"
+    );
+}
+
+#[test]
 fn zsh_describe_consumes_named_array_operand_after_options_and_separator() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1165,13 +1165,16 @@ print $prompt_theme $verbose_enabled
 }
 
 #[test]
-fn zsh_zstyle_target_parser_skips_leading_options() {
+fn zsh_zstyle_listing_mode_does_not_create_named_target() {
     let source = "#!/bin/zsh\nzstyle -L -a ':prezto:load' pmodule-dirs user_pmodule_dirs\nprint $user_pmodule_dirs\n";
     let model = model_with_dialect(source, ShellDialect::Zsh);
-    let binding = binding_for_name(&model, "user_pmodule_dirs");
 
-    assert!(binding.attributes.contains(BindingAttributes::ARRAY));
-    assert_eq!(binding.references.len(), 1);
+    assert!(
+        model
+            .bindings_for(&Name::from("user_pmodule_dirs"))
+            .is_empty()
+    );
+    assert_eq!(unresolved_names(&model), vec!["user_pmodule_dirs"]);
 }
 
 #[test]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1292,11 +1292,12 @@ fn zsh_describe_consumes_array_operands_after_group_separator() {
 #!/bin/zsh
 values=(git)
 more_values=(hg)
-_describe 'external command' values -- more_values
+more_descriptions=(hg:'run hg')
+_describe 'external command' values -- more_values more_descriptions
 ";
     let model = model_with_dialect(source, ShellDialect::Zsh);
 
-    for name in ["values", "more_values"] {
+    for name in ["values", "more_values", "more_descriptions"] {
         let binding = binding_for_name(&model, name);
         assert_eq!(binding.references.len(), 1);
         assert_eq!(

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1253,16 +1253,19 @@ fn zsh_describe_consumes_array_operands_after_dynamic_description() {
 #!/bin/zsh
 desc='external command'
 values=(git)
-_describe \"$desc\" values
+descriptions=(git:'run git')
+_describe \"$desc\" values descriptions
 ";
     let model = model_with_dialect(source, ShellDialect::Zsh);
-    let binding = binding_for_name(&model, "values");
 
-    assert_eq!(binding.references.len(), 1);
-    assert_eq!(
-        model.reference(binding.references[0]).span.slice(source),
-        "values"
-    );
+    for name in ["values", "descriptions"] {
+        let binding = binding_for_name(&model, name);
+        assert_eq!(binding.references.len(), 1);
+        assert_eq!(
+            model.reference(binding.references[0]).span.slice(source),
+            name
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Model zsh `zstyle -a/-s/-b` by-name result operands as semantic bindings.
- Treat `_describe` named array operands as implicit reads when the array is already bound.
- Add semantic and C001/C006 regression coverage for array, scalar, boolean, option-skipping, and `--` separator forms.

## Why

Bug #8 in the zsh tracker came from by-name zsh helpers being treated as plain string arguments. That made `zstyle -a ... user_pmodule_dirs` look like an undefined later read, and `_describe ... cmds` look like an unused assignment.

## Validation

- `cargo test -p shuck-semantic zsh_`
- `cargo test -p shuck-linter zsh_`
- `make test`