### PR TITLE
fix(linter): suppress zsh delayed expansion C005

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -10,6 +10,7 @@ pub struct SingleQuotedFragmentFact {
     dollar_quoted: bool,
     command_name: Option<Box<str>>,
     assignment_target: Option<Box<str>>,
+    shell_dialect: shuck_parser::ShellDialect,
     variable_set_operand: bool,
     literal_expansion_exempt: bool,
     literal_backslash_in_single_quotes_span: Option<Span>,
@@ -34,6 +35,10 @@ impl SingleQuotedFragmentFact {
 
     pub fn assignment_target(&self) -> Option<&str> {
         self.assignment_target.as_deref()
+    }
+
+    pub fn shell_dialect(&self) -> shuck_parser::ShellDialect {
+        self.shell_dialect
     }
 
     pub fn variable_set_operand(&self) -> bool {
@@ -468,6 +473,7 @@ pub(super) struct SurfaceFragmentFacts {
 pub(super) struct SurfaceScanContext<'a> {
     command_name: Option<&'a str>,
     assignment_target: Option<&'a str>,
+    shell_dialect: shuck_parser::ShellDialect,
     nested_word_command: bool,
     variable_set_operand: bool,
     literal_expansion_exempt: bool,
@@ -478,10 +484,15 @@ pub(super) struct SurfaceScanContext<'a> {
 }
 
 impl<'a> SurfaceScanContext<'a> {
-    pub(super) fn new(command_name: Option<&'a str>, nested_word_command: bool) -> Self {
+    pub(super) fn new(
+        command_name: Option<&'a str>,
+        nested_word_command: bool,
+        shell_dialect: shuck_parser::ShellDialect,
+    ) -> Self {
         Self {
             command_name,
             nested_word_command,
+            shell_dialect,
             subscript_suppresses_later_references: true,
             collect_open_double_quotes: true,
             collect_pattern_charclasses: false,
@@ -880,6 +891,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                             .assignment_target
                             .map(str::to_owned)
                             .map(String::into_boxed_str),
+                        shell_dialect: context.shell_dialect,
                         variable_set_operand: context.variable_set_operand,
                         literal_expansion_exempt: context.literal_expansion_exempt,
                         literal_backslash_in_single_quotes_span:

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -975,6 +975,7 @@ pub(super) fn detect_sudo_family_invoker(
 
 pub(super) fn single_quoted_literal_exempt_argument(
     command_name: Option<&str>,
+    shell_dialect: shuck_parser::ShellDialect,
     args: &[Word],
     arg_index: usize,
     body_arg_start: usize,
@@ -1013,6 +1014,9 @@ pub(super) fn single_quoted_literal_exempt_argument(
         "jq" => jq_literal_argument_index(body_args, source).contains(&relative_arg_index),
         "rename" => rename_program_argument_index(body_args, source) == Some(relative_arg_index),
         "rg" => rg_pattern_argument_index(body_args, source) == Some(relative_arg_index),
+        "sched" if shell_dialect == shuck_parser::ShellDialect::Zsh => {
+            sched_command_argument_index(body_args, source) == Some(relative_arg_index)
+        }
         "sh" | "bash" | "dash" | "ksh" | "zsh" => {
             shell_command_argument_index(body_args, source) == Some(relative_arg_index)
         }
@@ -1022,6 +1026,9 @@ pub(super) fn single_quoted_literal_exempt_argument(
         }),
         "unset" => true,
         "xprop" => xprop_value_argument_index(body_args, source) == Some(relative_arg_index),
+        "zstyle" if shell_dialect == shuck_parser::ShellDialect::Zsh => {
+            zstyle_eval_argument_index(body_args, source) == Some(relative_arg_index)
+        }
         _ if command_name.ends_with("awk") => {
             awk_literal_argument_index(body_args, source).contains(&relative_arg_index)
         }
@@ -1030,6 +1037,29 @@ pub(super) fn single_quoted_literal_exempt_argument(
         }
         _ => false,
     }
+}
+
+fn sched_command_argument_index(args: &[Word], source: &str) -> Option<usize> {
+    args.windows(2).enumerate().find_map(|(index, pair)| {
+        let time = static_word_text(&pair[0], source)?;
+        let starts_like_delay = time
+            .as_ref()
+            .strip_prefix('+')
+            .is_some_and(|tail| tail.chars().next().is_some_and(|ch| ch.is_ascii_digit()));
+        let starts_like_absolute_time = time
+            .as_ref()
+            .chars()
+            .next()
+            .is_some_and(|ch| ch.is_ascii_digit());
+        (starts_like_delay || starts_like_absolute_time).then_some(index + 1)
+    })
+}
+
+fn zstyle_eval_argument_index(args: &[Word], source: &str) -> Option<usize> {
+    args.windows(4).enumerate().find_map(|(index, window)| {
+        let flag = static_word_text(&window[0], source)?;
+        (flag.as_ref() == "-e").then_some(index + 3)
+    })
 }
 
 pub(super) fn single_quoted_literal_exempt_here_string(command_name: Option<&str>) -> bool {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -980,16 +980,11 @@ pub(super) fn single_quoted_literal_exempt_argument(
     arg_index: usize,
     body_arg_start: usize,
     word: &Word,
-    trap_action: Option<&Word>,
     source: &str,
 ) -> bool {
     let Some(command_name) = command_name else {
         return false;
     };
-
-    if trap_action.is_some_and(|action| std::ptr::eq(action, word)) {
-        return true;
-    }
 
     let Some(body_args) = args.get(body_arg_start..) else {
         return false;

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1634,7 +1634,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
     }
 
     fn surface_context(&self) -> SurfaceScanContext<'norm> {
-        SurfaceScanContext::new(self.surface_command_name, self.nested_word_command)
+        SurfaceScanContext::new(
+            self.surface_command_name,
+            self.nested_word_command,
+            self.semantic.shell_profile().dialect,
+        )
     }
 
     fn collect_surface_only_word(
@@ -1718,7 +1722,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 CompoundCommand::Conditional(command) => {
                     self.collect_conditional_expansion_words(
                         &command.expression,
-                        SurfaceScanContext::new(None, self.nested_word_command),
+                        SurfaceScanContext::new(
+                            None,
+                            self.nested_word_command,
+                            self.semantic.shell_profile().dialect,
+                        ),
                     );
                 }
                 CompoundCommand::Arithmetic(command) => {
@@ -1898,6 +1906,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         surface_context.variable_set_operand()
                     } else if single_quoted_literal_exempt_argument(
                         surface_command_name,
+                        self.semantic.shell_profile().dialect,
                         &command.args,
                         arg_index,
                         body_arg_start,
@@ -1955,7 +1964,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             }
             Command::Builtin(command) => match command {
                 BuiltinCommand::Break(command) => {
-                    let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
+                    let surface_context = SurfaceScanContext::new(
+                        None,
+                        self.nested_word_command,
+                        self.semantic.shell_profile().dialect,
+                    );
                     if let Some(word) = &command.depth {
                         self.push_word_with_surface(
                             word,
@@ -1971,7 +1984,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     );
                 }
                 BuiltinCommand::Continue(command) => {
-                    let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
+                    let surface_context = SurfaceScanContext::new(
+                        None,
+                        self.nested_word_command,
+                        self.semantic.shell_profile().dialect,
+                    );
                     if let Some(word) = &command.depth {
                         self.push_word_with_surface(
                             word,
@@ -1987,7 +2004,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     );
                 }
                 BuiltinCommand::Return(command) => {
-                    let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
+                    let surface_context = SurfaceScanContext::new(
+                        None,
+                        self.nested_word_command,
+                        self.semantic.shell_profile().dialect,
+                    );
                     if let Some(word) = &command.code {
                         self.push_word_with_surface(
                             word,
@@ -2003,7 +2024,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     );
                 }
                 BuiltinCommand::Exit(command) => {
-                    let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
+                    let surface_context = SurfaceScanContext::new(
+                        None,
+                        self.nested_word_command,
+                        self.semantic.shell_profile().dialect,
+                    );
                     if let Some(word) = &command.code {
                         self.push_word_with_surface(
                             word,
@@ -2020,7 +2045,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 }
             },
             Command::Decl(command) => {
-                let surface_context = SurfaceScanContext::new(None, self.nested_word_command);
+                let surface_context = SurfaceScanContext::new(
+                    None,
+                    self.nested_word_command,
+                    self.semantic.shell_profile().dialect,
+                );
                 for operand in &command.operands {
                     match operand {
                         DeclOperand::Flag(word) => {
@@ -2043,7 +2072,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 self.collect_words_with_context(
                     &function.args,
                     WordFactContext::Expansion(ExpansionContext::CommandArgument),
-                    SurfaceScanContext::new(None, self.nested_word_command),
+                    SurfaceScanContext::new(
+                        None,
+                        self.nested_word_command,
+                        self.semantic.shell_profile().dialect,
+                    ),
                 );
             }
         }
@@ -2099,8 +2132,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         reference,
                         self.source,
                         &mut |word| {
-                            let surface_context =
-                                SurfaceScanContext::new(None, self.nested_word_command);
+                            let surface_context = SurfaceScanContext::new(
+                                None,
+                                self.nested_word_command,
+                                self.semantic.shell_profile().dialect,
+                            );
                             collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
                                 &word.parts,
                                 self.source,
@@ -2137,7 +2173,11 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         assignment: &'a Assignment,
         context: WordFactContext,
     ) {
-        let surface_context = SurfaceScanContext::new(None, self.nested_word_command)
+        let surface_context = SurfaceScanContext::new(
+            None,
+            self.nested_word_command,
+            self.semantic.shell_profile().dialect,
+        )
             .with_assignment_target(assignment.target.name.as_str());
         let indexed_semantics = self.subscript_uses_index_arithmetic_semantics(
             Some(&assignment.target.name),

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1904,16 +1904,17 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                         .is_some_and(|operand| std::ptr::eq(word, operand))
                     {
                         surface_context.variable_set_operand()
-                    } else if single_quoted_literal_exempt_argument(
-                        surface_command_name,
-                        self.semantic.shell_profile().dialect,
-                        &command.args,
-                        arg_index,
-                        body_arg_start,
-                        word,
-                        trap_action,
-                        self.source,
-                    ) {
+                    } else if trap_action.is_some_and(|action| std::ptr::eq(action, word))
+                        || single_quoted_literal_exempt_argument(
+                            surface_command_name,
+                            self.semantic.shell_profile().dialect,
+                            &command.args,
+                            arg_index,
+                            body_arg_start,
+                            word,
+                            self.source,
+                        )
+                    {
                         surface_context.literal_expansion_exempt()
                     } else {
                         surface_context

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -22,6 +22,7 @@ impl Violation for SingleQuotedLiteral {
 struct ScanContext<'a> {
     command_name: Option<&'a str>,
     assignment_target: Option<&'a str>,
+    shell_dialect: shuck_parser::ShellDialect,
     variable_set_operand: bool,
     literal_expansion_exempt: bool,
 }
@@ -40,6 +41,7 @@ pub fn single_quoted_literal(checker: &mut Checker) {
             let context = ScanContext {
                 command_name: fragment.command_name(),
                 assignment_target: fragment.assignment_target(),
+                shell_dialect: fragment.shell_dialect(),
                 variable_set_operand: fragment.variable_set_operand(),
                 literal_expansion_exempt: fragment.literal_expansion_exempt(),
             };
@@ -100,7 +102,7 @@ fn should_report_single_quoted_literal(text: &str, context: ScanContext<'_>) -> 
 
     if context
         .assignment_target
-        .is_some_and(assignment_target_is_exempt)
+        .is_some_and(|target| assignment_target_is_exempt(target, context.shell_dialect))
     {
         return false;
     }
@@ -157,8 +159,18 @@ fn sed_text_is_exempt(text: &str) -> bool {
     false
 }
 
-fn assignment_target_is_exempt(target: &str) -> bool {
-    matches!(target, "PS1" | "PS2" | "PS3" | "PS4" | "PROMPT_COMMAND")
+fn assignment_target_is_exempt(target: &str, shell_dialect: shuck_parser::ShellDialect) -> bool {
+    if matches!(target, "PS1" | "PS2" | "PS3" | "PS4" | "PROMPT_COMMAND") {
+        return true;
+    }
+
+    shell_dialect == shuck_parser::ShellDialect::Zsh
+        && (matches!(target, "PROMPT" | "RPROMPT" | "RPS1" | "RPS2" | "SPROMPT")
+            || powerlevel10k_prompt_expansion_target(target))
+}
+
+fn powerlevel10k_prompt_expansion_target(target: &str) -> bool {
+    target.starts_with("POWERLEVEL9K_") && target.ends_with("_EXPANSION")
 }
 
 #[cfg(test)]
@@ -166,7 +178,8 @@ mod tests {
     use std::path::Path;
 
     use super::{
-        assignment_target_is_exempt, contains_sc2016_trigger, quoted_fragment_to_double_quotes,
+        assignment_target_is_exempt, contains_sc2016_trigger,
+        powerlevel10k_prompt_expansion_target, quoted_fragment_to_double_quotes,
         sed_text_is_exempt,
     };
     use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
@@ -219,10 +232,28 @@ mod tests {
     #[test]
     fn recognizes_prompt_assignment_exemptions() {
         for target in ["PS1", "PS2", "PS3", "PS4", "PROMPT_COMMAND"] {
-            assert!(assignment_target_is_exempt(target), "{target}");
+            assert!(
+                assignment_target_is_exempt(target, shuck_parser::ShellDialect::Bash),
+                "{target}"
+            );
         }
 
-        assert!(!assignment_target_is_exempt("HOME"));
+        assert!(!assignment_target_is_exempt(
+            "HOME",
+            shuck_parser::ShellDialect::Bash
+        ));
+        assert!(assignment_target_is_exempt(
+            "PROMPT",
+            shuck_parser::ShellDialect::Zsh
+        ));
+        assert!(!assignment_target_is_exempt(
+            "PROMPT",
+            shuck_parser::ShellDialect::Bash
+        ));
+        assert!(powerlevel10k_prompt_expansion_target(
+            "POWERLEVEL9K_VCS_CONTENT_EXPANSION"
+        ));
+        assert!(!powerlevel10k_prompt_expansion_target("POWERLEVEL9K_MODE"));
     }
 
     #[test]
@@ -277,6 +308,30 @@ mod tests {
             0
         );
         assert_eq!(c005("xprop -set WM_NAME '$HOME'\n"), 0);
+        assert_eq!(
+            c005("#!/bin/zsh\nzstyle -e ':completion:*' hosts 'reply=($PREFIX)'\n"),
+            0
+        );
+        assert_eq!(
+            c005("#!/bin/zsh\nzstyle ':completion:*' hosts '$PREFIX'\n"),
+            1
+        );
+        assert_eq!(
+            c005("#!/bin/bash\nzstyle -e ':completion:*' hosts 'reply=($PREFIX)'\n"),
+            1
+        );
+        assert_eq!(c005("#!/bin/zsh\nsched +1 'echo $HOME'\n"), 0);
+        assert_eq!(c005("#!/bin/bash\nsched +1 'echo $HOME'\n"), 1);
+        assert_eq!(c005("#!/bin/zsh\nPROMPT='$(pwd) '\n"), 0);
+        assert_eq!(c005("#!/bin/bash\nPROMPT='$(pwd) '\n"), 1);
+        assert_eq!(
+            c005("#!/bin/zsh\ntypeset -g POWERLEVEL9K_VCS_CONTENT_EXPANSION='${my_git_format}'\n"),
+            0
+        );
+        assert_eq!(
+            c005("#!/bin/zsh\ntypeset -g POWERLEVEL9K_MODE='${mode}'\n"),
+            1
+        );
         assert_eq!(
             c005(
                 "PERLIO=:utf8 perl -pe '$_=lc'\nperl -MConfig -le 'print $Config{installvendorlib}'\n"


### PR DESCRIPTION
## Summary

- Carry shell dialect through single-quoted fragment facts so C005 can make dialect-aware decisions.
- Exempt zsh delayed-expansion contexts from C005: `zstyle -e`, `sched`, prompt assignments, and Powerlevel10k `*_EXPANSION` settings.
- Add regression coverage that keeps the exemptions zsh-specific and preserves normal C005 reporting for ordinary single-quoted expansions.

## Validation

- `cargo test -p shuck-linter single_quoted_literal -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C005 SHUCK_LARGE_CORPUS_KEEP_GOING=1`
- `git diff --check`