### PR TITLE
Handle zsh completion helper variables

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -617,14 +617,18 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &command_child_index,
             self.source,
         );
+        let completion_registered_function_scopes = build_completion_registered_function_scopes(
+            self.semantic,
+            &commands,
+            &command_fact_indices_by_id,
+            &lists,
+            self.source,
+        );
         let completion_registered_function_command_flags =
             build_completion_registered_function_command_flags(
-                self.semantic,
                 semantic_analysis,
                 &commands,
-                &command_fact_indices_by_id,
-                &lists,
-                self.source,
+                &completion_registered_function_scopes,
             );
         let external_entrypoint_function_scopes = build_external_entrypoint_function_scopes(
             self.semantic,
@@ -967,6 +971,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             array_assignment_split_word_ids,
             brace_variable_before_bracket_spans,
             completion_registered_function_command_flags,
+            completion_registered_function_scopes,
             external_entrypoint_function_scopes,
             function_headers,
             function_definition_command_ids_by_scope,

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -247,6 +247,11 @@ fn build_completion_registered_function_scopes(
         function_candidates[command.id().index()] =
             completion_registered_function_candidate(semantic, command);
     }
+    let top_level_candidate_scopes = function_candidates
+        .iter()
+        .flatten()
+        .map(|candidate| candidate.scope)
+        .collect::<FxHashSet<_>>();
     let mut scopes = FxHashSet::default();
 
     for list in lists {
@@ -281,6 +286,9 @@ fn build_completion_registered_function_scopes(
     }
 
     for scope in semantic.scopes() {
+        if !top_level_candidate_scopes.contains(&scope.id) {
+            continue;
+        }
         let ScopeKind::Function(FunctionScopeKind::Named(names)) = &scope.kind else {
             continue;
         };
@@ -405,7 +413,25 @@ fn is_top_level_zsh_entrypoint_registration(
     semantic: &SemanticModel,
     command: &CommandFact<'_>,
 ) -> bool {
-    semantic.scope(command.scope()).parent.is_none() && !command.is_nested_word_command()
+    semantic.scope(command.scope()).parent.is_none()
+        && !command.is_nested_word_command()
+        && !has_structural_parent_command(semantic, command.id())
+}
+
+fn has_structural_parent_command(semantic: &SemanticModel, id: CommandId) -> bool {
+    let mut current = semantic.syntax_backed_command_parent_id(id);
+    while let Some(parent) = current {
+        if matches!(
+            semantic.command_kind(parent),
+            shuck_semantic::CommandKind::Compound(_)
+                | shuck_semantic::CommandKind::Function
+                | shuck_semantic::CommandKind::AnonymousFunction
+        ) {
+            return true;
+        }
+        current = semantic.syntax_backed_command_parent_id(parent);
+    }
+    false
 }
 
 fn function_command_slot_count(commands: &[CommandFact<'_>]) -> usize {
@@ -420,6 +446,9 @@ fn completion_registered_function_candidate(
     semantic: &SemanticModel,
     command: &CommandFact<'_>,
 ) -> Option<CompletionRegisteredFunctionCandidate> {
+    if !is_top_level_zsh_entrypoint_registration(semantic, command) {
+        return None;
+    }
     let Command::Function(function) = command.command() else {
         return None;
     };
@@ -468,11 +497,6 @@ fn command_registers_completion_function(
                 continue;
             }
             if text == expected_name {
-                return true;
-            }
-            if let Some((_, function)) = text.split_once('=')
-                && function == expected_name
-            {
                 return true;
             }
             return false;

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -256,15 +256,10 @@ fn build_completion_registered_function_scopes(
             };
 
             if list.segments()[index + 1..].iter().any(|later_segment| {
-                command_registers_completion_function(
-                    command_fact(
-                        commands,
-                        command_fact_indices_by_id,
-                        later_segment.command_id(),
-                    ),
-                    source,
-                    &candidate.name,
-                )
+                let later_command =
+                    command_fact(commands, command_fact_indices_by_id, later_segment.command_id());
+                is_top_level_zsh_entrypoint_registration(semantic, later_command)
+                    && command_registers_completion_function(later_command, source, &candidate.name)
             }) {
                 scopes.insert(candidate.scope);
             }
@@ -277,6 +272,7 @@ fn build_completion_registered_function_scopes(
         };
         if commands.iter().any(|later_command| {
             later_command.span().start.offset > command.span().end.offset
+                && is_top_level_zsh_entrypoint_registration(semantic, later_command)
                 && later_command.effective_or_literal_name() == Some("compdef")
                 && command_registers_completion_function(later_command, source, &candidate.name)
         }) {
@@ -290,6 +286,7 @@ fn build_completion_registered_function_scopes(
         };
         if commands.iter().any(|command| {
             command.span().start.offset > scope.span.end.offset
+                && is_top_level_zsh_entrypoint_registration(semantic, command)
                 && command.effective_or_literal_name() == Some("compdef")
                 && names.iter().any(|name| {
                     command_registers_completion_function(command, source, name.as_str())

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -221,21 +221,10 @@ fn build_function_parameter_fallback_spans(
 }
 
 fn build_completion_registered_function_command_flags(
-    semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
-    command_fact_indices_by_id: &[Option<usize>],
-    lists: &[ListFact<'_>],
-    source: &str,
+    registered_scopes: &FxHashSet<ScopeId>,
 ) -> Vec<bool> {
-    let registered_scopes = build_completion_registered_function_scopes(
-        semantic,
-        commands,
-        command_fact_indices_by_id,
-        lists,
-        source,
-    );
-
     let mut flags = vec![false; function_command_slot_count(commands)];
     for command in commands {
         flags[command.id().index()] = semantic_analysis
@@ -279,6 +268,34 @@ fn build_completion_registered_function_scopes(
             }) {
                 scopes.insert(candidate.scope);
             }
+        }
+    }
+
+    for command in commands {
+        let Some(candidate) = function_candidates[command.id().index()].as_ref() else {
+            continue;
+        };
+        if commands.iter().any(|later_command| {
+            later_command.span().start.offset > command.span().end.offset
+                && later_command.effective_or_literal_name() == Some("compdef")
+                && command_registers_completion_function(later_command, source, &candidate.name)
+        }) {
+            scopes.insert(candidate.scope);
+        }
+    }
+
+    for scope in semantic.scopes() {
+        let ScopeKind::Function(FunctionScopeKind::Named(names)) = &scope.kind else {
+            continue;
+        };
+        if commands.iter().any(|command| {
+            command.span().start.offset > scope.span.end.offset
+                && command.effective_or_literal_name() == Some("compdef")
+                && names.iter().any(|name| {
+                    command_registers_completion_function(command, source, name.as_str())
+                })
+        }) {
+            scopes.insert(scope.id);
         }
     }
 
@@ -440,35 +457,59 @@ fn command_registers_completion_function(
     source: &str,
     expected_name: &str,
 ) -> bool {
-    if command.effective_or_literal_name() != Some("complete") {
+    let command_name = command.effective_or_literal_name();
+
+    if command_name == Some("compdef") {
+        for word in command.body_args() {
+            let Some(text) = static_word_text(word, source) else {
+                continue;
+            };
+            if text == "--" {
+                continue;
+            }
+            if text.starts_with('-') {
+                continue;
+            }
+            if text == expected_name {
+                return true;
+            }
+            if let Some((_, function)) = text.split_once('=')
+                && function == expected_name
+            {
+                return true;
+            }
+            return false;
+        }
         return false;
     }
 
-    let mut expects_function_name = false;
-    for word in command.body_args() {
-        let Some(text) = static_word_text(word, source) else {
-            expects_function_name = false;
-            continue;
-        };
+    if command_name == Some("complete") {
+        let mut expects_function_name = false;
+        for word in command.body_args() {
+            let Some(text) = static_word_text(word, source) else {
+                expects_function_name = false;
+                continue;
+            };
 
-        if expects_function_name {
-            return text == expected_name;
-        }
+            if expects_function_name {
+                return text == expected_name;
+            }
 
-        if text == "--" {
-            return false;
-        }
-        if text == "-F" || text == "--function" {
-            expects_function_name = true;
-            continue;
-        }
-        if let Some(name) = text.strip_prefix("-F")
-            && !name.is_empty()
-        {
-            return name == expected_name;
-        }
-        if let Some(name) = text.strip_prefix("--function=") {
-            return name == expected_name;
+            if text == "--" {
+                return false;
+            }
+            if text == "-F" || text == "--function" {
+                expects_function_name = true;
+                continue;
+            }
+            if let Some(name) = text.strip_prefix("-F")
+                && !name.is_empty()
+            {
+                return name == expected_name;
+            }
+            if let Some(name) = text.strip_prefix("--function=") {
+                return name == expected_name;
+            }
         }
     }
 

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -494,6 +494,9 @@ fn command_registers_completion_function(
                 continue;
             }
             if text.starts_with('-') {
+                if text.contains('d') || text.contains('D') {
+                    return false;
+                }
                 continue;
             }
             if text == expected_name {

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -276,8 +276,7 @@ fn build_completion_registered_function_scopes(
             continue;
         };
         if commands.iter().any(|later_command| {
-            later_command.span().start.offset > command.span().end.offset
-                && is_unconditional_completion_registration(semantic, later_command)
+            is_unconditional_completion_registration(semantic, later_command)
                 && later_command.effective_or_literal_name() == Some("compdef")
                 && command_registers_completion_function(later_command, source, &candidate.name)
         }) {
@@ -293,8 +292,7 @@ fn build_completion_registered_function_scopes(
             continue;
         };
         if commands.iter().any(|command| {
-            command.span().start.offset > scope.span.end.offset
-                && is_unconditional_completion_registration(semantic, command)
+            is_unconditional_completion_registration(semantic, command)
                 && command.effective_or_literal_name() == Some("compdef")
                 && names.iter().any(|name| {
                     command_registers_completion_function(command, source, name.as_str())

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -486,18 +486,42 @@ fn command_registers_completion_function(
     let command_name = command.effective_or_literal_name();
 
     if command_name == Some("compdef") {
-        for word in command.body_args() {
+        let mut index = 0usize;
+        let args = command.body_args();
+        while let Some(word) = args.get(index) {
             let Some(text) = static_word_text(word, source) else {
-                continue;
+                return false;
             };
             if text == "--" {
-                continue;
+                index += 1;
+                break;
             }
-            if text.starts_with('-') {
-                if text.contains('d') || text.contains('D') {
-                    return false;
+            let Some(flags) = text.strip_prefix('-') else {
+                break;
+            };
+            if flags.is_empty() || flags.starts_with('-') {
+                break;
+            }
+            if flags.contains('d') || flags.contains('D') {
+                return false;
+            }
+            index += 1;
+            for flag in flags.chars() {
+                if matches!(flag, 'p' | 'P' | 'N') {
+                    if index >= args.len() {
+                        return false;
+                    }
+                    index += 1;
                 }
-                continue;
+            }
+        }
+
+        if let Some(word) = args.get(index) {
+            let Some(text) = static_word_text(word, source) else {
+                return false;
+            };
+            if text.contains('=') {
+                return false;
             }
             if text == expected_name {
                 return true;

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -263,7 +263,7 @@ fn build_completion_registered_function_scopes(
             if list.segments()[index + 1..].iter().any(|later_segment| {
                 let later_command =
                     command_fact(commands, command_fact_indices_by_id, later_segment.command_id());
-                is_top_level_zsh_entrypoint_registration(semantic, later_command)
+                is_unconditional_completion_registration(semantic, later_command)
                     && command_registers_completion_function(later_command, source, &candidate.name)
             }) {
                 scopes.insert(candidate.scope);
@@ -277,7 +277,7 @@ fn build_completion_registered_function_scopes(
         };
         if commands.iter().any(|later_command| {
             later_command.span().start.offset > command.span().end.offset
-                && is_top_level_zsh_entrypoint_registration(semantic, later_command)
+                && is_unconditional_completion_registration(semantic, later_command)
                 && later_command.effective_or_literal_name() == Some("compdef")
                 && command_registers_completion_function(later_command, source, &candidate.name)
         }) {
@@ -294,7 +294,7 @@ fn build_completion_registered_function_scopes(
         };
         if commands.iter().any(|command| {
             command.span().start.offset > scope.span.end.offset
-                && is_top_level_zsh_entrypoint_registration(semantic, command)
+                && is_unconditional_completion_registration(semantic, command)
                 && command.effective_or_literal_name() == Some("compdef")
                 && names.iter().any(|name| {
                     command_registers_completion_function(command, source, name.as_str())
@@ -434,6 +434,28 @@ fn has_structural_parent_command(semantic: &SemanticModel, id: CommandId) -> boo
     false
 }
 
+fn is_unconditional_completion_registration(
+    semantic: &SemanticModel,
+    command: &CommandFact<'_>,
+) -> bool {
+    if !is_top_level_zsh_entrypoint_registration(semantic, command) {
+        return false;
+    }
+    command.effective_or_literal_name() != Some("compdef")
+        || !has_binary_parent_command(semantic, command.id())
+}
+
+fn has_binary_parent_command(semantic: &SemanticModel, id: CommandId) -> bool {
+    let mut current = semantic.syntax_backed_command_parent_id(id);
+    while let Some(parent) = current {
+        if matches!(semantic.command_kind(parent), shuck_semantic::CommandKind::Binary) {
+            return true;
+        }
+        current = semantic.syntax_backed_command_parent_id(parent);
+    }
+    false
+}
+
 fn function_command_slot_count(commands: &[CommandFact<'_>]) -> usize {
     commands
         .iter()
@@ -507,7 +529,7 @@ fn command_registers_completion_function(
             }
             index += 1;
             for flag in flags.chars() {
-                if matches!(flag, 'p' | 'P' | 'N') {
+                if matches!(flag, 'p' | 'P') {
                     if index >= args.len() {
                         return false;
                     }

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -67,11 +67,11 @@ use shuck_parser::parser::Parser;
 use shuck_semantic::{
     ArithmeticLiteralBehavior, Binding, BindingAttributes, BindingId, BindingKind, CaseCliDispatch,
     Declaration, DeclarationBuiltin, DeclarationOperand as SemanticDeclarationOperand,
-    FieldSplittingBehavior, FileExpansionOrderBehavior, GlobDotBehavior, GlobFailureBehavior,
-    GlobPatternBehavior, NonpersistentAssignmentAnalysisContext,
+    FieldSplittingBehavior, FileExpansionOrderBehavior, FunctionScopeKind, GlobDotBehavior,
+    GlobFailureBehavior, GlobPatternBehavior, NonpersistentAssignmentAnalysisContext,
     NonpersistentAssignmentAnalysisOptions, NonpersistentAssignmentCommandContext,
     NonpersistentAssignmentExtraRead, OptionValue, PathnameExpansionBehavior, Reference,
-    ReferenceId, ReferenceKind, ScopeId, SemanticAnalysis, SemanticModel,
+    ReferenceId, ReferenceKind, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel,
     SemanticPipelineOperatorKind, SemanticValueFlow, ShellBehaviorAt, SubscriptIndexBehavior,
     ZshOptionState,
 };

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -47,6 +47,7 @@ pub struct LinterFacts<'a> {
     array_assignment_split_word_ids: Vec<WordOccurrenceId>,
     brace_variable_before_bracket_spans: Vec<Span>,
     completion_registered_function_command_flags: Vec<bool>,
+    completion_registered_function_scopes: FxHashSet<ScopeId>,
     external_entrypoint_function_scopes: FxHashSet<ScopeId>,
     function_headers: Vec<FunctionHeaderFact<'a>>,
     function_definition_command_ids_by_scope: FxHashMap<ScopeId, CommandId>,
@@ -669,6 +670,10 @@ impl<'a> LinterFacts<'a> {
             .get(id.index())
             .copied()
             .unwrap_or(false)
+    }
+
+    pub fn function_is_completion_registered(&self, scope: ScopeId) -> bool {
+        self.completion_registered_function_scopes.contains(&scope)
     }
 
     pub fn function_is_external_entrypoint(&self, scope: ScopeId) -> bool {

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -732,6 +732,29 @@ compdef -d grunt
 }
 
 #[test]
+fn marks_zsh_compdef_functions_after_option_operands() {
+    let source = "\
+#!/bin/zsh
+__grunt() {
+  print -r -- $verbose
+}
+compdef -P 'grunt-*' __grunt grunt
+";
+
+    with_facts(source, None, |_, facts| {
+        let flagged_lines = facts
+            .commands()
+            .iter()
+            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .map(|command| command.span().start.line)
+            .collect::<Vec<_>>();
+
+        assert!(!flagged_lines.is_empty());
+        assert!(flagged_lines.iter().all(|line| *line == 3));
+    });
+}
+
+#[test]
 fn marks_zsh_widget_and_hook_functions_as_external_entrypoints() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -640,6 +640,30 @@ compdef __grunt grunt
 }
 
 #[test]
+fn ignores_zsh_compdef_registrations_inside_function_bodies() {
+    let source = "\
+#!/bin/zsh
+__grunt() {
+  print -r -- $verbose
+}
+setup_completion() {
+  compdef __grunt grunt
+}
+";
+
+    with_facts(source, None, |_, facts| {
+        let flagged_lines = facts
+            .commands()
+            .iter()
+            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .map(|command| command.span().start.line)
+            .collect::<Vec<_>>();
+
+        assert_eq!(flagged_lines, Vec::<usize>::new());
+    });
+}
+
+#[test]
 fn marks_zsh_widget_and_hook_functions_as_external_entrypoints() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -732,6 +732,28 @@ compdef -d grunt
 }
 
 #[test]
+fn ignores_conditionally_executed_zsh_compdef_registrations() {
+    let source = "\
+#!/bin/zsh
+__grunt() {
+  print -r -- $verbose
+}
+[[ -n $commands[grunt] ]] && compdef __grunt grunt
+";
+
+    with_facts(source, None, |_, facts| {
+        let flagged_lines = facts
+            .commands()
+            .iter()
+            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .map(|command| command.span().start.line)
+            .collect::<Vec<_>>();
+
+        assert_eq!(flagged_lines, Vec::<usize>::new());
+    });
+}
+
+#[test]
 fn marks_zsh_compdef_functions_after_option_operands() {
     let source = "\
 #!/bin/zsh
@@ -739,6 +761,29 @@ __grunt() {
   print -r -- $verbose
 }
 compdef -P 'grunt-*' __grunt grunt
+";
+
+    with_facts(source, None, |_, facts| {
+        let flagged_lines = facts
+            .commands()
+            .iter()
+            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .map(|command| command.span().start.line)
+            .collect::<Vec<_>>();
+
+        assert!(!flagged_lines.is_empty());
+        assert!(flagged_lines.iter().all(|line| *line == 3));
+    });
+}
+
+#[test]
+fn marks_zsh_compdef_functions_after_pattern_and_name_mode_options() {
+    let source = "\
+#!/bin/zsh
+__grunt() {
+  print -r -- $verbose
+}
+compdef -P 'grunt-*' -N __grunt grunt
 ";
 
     with_facts(source, None, |_, facts| {

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -664,6 +664,52 @@ setup_completion() {
 }
 
 #[test]
+fn ignores_zsh_compdef_for_conditionally_defined_functions() {
+    let source = "\
+#!/bin/zsh
+if [[ -n $commands[grunt] ]]; then
+  __grunt() {
+    print -r -- $verbose
+  }
+fi
+compdef __grunt grunt
+";
+
+    with_facts(source, None, |_, facts| {
+        let flagged_lines = facts
+            .commands()
+            .iter()
+            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .map(|command| command.span().start.line)
+            .collect::<Vec<_>>();
+
+        assert_eq!(flagged_lines, Vec::<usize>::new());
+    });
+}
+
+#[test]
+fn ignores_zsh_compdef_service_aliases_for_function_matching() {
+    let source = "\
+#!/bin/zsh
+grunt() {
+  print -r -- $verbose
+}
+compdef __grunt=grunt
+";
+
+    with_facts(source, None, |_, facts| {
+        let flagged_lines = facts
+            .commands()
+            .iter()
+            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .map(|command| command.span().start.line)
+            .collect::<Vec<_>>();
+
+        assert_eq!(flagged_lines, Vec::<usize>::new());
+    });
+}
+
+#[test]
 fn marks_zsh_widget_and_hook_functions_as_external_entrypoints() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -710,6 +710,28 @@ compdef __grunt=grunt
 }
 
 #[test]
+fn ignores_zsh_compdef_deletion_modes_for_function_matching() {
+    let source = "\
+#!/bin/zsh
+grunt() {
+  print -r -- $verbose
+}
+compdef -d grunt
+";
+
+    with_facts(source, None, |_, facts| {
+        let flagged_lines = facts
+            .commands()
+            .iter()
+            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .map(|command| command.span().start.line)
+            .collect::<Vec<_>>();
+
+        assert_eq!(flagged_lines, Vec::<usize>::new());
+    });
+}
+
+#[test]
 fn marks_zsh_widget_and_hook_functions_as_external_entrypoints() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -617,6 +617,29 @@ complete -F _comp_cmd_later later
 }
 
 #[test]
+fn marks_commands_inside_zsh_compdef_registered_functions() {
+    let source = "\
+#!/bin/zsh
+__grunt() {
+  print -r -- $verbose
+}
+compdef __grunt grunt
+";
+
+    with_facts(source, None, |_, facts| {
+        let flagged_lines = facts
+            .commands()
+            .iter()
+            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .map(|command| command.span().start.line)
+            .collect::<Vec<_>>();
+
+        assert!(!flagged_lines.is_empty());
+        assert!(flagged_lines.iter().all(|line| *line == 3));
+    });
+}
+
+#[test]
 fn marks_zsh_widget_and_hook_functions_as_external_entrypoints() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/facts/tests/functions.rs
+++ b/crates/shuck-linter/src/facts/tests/functions.rs
@@ -800,6 +800,29 @@ compdef -P 'grunt-*' -N __grunt grunt
 }
 
 #[test]
+fn marks_later_zsh_functions_registered_by_earlier_compdef() {
+    let source = "\
+#!/bin/zsh
+compdef __grunt grunt
+__grunt() {
+  print -r -- $verbose
+}
+";
+
+    with_facts(source, None, |_, facts| {
+        let flagged_lines = facts
+            .commands()
+            .iter()
+            .filter(|command| facts.command_is_in_completion_registered_function(command.id()))
+            .map(|command| command.span().start.line)
+            .collect::<Vec<_>>();
+
+        assert!(!flagged_lines.is_empty());
+        assert!(flagged_lines.iter().all(|line| *line == 4));
+    });
+}
+
+#[test]
 fn marks_zsh_widget_and_hook_functions_as_external_entrypoints() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -603,6 +603,31 @@ compdef __example example
     }
 
     #[test]
+    fn zsh_completion_context_names_stay_reportable_without_top_level_compdef() {
+        let source = "\
+#!/bin/zsh
+function __grunt() {
+  print -r -- $verbose $missing
+}
+setup_completion() {
+  compdef __grunt grunt
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$verbose", "$missing"]
+        );
+    }
+
+    #[test]
     fn zsh_zstyle_array_query_defines_named_target() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -745,6 +745,29 @@ compdef -P 'grunt-*' -N __grunt grunt
     }
 
     #[test]
+    fn zsh_earlier_compdef_initializes_later_completion_context_names() {
+        let source = "\
+#!/bin/zsh
+compdef __grunt grunt
+function __grunt() {
+  print -r -- $verbose $missing
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
     fn zsh_arguments_without_state_action_keeps_state_names_reportable() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1,6 +1,6 @@
 use compact_str::CompactString;
 use rustc_hash::FxHashSet;
-use shuck_semantic::UninitializedCertainty;
+use shuck_semantic::{Reference, UninitializedCertainty};
 
 use crate::{Checker, Rule, Violation};
 
@@ -63,6 +63,9 @@ pub fn undefined_variable(checker: &mut Checker) {
         {
             continue;
         }
+        if is_zsh_completion_context_reference(checker, reference) {
+            continue;
+        }
         if !is_reportable_variable_reference(
             checker,
             reference,
@@ -88,6 +91,32 @@ pub fn undefined_variable(checker: &mut Checker) {
             reference.span,
         );
     }
+}
+
+fn is_zsh_completion_context_reference(checker: &Checker<'_>, reference: &Reference) -> bool {
+    checker.shell() == crate::ShellDialect::Zsh
+        && is_zsh_completion_context_name(reference.name.as_str())
+        && checker
+            .semantic_analysis()
+            .enclosing_function_scope_at(reference.span.start.offset)
+            .is_some_and(|scope| checker.facts().function_is_completion_registered(scope))
+}
+
+fn is_zsh_completion_context_name(name: &str) -> bool {
+    matches!(
+        name,
+        "CURRENT"
+            | "IPREFIX"
+            | "ISUFFIX"
+            | "PREFIX"
+            | "QIPREFIX"
+            | "QISUFFIX"
+            | "SUFFIX"
+            | "compstate"
+            | "curcontext"
+            | "verbose"
+            | "words"
+    )
 }
 
 #[cfg(test)]
@@ -483,6 +512,93 @@ printf '%s\\n' \"$bar\" \"$foo\" \"$b\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$b"]
+        );
+    }
+
+    #[test]
+    fn zsh_helpers_inherit_caller_scoped_zparseopts_arrays() {
+        let source = "\
+#!/bin/zsh
+safe_rm() {
+  if [[ ${#dry_run[@]} -gt 0 ]]; then
+    print -r -- dry
+  fi
+  print -r -- $missing
+}
+update_main() {
+  local -a dry_run
+  zparseopts -D -- -dry-run=dry_run
+  safe_rm target
+}
+update_main \"$@\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_arguments_initializes_completion_state_in_caller_scope() {
+        let source = "\
+#!/bin/zsh
+function __grunt() {
+  local curcontext=\"$curcontext\" state opts tasks
+  opts=()
+  tasks=()
+  _arguments \"${opts[@]}\" '*: :->tasks' || return
+  case $state in
+    tasks)
+      _describe -t grunt-task \"$verbose grunt task\" tasks || return 1
+    ;;
+  esac
+}
+compdef __grunt grunt
+print -r -- $missing
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_arguments_defines_completion_helper_variables() {
+        let source = "\
+#!/bin/zsh
+function __example() {
+  _arguments '*: :->state'
+  print -r -- $state $context $line $opt_args $state_descr $missing
+}
+compdef __example example
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -723,6 +723,30 @@ compdef __example example
     }
 
     #[test]
+    fn zsh_arguments_ignores_arrow_text_inside_option_descriptions() {
+        let source = "\
+#!/bin/zsh
+function __example() {
+  _arguments '--range[show start -> end]'
+  print -r -- $state $state_descr $missing
+}
+compdef __example example
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$state", "$state_descr", "$missing"]
+        );
+    }
+
+    #[test]
     fn zsh_zstyle_array_query_defines_named_target() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -676,6 +676,53 @@ compdef __grunt=grunt
     }
 
     #[test]
+    fn zsh_compdef_deletion_modes_do_not_initialize_completion_context_names() {
+        let source = "\
+#!/bin/zsh
+function grunt() {
+  print -r -- $verbose $missing
+}
+compdef -d grunt
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$verbose", "$missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_arguments_without_state_action_keeps_state_names_reportable() {
+        let source = "\
+#!/bin/zsh
+function __example() {
+  _arguments '--help[show help]'
+  print -r -- $context $line $opt_args $state $state_descr $missing
+}
+compdef __example example
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$state", "$state_descr", "$missing"]
+        );
+    }
+
+    #[test]
     fn zsh_zstyle_array_query_defines_named_target() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -628,6 +628,54 @@ setup_completion() {
     }
 
     #[test]
+    fn zsh_completion_context_names_stay_reportable_for_conditional_compdef_target() {
+        let source = "\
+#!/bin/zsh
+if [[ -n $commands[grunt] ]]; then
+  function __grunt() {
+    print -r -- $verbose $missing
+  }
+fi
+compdef __grunt grunt
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$verbose", "$missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_compdef_service_aliases_do_not_initialize_completion_context_names() {
+        let source = "\
+#!/bin/zsh
+function grunt() {
+  print -r -- $verbose $missing
+}
+compdef __grunt=grunt
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$verbose", "$missing"]
+        );
+    }
+
+    #[test]
     fn zsh_zstyle_array_query_defines_named_target() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -699,6 +699,52 @@ compdef -d grunt
     }
 
     #[test]
+    fn zsh_conditional_compdef_does_not_initialize_completion_context_names() {
+        let source = "\
+#!/bin/zsh
+function __grunt() {
+  print -r -- $verbose $missing
+}
+[[ -n $commands[grunt] ]] && compdef __grunt grunt
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$verbose", "$missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_compdef_name_mode_keeps_completion_context_names_initialized() {
+        let source = "\
+#!/bin/zsh
+function __grunt() {
+  print -r -- $verbose $missing
+}
+compdef -P 'grunt-*' -N __grunt grunt
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
     fn zsh_arguments_without_state_action_keeps_state_names_reportable() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-semantic/src/binding.rs
+++ b/crates/shuck-semantic/src/binding.rs
@@ -141,6 +141,8 @@ pub enum BuiltinBindingTargetKind {
     Zparseopts,
     /// `zstyle -a`, `zstyle -s`, or `zstyle -b`
     Zstyle,
+    /// zsh `_arguments`
+    ZshArguments,
 }
 
 /// High-level category for a semantic binding.

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -565,7 +565,31 @@ fn zsh_arguments_targets(include_state_targets: bool) -> Vec<(Name, BindingAttri
 fn zsh_arguments_has_state_action(args: &[&Word], source: &str) -> bool {
     args.iter()
         .filter_map(|word| static_word_text(word, source))
-        .any(|text| text.contains("->"))
+        .any(|text| zsh_argument_spec_has_state_action(&text))
+}
+
+fn zsh_argument_spec_has_state_action(text: &str) -> bool {
+    let mut bracket_depth = 0usize;
+    let mut previous_non_whitespace = None;
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '[' {
+            bracket_depth += 1;
+        } else if ch == ']' {
+            bracket_depth = bracket_depth.saturating_sub(1);
+        } else if ch == '-'
+            && chars.peek() == Some(&'>')
+            && bracket_depth == 0
+            && previous_non_whitespace == Some(':')
+        {
+            return true;
+        }
+
+        if !ch.is_whitespace() {
+            previous_non_whitespace = Some(ch);
+        }
+    }
+    false
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -157,6 +157,21 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     self.add_reference_if_bound(&argument, ReferenceKind::ImplicitRead, span);
                 }
             }
+            "_arguments" if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh => {
+                for (argument, attributes) in zsh_arguments_targets() {
+                    self.add_binding(
+                        &argument,
+                        BindingKind::ReadTarget,
+                        self.current_scope(),
+                        name_span,
+                        BindingOrigin::BuiltinTarget {
+                            definition_span: name_span,
+                            kind: BuiltinBindingTargetKind::ZshArguments,
+                        },
+                        attributes,
+                    );
+                }
+            }
             "let" => self.record_let_arithmetic_assignment_targets(args),
             "eval" => self.record_eval_argument_references(args),
             "trap" => self.record_trap_action_references(args),
@@ -527,6 +542,19 @@ fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAtt
     args.get(index + 2)
         .and_then(|word| named_target_word(word, source))
         .map(|(name, span)| (name, span, attributes))
+}
+
+fn zsh_arguments_targets() -> [(Name, BindingAttributes); 5] {
+    [
+        (Name::from("context"), BindingAttributes::ARRAY),
+        (Name::from("line"), BindingAttributes::ARRAY),
+        (
+            Name::from("opt_args"),
+            BindingAttributes::ARRAY | BindingAttributes::ASSOC,
+        ),
+        (Name::from("state"), BindingAttributes::ARRAY),
+        (Name::from("state_descr"), BindingAttributes::ARRAY),
+    ]
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -158,7 +158,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 }
             }
             "_arguments" if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh => {
-                for (argument, attributes) in zsh_arguments_targets() {
+                for (argument, attributes) in
+                    zsh_arguments_targets(zsh_arguments_has_state_action(args, self.source))
+                {
                     self.add_binding(
                         &argument,
                         BindingKind::ReadTarget,
@@ -544,17 +546,26 @@ fn zstyle_target(args: &[&Word], source: &str) -> Option<(Name, Span, BindingAtt
         .map(|(name, span)| (name, span, attributes))
 }
 
-fn zsh_arguments_targets() -> [(Name, BindingAttributes); 5] {
-    [
+fn zsh_arguments_targets(include_state_targets: bool) -> Vec<(Name, BindingAttributes)> {
+    let mut targets = vec![
         (Name::from("context"), BindingAttributes::ARRAY),
         (Name::from("line"), BindingAttributes::ARRAY),
         (
             Name::from("opt_args"),
             BindingAttributes::ARRAY | BindingAttributes::ASSOC,
         ),
-        (Name::from("state"), BindingAttributes::ARRAY),
-        (Name::from("state_descr"), BindingAttributes::ARRAY),
-    ]
+    ];
+    if include_state_targets {
+        targets.push((Name::from("state"), BindingAttributes::ARRAY));
+        targets.push((Name::from("state_descr"), BindingAttributes::ARRAY));
+    }
+    targets
+}
+
+fn zsh_arguments_has_state_action(args: &[&Word], source: &str) -> bool {
+    args.iter()
+        .filter_map(|word| static_word_text(word, source))
+        .any(|text| text.contains("->"))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- Recognize zsh `compdef`-registered completion functions in linter facts.
- Model zsh `_arguments` as initializing its caller-scope helper variables (`state`, `context`, `line`, `opt_args`, and `state_descr`).
- Suppress C006 for known zsh completion-context variables, such as `verbose`, only inside completion-registered functions.

## Validation

- `cargo test -p shuck-linter undefined_variable -- --nocapture`
- `cargo test -p shuck-linter marks_commands_inside_zsh_compdef_registered_functions -- --nocapture`
- `cargo test -p shuck-semantic zparseopts -- --nocapture`
- `cargo test -p shuck-semantic zsh_describe -- --nocapture`
- `cargo test -p shuck-linter`
- `target/debug/shuck check --no-cache --select C006 --output-format json-lines /tmp/zsh/dotfiler/update_core.zsh /tmp/zsh/zdot/core/update-impl.zsh /tmp/zsh/ohmyzsh/plugins/grunt/grunt.plugin.zsh`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C006`

## Residual

The `grunt.plugin.zsh:104` completion false positive is fixed. The two update helper diagnostics still reproduce when those helper files are analyzed as standalone modules because their `dry_run`/`force` arrays are supplied by external callers; that remains a separate reverse caller/callee ambient-contract problem rather than something this PR suppresses by path or comment shape.