### PR TITLE
refactor(parser): make ZshOptionState Copy

### DIFF
--- a/crates/shuck-parser/src/parser/zsh_options.rs
+++ b/crates/shuck-parser/src/parser/zsh_options.rs
@@ -63,7 +63,7 @@ pub enum ZshEmulationMode {
 /// table. Use [`ZshOptionState::zsh_default`] for native zsh parsing, then
 /// apply `setopt`, `unsetopt`, or `emulate` effects when a caller has already
 /// discovered them.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ZshOptionState {
     /// Whether unquoted parameter expansion is treated as eligible for
     /// shell-style word splitting.

--- a/crates/shuck-parser/src/parser/zsh_prescan.rs
+++ b/crates/shuck-parser/src/parser/zsh_prescan.rs
@@ -18,7 +18,7 @@ pub(super) struct ZshOptionTimelineEntry {
 
 impl ZshOptionTimeline {
     pub(super) fn build(input: &str, shell_profile: &ShellProfile) -> Option<Self> {
-        let initial = shell_profile.zsh_options()?.clone();
+        let initial = *shell_profile.zsh_options()?;
         if !might_mutate_zsh_parser_options(input) {
             return Some(Self {
                 initial,
@@ -26,7 +26,7 @@ impl ZshOptionTimeline {
             });
         }
 
-        let entries = ZshOptionPrescanner::new(input, initial.clone()).scan();
+        let entries = ZshOptionPrescanner::new(input, initial).scan();
         Some(Self {
             initial,
             entries: entries.into(),
@@ -186,7 +186,7 @@ impl<'a> ZshOptionPrescanner<'a> {
             match token {
                 PrescanToken::Word { text, end } => {
                     if is_prescan_function_body_start(function_header) {
-                        local_scopes.push(PrescanLocalScope::simple(self.state.clone()));
+                        local_scopes.push(PrescanLocalScope::simple(self.state));
                         function_header = PrescanFunctionHeaderState::None;
                     }
                     command_end = end;
@@ -236,7 +236,7 @@ impl<'a> ZshOptionPrescanner<'a> {
                         }
                         PrescanSeparator::OpenParen => {
                             if is_prescan_function_body_start(function_header) {
-                                local_scopes.push(PrescanLocalScope::subshell(self.state.clone()));
+                                local_scopes.push(PrescanLocalScope::subshell(self.state));
                                 function_header = PrescanFunctionHeaderState::None;
                             } else {
                                 let next_header = match function_header {
@@ -253,8 +253,7 @@ impl<'a> ZshOptionPrescanner<'a> {
                                     PrescanFunctionHeaderState::AfterWordOpenParen
                                         | PrescanFunctionHeaderState::AfterFunctionNameOpenParen
                                 ) {
-                                    local_scopes
-                                        .push(PrescanLocalScope::subshell(self.state.clone()));
+                                    local_scopes.push(PrescanLocalScope::subshell(self.state));
                                 }
                                 function_header = next_header;
                             }
@@ -281,8 +280,7 @@ impl<'a> ZshOptionPrescanner<'a> {
                         }
                         PrescanSeparator::OpenBrace => {
                             if is_prescan_function_body_start(function_header) {
-                                local_scopes
-                                    .push(PrescanLocalScope::brace_group(self.state.clone()));
+                                local_scopes.push(PrescanLocalScope::brace_group(self.state));
                             } else if let Some(scope) = local_scopes.last_mut() {
                                 scope.brace_depth += 1;
                             }
@@ -311,12 +309,12 @@ impl<'a> ZshOptionPrescanner<'a> {
     }
 
     fn finish_command(&mut self, words: &[String], end_offset: usize) {
-        let mut next = self.state.clone();
+        let mut next = self.state;
         if !apply_prescan_command_effects(words, &mut next) || next == self.state {
             return;
         }
 
-        self.state = next.clone();
+        self.state = next;
         self.entries.push(ZshOptionTimelineEntry {
             offset: end_offset,
             state: next,
@@ -496,7 +494,7 @@ impl<'a> ZshOptionPrescanner<'a> {
                 unreachable!("scope just matched");
             };
             if self.state != scope.saved_state {
-                self.state = scope.saved_state.clone();
+                self.state = scope.saved_state;
                 self.entries.push(ZshOptionTimelineEntry {
                     offset,
                     state: scope.saved_state,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1048,7 +1048,7 @@ impl SemanticModel {
 
     fn zsh_runtime_options_at(&self, offset: usize) -> Option<ZshOptionState> {
         self.shell_profile.zsh_options()?;
-        let ordinary = self.zsh_options_at(offset)?.clone();
+        let ordinary = *self.zsh_options_at(offset)?;
         let ambiguous_entry = self.zsh_runtime_ambiguous_entry_mask();
         if ambiguous_entry.is_empty() {
             return None;
@@ -1060,7 +1060,7 @@ impl SemanticModel {
             .zsh_runtime_analysis_for_function(function_scope)
             .and_then(|analysis| analysis.options_at(&self.scopes, offset));
 
-        Some(ambient.map_or(ordinary.clone(), |options| ordinary.merge(options)))
+        Some(ambient.map_or(ordinary, |options| ordinary.merge(options)))
     }
 
     fn zsh_runtime_by_function(&self) -> &FxHashMap<ScopeId, OnceLock<Option<ZshOptionAnalysis>>> {
@@ -1088,7 +1088,7 @@ impl SemanticModel {
         function_scope: ScopeId,
     ) -> Option<ZshOptionAnalysis> {
         let function_entry_offset = self.scope(function_scope).span.start.offset;
-        let mut function_entry = self.zsh_options_at(function_entry_offset)?.clone();
+        let mut function_entry = *self.zsh_options_at(function_entry_offset)?;
         for field in self.zsh_runtime_ambiguous_entry_mask().iter() {
             crate::zsh_options::set_public_option_field(
                 &mut function_entry,

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -76,7 +76,7 @@ impl ShellProfileKey {
     fn from_profile(profile: &ShellProfile) -> Self {
         Self {
             dialect: profile.dialect,
-            options: profile.options.clone(),
+            options: profile.options,
         }
     }
 }

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -95,7 +95,7 @@ struct InternalState {
 
 impl InternalState {
     fn from_profile(profile: &ShellProfile) -> Option<Self> {
-        Some(Self::from_public(profile.zsh_options()?.clone()))
+        Some(Self::from_public(*profile.zsh_options()?))
     }
 
     fn from_public(public: ZshOptionState) -> Self {
@@ -603,9 +603,9 @@ impl<'a> Analyzer<'a> {
         state: EvalState,
         leak: LeakBehavior,
     ) -> EvalState {
-        self.record_scope_entry(scope, &state.current.public);
+        self.record_scope_entry(scope, state.current.public);
         let recorded = self.recorded_program.command(command);
-        self.record_snapshot(scope, recorded.span.start.offset, &state.current.public);
+        self.record_snapshot(scope, recorded.span.start.offset, state.current.public);
         self.analyze_command(scope, command, state, leak)
     }
 
@@ -616,10 +616,10 @@ impl<'a> Analyzer<'a> {
         mut state: EvalState,
         leak: LeakBehavior,
     ) -> EvalState {
-        self.record_scope_entry(scope, &state.current.public);
+        self.record_scope_entry(scope, state.current.public);
         for &command in self.recorded_program.commands_in(commands) {
             let recorded = self.recorded_program.command(command);
-            self.record_snapshot(scope, recorded.span.start.offset, &state.current.public);
+            self.record_snapshot(scope, recorded.span.start.offset, state.current.public);
             state = self.analyze_command(scope, command, state, leak);
         }
         state
@@ -948,7 +948,7 @@ impl<'a> Analyzer<'a> {
         let localize = local && in_function;
         let fields = ZshOptionField::ALL;
         let next_public = ZshOptionState::for_emulate(mode);
-        state.current.public = next_public.clone();
+        state.current.public = next_public;
         state.current.emulation = EmulationState::from_mode(mode);
         if localize {
             state.current.local_options = OptionValue::On;
@@ -1037,13 +1037,13 @@ impl<'a> Analyzer<'a> {
         match leak {
             LeakBehavior::Never => {}
             LeakBehavior::Always => {
-                state.outward.public = next.clone();
+                state.outward.public = *next;
                 state.outward_touched.insert_all(fields.iter().copied());
             }
             LeakBehavior::Function => match state.current.local_options {
                 OptionValue::On => {}
                 OptionValue::Off => {
-                    state.outward.public = next.clone();
+                    state.outward.public = *next;
                     state.outward_touched.insert_all(fields.iter().copied());
                 }
                 OptionValue::Unknown => {
@@ -1107,27 +1107,24 @@ impl<'a> Analyzer<'a> {
         }
     }
 
-    fn record_scope_entry(&mut self, scope: ScopeId, state: &ZshOptionState) {
+    fn record_scope_entry(&mut self, scope: ScopeId, state: ZshOptionState) {
         self.scope_entries
             .entry(scope)
-            .and_modify(|current| *current = current.merge(state))
-            .or_insert_with(|| state.clone());
+            .and_modify(|current| *current = current.merge(&state))
+            .or_insert(state);
     }
 
-    fn record_snapshot(&mut self, scope: ScopeId, offset: usize, state: &ZshOptionState) {
+    fn record_snapshot(&mut self, scope: ScopeId, offset: usize, state: ZshOptionState) {
         let snapshots = self.snapshots.entry(scope).or_default();
         if let Some(existing) = snapshots
             .iter_mut()
             .find(|snapshot| snapshot.offset == offset)
         {
-            existing.state = existing.state.merge(state);
+            existing.state = existing.state.merge(&state);
             return;
         }
 
-        snapshots.push(ZshOptionSnapshot {
-            offset,
-            state: state.clone(),
-        });
+        snapshots.push(ZshOptionSnapshot { offset, state });
     }
 }
 


### PR DESCRIPTION
## Summary
- `ZshOptionState` is 27 `OptionValue` fields (each a 1-byte unit enum). It's already a Plain-Old-Data struct of 27 bytes; deriving `Copy` lets it be passed by value through the option-state analyzer and prescanner instead of threading `&ZshOptionState` references through merge/snapshot helpers.
- Removes 11 `.clone()` calls and 4 `&ZshOptionState` borrows. `record_snapshot` and `record_scope_entry` now take state by value.

## Performance impact
None measurable. `Clone` for a struct of `Copy` fields was already lowered to a 27-byte memcpy by the compiler, so the prior `.clone()` calls weren't allocating — they were copying the same bytes that move semantics would copy. Verified with dhat:

| | bytes | blocks |
|---|---|---|
| main | 247,099,252 | 728,214 |
| this PR | 247,099,252 | 728,214 |

Wall clock on `romkatv__powerlevel10k__internal__p10k.zsh` (12 iterations × 5 runs each, profiling profile):
- main median: 79.1 ms
- this PR median: 77.8 ms

Within run-to-run variance (±5 ms). Diagnostic count unchanged at 1,718.

## Test plan
- [x] `cargo test -p shuck-parser --lib` (697 pass)
- [x] `cargo test -p shuck-semantic --lib` (402 pass)
- [x] `cargo test -p shuck-linter --lib` (3,262 pass)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] Diagnostic output diff vs. main on p10k.zsh: empty