### PR TITLE
perf(parser): box fat WordPart variant payloads

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -1348,9 +1348,9 @@ pub enum BourneParameterExpansion {
     },
     Indirect {
         reference: VarRef,
-        operator: Option<ParameterOp>,
+        operator: Option<Box<ParameterOp>>,
         operand: Option<SourceText>,
-        operand_word_ast: Option<Word>,
+        operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
     PrefixMatch {
@@ -1360,17 +1360,17 @@ pub enum BourneParameterExpansion {
     Slice {
         reference: VarRef,
         offset: SourceText,
-        offset_ast: Option<ArithmeticExprNode>,
-        offset_word_ast: Word,
+        offset_ast: Option<Box<ArithmeticExprNode>>,
+        offset_word_ast: Box<Word>,
         length: Option<SourceText>,
-        length_ast: Option<ArithmeticExprNode>,
-        length_word_ast: Option<Word>,
+        length_ast: Option<Box<ArithmeticExprNode>>,
+        length_word_ast: Option<Box<Word>>,
     },
     Operation {
         reference: VarRef,
-        operator: ParameterOp,
+        operator: Box<ParameterOp>,
         operand: Option<SourceText>,
-        operand_word_ast: Option<Word>,
+        operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
     Transformation {
@@ -1387,7 +1387,7 @@ impl BourneParameterExpansion {
             }
             | Self::Operation {
                 operand_word_ast, ..
-            } => operand_word_ast.as_ref(),
+            } => operand_word_ast.as_deref(),
             Self::Access { .. }
             | Self::Length { .. }
             | Self::Indices { .. }
@@ -1416,7 +1416,7 @@ impl BourneParameterExpansion {
         match self {
             Self::Slice {
                 length_word_ast, ..
-            } => length_word_ast.as_ref(),
+            } => length_word_ast.as_deref(),
             Self::Access { .. }
             | Self::Length { .. }
             | Self::Indices { .. }
@@ -1441,7 +1441,7 @@ pub struct ZshParameterExpansion {
 pub enum ZshExpansionTarget {
     Reference(VarRef),
     Nested(Box<ParameterExpansion>),
-    Word(Word),
+    Word(Box<Word>),
     Empty,
 }
 
@@ -1449,14 +1449,14 @@ pub enum ZshExpansionTarget {
 pub struct ZshModifier {
     pub name: char,
     pub argument: Option<SourceText>,
-    pub argument_word_ast: Option<Word>,
+    pub argument_word_ast: Option<Box<Word>>,
     pub argument_delimiter: Option<char>,
     pub span: Span,
 }
 
 impl ZshModifier {
     pub fn argument_word_ast(&self) -> Option<&Word> {
-        self.argument_word_ast.as_ref()
+        self.argument_word_ast.as_deref()
     }
 }
 
@@ -1465,35 +1465,35 @@ pub enum ZshExpansionOperation {
     PatternOperation {
         kind: ZshPatternOp,
         operand: SourceText,
-        operand_word_ast: Word,
+        operand_word_ast: Box<Word>,
     },
     Defaulting {
         kind: ZshDefaultingOp,
         operand: SourceText,
-        operand_word_ast: Word,
+        operand_word_ast: Box<Word>,
         colon_variant: bool,
     },
     TrimOperation {
         kind: ZshTrimOp,
         operand: SourceText,
-        operand_word_ast: Word,
+        operand_word_ast: Box<Word>,
     },
     ReplacementOperation {
         kind: ZshReplacementOp,
         pattern: SourceText,
-        pattern_word_ast: Word,
+        pattern_word_ast: Box<Word>,
         replacement: Option<SourceText>,
-        replacement_word_ast: Option<Word>,
+        replacement_word_ast: Option<Box<Word>>,
     },
     Slice {
         offset: SourceText,
-        offset_word_ast: Word,
+        offset_word_ast: Box<Word>,
         length: Option<SourceText>,
-        length_word_ast: Option<Word>,
+        length_word_ast: Option<Box<Word>>,
     },
     Unknown {
         text: SourceText,
-        word_ast: Word,
+        word_ast: Box<Word>,
     },
 }
 
@@ -1532,7 +1532,7 @@ impl ZshExpansionOperation {
             Self::ReplacementOperation {
                 replacement_word_ast,
                 ..
-            } => replacement_word_ast.as_ref(),
+            } => replacement_word_ast.as_deref(),
             Self::PatternOperation { .. }
             | Self::Defaulting { .. }
             | Self::TrimOperation { .. }
@@ -1558,7 +1558,7 @@ impl ZshExpansionOperation {
         match self {
             Self::Slice {
                 length_word_ast, ..
-            } => length_word_ast.as_ref(),
+            } => length_word_ast.as_deref(),
             Self::PatternOperation { .. }
             | Self::Defaulting { .. }
             | Self::TrimOperation { .. }
@@ -2790,20 +2790,20 @@ pub enum WordPart {
     ArithmeticExpansion {
         expression: SourceText,
         /// Typed arithmetic view of `expression`.
-        expression_ast: Option<ArithmeticExprNode>,
+        expression_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `expression`.
-        expression_word_ast: Word,
+        expression_word_ast: Box<Word>,
         syntax: ArithmeticExpansionSyntax,
     },
     /// Unified parameter-expansion family for `${...}` forms.
-    Parameter(ParameterExpansion),
+    Parameter(Box<ParameterExpansion>),
     /// Parameter expansion with operator ${var:-default}, ${var:=default}, etc.
     /// `colon_variant` distinguishes `:-` (unset-or-empty) from `-` (unset-only).
     ParameterExpansion {
         reference: VarRef,
-        operator: ParameterOp,
+        operator: Box<ParameterOp>,
         operand: Option<SourceText>,
-        operand_word_ast: Option<Word>,
+        operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
     /// Length expansion ${#var}
@@ -2819,36 +2819,36 @@ pub enum WordPart {
         reference: VarRef,
         offset: SourceText,
         /// Typed arithmetic view of `offset` when it parses as arithmetic.
-        offset_ast: Option<ArithmeticExprNode>,
+        offset_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `offset`.
-        offset_word_ast: Word,
+        offset_word_ast: Box<Word>,
         length: Option<SourceText>,
         /// Typed arithmetic view of `length` when it parses as arithmetic.
-        length_ast: Option<ArithmeticExprNode>,
+        length_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `length`.
-        length_word_ast: Option<Word>,
+        length_word_ast: Option<Box<Word>>,
     },
     /// Array slice `${arr[@]:offset:length}`
     ArraySlice {
         reference: VarRef,
         offset: SourceText,
         /// Typed arithmetic view of `offset` when it parses as arithmetic.
-        offset_ast: Option<ArithmeticExprNode>,
+        offset_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `offset`.
-        offset_word_ast: Word,
+        offset_word_ast: Box<Word>,
         length: Option<SourceText>,
         /// Typed arithmetic view of `length` when it parses as arithmetic.
-        length_ast: Option<ArithmeticExprNode>,
+        length_ast: Option<Box<ArithmeticExprNode>>,
         /// Parsed shell-word view of `length`.
-        length_word_ast: Option<Word>,
+        length_word_ast: Option<Box<Word>>,
     },
     /// Indirect expansion `${!var}` - expands to value of variable named by var's value
     /// Optionally composed with an operator: `${!var:-default}`, `${!var:=val}`, etc.
     IndirectExpansion {
         reference: VarRef,
-        operator: Option<ParameterOp>,
+        operator: Option<Box<ParameterOp>>,
         operand: Option<SourceText>,
-        operand_word_ast: Option<Word>,
+        operand_word_ast: Option<Box<Word>>,
         colon_variant: bool,
     },
     /// Prefix matching `${!prefix*}` or `${!prefix@}` - names of variables with given prefix
@@ -3181,7 +3181,7 @@ fn fmt_word_part_with_source_mode(
             operand,
             colon_variant,
             ..
-        } => match operator {
+        } => match operator.as_ref() {
             ParameterOp::UseDefault => {
                 let c = if *colon_variant { ":" } else { "" };
                 write!(f, "${{")?;
@@ -3375,7 +3375,7 @@ fn fmt_word_part_with_source_mode(
             fmt_var_ref_with_source(&mut reference_syntax, reference, source)?;
             if let Some(op) = operator {
                 let c = if *colon_variant { ":" } else { "" };
-                let op_char = match op {
+                let op_char = match op.as_ref() {
                     ParameterOp::UseDefault => "-",
                     ParameterOp::AssignDefault => "=",
                     ParameterOp::UseReplacement => "+",
@@ -3716,13 +3716,13 @@ pub enum ParameterOp {
     ReplaceFirst {
         pattern: Pattern,
         replacement: SourceText,
-        replacement_word_ast: Word,
+        replacement_word_ast: Box<Word>,
     },
     /// // pattern replacement (all occurrences)
     ReplaceAll {
         pattern: Pattern,
         replacement: SourceText,
-        replacement_word_ast: Word,
+        replacement_word_ast: Box<Word>,
     },
     /// ^ uppercase first char
     UpperFirst,
@@ -4280,13 +4280,13 @@ mod tests {
             }
         ])));
         assert!(word_is_standalone_status_capture(&word(vec![
-            WordPart::Parameter(ParameterExpansion {
+            WordPart::Parameter(Box::new(ParameterExpansion {
                 syntax: ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access {
                     reference: plain_ref("?"),
                 }),
                 span: Span::new(),
                 raw_body: "?".into(),
-            })
+            }))
         ])));
         assert!(!word_is_standalone_status_capture(&word(vec![
             WordPart::Variable("name".into())
@@ -4411,11 +4411,11 @@ mod tests {
                 WordPartNode::new(
                     WordPart::ParameterExpansion {
                         reference: plain_ref("PREFIXED_VERSION"),
-                        operator: ParameterOp::UseDefault,
+                        operator: Box::new(ParameterOp::UseDefault),
                         operand: Some("$PROVIDED_VERSION".into()),
-                        operand_word_ast: Some(word(vec![WordPart::Variable(
+                        operand_word_ast: Some(Box::new(word(vec![WordPart::Variable(
                             "PROVIDED_VERSION".into(),
-                        )])),
+                        )]))),
                         colon_variant: true,
                     },
                     Span::new(),
@@ -4557,7 +4557,7 @@ mod tests {
         let w = word(vec![WordPart::ArithmeticExpansion {
             expression: "1+2".into(),
             expression_ast: None,
-            expression_word_ast: Word::literal("1+2"),
+            expression_word_ast: Box::new(Word::literal("1+2")),
             syntax: ArithmeticExpansionSyntax::DollarParenParen,
         }]);
         assert_eq!(format!("{w}"), "$((1+2))");
@@ -4599,10 +4599,10 @@ mod tests {
             reference: plain_ref("var"),
             offset: "2".into(),
             offset_ast: None,
-            offset_word_ast: Word::literal("2"),
+            offset_word_ast: Box::new(Word::literal("2")),
             length: Some("3".into()),
             length_ast: None,
-            length_word_ast: Some(Word::literal("3")),
+            length_word_ast: Some(Box::new(Word::literal("3"))),
         }]);
         assert_eq!(format!("{w}"), "${var:2:3}");
     }
@@ -4613,7 +4613,7 @@ mod tests {
             reference: plain_ref("var"),
             offset: "2".into(),
             offset_ast: None,
-            offset_word_ast: Word::literal("2"),
+            offset_word_ast: Box::new(Word::literal("2")),
             length: None,
             length_ast: None,
             length_word_ast: None,
@@ -4627,10 +4627,10 @@ mod tests {
             reference: selector_ref("arr", SubscriptSelector::At),
             offset: "1".into(),
             offset_ast: None,
-            offset_word_ast: Word::literal("1"),
+            offset_word_ast: Box::new(Word::literal("1")),
             length: Some("2".into()),
             length_ast: None,
-            length_word_ast: Some(Word::literal("2")),
+            length_word_ast: Some(Box::new(Word::literal("2"))),
         }]);
         assert_eq!(format!("{w}"), "${arr[@]:1:2}");
     }
@@ -4641,7 +4641,7 @@ mod tests {
             reference: selector_ref("arr", SubscriptSelector::At),
             offset: "1".into(),
             offset_ast: None,
-            offset_word_ast: Word::literal("1"),
+            offset_word_ast: Box::new(Word::literal("1")),
             length: None,
             length_ast: None,
             length_word_ast: None,
@@ -4793,9 +4793,9 @@ mod tests {
     fn word_display_parameter_expansion_use_default_colon() {
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::UseDefault,
+            operator: Box::new(ParameterOp::UseDefault),
             operand: Some("fallback".into()),
-            operand_word_ast: Some(Word::literal("fallback")),
+            operand_word_ast: Some(Box::new(Word::literal("fallback"))),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:-fallback}");
@@ -4805,9 +4805,9 @@ mod tests {
     fn word_display_parameter_expansion_use_default_no_colon() {
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::UseDefault,
+            operator: Box::new(ParameterOp::UseDefault),
             operand: Some("fallback".into()),
-            operand_word_ast: Some(Word::literal("fallback")),
+            operand_word_ast: Some(Box::new(Word::literal("fallback"))),
             colon_variant: false,
         }]);
         assert_eq!(format!("{w}"), "${var-fallback}");
@@ -4817,9 +4817,9 @@ mod tests {
     fn word_display_parameter_expansion_assign_default() {
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::AssignDefault,
+            operator: Box::new(ParameterOp::AssignDefault),
             operand: Some("val".into()),
-            operand_word_ast: Some(Word::literal("val")),
+            operand_word_ast: Some(Box::new(Word::literal("val"))),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:=val}");
@@ -4829,9 +4829,9 @@ mod tests {
     fn word_display_parameter_expansion_use_replacement() {
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::UseReplacement,
+            operator: Box::new(ParameterOp::UseReplacement),
             operand: Some("alt".into()),
-            operand_word_ast: Some(Word::literal("alt")),
+            operand_word_ast: Some(Box::new(Word::literal("alt"))),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:+alt}");
@@ -4841,9 +4841,9 @@ mod tests {
     fn word_display_parameter_expansion_error() {
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::Error,
+            operator: Box::new(ParameterOp::Error),
             operand: Some("msg".into()),
-            operand_word_ast: Some(Word::literal("msg")),
+            operand_word_ast: Some(Box::new(Word::literal("msg"))),
             colon_variant: true,
         }]);
         assert_eq!(format!("{w}"), "${var:?msg}");
@@ -4854,9 +4854,9 @@ mod tests {
         // RemovePrefixShort
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::RemovePrefixShort {
+            operator: Box::new(ParameterOp::RemovePrefixShort {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
-            },
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4866,9 +4866,9 @@ mod tests {
         // RemovePrefixLong
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::RemovePrefixLong {
+            operator: Box::new(ParameterOp::RemovePrefixLong {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
-            },
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4878,9 +4878,9 @@ mod tests {
         // RemoveSuffixShort
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::RemoveSuffixShort {
+            operator: Box::new(ParameterOp::RemoveSuffixShort {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
-            },
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4890,9 +4890,9 @@ mod tests {
         // RemoveSuffixLong
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::RemoveSuffixLong {
+            operator: Box::new(ParameterOp::RemoveSuffixLong {
                 pattern: pattern(vec![PatternPart::Literal("pat".into())]),
-            },
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4904,11 +4904,11 @@ mod tests {
     fn word_display_parameter_expansion_replace() {
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::ReplaceFirst {
+            operator: Box::new(ParameterOp::ReplaceFirst {
                 pattern: pattern(vec![PatternPart::Literal("old".into())]),
                 replacement: "new".into(),
-                replacement_word_ast: Word::literal("new"),
-            },
+                replacement_word_ast: Box::new(Word::literal("new")),
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4917,11 +4917,11 @@ mod tests {
 
         let w = word(vec![WordPart::ParameterExpansion {
             reference: plain_ref("var"),
-            operator: ParameterOp::ReplaceAll {
+            operator: Box::new(ParameterOp::ReplaceAll {
                 pattern: pattern(vec![PatternPart::Literal("old".into())]),
                 replacement: "new".into(),
-                replacement_word_ast: Word::literal("new"),
-            },
+                replacement_word_ast: Box::new(Word::literal("new")),
+            }),
             operand: None,
             operand_word_ast: None,
             colon_variant: false,
@@ -4934,7 +4934,7 @@ mod tests {
         let check = |op: ParameterOp, expected: &str| {
             let w = word(vec![WordPart::ParameterExpansion {
                 reference: plain_ref("var"),
-                operator: op,
+                operator: Box::new(op),
                 operand: None,
                 operand_word_ast: None,
                 colon_variant: false,

--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -4190,7 +4190,7 @@ mod tests {
     #[test]
     fn standalone_zsh_force_glob_helper_rejects_affixed_and_nested_words() {
         let span = Span::new();
-        let forced = WordPart::Parameter(zsh_parameter_with_modifiers(&['~'], span));
+        let forced = WordPart::Parameter(Box::new(zsh_parameter_with_modifiers(&['~'], span)));
 
         assert!(word_is_standalone_zsh_force_glob_parameter(&word(vec![
             forced.clone()
@@ -4249,7 +4249,10 @@ mod tests {
             parts: vec![WordPartNode::new(
                 WordPart::DoubleQuoted {
                     parts: vec![WordPartNode::new(
-                        WordPart::Parameter(zsh_parameter_with_modifiers(&['~'], forced_span)),
+                        WordPart::Parameter(Box::new(zsh_parameter_with_modifiers(
+                            &['~'],
+                            forced_span,
+                        ))),
                         forced_span,
                     )],
                     dollar: false,

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -596,7 +596,7 @@ fn collect_base_prefix_spans_in_parameter_expansion(
             } => {
                 collect_base_prefix_spans_in_var_ref(reference, source, spans);
                 collect_base_prefix_spans_in_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     spans,
@@ -667,7 +667,7 @@ fn collect_base_prefix_spans_in_arithmetic_parameter_expansion(
             } => {
                 collect_base_prefix_spans_in_var_ref(reference, source, spans);
                 collect_base_prefix_spans_in_arithmetic_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     spans,
@@ -886,7 +886,7 @@ fn collect_base_prefix_spans_in_arithmetic_word_part(
         } => {
             collect_base_prefix_spans_in_var_ref(reference, source, spans);
             collect_base_prefix_spans_in_arithmetic_fragment(
-                operand_word_ast.as_ref(),
+                operand_word_ast.as_deref(),
                 operand.as_ref(),
                 source,
                 spans,

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -684,7 +684,7 @@ fn collect_use_replacement_expansion_spans(parts: &[WordPartNode], spans: &mut V
             | WordPart::IndirectExpansion {
                 operator: Some(operator),
                 ..
-            } if matches!(operator, ParameterOp::UseReplacement) => spans.push(part.span),
+            } if matches!(operator.as_ref(), ParameterOp::UseReplacement) => spans.push(part.span),
             WordPart::Parameter(_)
             | WordPart::ParameterExpansion { .. }
             | WordPart::IndirectExpansion { .. } => {}
@@ -703,7 +703,7 @@ fn parameter_uses_replacement_operator(parameter: &ParameterExpansion) -> bool {
             ..
         }
         | BourneParameterExpansion::Operation { operator, .. } => {
-            matches!(operator, ParameterOp::UseReplacement)
+            matches!(operator.as_ref(), ParameterOp::UseReplacement)
         }
         BourneParameterExpansion::Access { .. }
         | BourneParameterExpansion::Length { .. }

--- a/crates/shuck-linter/src/facts/command_options/mod.rs
+++ b/crates/shuck-linter/src/facts/command_options/mod.rs
@@ -1064,7 +1064,9 @@ fn rm_path_parameter_expansion_is_unsafe(parameter: &ParameterExpansion) -> bool
                 operand: _,
                 colon_variant: _,
                 ..
-            } => operator.as_ref().is_none_or(rm_path_parameter_op_is_unsafe),
+            } => operator
+                .as_deref()
+                .is_none_or(rm_path_parameter_op_is_unsafe),
             BourneParameterExpansion::Operation { operator, .. } => {
                 rm_path_parameter_op_is_unsafe(operator)
             }

--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -1603,7 +1603,7 @@ fn collect_status_parameter_spans_in_word_part(
             }
             collect_status_parameter_spans_in_var_ref(reference, source, spans);
             collect_status_parameter_spans_in_fragment(
-                operand_word_ast.as_ref(),
+                operand_word_ast.as_deref(),
                 operand.as_ref(),
                 source,
                 spans,
@@ -1689,7 +1689,7 @@ fn collect_status_parameter_spans_in_parameter_expansion(
             } => {
                 collect_status_parameter_spans_in_var_ref(reference, source, spans);
                 collect_status_parameter_spans_in_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     spans,

--- a/crates/shuck-linter/src/facts/substitutions.rs
+++ b/crates/shuck-linter/src/facts/substitutions.rs
@@ -385,7 +385,7 @@ fn collect_word_substitution_occurrences<'a>(
                 collect_word_substitution_occurrences(parts, true, occurrences);
             }
             WordPart::ArithmeticExpansion { expression_ast, .. } => {
-                visit_arithmetic_words_in_expression(expression_ast.as_ref(), quoted, occurrences);
+                visit_arithmetic_words_in_expression(expression_ast.as_deref(), quoted, occurrences);
             }
             WordPart::CommandSubstitution { body, syntax } => {
                 occurrences.push(SubstitutionOccurrence {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -919,12 +919,12 @@ impl<'a> SurfaceFragmentSink<'a> {
                         .push(LegacyArithmeticFragmentFact { span: part.span });
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
-                        expression_ast.as_ref(),
+                        expression_ast.as_deref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
                     );
-                    if let Some(expression_ast) = expression_ast.as_ref() {
+                    if let Some(expression_ast) = expression_ast.as_deref() {
                         visit_arithmetic_words(expression_ast, &mut |word| {
                             self.collect_word(word, context);
                         });
@@ -940,12 +940,12 @@ impl<'a> SurfaceFragmentSink<'a> {
                 } => {
                     collect_positional_parameter_operator_spans_in_arithmetic(
                         part.span,
-                        expression_ast.as_ref(),
+                        expression_ast.as_deref(),
                         expression,
                         self.source,
                         &mut self.facts.positional_parameter_operator_spans,
                     );
-                    if let Some(expression_ast) = expression_ast.as_ref() {
+                    if let Some(expression_ast) = expression_ast.as_deref() {
                         visit_arithmetic_words(expression_ast, &mut |word| {
                             self.collect_word(word, context);
                         });
@@ -1007,7 +1007,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         }
                     }
                     if matches!(
-                        operator,
+                        operator.as_ref(),
                         ParameterOp::UpperFirst
                             | ParameterOp::UpperAll
                             | ParameterOp::LowerFirst
@@ -1016,7 +1016,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                         self.record_case_modification(part.span);
                     }
                     if matches!(
-                        operator,
+                        operator.as_ref(),
                         ParameterOp::ReplaceFirst { .. } | ParameterOp::ReplaceAll { .. }
                     ) {
                         self.record_replacement_expansion(part.span);
@@ -1031,7 +1031,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     self.collect_parameter_operator_patterns(
                         operator,
                         operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand_word_ast.as_deref(),
                         context,
                     );
                 }
@@ -1107,7 +1107,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     self.collect_parameter_operator_patterns(
                         operator,
                         operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand_word_ast.as_deref(),
                         context,
                     );
                 }
@@ -1413,7 +1413,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                     self.collect_parameter_operator_patterns(
                         operator,
                         operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand_word_ast.as_deref(),
                         context,
                     );
                 }
@@ -2036,7 +2036,7 @@ fn classify_parameter_expansion_walk<'a>(
                         classification.has_array_reference = true;
                     }
                     if matches!(
-                        operator,
+                        operator.as_ref(),
                         ParameterOp::UpperFirst
                             | ParameterOp::UpperAll
                             | ParameterOp::LowerFirst
@@ -2045,7 +2045,7 @@ fn classify_parameter_expansion_walk<'a>(
                         classification.has_case_modification = true;
                     }
                     if matches!(
-                        operator,
+                        operator.as_ref(),
                         ParameterOp::ReplaceFirst { .. } | ParameterOp::ReplaceAll { .. }
                     ) {
                         classification.has_replacement_expansion = true;

--- a/crates/shuck-linter/src/facts/word_spans/arrays.rs
+++ b/crates/shuck-linter/src/facts/word_spans/arrays.rs
@@ -228,7 +228,7 @@ pub(crate) fn collect_array_expansion_spans(
                 reference,
                 operator,
                 ..
-            } if !matches!(operator, ParameterOp::UseReplacement)
+            } if !matches!(operator.as_ref(), ParameterOp::UseReplacement)
                 && reference.has_array_selector()
                 && (!quoted || !only_unquoted) =>
             {
@@ -238,7 +238,7 @@ pub(crate) fn collect_array_expansion_spans(
                 reference,
                 operator,
                 ..
-            } if !matches!(operator, Some(ParameterOp::UseReplacement))
+            } if !matches!(operator.as_deref(), Some(ParameterOp::UseReplacement))
                 && reference.has_array_selector()
                 && (!quoted || !only_unquoted) =>
             {
@@ -947,7 +947,10 @@ pub(crate) fn parameter_is_array_like(parameter: &ParameterExpansion) -> bool {
                 reference,
                 operator,
                 ..
-            } => !matches!(operator, ParameterOp::UseReplacement) && reference.has_array_selector(),
+            } => {
+                !matches!(operator.as_ref(), ParameterOp::UseReplacement)
+                    && reference.has_array_selector()
+            }
             BourneParameterExpansion::Transformation { reference, .. } => {
                 reference.has_array_selector()
             }
@@ -1009,7 +1012,7 @@ pub(crate) fn parameter_uses_replacement_operator(parameter: &ParameterExpansion
             ..
         }
         | BourneParameterExpansion::Operation { operator, .. } => {
-            matches!(operator, ParameterOp::UseReplacement)
+            matches!(operator.as_ref(), ParameterOp::UseReplacement)
         }
         BourneParameterExpansion::Access { .. }
         | BourneParameterExpansion::Length { .. }
@@ -1094,7 +1097,7 @@ pub(crate) fn part_uses_assign_default_operator(part: &WordPart) -> bool {
         | WordPart::IndirectExpansion {
             operator: Some(operator),
             ..
-        } => matches!(operator, ParameterOp::AssignDefault),
+        } => matches!(operator.as_ref(), ParameterOp::AssignDefault),
         _ => false,
     }
 }
@@ -1151,7 +1154,7 @@ pub(crate) fn parameter_uses_unquoted_all_elements_array_expansion(
             operator,
             ..
         } => {
-            !matches!(operator, ParameterOp::UseReplacement)
+            !matches!(operator.as_ref(), ParameterOp::UseReplacement)
                 && var_ref_uses_all_elements_at_splat(reference)
         }
         BourneParameterExpansion::Transformation { reference, .. } => {
@@ -1179,7 +1182,7 @@ pub(crate) fn parameter_uses_direct_all_elements_array_expansion(
             operator,
             ..
         } => {
-            !matches!(operator, ParameterOp::UseReplacement)
+            !matches!(operator.as_ref(), ParameterOp::UseReplacement)
                 && var_ref_uses_all_elements_at_splat(reference)
         }
         BourneParameterExpansion::Transformation { reference, .. } => {
@@ -1200,9 +1203,10 @@ pub(crate) fn parameter_uses_replacement_all_elements_array_expansion(
         syntax,
         BourneParameterExpansion::Operation {
             reference,
-            operator: ParameterOp::UseReplacement,
+            operator,
             ..
-        } if var_ref_uses_all_elements_at_splat(reference)
+        } if matches!(operator.as_ref(), ParameterOp::UseReplacement)
+            && var_ref_uses_all_elements_at_splat(reference)
     )
 }
 
@@ -1274,12 +1278,12 @@ pub(crate) fn parameter_uses_assign_default_operator(parameter: &ParameterExpans
 
     match syntax {
         BourneParameterExpansion::Operation { operator, .. } => {
-            matches!(operator, ParameterOp::AssignDefault)
+            matches!(operator.as_ref(), ParameterOp::AssignDefault)
         }
         BourneParameterExpansion::Indirect {
             operator: Some(operator),
             ..
-        } => matches!(operator, ParameterOp::AssignDefault),
+        } => matches!(operator.as_ref(), ParameterOp::AssignDefault),
         _ => false,
     }
 }

--- a/crates/shuck-linter/src/facts/word_spans/expansions.rs
+++ b/crates/shuck-linter/src/facts/word_spans/expansions.rs
@@ -190,7 +190,7 @@ pub(crate) fn collect_use_replacement_spans(parts: &[WordPartNode], spans: &mut 
             | WordPart::IndirectExpansion {
                 operator: Some(operator),
                 ..
-            } if matches!(operator, ParameterOp::UseReplacement) => spans.push(part.span),
+            } if matches!(operator.as_ref(), ParameterOp::UseReplacement) => spans.push(part.span),
             WordPart::Literal(_)
             | WordPart::SingleQuoted { .. }
             | WordPart::Variable(_)

--- a/crates/shuck-linter/src/facts/words/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/words/arithmetic.rs
@@ -1446,7 +1446,7 @@ pub(super) fn collect_arithmetic_spans_in_parameter_expansion(
                     command_substitution_spans,
                 );
                 collect_arithmetic_spans_in_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     collect_dollar_spans,
@@ -1469,7 +1469,7 @@ pub(super) fn collect_arithmetic_spans_in_parameter_expansion(
                     command_substitution_spans,
                 );
                 collect_arithmetic_spans_in_fragment(
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     operand.as_ref(),
                     source,
                     collect_dollar_spans,

--- a/crates/shuck-linter/src/facts/words/expansion.rs
+++ b/crates/shuck-linter/src/facts/words/expansion.rs
@@ -905,7 +905,7 @@ pub(super) fn analyze_part(
                 field_splitting: substitution_field_splitting_hazard(in_double_quotes, behavior),
                 pathname_matching: substitution_pathname_matching_hazard(in_double_quotes, behavior),
                 runtime_pattern: operator
-                    .as_ref()
+                    .as_deref()
                     .is_some_and(parameter_operator_uses_pattern),
                 ..ExpansionHazards::default()
             },
@@ -1009,7 +1009,7 @@ pub(super) fn analyze_parameter_part(
                             behavior,
                         ),
                     runtime_pattern: operator
-                        .as_ref()
+                        .as_deref()
                         .is_some_and(parameter_operator_uses_pattern),
                     ..ExpansionHazards::default()
                 },

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2724,7 +2724,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     ..
                 } => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
                     operator,
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     enclosing_expansion_context,
                     host_kind,
                 ),
@@ -2767,7 +2767,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 },
             ) => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
                 operator,
-                operand_word_ast.as_ref(),
+                operand_word_ast.as_deref(),
                 enclosing_expansion_context,
                 host_kind,
             ),

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -168,11 +168,11 @@ impl<'a> SafeValueIndex<'a> {
                 ..
             } => {
                 self.indirect_name_is_safe(reference, span, query)
-                    && operator.as_ref().is_none_or(|operator| {
+                    && operator.as_deref().is_none_or(|operator| {
                         self.parameter_operator_is_safe(
                             &reference.name,
                             operator,
-                            operand_word_ast.as_ref(),
+                            operand_word_ast.as_deref(),
                             span,
                             query,
                         )
@@ -191,7 +191,7 @@ impl<'a> SafeValueIndex<'a> {
             } => self.parameter_expansion_is_safe(
                 reference,
                 operator,
-                operand_word_ast.as_ref(),
+                operand_word_ast.as_deref(),
                 span,
                 query,
             ),
@@ -3685,11 +3685,11 @@ impl<'a> SafeValueIndex<'a> {
                     ..
                 } => {
                     self.indirect_name_is_safe(reference, at, query)
-                        && operator.as_ref().is_none_or(|operator| {
+                        && operator.as_deref().is_none_or(|operator| {
                             self.parameter_operator_is_safe(
                                 &reference.name,
                                 operator,
-                                operand_word_ast.as_ref(),
+                                operand_word_ast.as_deref(),
                                 at,
                                 query,
                             )
@@ -3713,7 +3713,7 @@ impl<'a> SafeValueIndex<'a> {
                 } => self.parameter_expansion_is_safe(
                     reference,
                     operator,
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     at,
                     query,
                 ),

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -691,11 +691,11 @@ impl<'a> Parser<'a> {
                 syntax,
             } => HeredocBodyPart::ArithmeticExpansion {
                 expression,
-                expression_ast,
-                expression_word_ast,
+                expression_ast: expression_ast.map(|ast| *ast),
+                expression_word_ast: *expression_word_ast,
                 syntax,
             },
-            WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(Box::new(parameter)),
+            WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(parameter),
             other => panic!("unsupported heredoc body part: {other:?}"),
         };
 
@@ -3925,7 +3925,7 @@ impl<'a> Parser<'a> {
                 ..
             } => {
                 Self::rebase_var_ref(reference, base);
-                match operator {
+                match operator.as_mut() {
                     ParameterOp::RemovePrefixShort { pattern }
                     | ParameterOp::RemovePrefixLong { pattern }
                     | ParameterOp::RemoveSuffixShort { pattern }
@@ -4706,33 +4706,33 @@ impl<'a> Parser<'a> {
         let Some(syntax) = syntax else {
             unreachable!("matched Some above");
         };
-        WordPart::Parameter(ParameterExpansion {
+        WordPart::Parameter(Box::new(ParameterExpansion {
             syntax: ParameterExpansionSyntax::Bourne(syntax),
             span,
             raw_body,
-        })
+        }))
     }
 
-    fn enrich_parameter_operator(&self, operator: ParameterOp) -> ParameterOp {
-        match operator {
+    fn enrich_parameter_operator(&self, operator: Box<ParameterOp>) -> Box<ParameterOp> {
+        match *operator {
             ParameterOp::ReplaceFirst {
                 pattern,
                 replacement,
                 ..
-            } => ParameterOp::ReplaceFirst {
+            } => Box::new(ParameterOp::ReplaceFirst {
                 pattern,
-                replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                replacement_word_ast: Box::new(self.parse_source_text_as_word(&replacement)),
                 replacement,
-            },
+            }),
             ParameterOp::ReplaceAll {
                 pattern,
                 replacement,
                 ..
-            } => ParameterOp::ReplaceAll {
+            } => Box::new(ParameterOp::ReplaceAll {
                 pattern,
-                replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                replacement_word_ast: Box::new(self.parse_source_text_as_word(&replacement)),
                 replacement,
-            },
+            }),
             ParameterOp::UseDefault
             | ParameterOp::AssignDefault
             | ParameterOp::UseReplacement
@@ -4783,11 +4783,11 @@ impl<'a> Parser<'a> {
         part_end: Position,
     ) -> WordPart {
         let syntax = self.parse_zsh_parameter_syntax(&raw_body, raw_body.span().start);
-        WordPart::Parameter(ParameterExpansion {
+        WordPart::Parameter(Box::new(ParameterExpansion {
             syntax: ParameterExpansionSyntax::Zsh(syntax),
             span: Span::from_positions(part_start, part_end),
             raw_body,
-        })
+        }))
     }
 
     fn parse_zsh_modifier_group(
@@ -4843,7 +4843,7 @@ impl<'a> Parser<'a> {
 
             let argument_word_ast = argument
                 .as_ref()
-                .map(|argument| self.parse_source_text_as_word(argument));
+                .map(|argument| Box::new(self.parse_source_text_as_word(argument)));
 
             modifiers.push(ZshModifier {
                 name,
@@ -4978,7 +4978,7 @@ impl<'a> Parser<'a> {
         {
             ZshExpansionTarget::Reference(reference)
         } else {
-            ZshExpansionTarget::Word(word)
+            ZshExpansionTarget::Word(Box::new(word))
         }
     }
 
@@ -5256,7 +5256,7 @@ impl<'a> Parser<'a> {
             );
             return ZshExpansionOperation::PatternOperation {
                 kind: ZshPatternOp::Filter,
-                operand_word_ast: self.parse_source_text_as_word(&operand),
+                operand_word_ast: Box::new(self.parse_source_text_as_word(&operand)),
                 operand,
             };
         }
@@ -5284,7 +5284,7 @@ impl<'a> Parser<'a> {
             );
             return ZshExpansionOperation::Defaulting {
                 kind,
-                operand_word_ast: self.parse_source_text_as_word(&operand),
+                operand_word_ast: Box::new(self.parse_source_text_as_word(&operand)),
                 operand,
                 colon_variant: true,
             };
@@ -5302,7 +5302,7 @@ impl<'a> Parser<'a> {
             let operand = self.zsh_operation_source_text(text, base, prefix_len, text.len());
             return ZshExpansionOperation::TrimOperation {
                 kind,
-                operand_word_ast: self.parse_source_text_as_word(&operand),
+                operand_word_ast: Box::new(self.parse_source_text_as_word(&operand)),
                 operand,
             };
         }
@@ -5326,8 +5326,10 @@ impl<'a> Parser<'a> {
             });
             return ZshExpansionOperation::ReplacementOperation {
                 kind,
-                pattern_word_ast: self.parse_source_text_as_word(&pattern),
-                replacement_word_ast: self.parse_optional_source_text_as_word(replacement.as_ref()),
+                pattern_word_ast: Box::new(self.parse_source_text_as_word(&pattern)),
+                replacement_word_ast: self
+                    .parse_optional_source_text_as_word(replacement.as_ref())
+                    .map(Box::new),
                 pattern,
                 replacement,
             };
@@ -5337,7 +5339,7 @@ impl<'a> Parser<'a> {
             if Self::zsh_modifier_suffix_candidate(rest) {
                 let text = self.source_text(text.to_string(), base, base.advanced_by(text));
                 return ZshExpansionOperation::Unknown {
-                    word_ast: self.parse_source_text_as_word(&text),
+                    word_ast: Box::new(self.parse_source_text_as_word(&text)),
                     text,
                 };
             }
@@ -5350,8 +5352,10 @@ impl<'a> Parser<'a> {
                     self.zsh_operation_source_text(text, base, 1 + separator + 1, text.len())
                 });
                 return ZshExpansionOperation::Slice {
-                    offset_word_ast: self.parse_source_text_as_word(&offset),
-                    length_word_ast: self.parse_optional_source_text_as_word(length.as_ref()),
+                    offset_word_ast: Box::new(self.parse_source_text_as_word(&offset)),
+                    length_word_ast: self
+                        .parse_optional_source_text_as_word(length.as_ref())
+                        .map(Box::new),
                     offset,
                     length,
                 };
@@ -5360,7 +5364,7 @@ impl<'a> Parser<'a> {
 
         let text = self.source_text(text.to_string(), base, base.advanced_by(text));
         ZshExpansionOperation::Unknown {
-            word_ast: self.parse_source_text_as_word(&text),
+            word_ast: Box::new(self.parse_source_text_as_word(&text)),
             text,
         }
     }

--- a/crates/shuck-parser/src/parser/tests/mod.rs
+++ b/crates/shuck-parser/src/parser/tests/mod.rs
@@ -362,8 +362,8 @@ fn expect_substring_part(
     part: &WordPart,
 ) -> (
     &VarRef,
-    &Option<ArithmeticExprNode>,
-    &Option<ArithmeticExprNode>,
+    Option<&ArithmeticExprNode>,
+    Option<&ArithmeticExprNode>,
 ) {
     match part {
         WordPart::Substring {
@@ -371,14 +371,16 @@ fn expect_substring_part(
             offset_ast,
             length_ast,
             ..
-        } => (reference, offset_ast, length_ast),
+        } => (reference, offset_ast.as_deref(), length_ast.as_deref()),
         WordPart::Parameter(parameter) => match &parameter.syntax {
             ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Slice {
                 reference,
                 offset_ast,
                 length_ast,
                 ..
-            }) if !reference.has_array_selector() => (reference, offset_ast, length_ast),
+            }) if !reference.has_array_selector() => {
+                (reference, offset_ast.as_deref(), length_ast.as_deref())
+            }
             _ => panic!("expected substring part, got {:?}", part),
         },
         _ => panic!("expected substring part, got {:?}", part),
@@ -389,8 +391,8 @@ fn expect_array_slice_part(
     part: &WordPart,
 ) -> (
     &VarRef,
-    &Option<ArithmeticExprNode>,
-    &Option<ArithmeticExprNode>,
+    Option<&ArithmeticExprNode>,
+    Option<&ArithmeticExprNode>,
 ) {
     match part {
         WordPart::ArraySlice {
@@ -398,14 +400,16 @@ fn expect_array_slice_part(
             offset_ast,
             length_ast,
             ..
-        } => (reference, offset_ast, length_ast),
+        } => (reference, offset_ast.as_deref(), length_ast.as_deref()),
         WordPart::Parameter(parameter) => match &parameter.syntax {
             ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Slice {
                 reference,
                 offset_ast,
                 length_ast,
                 ..
-            }) if reference.has_array_selector() => (reference, offset_ast, length_ast),
+            }) if reference.has_array_selector() => {
+                (reference, offset_ast.as_deref(), length_ast.as_deref())
+            }
             _ => panic!("expected array slice part, got {:?}", part),
         },
         _ => panic!("expected array slice part, got {:?}", part),
@@ -421,14 +425,14 @@ fn expect_parameter_operation_part(
             operator,
             operand,
             ..
-        } => (reference, operator, operand.as_ref()),
+        } => (reference, operator.as_ref(), operand.as_ref()),
         WordPart::Parameter(parameter) => match &parameter.syntax {
             ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
                 reference,
                 operator,
                 operand,
                 ..
-            }) => (reference, operator, operand.as_ref()),
+            }) => (reference, operator.as_ref(), operand.as_ref()),
             _ => panic!("expected parameter operation part, got {:?}", part),
         },
         _ => panic!("expected parameter operation part, got {:?}", part),
@@ -461,7 +465,7 @@ fn expect_indirect_expansion_part(
             ..
         } => (
             reference,
-            operator.as_ref(),
+            operator.as_deref(),
             operand.as_ref(),
             *colon_variant,
         ),
@@ -474,7 +478,7 @@ fn expect_indirect_expansion_part(
                 ..
             }) => (
                 reference,
-                operator.as_ref(),
+                operator.as_deref(),
                 operand.as_ref(),
                 *colon_variant,
             ),

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -65,13 +65,13 @@ fn collect_bourne_parameter_trim_patterns(
             }
             WordPart::Parameter(parameter) => {
                 if let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
-                    operator:
-                        ParameterOp::RemovePrefixShort { pattern }
-                        | ParameterOp::RemovePrefixLong { pattern }
-                        | ParameterOp::RemoveSuffixShort { pattern }
-                        | ParameterOp::RemoveSuffixLong { pattern },
+                    operator,
                     ..
                 }) = &parameter.syntax
+                    && let ParameterOp::RemovePrefixShort { pattern }
+                    | ParameterOp::RemovePrefixLong { pattern }
+                    | ParameterOp::RemoveSuffixShort { pattern }
+                    | ParameterOp::RemoveSuffixLong { pattern } = operator.as_ref()
                 {
                     patterns.push(pattern.render(source));
                 }
@@ -1233,14 +1233,17 @@ fn test_parse_word_fragment_rebases_indirect_operator_spans() {
     let parameter = expect_parameter(&word);
 
     let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Indirect {
-        operator:
-            Some(ParameterOp::ReplaceAll {
-                replacement,
-                replacement_word_ast,
-                ..
-            }),
+        operator: Some(operator),
         ..
     }) = &parameter.syntax
+    else {
+        panic!("expected indirect replacement operator");
+    };
+    let ParameterOp::ReplaceAll {
+        replacement,
+        replacement_word_ast,
+        ..
+    } = operator.as_ref()
     else {
         panic!("expected indirect replacement operator");
     };
@@ -1289,7 +1292,7 @@ fn test_parse_special_hash_parameter_prefix_removal() {
     };
 
     assert_eq!(reference.name.as_str(), "#");
-    match operator {
+    match operator.as_ref() {
         ParameterOp::RemovePrefixShort { pattern } => assert_eq!(pattern.render(input), "*/"),
         other => panic!("expected short prefix removal, got {other:?}"),
     }
@@ -4326,7 +4329,10 @@ fn test_parse_long_suffix_trim_operator_inside_double_quotes() {
         else {
             panic!("expected parameter operation");
         };
-        assert!(matches!(operator, ParameterOp::RemoveSuffixLong { .. }));
+        assert!(matches!(
+            operator.as_ref(),
+            ParameterOp::RemoveSuffixLong { .. }
+        ));
     }
 }
 

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4679,15 +4679,17 @@ impl<'a> Parser<'a> {
                                 let operator = if replace_all {
                                     ParameterOp::ReplaceAll {
                                         pattern,
-                                        replacement_word_ast: self
-                                            .parse_source_text_as_word(&replacement),
+                                        replacement_word_ast: Box::new(
+                                            self.parse_source_text_as_word(&replacement),
+                                        ),
                                         replacement,
                                     }
                                 } else {
                                     ParameterOp::ReplaceFirst {
                                         pattern,
-                                        replacement_word_ast: self
-                                            .parse_source_text_as_word(&replacement),
+                                        replacement_word_ast: Box::new(
+                                            self.parse_source_text_as_word(&replacement),
+                                        ),
                                         replacement,
                                     }
                                 };
@@ -4947,15 +4949,17 @@ impl<'a> Parser<'a> {
                             let operator = if replace_all {
                                 ParameterOp::ReplaceAll {
                                     pattern,
-                                    replacement_word_ast: self
-                                        .parse_source_text_as_word(&replacement),
+                                    replacement_word_ast: Box::new(
+                                        self.parse_source_text_as_word(&replacement),
+                                    ),
                                     replacement,
                                 }
                             } else {
                                 ParameterOp::ReplaceFirst {
                                     pattern,
-                                    replacement_word_ast: self
-                                        .parse_source_text_as_word(&replacement),
+                                    replacement_word_ast: Box::new(
+                                        self.parse_source_text_as_word(&replacement),
+                                    ),
                                     replacement,
                                 }
                             };
@@ -5584,8 +5588,11 @@ impl<'a> Parser<'a> {
         syntax: ArithmeticExpansionSyntax,
     ) -> WordPart {
         WordPart::ArithmeticExpansion {
-            expression_ast: self.parse_source_text_as_arithmetic(&expression).ok(),
-            expression_word_ast: self.parse_source_text_as_word(&expression),
+            expression_ast: self
+                .parse_source_text_as_arithmetic(&expression)
+                .ok()
+                .map(Box::new),
+            expression_word_ast: Box::new(self.parse_source_text_as_word(&expression)),
             expression,
             syntax,
         }
@@ -5598,10 +5605,12 @@ impl<'a> Parser<'a> {
         operand: Option<SourceText>,
         colon_variant: bool,
     ) -> WordPart {
-        let operand_word_ast = self.parse_optional_source_text_as_word(operand.as_ref());
+        let operand_word_ast = self
+            .parse_optional_source_text_as_word(operand.as_ref())
+            .map(Box::new);
         WordPart::ParameterExpansion {
             reference,
-            operator,
+            operator: Box::new(operator),
             operand,
             operand_word_ast,
             colon_variant,
@@ -5615,10 +5624,12 @@ impl<'a> Parser<'a> {
         operand: Option<SourceText>,
         colon_variant: bool,
     ) -> WordPart {
-        let operand_word_ast = self.parse_optional_source_text_as_word(operand.as_ref());
+        let operand_word_ast = self
+            .parse_optional_source_text_as_word(operand.as_ref())
+            .map(Box::new);
         WordPart::IndirectExpansion {
             reference,
-            operator,
+            operator: operator.map(Box::new),
             operand,
             operand_word_ast,
             colon_variant,
@@ -5631,12 +5642,17 @@ impl<'a> Parser<'a> {
         offset: SourceText,
         length: Option<SourceText>,
     ) -> WordPart {
-        let offset_ast = self.maybe_parse_source_text_as_arithmetic(&offset);
-        let offset_word_ast = self.parse_source_text_as_word(&offset);
+        let offset_ast = self
+            .maybe_parse_source_text_as_arithmetic(&offset)
+            .map(Box::new);
+        let offset_word_ast = Box::new(self.parse_source_text_as_word(&offset));
         let length_ast = length
             .as_ref()
-            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length));
-        let length_word_ast = self.parse_optional_source_text_as_word(length.as_ref());
+            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length))
+            .map(Box::new);
+        let length_word_ast = self
+            .parse_optional_source_text_as_word(length.as_ref())
+            .map(Box::new);
         WordPart::Substring {
             reference,
             offset,
@@ -5780,13 +5796,17 @@ impl<'a> Parser<'a> {
                     let operator = if replace_all {
                         ParameterOp::ReplaceAll {
                             pattern,
-                            replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                            replacement_word_ast: Box::new(
+                                self.parse_source_text_as_word(&replacement),
+                            ),
                             replacement,
                         }
                     } else {
                         ParameterOp::ReplaceFirst {
                             pattern,
-                            replacement_word_ast: self.parse_source_text_as_word(&replacement),
+                            replacement_word_ast: Box::new(
+                                self.parse_source_text_as_word(&replacement),
+                            ),
                             replacement,
                         }
                     };
@@ -5875,12 +5895,17 @@ impl<'a> Parser<'a> {
         offset: SourceText,
         length: Option<SourceText>,
     ) -> WordPart {
-        let offset_ast = self.maybe_parse_source_text_as_arithmetic(&offset);
-        let offset_word_ast = self.parse_source_text_as_word(&offset);
+        let offset_ast = self
+            .maybe_parse_source_text_as_arithmetic(&offset)
+            .map(Box::new);
+        let offset_word_ast = Box::new(self.parse_source_text_as_word(&offset));
         let length_ast = length
             .as_ref()
-            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length));
-        let length_word_ast = self.parse_optional_source_text_as_word(length.as_ref());
+            .and_then(|length| self.maybe_parse_source_text_as_arithmetic(length))
+            .map(Box::new);
+        let length_word_ast = self
+            .parse_optional_source_text_as_word(length.as_ref())
+            .map(Box::new);
         WordPart::ArraySlice {
             reference,
             offset,

--- a/crates/shuck-semantic/src/builder/inert.rs
+++ b/crates/shuck-semantic/src/builder/inert.rs
@@ -195,9 +195,9 @@ mod tests {
                     subscript: None,
                     span: Span::new(),
                 },
-                operator: ParameterOp::UseDefault,
+                operator: Box::new(ParameterOp::UseDefault),
                 operand: Some(SourceText::from("fallback")),
-                operand_word_ast: Some(Word::literal("fallback")),
+                operand_word_ast: Some(Box::new(Word::literal("fallback"))),
                 colon_variant: true,
             },
         ]))]);

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -357,7 +357,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
             WordPart::ArithmeticExpansion { expression_ast, .. } => {
                 self.visit_optional_arithmetic_expr_into(
-                    expression_ast.as_ref(),
+                    expression_ast.as_deref(),
                     flow,
                     nested_regions,
                 );
@@ -388,13 +388,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 if parameter_operator_guards_unset_reference(operator) {
                     self.record_guarded_parameter_reference(reference_id);
                 }
-                if matches!(operator, ParameterOp::AssignDefault) {
+                if matches!(operator.as_ref(), ParameterOp::AssignDefault) {
                     self.add_parameter_default_binding(reference);
                 }
                 self.visit_parameter_operator_operand(
                     operator,
                     operand.as_ref(),
-                    operand_word_ast.as_ref(),
+                    operand_word_ast.as_deref(),
                     kind,
                     flow,
                     nested_regions,
@@ -466,7 +466,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     self.visit_parameter_operator_operand(
                         operator,
                         operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand_word_ast.as_deref(),
                         kind,
                         flow,
                         nested_regions,
@@ -486,8 +486,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     nested_regions,
                     reference.span,
                 );
-                self.visit_optional_arithmetic_expr_into(offset_ast.as_ref(), flow, nested_regions);
-                self.visit_optional_arithmetic_expr_into(length_ast.as_ref(), flow, nested_regions);
+                self.visit_optional_arithmetic_expr_into(
+                    offset_ast.as_deref(),
+                    flow,
+                    nested_regions,
+                );
+                self.visit_optional_arithmetic_expr_into(
+                    length_ast.as_deref(),
+                    flow,
+                    nested_regions,
+                );
             }
             WordPart::ArraySlice {
                 reference,
@@ -502,8 +510,16 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     nested_regions,
                     reference.span,
                 );
-                self.visit_optional_arithmetic_expr_into(offset_ast.as_ref(), flow, nested_regions);
-                self.visit_optional_arithmetic_expr_into(length_ast.as_ref(), flow, nested_regions);
+                self.visit_optional_arithmetic_expr_into(
+                    offset_ast.as_deref(),
+                    flow,
+                    nested_regions,
+                );
+                self.visit_optional_arithmetic_expr_into(
+                    length_ast.as_deref(),
+                    flow,
+                    nested_regions,
+                );
             }
             WordPart::Transformation { reference, .. } => {
                 self.visit_var_ref_reference(
@@ -652,7 +668,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         self.visit_parameter_operator_operand(
                             operator,
                             operand.as_ref(),
-                            operand_word_ast.as_ref(),
+                            operand_word_ast.as_deref(),
                             kind,
                             flow,
                             nested_regions,
@@ -674,12 +690,12 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                         span,
                     );
                     self.visit_parameter_slice_arithmetic_expr_into(
-                        offset_ast.as_ref(),
+                        offset_ast.as_deref(),
                         flow,
                         nested_regions,
                     );
                     self.visit_parameter_slice_arithmetic_expr_into(
-                        length_ast.as_ref(),
+                        length_ast.as_deref(),
                         flow,
                         nested_regions,
                     );
@@ -701,13 +717,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     if parameter_operator_guards_unset_reference(operator) {
                         self.record_guarded_parameter_reference(reference_id);
                     }
-                    if matches!(operator, ParameterOp::AssignDefault) {
+                    if matches!(operator.as_ref(), ParameterOp::AssignDefault) {
                         self.add_parameter_default_binding(reference);
                     }
                     self.visit_parameter_operator_operand(
                         operator,
                         operand.as_ref(),
-                        operand_word_ast.as_ref(),
+                        operand_word_ast.as_deref(),
                         kind,
                         flow,
                         nested_regions,


### PR DESCRIPTION
## Summary

- Shrinks `WordPartNode` from **904 → 352 bytes (-61%)** by boxing the inline `Word`/`ArithmeticExprNode` fields on the fat `WordPart` variants and the parallel inline fields in `BourneParameterExpansion`, `ZshExpansionTarget`, `ZshExpansionOperation`, `ZshModifier`, and `ParameterOp`.
- Targets the `word_with_part_buffer` allocation hotspot — every word allocation in the parser was previously sized by the worst-case `WordPart` variant (`Substring`/`ArraySlice`/`Parameter`), even for the dominant 1-part literal case.
- Pattern matches stay struct-style; only constructors and a few accessor sites changed.

## Measurements

`xwmx__nb__nb` fixture, profiling build, 30 iterations:

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Wall clock (median) | 145 ms | 132 ms | **-9%** |
| Total bytes allocated (12 iter dhat) | 4.03 GB | 3.57 GB | -11% |
| Peak memory (t-gmax) | 199 MB | 180 MB | -9% |
| `word_with_part_buffer` bytes | 12.6% / 443 MB | 5.6% / 172 MB | **-61%** |
| Total allocation count | 7.25M | 7.48M | +3% |

The +3% block count comes from the per-construction `Box::new` wraps (mainly `WordPart::Parameter(Box<ParameterExpansion>)` at the two `parameter_word_part_from_legacy` call sites), but is more than offset by the per-Vec byte savings — wall clock improves 9%.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` all passing
- [ ] Large-corpus comparison (`make test-large-corpus`) — should be unaffected since this is a pure AST-shape change with identical observable parser output.