### PR TITLE
fix(semantic): model zsh pipeline tail scope

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -108,6 +108,44 @@ echo \"$count\"
     }
 
     #[test]
+    fn ignores_zsh_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+header=
+printf '%s\\n' x |& grep x | while read -r _; do header=ok; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_nonfinal_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+header=
+print x | { header=bad; print y; } | cat
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -238,6 +238,52 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_always_body_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+{ emulate sh; } always { :; }
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["header"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_always_cleanup_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+{ :; } always { emulate sh; }
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -169,6 +169,29 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_compound_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+{ emulate sh; }
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -192,6 +192,29 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_if_condition_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+if emulate sh; then :; fi
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -215,6 +215,29 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_binary_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+emulate sh && :
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -146,6 +146,29 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+emulate sh
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -131,6 +131,26 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+emulate sh
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -151,6 +151,26 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_compound_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+{ emulate sh; }
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -191,6 +191,26 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_binary_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+emulate sh && :
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -211,6 +211,46 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_always_body_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+{ emulate sh; } always { :; }
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$header"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_always_cleanup_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+{ :; } always { emulate sh; }
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -99,6 +99,38 @@ echo \"$count\"
     }
 
     #[test]
+    fn ignores_zsh_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+header=
+printf '%s\\n' x |& grep x | while read -r _; do header=ok; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_nonfinal_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+header=
+print x | { header=bad; print y; } | cat
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -171,6 +171,26 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn reports_zsh_if_condition_sh_emulation_final_pipeline_component_assignments() {
+        let source = "\
+#!/bin/zsh
+if emulate sh; then :; fi
+header=
+printf '%s\\n' x | while read -r _; do header=bad; done
+print -r -- \"$header\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$header"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_option_map_keys_without_visible_opts_binding() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -14,7 +14,7 @@ use shuck_ast::{
     static_word_text, try_static_word_parts_text,
 };
 use shuck_indexer::Indexer;
-use shuck_parser::{ShellDialect, ShellProfile, ZshEmulationMode, parser::Parser};
+use shuck_parser::{ShellDialect, ShellProfile, ZshEmulationMode, ZshOptionState, parser::Parser};
 use smallvec::SmallVec;
 
 use crate::binding::{
@@ -155,6 +155,17 @@ impl Default for FlowState {
 }
 
 impl FlowState {
+    fn for_shell_profile(profile: &ShellProfile) -> Self {
+        let mut flow = Self::default();
+        if profile.dialect == ShellDialect::Zsh {
+            flow.pipeline_tail_runs_in_current_shell =
+                profile.zsh_options().is_some_and(|options| {
+                    *options != ZshOptionState::for_emulate(ZshEmulationMode::Sh)
+                });
+        }
+        flow
+    }
+
     fn conditional(self) -> Self {
         Self {
             conditionally_executed: true,
@@ -253,7 +264,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             arithmetic_reference_kind: ReferenceKind::ArithmeticRead,
             word_reference_kind_override: None,
         };
-        let file_commands = builder.visit_stmt_seq(&file.body, FlowState::default());
+        let file_commands = builder.visit_stmt_seq(
+            &file.body,
+            FlowState::for_shell_profile(&builder.shell_profile),
+        );
         builder.recorded_program.set_file_commands(file_commands);
         builder.mark_scope_completed(ScopeId(0));
         builder.drain_deferred_functions();

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -14,7 +14,7 @@ use shuck_ast::{
     static_word_text, try_static_word_parts_text,
 };
 use shuck_indexer::Indexer;
-use shuck_parser::{ShellProfile, ZshEmulationMode, parser::Parser};
+use shuck_parser::{ShellDialect, ShellProfile, ZshEmulationMode, parser::Parser};
 use smallvec::SmallVec;
 
 use crate::binding::{
@@ -129,7 +129,7 @@ fn semantic_statement_span(stmt: &Stmt) -> Span {
     Span::from_positions(stmt.span.start, end)
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct FlowState {
     in_function: bool,
     loop_depth: u32,
@@ -137,6 +137,21 @@ struct FlowState {
     in_block: bool,
     exit_status_checked: bool,
     conditionally_executed: bool,
+    pipeline_tail_runs_in_current_shell: bool,
+}
+
+impl Default for FlowState {
+    fn default() -> Self {
+        Self {
+            in_function: false,
+            loop_depth: 0,
+            in_subshell: false,
+            in_block: false,
+            exit_status_checked: false,
+            conditionally_executed: false,
+            pipeline_tail_runs_in_current_shell: true,
+        }
+    }
 }
 
 impl FlowState {

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -161,6 +161,12 @@ impl FlowState {
             ..self
         }
     }
+
+    fn with_zsh_emulation(mut self, mode: Option<ZshEmulationMode>) -> Self {
+        self.pipeline_tail_runs_in_current_shell =
+            !matches!(mode, None | Some(ZshEmulationMode::Sh));
+        self
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -84,13 +84,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 let info = recorded_command_info(command, self.source, self.runtime.bash_enabled());
                 flow_after_zsh_effects(flow, &info.zsh_effects)
             }
-            Command::Compound(CompoundCommand::BraceGroup(commands)) => self.flow_after_stmt_seq(
-                commands,
-                FlowState {
-                    in_block: true,
-                    ..flow
-                },
-            ),
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => {
+                let after_block = self.flow_after_stmt_seq(
+                    commands,
+                    FlowState {
+                        in_block: true,
+                        ..flow
+                    },
+                );
+                flow_after_nested_current_shell_effects(flow, after_block)
+            }
             Command::Compound(CompoundCommand::If(command)) => {
                 self.flow_after_stmt_seq(&command.condition, flow)
             }
@@ -107,11 +110,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 };
                 let after_body = self.flow_after_stmt_seq(&command.body, block_flow);
                 let after_always = self.flow_after_stmt_seq(&command.always_body, after_body);
-                FlowState {
-                    pipeline_tail_runs_in_current_shell: after_always
-                        .pipeline_tail_runs_in_current_shell,
-                    ..flow
-                }
+                flow_after_nested_current_shell_effects(flow, after_always)
             }
             Command::Compound(CompoundCommand::Time(command)) => command
                 .command
@@ -1115,4 +1114,11 @@ fn flow_after_zsh_effects(mut flow: FlowState, effects: &[RecordedZshCommandEffe
         }
     }
     flow
+}
+
+fn flow_after_nested_current_shell_effects(flow: FlowState, after_nested: FlowState) -> FlowState {
+    FlowState {
+        pipeline_tail_runs_in_current_shell: after_nested.pipeline_tail_runs_in_current_shell,
+        ..flow
+    }
 }

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -374,9 +374,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     pub(super) fn visit_pipeline_binary(
         &mut self,
         command: &'a BinaryCommand,
-        mut flow: FlowState,
+        flow: FlowState,
     ) -> CommandId {
-        flow.in_subshell = true;
+        let tail_runs_in_current_shell = self.shell_profile.dialect == ShellDialect::Zsh
+            && flow.pipeline_tail_runs_in_current_shell;
+        let pipeline_child_flow = FlowState {
+            in_subshell: true,
+            pipeline_tail_runs_in_current_shell: false,
+            ..flow
+        };
         let mut segments = Vec::with_capacity(2);
         for (stmt, operator_before) in [
             (&command.left, None),
@@ -388,17 +394,27 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 }),
             ),
         ] {
+            let is_tail_segment = operator_before.is_some();
+            let segment_runs_in_current_shell = tail_runs_in_current_shell && is_tail_segment;
             let segment_is_nested_pipeline = matches!(
                 &stmt.command,
                 Command::Binary(binary) if matches!(binary.op, BinaryOp::Pipe | BinaryOp::PipeAll)
             );
-            let scope = if segment_is_nested_pipeline {
+            let scope = if segment_is_nested_pipeline || segment_runs_in_current_shell {
                 self.current_scope()
             } else {
                 self.push_scope(ScopeKind::Pipeline, self.current_scope(), stmt.span)
             };
-            let recorded = self.visit_stmt(stmt, flow);
-            if !segment_is_nested_pipeline {
+            let segment_flow = if segment_runs_in_current_shell {
+                FlowState {
+                    pipeline_tail_runs_in_current_shell: true,
+                    ..flow
+                }
+            } else {
+                pipeline_child_flow
+            };
+            let recorded = self.visit_stmt(stmt, segment_flow);
+            if !segment_is_nested_pipeline && !segment_runs_in_current_shell {
                 self.pop_scope(scope);
                 self.mark_scope_completed(scope);
             }

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -104,6 +104,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 .command
                 .as_deref()
                 .map_or(flow, |command| self.flow_after_statement(command, flow)),
+            Command::Binary(command) => match command.op {
+                BinaryOp::And | BinaryOp::Or => self.flow_after_statement(&command.left, flow),
+                BinaryOp::Pipe | BinaryOp::PipeAll
+                    if self.shell_profile.dialect == ShellDialect::Zsh
+                        && flow.pipeline_tail_runs_in_current_shell =>
+                {
+                    self.flow_after_statement(&command.right, flow)
+                }
+                BinaryOp::Pipe | BinaryOp::PipeAll => flow,
+            },
             _ => flow,
         }
     }

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -100,6 +100,19 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             Command::Compound(CompoundCommand::Until(command)) => {
                 self.flow_after_stmt_seq(&command.condition, flow)
             }
+            Command::Compound(CompoundCommand::Always(command)) => {
+                let block_flow = FlowState {
+                    in_block: true,
+                    ..flow
+                };
+                let after_body = self.flow_after_stmt_seq(&command.body, block_flow);
+                let after_always = self.flow_after_stmt_seq(&command.always_body, after_body);
+                FlowState {
+                    pipeline_tail_runs_in_current_shell: after_always
+                        .pipeline_tail_runs_in_current_shell,
+                    ..flow
+                }
+            }
             Command::Compound(CompoundCommand::Time(command)) => command
                 .command
                 .as_deref()

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -59,7 +59,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     pub(super) fn visit_stmt_seq_into(
         &mut self,
         commands: &'a StmtSeq,
-        flow: FlowState,
+        mut flow: FlowState,
         recorded: &mut Vec<CommandId>,
     ) {
         recorded.reserve(commands.len());
@@ -70,7 +70,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             self.observer
                 .recorded_statement_sequence_command(commands.span, stmt.span, command);
             recorded.push(command);
+            flow = self.flow_after_statement(stmt, flow);
         }
+    }
+
+    fn flow_after_statement(&self, stmt: &'a Stmt, flow: FlowState) -> FlowState {
+        let info = recorded_command_info(&stmt.command, self.source, self.runtime.bash_enabled());
+        flow_after_zsh_effects(flow, &info.zsh_effects)
     }
 
     pub(super) fn visit_stmt(&mut self, stmt: &'a Stmt, flow: FlowState) -> CommandId {
@@ -1035,4 +1041,19 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             .find(|scope| !matches!(self.scopes[scope.index()].kind, ScopeKind::Function(_)))
             .unwrap_or(ScopeId(0))
     }
+}
+
+fn flow_after_zsh_effects(mut flow: FlowState, effects: &[RecordedZshCommandEffect]) -> FlowState {
+    for effect in effects {
+        match effect {
+            RecordedZshCommandEffect::Emulate { mode, .. } => {
+                flow = flow.with_zsh_emulation(Some(*mode));
+            }
+            RecordedZshCommandEffect::EmulateUnknown { .. } => {
+                flow = flow.with_zsh_emulation(None);
+            }
+            RecordedZshCommandEffect::SetOptions { .. } => {}
+        }
+    }
+    flow
 }

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -75,8 +75,35 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     }
 
     fn flow_after_statement(&self, stmt: &'a Stmt, flow: FlowState) -> FlowState {
-        let info = recorded_command_info(&stmt.command, self.source, self.runtime.bash_enabled());
-        flow_after_zsh_effects(flow, &info.zsh_effects)
+        self.flow_after_command(&stmt.command, flow)
+    }
+
+    fn flow_after_command(&self, command: &'a Command, flow: FlowState) -> FlowState {
+        match command {
+            Command::Simple(_) => {
+                let info = recorded_command_info(command, self.source, self.runtime.bash_enabled());
+                flow_after_zsh_effects(flow, &info.zsh_effects)
+            }
+            Command::Compound(CompoundCommand::BraceGroup(commands)) => self.flow_after_stmt_seq(
+                commands,
+                FlowState {
+                    in_block: true,
+                    ..flow
+                },
+            ),
+            Command::Compound(CompoundCommand::Time(command)) => command
+                .command
+                .as_deref()
+                .map_or(flow, |command| self.flow_after_statement(command, flow)),
+            _ => flow,
+        }
+    }
+
+    fn flow_after_stmt_seq(&self, commands: &'a StmtSeq, mut flow: FlowState) -> FlowState {
+        for stmt in commands.iter() {
+            flow = self.flow_after_statement(stmt, flow);
+        }
+        flow
     }
 
     pub(super) fn visit_stmt(&mut self, stmt: &'a Stmt, flow: FlowState) -> CommandId {

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -91,6 +91,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     ..flow
                 },
             ),
