### PR TITLE
fix(semantic): model zparseopts targets

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -503,6 +503,7 @@ fn binding_establishes_array_history(
         | BindingKind::LoopVariable
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment
         | BindingKind::Nameref => binding_is_array_like(binding),
     }
@@ -534,6 +535,7 @@ fn binding_resets_array_history(binding: &Binding, builtin_history: &BuiltinArra
         | BindingKind::Declaration(_)
         | BindingKind::FunctionDefinition
         | BindingKind::Nameref
+        | BindingKind::ZparseoptsTarget
         | BindingKind::Imported => false,
     }
 }
@@ -559,6 +561,7 @@ fn declaration_resets_array_history(binding: &Binding) -> bool {
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment
         | BindingKind::Nameref
         | BindingKind::Imported

--- a/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
@@ -111,6 +111,7 @@ fn binding_contributes_known_variable_name(binding: &Binding) -> bool {
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment
         | BindingKind::Nameref => true,
     }

--- a/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
+++ b/crates/shuck-linter/src/rules/correctness/shell_quoting_reuse.rs
@@ -149,6 +149,7 @@ fn binding_assignment_context(kind: BindingKind) -> Option<WordFactContext> {
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment
         | BindingKind::Nameref
         | BindingKind::Imported => None,
@@ -386,6 +387,7 @@ fn is_test_v_variable_binding(binding: &Binding) -> bool {
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment
         | BindingKind::Nameref => true,
     }

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -424,6 +424,48 @@ printf '%s\\n' \"$target\"
     }
 
     #[test]
+    fn zparseopts_stacked_looking_specs_initialize_targets() {
+        let source = "\
+#!/bin/zsh
+zparseopts -- -DEK=dest
+printf '%s\\n' \"$dest\" \"$missing\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
+    fn zparseopts_mapping_does_not_initialize_spec_alias_names() {
+        let source = "\
+#!/bin/zsh
+zparseopts -A bar -M a=foo b+: c:=b
+printf '%s\\n' \"$bar\" \"$foo\" \"$b\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$b"]
+        );
+    }
+
+    #[test]
     fn subscript_suppression_hides_later_same_name_uses() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -445,6 +445,27 @@ printf '%s\\n' \"$dest\" \"$missing\"
     }
 
     #[test]
+    fn zparseopts_escaped_equals_in_spec_names_do_not_initialize_suffixes() {
+        let source = "\
+#!/bin/zsh
+zparseopts -a opts -- foo\\=bar foo\\=baz=dest
+printf '%s\\n' \"$opts\" \"$dest\" \"$bar\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$bar"]
+        );
+    }
+
+    #[test]
     fn zparseopts_mapping_does_not_initialize_spec_alias_names() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -337,6 +337,93 @@ print -r -- ${functions[iterm2_precmd]}
     }
 
     #[test]
