### PR TITLE
fix(linter): allow zsh brace-expanded declaration assignments

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -139,17 +139,18 @@ fn build_assignment_like_command_name_spans<'a>(
     let mut spans = Vec::new();
 
     for fact in commands {
-        collect_assignment_like_command_name_spans_in_command(fact.command(), source, &mut spans);
+        collect_assignment_like_command_name_spans_in_command(fact, source, &mut spans);
     }
 
     spans
 }
 
 fn collect_assignment_like_command_name_spans_in_command(
-    command: &Command,
+    fact: &CommandFact<'_>,
     source: &str,
     spans: &mut Vec<Span>,
 ) {
+    let command = fact.command();
     match command {
         Command::Simple(command) => {
             collect_assignment_like_command_name_span(&command.name, source, spans);
@@ -157,6 +158,10 @@ fn collect_assignment_like_command_name_spans_in_command(
         Command::Decl(command) => {
             for operand in &command.operands {
                 if let DeclOperand::Dynamic(word) = operand {
+                    if zsh_declaration_brace_assignment_target(word, source, fact.shell_behavior())
+                    {
+                        continue;
+                    }
                     collect_assignment_like_command_name_span(word, source, spans);
                 }
             }
@@ -188,6 +193,26 @@ fn assignment_like_command_name_span(word: &Word, source: &str) -> Option<Span> 
     } else {
         (!is_shell_variable_name(target)).then_some(word.span)
     }
+}
+
+fn zsh_declaration_brace_assignment_target(
+    word: &Word,
+    source: &str,
+    behavior: &ShellBehaviorAt<'_>,
+) -> bool {
+    if behavior.zsh_options().is_none() {
+        return false;
+    }
+
+    let prefix = leading_literal_word_prefix(word, source);
+    let Some(target_end) = prefix.find("+=").or_else(|| prefix.find('=')) else {
+        return false;
+    };
+    let target_end_offset = word.span.start.offset + target_end;
+
+    word.brace_syntax()
+        .iter()
+        .any(|brace| brace.expands() && brace.span.end.offset <= target_end_offset)
 }
 
 fn bare_command_name_assignment_span<'a>(

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -116,4 +116,39 @@ rvm_info="
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
+
+    #[test]
+    fn ignores_zsh_declaration_brace_expanded_assignment_targets() {
+        let source = "\
+#!/bin/zsh
+typeset -g POWERLEVEL9K_{LEFT,RIGHT}_{LEFT,RIGHT}_WHITESPACE=
+typeset -g POWERLEVEL9K_PROMPT_CHAR_{OK,ERROR}_VIINS_CONTENT_EXPANSION='>'
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PlusPrefixInAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn still_reports_non_zsh_declaration_brace_assignment_targets() {
+        let source = "\
+#!/bin/bash
+declare POWERLEVEL9K_{LEFT,RIGHT}_WHITESPACE=
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PlusPrefixInAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["POWERLEVEL9K_{LEFT,RIGHT}_WHITESPACE="]
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Stop reporting C117 for zsh declaration operands whose assignment target uses active brace expansion, such as `typeset -g POWERLEVEL9K_{LEFT,RIGHT}_...=...`.
- Keep the behavior fact-level so the C117 rule remains a simple consumer of precomputed assignment-like command-name spans.
- Add regression coverage for the zsh `typeset -g` case and for the non-zsh `declare` case that should still report.

## Root Cause

C117 treated dynamic declaration operands with assignment-like text as invalid whenever the target was not a plain shell variable name. In zsh, declaration builtins can use brace expansion in assignment targets, so those operands should not be considered command-like assignment mistakes.

## Validation

- `cargo test -p shuck-linter plus_prefix_in_assignment`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C117`
- `make test`