### PR TITLE
Fix zsh assignment-like forms

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
@@ -77,7 +77,9 @@ fn numeric_assignment_target_span(text: &str, start: Position) -> Option<Span> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
+    use std::path::Path;
+
+    use crate::test::{test_snippet, test_snippet_at_path};
     use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
@@ -133,6 +135,22 @@ a2=1
             source,
             &LinterSettings::for_rule(Rule::AssignmentToNumericVariable)
                 .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_plugin_numeric_zero_assignments_despite_bash_compat_shebang() {
+        let source = r#"#!/usr/bin/bash
+# shellcheck disable=SC1090,SC2154
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+0="${${(M)0:#/*}:-$PWD/$0}"
+"#;
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/ohmyzsh/plugins/shell-proxy/shell-proxy.plugin.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentToNumericVariable),
         );
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -118,6 +118,22 @@ rvm_info="
     }
 
     #[test]
+    fn ignores_zsh_word_splitting_expansion_in_command_position() {
+        let source = "\
+#!/bin/zsh
+local -a UNPACKCMD
+UNPACKCMD=( dd if=$pkg ibs=$o skip=1 )
+local COMPRESSION=\"$($=UNPACKCMD | file -)\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PlusPrefixInAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_zsh_declaration_brace_expanded_assignment_targets() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/shell.rs
+++ b/crates/shuck-linter/src/shell.rs
@@ -50,8 +50,16 @@ impl ShellDialect {
 
     pub fn infer(source: &str, path: Option<&Path>) -> Self {
         let extension_dialect = path.map_or(Self::Unknown, Self::infer_from_extension);
+        let shebang_dialect = Self::infer_from_shebang(source);
         Self::infer_from_shellcheck_header(source)
-            .or_else(|| Self::infer_from_shebang(source))
+            .or_else(|| {
+                Self::zsh_extension_compat_shebang_override(
+                    source,
+                    extension_dialect,
+                    shebang_dialect,
+                )
+            })
+            .or(shebang_dialect)
             .or_else(|| match extension_dialect {
                 Self::Unknown | Self::Sh => Self::infer_from_source_markers(source),
                 dialect => Some(dialect),
@@ -79,6 +87,18 @@ impl ShellDialect {
     fn infer_from_shebang(source: &str) -> Option<Self> {
         let interpreter = shuck_parser::shebang::interpreter_name(source.lines().next()?)?;
         Some(Self::from_name(interpreter))
+    }
+
+    fn zsh_extension_compat_shebang_override(
+        source: &str,
+        extension_dialect: Self,
+        shebang_dialect: Option<Self>,
+    ) -> Option<Self> {
+        if extension_dialect != Self::Zsh || shebang_dialect != Some(Self::Bash) {
+            return None;
+        }
+
+        (Self::infer_from_source_markers(source) == Some(Self::Zsh)).then_some(Self::Zsh)
     }
 
     fn infer_from_shellcheck_header(source: &str) -> Option<Self> {
@@ -569,6 +589,18 @@ zstyle -s ':omz:update' mode update_mode
 autoload -U compaudit compinit
 "#;
         let inferred = ShellDialect::infer(source, Some(Path::new("/tmp/oh-my-zsh.sh")));
+        assert_eq!(inferred, ShellDialect::Zsh);
+    }
+
+    #[test]
+    fn zsh_extension_and_markers_win_over_bash_compat_shebang() {
+        let source = r#"#!/usr/bin/bash
+0="${${ZERO:-${0:#$ZSH_ARGZERO}}:-${(%):-%N}}"
+"#;
+        let inferred = ShellDialect::infer(
+            source,
+            Some(Path::new("/tmp/plugin/shell-proxy.plugin.zsh")),
+        );
         assert_eq!(inferred, ShellDialect::Zsh);
     }
 

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -5007,6 +5007,9 @@ impl<'a> Parser<'a> {
         };
 
         Self::is_valid_identifier(name)
+            || name
+                .strip_prefix('+')
+                .is_some_and(Self::is_valid_identifier)
             || name.bytes().all(|byte| byte.is_ascii_digit())
             || Self::is_plain_special_parameter_name(name)
     }

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -7519,7 +7519,7 @@ fn test_zsh_parameter_bare_prefix_flags_record_modifier_sequence() {
 
 #[test]
 fn test_zsh_bare_dollar_prefix_flag_parses_as_parameter_word() {
-    let source = "$=UNPACKCMD\n";
+    let source = "$=UNPACKCMD $=arr[1] $=+ice[extract]\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)
         .parse()
         .unwrap();
@@ -7542,6 +7542,28 @@ fn test_zsh_bare_dollar_prefix_flag_parses_as_parameter_word() {
         panic!("expected split target reference");
     };
     assert_eq!(reference.name.as_str(), "UNPACKCMD");
+
+    let subscripted = expect_parameter(&command.args[0]);
+    assert_eq!(subscripted.raw_body.slice(source), "=arr[1]");
+    let ParameterExpansionSyntax::Zsh(subscripted) = &subscripted.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    let ZshExpansionTarget::Reference(reference) = &subscripted.target else {
+        panic!("expected subscripted target reference");
+    };
+    assert_eq!(reference.name.as_str(), "arr");
+    expect_subscript(reference, source, "1");
+
+    let probe = expect_parameter(&command.args[1]);
+    assert_eq!(probe.raw_body.slice(source), "=+ice[extract]");
+    let ParameterExpansionSyntax::Zsh(probe) = &probe.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    let ZshExpansionTarget::Reference(reference) = &probe.target else {
+        panic!("expected probe target reference");
+    };
+    assert_eq!(reference.name.as_str(), "+ice");
+    expect_subscript(reference, source, "extract");
 }
 
 #[test]

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -7518,6 +7518,33 @@ fn test_zsh_parameter_bare_prefix_flags_record_modifier_sequence() {
 }
 
 #[test]
+fn test_zsh_bare_dollar_prefix_flag_parses_as_parameter_word() {
+    let source = "$=UNPACKCMD\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    let parameter = expect_parameter(&command.name);
+    assert_eq!(parameter.raw_body.slice(source), "=UNPACKCMD");
+    let ParameterExpansionSyntax::Zsh(parameter) = &parameter.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert_eq!(
+        parameter
+            .modifiers
+            .iter()
+            .map(|modifier| modifier.name)
+            .collect::<Vec<_>>(),
+        vec!['=']
+    );
+    let ZshExpansionTarget::Reference(reference) = &parameter.target else {
+        panic!("expected split target reference");
+    };
+    assert_eq!(reference.name.as_str(), "UNPACKCMD");
+}
+
+#[test]
 fn test_zsh_parameter_word_target_accepts_quoted_command_substitution_text() {
     let source = "print ${\"$(xcode-select -p)\"%%/Contents/Developer*}\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3141,6 +3141,69 @@ impl<'a> Parser<'a> {
         Self::zsh_modifier_suffix_candidate_chars(&mut lookahead)
     }
 
+    fn parse_zsh_bare_prefixed_parameter(
+        &mut self,
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+        cursor: &mut Position,
+        part_start: Position,
+    ) -> Option<WordPart> {
+        if !self.dialect.features().zsh_parameter_modifiers
+            || !chars
+                .peek()
+                .copied()
+                .is_some_and(Self::zsh_bare_parameter_prefix_modifier)
+        {
+            return None;
+        }
+
+        let mut lookahead = chars.clone();
+        while lookahead
+            .peek()
+            .copied()
+            .is_some_and(Self::zsh_bare_parameter_prefix_modifier)
+        {
+            lookahead.next();
+        }
+        if !lookahead
+            .peek()
+            .copied()
+            .is_some_and(Self::zsh_bare_parameter_target_start)
+        {
+            return None;
+        }
+
+        let raw_body_start = *cursor;
+        let mut raw_body = String::new();
+        while chars
+            .peek()
+            .copied()
+            .is_some_and(Self::zsh_bare_parameter_prefix_modifier)
+        {
+            raw_body.push(Self::next_word_char_unwrap(chars, cursor));
+        }
+
+        let first = Self::next_word_char_unwrap(chars, cursor);
+        raw_body.push(first);
+        if first.is_ascii_alphabetic() || first == '_' {
+            raw_body.push_str(&Self::read_word_while(chars, cursor, |ch| {
+                ch.is_ascii_alphanumeric() || ch == '_'
+            }));
+        }
+
+        let raw_body = self.source_text(raw_body, raw_body_start, *cursor);
+        Some(self.zsh_parameter_word_part(raw_body, part_start, *cursor))
+    }
+
+    fn zsh_bare_parameter_prefix_modifier(ch: char) -> bool {
+        matches!(ch, '=' | '^' | '~')
+    }
+
+    fn zsh_bare_parameter_target_start(ch: char) -> bool {
+        matches!(ch, '?' | '#' | '@' | '*' | '!' | '$' | '-')
+            || ch.is_ascii_alphanumeric()
+            || ch == '_'
+    }
+
     fn zsh_modifier_suffix_candidate_chars(
         chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
     ) -> bool {
@@ -5182,6 +5245,14 @@ impl<'a> Parser<'a> {
             }
 
             if let Some(&c) = chars.peek() {
+                if let Some(part) =
+                    self.parse_zsh_bare_prefixed_parameter(&mut chars, &mut cursor, part_start)
+                {
+                    Self::push_word_part(parts, part, part_start, cursor);
+                    current_start = cursor;
+                    continue;
+                }
+
                 if matches!(c, '?' | '#' | '@' | '*' | '!' | '$' | '-') || c.is_ascii_digit() {
                     let name = Self::next_word_char_unwrap(&mut chars, &mut cursor).to_string();
                     Self::push_word_part(

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3146,6 +3146,7 @@ impl<'a> Parser<'a> {
         chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
         cursor: &mut Position,
         part_start: Position,
+        source_backed: bool,
     ) -> Option<WordPart> {
         if !self.dialect.features().zsh_parameter_modifiers
             || !chars
@@ -3164,32 +3165,47 @@ impl<'a> Parser<'a> {
         {
             lookahead.next();
         }
-        if !lookahead
-            .peek()
-            .copied()
-            .is_some_and(Self::zsh_bare_parameter_target_start)
-        {
+        if !Self::zsh_bare_parameter_target_starts(&lookahead) {
             return None;
         }
 
         let raw_body_start = *cursor;
-        let mut raw_body = String::new();
+        let mut raw_body_text = String::new();
         while chars
             .peek()
             .copied()
             .is_some_and(Self::zsh_bare_parameter_prefix_modifier)
         {
-            raw_body.push(Self::next_word_char_unwrap(chars, cursor));
+            raw_body_text.push(Self::next_word_char_unwrap(chars, cursor));
         }
 
         let first = Self::next_word_char_unwrap(chars, cursor);
-        raw_body.push(first);
-        if first.is_ascii_alphabetic() || first == '_' {
-            raw_body.push_str(&Self::read_word_while(chars, cursor, |ch| {
+        raw_body_text.push(first);
+        if first == '+' {
+            raw_body_text.push_str(&Self::read_word_while(chars, cursor, |ch| {
+                ch.is_ascii_alphanumeric() || ch == '_'
+            }));
+        } else if first.is_ascii_alphabetic() || first == '_' {
+            raw_body_text.push_str(&Self::read_word_while(chars, cursor, |ch| {
                 ch.is_ascii_alphanumeric() || ch == '_'
             }));
         }
+        if Self::consume_word_char_if(chars, cursor, '[') {
+            raw_body_text.push('[');
+            let (index, raw_index) = self.read_array_index(chars, cursor, source_backed);
+            raw_body_text.push_str(raw_index.as_ref().unwrap_or(&index).slice(self.input));
+            raw_body_text.push(']');
+        }
 
+        let span = Span::from_positions(raw_body_start, *cursor);
+        let raw_body = if source_backed
+            && span.end.offset <= self.input.len()
+            && span.slice(self.input) == raw_body_text
+        {
+            span.slice(self.input).to_owned()
+        } else {
+            raw_body_text
+        };
         let raw_body = self.source_text(raw_body, raw_body_start, *cursor);
         Some(self.zsh_parameter_word_part(raw_body, part_start, *cursor))
     }
@@ -3202,6 +3218,17 @@ impl<'a> Parser<'a> {
         matches!(ch, '?' | '#' | '@' | '*' | '!' | '$' | '-')
             || ch.is_ascii_alphanumeric()
             || ch == '_'
+    }
+
+    fn zsh_bare_parameter_target_starts(chars: &std::iter::Peekable<std::str::Chars<'_>>) -> bool {
+        let mut lookahead = chars.clone();
+        match lookahead.next() {
+            Some('+') => lookahead
+                .next()
+                .is_some_and(|ch| ch.is_ascii_alphanumeric() || ch == '_'),
+            Some(ch) => Self::zsh_bare_parameter_target_start(ch),
+            None => false,
+        }
     }
 
     fn zsh_modifier_suffix_candidate_chars(
@@ -5245,9 +5272,12 @@ impl<'a> Parser<'a> {
             }
 
             if let Some(&c) = chars.peek() {
-                if let Some(part) =
-                    self.parse_zsh_bare_prefixed_parameter(&mut chars, &mut cursor, part_start)
-                {
+                if let Some(part) = self.parse_zsh_bare_prefixed_parameter(
+                    &mut chars,
+                    &mut cursor,
+                    part_start,
+                    source_backed,
+                ) {
                     Self::push_word_part(parts, part, part_start, cursor);
                     current_start = cursor;
                     continue;


### PR DESCRIPTION
## Summary

- Infer `.zsh` files with zsh syntax markers as zsh even when they carry a bash compatibility shebang, preserving shellcheck header overrides.
- Parse bare zsh parameter prefix expansions such as `$=UNPACKCMD` as zsh parameter words in command position.
- Add focused regressions for shell-proxy numeric `0=...` assignment forms and rpm2cpio-style `$=...` command-position expansion.

## Tests

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p shuck-parser test_zsh_bare_dollar_prefix_flag_parses_as_parameter_word`
- `cargo test -p shuck-linter ignores_zsh_plugin_numeric_zero_assignments_despite_bash_compat_shebang`
- `cargo test -p shuck-linter ignores_zsh_word_splitting_expansion_in_command_position`
- `cargo test -p shuck-linter zsh_extension_and_markers_win_over_bash_compat_shebang`
- `cargo run -q -p shuck-cli -- check --no-cache --output-format json-lines /tmp/zsh/ohmyzsh/plugins/shell-proxy/shell-proxy.plugin.zsh /tmp/zsh/zinit/share/rpm2cpio.zsh | rg 'C116|C117|shell-proxy|rpm2cpio' || true`
- `cargo test -p shuck-parser`
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C116,C117`