### PR TITLE
fix(linter): treat zsh config namespaces as consumed

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -129,7 +129,7 @@ fn matches_zsh_config_contract(
     shell: ShellDialect,
 ) -> bool {
     let lower = lower_path(path);
-    shell == ShellDialect::Zsh
+    shell_matches_zsh_config_context(shell, &lower)
         && zsh_config_consumed_prefixes(collector.source, &lower)
             .next()
             .is_some()
@@ -165,13 +165,24 @@ fn zsh_config_prefix_path_shape(prefix: &str, lower_path: &str) -> bool {
     }
 }
 
+fn shell_matches_zsh_config_context(shell: ShellDialect, lower_path: &str) -> bool {
+    shell == ShellDialect::Zsh
+        || (shell == ShellDialect::Unknown
+            && (p10k_config_path_shape(lower_path) || zsh_dotfile_path_shape(lower_path)))
+}
+
 fn p10k_config_path_shape(lower_path: &str) -> bool {
+    let file_name = path_file_name(lower_path);
+    if file_name == ".p10k.zsh"
+        || file_name == "p10k.zsh"
+        || (file_name.starts_with("p10k-") && file_name.ends_with(".zsh"))
+    {
+        return true;
+    }
+
     path_matches_any(
         lower_path,
         &[
-            "/.p10k.zsh",
-            "/p10k.zsh",
-            "/p10k-",
             "/powerlevel10k/config/",
             "/powerlevel10k/internal/configure.zsh",
         ],
@@ -179,23 +190,32 @@ fn p10k_config_path_shape(lower_path: &str) -> bool {
 }
 
 fn zsh_dotfile_path_shape(lower_path: &str) -> bool {
-    path_matches_any(
+    path_has_component(
         lower_path,
         &[
-            "/.zshrc",
-            "/zshrc",
-            "/.zshenv",
-            "/zshenv",
-            "/.zprofile",
-            "/zprofile",
-            "/.zlogin",
-            "/zlogin",
-            "/.zlogout",
-            "/zlogout",
-            "/zdot/",
-            "/zsh/config/",
+            ".zshrc",
+            "zshrc",
+            ".zshenv",
+            "zshenv",
+            ".zprofile",
+            "zprofile",
+            ".zlogin",
+            "zlogin",
+            ".zlogout",
+            "zlogout",
+            "zdot",
         ],
-    )
+    ) || lower_path.contains("/zsh/config/")
+}
+
+fn path_has_component(lower_path: &str, names: &[&str]) -> bool {
+    lower_path
+        .split('/')
+        .any(|component| names.contains(&component))
+}
+
+fn path_file_name(lower_path: &str) -> &str {
+    lower_path.rsplit('/').next().unwrap_or(lower_path)
 }
 
 fn sourced_runtime_path_shape(lower: &str) -> bool {
@@ -575,6 +595,31 @@ ZDOT_MODULE_NAME=prompt
     #[test]
     fn ordinary_zsh_paths_do_not_get_config_prefix_contracts() {
         let path = Path::new("/tmp/project/plugins/example.zsh");
+        let source = "\
+POWERLEVEL9K_DIR_FOREGROUND=31
+ZDOT_MODULE_NAME=prompt
+";
+
+        assert!(contract_for_shell(path, source, ShellDialect::Zsh).is_none());
+    }
+
+    #[test]
+    fn shebangless_zsh_dotfiles_get_config_prefix_contracts() {
+        let path = Path::new("/tmp/home/.zshrc");
+        let source = "\
+POWERLEVEL9K_DIR_FOREGROUND=31
+ZDOT_MODULE_NAME=prompt
+";
+
+        let contract = contract_for_shell(path, source, ShellDialect::Unknown).unwrap();
+
+        assert!(has_consumed_prefix(&contract, "POWERLEVEL9K_"));
+        assert!(has_consumed_prefix(&contract, "ZDOT_"));
+    }
+
+    #[test]
+    fn zshrc_named_directories_do_not_count_as_dotfiles() {
+        let path = Path::new("/tmp/project/zshrc-theme/prompt.zsh");
         let source = "\
 POWERLEVEL9K_DIR_FOREGROUND=31
 ZDOT_MODULE_NAME=prompt

--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -125,31 +125,77 @@ fn build_sourced_runtime_contract(
 
 fn matches_zsh_config_contract(
     collector: &AmbientContractCollector<'_>,
-    _path: &Path,
+    path: &Path,
     shell: ShellDialect,
 ) -> bool {
+    let lower = lower_path(path);
     shell == ShellDialect::Zsh
-        && zsh_config_consumed_prefixes(collector.source)
+        && zsh_config_consumed_prefixes(collector.source, &lower)
             .next()
             .is_some()
 }
 
 fn build_zsh_config_contract(
     collector: &AmbientContractCollector<'_>,
-    _path: &Path,
+    path: &Path,
     _shell: ShellDialect,
 ) -> FileContract {
+    let lower = lower_path(path);
     let mut contract = FileContract::default();
-    for prefix in zsh_config_consumed_prefixes(collector.source) {
+    for prefix in zsh_config_consumed_prefixes(collector.source, &lower) {
         contract.add_externally_consumed_binding_prefix(Name::from(prefix));
     }
     contract
 }
 
-fn zsh_config_consumed_prefixes(source: &str) -> impl Iterator<Item = &'static str> + '_ {
-    ["POWERLEVEL9K_", "ZDOT_"]
-        .into_iter()
-        .filter(|prefix| source.contains(prefix))
+fn zsh_config_consumed_prefixes<'a>(
+    source: &'a str,
+    lower_path: &'a str,
+) -> impl Iterator<Item = &'static str> + 'a {
+    ["POWERLEVEL9K_", "ZDOT_"].into_iter().filter(|prefix| {
+        source.contains(prefix) && zsh_config_prefix_path_shape(prefix, lower_path)
+    })
+}
+
+fn zsh_config_prefix_path_shape(prefix: &str, lower_path: &str) -> bool {
+    match prefix {
+        "POWERLEVEL9K_" => p10k_config_path_shape(lower_path) || zsh_dotfile_path_shape(lower_path),
+        "ZDOT_" => zsh_dotfile_path_shape(lower_path),
+        _ => false,
+    }
+}
+
+fn p10k_config_path_shape(lower_path: &str) -> bool {
+    path_matches_any(
+        lower_path,
+        &[
+            "/.p10k.zsh",
+            "/p10k.zsh",
+            "/p10k-",
+            "/powerlevel10k/config/",
+            "/powerlevel10k/internal/configure.zsh",
+        ],
+    )
+}
+
+fn zsh_dotfile_path_shape(lower_path: &str) -> bool {
+    path_matches_any(
+        lower_path,
+        &[
+            "/.zshrc",
+            "/zshrc",
+            "/.zshenv",
+            "/zshenv",
+            "/.zprofile",
+            "/zprofile",
+            "/.zlogin",
+            "/zlogin",
+            "/.zlogout",
+            "/zlogout",
+            "/zdot/",
+            "/zsh/config/",
+        ],
+    )
 }
 
 fn sourced_runtime_path_shape(lower: &str) -> bool {
@@ -505,7 +551,7 @@ helper() {
 
     #[test]
     fn zsh_config_namespaces_get_consumed_prefix_contracts() {
-        let path = Path::new("/tmp/powerlevel10k/.p10k.zsh");
+        let path = Path::new("/tmp/zdot/.zshrc");
         let source = "\
 POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir vcs)
 ZDOT_MODULE_NAME=prompt
@@ -524,6 +570,17 @@ ZDOT_MODULE_NAME=prompt
         let source = "POWERLEVEL9K_DIR_FOREGROUND=31\n";
 
         assert!(contract_for_shell(path, source, ShellDialect::Sh).is_none());
+    }
+
+    #[test]
+    fn ordinary_zsh_paths_do_not_get_config_prefix_contracts() {
+        let path = Path::new("/tmp/project/plugins/example.zsh");
+        let source = "\
+POWERLEVEL9K_DIR_FOREGROUND=31
+ZDOT_MODULE_NAME=prompt
+";
+
+        assert!(contract_for_shell(path, source, ShellDialect::Zsh).is_none());
     }
 
     #[test]

--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -61,10 +61,16 @@ impl FileEntryContractCollector for AmbientContractCollector<'_> {
 }
 
 fn providers() -> &'static [AmbientContractProvider] {
-    &[AmbientContractProvider {
-        matches: matches_sourced_runtime_contract,
-        build: build_sourced_runtime_contract,
-    }]
+    &[
+        AmbientContractProvider {
+            matches: matches_sourced_runtime_contract,
+            build: build_sourced_runtime_contract,
+        },
+        AmbientContractProvider {
+            matches: matches_zsh_config_contract,
+            build: build_zsh_config_contract,
+        },
+    ]
 }
 
 fn merge_contract(merged: &mut FileContract, contract: FileContract) {
@@ -77,6 +83,9 @@ fn merge_contract(merged: &mut FileContract, contract: FileContract) {
     }
     for function in contract.provided_functions {
         merged.add_provided_function(function);
+    }
+    for prefix in contract.externally_consumed_binding_prefixes {
+        merged.add_externally_consumed_binding_prefix(prefix);
     }
 }
 
@@ -112,6 +121,35 @@ fn build_sourced_runtime_contract(
         ));
     }
     contract
+}
+
+fn matches_zsh_config_contract(
+    collector: &AmbientContractCollector<'_>,
+    _path: &Path,
+    shell: ShellDialect,
+) -> bool {
+    shell == ShellDialect::Zsh
+        && zsh_config_consumed_prefixes(collector.source)
+            .next()
+            .is_some()
+}
+
+fn build_zsh_config_contract(
+    collector: &AmbientContractCollector<'_>,
+    _path: &Path,
+    _shell: ShellDialect,
+) -> FileContract {
+    let mut contract = FileContract::default();
+    for prefix in zsh_config_consumed_prefixes(collector.source) {
+        contract.add_externally_consumed_binding_prefix(Name::from(prefix));
+    }
+    contract
+}
+
+fn zsh_config_consumed_prefixes(source: &str) -> impl Iterator<Item = &'static str> + '_ {
+    ["POWERLEVEL9K_", "ZDOT_"]
+        .into_iter()
+        .filter(|prefix| source.contains(prefix))
 }
 
 fn sourced_runtime_path_shape(lower: &str) -> bool {
@@ -368,10 +406,14 @@ mod tests {
     };
 
     fn contract_for(path: &Path, source: &str) -> Option<FileContract> {
+        contract_for_shell(path, source, ShellDialect::Sh)
+    }
+
+    fn contract_for_shell(path: &Path, source: &str, shell: ShellDialect) -> Option<FileContract> {
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let mut observer = NoopTraversalObserver;
-        let mut collector = AmbientContractCollector::new(source, Some(path), ShellDialect::Sh);
+        let mut collector = AmbientContractCollector::new(source, Some(path), shell);
         let _semantic = build_with_observer_with_options(
             &output.file,
             source,
@@ -399,6 +441,13 @@ mod tests {
                 && binding.file_entry_initialization
                     == shuck_semantic::FileEntryBindingInitialization::AmbientOnly
         })
+    }
+
+    fn has_consumed_prefix(contract: &FileContract, prefix: &str) -> bool {
+        contract
+            .externally_consumed_binding_prefixes
+            .iter()
+            .any(|consumed_prefix| consumed_prefix.as_str() == prefix)
     }
 
     #[test]
@@ -452,6 +501,29 @@ helper() {
         assert!(!has_initialized_binding(&contract, "green"));
         assert!(!has_initialized_binding(&contract, "reset_color"));
         assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn zsh_config_namespaces_get_consumed_prefix_contracts() {
+        let path = Path::new("/tmp/powerlevel10k/.p10k.zsh");
+        let source = "\
+POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir vcs)
+ZDOT_MODULE_NAME=prompt
+";
+
+        let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+        assert!(has_consumed_prefix(&contract, "POWERLEVEL9K_"));
+        assert!(has_consumed_prefix(&contract, "ZDOT_"));
+        assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn zsh_config_prefix_contracts_are_zsh_only() {
+        let path = Path::new("/tmp/project/script.sh");
+        let source = "POWERLEVEL9K_DIR_FOREGROUND=31\n";
+
+        assert!(contract_for_shell(path, source, ShellDialect::Sh).is_none());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -380,7 +380,9 @@ fn binding_family_key(
 mod tests {
     use std::path::Path;
 
-    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::test::{
+        test_path_with_fix, test_snippet, test_snippet_at_path, test_snippet_with_fix,
+    };
     use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
@@ -938,6 +940,25 @@ foo=1
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn zsh_config_namespaces_are_external_consumers() {
+        let source = "\
+#!/usr/bin/env zsh
+POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir vcs)
+POWERLEVEL9K_DIR_FOREGROUND=31
+ZDOT_MODULE_NAME=prompt
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/powerlevel10k/.p10k.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -952,13 +952,34 @@ ZDOT_MODULE_NAME=prompt
 ordinary=1
 ";
         let diagnostics = test_snippet_at_path(
-            Path::new("/tmp/powerlevel10k/.p10k.zsh"),
+            Path::new("/tmp/zdot/.zshrc"),
             source,
             &LinterSettings::for_rule(Rule::UnusedAssignment),
         );
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
+    fn zsh_config_namespace_names_still_report_on_ordinary_paths() {
+        let source = "\
+#!/usr/bin/env zsh
+POWERLEVEL9K_DIR_FOREGROUND=31
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/plugins/prompt.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "POWERLEVEL9K_DIR_FOREGROUND"
+        );
+        assert_eq!(diagnostics[1].span.slice(source), "ordinary");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -945,7 +945,6 @@ foo=1
     #[test]
     fn zsh_config_namespaces_are_external_consumers() {
         let source = "\
-#!/usr/bin/env zsh
 POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(dir vcs)
 POWERLEVEL9K_DIR_FOREGROUND=31
 ZDOT_MODULE_NAME=prompt
@@ -970,6 +969,27 @@ ordinary=1
 ";
         let diagnostics = test_snippet_at_path(
             Path::new("/tmp/project/plugins/prompt.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "POWERLEVEL9K_DIR_FOREGROUND"
+        );
+        assert_eq!(diagnostics[1].span.slice(source), "ordinary");
+    }
+
+    #[test]
+    fn zsh_config_namespace_names_still_report_in_zshrc_named_directories() {
+        let source = "\
+#!/usr/bin/env zsh
+POWERLEVEL9K_DIR_FOREGROUND=31
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/zshrc-theme/prompt.zsh"),
             source,
             &LinterSettings::for_rule(Rule::UnusedAssignment),
         );

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -6828,6 +6828,7 @@ printf '%s\\n' $pkgname
                     )],
                     provided_functions: Vec::new(),
                     externally_consumed_bindings: false,
+                    externally_consumed_binding_prefixes: Vec::new(),
                 }),
                 ..SemanticBuildOptions::default()
             },

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -199,6 +199,8 @@ pub struct FileContract {
     pub provided_functions: Vec<FunctionContract>,
     /// Whether the file may consume bindings through external runtime behavior.
     pub externally_consumed_bindings: bool,
+    /// Binding name prefixes consumed through external runtime behavior.
+    pub externally_consumed_binding_prefixes: Vec<Name>,
 }
 
 /// Build-time collector for file-entry contracts discovered during semantic traversal.
@@ -241,6 +243,17 @@ impl FileContract {
         }
     }
 
+    /// Marks a binding name prefix as externally consumed by this file.
+    pub fn add_externally_consumed_binding_prefix(&mut self, prefix: Name) {
+        if !self
+            .externally_consumed_binding_prefixes
+            .iter()
+            .any(|existing| existing == &prefix)
+        {
+            self.externally_consumed_binding_prefixes.push(prefix);
+        }
+    }
+
     /// Adds or merges a provided function into the file contract.
     pub fn add_provided_function(&mut self, function: FunctionContract) {
         let mut merged = false;
@@ -277,6 +290,9 @@ impl FileContract {
 
         for contract in contracts {
             merged.externally_consumed_bindings |= contract.externally_consumed_bindings;
+            for prefix in &contract.externally_consumed_binding_prefixes {
+                merged.add_externally_consumed_binding_prefix(prefix.clone());
+            }
             for name in &contract.required_reads {
                 merged.add_required_read(name.clone());
             }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1946,12 +1946,18 @@ impl SemanticModel {
             && contract.provided_bindings.is_empty()
             && contract.provided_functions.is_empty()
             && !contract.externally_consumed_bindings
+            && contract.externally_consumed_binding_prefixes.is_empty()
         {
             return;
         }
 
         if contract.externally_consumed_bindings {
             self.mark_file_entry_consumed_bindings();
+        }
+        if !contract.externally_consumed_binding_prefixes.is_empty() {
+            self.mark_file_entry_consumed_binding_prefixes(
+                &contract.externally_consumed_binding_prefixes,
+            );
         }
 
         let mut synthetic_reads = self.synthetic_reads.clone();
@@ -2008,6 +2014,23 @@ impl SemanticModel {
     fn mark_file_entry_consumed_bindings(&mut self) {
         for binding in &mut self.bindings {
             if file_entry_contract_can_consume_binding(binding) {
+                binding.attributes |= BindingAttributes::EXTERNALLY_CONSUMED;
+            }
+        }
+        self.heuristic_unused_assignments.retain(|binding_id| {
+            !self.bindings[binding_id.index()]
+                .attributes
+                .contains(BindingAttributes::EXTERNALLY_CONSUMED)
+        });
+    }
+
+    fn mark_file_entry_consumed_binding_prefixes(&mut self, prefixes: &[Name]) {
+        for binding in &mut self.bindings {
+            if file_entry_contract_can_consume_binding(binding)
+                && prefixes
+                    .iter()
+                    .any(|prefix| binding.name.as_str().starts_with(prefix.as_str()))
+            {
                 binding.attributes |= BindingAttributes::EXTERNALLY_CONSUMED;
             }
         }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -895,6 +895,7 @@ printf '%s\\n' \"$pkgname\"
                 )],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
         },
@@ -3104,6 +3105,7 @@ echo $value
                 )],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
         },
@@ -8696,6 +8698,7 @@ fn file_entry_contracts_seed_multiple_first_command_reads_as_imported_bindings()
                 ],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
         },
@@ -8761,6 +8764,7 @@ build() {
                 ],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
         },
@@ -8837,6 +8841,7 @@ hook() {
                 ],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
         },
@@ -8893,6 +8898,7 @@ fn initialized_file_entry_bindings_suppress_uninitialized_reads() {
                 )],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
         },
@@ -8927,6 +8933,7 @@ fn file_entry_contracts_can_mark_assignments_as_caller_consumed() {
                 provided_bindings: Vec::new(),
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: true,
+                externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
         },


### PR DESCRIPTION
## Summary

- Add prefix-level external-consumption support to semantic file-entry contracts.
- Teach zsh ambient contracts that `POWERLEVEL9K_` and `ZDOT_` configuration namespaces may be consumed dynamically outside single-file analysis.
- Add C001 regression coverage so those zsh config globals stay quiet while unrelated unused assignments are still reported.

## Validation

- `cargo test -p shuck-linter zsh_config_namespaces -- --nocapture`
- `cargo test -p shuck-linter unused_assignment -- --nocapture`
- `cargo test -p shuck-semantic file_entry_contract -- --nocapture`
- `cargo test -p shuck-linter ambient_contracts -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001`
- `make test`