+    fn zparseopts_targets_initialize_option_arrays() {
+        let source = "\
+#!/bin/zsh
+zparseopts -D -E -F -a all -A optmap -- \\
+  h=help -help=help \\
+  v+:=verbose -verbose+:=verbose \\
+  o:=output -output:=output
+printf '%s\\n' \"$all\" \"$optmap\" \"$help\" \"$verbose\" \"$output\" \"$missing\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
+    fn zparseopts_attached_array_targets_are_arrays() {
+        let source = "\
+#!/bin/zsh
+zparseopts -aall -Aassoc -- x:=xout y=yout
+printf '%s\\n' \"${all[1]}\" \"${assoc[-x]}\" \"${xout[1]}\" \"${yout[1]}\" \"$missing\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
+    fn zparseopts_dynamic_targets_still_report_dynamic_names() {
+        let source = "\
+#!/bin/zsh
+zparseopts -a$aggregate -- x=$target_name
+printf '%s\\n' \"$aggregate\" \"$target_name\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$aggregate", "$target_name"]
+        );
+    }
+
+    #[test]
+    fn zparseopts_targets_do_not_initialize_names_in_bash() {
+        let source = "\
+#!/bin/bash
+zparseopts -- x=target
+printf '%s\\n' \"$target\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Bash),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$target"]
+        );
+    }
+
+    #[test]
     fn subscript_suppression_hides_later_same_name_uses() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -249,6 +249,7 @@ fn is_reportable_unused_assignment(kind: BindingKind, _attributes: BindingAttrib
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment => true,
         BindingKind::AppendAssignment | BindingKind::ParameterDefaultAssignment => false,
         BindingKind::Declaration(_) => true,

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -137,6 +137,8 @@ pub enum BuiltinBindingTargetKind {
     Printf,
     /// `getopts`
     Getopts,
+    /// `zparseopts`
+    Zparseopts,
 }
 
 /// High-level category for a semantic binding.
@@ -164,6 +166,8 @@ pub enum BindingKind {
     PrintfTarget,
     /// A target created by `getopts`.
     GetoptsTarget,
+    /// A target created by `zparseopts`.
+    ZparseoptsTarget,
     /// An arithmetic assignment binding.
     ArithmeticAssignment,
     /// A nameref binding.
@@ -178,7 +182,9 @@ pub(crate) fn is_array_like_binding(binding: &Binding) -> bool {
         .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
         || matches!(
             binding.kind,
-            BindingKind::ArrayAssignment | BindingKind::MapfileTarget
+            BindingKind::ArrayAssignment
+                | BindingKind::MapfileTarget
+                | BindingKind::ZparseoptsTarget
         )
 }
 

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -801,6 +801,7 @@ fn getopts_target(args: &[&Word], source: &str) -> Option<(Name, Span)> {
 fn zparseopts_targets(args: &[&Word], source: &str) -> Vec<(Name, Span, BindingAttributes)> {
     let mut targets = Vec::new();
     let mut index = 0;
+    let mut mapping_enabled = false;
 
     while let Some(word) = args.get(index) {
         let Some(text) = static_word_text(word, source) else {
@@ -810,69 +811,69 @@ fn zparseopts_targets(args: &[&Word], source: &str) -> Vec<(Name, Span, BindingA
             index += 1;
             break;
         }
-        let Some(flags) = text.strip_prefix('-') else {
-            break;
-        };
-        if flags.is_empty() {
-            break;
+        match text.as_ref() {
+            "-D" | "-E" | "-F" | "-K" => {
+                index += 1;
+                continue;
+            }
+            "-M" => {
+                mapping_enabled = true;
+                index += 1;
+                continue;
+            }
+            "-a" | "-A" => {
+                let attributes = zparseopts_aggregate_target_attributes(&text);
+                if let Some((name, span)) = args
+                    .get(index + 1)
+                    .and_then(|word| named_target_word(word, source))
+                {
+                    targets.push((name, span, attributes));
+                    index += 2;
+                    continue;
+                }
+                index += 1;
+                continue;
+            }
+            _ => {}
         }
 
-        let mut consumed_option = false;
-        let mut stop_after_target = false;
-        for (offset, flag) in flags.char_indices() {
-            match flag {
-                'D' | 'E' | 'F' | 'K' | 'M' => {
-                    consumed_option = true;
-                }
-                'a' | 'A' => {
-                    consumed_option = true;
-                    let attached_offset = offset + flag.len_utf8();
-                    let attributes = if flag == 'A' {
-                        BindingAttributes::ARRAY | BindingAttributes::ASSOC
-                    } else {
-                        BindingAttributes::ARRAY
-                    };
-                    if attached_offset < flags.len() {
-                        if let Some(target) = zparseopts_attached_array_target(
-                            word,
-                            source,
-                            &flags[attached_offset..],
-                            attributes,
-                        ) {
-                            targets.push(target);
-                        }
-                    } else if let Some((name, span)) = args
-                        .get(index + 1)
-                        .and_then(|word| named_target_word(word, source))
-                    {
-                        targets.push((name, span, attributes));
-                        index += 1;
-                    }
-                    stop_after_target = true;
-                    break;
-                }
-                _ => {
-                    consumed_option = false;
-                    break;
-                }
+        if (text.starts_with("-a") || text.starts_with("-A")) && !text.contains('=') {
+            let attributes = zparseopts_aggregate_target_attributes(&text);
+            if let Some(target_text) = text.get(2..)
+                && let Some(target) =
+                    zparseopts_attached_array_target(word, source, target_text, attributes)
+            {
+                targets.push(target);
+                index += 1;
+                continue;
             }
         }
-        if !consumed_option {
-            break;
-        }
-        index += 1;
-        if stop_after_target {
-            continue;
-        }
+
+        break;
     }
 
+    let spec_names = mapping_enabled.then(|| {
+        args[index..]
+            .iter()
+            .filter_map(|word| zparseopts_spec_name(word, source))
+            .collect::<FxHashSet<_>>()
+    });
+
     for word in &args[index..] {
-        if let Some(target) = zparseopts_spec_target(word, source) {
+        if let Some(target) = zparseopts_spec_target(word, source, spec_names.as_ref()) {
             targets.push(target);
         }
     }
 
     targets
+}
+
+fn zparseopts_aggregate_target_attributes(text: &str) -> BindingAttributes {
+    if text.starts_with("-A") {
+        BindingAttributes::ARRAY | BindingAttributes::ASSOC
+    } else {
+        BindingAttributes::ARRAY
+    }
 }
 
 fn zparseopts_attached_array_target(
@@ -894,11 +895,25 @@ fn zparseopts_attached_array_target(
     ))
 }
 
-fn zparseopts_spec_target(word: &Word, source: &str) -> Option<(Name, Span, BindingAttributes)> {
+fn zparseopts_spec_name(word: &Word, source: &str) -> Option<Box<str>> {
+    let text = static_word_text(word, source)?;
+    let spec = text.split_once('=').map_or(text.as_ref(), |(spec, _)| spec);
+    let spec = spec.trim_end_matches(':').trim_end_matches('+');
+    (!spec.is_empty()).then_some(spec.into())
+}
+
+fn zparseopts_spec_target(
+    word: &Word,
+    source: &str,
+    mapped_spec_names: Option<&FxHashSet<Box<str>>>,
+) -> Option<(Name, Span, BindingAttributes)> {
     let text = static_word_text(word, source)?;
     let target_start = text.find('=')? + 1;
     let target = &text[target_start..];
     if !is_name(target) {
+        return None;
+    }
+    if mapped_spec_names.is_some_and(|spec_names| spec_names.contains(target)) {
         return None;
     }
 

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -896,8 +896,8 @@ fn zparseopts_attached_array_target(
 }
 
 fn zparseopts_spec_name(word: &Word, source: &str) -> Option<Box<str>> {
-    let text = static_word_text(word, source)?;
-    let spec = text.split_once('=').map_or(text.as_ref(), |(spec, _)| spec);
+    let text = word.span.slice(source);
+    let spec = zparseopts_spec_separator_offset(text).map_or(text, |offset| &text[..offset]);
     let spec = spec.trim_end_matches(':').trim_end_matches('+');
     (!spec.is_empty()).then_some(spec.into())
 }
@@ -907,8 +907,8 @@ fn zparseopts_spec_target(
     source: &str,
     mapped_spec_names: Option<&FxHashSet<Box<str>>>,
 ) -> Option<(Name, Span, BindingAttributes)> {
-    let text = static_word_text(word, source)?;
-    let target_start = text.find('=')? + 1;
+    let text = word.span.slice(source);
+    let target_start = zparseopts_spec_separator_offset(text)? + 1;
     let target = &text[target_start..];
     if !is_name(target) {
         return None;
@@ -922,6 +922,22 @@ fn zparseopts_spec_target(
         word_text_offset_span(word.span, source, target_start, text.len()),
         BindingAttributes::ARRAY,
     ))
+}
+
+fn zparseopts_spec_separator_offset(text: &str) -> Option<usize> {
+    let mut escaped = false;
+    for (index, ch) in text.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' => escaped = true,
+            '=' => return Some(index),
+            _ => {}
+        }
+    }
+    None
 }
 
 fn variable_set_test_operand_name(

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -798,6 +798,117 @@ fn getopts_target(args: &[&Word], source: &str) -> Option<(Name, Span)> {
     args.get(1).and_then(|word| named_target_word(word, source))
 }
 
+fn zparseopts_targets(args: &[&Word], source: &str) -> Vec<(Name, Span, BindingAttributes)> {
+    let mut targets = Vec::new();
+    let mut index = 0;
+
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+        if text == "--" {
+            index += 1;
+            break;
+        }
+        let Some(flags) = text.strip_prefix('-') else {
+            break;
+        };
+        if flags.is_empty() {
+            break;
+        }
+
+        let mut consumed_option = false;
+        let mut stop_after_target = false;
+        for (offset, flag) in flags.char_indices() {
+            match flag {
+                'D' | 'E' | 'F' | 'K' | 'M' => {
+                    consumed_option = true;
+                }
+                'a' | 'A' => {
+                    consumed_option = true;
+                    let attached_offset = offset + flag.len_utf8();
+                    let attributes = if flag == 'A' {
+                        BindingAttributes::ARRAY | BindingAttributes::ASSOC
+                    } else {
+                        BindingAttributes::ARRAY
+                    };
+                    if attached_offset < flags.len() {
+                        if let Some(target) = zparseopts_attached_array_target(
+                            word,
+                            source,
+                            &flags[attached_offset..],
+                            attributes,
+                        ) {
+                            targets.push(target);
+                        }
+                    } else if let Some((name, span)) = args
+                        .get(index + 1)
+                        .and_then(|word| named_target_word(word, source))
+                    {
+                        targets.push((name, span, attributes));
+                        index += 1;
+                    }
+                    stop_after_target = true;
+                    break;
+                }
+                _ => {
+                    consumed_option = false;
+                    break;
+                }
+            }
+        }
+        if !consumed_option {
+            break;
+        }
+        index += 1;
+        if stop_after_target {
+            continue;
+        }
+    }
+
+    for word in &args[index..] {
+        if let Some(target) = zparseopts_spec_target(word, source) {
+            targets.push(target);
+        }
+    }
+
+    targets
+}
+
+fn zparseopts_attached_array_target(
+    word: &Word,
+    source: &str,
+    target_text: &str,
+    attributes: BindingAttributes,
+) -> Option<(Name, Span, BindingAttributes)> {
+    if !is_name(target_text) {
+        return None;
+    }
+
+    let text = static_word_text(word, source)?;
+    let start = text.len().saturating_sub(target_text.len());
+    Some((
+        Name::from(target_text),
+        word_text_offset_span(word.span, source, start, text.len()),
+        attributes,
+    ))
+}
+
+fn zparseopts_spec_target(word: &Word, source: &str) -> Option<(Name, Span, BindingAttributes)> {
+    let text = static_word_text(word, source)?;
+    let target_start = text.find('=')? + 1;
+    let target = &text[target_start..];
+    if !is_name(target) {
+        return None;
+    }
+
+    Some((
+        Name::from(target),
+        word_text_offset_span(word.span, source, target_start, text.len()),
+        BindingAttributes::ARRAY,
+    ))
+}
+
 fn variable_set_test_operand_name(
     expression: &ConditionalExpr,
     source: &str,

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -104,6 +104,21 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     );
                 }
             }
+            "zparseopts" if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh => {
+                for (argument, span, attributes) in zparseopts_targets(args, self.source) {
+                    self.add_binding(
+                        &argument,
+                        BindingKind::ZparseoptsTarget,
+                        self.current_scope(),
+                        span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: span,
+                            kind: BuiltinBindingTargetKind::Zparseopts,
+                        },
+                        attributes,
+                    );
+                }
+            }
             "let" => self.record_let_arithmetic_assignment_targets(args),
             "eval" => self.record_eval_argument_references(args),
             "trap" => self.record_trap_action_references(args),

--- a/crates/shuck-semantic/src/dataflow.rs
+++ b/crates/shuck-semantic/src/dataflow.rs
@@ -869,6 +869,7 @@ fn participates_in_unused_assignment_family(
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment
         | BindingKind::Declaration(_) => true,
         BindingKind::FunctionDefinition | BindingKind::Imported | BindingKind::Nameref => false,
@@ -887,6 +888,7 @@ fn can_survive_unused_assignment_branch_collapse(
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment => true,
         BindingKind::Declaration(_) => {
             attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
@@ -2634,6 +2636,7 @@ fn binding_initializes_name(binding: &Binding) -> Option<ContractCertainty> {
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment => Some(ContractCertainty::Definite),
     }
 }

--- a/crates/shuck-semantic/src/nonpersistent.rs
+++ b/crates/shuck-semantic/src/nonpersistent.rs
@@ -463,6 +463,7 @@ fn is_nonpersistent_assignment_candidate(kind: BindingKind, attributes: BindingA
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment => !attributes.contains(BindingAttributes::LOCAL),
         BindingKind::Declaration(_) => {
             attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)
@@ -487,6 +488,7 @@ fn is_nonpersistent_later_use_binding(kind: BindingKind, attributes: BindingAttr
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ParameterDefaultAssignment
         | BindingKind::FunctionDefinition
         | BindingKind::Imported
@@ -505,6 +507,7 @@ fn is_persistent_subshell_reset_binding(kind: BindingKind, attributes: BindingAt
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
         | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment => !attributes.contains(BindingAttributes::LOCAL),
         BindingKind::Declaration(_) => {
             attributes.contains(BindingAttributes::DECLARATION_INITIALIZED)

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -4700,6 +4700,46 @@ fn zparseopts_attached_and_separator_targets_are_precise() {
 }
 
 #[test]
+fn zparseopts_control_options_are_not_stacked() {
+    let source = "zparseopts -- -DEK=dest\n";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let binding = model
+        .bindings()
+        .iter()
+        .find(|binding| {
+            binding.name == "dest" && matches!(binding.kind, BindingKind::ZparseoptsTarget)
+        })
+        .expect("expected -DEK spec target");
+
+    assert_eq!(binding.span.slice(source), "dest");
+    assert!(binding.attributes.contains(BindingAttributes::ARRAY));
+}
+
+#[test]
+fn zparseopts_mapping_does_not_bind_targets_that_name_specs() {
+    let source = "zparseopts -A bar -M a=foo b+: c:=b\n";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let targets = model
+        .bindings()
+        .iter()
+        .filter(|binding| matches!(binding.kind, BindingKind::ZparseoptsTarget))
+        .map(|binding| {
+            (
+                binding.name.as_str().to_owned(),
+                binding.attributes.contains(BindingAttributes::ASSOC),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        targets,
+        vec![("bar".to_owned(), true), ("foo".to_owned(), false)]
+    );
+}
+
+#[test]
 fn zparseopts_dynamic_targets_do_not_create_static_bindings() {
     let source = "zparseopts -a$aggregate -- x=$target\n";
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -4717,6 +4717,21 @@ fn zparseopts_control_options_are_not_stacked() {
 }
 
 #[test]
+fn zparseopts_escaped_equals_in_spec_name_is_not_a_target_separator() {
+    let source = "zparseopts -a opts -- foo\\=bar foo\\=baz=dest\n";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let targets = model
+        .bindings()
+        .iter()
+        .filter(|binding| matches!(binding.kind, BindingKind::ZparseoptsTarget))
+        .map(|binding| binding.name.as_str().to_owned())
+        .collect::<Vec<_>>();
+
+    assert_eq!(targets, vec!["opts".to_owned(), "dest".to_owned()]);
+}
+
+#[test]
 fn zparseopts_mapping_does_not_bind_targets_that_name_specs() {
     let source = "zparseopts -A bar -M a=foo b+: c:=b\n";
     let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -4627,6 +4627,105 @@ mapfile
 }
 
 #[test]
+fn zparseopts_targets_record_array_bindings_in_zsh() {
+    let source = "\
+zparseopts -D -E -F -a all -A assoc -- \\
+  h=help -help=help \\
+  v+:=verbose -verbose+:=verbose
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let target = |name: &str| {
+        model
+            .bindings()
+            .iter()
+            .find(|binding| {
+                binding.name == name && matches!(binding.kind, BindingKind::ZparseoptsTarget)
+            })
+            .unwrap_or_else(|| panic!("missing zparseopts target {name}"))
+    };
+
+    let all = target("all");
+    assert_eq!(all.span.slice(source), "all");
+    assert!(all.attributes.contains(BindingAttributes::ARRAY));
+    assert!(!all.attributes.contains(BindingAttributes::ASSOC));
+    assert!(matches!(
+        all.origin,
+        BindingOrigin::BuiltinTarget {
+            kind: BuiltinBindingTargetKind::Zparseopts,
+            ..
+        }
+    ));
+
+    let assoc = target("assoc");
+    assert_eq!(assoc.span.slice(source), "assoc");
+    assert!(assoc.attributes.contains(BindingAttributes::ARRAY));
+    assert!(assoc.attributes.contains(BindingAttributes::ASSOC));
+
+    for name in ["help", "verbose"] {
+        let binding = target(name);
+        assert_eq!(binding.span.slice(source), name);
+        assert!(binding.attributes.contains(BindingAttributes::ARRAY));
+        assert!(!binding.attributes.contains(BindingAttributes::ASSOC));
+    }
+}
+
+#[test]
+fn zparseopts_attached_and_separator_targets_are_precise() {
+    let source = "zparseopts -aall -Aassoc -- -long=long_target s=short_target\n";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let targets = model
+        .bindings()
+        .iter()
+        .filter(|binding| matches!(binding.kind, BindingKind::ZparseoptsTarget))
+        .map(|binding| {
+            (
+                binding.name.as_str().to_owned(),
+                binding.span.slice(source).to_owned(),
+                binding.attributes.contains(BindingAttributes::ASSOC),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        targets,
+        vec![
+            ("all".to_owned(), "all".to_owned(), false),
+            ("assoc".to_owned(), "assoc".to_owned(), true),
+            ("long_target".to_owned(), "long_target".to_owned(), false),
+            ("short_target".to_owned(), "short_target".to_owned(), false),
+        ]
+    );
+}
+
+#[test]
+fn zparseopts_dynamic_targets_do_not_create_static_bindings() {
+    let source = "zparseopts -a$aggregate -- x=$target\n";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    assert!(
+        !model
+            .bindings()
+            .iter()
+            .any(|binding| matches!(binding.kind, BindingKind::ZparseoptsTarget))
+    );
+}
+
+#[test]
+fn zparseopts_targets_are_zsh_only() {
+    let source = "zparseopts -- x=target\n";
+    let model = model_with_dialect(source, ShellDialect::Bash);
+
+    assert!(
+        !model
+            .bindings()
+            .iter()
+            .any(|binding| matches!(binding.kind, BindingKind::ZparseoptsTarget))
+    );
+}
+
+#[test]
 fn mapfile_missing_option_operand_does_not_panic() {
     let source = "mapfile -u\n";
     let model = model(source);


### PR DESCRIPTION
## Summary

- model zsh `zparseopts` target operands as semantic builtin target bindings
- mark `-a` targets as arrays and `-A` targets as associative arrays
- add semantic and C006 regression coverage for explicit, attached, dynamic, and non-zsh cases

## Root Cause

Shuck did not model `zparseopts` as a zsh builtin that writes option arrays, so later reads of those target names could be reported as C006 before-assignment diagnostics.

## Validation

- `cargo test -p shuck-semantic zparseopts -- --nocapture`
- `cargo test -p shuck-linter zparseopts -- --nocapture`
- `cargo test -p shuck-linter undefined_variable -- --nocapture`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006`