### PR TITLE
fix(linter): model zsh function arity entrypoints

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -620,6 +620,13 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 &lists,
                 self.source,
             );
+        let external_entrypoint_function_scopes = build_external_entrypoint_function_scopes(
+            self.semantic,
+            &commands,
+            &command_fact_indices_by_id,
+            &lists,
+            self.source,
+        );
         annotate_conditional_assignment_value_paths(self.semantic, &lists, &mut binding_values);
         let statement_facts = build_statement_facts(&commands, self.semantic);
         let background_semicolon_spans =
@@ -954,6 +961,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             array_assignment_split_word_ids,
             brace_variable_before_bracket_spans,
             completion_registered_function_command_flags,
+            external_entrypoint_function_scopes,
             function_headers,
             function_definition_command_ids_by_scope,
             case_cli_reachable_function_scopes,

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -310,6 +310,9 @@ fn build_external_entrypoint_function_scopes(
     let mut zsh_widget_functions = FxHashMap::<Box<str>, Box<str>>::default();
     let mut zsh_hook_functions = FxHashSet::<(Box<str>, Box<str>)>::default();
     for command in commands {
+        if !is_top_level_zsh_entrypoint_registration(semantic, command) {
+            continue;
+        }
         match command_zsh_external_entrypoint_action(command, source) {
             Some(ZshExternalEntrypointAction::RegisterWidget { widget, function }) => {
                 zsh_widget_functions.insert(widget, function);
@@ -364,6 +367,13 @@ fn build_external_entrypoint_function_scopes(
     }
 
     scopes
+}
+
+fn is_top_level_zsh_entrypoint_registration(
+    semantic: &SemanticModel,
+    command: &CommandFact<'_>,
+) -> bool {
+    semantic.scope(command.scope()).parent.is_none() && !command.is_nested_word_command()
 }
 
 fn function_command_slot_count(commands: &[CommandFact<'_>]) -> usize {

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -478,6 +478,7 @@ fn command_zsh_external_entrypoint_action(
     match command.effective_or_literal_name()? {
         "zle" => zle_external_entrypoint_action(command, source),
         "add-zsh-hook" => add_zsh_hook_external_entrypoint_action(command, source),
+        "add-zle-hook-widget" => add_zsh_hook_external_entrypoint_action(command, source),
         _ => None,
     }
 }
@@ -571,6 +572,9 @@ fn add_zsh_hook_option_contains(arg: &str, flag: char) -> bool {
 }
 
 fn zsh_hook_function_pattern_matches(pattern: &str, function: &str) -> bool {
+    if pattern_contains_unsupported_zsh_metachar(pattern) {
+        return true;
+    }
     zsh_simple_glob_pattern_matches(pattern.as_bytes(), function.as_bytes())
 }
 
@@ -585,11 +589,71 @@ fn zsh_simple_glob_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
                 || (!text.is_empty() && zsh_simple_glob_pattern_matches(pattern, &text[1..]))
         }
         b'?' => !text.is_empty() && zsh_simple_glob_pattern_matches(&pattern[1..], &text[1..]),
+        b'[' => zsh_bracket_pattern_matches(pattern, text),
+        b'<' if pattern.starts_with(b"<->") => zsh_numeric_pattern_matches(&pattern[3..], text),
         literal => {
             text.first().is_some_and(|byte| *byte == literal)
                 && zsh_simple_glob_pattern_matches(&pattern[1..], &text[1..])
         }
     }
+}
+
+fn pattern_contains_unsupported_zsh_metachar(pattern: &str) -> bool {
+    pattern
+        .bytes()
+        .any(|byte| matches!(byte, b'(' | b')' | b'|' | b'~' | b'^' | b'#'))
+}
+
+fn zsh_numeric_pattern_matches(pattern_after_numeric: &[u8], text: &[u8]) -> bool {
+    let digit_count = text
+        .iter()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    (1..=digit_count).any(|consumed| {
+        zsh_simple_glob_pattern_matches(pattern_after_numeric, &text[consumed..])
+    })
+}
+
+fn zsh_bracket_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
+    let Some(&candidate) = text.first() else {
+        return false;
+    };
+    let Some(close_index) = pattern.iter().position(|byte| *byte == b']') else {
+        return candidate == b'[' && zsh_simple_glob_pattern_matches(&pattern[1..], &text[1..]);
+    };
+    if close_index == 1 {
+        return candidate == b'[' && zsh_simple_glob_pattern_matches(&pattern[1..], &text[1..]);
+    }
+
+    let class = &pattern[1..close_index];
+    let (negated, class) = match class {
+        [b'!' | b'^', rest @ ..] => (true, rest),
+        _ => (false, class),
+    };
+    let matched = zsh_bracket_class_contains(class, candidate);
+    if matched != negated {
+        zsh_simple_glob_pattern_matches(&pattern[close_index + 1..], &text[1..])
+    } else {
+        false
+    }
+}
+
+fn zsh_bracket_class_contains(class: &[u8], candidate: u8) -> bool {
+    let mut index = 0;
+    while index < class.len() {
+        if index + 2 < class.len() && class[index + 1] == b'-' {
+            if class[index] <= candidate && candidate <= class[index + 2] {
+                return true;
+            }
+            index += 3;
+        } else {
+            if class[index] == candidate {
+                return true;
+            }
+            index += 1;
+        }
+    }
+    false
 }
 
 fn static_command_args(command: &CommandFact<'_>, source: &str) -> Option<Vec<String>> {

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -308,7 +308,7 @@ fn build_external_entrypoint_function_scopes(
     }
 
     let mut zsh_widget_functions = FxHashMap::<Box<str>, Box<str>>::default();
-    let mut zsh_hook_functions = FxHashSet::<(Box<str>, Box<str>)>::default();
+    let mut zsh_hook_targets = FxHashSet::<(Box<str>, ZshHookTarget)>::default();
     for command in commands {
         if !is_top_level_zsh_entrypoint_registration(semantic, command) {
             continue;
@@ -322,16 +322,28 @@ fn build_external_entrypoint_function_scopes(
                     zsh_widget_functions.remove(&widget);
                 }
             }
-            Some(ZshExternalEntrypointAction::RegisterHook { hook, function }) => {
-                zsh_hook_functions.insert((hook, function));
+            Some(ZshExternalEntrypointAction::RegisterHookFunction { hook, function }) => {
+                zsh_hook_targets.insert((hook, ZshHookTarget::Function(function)));
             }
-            Some(ZshExternalEntrypointAction::UnregisterHook { hook, function }) => {
-                zsh_hook_functions.remove(&(hook, function));
+            Some(ZshExternalEntrypointAction::RegisterHookWidget { hook, widget }) => {
+                zsh_hook_targets.insert((hook, ZshHookTarget::Widget(widget)));
             }
-            Some(ZshExternalEntrypointAction::UnregisterHookPattern { hook, pattern }) => {
-                zsh_hook_functions.retain(|(registered_hook, registered_function)| {
+            Some(ZshExternalEntrypointAction::UnregisterHookFunction { hook, function }) => {
+                zsh_hook_targets.remove(&(hook, ZshHookTarget::Function(function)));
+            }
+            Some(ZshExternalEntrypointAction::UnregisterHookWidget { hook, widget }) => {
+                zsh_hook_targets.remove(&(hook, ZshHookTarget::Widget(widget)));
+            }
+            Some(ZshExternalEntrypointAction::UnregisterHookFunctionPattern { hook, pattern }) => {
+                zsh_hook_targets.retain(|(registered_hook, registered_target)| {
                     registered_hook.as_ref() != hook.as_ref()
-                        || !zsh_hook_function_pattern_matches(&pattern, registered_function)
+                        || !registered_target.is_function_matching_pattern(&pattern)
+                });
+            }
+            Some(ZshExternalEntrypointAction::UnregisterHookWidgetPattern { hook, pattern }) => {
+                zsh_hook_targets.retain(|(registered_hook, registered_target)| {
+                    registered_hook.as_ref() != hook.as_ref()
+                        || !registered_target.is_widget_matching_pattern(&pattern)
                 });
             }
             None => {}
@@ -342,9 +354,9 @@ fn build_external_entrypoint_function_scopes(
         if zsh_widget_functions
             .values()
             .any(|name| name.as_ref() == candidate.name.as_ref())
-            || zsh_hook_functions
+            || zsh_hook_targets
                 .iter()
-                .any(|(_, name)| name.as_ref() == candidate.name.as_ref())
+                .any(|(_, target)| target.matches_function(&candidate.name, &zsh_widget_functions))
         {
             scopes.insert(candidate.scope);
         }
@@ -466,9 +478,50 @@ fn command_registers_completion_function(
 enum ZshExternalEntrypointAction {
     RegisterWidget { widget: Box<str>, function: Box<str> },
     UnregisterWidgets { widgets: Vec<Box<str>> },
-    RegisterHook { hook: Box<str>, function: Box<str> },
-    UnregisterHook { hook: Box<str>, function: Box<str> },
-    UnregisterHookPattern { hook: Box<str>, pattern: Box<str> },
+    RegisterHookFunction { hook: Box<str>, function: Box<str> },
+    RegisterHookWidget { hook: Box<str>, widget: Box<str> },
+    UnregisterHookFunction { hook: Box<str>, function: Box<str> },
+    UnregisterHookWidget { hook: Box<str>, widget: Box<str> },
+    UnregisterHookFunctionPattern { hook: Box<str>, pattern: Box<str> },
+    UnregisterHookWidgetPattern { hook: Box<str>, pattern: Box<str> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ZshHookTarget {
+    Function(Box<str>),
+    Widget(Box<str>),
+}
+
+impl ZshHookTarget {
+    fn matches_function(
+        &self,
+        function: &str,
+        widget_functions: &FxHashMap<Box<str>, Box<str>>,
+    ) -> bool {
+        match self {
+            Self::Function(name) => name.as_ref() == function,
+            Self::Widget(widget) => {
+                widget.as_ref() == function
+                    || widget_functions
+                        .get(widget)
+                        .is_some_and(|name| name.as_ref() == function)
+            }
+        }
+    }
+
+    fn is_function_matching_pattern(&self, pattern: &str) -> bool {
+        match self {
+            Self::Function(name) => zsh_hook_function_pattern_matches(pattern, name),
+            Self::Widget(_) => false,
+        }
+    }
+
+    fn is_widget_matching_pattern(&self, pattern: &str) -> bool {
+        match self {
+            Self::Function(_) => false,
+            Self::Widget(name) => zsh_hook_function_pattern_matches(pattern, name),
+        }
+    }
 }
 
 fn command_zsh_external_entrypoint_action(
@@ -477,8 +530,16 @@ fn command_zsh_external_entrypoint_action(
 ) -> Option<ZshExternalEntrypointAction> {
     match command.effective_or_literal_name()? {
         "zle" => zle_external_entrypoint_action(command, source),
-        "add-zsh-hook" => add_zsh_hook_external_entrypoint_action(command, source),
-        "add-zle-hook-widget" => add_zsh_hook_external_entrypoint_action(command, source),
+        "add-zsh-hook" => add_zsh_hook_external_entrypoint_action(
+            command,
+            source,
+            AddZshHookTargetKind::Function,
+        ),
+        "add-zle-hook-widget" => add_zsh_hook_external_entrypoint_action(
+            command,
+            source,
+            AddZshHookTargetKind::Widget,
+        ),
         _ => None,
     }
 }
@@ -524,6 +585,7 @@ fn zle_external_entrypoint_action(
 fn add_zsh_hook_external_entrypoint_action(
     command: &CommandFact<'_>,
     source: &str,
+    target_kind: AddZshHookTargetKind,
 ) -> Option<ZshExternalEntrypointAction> {
     let args = static_command_args(command, source)?;
     let removal_mode = add_zsh_hook_removal_mode(&args);
@@ -532,24 +594,51 @@ fn add_zsh_hook_external_entrypoint_action(
         .filter(|arg| !arg.starts_with('-'))
         .collect::<Vec<_>>();
     match operands.as_slice() {
-        [hook, function, ..] if removal_mode == Some(AddZshHookRemovalMode::Exact) => {
-            Some(ZshExternalEntrypointAction::UnregisterHook {
+        [hook, function, ..] if removal_mode == Some(AddZshHookRemovalMode::Exact) => match target_kind
+        {
+            AddZshHookTargetKind::Function => Some(ZshExternalEntrypointAction::UnregisterHookFunction {
                 hook: hook.as_str().into(),
                 function: function.as_str().into(),
-            })
-        }
-        [hook, pattern, ..] if removal_mode == Some(AddZshHookRemovalMode::Pattern) => {
-            Some(ZshExternalEntrypointAction::UnregisterHookPattern {
+            }),
+            AddZshHookTargetKind::Widget => Some(ZshExternalEntrypointAction::UnregisterHookWidget {
                 hook: hook.as_str().into(),
-                pattern: pattern.as_str().into(),
-            })
+                widget: function.as_str().into(),
+            }),
+        },
+        [hook, pattern, ..] if removal_mode == Some(AddZshHookRemovalMode::Pattern) => {
+            match target_kind {
+                AddZshHookTargetKind::Function => Some(
+                    ZshExternalEntrypointAction::UnregisterHookFunctionPattern {
+                        hook: hook.as_str().into(),
+                        pattern: pattern.as_str().into(),
+                    },
+                ),
+                AddZshHookTargetKind::Widget => Some(
+                    ZshExternalEntrypointAction::UnregisterHookWidgetPattern {
+                        hook: hook.as_str().into(),
+                        pattern: pattern.as_str().into(),
+                    },
+                ),
+            }
         }
-        [hook, function, ..] if removal_mode.is_none() => Some(ZshExternalEntrypointAction::RegisterHook {
-            hook: hook.as_str().into(),
-            function: function.as_str().into(),
-        }),
+        [hook, function, ..] if removal_mode.is_none() => match target_kind {
+            AddZshHookTargetKind::Function => Some(ZshExternalEntrypointAction::RegisterHookFunction {
+                hook: hook.as_str().into(),
+                function: function.as_str().into(),
+            }),
+            AddZshHookTargetKind::Widget => Some(ZshExternalEntrypointAction::RegisterHookWidget {
+                hook: hook.as_str().into(),
+                widget: function.as_str().into(),
+            }),
+        },
         _ => None,
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AddZshHookTargetKind {
+    Function,
+    Widget,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -285,6 +285,63 @@ fn build_completion_registered_function_scopes(
     scopes
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
+fn build_external_entrypoint_function_scopes(
+    semantic: &SemanticModel,
+    commands: &[CommandFact<'_>],
+    command_fact_indices_by_id: &[Option<usize>],
+    lists: &[ListFact<'_>],
+    source: &str,
+) -> FxHashSet<ScopeId> {
+    let mut function_candidates = Vec::new();
+    function_candidates.resize_with(function_command_slot_count(commands), || None);
+    for command in commands {
+        function_candidates[command.id().index()] =
+            external_entrypoint_function_candidate(semantic, command);
+    }
+
+    let mut scopes = FxHashSet::default();
+    for candidate in function_candidates.iter().flatten() {
+        if is_zsh_special_hook_name(&candidate.name) {
+            scopes.insert(candidate.scope);
+        }
+    }
+
+    for command in commands {
+        if let Some(name) = command_registers_zsh_external_entrypoint(command, source) {
+            for candidate in function_candidates.iter().flatten() {
+                if candidate.name.as_ref() == name.as_ref() {
+                    scopes.insert(candidate.scope);
+                }
+            }
+        }
+    }
+
+    for list in lists {
+        for (index, segment) in list.segments().iter().enumerate() {
+            let Some(candidate) = function_candidates[segment.command_id().index()].as_ref() else {
+                continue;
+            };
+
+            if list.segments()[index + 1..].iter().any(|later_segment| {
+                command_registers_completion_function(
+                    command_fact(
+                        commands,
+                        command_fact_indices_by_id,
+                        later_segment.command_id(),
+                    ),
+                    source,
+                    &candidate.name,
+                )
+            }) {
+                scopes.insert(candidate.scope);
+            }
+        }
+    }
+
+    scopes
+}
+
 fn function_command_slot_count(commands: &[CommandFact<'_>]) -> usize {
     commands
         .iter()
@@ -306,6 +363,23 @@ fn completion_registered_function_candidate(
     Some(CompletionRegisteredFunctionCandidate {
         scope,
         name: name.as_str().to_owned().into_boxed_str(),
+    })
+}
+
+fn external_entrypoint_function_candidate(
+    semantic: &SemanticModel,
+    command: &CommandFact<'_>,
+) -> Option<CompletionRegisteredFunctionCandidate> {
+    let Command::Function(function) = command.command() else {
+        return None;
+    };
+    let (name, _) = function.static_name_entries().next()?;
+    let scope = semantic.scope_at(function.body.span.start.offset);
+    let name_text = name.as_str();
+
+    Some(CompletionRegisteredFunctionCandidate {
+        scope,
+        name: name_text.to_owned().into_boxed_str(),
     })
 }
 
@@ -347,6 +421,58 @@ fn command_registers_completion_function(
     }
 
     false
+}
+
+fn command_registers_zsh_external_entrypoint(
+    command: &CommandFact<'_>,
+    source: &str,
+) -> Option<Box<str>> {
+    match command.effective_or_literal_name()? {
+        "zle" => zle_registered_function(command, source),
+        "add-zsh-hook" => add_zsh_hook_registered_function(command, source),
+        _ => None,
+    }
+}
+
+fn zle_registered_function(command: &CommandFact<'_>, source: &str) -> Option<Box<str>> {
+    let args = static_command_args(command, source)?;
+    let registration_index = args.iter().position(|arg| arg == "-N")?;
+    let operands = args[registration_index + 1..]
+        .iter()
+        .filter(|arg| !arg.starts_with('-'))
+        .collect::<Vec<_>>();
+    match operands.as_slice() {
+        [widget] => Some(widget.as_str().into()),
+        [_, function, ..] => Some(function.as_str().into()),
+        _ => None,
+    }
+}
+
+fn add_zsh_hook_registered_function(command: &CommandFact<'_>, source: &str) -> Option<Box<str>> {
+    let args = static_command_args(command, source)?;
+    let operands = args
+        .iter()
+        .filter(|arg| !arg.starts_with('-'))
+        .collect::<Vec<_>>();
+    match operands.as_slice() {
+        [_, function, ..] => Some(function.as_str().into()),
+        _ => None,
+    }
+}
+
+fn static_command_args(command: &CommandFact<'_>, source: &str) -> Option<Vec<String>> {
+    command
+        .body_args()
+        .iter()
+        .map(|word| static_word_text(word, source).map(|text| text.into_owned()))
+        .collect()
+}
+
+fn is_zsh_special_hook_name(name: &str) -> bool {
+    matches!(
+        name,
+        "precmd" | "preexec" | "chpwd" | "periodic" | "zshaddhistory" | "zshexit"
+    )
 }
 
 #[derive(Debug, Clone)]

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -328,6 +328,12 @@ fn build_external_entrypoint_function_scopes(
             Some(ZshExternalEntrypointAction::UnregisterHook { hook, function }) => {
                 zsh_hook_functions.remove(&(hook, function));
             }
+            Some(ZshExternalEntrypointAction::UnregisterHookPattern { hook, pattern }) => {
+                zsh_hook_functions.retain(|(registered_hook, registered_function)| {
+                    registered_hook.as_ref() != hook.as_ref()
+                        || !zsh_hook_function_pattern_matches(&pattern, registered_function)
+                });
+            }
             None => {}
         }
     }
@@ -462,6 +468,7 @@ enum ZshExternalEntrypointAction {
     UnregisterWidgets { widgets: Vec<Box<str>> },
     RegisterHook { hook: Box<str>, function: Box<str> },
     UnregisterHook { hook: Box<str>, function: Box<str> },
+    UnregisterHookPattern { hook: Box<str>, pattern: Box<str> },
 }
 
 fn command_zsh_external_entrypoint_action(
@@ -518,19 +525,25 @@ fn add_zsh_hook_external_entrypoint_action(
     source: &str,
 ) -> Option<ZshExternalEntrypointAction> {
     let args = static_command_args(command, source)?;
-    let removes_hook = args
-        .iter()
-        .any(|arg| is_add_zsh_hook_removal_option(arg.as_str()));
+    let removal_mode = add_zsh_hook_removal_mode(&args);
     let operands = args
         .iter()
         .filter(|arg| !arg.starts_with('-'))
         .collect::<Vec<_>>();
     match operands.as_slice() {
-        [hook, function, ..] if removes_hook => Some(ZshExternalEntrypointAction::UnregisterHook {
-            hook: hook.as_str().into(),
-            function: function.as_str().into(),
-        }),
-        [hook, function, ..] => Some(ZshExternalEntrypointAction::RegisterHook {
+        [hook, function, ..] if removal_mode == Some(AddZshHookRemovalMode::Exact) => {
+            Some(ZshExternalEntrypointAction::UnregisterHook {
+                hook: hook.as_str().into(),
+                function: function.as_str().into(),
+            })
+        }
+        [hook, pattern, ..] if removal_mode == Some(AddZshHookRemovalMode::Pattern) => {
+            Some(ZshExternalEntrypointAction::UnregisterHookPattern {
+                hook: hook.as_str().into(),
+                pattern: pattern.as_str().into(),
+            })
+        }
+        [hook, function, ..] if removal_mode.is_none() => Some(ZshExternalEntrypointAction::RegisterHook {
             hook: hook.as_str().into(),
             function: function.as_str().into(),
         }),
@@ -538,8 +551,45 @@ fn add_zsh_hook_external_entrypoint_action(
     }
 }
 
-fn is_add_zsh_hook_removal_option(arg: &str) -> bool {
-    arg.starts_with('-') && arg != "--" && arg.chars().skip(1).any(|c| matches!(c, 'd' | 'D'))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AddZshHookRemovalMode {
+    Exact,
+    Pattern,
+}
+
+fn add_zsh_hook_removal_mode(args: &[String]) -> Option<AddZshHookRemovalMode> {
+    if args.iter().any(|arg| add_zsh_hook_option_contains(arg, 'D')) {
+        return Some(AddZshHookRemovalMode::Pattern);
+    }
+    args.iter()
+        .any(|arg| add_zsh_hook_option_contains(arg, 'd'))
+        .then_some(AddZshHookRemovalMode::Exact)
+}
+
+fn add_zsh_hook_option_contains(arg: &str, flag: char) -> bool {
+    arg.starts_with('-') && arg != "--" && arg.chars().skip(1).any(|c| c == flag)
+}
+
+fn zsh_hook_function_pattern_matches(pattern: &str, function: &str) -> bool {
+    zsh_simple_glob_pattern_matches(pattern.as_bytes(), function.as_bytes())
+}
+
+fn zsh_simple_glob_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
+    if pattern.is_empty() {
+        return text.is_empty();
+    }
+
+    match pattern[0] {
+        b'*' => {
+            zsh_simple_glob_pattern_matches(&pattern[1..], text)
+                || (!text.is_empty() && zsh_simple_glob_pattern_matches(pattern, &text[1..]))
+        }
+        b'?' => !text.is_empty() && zsh_simple_glob_pattern_matches(&pattern[1..], &text[1..]),
+        literal => {
+            text.first().is_some_and(|byte| *byte == literal)
+                && zsh_simple_glob_pattern_matches(&pattern[1..], &text[1..])
+        }
+    }
 }
 
 fn static_command_args(command: &CommandFact<'_>, source: &str) -> Option<Vec<String>> {

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -450,6 +450,12 @@ fn zle_registered_function(command: &CommandFact<'_>, source: &str) -> Option<Bo
 
 fn add_zsh_hook_registered_function(command: &CommandFact<'_>, source: &str) -> Option<Box<str>> {
     let args = static_command_args(command, source)?;
+    if args
+        .iter()
+        .any(|arg| is_add_zsh_hook_removal_option(arg.as_str()))
+    {
+        return None;
+    }
     let operands = args
         .iter()
         .filter(|arg| !arg.starts_with('-'))
@@ -458,6 +464,10 @@ fn add_zsh_hook_registered_function(command: &CommandFact<'_>, source: &str) -> 
         [_, function, ..] => Some(function.as_str().into()),
         _ => None,
     }
+}
+
+fn is_add_zsh_hook_removal_option(arg: &str) -> bool {
+    arg.starts_with('-') && arg != "--" && arg.chars().skip(1).any(|c| matches!(c, 'd' | 'D'))
 }
 
 fn static_command_args(command: &CommandFact<'_>, source: &str) -> Option<Vec<String>> {
@@ -471,7 +481,13 @@ fn static_command_args(command: &CommandFact<'_>, source: &str) -> Option<Vec<St
 fn is_zsh_special_hook_name(name: &str) -> bool {
     matches!(
         name,
-        "precmd" | "preexec" | "chpwd" | "periodic" | "zshaddhistory" | "zshexit"
+        "precmd"
+            | "preexec"
+            | "chpwd"
+            | "periodic"
+            | "zshaddhistory"
+            | "zsh_directory_name"
+            | "zshexit"
     )
 }
 

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -599,9 +599,16 @@ fn zsh_simple_glob_pattern_matches(pattern: &[u8], text: &[u8]) -> bool {
 }
 
 fn pattern_contains_unsupported_zsh_metachar(pattern: &str) -> bool {
-    pattern
-        .bytes()
-        .any(|byte| matches!(byte, b'(' | b')' | b'|' | b'~' | b'^' | b'#'))
+    let mut in_bracket_class = false;
+    for byte in pattern.bytes() {
+        match byte {
+            b'[' if !in_bracket_class => in_bracket_class = true,
+            b']' if in_bracket_class => in_bracket_class = false,
+            b'(' | b')' | b'|' | b'~' | b'#' if !in_bracket_class => return true,
+            _ => {}
+        }
+    }
+    false
 }
 
 fn zsh_numeric_pattern_matches(pattern_after_numeric: &[u8], text: &[u8]) -> bool {

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -307,13 +307,37 @@ fn build_external_entrypoint_function_scopes(
         }
     }
 
+    let mut zsh_widget_functions = FxHashMap::<Box<str>, Box<str>>::default();
+    let mut zsh_hook_functions = FxHashSet::<(Box<str>, Box<str>)>::default();
     for command in commands {
-        if let Some(name) = command_registers_zsh_external_entrypoint(command, source) {
-            for candidate in function_candidates.iter().flatten() {
-                if candidate.name.as_ref() == name.as_ref() {
-                    scopes.insert(candidate.scope);
+        match command_zsh_external_entrypoint_action(command, source) {
+            Some(ZshExternalEntrypointAction::RegisterWidget { widget, function }) => {
+                zsh_widget_functions.insert(widget, function);
+            }
+            Some(ZshExternalEntrypointAction::UnregisterWidgets { widgets }) => {
+                for widget in widgets {
+                    zsh_widget_functions.remove(&widget);
                 }
             }
+            Some(ZshExternalEntrypointAction::RegisterHook { hook, function }) => {
+                zsh_hook_functions.insert((hook, function));
+            }
+            Some(ZshExternalEntrypointAction::UnregisterHook { hook, function }) => {
+                zsh_hook_functions.remove(&(hook, function));
+            }
+            None => {}
+        }
+    }
+
+    for candidate in function_candidates.iter().flatten() {
+        if zsh_widget_functions
+            .values()
+            .any(|name| name.as_ref() == candidate.name.as_ref())
+            || zsh_hook_functions
+                .iter()
+                .any(|(_, name)| name.as_ref() == candidate.name.as_ref())
+        {
+            scopes.insert(candidate.scope);
         }
     }
 
@@ -423,45 +447,83 @@ fn command_registers_completion_function(
     false
 }
 
-fn command_registers_zsh_external_entrypoint(
+enum ZshExternalEntrypointAction {
+    RegisterWidget { widget: Box<str>, function: Box<str> },
+    UnregisterWidgets { widgets: Vec<Box<str>> },
+    RegisterHook { hook: Box<str>, function: Box<str> },
+    UnregisterHook { hook: Box<str>, function: Box<str> },
+}
+
+fn command_zsh_external_entrypoint_action(
     command: &CommandFact<'_>,
     source: &str,
-) -> Option<Box<str>> {
+) -> Option<ZshExternalEntrypointAction> {
     match command.effective_or_literal_name()? {
-        "zle" => zle_registered_function(command, source),
-        "add-zsh-hook" => add_zsh_hook_registered_function(command, source),
+        "zle" => zle_external_entrypoint_action(command, source),
+        "add-zsh-hook" => add_zsh_hook_external_entrypoint_action(command, source),
         _ => None,
     }
 }
 
-fn zle_registered_function(command: &CommandFact<'_>, source: &str) -> Option<Box<str>> {
+fn zle_external_entrypoint_action(
+    command: &CommandFact<'_>,
+    source: &str,
+) -> Option<ZshExternalEntrypointAction> {
     let args = static_command_args(command, source)?;
-    let registration_index = args.iter().position(|arg| arg == "-N")?;
-    let operands = args[registration_index + 1..]
-        .iter()
-        .filter(|arg| !arg.starts_with('-'))
-        .collect::<Vec<_>>();
-    match operands.as_slice() {
-        [widget] => Some(widget.as_str().into()),
-        [_, function, ..] => Some(function.as_str().into()),
-        _ => None,
+
+    if let Some(registration_index) = args.iter().position(|arg| arg == "-N") {
+        let operands = args[registration_index + 1..]
+            .iter()
+            .filter(|arg| !arg.starts_with('-'))
+            .collect::<Vec<_>>();
+        return match operands.as_slice() {
+            [widget] => Some(ZshExternalEntrypointAction::RegisterWidget {
+                widget: widget.as_str().into(),
+                function: widget.as_str().into(),
+            }),
+            [widget, function, ..] => Some(ZshExternalEntrypointAction::RegisterWidget {
+                widget: widget.as_str().into(),
+                function: function.as_str().into(),
+            }),
+            _ => None,
+        };
     }
+
+    if let Some(removal_index) = args.iter().position(|arg| arg == "-D") {
+        let widgets = args[removal_index + 1..]
+            .iter()
+            .filter(|arg| !arg.starts_with('-'))
+            .map(|arg| arg.as_str().into())
+            .collect::<Vec<_>>();
+        if !widgets.is_empty() {
+            return Some(ZshExternalEntrypointAction::UnregisterWidgets { widgets });
+        }
+    }
+
+    None
 }
 
-fn add_zsh_hook_registered_function(command: &CommandFact<'_>, source: &str) -> Option<Box<str>> {
+fn add_zsh_hook_external_entrypoint_action(
+    command: &CommandFact<'_>,
+    source: &str,
+) -> Option<ZshExternalEntrypointAction> {
     let args = static_command_args(command, source)?;
-    if args
+    let removes_hook = args
         .iter()
-        .any(|arg| is_add_zsh_hook_removal_option(arg.as_str()))
-    {
-        return None;
-    }
+        .any(|arg| is_add_zsh_hook_removal_option(arg.as_str()));
     let operands = args
         .iter()
         .filter(|arg| !arg.starts_with('-'))
         .collect::<Vec<_>>();
     match operands.as_slice() {
-        [_, function, ..] => Some(function.as_str().into()),
+        [hook, function, ..] if removes_hook => Some(ZshExternalEntrypointAction::UnregisterHook {
+            hook: hook.as_str().into(),
+            function: function.as_str().into(),
+        }),
+        [hook, function, ..] => Some(ZshExternalEntrypointAction::RegisterHook {
+            hook: hook.as_str().into(),
+            function: function.as_str().into(),
+        }),
         _ => None,
     }
 }

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -47,6 +47,7 @@ pub struct LinterFacts<'a> {
     array_assignment_split_word_ids: Vec<WordOccurrenceId>,
     brace_variable_before_bracket_spans: Vec<Span>,
     completion_registered_function_command_flags: Vec<bool>,
+    external_entrypoint_function_scopes: FxHashSet<ScopeId>,
     function_headers: Vec<FunctionHeaderFact<'a>>,
     function_definition_command_ids_by_scope: FxHashMap<ScopeId, CommandId>,
     case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
@@ -668,6 +669,10 @@ impl<'a> LinterFacts<'a> {
             .get(id.index())
             .copied()
             .unwrap_or(false)
+    }
+
+    pub fn function_is_external_entrypoint(&self, scope: ScopeId) -> bool {
+        self.external_entrypoint_function_scopes.contains(&scope)
     }
 
     pub fn function_headers(&self) -> &[FunctionHeaderFact<'a>] {

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -635,6 +635,9 @@ latent_widget_impl() { print -r -- \"$1\"; }
 latent_hook_impl() { print -r -- \"$1\"; }
 pattern_removed_hook() { print -r -- \"$1\"; }
 pattern_kept_hook() { print -r -- \"$1\"; }
+zle_hook_widget_impl() { print -r -- \"$1\"; }
+bracket_removed_hook() { print -r -- \"$1\"; }
+number_removed_hook_12() { print -r -- \"$1\"; }
 zle -N single_operand_widget
 zle -N widget-name widget_impl
 zle -N deleted-widget deleted_widget_impl
@@ -649,6 +652,11 @@ add-zsh-hook -UD chpwd removed_chpwd
 add-zsh-hook precmd pattern_removed_hook
 add-zsh-hook precmd pattern_kept_hook
 add-zsh-hook -D precmd 'pattern_removed_*'
+add-zle-hook-widget line-init zle_hook_widget_impl
+add-zsh-hook precmd bracket_removed_hook
+add-zsh-hook precmd number_removed_hook_12
+add-zsh-hook -D precmd 'bracket_removed_[hr]ook'
+add-zsh-hook -D precmd 'number_removed_hook_<->'
 zle -N \"$widget_name\" dynamic_widget
 setup_widget() { zle -N latent-widget latent_widget_impl; }
 setup_hook() { add-zsh-hook precmd latent_hook_impl; }
@@ -681,7 +689,8 @@ setup_hook() { add-zsh-hook precmd latent_hook_impl; }
                     "precmd",
                     "zsh_directory_name",
                     "shared_widget_impl",
-                    "pattern_kept_hook"
+                    "pattern_kept_hook",
+                    "zle_hook_widget_impl"
                 ]
             );
         },

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -633,6 +633,8 @@ deleted_widget_impl() { print -r -- \"$1\"; }
 shared_widget_impl() { print -r -- \"$1\"; }
 latent_widget_impl() { print -r -- \"$1\"; }
 latent_hook_impl() { print -r -- \"$1\"; }
+pattern_removed_hook() { print -r -- \"$1\"; }
+pattern_kept_hook() { print -r -- \"$1\"; }
 zle -N single_operand_widget
 zle -N widget-name widget_impl
 zle -N deleted-widget deleted_widget_impl
@@ -644,6 +646,9 @@ add-zsh-hook -Uz precmd precmd_refresh
 add-zsh-hook chpwd removed_chpwd
 add-zsh-hook -d precmd removed_precmd
 add-zsh-hook -UD chpwd removed_chpwd
+add-zsh-hook precmd pattern_removed_hook
+add-zsh-hook precmd pattern_kept_hook
+add-zsh-hook -D precmd 'pattern_removed_*'
 zle -N \"$widget_name\" dynamic_widget
 setup_widget() { zle -N latent-widget latent_widget_impl; }
 setup_hook() { add-zsh-hook precmd latent_hook_impl; }
@@ -675,7 +680,8 @@ setup_hook() { add-zsh-hook precmd latent_hook_impl; }
                     "precmd_refresh",
                     "precmd",
                     "zsh_directory_name",
-                    "shared_widget_impl"
+                    "shared_widget_impl",
+                    "pattern_kept_hook"
                 ]
             );
         },

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -624,11 +624,16 @@ single_operand_widget() { print -r -- \"$1\"; }
 widget_impl() { print -r -- \"$1\"; }
 precmd_refresh() { (( $# )) && print -r -- \"$1\"; }
 precmd() { print -r -- \"$1\"; }
+zsh_directory_name() { print -r -- \"$1\"; }
 not_external() { print -r -- \"$1\"; }
 dynamic_widget() { print -r -- \"$1\"; }
+removed_precmd() { print -r -- \"$1\"; }
+removed_chpwd() { print -r -- \"$1\"; }
 zle -N single_operand_widget
 zle -N widget-name widget_impl
 add-zsh-hook -Uz precmd precmd_refresh
+add-zsh-hook -d precmd removed_precmd
+add-zsh-hook -UD chpwd removed_chpwd
 zle -N \"$widget_name\" dynamic_widget
 ";
 
@@ -656,7 +661,8 @@ zle -N \"$widget_name\" dynamic_widget
                     "single_operand_widget",
                     "widget_impl",
                     "precmd_refresh",
-                    "precmd"
+                    "precmd",
+                    "zsh_directory_name"
                 ]
             );
         },

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -629,9 +629,17 @@ not_external() { print -r -- \"$1\"; }
 dynamic_widget() { print -r -- \"$1\"; }
 removed_precmd() { print -r -- \"$1\"; }
 removed_chpwd() { print -r -- \"$1\"; }
+deleted_widget_impl() { print -r -- \"$1\"; }
+shared_widget_impl() { print -r -- \"$1\"; }
 zle -N single_operand_widget
 zle -N widget-name widget_impl
+zle -N deleted-widget deleted_widget_impl
+zle -D deleted-widget
+zle -N first-widget shared_widget_impl
+zle -N second-widget shared_widget_impl
+zle -D first-widget
 add-zsh-hook -Uz precmd precmd_refresh
+add-zsh-hook chpwd removed_chpwd
 add-zsh-hook -d precmd removed_precmd
 add-zsh-hook -UD chpwd removed_chpwd
 zle -N \"$widget_name\" dynamic_widget
@@ -662,7 +670,8 @@ zle -N \"$widget_name\" dynamic_widget
                     "widget_impl",
                     "precmd_refresh",
                     "precmd",
-                    "zsh_directory_name"
+                    "zsh_directory_name",
+                    "shared_widget_impl"
                 ]
             );
         },

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -638,6 +638,8 @@ pattern_kept_hook() { print -r -- \"$1\"; }
 zle_hook_widget_impl() { print -r -- \"$1\"; }
 bracket_removed_hook() { print -r -- \"$1\"; }
 number_removed_hook_12() { print -r -- \"$1\"; }
+negated_class_removed_hook() { print -r -- \"$1\"; }
+negated_class_kept_hook() { print -r -- \"$1\"; }
 zle -N single_operand_widget
 zle -N widget-name widget_impl
 zle -N deleted-widget deleted_widget_impl
@@ -655,8 +657,11 @@ add-zsh-hook -D precmd 'pattern_removed_*'
 add-zle-hook-widget line-init zle_hook_widget_impl
 add-zsh-hook precmd bracket_removed_hook
 add-zsh-hook precmd number_removed_hook_12
+add-zsh-hook precmd negated_class_removed_hook
+add-zsh-hook precmd negated_class_kept_hook
 add-zsh-hook -D precmd 'bracket_removed_[hr]ook'
 add-zsh-hook -D precmd 'number_removed_hook_<->'
+add-zsh-hook -D precmd 'negated_class_[^k]*'
 zle -N \"$widget_name\" dynamic_widget
 setup_widget() { zle -N latent-widget latent_widget_impl; }
 setup_hook() { add-zsh-hook precmd latent_hook_impl; }
@@ -690,7 +695,8 @@ setup_hook() { add-zsh-hook precmd latent_hook_impl; }
                     "zsh_directory_name",
                     "shared_widget_impl",
                     "pattern_kept_hook",
-                    "zle_hook_widget_impl"
+                    "zle_hook_widget_impl",
+                    "negated_class_kept_hook"
                 ]
             );
         },

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -636,6 +636,7 @@ latent_hook_impl() { print -r -- \"$1\"; }
 pattern_removed_hook() { print -r -- \"$1\"; }
 pattern_kept_hook() { print -r -- \"$1\"; }
 zle_hook_widget_impl() { print -r -- \"$1\"; }
+zle_hook_backing_impl() { print -r -- \"$1\"; }
 bracket_removed_hook() { print -r -- \"$1\"; }
 number_removed_hook_12() { print -r -- \"$1\"; }
 negated_class_removed_hook() { print -r -- \"$1\"; }
@@ -655,6 +656,8 @@ add-zsh-hook precmd pattern_removed_hook
 add-zsh-hook precmd pattern_kept_hook
 add-zsh-hook -D precmd 'pattern_removed_*'
 add-zle-hook-widget line-init zle_hook_widget_impl
+zle -N zle-hook-widget-alias zle_hook_backing_impl
+add-zle-hook-widget line-init zle-hook-widget-alias
 add-zsh-hook precmd bracket_removed_hook
 add-zsh-hook precmd number_removed_hook_12
 add-zsh-hook precmd negated_class_removed_hook
@@ -696,6 +699,7 @@ setup_hook() { add-zsh-hook precmd latent_hook_impl; }
                     "shared_widget_impl",
                     "pattern_kept_hook",
                     "zle_hook_widget_impl",
+                    "zle_hook_backing_impl",
                     "negated_class_kept_hook"
                 ]
             );

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -631,6 +631,8 @@ removed_precmd() { print -r -- \"$1\"; }
 removed_chpwd() { print -r -- \"$1\"; }
 deleted_widget_impl() { print -r -- \"$1\"; }
 shared_widget_impl() { print -r -- \"$1\"; }
+latent_widget_impl() { print -r -- \"$1\"; }
+latent_hook_impl() { print -r -- \"$1\"; }
 zle -N single_operand_widget
 zle -N widget-name widget_impl
 zle -N deleted-widget deleted_widget_impl
@@ -643,6 +645,8 @@ add-zsh-hook chpwd removed_chpwd
 add-zsh-hook -d precmd removed_precmd
 add-zsh-hook -UD chpwd removed_chpwd
 zle -N \"$widget_name\" dynamic_widget
+setup_widget() { zle -N latent-widget latent_widget_impl; }
+setup_hook() { add-zsh-hook precmd latent_hook_impl; }
 ";
 
     with_facts_dialect(

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -615,3 +615,50 @@ complete -F _comp_cmd_later later
         assert!(flagged_lines.iter().all(|line| *line == 3));
     });
 }
+
+#[test]
+fn marks_zsh_widget_and_hook_functions_as_external_entrypoints() {
+    let source = "\
+#!/bin/zsh
+single_operand_widget() { print -r -- \"$1\"; }
+widget_impl() { print -r -- \"$1\"; }
+precmd_refresh() { (( $# )) && print -r -- \"$1\"; }
+precmd() { print -r -- \"$1\"; }
+not_external() { print -r -- \"$1\"; }
+dynamic_widget() { print -r -- \"$1\"; }
+zle -N single_operand_widget
+zle -N widget-name widget_impl
+add-zsh-hook -Uz precmd precmd_refresh
+zle -N \"$widget_name\" dynamic_widget
+";
+
+    with_facts_dialect(
+        source,
+        None,
+        ParseShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            let external_names = facts
+                .function_headers()
+                .iter()
+                .filter_map(|header| {
+                    let scope = header.function_scope()?;
+                    facts
+                        .function_is_external_entrypoint(scope)
+                        .then(|| header.static_name_entry().map(|(name, _)| name.as_str()))
+                        .flatten()
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                external_names,
+                vec![
+                    "single_operand_widget",
+                    "widget_impl",
+                    "precmd_refresh",
+                    "precmd"
+                ]
+            );
+        },
+    );
+}

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -498,6 +498,23 @@ shared_widget
     }
 
     #[test]
+    fn ignores_zsh_functions_registered_as_zle_hook_widgets() {
+        let source = "\
+#!/bin/zsh
+line_init_widget() { print -r -- \"$1\"; }
+add-zle-hook-widget line-init line_init_widget
+line_init_widget
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_zsh_functions_registered_by_unexecuted_setup_functions() {
         let source = "\
 #!/bin/zsh
@@ -522,6 +539,46 @@ latent_hook
         assert_eq!(
             diagnostics[1].span.slice(source),
             "latent_hook() { print -r -- \"$1\"; }"
+        );
+    }
+
+    #[test]
+    fn reports_zsh_functions_removed_from_hooks_by_richer_patterns() {
+        let source = "\
+#!/bin/zsh
+cb_1() { print -r -- \"$1\"; }
+cb_2() { print -r -- \"$1\"; }
+cb_10() { print -r -- \"$1\"; }
+cb_keep() { print -r -- \"$1\"; }
+add-zsh-hook precmd cb_1
+add-zsh-hook precmd cb_2
+add-zsh-hook precmd cb_10
+add-zsh-hook precmd cb_keep
+add-zsh-hook -D precmd 'cb_[12]'
+add-zsh-hook -D precmd 'cb_<->'
+cb_1
+cb_2
+cb_10
+cb_keep
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "cb_1() { print -r -- \"$1\"; }"
+        );
+        assert_eq!(
+            diagnostics[1].span.slice(source),
+            "cb_2() { print -r -- \"$1\"; }"
+        );
+        assert_eq!(
+            diagnostics[2].span.slice(source),
+            "cb_10() { print -r -- \"$1\"; }"
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet;
 use shuck_ast::Span;
 use shuck_semantic::BindingId;
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct FunctionCalledWithoutArgs {
     pub name: CompactString,
@@ -48,6 +48,9 @@ pub fn function_called_without_args(checker: &mut Checker) {
         if positional.resets_positional_parameters() {
             continue;
         }
+        if zsh_function_arity_is_externally_defined(checker, function_scope) {
+            continue;
+        }
         if !header.call_arity().called_only_without_args() {
             continue;
         }
@@ -63,10 +66,25 @@ pub fn function_called_without_args(checker: &mut Checker) {
     }
 }
 
+fn zsh_function_arity_is_externally_defined(
+    checker: &Checker<'_>,
+    function_scope: shuck_semantic::ScopeId,
+) -> bool {
+    checker.shell() == ShellDialect::Zsh
+        && (checker
+            .facts()
+            .function_is_external_entrypoint(function_scope)
+            || checker
+                .facts()
+                .function_positional_parameter_facts(function_scope)
+                .required_arg_count()
+                == 0)
+}
+
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_functions_called_without_arguments() {
@@ -285,6 +303,137 @@ die
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "die() { echo \"$#\"; }");
+    }
+
+    #[test]
+    fn ignores_zsh_callback_functions_that_read_optional_positional_parameters() {
+        let source = "\
+#!/bin/zsh
+single_operand_widget() {
+  print -r -- \"$1\"
+}
+_zsh_autosuggest_toggle() {
+  [[ -n \"$1\" ]] && BUFFER=\"$1\"
+  printf '%s\n' \"$@\"
+}
+zle -N single_operand_widget
+zle -N autosuggest-toggle _zsh_autosuggest_toggle
+single_operand_widget
+_zsh_autosuggest_toggle
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_zsh_hook_functions_registered_with_flags() {
+        let source = "\
+#!/bin/zsh
+precmd_refresh() { print -r -- \"$1\"; }
+add-zsh-hook -Uz precmd precmd_refresh
+precmd_refresh
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_zsh_standard_hook_functions() {
+        let source = "\
+#!/bin/zsh
+precmd() { print -r -- \"$1\"; }
+precmd
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_zsh_functions_called_without_required_arguments() {
+        let source = "\
+#!/bin/zsh
+greet() { print -r -- \"$1\"; }
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "greet() { print -r -- \"$1\"; }"
+        );
+    }
+
+    #[test]
+    fn reports_zsh_functions_with_dynamic_widget_registration() {
+        let source = "\
+#!/bin/zsh
+dynamic_widget() { print -r -- \"$1\"; }
+zle -N \"$widget_name\" dynamic_widget
+dynamic_widget
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "dynamic_widget() { print -r -- \"$1\"; }"
+        );
+    }
+
+    #[test]
+    fn ignores_zsh_functions_that_only_forward_special_positionals() {
+        let source = "\
+#!/bin/zsh
+forward() { print -r -- \"$@\"; }
+forward
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_zsh_functions_that_only_read_argument_count() {
+        let source = "\
+#!/bin/zsh
+has_args() { (( $# )) && print -r -- ok; }
+has_args
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -470,6 +470,34 @@ shared_widget
     }
 
     #[test]
+    fn reports_zsh_functions_registered_by_unexecuted_setup_functions() {
+        let source = "\
+#!/bin/zsh
+latent_widget() { print -r -- \"$1\"; }
+latent_hook() { print -r -- \"$1\"; }
+setup_widget() { zle -N latent-widget latent_widget; }
+setup_hook() { add-zsh-hook precmd latent_hook; }
+latent_widget
+latent_hook
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "latent_widget() { print -r -- \"$1\"; }"
+        );
+        assert_eq!(
+            diagnostics[1].span.slice(source),
+            "latent_hook() { print -r -- \"$1\"; }"
+        );
+    }
+
+    #[test]
     fn reports_zsh_functions_with_dynamic_widget_registration() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -502,8 +502,12 @@ shared_widget
         let source = "\
 #!/bin/zsh
 line_init_widget() { print -r -- \"$1\"; }
+line_init_impl() { print -r -- \"$1\"; }
+zle -N line-init-alias line_init_impl
 add-zle-hook-widget line-init line_init_widget
+add-zle-hook-widget line-init line-init-alias
 line_init_widget
+line_init_impl
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -429,6 +429,34 @@ removed_chpwd
     }
 
     #[test]
+    fn reports_zsh_functions_removed_from_hooks_by_pattern() {
+        let source = "\
+#!/bin/zsh
+cb_one() { print -r -- \"$1\"; }
+cb_two() { print -r -- \"$1\"; }
+cb_keep() { print -r -- \"$1\"; }
+add-zsh-hook precmd cb_one
+add-zsh-hook precmd cb_two
+add-zsh-hook precmd cb_keep
+add-zsh-hook -D precmd 'cb_t*'
+cb_one
+cb_two
+cb_keep
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "cb_two() { print -r -- \"$1\"; }"
+        );
+    }
+
+    #[test]
     fn reports_zsh_functions_removed_from_widgets() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -549,16 +549,23 @@ latent_hook
 cb_1() { print -r -- \"$1\"; }
 cb_2() { print -r -- \"$1\"; }
 cb_10() { print -r -- \"$1\"; }
+cb_a() { print -r -- \"$1\"; }
+cb_x() { print -r -- \"$1\"; }
 cb_keep() { print -r -- \"$1\"; }
 add-zsh-hook precmd cb_1
 add-zsh-hook precmd cb_2
 add-zsh-hook precmd cb_10
+add-zsh-hook precmd cb_a
+add-zsh-hook precmd cb_x
 add-zsh-hook precmd cb_keep
 add-zsh-hook -D precmd 'cb_[12]'
 add-zsh-hook -D precmd 'cb_<->'
+add-zsh-hook -D precmd 'cb_[^x]'
 cb_1
 cb_2
 cb_10
+cb_a
+cb_x
 cb_keep
 ";
         let diagnostics = test_snippet(
@@ -567,7 +574,7 @@ cb_keep
                 .with_shell(ShellDialect::Zsh),
         );
 
-        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics.len(), 4);
         assert_eq!(
             diagnostics[0].span.slice(source),
             "cb_1() { print -r -- \"$1\"; }"
@@ -579,6 +586,10 @@ cb_keep
         assert_eq!(
             diagnostics[2].span.slice(source),
             "cb_10() { print -r -- \"$1\"; }"
+        );
+        assert_eq!(
+            diagnostics[3].span.slice(source),
+            "cb_a() { print -r -- \"$1\"; }"
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -405,6 +405,7 @@ greet
 #!/bin/zsh
 removed_precmd() { print -r -- \"$1\"; }
 removed_chpwd() { print -r -- \"$1\"; }
+add-zsh-hook chpwd removed_chpwd
 add-zsh-hook -d precmd removed_precmd
 add-zsh-hook -UD chpwd removed_chpwd
 removed_precmd
@@ -425,6 +426,47 @@ removed_chpwd
             diagnostics[1].span.slice(source),
             "removed_chpwd() { print -r -- \"$1\"; }"
         );
+    }
+
+    #[test]
+    fn reports_zsh_functions_removed_from_widgets() {
+        let source = "\
+#!/bin/zsh
+removed_widget() { print -r -- \"$1\"; }
+zle -N removed-widget removed_widget
+zle -D removed-widget
+removed_widget
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "removed_widget() { print -r -- \"$1\"; }"
+        );
+    }
+
+    #[test]
+    fn ignores_zsh_functions_still_registered_as_widgets() {
+        let source = "\
+#!/bin/zsh
+shared_widget() { print -r -- \"$1\"; }
+zle -N first-widget shared_widget
+zle -N second-widget shared_widget
+zle -D first-widget
+shared_widget
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -364,6 +364,22 @@ precmd
     }
 
     #[test]
+    fn ignores_zsh_directory_name_hook_function() {
+        let source = "\
+#!/bin/zsh
+zsh_directory_name() { print -r -- \"$1\"; }
+zsh_directory_name
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_zsh_functions_called_without_required_arguments() {
         let source = "\
 #!/bin/zsh
@@ -380,6 +396,34 @@ greet
         assert_eq!(
             diagnostics[0].span.slice(source),
             "greet() { print -r -- \"$1\"; }"
+        );
+    }
+
+    #[test]
+    fn reports_zsh_functions_removed_from_hooks() {
+        let source = "\
+#!/bin/zsh
+removed_precmd() { print -r -- \"$1\"; }
+removed_chpwd() { print -r -- \"$1\"; }
+add-zsh-hook -d precmd removed_precmd
+add-zsh-hook -UD chpwd removed_chpwd
+removed_precmd
+removed_chpwd
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "removed_precmd() { print -r -- \"$1\"; }"
+        );
+        assert_eq!(
+            diagnostics[1].span.slice(source),
+            "removed_chpwd() { print -r -- \"$1\"; }"
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -329,6 +329,30 @@ shared_widget
     }
 
     #[test]
+    fn reports_zsh_call_sites_registered_by_unexecuted_setup_functions() {
+        let source = "\
+#!/bin/zsh
+latent_widget() { print -r -- \"$1\"; }
+latent_hook() { print -r -- \"$1\"; }
+setup_widget() { zle -N latent-widget latent_widget; }
+setup_hook() { add-zsh-hook precmd latent_hook; }
+latent_widget
+latent_hook
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "latent_widget");
+        assert_eq!(diagnostics[0].span.start.line, 6);
+        assert_eq!(diagnostics[1].span.slice(source), "latent_hook");
+        assert_eq!(diagnostics[1].span.start.line, 7);
+    }
+
+    #[test]
     fn reports_zsh_call_sites_with_dynamic_widget_registration() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -402,8 +402,12 @@ shared_widget
         let source = "\
 #!/bin/zsh
 line_init_widget() { print -r -- \"$1\"; }
+line_init_impl() { print -r -- \"$1\"; }
+zle -N line-init-alias line_init_impl
 add-zle-hook-widget line-init line_init_widget
+add-zle-hook-widget line-init line-init-alias
 line_init_widget
+line_init_impl
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -231,6 +231,22 @@ preexec
     }
 
     #[test]
+    fn ignores_zsh_directory_name_call_sites() {
+        let source = "\
+#!/bin/zsh
+zsh_directory_name() { print -r -- \"$1\"; }
+zsh_directory_name
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
     fn reports_zsh_call_sites_missing_required_arguments() {
         let source = "\
 #!/bin/zsh
@@ -246,6 +262,30 @@ greet
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet");
         assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
+    fn reports_zsh_call_sites_removed_from_hooks() {
+        let source = "\
+#!/bin/zsh
+removed_precmd() { print -r -- \"$1\"; }
+removed_chpwd() { print -r -- \"$1\"; }
+add-zsh-hook -d precmd removed_precmd
+add-zsh-hook -UD chpwd removed_chpwd
+removed_precmd
+removed_chpwd
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "removed_precmd");
+        assert_eq!(diagnostics[0].span.start.line, 6);
+        assert_eq!(diagnostics[1].span.slice(source), "removed_chpwd");
+        assert_eq!(diagnostics[1].span.start.line, 7);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet;
 use shuck_ast::Span;
 use shuck_semantic::BindingId;
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct FunctionReferencesUnsetParam {
     pub name: CompactString,
@@ -50,6 +50,9 @@ pub fn function_references_unset_param(checker: &mut Checker) {
         if !positional.uses_positional_parameters() || positional.resets_positional_parameters() {
             continue;
         }
+        if zsh_function_arity_is_externally_defined(checker, function_scope) {
+            continue;
+        }
         let call_arity = header.call_arity();
         if !call_arity.called_only_without_args() {
             continue;
@@ -69,6 +72,21 @@ pub fn function_references_unset_param(checker: &mut Checker) {
     }
 }
 
+fn zsh_function_arity_is_externally_defined(
+    checker: &Checker<'_>,
+    function_scope: shuck_semantic::ScopeId,
+) -> bool {
+    checker.shell() == ShellDialect::Zsh
+        && (checker
+            .facts()
+            .function_is_external_entrypoint(function_scope)
+            || checker
+                .facts()
+                .function_positional_parameter_facts(function_scope)
+                .required_arg_count()
+                == 0)
+}
+
 #[cfg(test)]
 mod tests {
     use shuck_indexer::Indexer;
@@ -76,7 +94,8 @@ mod tests {
 
     use crate::test::test_snippet;
     use crate::{
-        LinterSettings, Rule, ShellCheckCodeMap, lint_file_with_directives, parse_directives,
+        LinterSettings, Rule, ShellCheckCodeMap, ShellDialect, lint_file_with_directives,
+        parse_directives,
     };
 
     #[test]
@@ -162,6 +181,122 @@ usage
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "usage");
         assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
+    fn ignores_zsh_widget_and_hook_callbacks_with_optional_arguments() {
+        let source = "\
+#!/bin/zsh
+single_operand_widget() {
+  print -r -- \"$1\"
+}
+_zsh_autosuggest_widget_accept() {
+  local original_widget=\"$1\"
+  shift || true
+  \"$original_widget\" \"$@\"
+}
+precmd_refresh() {
+  (( $# )) && print -r -- \"$1\"
+}
+zle -N autosuggest-accept _zsh_autosuggest_widget_accept
+zle -N single_operand_widget
+add-zsh-hook precmd precmd_refresh
+_zsh_autosuggest_widget_accept
+single_operand_widget
+precmd_refresh
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_zsh_standard_hook_call_sites() {
+        let source = "\
+#!/bin/zsh
+preexec() { print -r -- \"$1\"; }
+preexec
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_zsh_call_sites_missing_required_arguments() {
+        let source = "\
+#!/bin/zsh
+greet() { print -r -- \"$1 $2\"; }
+greet
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "greet");
+        assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
+    fn reports_zsh_call_sites_with_dynamic_widget_registration() {
+        let source = "\
+#!/bin/zsh
+dynamic_widget() { print -r -- \"$1 $2\"; }
+zle -N \"$widget_name\" dynamic_widget
+dynamic_widget
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "dynamic_widget");
+        assert_eq!(diagnostics[0].span.start.line, 4);
+    }
+
+    #[test]
+    fn ignores_zsh_call_sites_for_special_positional_forwarders() {
+        let source = "\
+#!/bin/zsh
+forward() { print -r -- \"$@\"; }
+forward
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_zsh_call_sites_for_argument_count_checks() {
+        let source = "\
+#!/bin/zsh
+has_args() { (( $# )) && print -r -- ok; }
+has_args
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -322,16 +322,23 @@ cb_keep
 cb_1() { print -r -- \"$1\"; }
 cb_2() { print -r -- \"$1\"; }
 cb_10() { print -r -- \"$1\"; }
+cb_a() { print -r -- \"$1\"; }
+cb_x() { print -r -- \"$1\"; }
 cb_keep() { print -r -- \"$1\"; }
 add-zsh-hook precmd cb_1
 add-zsh-hook precmd cb_2
 add-zsh-hook precmd cb_10
+add-zsh-hook precmd cb_a
+add-zsh-hook precmd cb_x
 add-zsh-hook precmd cb_keep
 add-zsh-hook -D precmd 'cb_[12]'
 add-zsh-hook -D precmd 'cb_<->'
+add-zsh-hook -D precmd 'cb_[^x]'
 cb_1
 cb_2
 cb_10
+cb_a
+cb_x
 cb_keep
 ";
         let diagnostics = test_snippet(
@@ -340,13 +347,15 @@ cb_keep
                 .with_shell(ShellDialect::Zsh),
         );
 
-        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics.len(), 4);
         assert_eq!(diagnostics[0].span.slice(source), "cb_1");
-        assert_eq!(diagnostics[0].span.start.line, 12);
+        assert_eq!(diagnostics[0].span.start.line, 17);
         assert_eq!(diagnostics[1].span.slice(source), "cb_2");
-        assert_eq!(diagnostics[1].span.start.line, 13);
+        assert_eq!(diagnostics[1].span.start.line, 18);
         assert_eq!(diagnostics[2].span.slice(source), "cb_10");
-        assert_eq!(diagnostics[2].span.start.line, 14);
+        assert_eq!(diagnostics[2].span.start.line, 19);
+        assert_eq!(diagnostics[3].span.slice(source), "cb_a");
+        assert_eq!(diagnostics[3].span.start.line, 20);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -316,6 +316,40 @@ cb_keep
     }
 
     #[test]
+    fn reports_zsh_call_sites_removed_from_hooks_by_richer_patterns() {
+        let source = "\
+#!/bin/zsh
+cb_1() { print -r -- \"$1\"; }
+cb_2() { print -r -- \"$1\"; }
+cb_10() { print -r -- \"$1\"; }
+cb_keep() { print -r -- \"$1\"; }
+add-zsh-hook precmd cb_1
+add-zsh-hook precmd cb_2
+add-zsh-hook precmd cb_10
+add-zsh-hook precmd cb_keep
+add-zsh-hook -D precmd 'cb_[12]'
+add-zsh-hook -D precmd 'cb_<->'
+cb_1
+cb_2
+cb_10
+cb_keep
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 3);
+        assert_eq!(diagnostics[0].span.slice(source), "cb_1");
+        assert_eq!(diagnostics[0].span.start.line, 12);
+        assert_eq!(diagnostics[1].span.slice(source), "cb_2");
+        assert_eq!(diagnostics[1].span.start.line, 13);
+        assert_eq!(diagnostics[2].span.slice(source), "cb_10");
+        assert_eq!(diagnostics[2].span.start.line, 14);
+    }
+
+    #[test]
     fn reports_zsh_call_sites_removed_from_widgets() {
         let source = "\
 #!/bin/zsh
@@ -344,6 +378,23 @@ zle -N first-widget shared_widget
 zle -N second-widget shared_widget
 zle -D first-widget
 shared_widget
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_zsh_call_sites_registered_as_zle_hook_widgets() {
+        let source = "\
+#!/bin/zsh
+line_init_widget() { print -r -- \"$1\"; }
+add-zle-hook-widget line-init line_init_widget
+line_init_widget
 ";
         let diagnostics = test_snippet(
             source,

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -290,6 +290,32 @@ removed_chpwd
     }
 
     #[test]
+    fn reports_zsh_call_sites_removed_from_hooks_by_pattern() {
+        let source = "\
+#!/bin/zsh
+cb_one() { print -r -- \"$1\"; }
+cb_two() { print -r -- \"$1\"; }
+cb_keep() { print -r -- \"$1\"; }
+add-zsh-hook precmd cb_one
+add-zsh-hook precmd cb_two
+add-zsh-hook precmd cb_keep
+add-zsh-hook -D precmd 'cb_t*'
+cb_one
+cb_two
+cb_keep
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "cb_two");
+        assert_eq!(diagnostics[0].span.start.line, 10);
+    }
+
+    #[test]
     fn reports_zsh_call_sites_removed_from_widgets() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -270,6 +270,7 @@ greet
 #!/bin/zsh
 removed_precmd() { print -r -- \"$1\"; }
 removed_chpwd() { print -r -- \"$1\"; }
+add-zsh-hook chpwd removed_chpwd
 add-zsh-hook -d precmd removed_precmd
 add-zsh-hook -UD chpwd removed_chpwd
 removed_precmd
@@ -283,9 +284,48 @@ removed_chpwd
 
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.slice(source), "removed_precmd");
-        assert_eq!(diagnostics[0].span.start.line, 6);
+        assert_eq!(diagnostics[0].span.start.line, 7);
         assert_eq!(diagnostics[1].span.slice(source), "removed_chpwd");
-        assert_eq!(diagnostics[1].span.start.line, 7);
+        assert_eq!(diagnostics[1].span.start.line, 8);
+    }
+
+    #[test]
+    fn reports_zsh_call_sites_removed_from_widgets() {
+        let source = "\
+#!/bin/zsh
+removed_widget() { print -r -- \"$1\"; }
+zle -N removed-widget removed_widget
+zle -D removed-widget
+removed_widget
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "removed_widget");
+        assert_eq!(diagnostics[0].span.start.line, 5);
+    }
+
+    #[test]
+    fn ignores_zsh_call_sites_still_registered_as_widgets() {
+        let source = "\
+#!/bin/zsh
+shared_widget() { print -r -- \"$1\"; }
+zle -N first-widget shared_widget
+zle -N second-widget shared_widget
+zle -D first-widget
+shared_widget
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]

--- a/docs/rules/C097.yaml
+++ b/docs/rules/C097.yaml
@@ -10,6 +10,7 @@ shells:
   - bash
   - dash
   - ksh
+  - zsh
 description: A function that reads positional parameters is called with no arguments.
 rationale: Pass the expected arguments or guard against missing parameters.
 safe_fix: false

--- a/docs/rules/C123.yaml
+++ b/docs/rules/C123.yaml
@@ -10,6 +10,7 @@ shells:
   - bash
   - dash
   - ksh
+  - zsh
 description: A function references a positional parameter that is never passed by callers.
 rationale: Pass the expected arguments at every call site.
 safe_fix: false

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -2687,7 +2687,8 @@
       "sh",
       "bash",
       "dash",
-      "ksh"
+      "ksh",
+      "zsh"
     ],
     "shellcheckCode": "SC2120",
     "implemented": true,
@@ -3359,7 +3360,8 @@
       "sh",
       "bash",
       "dash",
-      "ksh"
+      "ksh",
+      "zsh"
     ],
     "shellcheckCode": "SC2119",
     "implemented": true,


### PR DESCRIPTION
## Summary

- Keep C097/C123 enabled for zsh by adding zsh to the rule metadata.
- Model zsh external entrypoints registered with `zle -N`, `add-zsh-hook`, and standard hook function names so callback arity is not judged from local zero-argument calls.
- Treat zsh functions that only use special positional forms like `"$@"`/`$#` as safe for zero-argument calls, while still reporting ordinary zsh functions that read required indexed arguments like `$1` or `$2`.

## Root Cause

The arity checks assumed local call sites fully describe how a shell function is invoked. In zsh, widgets and hooks are often invoked by the shell itself, and forwarding/special positional forms can be valid with an empty argument list. That made zsh callback-style functions look like ordinary functions called with too few arguments.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-linter function_called_without_args`
- `cargo test -p shuck-linter function_references_unset_param`
- `cargo test -p shuck-linter marks_zsh_widget_and_hook_functions_as_external_entrypoints`
- `make test`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C097,C123`
