### PR TITLE
Fix zsh array comma detection

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
+++ b/crates/shuck-linter/src/rules/correctness/comma_array_elements.rs
@@ -85,6 +85,43 @@ opts=(
     }
 
     #[test]
+    fn ignores_zsh_subscript_ranges_and_glob_qualifier_commas() {
+        let source = "\
+#!/bin/zsh
+spinner=(a b c)
+spinner=($spinner[2,-1] $spinner[1])
+reply+=($_p9k__display_v[k,k+1])
+tmp=( ${expanded_path}*(N-*,N-/) )
+files=( **/*(.om[1,3]) *.log(#q.om[1,3]) )
+parents=( ${(@)${:-{$#parts..1}}/(#m)*/$parent${(pj./.)parts[1,MATCH]}} )
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::CommaArrayElements).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_non_zsh_commas_that_resemble_zsh_subscripts_and_qualifiers() {
+        let source = "\
+#!/bin/bash
+spinner=($spinner[2,-1])
+files=(**/*(.om[1,3]))
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::CommaArrayElements));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["($spinner[2,-1])", "(**/*(.om[1,3]))"]
+        );
+    }
+
+    #[test]
     fn reports_comma_separated_array_literals_in_zsh() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -1627,6 +1627,72 @@ fn test_compound_array_process_substitution_stays_typed_for_comma_detection() {
 }
 
 #[test]
