### PR TITLE
fix(linter): model zsh by-name builtin effects

### DIFF
--- a/crates/shuck-benchmark/examples/large_corpus_profile.rs
+++ b/crates/shuck-benchmark/examples/large_corpus_profile.rs
@@ -31,11 +31,6 @@ const LARGE_CORPUS_STATIC_IGNORE_SUFFIXES: &[&str] = &[
     "moovweb__gvm__examples__native__ltmain.sh",
     "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh",
 ];
-const LARGE_CORPUS_STATIC_ZSH_OVERRIDE_SUFFIXES: &[&str] = &[
-    "ohmyzsh__ohmyzsh__oh-my-zsh.sh",
-    "ohmyzsh__ohmyzsh__tools__check_for_upgrade.sh",
-];
-
 type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 #[derive(Debug)]
@@ -517,10 +512,6 @@ fn resolve_shell(path: &Path, src: &[u8]) -> String {
     if trimmed_first_line.starts_with("#compdef") || trimmed_first_line.starts_with("#autoload") {
         return "zsh".into();
     }
-    if path_has_large_corpus_static_zsh_override(path) {
-        return "zsh".into();
-    }
-
     match ShellDialect::infer(source, Some(path)) {
         ShellDialect::Bash => "bash".into(),
         ShellDialect::Ksh | ShellDialect::Mksh => "ksh".into(),
@@ -611,10 +602,6 @@ fn normalize_cache_rel_path(path: &Path) -> String {
 
 fn path_is_statically_ignored_large_corpus_fixture(path: &Path) -> bool {
     path_matches_large_corpus_suffix(path, LARGE_CORPUS_STATIC_IGNORE_SUFFIXES)
-}
-
-fn path_has_large_corpus_static_zsh_override(path: &Path) -> bool {
-    path_matches_large_corpus_suffix(path, LARGE_CORPUS_STATIC_ZSH_OVERRIDE_SUFFIXES)
 }
 
 fn path_matches_large_corpus_suffix(path: &Path, suffixes: &[&str]) -> bool {

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -60,10 +60,6 @@ const LARGE_CORPUS_STATIC_IGNORE_SUFFIXES: &[&str] = &[
     "moovweb__gvm__examples__native__ltmain.sh",
     "ohmyzsh__ohmyzsh__plugins__alias-finder__tests__test_run.sh",
 ];
-const LARGE_CORPUS_STATIC_ZSH_OVERRIDE_SUFFIXES: &[&str] = &[
-    "ohmyzsh__ohmyzsh__oh-my-zsh.sh",
-    "ohmyzsh__ohmyzsh__tools__check_for_upgrade.sh",
-];
 const LARGE_CORPUS_SHELLCHECK_UNSUPPORTED_REPO_PREFIXES: &[&str] = &["ohmyzsh__ohmyzsh__"];
 const LARGE_CORPUS_SHELLCHECK_PARSE_IGNORE_SUFFIXES: &[&str] = &[
     "SlackBuildsOrg__slackbuilds__network__modemu2k__modemu2k.SlackBuild",
@@ -1960,10 +1956,6 @@ fn effective_large_corpus_shell(fixture: &LargeCorpusFixture) -> &str {
 }
 
 fn fixture_looks_like_zsh(fixture: &LargeCorpusFixture) -> bool {
-    if path_has_large_corpus_static_zsh_override(&fixture.path) {
-        return true;
-    }
-
     let Some(name) = fixture.path.file_name().and_then(|name| name.to_str()) else {
         return false;
     };
@@ -1982,10 +1974,6 @@ fn path_is_statically_ignored_large_corpus_fixture(path: &Path) -> bool {
 
 fn path_is_ignored_large_corpus_shellcheck_parse_fixture(path: &Path) -> bool {
     path_matches_large_corpus_suffix(path, LARGE_CORPUS_SHELLCHECK_PARSE_IGNORE_SUFFIXES)
-}
-
-fn path_has_large_corpus_static_zsh_override(path: &Path) -> bool {
-    path_matches_large_corpus_suffix(path, LARGE_CORPUS_STATIC_ZSH_OVERRIDE_SUFFIXES)
 }
 
 fn path_is_shellcheck_unsupported_large_corpus_fixture(path: &Path) -> bool {
@@ -2355,10 +2343,6 @@ fn resolve_shell(path: &Path, src: &[u8]) -> String {
     if trimmed_first_line.starts_with("#compdef") || trimmed_first_line.starts_with("#autoload") {
         return "zsh".into();
     }
-    if path_has_large_corpus_static_zsh_override(path) {
-        return "zsh".into();
-    }
-
     match shuck_linter::ShellDialect::infer(source, Some(path)) {
         shuck_linter::ShellDialect::Bash => "bash".into(),
         shuck_linter::ShellDialect::Ksh | shuck_linter::ShellDialect::Mksh => "ksh".into(),
@@ -2898,11 +2882,11 @@ mod tests {
     }
 
     #[test]
-    fn resolve_shell_static_zsh_override_is_zsh() {
+    fn resolve_shell_zsh_source_marker_before_sh_extension_is_zsh() {
         assert_eq!(
             resolve_shell(
                 Path::new("ohmyzsh__ohmyzsh__oh-my-zsh.sh"),
-                b"# comment only\n",
+                b"[[ -n \"$ZSH\" ]] || export ZSH=\"${${(%):-%x}:a:h}\"\n",
             ),
             "zsh"
         );
@@ -3341,15 +3325,20 @@ mod tests {
     }
 
     #[test]
-    fn static_zsh_override_paths_are_selected_for_large_corpus_zsh_parse() {
+    fn zsh_source_markers_are_selected_for_large_corpus_zsh_parse() {
+        let path = Path::new("ohmyzsh__ohmyzsh__tools__check_for_upgrade.sh");
+        let shell = resolve_shell(
+            path,
+            b"emulate -L zsh\nzstyle -s ':omz:update' mode update_mode\n",
+        );
         let fixture = LargeCorpusFixture {
-            path: PathBuf::from("ohmyzsh__ohmyzsh__tools__check_for_upgrade.sh"),
-            cache_rel_path: PathBuf::from("ohmyzsh__ohmyzsh__tools__check_for_upgrade.sh"),
-            shell: "sh".into(),
+            path: path.to_path_buf(),
+            cache_rel_path: path.to_path_buf(),
+            shell,
             source_hash: String::new(),
         };
 
-        assert_eq!(effective_large_corpus_shell(&fixture), "zsh");
+        assert_eq!(fixture.shell, "zsh");
         assert!(fixture_selected_for_large_corpus_zsh_parse(&fixture));
         assert!(!fixture_supported_for_large_corpus(&fixture, None));
     }

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -2901,6 +2901,17 @@ mod tests {
     }
 
     #[test]
+    fn resolve_shell_bash_extension_ignores_zsh_compatibility_guards() {
+        assert_eq!(
+            resolve_shell(
+                Path::new("git-completion.bash"),
+                b"if [[ -n ${ZSH_VERSION-} ]]; then\n  emulate -L zsh\nfi\n",
+            ),
+            "bash"
+        );
+    }
+
+    #[test]
     fn resolve_shell_bom_prefixed_bash_shebang_without_extension() {
         assert_eq!(
             resolve_shell(

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -567,6 +567,66 @@ print -r -- $user_pmodule_dirs
     }
 
     #[test]
+    fn zsh_zstyle_option_parsing_finds_targets_after_flags_and_double_dash() {
+        let source = "\
+#!/bin/zsh
+zstyle -q -a ':prezto:load' pmodule-dirs configured_modules
+print -r -- $configured_modules
+zstyle -q -s -- ':prezto:module:editor' key-bindings key_bindings
+print -r -- $key_bindings
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_zstyle_dynamic_context_and_style_still_assign_static_targets() {
+        let source = "\
+#!/bin/zsh
+context=':prezto:module:prompt'
+style=theme
+zstyle -s $context $style prompt_theme
+print -r -- $prompt_theme
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_zstyle_without_by_name_mode_or_static_target_does_not_create_bindings() {
+        let source = "\
+#!/bin/zsh
+target=resolved_target
+zstyle ':prezto:module:prompt' theme ignored_theme
+print -r -- $ignored_theme
+zstyle -s ':prezto:module:prompt' theme $target
+print -r -- $resolved_target
+zstyle -e ':prezto:module:prompt' theme 'reply=(default)'
+print -r -- $reply
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$ignored_theme", "$resolved_target", "$reply"]
+        );
+    }
+
+    #[test]
     fn zsh_zstyle_other_modes_do_not_define_named_targets() {
         for option in ["-g", "-d", "-m", "-t"] {
             let source = format!(

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -609,6 +609,31 @@ _describe -t tag -T display description consumed -U
     }
 
     #[test]
+    fn zsh_describe_o_option_value_is_not_an_array_read() {
+        let source = "\
+#!/bin/zsh
+opt=-o
+nosort=1
+description=1
+consumed=(init:Initialize update:Update)
+_describe -o nosort description consumed
+_describe $opt nosort description consumed
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["nosort", "description"]
+        );
+    }
+
+    #[test]
     fn zsh_describe_does_not_treat_trailing_option_operands_as_reads() {
         let source = "\
 #!/bin/zsh
@@ -832,10 +857,10 @@ unused=(other:'unused')
     }
 
     #[test]
-    fn zsh_describe_does_not_consume_descriptor_after_dynamic_options() {
+    fn zsh_describe_does_not_consume_descriptor_after_dynamic_no_value_options() {
         let source = "\
 #!/bin/zsh
-opts='-o'
+opts='-O'
 desc=(not:target)
 values=(git)
 _describe \"$opts\" desc values

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -562,7 +562,7 @@ _describe -V -t git-refs 'Git References' refs -U
     }
 
     #[test]
-    fn zsh_describe_reads_all_static_array_operands_after_the_description() {
+    fn zsh_describe_reads_up_to_two_static_array_operands_after_the_description() {
         let source = "\
 #!/bin/zsh
 primary=(init:Initialize update:Update)
@@ -575,11 +575,17 @@ _describe -- 'command' primary secondary tertiary
             &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
         );
 
-        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["tertiary"]
+        );
     }
 
     #[test]
-    fn zsh_describe_does_not_treat_options_or_description_as_reads() {
+    fn zsh_describe_does_not_treat_options_as_reads() {
         let source = "\
 #!/bin/zsh
 tag=1
@@ -598,7 +604,7 @@ _describe -t tag -T display description consumed -U
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["tag", "display", "description"]
+            vec!["tag", "display"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -543,6 +543,109 @@ functions[iterm2_precmd]=x
     }
 
     #[test]
+    fn zsh_describe_by_name_arrays_count_as_reads() {
+        let source = "\
+#!/bin/zsh
+cmds=(init:Initialize update:Update)
+subcmds=(add:Add remove:Remove)
+refs=(main:Main)
+_describe 'command' cmds
+_describe -t commands command subcmds
+_describe -V -t git-refs 'Git References' refs -U
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_describe_reads_all_static_array_operands_after_the_description() {
+        let source = "\
+#!/bin/zsh
+primary=(init:Initialize update:Update)
+secondary=(add:Add remove:Remove)
+tertiary=(main:Main)
+_describe -- 'command' primary secondary tertiary
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_describe_does_not_treat_options_or_description_as_reads() {
+        let source = "\
+#!/bin/zsh
+tag=1
+display=1
+description=1
+consumed=(init:Initialize update:Update)
+_describe -t tag -T display description consumed -U
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["tag", "display", "description"]
+        );
+    }
+
+    #[test]
+    fn zsh_describe_ignores_dynamic_array_names() {
+        let source = "\
+#!/bin/zsh
+target=choices
+choices=(init:Initialize update:Update)
+_describe 'command' $target
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["choices"]
+        );
+    }
+
+    #[test]
+    fn describe_by_name_reads_are_zsh_only() {
+        let source = "\
+#!/bin/bash
+cmds=(init update)
+_describe 'command' cmds
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Bash),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["cmds"]
+        );
+    }
+
+    #[test]
     fn read_rest_names_are_treated_as_intentional_placeholders() {
         let source = "#!/bin/bash\nread -r cron_id rest\nprintf '%s\\n' \"$cron_id\"\n";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedAssignment));

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -603,6 +603,31 @@ _describe -t tag -T display description consumed -U
     }
 
     #[test]
+    fn zsh_describe_does_not_treat_trailing_option_operands_as_reads() {
+        let source = "\
+#!/bin/zsh
+cmds=(init:Initialize update:Update)
+group=commands
+message=Commands
+prefix='('
+suffix=')'
+_describe 'command' cmds -V group -X message -P prefix -S suffix -U
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["group", "message", "prefix", "suffix"]
+        );
+    }
+
+    #[test]
     fn zsh_describe_ignores_dynamic_array_names() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -609,7 +609,7 @@ _describe -t tag -T display description consumed -U
     }
 
     #[test]
-    fn zsh_describe_o_option_value_is_not_an_array_read() {
+    fn zsh_describe_o_option_does_not_take_a_value() {
         let source = "\
 #!/bin/zsh
 opt=-o
@@ -629,7 +629,7 @@ _describe $opt nosort description consumed
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["nosort", "description"]
+            vec!["nosort"]
         );
     }
 
@@ -860,7 +860,7 @@ unused=(other:'unused')
     fn zsh_describe_does_not_consume_descriptor_after_dynamic_no_value_options() {
         let source = "\
 #!/bin/zsh
-opts='-O'
+opts='-o'
 desc=(not:target)
 values=(git)
 _describe \"$opts\" desc values

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -135,7 +135,8 @@ impl ShellDialect {
 fn line_has_bash_marker(line: &str) -> bool {
     contains_unquoted_parameter(line, "BASH_SOURCE")
         || contains_unquoted_parameter(line, "BASH_VERSION")
-        || contains_shell_word(line, "PROMPT_COMMAND")
+        || contains_unquoted_parameter(line, "PROMPT_COMMAND")
+        || starts_with_assignment(line, "PROMPT_COMMAND")
         || starts_with_shell_word(line, "shopt")
 }
 
@@ -168,8 +169,11 @@ fn starts_with_shell_word(line: &str, needle: &str) -> bool {
         .is_some_and(|word| *word == needle)
 }
 
-fn contains_shell_word(line: &str, needle: &str) -> bool {
-    shell_words(line).iter().any(|word| *word == needle)
+fn starts_with_assignment(line: &str, name: &str) -> bool {
+    let Some(suffix) = line.trim_start().strip_prefix(name) else {
+        return false;
+    };
+    suffix.starts_with('=') || suffix.starts_with("+=")
 }
 
 fn contains_unquoted_parameter(line: &str, name: &str) -> bool {
@@ -302,7 +306,7 @@ autoload -U compaudit compinit
     #[test]
     fn ignores_quoted_dialect_marker_names_without_shell_usage() {
         let inferred = ShellDialect::infer(
-            "printf '%s\\n' \"ZSH_VERSION\" \"BASH_VERSION\"\n",
+            "printf '%s\\n' \"ZSH_VERSION\" \"BASH_VERSION\" \"PROMPT_COMMAND\"\n",
             Some(Path::new("/tmp/example.sh")),
         );
         assert_eq!(inferred, ShellDialect::Sh);

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -51,6 +51,7 @@ impl ShellDialect {
     pub fn infer(source: &str, path: Option<&Path>) -> Self {
         Self::infer_from_shellcheck_header(source)
             .or_else(|| Self::infer_from_shebang(source))
+            .or_else(|| Self::infer_from_source_markers(source))
             .unwrap_or_else(|| {
                 path.map_or(Self::Unknown, |path| {
                     match path
@@ -99,6 +100,82 @@ impl ShellDialect {
 
         None
     }
+
+    fn infer_from_source_markers(source: &str) -> Option<Self> {
+        let mut saw_bash_marker = false;
+        let mut saw_zsh_marker = false;
+
+        for line in source.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with('#') {
+                let comment = trimmed.trim_start_matches('#').trim_start();
+                if comment.starts_with("compdef") || comment.starts_with("autoload") {
+                    saw_zsh_marker = true;
+                }
+                continue;
+            }
+
+            let code = trimmed.split('#').next().unwrap_or(trimmed);
+            saw_bash_marker |= line_has_bash_marker(code);
+            saw_zsh_marker |= line_has_zsh_marker(code);
+
+            if saw_bash_marker && saw_zsh_marker {
+                return None;
+            }
+        }
+
+        match (saw_bash_marker, saw_zsh_marker) {
+            (true, false) => Some(Self::Bash),
+            (false, true) => Some(Self::Zsh),
+            _ => None,
+        }
+    }
+}
+
+fn line_has_bash_marker(line: &str) -> bool {
+    contains_shell_word(line, "BASH_SOURCE")
+        || contains_shell_word(line, "BASH_VERSION")
+        || contains_shell_word(line, "PROMPT_COMMAND")
+        || starts_with_shell_word(line, "shopt")
+}
+
+fn line_has_zsh_marker(line: &str) -> bool {
+    contains_shell_word(line, "ZSH_VERSION")
+        || contains_shell_word(line, "ZSH_EVAL_CONTEXT")
+        || starts_with_shell_word(line, "zstyle")
+        || starts_with_shell_word(line, "zmodload")
+        || line_has_zsh_emulate_marker(line)
+        || line_has_zsh_autoload_marker(line)
+        || line.contains("${${")
+        || line.contains("${(%):-%x}")
+        || line.contains("${+commands[")
+}
+
+fn line_has_zsh_emulate_marker(line: &str) -> bool {
+    let words = shell_words(line);
+    words.first().is_some_and(|word| *word == "emulate")
+        && words.iter().skip(1).any(|word| *word == "zsh")
+}
+
+fn line_has_zsh_autoload_marker(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("autoload ") && trimmed.split_whitespace().any(|word| word.starts_with('-'))
+}
+
+fn starts_with_shell_word(line: &str, needle: &str) -> bool {
+    shell_words(line)
+        .first()
+        .is_some_and(|word| *word == needle)
+}
+
+fn contains_shell_word(line: &str, needle: &str) -> bool {
+    shell_words(line).iter().any(|word| *word == needle)
+}
+
+fn shell_words(line: &str) -> Vec<&str> {
+    line.split(|ch: char| !(ch == '_' || ch.is_ascii_alphanumeric()))
+        .filter(|word| !word.is_empty())
+        .collect()
 }
 
 #[cfg(test)]
@@ -121,6 +198,56 @@ mod tests {
     fn infers_from_extension_when_shebang_is_missing() {
         let inferred = ShellDialect::infer("local foo=bar\n", Some(Path::new("/tmp/example.bash")));
         assert_eq!(inferred, ShellDialect::Bash);
+    }
+
+    #[test]
+    fn infers_zsh_from_source_markers_before_sh_extension() {
+        let source = r#"
+[[ -n "$ZSH" ]] || export ZSH="${${(%):-%x}:a:h}"
+zstyle -s ':omz:update' mode update_mode
+autoload -U compaudit compinit
+"#;
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/oh-my-zsh.sh")));
+        assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn infers_zsh_from_compdef_comment_before_sh_extension() {
+        let inferred = ShellDialect::infer(
+            "#compdef git\n_arguments '*:: :->args'\n",
+            Some(Path::new("/tmp/_git.sh")),
+        );
+        assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn infers_bash_from_source_markers_before_sh_extension() {
+        let source = r#"
+if [[ "${BASH_SOURCE[0]}" == */* ]]; then
+  shopt -s promptvars
+  PROMPT_COMMAND=update_prompt
+fi
+"#;
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/gitstatus.plugin.sh")));
+        assert_eq!(inferred, ShellDialect::Bash);
+    }
+
+    #[test]
+    fn keeps_plain_sh_extension_as_sh_without_specific_markers() {
+        let inferred = ShellDialect::infer(
+            "local foo=bar\n[[ -n $foo ]] && echo \"$foo\"\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn ambiguous_bash_and_zsh_markers_fall_back_to_extension() {
+        let inferred = ShellDialect::infer(
+            "echo \"$BASH_VERSION $ZSH_VERSION\"\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(inferred, ShellDialect::Sh);
     }
 
     #[test]

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -105,18 +105,18 @@ impl ShellDialect {
         let mut saw_bash_marker = false;
         let mut saw_zsh_marker = false;
         let mut at_directive_prefix = true;
-        let mut heredoc_delimiter: Option<(String, bool)> = None;
+        let mut heredoc_delimiters: Vec<(String, bool)> = Vec::new();
 
         for line in source.lines() {
             let trimmed = line.trim_start();
-            if let Some((delimiter, strip_tabs)) = heredoc_delimiter.as_ref() {
+            if let Some((delimiter, strip_tabs)) = heredoc_delimiters.first() {
                 let candidate = if *strip_tabs {
                     line.trim_start_matches('\t')
                 } else {
                     line
                 };
                 if candidate.trim_end() == delimiter {
-                    heredoc_delimiter = None;
+                    heredoc_delimiters.remove(0);
                 }
                 continue;
             }
@@ -137,7 +137,7 @@ impl ShellDialect {
             let code = code_before_comment(trimmed);
             saw_bash_marker |= line_has_bash_marker(code);
             saw_zsh_marker |= line_has_zsh_marker(code);
-            heredoc_delimiter = line_heredoc_delimiter(code);
+            heredoc_delimiters.extend(line_heredoc_delimiters(code));
             at_directive_prefix = false;
 
             if saw_bash_marker && saw_zsh_marker {
@@ -217,9 +217,7 @@ fn code_before_comment(line: &str) -> &str {
         if byte == b'#'
             && !in_single_quotes
             && !in_double_quotes
-            && bytes[..index]
-                .last()
-                .is_none_or(|previous| previous.is_ascii_whitespace() || shell_separator(*previous))
+            && hash_starts_comment(bytes, index)
         {
             return &line[..index];
         }
@@ -229,19 +227,56 @@ fn code_before_comment(line: &str) -> &str {
     line
 }
 
-fn line_heredoc_delimiter(line: &str) -> Option<(String, bool)> {
+fn hash_starts_comment(bytes: &[u8], index: usize) -> bool {
+    if index == 0 {
+        return true;
+    }
+    let previous_index = index - 1;
+    let previous = bytes[previous_index];
+    (previous.is_ascii_whitespace() || shell_separator(previous))
+        && !is_escaped_byte(bytes, previous_index)
+}
+
+fn is_escaped_byte(bytes: &[u8], index: usize) -> bool {
+    let mut backslashes = 0usize;
+    for byte in bytes[..index].iter().rev() {
+        if *byte == b'\\' {
+            backslashes += 1;
+        } else {
+            break;
+        }
+    }
+    backslashes % 2 == 1
+}
+
+fn line_heredoc_delimiters(line: &str) -> Vec<(String, bool)> {
+    let mut delimiters = Vec::new();
+    let mut rest = line;
+
+    while let Some((delimiter, consumed)) = next_heredoc_delimiter(rest) {
+        delimiters.push(delimiter);
+        rest = &rest[consumed.min(rest.len())..];
+    }
+
+    delimiters
+}
+
+fn next_heredoc_delimiter(line: &str) -> Option<((String, bool), usize)> {
     let redirect_start = heredoc_redirect_start(line)?;
     let mut rest = &line[redirect_start + 2..];
     let strip_tabs = rest.starts_with('-');
+    let mut consumed = redirect_start + 2;
     if strip_tabs {
         rest = &rest[1..];
+        consumed += 1;
     }
     let delimiter = heredoc_delimiter_token(rest)?;
+    consumed += delimiter.len();
     let delimiter = delimiter
         .trim_matches('\'')
         .trim_matches('"')
         .trim_matches('\\');
-    (!delimiter.is_empty()).then(|| (delimiter.to_owned(), strip_tabs))
+    (!delimiter.is_empty()).then(|| ((delimiter.to_owned(), strip_tabs), consumed))
 }
 
 fn heredoc_delimiter_token(rest: &str) -> Option<&str> {
@@ -583,6 +618,28 @@ cat <<EOF; printf '%s\\n' done
 $ZSH_VERSION
 EOF
 printf '%s\\n' \"$ZSH_VERSION\"
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn multiple_heredoc_bodies_stay_inert_during_source_marker_inference() {
+        let source = "\
+cat <<EOF <<BAR
+plain text
+EOF
+$ZSH_VERSION
+BAR
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn escaped_whitespace_before_hash_does_not_start_a_comment() {
+        let source = "\
+printf '%s\\n' foo\\ # \"$ZSH_VERSION\"
 ";
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
         assert_eq!(inferred, ShellDialect::Zsh);

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -185,11 +185,8 @@ fn line_has_zsh_autoload_marker(line: &str) -> bool {
 }
 
 fn line_heredoc_delimiter(line: &str) -> Option<(String, bool)> {
-    let redirect_start = line.find("<<")?;
+    let redirect_start = heredoc_redirect_start(line)?;
     let mut rest = &line[redirect_start + 2..];
-    if rest.starts_with('<') {
-        return None;
-    }
     let strip_tabs = rest.starts_with('-');
     if strip_tabs {
         rest = &rest[1..];
@@ -200,6 +197,86 @@ fn line_heredoc_delimiter(line: &str) -> Option<(String, bool)> {
         .trim_matches('"')
         .trim_matches('\\');
     (!delimiter.is_empty()).then(|| (delimiter.to_owned(), strip_tabs))
+}
+
+fn heredoc_redirect_start(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut index = 0usize;
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut escaped = false;
+    let mut arithmetic_depth = 0usize;
+
+    while index + 1 < bytes.len() {
+        if escaped {
+            escaped = false;
+            index += 1;
+            continue;
+        }
+
+        let byte = bytes[index];
+        if byte == b'\\' {
+            escaped = true;
+            index += 1;
+            continue;
+        }
+
+        if arithmetic_depth > 0 {
+            if bytes.get(index..index + 2) == Some(b"))") {
+                arithmetic_depth -= 1;
+                index += 2;
+            } else {
+                index += 1;
+            }
+            continue;
+        }
+
+        if byte == b'\'' && !in_double_quotes {
+            in_single_quotes = !in_single_quotes;
+            index += 1;
+            continue;
+        }
+        if byte == b'"' && !in_single_quotes {
+            in_double_quotes = !in_double_quotes;
+            index += 1;
+            continue;
+        }
+        if in_single_quotes || in_double_quotes {
+            index += 1;
+            continue;
+        }
+
+        if bytes.get(index..index + 3) == Some(b"$((") {
+            arithmetic_depth += 1;
+            index += 3;
+            continue;
+        }
+        if bytes.get(index..index + 2) == Some(b"((") && arithmetic_command_start(bytes, index) {
+            arithmetic_depth += 1;
+            index += 2;
+            continue;
+        }
+
+        if bytes.get(index..index + 2) == Some(b"<<") {
+            if bytes.get(index + 2) != Some(&b'<') {
+                return Some(index);
+            }
+            index += 3;
+            continue;
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+fn arithmetic_command_start(bytes: &[u8], index: usize) -> bool {
+    bytes[..index]
+        .iter()
+        .rev()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .is_none_or(|byte| matches!(*byte, b';' | b'&' | b'|' | b'('))
 }
 
 fn starts_with_shell_word(line: &str, needle: &str) -> bool {
@@ -404,6 +481,17 @@ EOF
     fn here_strings_do_not_hide_later_source_markers() {
         let source = "\
 cat <<< \"$value\"
+zstyle -s ':omz:update' mode update_mode
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn arithmetic_shifts_do_not_hide_later_source_markers() {
+        let source = "\
+((x<<1))
+value=$((1<<2))
 zstyle -s ':omz:update' mode update_mode
 ";
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -133,15 +133,19 @@ impl ShellDialect {
 }
 
 fn line_has_bash_marker(line: &str) -> bool {
-    contains_shell_word(line, "BASH_SOURCE")
-        || contains_shell_word(line, "BASH_VERSION")
+    line.contains("$BASH_SOURCE")
+        || line.contains("${BASH_SOURCE")
+        || line.contains("$BASH_VERSION")
+        || line.contains("${BASH_VERSION")
         || contains_shell_word(line, "PROMPT_COMMAND")
         || starts_with_shell_word(line, "shopt")
 }
 
 fn line_has_zsh_marker(line: &str) -> bool {
-    contains_shell_word(line, "ZSH_VERSION")
-        || contains_shell_word(line, "ZSH_EVAL_CONTEXT")
+    line.contains("$ZSH_VERSION")
+        || line.contains("${ZSH_VERSION")
+        || line.contains("$ZSH_EVAL_CONTEXT")
+        || line.contains("${ZSH_EVAL_CONTEXT")
         || starts_with_shell_word(line, "zstyle")
         || starts_with_shell_word(line, "zmodload")
         || line_has_zsh_emulate_marker(line)
@@ -224,6 +228,15 @@ autoload -U compaudit compinit
     fn ignores_free_form_comments_that_mention_zsh_directive_words() {
         let inferred = ShellDialect::infer(
             "# autoload helper cache\n# compdef examples live elsewhere\nprintf '%s\\n' ok\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn ignores_quoted_dialect_marker_names_without_shell_usage() {
+        let inferred = ShellDialect::infer(
+            "printf '%s\\n' \"ZSH_VERSION\" \"BASH_VERSION\"\n",
             Some(Path::new("/tmp/example.sh")),
         );
         assert_eq!(inferred, ShellDialect::Sh);

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -104,20 +104,28 @@ impl ShellDialect {
     fn infer_from_source_markers(source: &str) -> Option<Self> {
         let mut saw_bash_marker = false;
         let mut saw_zsh_marker = false;
+        let mut at_directive_prefix = true;
 
         for line in source.lines() {
             let trimmed = line.trim_start();
+            if trimmed.is_empty() || trimmed.starts_with("#!") {
+                continue;
+            }
             if trimmed.starts_with('#') {
                 let comment = trimmed.strip_prefix('#').unwrap_or_default();
-                if comment.starts_with("compdef") || comment.starts_with("autoload") {
+                if at_directive_prefix
+                    && (comment.starts_with("compdef") || comment.starts_with("autoload"))
+                {
                     saw_zsh_marker = true;
                 }
+                at_directive_prefix = false;
                 continue;
             }
 
             let code = trimmed.split('#').next().unwrap_or(trimmed);
             saw_bash_marker |= line_has_bash_marker(code);
             saw_zsh_marker |= line_has_zsh_marker(code);
+            at_directive_prefix = false;
 
             if saw_bash_marker && saw_zsh_marker {
                 return None;
@@ -179,6 +187,9 @@ fn starts_with_assignment(line: &str, name: &str) -> bool {
 fn contains_unquoted_parameter(line: &str, name: &str) -> bool {
     let name_bytes = name.as_bytes();
     contains_unquoted_marker(line, |bytes, index| {
+        if bytes.get(index) != Some(&b'$') {
+            return false;
+        }
         let braced_start = index + 2;
         let braced_end = braced_start + name_bytes.len();
         if bytes.get(index + 1) == Some(&b'{')
@@ -295,6 +306,15 @@ autoload -U compaudit compinit
     }
 
     #[test]
+    fn ignores_late_compdef_comment_markers_after_real_content() {
+        let inferred = ShellDialect::infer(
+            "printf '%s\\n' ok\n#compdef git\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
     fn ignores_free_form_comments_that_mention_zsh_directive_words() {
         let inferred = ShellDialect::infer(
             "# autoload helper cache\n# compdef examples live elsewhere\nprintf '%s\\n' ok\n",
@@ -309,6 +329,13 @@ autoload -U compaudit compinit
             "printf '%s\\n' \"ZSH_VERSION\" \"BASH_VERSION\" \"PROMPT_COMMAND\"\n",
             Some(Path::new("/tmp/example.sh")),
         );
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn ignores_single_literal_dialect_marker_names_without_dollar_prefix() {
+        let inferred =
+            ShellDialect::infer("echo ZSH_VERSION\n", Some(Path::new("/tmp/example.sh")));
         assert_eq!(inferred, ShellDialect::Sh);
     }
 

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -108,7 +108,7 @@ impl ShellDialect {
         for line in source.lines() {
             let trimmed = line.trim_start();
             if trimmed.starts_with('#') {
-                let comment = trimmed.trim_start_matches('#').trim_start();
+                let comment = trimmed.strip_prefix('#').unwrap_or_default();
                 if comment.starts_with("compdef") || comment.starts_with("autoload") {
                     saw_zsh_marker = true;
                 }
@@ -218,6 +218,15 @@ autoload -U compaudit compinit
             Some(Path::new("/tmp/_git.sh")),
         );
         assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn ignores_free_form_comments_that_mention_zsh_directive_words() {
+        let inferred = ShellDialect::infer(
+            "# autoload helper cache\n# compdef examples live elsewhere\nprintf '%s\\n' ok\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(inferred, ShellDialect::Sh);
     }
 
     #[test]

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -219,7 +219,7 @@ fn code_before_comment(line: &str) -> &str {
             && !in_double_quotes
             && bytes[..index]
                 .last()
-                .is_none_or(|previous| previous.is_ascii_whitespace())
+                .is_none_or(|previous| previous.is_ascii_whitespace() || shell_separator(*previous))
         {
             return &line[..index];
         }
@@ -236,12 +236,19 @@ fn line_heredoc_delimiter(line: &str) -> Option<(String, bool)> {
     if strip_tabs {
         rest = &rest[1..];
     }
-    let delimiter = rest.split_whitespace().next()?;
+    let delimiter = heredoc_delimiter_token(rest)?;
     let delimiter = delimiter
         .trim_matches('\'')
         .trim_matches('"')
         .trim_matches('\\');
     (!delimiter.is_empty()).then(|| (delimiter.to_owned(), strip_tabs))
+}
+
+fn heredoc_delimiter_token(rest: &str) -> Option<&str> {
+    let end = rest
+        .find(|ch: char| ch.is_whitespace() || shell_separator_char(ch))
+        .unwrap_or(rest.len());
+    (end > 0).then(|| &rest[..end])
 }
 
 fn heredoc_redirect_start(line: &str) -> Option<usize> {
@@ -322,6 +329,14 @@ fn arithmetic_command_start(bytes: &[u8], index: usize) -> bool {
         .rev()
         .find(|byte| !byte.is_ascii_whitespace())
         .is_none_or(|byte| matches!(*byte, b';' | b'&' | b'|' | b'('))
+}
+
+fn shell_separator(byte: u8) -> bool {
+    matches!(byte, b';' | b'&' | b'|' | b'(' | b')')
+}
+
+fn shell_separator_char(ch: char) -> bool {
+    matches!(ch, ';' | '&' | '|' | '(' | ')')
 }
 
 fn starts_with_shell_word(line: &str, needle: &str) -> bool {
@@ -547,6 +562,27 @@ zstyle -s ':omz:update' mode update_mode
     fn hash_expansions_do_not_hide_later_source_markers_on_the_same_line() {
         let source = "\
 prefix=${name#refs/heads/}; printf '%s\\n' \"$ZSH_VERSION\"
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn comments_after_separators_do_not_count_as_source_markers() {
+        let source = "\
+printf '%s\\n' ok;# \"$ZSH_VERSION\"
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn heredoc_delimiters_stop_before_shell_separators() {
+        let source = "\
+cat <<EOF; printf '%s\\n' done
+$ZSH_VERSION
+EOF
+printf '%s\\n' \"$ZSH_VERSION\"
 ";
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
         assert_eq!(inferred, ShellDialect::Zsh);

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -146,9 +146,9 @@ fn line_has_zsh_marker(line: &str) -> bool {
         || starts_with_shell_word(line, "zmodload")
         || line_has_zsh_emulate_marker(line)
         || line_has_zsh_autoload_marker(line)
-        || line.contains("${${")
-        || line.contains("${(%):-%x}")
-        || line.contains("${+commands[")
+        || contains_unquoted_literal(line, "${${")
+        || contains_unquoted_literal(line, "${(%):-%x}")
+        || contains_unquoted_literal(line, "${+commands[")
 }
 
 fn line_has_zsh_emulate_marker(line: &str) -> bool {
@@ -173,8 +173,41 @@ fn contains_shell_word(line: &str, needle: &str) -> bool {
 }
 
 fn contains_unquoted_parameter(line: &str, name: &str) -> bool {
-    let bytes = line.as_bytes();
     let name_bytes = name.as_bytes();
+    contains_unquoted_marker(line, |bytes, index| {
+        let braced_start = index + 2;
+        let braced_end = braced_start + name_bytes.len();
+        if bytes.get(index + 1) == Some(&b'{')
+            && bytes
+                .get(braced_start..braced_end)
+                .is_some_and(|candidate| candidate == name_bytes)
+            && bytes
+                .get(braced_end)
+                .is_none_or(|byte| !is_shell_name_byte(*byte))
+        {
+            return true;
+        }
+        let plain_start = index + 1;
+        let plain_end = plain_start + name_bytes.len();
+        bytes
+            .get(plain_start..plain_end)
+            .is_some_and(|candidate| candidate == name_bytes)
+            && bytes
+                .get(plain_end)
+                .is_none_or(|byte| !is_shell_name_byte(*byte))
+    })
+}
+
+fn contains_unquoted_literal(line: &str, literal: &str) -> bool {
+    contains_unquoted_marker(line, |bytes, index| {
+        bytes
+            .get(index..index + literal.len())
+            .is_some_and(|candidate| candidate == literal.as_bytes())
+    })
+}
+
+fn contains_unquoted_marker(line: &str, mut matches_at: impl FnMut(&[u8], usize) -> bool) -> bool {
+    let bytes = line.as_bytes();
     let mut index = 0;
     let mut in_single_quotes = false;
     let mut escaped = false;
@@ -196,30 +229,8 @@ fn contains_unquoted_parameter(line: &str, name: &str) -> bool {
             index += 1;
             continue;
         }
-        if !in_single_quotes && byte == b'$' {
-            let braced_start = index + 2;
-            let braced_end = braced_start + name_bytes.len();
-            if bytes.get(index + 1) == Some(&b'{')
-                && bytes
-                    .get(braced_start..braced_end)
-                    .is_some_and(|candidate| candidate == name_bytes)
-                && bytes
-                    .get(braced_end)
-                    .is_none_or(|byte| !is_shell_name_byte(*byte))
-            {
-                return true;
-            }
-            let plain_start = index + 1;
-            let plain_end = plain_start + name_bytes.len();
-            if bytes
-                .get(plain_start..plain_end)
-                .is_some_and(|candidate| candidate == name_bytes)
-                && bytes
-                    .get(plain_end)
-                    .is_none_or(|byte| !is_shell_name_byte(*byte))
-            {
-                return true;
-            }
+        if !in_single_quotes && matches_at(bytes, index) {
+            return true;
         }
         index += 1;
     }
@@ -301,6 +312,15 @@ autoload -U compaudit compinit
     fn ignores_literal_or_escaped_dialect_parameter_markers() {
         let inferred = ShellDialect::infer(
             "printf '%s\\n' '${ZSH_VERSION}' \"\\$BASH_VERSION\" \"$ZSH_VERSIONED\"\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn ignores_literal_or_escaped_zsh_expansion_markers() {
+        let inferred = ShellDialect::infer(
+            "printf '%s\\n' '${${(%):-%x}:a:h}' \"\\${+commands[git]}\"\n",
             Some(Path::new("/tmp/example.sh")),
         );
         assert_eq!(inferred, ShellDialect::Sh);

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -49,27 +49,31 @@ impl ShellDialect {
     }
 
     pub fn infer(source: &str, path: Option<&Path>) -> Self {
+        let extension_dialect = path.map_or(Self::Unknown, Self::infer_from_extension);
         Self::infer_from_shellcheck_header(source)
             .or_else(|| Self::infer_from_shebang(source))
-            .or_else(|| Self::infer_from_source_markers(source))
-            .unwrap_or_else(|| {
-                path.map_or(Self::Unknown, |path| {
-                    match path
-                        .extension()
-                        .and_then(|ext| ext.to_str())
-                        .map(|ext| ext.to_ascii_lowercase())
-                        .as_deref()
-                    {
-                        Some("sh") => Self::Sh,
-                        Some("bash") => Self::Bash,
-                        Some("dash") => Self::Dash,
-                        Some("ksh") => Self::Ksh,
-                        Some("mksh") => Self::Mksh,
-                        Some("zsh") => Self::Zsh,
-                        _ => Self::Unknown,
-                    }
-                })
+            .or_else(|| match extension_dialect {
+                Self::Unknown | Self::Sh => Self::infer_from_source_markers(source),
+                dialect => Some(dialect),
             })
+            .unwrap_or(extension_dialect)
+    }
+
+    fn infer_from_extension(path: &Path) -> Self {
+        match path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|ext| ext.to_ascii_lowercase())
+            .as_deref()
+        {
+            Some("sh") => Self::Sh,
+            Some("bash") => Self::Bash,
+            Some("dash") => Self::Dash,
+            Some("ksh") => Self::Ksh,
+            Some("mksh") => Self::Mksh,
+            Some("zsh") => Self::Zsh,
+            _ => Self::Unknown,
+        }
     }
 
     fn infer_from_shebang(source: &str) -> Option<Self> {
@@ -485,6 +489,17 @@ mod tests {
     #[test]
     fn infers_from_extension_when_shebang_is_missing() {
         let inferred = ShellDialect::infer("local foo=bar\n", Some(Path::new("/tmp/example.bash")));
+        assert_eq!(inferred, ShellDialect::Bash);
+    }
+
+    #[test]
+    fn explicit_bash_extension_wins_over_embedded_zsh_guards() {
+        let source = "\
+if [[ -n ${ZSH_VERSION-} ]]; then
+  emulate -L zsh
+fi
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/git-completion.bash")));
         assert_eq!(inferred, ShellDialect::Bash);
     }
 

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -115,7 +115,7 @@ impl ShellDialect {
                 } else {
                     line
                 };
-                if candidate.trim_end() == delimiter {
+                if candidate == delimiter {
                     heredoc_delimiters.remove(0);
                 }
                 continue;
@@ -632,6 +632,13 @@ EOF
 $ZSH_VERSION
 BAR
 ";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn heredoc_terminators_do_not_allow_trailing_blanks() {
+        let source = "cat <<EOF\nEOF   \n$ZSH_VERSION\nEOF\n";
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
         assert_eq!(inferred, ShellDialect::Sh);
     }

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -308,9 +308,37 @@ fn normalize_heredoc_delimiter(delimiter: &str) -> String {
 }
 
 fn heredoc_delimiter_token(rest: &str) -> Option<&str> {
-    let end = rest
-        .find(|ch: char| ch.is_whitespace() || shell_separator_char(ch))
-        .unwrap_or(rest.len());
+    let mut end = rest.len();
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut escaped = false;
+
+    for (index, ch) in rest.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' && !in_single_quotes {
+            escaped = true;
+            continue;
+        }
+        if ch == '\'' && !in_double_quotes {
+            in_single_quotes = !in_single_quotes;
+            continue;
+        }
+        if ch == '"' && !in_single_quotes {
+            in_double_quotes = !in_double_quotes;
+            continue;
+        }
+        if !in_single_quotes
+            && !in_double_quotes
+            && (ch.is_whitespace() || shell_separator_char(ch))
+        {
+            end = index;
+            break;
+        }
+    }
+
     (end > 0).then(|| &rest[..end])
 }
 
@@ -707,6 +735,18 @@ cat <<- \tBAR
         let source = "cat <<\\\\EOF\n$ZSH_VERSION\n\\EOF\n";
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
         assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn quoted_heredoc_delimiter_separators_do_not_stick_scanner() {
+        let source = "\
+cat <<'EOF)'
+$ZSH_VERSION
+EOF)
+printf '%s\\n' \"$ZSH_VERSION\"
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Zsh);
     }
 
     #[test]

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -187,6 +187,9 @@ fn line_has_zsh_autoload_marker(line: &str) -> bool {
 fn line_heredoc_delimiter(line: &str) -> Option<(String, bool)> {
     let redirect_start = line.find("<<")?;
     let mut rest = &line[redirect_start + 2..];
+    if rest.starts_with('<') {
+        return None;
+    }
     let strip_tabs = rest.starts_with('-');
     if strip_tabs {
         rest = &rest[1..];
@@ -395,6 +398,16 @@ EOF
 ";
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
         assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn here_strings_do_not_hide_later_source_markers() {
+        let source = "\
+cat <<< \"$value\"
+zstyle -s ':omz:update' mode update_mode
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Zsh);
     }
 
     #[test]

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -427,7 +427,7 @@ fn shell_separator(byte: u8) -> bool {
 }
 
 fn shell_separator_char(ch: char) -> bool {
-    matches!(ch, ';' | '&' | '|' | '(' | ')')
+    matches!(ch, ';' | '&' | '|' | '(' | ')' | '<' | '>')
 }
 
 fn starts_with_shell_word(line: &str, needle: &str) -> bool {
@@ -743,6 +743,18 @@ cat <<- \tBAR
 cat <<'EOF)'
 $ZSH_VERSION
 EOF)
+printf '%s\\n' \"$ZSH_VERSION\"
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn heredoc_delimiter_stops_before_following_redirection() {
+        let source = "\
+cat <<EOF>/tmp/out
+$ZSH_VERSION
+EOF
 printf '%s\\n' \"$ZSH_VERSION\"
 ";
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -105,9 +105,21 @@ impl ShellDialect {
         let mut saw_bash_marker = false;
         let mut saw_zsh_marker = false;
         let mut at_directive_prefix = true;
+        let mut heredoc_delimiter: Option<(String, bool)> = None;
 
         for line in source.lines() {
             let trimmed = line.trim_start();
+            if let Some((delimiter, strip_tabs)) = heredoc_delimiter.as_ref() {
+                let candidate = if *strip_tabs {
+                    line.trim_start_matches('\t')
+                } else {
+                    line
+                };
+                if candidate.trim_end() == delimiter {
+                    heredoc_delimiter = None;
+                }
+                continue;
+            }
             if trimmed.is_empty() || trimmed.starts_with("#!") {
                 continue;
             }
@@ -125,6 +137,7 @@ impl ShellDialect {
             let code = trimmed.split('#').next().unwrap_or(trimmed);
             saw_bash_marker |= line_has_bash_marker(code);
             saw_zsh_marker |= line_has_zsh_marker(code);
+            heredoc_delimiter = line_heredoc_delimiter(code);
             at_directive_prefix = false;
 
             if saw_bash_marker && saw_zsh_marker {
@@ -169,6 +182,21 @@ fn line_has_zsh_emulate_marker(line: &str) -> bool {
 fn line_has_zsh_autoload_marker(line: &str) -> bool {
     let trimmed = line.trim_start();
     trimmed.starts_with("autoload ") && trimmed.split_whitespace().any(|word| word.starts_with('-'))
+}
+
+fn line_heredoc_delimiter(line: &str) -> Option<(String, bool)> {
+    let redirect_start = line.find("<<")?;
+    let mut rest = &line[redirect_start + 2..];
+    let strip_tabs = rest.starts_with('-');
+    if strip_tabs {
+        rest = &rest[1..];
+    }
+    let delimiter = rest.split_whitespace().next()?;
+    let delimiter = delimiter
+        .trim_matches('\'')
+        .trim_matches('"')
+        .trim_matches('\\');
+    (!delimiter.is_empty()).then(|| (delimiter.to_owned(), strip_tabs))
 }
 
 fn starts_with_shell_word(line: &str, needle: &str) -> bool {
@@ -354,6 +382,18 @@ autoload -U compaudit compinit
             "printf '%s\\n' '${${(%):-%x}:a:h}' \"\\${+commands[git]}\"\n",
             Some(Path::new("/tmp/example.sh")),
         );
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn ignores_dialect_markers_inside_heredoc_bodies() {
+        let source = "\
+cat <<'EOF'
+$ZSH_VERSION
+${BASH_SOURCE[0]}
+EOF
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
         assert_eq!(inferred, ShellDialect::Sh);
     }
 

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -133,19 +133,15 @@ impl ShellDialect {
 }
 
 fn line_has_bash_marker(line: &str) -> bool {
-    line.contains("$BASH_SOURCE")
-        || line.contains("${BASH_SOURCE")
-        || line.contains("$BASH_VERSION")
-        || line.contains("${BASH_VERSION")
+    contains_unquoted_parameter(line, "BASH_SOURCE")
+        || contains_unquoted_parameter(line, "BASH_VERSION")
         || contains_shell_word(line, "PROMPT_COMMAND")
         || starts_with_shell_word(line, "shopt")
 }
 
 fn line_has_zsh_marker(line: &str) -> bool {
-    line.contains("$ZSH_VERSION")
-        || line.contains("${ZSH_VERSION")
-        || line.contains("$ZSH_EVAL_CONTEXT")
-        || line.contains("${ZSH_EVAL_CONTEXT")
+    contains_unquoted_parameter(line, "ZSH_VERSION")
+        || contains_unquoted_parameter(line, "ZSH_EVAL_CONTEXT")
         || starts_with_shell_word(line, "zstyle")
         || starts_with_shell_word(line, "zmodload")
         || line_has_zsh_emulate_marker(line)
@@ -174,6 +170,65 @@ fn starts_with_shell_word(line: &str, needle: &str) -> bool {
 
 fn contains_shell_word(line: &str, needle: &str) -> bool {
     shell_words(line).iter().any(|word| *word == needle)
+}
+
+fn contains_unquoted_parameter(line: &str, name: &str) -> bool {
+    let bytes = line.as_bytes();
+    let name_bytes = name.as_bytes();
+    let mut index = 0;
+    let mut in_single_quotes = false;
+    let mut escaped = false;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if escaped {
+            escaped = false;
+            index += 1;
+            continue;
+        }
+        if byte == b'\\' {
+            escaped = true;
+            index += 1;
+            continue;
+        }
+        if byte == b'\'' {
+            in_single_quotes = !in_single_quotes;
+            index += 1;
+            continue;
+        }
+        if !in_single_quotes && byte == b'$' {
+            let braced_start = index + 2;
+            let braced_end = braced_start + name_bytes.len();
+            if bytes.get(index + 1) == Some(&b'{')
+                && bytes
+                    .get(braced_start..braced_end)
+                    .is_some_and(|candidate| candidate == name_bytes)
+                && bytes
+                    .get(braced_end)
+                    .is_none_or(|byte| !is_shell_name_byte(*byte))
+            {
+                return true;
+            }
+            let plain_start = index + 1;
+            let plain_end = plain_start + name_bytes.len();
+            if bytes
+                .get(plain_start..plain_end)
+                .is_some_and(|candidate| candidate == name_bytes)
+                && bytes
+                    .get(plain_end)
+                    .is_none_or(|byte| !is_shell_name_byte(*byte))
+            {
+                return true;
+            }
+        }
+        index += 1;
+    }
+
+    false
+}
+
+fn is_shell_name_byte(byte: u8) -> bool {
+    byte == b'_' || byte.is_ascii_alphanumeric()
 }
 
 fn shell_words(line: &str) -> Vec<&str> {
@@ -240,6 +295,30 @@ autoload -U compaudit compinit
             Some(Path::new("/tmp/example.sh")),
         );
         assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn ignores_literal_or_escaped_dialect_parameter_markers() {
+        let inferred = ShellDialect::infer(
+            "printf '%s\\n' '${ZSH_VERSION}' \"\\$BASH_VERSION\" \"$ZSH_VERSIONED\"\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn infers_from_executed_dialect_parameter_markers() {
+        let zsh = ShellDialect::infer(
+            "printf '%s\\n' \"$ZSH_VERSION\"\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(zsh, ShellDialect::Zsh);
+
+        let bash = ShellDialect::infer(
+            "printf '%s\\n' \"${BASH_SOURCE[0]}\"\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(bash, ShellDialect::Bash);
     }
 
     #[test]

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -134,7 +134,7 @@ impl ShellDialect {
                 continue;
             }
 
-            let code = trimmed.split('#').next().unwrap_or(trimmed);
+            let code = code_before_comment(trimmed);
             saw_bash_marker |= line_has_bash_marker(code);
             saw_zsh_marker |= line_has_zsh_marker(code);
             heredoc_delimiter = line_heredoc_delimiter(code);
@@ -182,6 +182,51 @@ fn line_has_zsh_emulate_marker(line: &str) -> bool {
 fn line_has_zsh_autoload_marker(line: &str) -> bool {
     let trimmed = line.trim_start();
     trimmed.starts_with("autoload ") && trimmed.split_whitespace().any(|word| word.starts_with('-'))
+}
+
+fn code_before_comment(line: &str) -> &str {
+    let bytes = line.as_bytes();
+    let mut index = 0usize;
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut escaped = false;
+
+    while index < bytes.len() {
+        if escaped {
+            escaped = false;
+            index += 1;
+            continue;
+        }
+
+        let byte = bytes[index];
+        if byte == b'\\' {
+            escaped = true;
+            index += 1;
+            continue;
+        }
+        if byte == b'\'' && !in_double_quotes {
+            in_single_quotes = !in_single_quotes;
+            index += 1;
+            continue;
+        }
+        if byte == b'"' && !in_single_quotes {
+            in_double_quotes = !in_double_quotes;
+            index += 1;
+            continue;
+        }
+        if byte == b'#'
+            && !in_single_quotes
+            && !in_double_quotes
+            && bytes[..index]
+                .last()
+                .is_none_or(|previous| previous.is_ascii_whitespace())
+        {
+            return &line[..index];
+        }
+        index += 1;
+    }
+
+    line
 }
 
 fn line_heredoc_delimiter(line: &str) -> Option<(String, bool)> {
@@ -493,6 +538,15 @@ zstyle -s ':omz:update' mode update_mode
 ((x<<1))
 value=$((1<<2))
 zstyle -s ':omz:update' mode update_mode
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn hash_expansions_do_not_hide_later_source_markers_on_the_same_line() {
+        let source = "\
+prefix=${name#refs/heads/}; printf '%s\\n' \"$ZSH_VERSION\"
 ";
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
         assert_eq!(inferred, ShellDialect::Zsh);

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -279,11 +279,32 @@ fn next_heredoc_delimiter(line: &str) -> Option<((String, bool), usize)> {
     consumed += blanks;
     let delimiter = heredoc_delimiter_token(rest)?;
     consumed += delimiter.len();
-    let delimiter = delimiter
-        .trim_matches('\'')
-        .trim_matches('"')
-        .trim_matches('\\');
+    let delimiter = normalize_heredoc_delimiter(delimiter);
     (!delimiter.is_empty()).then(|| ((delimiter.to_owned(), strip_tabs), consumed))
+}
+
+fn normalize_heredoc_delimiter(delimiter: &str) -> String {
+    let mut normalized = String::with_capacity(delimiter.len());
+    let mut chars = delimiter.chars();
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\'' if !in_double_quotes => in_single_quotes = !in_single_quotes,
+            '"' if !in_single_quotes => in_double_quotes = !in_double_quotes,
+            '\\' if !in_single_quotes => {
+                if let Some(escaped) = chars.next() {
+                    normalized.push(escaped);
+                } else {
+                    normalized.push(ch);
+                }
+            }
+            _ => normalized.push(ch),
+        }
+    }
+
+    normalized
 }
 
 fn heredoc_delimiter_token(rest: &str) -> Option<&str> {
@@ -677,6 +698,13 @@ cat <<- \tBAR
 \t$ZSH_VERSION
 \tBAR
 ";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
+    fn heredoc_delimiter_quote_removal_preserves_escaped_backslash() {
+        let source = "cat <<\\\\EOF\n$ZSH_VERSION\n\\EOF\n";
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
         assert_eq!(inferred, ShellDialect::Sh);
     }

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -274,6 +274,9 @@ fn next_heredoc_delimiter(line: &str) -> Option<((String, bool), usize)> {
         rest = &rest[1..];
         consumed += 1;
     }
+    let blanks = rest.len() - rest.trim_start().len();
+    rest = &rest[blanks..];
+    consumed += blanks;
     let delimiter = heredoc_delimiter_token(rest)?;
     consumed += delimiter.len();
     let delimiter = delimiter
@@ -432,6 +435,7 @@ fn contains_unquoted_marker(line: &str, mut matches_at: impl FnMut(&[u8], usize)
     let bytes = line.as_bytes();
     let mut index = 0;
     let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
     let mut escaped = false;
 
     while index < bytes.len() {
@@ -446,8 +450,13 @@ fn contains_unquoted_marker(line: &str, mut matches_at: impl FnMut(&[u8], usize)
             index += 1;
             continue;
         }
-        if byte == b'\'' {
+        if byte == b'\'' && !in_double_quotes {
             in_single_quotes = !in_single_quotes;
+            index += 1;
+            continue;
+        }
+        if byte == b'"' && !in_single_quotes {
+            in_double_quotes = !in_double_quotes;
             index += 1;
             continue;
         }
@@ -659,6 +668,20 @@ BAR
     }
 
     #[test]
+    fn heredoc_delimiters_allow_blanks_after_redirect_operator() {
+        let source = "\
+cat << EOF
+$ZSH_VERSION
+EOF
+cat <<- \tBAR
+\t$ZSH_VERSION
+\tBAR
+";
+        let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/example.sh")));
+        assert_eq!(inferred, ShellDialect::Sh);
+    }
+
+    #[test]
     fn escaped_whitespace_before_hash_does_not_start_a_comment() {
         let source = "\
 printf '%s\\n' foo\\ # \"$ZSH_VERSION\"
@@ -674,6 +697,12 @@ printf '%s\\n' foo\\ # \"$ZSH_VERSION\"
             Some(Path::new("/tmp/example.sh")),
         );
         assert_eq!(zsh, ShellDialect::Zsh);
+
+        let zsh_after_apostrophe = ShellDialect::infer(
+            "printf '%s\\n' \"can't\" \"$ZSH_VERSION\"\n",
+            Some(Path::new("/tmp/example.sh")),
+        );
+        assert_eq!(zsh_after_apostrophe, ShellDialect::Zsh);
 
         let bash = ShellDialect::infer(
             "printf '%s\\n' \"${BASH_SOURCE[0]}\"\n",

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -487,8 +487,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         };
 
         match value.as_str() {
-            "-o" | "-t" => DescribeDynamicStart::OptionWithValue,
-            "-O" => DescribeDynamicStart::OptionWithoutValue,
+            "-t" => DescribeDynamicStart::OptionWithValue,
+            "-o" | "-O" => DescribeDynamicStart::OptionWithoutValue,
             _ if value.starts_with('-') && value != "-" => DescribeDynamicStart::Unknown,
             _ => DescribeDynamicStart::Descriptor,
         }
@@ -557,7 +557,7 @@ fn describe_array_names(
             break;
         }
         index += 1;
-        if text == "-o" || text == "-t" {
+        if text == "-t" {
             index += 1;
         }
     }

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -496,24 +496,37 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 }
 
 fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAttributes)> {
-    let index = 0usize;
-    let word = args.get(index)?;
-    let text = static_word_text(word, source)?;
-    match text.as_ref() {
-        "--" => None,
-        "-a" | "-s" | "-b" => {
-            let attributes = if text == "-a" {
-                BindingAttributes::ARRAY
-            } else {
-                BindingAttributes::empty()
-            };
-            args.get(index + 3)
-                .and_then(|word| named_target_word(word, source))
-                .map(|(name, span)| (name, span, attributes))
+    let mut index = 0usize;
+    let mut attributes = None;
+    while let Some(word) = args.get(index) {
+        let Some(text) = static_word_text(word, source) else {
+            break;
+        };
+        if text == "--" {
+            index += 1;
+            break;
         }
-        _ if text.starts_with('-') && text != "-" => None,
-        _ => None,
+        let Some(flags) = text.strip_prefix('-') else {
+            break;
+        };
+        if flags.is_empty() || flags.starts_with('-') {
+            break;
+        }
+        for flag in flags.chars() {
+            match flag {
+                'a' => attributes = Some(BindingAttributes::ARRAY),
+                'b' | 's' => attributes = Some(BindingAttributes::empty()),
+                'q' => {}
+                _ => return None,
+            }
+        }
+        index += 1;
     }
+
+    let attributes = attributes?;
+    args.get(index + 2)
+        .and_then(|word| named_target_word(word, source))
+        .map(|(name, span)| (name, span, attributes))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -487,8 +487,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         };
 
         match value.as_str() {
-            "-t" => DescribeDynamicStart::OptionWithValue,
-            "-o" | "-O" => DescribeDynamicStart::OptionWithoutValue,
+            "-o" | "-t" => DescribeDynamicStart::OptionWithValue,
+            "-O" => DescribeDynamicStart::OptionWithoutValue,
             _ if value.starts_with('-') && value != "-" => DescribeDynamicStart::Unknown,
             _ => DescribeDynamicStart::Descriptor,
         }
@@ -557,7 +557,7 @@ fn describe_array_names(
             break;
         }
         index += 1;
-        if text == "-t" {
+        if text == "-o" || text == "-t" {
             index += 1;
         }
     }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1273,7 +1273,7 @@ _describe \"$desc\" values descriptions
 fn zsh_describe_skips_descriptor_after_dynamic_no_value_options() {
     let source = "\
 #!/bin/zsh
-opts='-O'
+opts='-o'
 desc=(not:target)
 values=(git)
 _describe \"$opts\" desc values

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1270,10 +1270,10 @@ _describe \"$desc\" values descriptions
 }
 
 #[test]
-fn zsh_describe_skips_descriptor_after_dynamic_options() {
+fn zsh_describe_skips_descriptor_after_dynamic_no_value_options() {
     let source = "\
 #!/bin/zsh
-opts='-o'
+opts='-O'
 desc=(not:target)
 values=(git)
 _describe \"$opts\" desc values


### PR DESCRIPTION
## Summary

- model zsh `zstyle -a/-s/-b` target operands as by-name assignments for C006
- model zsh `_describe` array operands as by-name reads for C001
- infer zsh/bash dialect from source markers before falling back to `.sh` extension defaults, and remove large-corpus path-specific zsh overrides

## Root Cause

Some zsh builtins and completion helpers pass variable names as operands. Shuck treated those operands as plain strings, so later reads could look unassigned and helper-consumed arrays could look unused.

## Validation

- `cargo test -p shuck-linter zstyle_`
- `cargo test -p shuck-linter describe_`
- `cargo fmt`
- `git diff --check`
- `make test`