+            Command::Compound(CompoundCommand::If(command)) => {
+                self.flow_after_stmt_seq(&command.condition, flow)
+            }
+            Command::Compound(CompoundCommand::While(command)) => {
+                self.flow_after_stmt_seq(&command.condition, flow)
+            }
+            Command::Compound(CompoundCommand::Until(command)) => {
+                self.flow_after_stmt_seq(&command.condition, flow)
+            }
             Command::Compound(CompoundCommand::Time(command)) => command
                 .command
                 .as_deref()

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1330,6 +1330,48 @@ print -r -- \"$value\"
 }
 
 #[test]
+fn zsh_always_body_sh_emulation_keeps_later_pipeline_tail_in_pipeline_scope() {
+    let source = "\
+{ emulate sh; } always { :; }
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
+fn zsh_always_cleanup_sh_emulation_keeps_later_pipeline_tail_in_pipeline_scope() {
+    let source = "\
+{ :; } always { emulate sh; }
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
 fn zsh_emulation_restores_native_pipeline_tail_scope() {
     let source = "\
 emulate sh

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1199,6 +1199,49 @@ print -r -- \"$value\"
 }
 
 #[test]
+fn zsh_sh_emulation_keeps_pipeline_tail_in_pipeline_scope() {
+    let source = "\
+emulate sh
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
+fn zsh_emulation_restores_native_pipeline_tail_scope() {
+    let source = "\
+emulate sh
+emulate zsh
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(!matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
 fn zsh_nonfinal_pipeline_segments_keep_pipeline_scope() {
     let source = "\
 value=old

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1220,6 +1220,53 @@ print -r -- \"$value\"
 }
 
 #[test]
+fn zsh_initial_sh_emulation_keeps_pipeline_tail_in_pipeline_scope() {
+    let source = "\
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(
+        source,
+        ShellProfile::with_zsh_options(
+            ShellDialect::Zsh,
+            ZshOptionState::for_emulate(ZshEmulationMode::Sh),
+        ),
+    );
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
+fn zsh_compound_sh_emulation_keeps_later_pipeline_tail_in_pipeline_scope() {
+    let source = "\
+{ emulate sh; }
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
 fn zsh_emulation_restores_native_pipeline_tail_scope() {
     let source = "\
 emulate sh

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -2921,6 +2921,33 @@ done
 }
 
 #[test]
+fn brace_group_effect_scan_preserves_sibling_flow_context() {
+    let source = "\
+{ emulate sh; }
+echo ok
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let model = SemanticModel::build(&output.file, source, &indexer);
+
+    let Command::Compound(CompoundCommand::BraceGroup(commands)) = &output.file.body[0].command
+    else {
+        panic!("expected brace group");
+    };
+    let Command::Simple(inner_command) = &commands[0].command else {
+        panic!("expected inner simple command");
+    };
+    let inner_context = model.flow_context_at(&inner_command.span).unwrap();
+    assert!(inner_context.in_block);
+
+    let Command::Simple(sibling_command) = &output.file.body[1].command else {
+        panic!("expected sibling simple command");
+    };
+    let sibling_context = model.flow_context_at(&sibling_command.span).unwrap();
+    assert!(!sibling_context.in_block);
+}
+
+#[test]
 fn command_contexts_track_nested_words_and_condition_roles() {
     let source = "\
 echo $(if probe; then inner; fi)

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1179,6 +1179,48 @@ fn records_pipeline_segment_scopes() {
 }
 
 #[test]
+fn zsh_final_pipeline_segment_uses_enclosing_scope() {
+    let source = "\
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(!matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
+fn zsh_nonfinal_pipeline_segments_keep_pipeline_scope() {
+    let source = "\
+value=old
+{ value=left; print x; } | { value=middle; print y; } | cat
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    for assignment in ["value=left", "value=middle"] {
+        let binding = model
+            .bindings()
+            .iter()
+            .find(|binding| binding.span.start.offset == source.find(assignment).unwrap())
+            .unwrap();
+        assert!(matches!(
+            model.scope_kind(binding.scope),
+            ScopeKind::Pipeline
+        ));
+    }
+}
+
+#[test]
 fn indexed_scope_lookup_matches_linear_scan_for_all_offsets() {
     let source = "\
 outer() {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1267,6 +1267,27 @@ print -r -- \"$value\"
 }
 
 #[test]
+fn zsh_if_condition_sh_emulation_keeps_later_pipeline_tail_in_pipeline_scope() {
+    let source = "\
+if emulate sh; then :; fi
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
 fn zsh_emulation_restores_native_pipeline_tail_scope() {
     let source = "\
 emulate sh

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -1288,6 +1288,48 @@ print -r -- \"$value\"
 }
 
 #[test]
+fn zsh_logical_left_sh_emulation_keeps_later_pipeline_tail_in_pipeline_scope() {
+    let source = "\
+emulate sh && :
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
+fn zsh_pipeline_tail_sh_emulation_keeps_later_pipeline_tail_in_pipeline_scope() {
+    let source = "\
+print setup | emulate sh
+value=old
+printf '%s\\n' x | value=new
+print -r -- \"$value\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+
+    let pipeline_assignment = model
+        .bindings()
+        .iter()
+        .find(|binding| binding.span.start.offset == source.find("value=new").unwrap())
+        .unwrap();
+    assert!(matches!(
+        model.scope_kind(pipeline_assignment.scope),
+        ScopeKind::Pipeline
+    ));
+}
+
+#[test]
 fn zsh_emulation_restores_native_pipeline_tail_scope() {
     let source = "\
 emulate sh


### PR DESCRIPTION
## Summary

- Treat the final segment of native zsh pipelines as running in the enclosing shell scope.
- Keep non-final zsh pipeline segments in pipeline scopes so C150/C155 still report real nonpersistent assignments.
- Add semantic and rule-level regression coverage for final and non-final zsh pipeline components.

## Root Cause

The semantic traversal marked every pipeline component as subshell-like. That is right for sh/bash-style pipeline side effects, but native zsh runs the final pipeline component in the current shell. As a result, C150/C155 incorrectly reported assignments in final zsh pipeline segments, including the zinit `header` assignment case.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-semantic zsh_ -- --nocapture`
- `cargo test -p shuck-linter zsh_final_pipeline_component_assignments -- --nocapture`
- `cargo test -p shuck-linter zsh_nonfinal_pipeline_component_assignments -- --nocapture`
- `cargo test -p shuck-linter subshell_ -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C150,C155`