+fn test_zsh_array_comma_detection_ignores_subscript_ranges_and_glob_qualifiers() {
+    let input = r#"arr=(
+  $spinner[2,-1]
+  $_p9k__display_v[k,k+1]
+  ${assoc[$key,$fallback]}
+  ${arr[1,${last:-2}]}
+  ${(@)${:-{$#parts..1}}/(#m)*/$parent${(pj./.)parts[1,MATCH]}}
+  **/*(.om[1,3])
+  *.log(#q.om[1,3])
+  ${expanded_path}*(N-*,N-/)
+  "${dir}"/*(.om[1,3])
+  plain(group,with,commas)
+  a,b
+  ${expanded_path}(N-*,N-/)
+)
+"#;
+    let output = Parser::with_dialect(input, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let AstCommand::Simple(command) = &output.file.body[0].command else {
+        panic!("expected simple command");
+    };
+    let AssignmentValue::Compound(array) = &command.assignments[0].value else {
+        panic!("expected compound array assignment");
+    };
+
+    let expected = [
+        ("$spinner[2,-1]", false),
+        ("$_p9k__display_v[k,k+1]", false),
+        ("${assoc[$key,$fallback]}", false),
+        ("${arr[1,${last:-2}]}", false),
+        (
+            "${(@)${:-{$#parts..1}}/(#m)*/$parent${(pj./.)parts[1,MATCH]}}",
+            false,
+        ),
+        ("**/*(.om[1,3])", false),
+        ("*.log(#q.om[1,3])", false),
+        ("${expanded_path}*(N-*,N-/)", false),
+        ("\"${dir}\"/*(.om[1,3])", false),
+        ("plain(group,with,commas)", true),
+        ("a,b", true),
+        ("${expanded_path}(N-*,N-/)", true),
+    ];
+
+    assert_eq!(
+        array.elements.len(),
+        expected.len(),
+        "{:#?}",
+        array.elements
+    );
+    for (index, (expected_span, expected_comma)) in expected.into_iter().enumerate() {
+        let ArrayElem::Sequential(value) = &array.elements[index] else {
+            panic!("expected sequential element at index {index}");
+        };
+        assert_eq!(value.span.slice(input), expected_span);
+        assert_eq!(
+            value.has_top_level_unquoted_comma(),
+            expected_comma,
+            "unexpected comma flag for {}: {:#?}",
+            value.span.slice(input),
+            value.word
+        );
+    }
+}
+
+#[test]
 fn test_word_part_spans_track_mixed_expansions() {
     let input = "echo pre${name:-fallback}$(printf hi)$((1+2))post\n";
     let script = Parser::new(input).parse().unwrap().file;

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -1452,7 +1452,9 @@ impl<'a> Parser<'a> {
                 }
                 ',' if !in_single && !in_ansi_c_single && !in_double && !in_backtick => {
                     let comma_offset = word.span.start.offset + index;
-                    if !self.comma_is_brace_separator(word, comma_offset, was_escaped) {
+                    if !self.comma_is_brace_separator(word, comma_offset, was_escaped)
+                        && !self.comma_is_zsh_word_syntax(word, comma_offset)
+                    {
                         return true;
                     }
                 }
@@ -1862,6 +1864,71 @@ impl<'a> Parser<'a> {
             .copied()
             .filter(|brace| brace.expands())
             .any(|brace| brace.span.start.offset <= offset && offset < brace.span.end.offset)
+    }
+
+    fn comma_is_zsh_word_syntax(&self, word: &Word, comma_offset: usize) -> bool {
+        self.dialect == ShellDialect::Zsh
+            && (word
+                .parts
+                .iter()
+                .any(|part| word_part_has_zsh_syntax_comma(&part.kind, comma_offset))
+                || self.comma_is_zsh_terminal_glob_group_syntax(word, comma_offset))
+    }
+
+    fn comma_is_zsh_terminal_glob_group_syntax(&self, word: &Word, comma_offset: usize) -> bool {
+        if comma_offset < word.span.start.offset || word.span.end.offset <= comma_offset {
+            return false;
+        }
+
+        let text = word.span.slice(self.input);
+        let relative_comma = comma_offset - word.span.start.offset;
+        let Some(group_start) = Self::enclosing_terminal_group_start(text, relative_comma) else {
+            return false;
+        };
+
+        Self::text_has_zsh_glob_syntax(&text[..group_start])
+    }
+
+    fn enclosing_terminal_group_start(text: &str, target: usize) -> Option<usize> {
+        if !text.ends_with(')') || target >= text.len() {
+            return None;
+        }
+
+        let mut depth = 0usize;
+        let mut group_start = None;
+        for (index, ch) in text.char_indices().rev() {
+            match ch {
+                ')' => depth += 1,
+                '(' => {
+                    depth = depth.checked_sub(1)?;
+                    if depth == 0 {
+                        group_start = Some(index);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let group_start = group_start?;
+        (group_start < target && target < text.len() - ')'.len_utf8()).then_some(group_start)
+    }
+
+    fn text_has_zsh_glob_syntax(text: &str) -> bool {
+        let mut escaped = false;
+        for ch in text.chars() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            match ch {
+                '\\' => escaped = true,
+                '*' | '?' | '[' => return true,
+                _ => {}
+            }
+        }
+
+        false
     }
 
     fn inside_unquoted_brace_group(&self, word: &Word, target_offset: usize) -> bool {
@@ -6246,6 +6313,179 @@ impl<'a> Parser<'a> {
 
         false
     }
+}
+
+fn word_part_has_zsh_syntax_comma(part: &WordPart, comma_offset: usize) -> bool {
+    match part {
+        WordPart::ZshQualifiedGlob(glob) => glob
+            .qualifiers
+            .as_ref()
+            .is_some_and(|qualifiers| span_contains_offset(qualifiers.span, comma_offset)),
+        WordPart::DoubleQuoted { parts, .. } => parts
+            .iter()
+            .any(|part| word_part_has_zsh_syntax_comma(&part.kind, comma_offset)),
+        WordPart::Parameter(expansion) => {
+            parameter_expansion_has_zsh_syntax_comma(expansion, comma_offset)
+        }
+        WordPart::ParameterExpansion {
+            reference,
+            operand_word_ast,
+            ..
+        }
+        | WordPart::IndirectExpansion {
+            reference,
+            operand_word_ast,
+            ..
+        } => {
+            var_ref_subscript_contains_offset(reference, comma_offset)
+                || operand_word_ast
+                    .as_deref()
+                    .is_some_and(|word| word_has_zsh_syntax_comma(word, comma_offset))
+        }
+        WordPart::Length(reference)
+        | WordPart::ArrayAccess(reference)
+        | WordPart::ArrayLength(reference)
+        | WordPart::ArrayIndices(reference)
+        | WordPart::Transformation { reference, .. } => {
+            var_ref_subscript_contains_offset(reference, comma_offset)
+        }
+        WordPart::Substring {
+            reference,
+            offset_word_ast,
+            length_word_ast,
+            ..
+        }
+        | WordPart::ArraySlice {
+            reference,
+            offset_word_ast,
+            length_word_ast,
+            ..
+        } => {
+            var_ref_subscript_contains_offset(reference, comma_offset)
+                || word_has_zsh_syntax_comma(offset_word_ast, comma_offset)
+                || length_word_ast
+                    .as_deref()
+                    .is_some_and(|word| word_has_zsh_syntax_comma(word, comma_offset))
+        }
+        WordPart::ArithmeticExpansion {
+            expression_word_ast,
+            ..
+        } => word_has_zsh_syntax_comma(expression_word_ast, comma_offset),
+        _ => false,
+    }
+}
+
+fn parameter_expansion_has_zsh_syntax_comma(
+    expansion: &ParameterExpansion,
+    comma_offset: usize,
+) -> bool {
+    match &expansion.syntax {
+        ParameterExpansionSyntax::Bourne(expansion) => {
+            bourne_parameter_expansion_has_zsh_syntax_comma(expansion, comma_offset)
+        }
+        ParameterExpansionSyntax::Zsh(expansion) => {
+            zsh_parameter_expansion_has_zsh_syntax_comma(expansion, comma_offset)
+        }
+    }
+}
+
+fn bourne_parameter_expansion_has_zsh_syntax_comma(
+    expansion: &BourneParameterExpansion,
+    comma_offset: usize,
+) -> bool {
+    match expansion {
+        BourneParameterExpansion::Access { reference }
+        | BourneParameterExpansion::Length { reference }
+        | BourneParameterExpansion::Indices { reference }
+        | BourneParameterExpansion::Transformation { reference, .. } => {
+            var_ref_subscript_contains_offset(reference, comma_offset)
+        }
+        BourneParameterExpansion::Indirect {
+            reference,
+            operand_word_ast,
+            ..
+        }
+        | BourneParameterExpansion::Operation {
+            reference,
+            operand_word_ast,
+            ..
+        } => {
+            var_ref_subscript_contains_offset(reference, comma_offset)
+                || operand_word_ast
+                    .as_deref()
+                    .is_some_and(|word| word_has_zsh_syntax_comma(word, comma_offset))
+        }
+        BourneParameterExpansion::Slice {
+            reference,
+            offset_word_ast,
+            length_word_ast,
+            ..
+        } => {
+            var_ref_subscript_contains_offset(reference, comma_offset)
+                || word_has_zsh_syntax_comma(offset_word_ast, comma_offset)
+                || length_word_ast
+                    .as_deref()
+                    .is_some_and(|word| word_has_zsh_syntax_comma(word, comma_offset))
+        }
+        BourneParameterExpansion::PrefixMatch { .. } => false,
+    }
+}
+
+fn zsh_parameter_expansion_has_zsh_syntax_comma(
+    expansion: &ZshParameterExpansion,
+    comma_offset: usize,
+) -> bool {
+    zsh_expansion_target_has_zsh_syntax_comma(&expansion.target, comma_offset)
+        || expansion.modifiers.iter().any(|modifier| {
+            modifier
+                .argument_word_ast()
+                .is_some_and(|word| word_has_zsh_syntax_comma(word, comma_offset))
+        })
+        || expansion
+            .operation
+            .as_ref()
+            .is_some_and(|operation| zsh_operation_has_zsh_syntax_comma(operation, comma_offset))
+}
+
+fn zsh_expansion_target_has_zsh_syntax_comma(
+    target: &ZshExpansionTarget,
+    comma_offset: usize,
+) -> bool {
+    match target {
+        ZshExpansionTarget::Reference(reference) => {
+            var_ref_subscript_contains_offset(reference, comma_offset)
+        }
+        ZshExpansionTarget::Nested(expansion) => {
+            parameter_expansion_has_zsh_syntax_comma(expansion, comma_offset)
+        }
+        ZshExpansionTarget::Word(word) => word_has_zsh_syntax_comma(word, comma_offset),
+        ZshExpansionTarget::Empty => false,
+    }
+}
+
+fn zsh_operation_has_zsh_syntax_comma(
+    operation: &ZshExpansionOperation,
+    comma_offset: usize,
+) -> bool {
+    operation
+        .operand_word_ast()
+        .is_some_and(|word| word_has_zsh_syntax_comma(word, comma_offset))
+}
+
+fn word_has_zsh_syntax_comma(word: &Word, comma_offset: usize) -> bool {
+    word.parts
+        .iter()
+        .any(|part| word_part_has_zsh_syntax_comma(&part.kind, comma_offset))
+}
+
+fn var_ref_subscript_contains_offset(reference: &VarRef, offset: usize) -> bool {
+    reference.subscript.as_deref().is_some_and(|subscript| {
+        span_contains_offset(subscript.syntax_source_text().span(), offset)
+    })
+}
+
+fn span_contains_offset(span: Span, offset: usize) -> bool {
+    span.start.offset <= offset && offset < span.end.offset
 }
 
 #[inline]


### PR DESCRIPTION
## Summary

Fix C151 false positives for zsh compound array elements whose commas are part of zsh syntax rather than array-element separators.

The parser now treats commas inside zsh subscript syntax and terminal glob qualifier groups as zsh word syntax when computing `ArrayValueWord::has_top_level_unquoted_comma`. This keeps the linter rule parser-driven while preserving reports for real top-level commas.

## Root Cause

`raw_text_has_top_level_unquoted_array_comma` scanned raw array element text and only excluded quotes, command substitutions, arithmetic, parameter substitutions, and brace syntax. Zsh-specific commas in forms like `$spinner[2,-1]`, `$_p9k__display_v[k,k+1]`, and `${expanded_path}*(N-*,N-/)` were therefore marked as top-level array commas and reported by C151.

## Tests

- `cargo test -p shuck-linter comma_array_elements -- --nocapture`
- `cargo test -p shuck-parser comma -- --nocapture`
- `cargo fmt`
- `git diff --check`
- Full `/tmp/zsh` sweep checked for `C151`: 0 matches, stderr clean