### PR TITLE
fix(linter): handle zsh option-map commas

### DIFF
--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -823,9 +823,14 @@ fn has_unclosed_assoc_key_prefix(word: &Word, source: &str) -> bool {
     saw_equals
 }
 
-fn collect_comma_array_assignment_spans(command: &Command, source: &str, spans: &mut Vec<Span>) {
+fn collect_comma_array_assignment_spans(
+    command: &Command,
+    source: &str,
+    shell: ShellDialect,
+    spans: &mut Vec<Span>,
+) {
     for assignment in command_assignments(command) {
-        if let Some(span) = comma_array_assignment_span(assignment, source) {
+        if let Some(span) = comma_array_assignment_span(assignment, source, shell) {
             spans.push(span);
         }
     }
@@ -834,7 +839,7 @@ fn collect_comma_array_assignment_spans(command: &Command, source: &str, spans: 
         let DeclOperand::Assignment(assignment) = operand else {
             continue;
         };
-        if let Some(span) = comma_array_assignment_span(assignment, source) {
+        if let Some(span) = comma_array_assignment_span(assignment, source, shell) {
             spans.push(span);
         }
     }
@@ -881,23 +886,53 @@ fn ifs_literal_backslash_assignment_value_span(
         .then_some(word.span)
 }
 
-fn comma_array_assignment_span(assignment: &Assignment, source: &str) -> Option<Span> {
+fn comma_array_assignment_span(
+    assignment: &Assignment,
+    source: &str,
+    shell: ShellDialect,
+) -> Option<Span> {
     let AssignmentValue::Compound(array) = &assignment.value else {
         return None;
     };
-    if !array_value_has_unquoted_comma(array, source) {
+    if !array_value_has_unquoted_comma(array, source, shell) {
         return None;
     }
 
     compound_assignment_paren_span(assignment, source)
 }
 
-fn array_value_has_unquoted_comma(array: &shuck_ast::ArrayExpr, source: &str) -> bool {
-    let _ = source;
-    array
-        .elements
-        .iter()
-        .any(|element| element.value().has_top_level_unquoted_comma())
+fn array_value_has_unquoted_comma(
+    array: &shuck_ast::ArrayExpr,
+    source: &str,
+    shell: ShellDialect,
+) -> bool {
+    array.elements.iter().any(|element| {
+        let value = element.value();
+        value.has_top_level_unquoted_comma()
+            && !(shell == ShellDialect::Zsh && zsh_option_map_value_allows_comma(value, source))
+    })
+}
+
+fn zsh_option_map_value_allows_comma(value: &shuck_ast::ArrayValueWord, source: &str) -> bool {
+    let Some(text) = static_word_text(value, source) else {
+        return false;
+    };
+    let aliases = text.split(':').next().unwrap_or_default();
+    let Some(rest) = aliases.strip_prefix("opt_") else {
+        return false;
+    };
+
+    let parts = rest.split(',').collect::<Vec<_>>();
+    parts.len() > 1 && parts.iter().copied().all(zsh_option_alias_part)
+}
+
+fn zsh_option_alias_part(part: &str) -> bool {
+    part.starts_with('-')
+        && part.len() > 1
+        && part
+            .bytes()
+            .skip(1)
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
 }
 
 fn compound_assignment_paren_span(assignment: &Assignment, source: &str) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -827,10 +827,11 @@ fn collect_comma_array_assignment_spans(
     command: &Command,
     source: &str,
     shell: ShellDialect,
+    semantic: &SemanticModel,
     spans: &mut Vec<Span>,
 ) {
     for assignment in command_assignments(command) {
-        if let Some(span) = comma_array_assignment_span(assignment, source, shell) {
+        if let Some(span) = comma_array_assignment_span(assignment, source, shell, semantic) {
             spans.push(span);
         }
     }
@@ -839,7 +840,7 @@ fn collect_comma_array_assignment_spans(
         let DeclOperand::Assignment(assignment) = operand else {
             continue;
         };
-        if let Some(span) = comma_array_assignment_span(assignment, source, shell) {
+        if let Some(span) = comma_array_assignment_span(assignment, source, shell, semantic) {
             spans.push(span);
         }
     }
@@ -890,11 +891,12 @@ fn comma_array_assignment_span(
     assignment: &Assignment,
     source: &str,
     shell: ShellDialect,
+    semantic: &SemanticModel,
 ) -> Option<Span> {
     let AssignmentValue::Compound(array) = &assignment.value else {
         return None;
     };
-    if !array_value_has_unquoted_comma(array, source, shell) {
+    if !array_value_has_unquoted_comma(assignment, array, source, shell, semantic) {
         return None;
     }
 
@@ -902,15 +904,38 @@ fn comma_array_assignment_span(
 }
 
 fn array_value_has_unquoted_comma(
+    assignment: &Assignment,
     array: &shuck_ast::ArrayExpr,
     source: &str,
     shell: ShellDialect,
+    semantic: &SemanticModel,
 ) -> bool {
+    let allow_zsh_option_map_values =
+        shell == ShellDialect::Zsh && assignment_target_has_assoc_context(assignment, semantic);
+
     array.elements.iter().any(|element| {
         let value = element.value();
         value.has_top_level_unquoted_comma()
-            && !(shell == ShellDialect::Zsh && zsh_option_map_value_allows_comma(value, source))
+            && !(allow_zsh_option_map_values && zsh_option_map_value_allows_comma(value, source))
     })
+}
+
+fn assignment_target_has_assoc_context(assignment: &Assignment, semantic: &SemanticModel) -> bool {
+    semantic
+        .binding_for_definition_span(assignment.target.name_span)
+        .is_some_and(|binding| {
+            semantic
+                .binding(binding)
+                .attributes
+                .contains(BindingAttributes::ASSOC)
+        })
+        || semantic
+            .previous_visible_binding(
+                &assignment.target.name,
+                assignment.target.name_span,
+                Some(assignment.target.name_span),
+            )
+            .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
 }
 
 fn zsh_option_map_value_allows_comma(value: &shuck_ast::ArrayValueWord, source: &str) -> bool {

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -935,7 +935,10 @@ fn assignment_target_has_assoc_context(assignment: &Assignment, semantic: &Seman
                 assignment.target.name_span,
                 Some(assignment.target.name_span),
             )
-            .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
+            .is_some_and(|binding| {
+                binding.attributes.contains(BindingAttributes::ASSOC)
+                    && !semantic.binding_cleared_before(binding.id, assignment.target.name_span)
+            })
 }
 
 fn zsh_option_map_value_allows_comma(value: &shuck_ast::ArrayValueWord, source: &str) -> bool {

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -203,6 +203,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 collect_comma_array_assignment_spans(
                     visit.command,
                     self.source,
+                    self.shell,
                     &mut comma_array_assignment_spans,
                 );
                 collect_ifs_literal_backslash_assignment_value_spans(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -204,6 +204,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     visit.command,
                     self.source,
                     self.shell,
+                    self.semantic,
                     &mut comma_array_assignment_spans,
                 );
                 collect_ifs_literal_backslash_assignment_value_spans(

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -89,6 +89,7 @@ opts=(
         let source = "\
 #!/bin/zsh
 parts=(alpha,beta)
+values=(opt_-q,--quiet)
 ";
         let diagnostics = test_snippet(
             source,
@@ -100,7 +101,7 @@ parts=(alpha,beta)
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["(alpha,beta)"]
+            vec!["(alpha,beta)", "(opt_-q,--quiet)"]
         );
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -90,6 +90,9 @@ opts=(
 #!/bin/zsh
 parts=(alpha,beta)
 values=(opt_-q,--quiet)
+typeset -A opts
+unset opts
+opts=(opt_-r,--reset)
 ";
         let diagnostics = test_snippet(
             source,
@@ -101,7 +104,7 @@ values=(opt_-q,--quiet)
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["(alpha,beta)", "(opt_-q,--quiet)"]
+            vec!["(alpha,beta)", "(opt_-q,--quiet)", "(opt_-r,--reset)"]
         );
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -22,7 +22,7 @@ pub fn comma_array_elements(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_comma_separated_array_literals() {
@@ -64,5 +64,43 @@ e=({$XDG_CONFIG_HOME,$HOME}/{alacritty,}/{.,}alacritty.ym?)
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_option_map_values() {
+        let source = "\
+#!/bin/zsh
+local -A opts
+opts=(
+  -q       opt_-q,--quiet:\"update:[quiet mode] *:[less output]\"
+  --quiet  opt_-q,--quiet
+)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CommaArrayElements).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_comma_separated_array_literals_in_zsh() {
+        let source = "\
+#!/bin/zsh
+parts=(alpha,beta)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CommaArrayElements).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["(alpha,beta)"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Keep C151 active for native zsh scripts while allowing zsh option-map alias values such as `opt_-q,--quiet`.
- Thread the shell dialect into comma-array fact collection so zsh-specific data shapes can be handled narrowly.
- Add regression coverage for zsh option-map values and for ordinary comma-separated zsh arrays still reporting.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-linter comma_array_elements -- --nocapture`
- `cargo test -p shuck-linter rules::correctness::tests::rules -- --nocapture`
- `cargo run -p shuck-cli -- check --select C151 /tmp/zsh/zinit/zinit.zsh`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C151`