### PR TITLE
Fix zsh subshell side-effect modeling

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1169,8 +1169,17 @@ fn nonpersistent_assignment_reaches_later_use(
     let assignment_transient = semantic.innermost_transient_scope_within_function(assignment_scope);
     let later_use_scope = semantic.scope_at(effect.later_use_span.start.offset);
     let later_use_transient = semantic.innermost_transient_scope_within_function(later_use_scope);
-    if later_use_transient.is_some() && later_use_transient != assignment_transient {
-        return false;
+    if let Some(later_use_transient) = later_use_transient {
+        let Some(assignment_transient) = assignment_transient else {
+            return false;
+        };
+        if later_use_transient != assignment_transient
+            && !semantic
+                .ancestor_scopes(assignment_transient)
+                .any(|scope| scope == later_use_transient)
+        {
+            return false;
+        }
     }
 
     true
@@ -1651,7 +1660,7 @@ fn zsh_pipeline_tail_runs_in_current_shell(
     }
 
     command_is_pipeline_tail_operand(semantic, command.id(), source)
-        || command_is_preceded_by_pipeline_operator(command.span(), source)
+        || command_is_textual_pipeline_tail_operand(command.span(), source)
 }
 
 fn command_is_pipeline_tail_operand(
@@ -1690,10 +1699,16 @@ fn binary_child_is_pipe_tail_operand(
     before_child.ends_with('|') && !before_child.ends_with("||")
 }
 
-fn command_is_preceded_by_pipeline_operator(command_span: Span, source: &str) -> bool {
+fn command_is_textual_pipeline_tail_operand(command_span: Span, source: &str) -> bool {
     let before_command = &source[..command_span.start.offset];
     let before_command = before_command.trim_end();
-    before_command.ends_with('|') && !before_command.ends_with("||")
+    if !before_command.ends_with('|') || before_command.ends_with("||") {
+        return false;
+    }
+
+    let after_command = &source[command_span.end.offset..];
+    let after_command = after_command.trim_start();
+    !after_command.starts_with('|')
 }
 
 fn reset_site_control_ancestors_contain_later_use(

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1566,8 +1566,7 @@ fn zsh_set_a_outparam_positions(args: &[&Word], source: &str) -> Vec<usize> {
     for word in args {
         let text = word.span.slice(source);
         if !saw_array_flag {
-            if static_word_text(word, source).is_some_and(|text| text == "-A" || text == "-AArray")
-            {
+            if static_word_text(word, source).is_some_and(|text| text == "-A") {
                 saw_array_flag = true;
             }
             continue;

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1398,7 +1398,7 @@ fn reset_flow_span_for_command(
         .filter(|span| {
             let before_command = &source[span.start.offset..command_span.start.offset];
             let before_command = before_command.trim_end();
-            before_command.ends_with('|') && !before_command.ends_with("||")
+            text_ends_with_pipeline_operator(before_command)
         })
         .min_by_key(|span| span.end.offset - span.start.offset)
         .unwrap_or(command_span);
@@ -1612,17 +1612,45 @@ fn resolved_function_scope_for_command(
             command_is_inside_function_body(semantic, command.scope()).then(|| {
                 semantic_analysis
                     .function_call_arity_sites(&name)
-                    .find_map(|(site, binding)| (site.name_span == name_span).then_some(binding))
+                    .find_map(|(site, binding)| {
+                        (site.name_span == name_span
+                            && fallback_function_binding_is_callable_from_function_body(
+                                semantic, command, name_span, binding,
+                            ))
+                        .then_some(binding)
+                    })
             })?
         })?;
     let scope = semantic_analysis.function_scope_for_binding(binding)?;
     Some((scope, name_span))
 }
 
+fn fallback_function_binding_is_callable_from_function_body(
+    semantic: &SemanticModel,
+    command: &CommandFact<'_>,
+    call_name_span: Span,
+    binding: BindingId,
+) -> bool {
+    let binding = semantic.binding(binding);
+    if binding.span.start.offset <= call_name_span.start.offset {
+        return true;
+    }
+
+    enclosing_function_scope(semantic, command.scope()) != enclosing_function_scope(semantic, binding.scope)
+}
+
 fn command_is_inside_function_body(semantic: &SemanticModel, scope: ScopeId) -> bool {
+    enclosing_function_scope(semantic, scope).is_some()
+}
+
+fn enclosing_function_scope(semantic: &SemanticModel, scope: ScopeId) -> Option<ScopeId> {
+    if matches!(semantic.scope_kind(scope), ScopeKind::Function(_)) {
+        return Some(scope);
+    }
+
     semantic
         .ancestor_scopes(scope)
-        .any(|scope| matches!(semantic.scope_kind(scope), ScopeKind::Function(_)))
+        .find(|scope| matches!(semantic.scope_kind(*scope), ScopeKind::Function(_)))
 }
 
 fn command_runs_in_persistent_shell_context(
@@ -1696,19 +1724,23 @@ fn binary_child_is_pipe_tail_operand(
 
     let before_child = &source[parent_span.start.offset..child_span.start.offset];
     let before_child = before_child.trim_end();
-    before_child.ends_with('|') && !before_child.ends_with("||")
+    text_ends_with_pipeline_operator(before_child)
 }
 
 fn command_is_textual_pipeline_tail_operand(command_span: Span, source: &str) -> bool {
     let before_command = &source[..command_span.start.offset];
     let before_command = before_command.trim_end();
-    if !before_command.ends_with('|') || before_command.ends_with("||") {
+    if !text_ends_with_pipeline_operator(before_command) {
         return false;
     }
 
     let after_command = &source[command_span.end.offset..];
     let after_command = after_command.trim_start();
     !after_command.starts_with('|')
+}
+
+fn text_ends_with_pipeline_operator(text: &str) -> bool {
+    text.ends_with("|&") || (text.ends_with('|') && !text.ends_with("||"))
 }
 
 fn reset_site_control_ancestors_contain_later_use(

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1125,6 +1125,12 @@ fn build_nonpersistent_assignment_spans(
                 reset.name == effect.name
                     && reset.span.start.offset > effect.assignment_span.end.offset
                     && reset.span.start.offset < effect.later_use_span.start.offset
+                    && nonpersistent_reset_site_covers_later_use(
+                        semantic,
+                        semantic_analysis,
+                        &effect,
+                        reset,
+                    )
             })
         {
             continue;
@@ -1189,6 +1195,42 @@ fn nonpersistent_assignment_reaches_later_use(
     })
 }
 
+fn nonpersistent_reset_site_covers_later_use(
+    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
+    effect: &shuck_semantic::NonpersistentAssignmentEffect,
+    reset: &NonpersistentAssignmentExtraResetSite,
+) -> bool {
+    let reset_blocks = semantic_analysis
+        .block_ids_for_span(reset.flow_span)
+        .iter()
+        .copied()
+        .collect::<FxHashSet<_>>();
+    if reset_blocks.is_empty() {
+        return false;
+    }
+    if !reset_site_control_ancestors_contain_later_use(
+        semantic,
+        reset.command_id,
+        effect.later_use_span,
+    ) {
+        return false;
+    }
+
+    let later_use_blocks = semantic_analysis.block_ids_for_span(effect.later_use_span);
+    if later_use_blocks.is_empty() {
+        return true;
+    }
+
+    let assignment_scope = semantic.binding(effect.assignment_binding).scope;
+    let entry = semantic_analysis
+        .flow_entry_block_for_binding_scopes(&[assignment_scope], effect.later_use_span.start.offset);
+    later_use_blocks
+        .iter()
+        .copied()
+        .all(|target| semantic_analysis.blocks_cover_all_paths_to_block(entry, target, &reset_blocks))
+}
+
 fn span_contains(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }
@@ -1248,6 +1290,8 @@ struct NonpersistentAssignmentSpans {
 struct NonpersistentAssignmentExtraResetSite {
     name: Name,
     span: Span,
+    flow_span: Span,
+    command_id: CommandId,
 }
 
 fn build_nonpersistent_assignment_extra_reset_sites(
@@ -1273,10 +1317,14 @@ fn build_nonpersistent_assignment_extra_reset_sites(
                 resets.push(NonpersistentAssignmentExtraResetSite {
                     name: Name::from("REPLY"),
                     span: reset_span,
+                    flow_span: command.span(),
+                    command_id: command.id(),
                 });
                 resets.push(NonpersistentAssignmentExtraResetSite {
                     name: Name::from("reply"),
                     span: reset_span,
+                    flow_span: command.span(),
+                    command_id: command.id(),
                 });
             }
             continue;
@@ -1286,6 +1334,8 @@ fn build_nonpersistent_assignment_extra_reset_sites(
             resets.extend(names.iter().cloned().map(|name| NonpersistentAssignmentExtraResetSite {
                 name,
                 span: call_name_span,
+                flow_span: command.span(),
+                command_id: command.id(),
             }));
         }
 
@@ -1304,6 +1354,8 @@ fn build_nonpersistent_assignment_extra_reset_sites(
                 resets.push(NonpersistentAssignmentExtraResetSite {
                     name: Name::from(name.as_ref()),
                     span: argument.span,
+                    flow_span: command.span(),
+                    command_id: command.id(),
                 });
             }
         }
@@ -1315,8 +1367,16 @@ fn build_nonpersistent_assignment_extra_reset_sites(
             .cmp(right.name.as_str())
             .then_with(|| left.span.start.offset.cmp(&right.span.start.offset))
             .then_with(|| left.span.end.offset.cmp(&right.span.end.offset))
+            .then_with(|| left.flow_span.start.offset.cmp(&right.flow_span.start.offset))
+            .then_with(|| left.flow_span.end.offset.cmp(&right.flow_span.end.offset))
+            .then_with(|| left.command_id.index().cmp(&right.command_id.index()))
     });
-    resets.dedup_by(|left, right| left.name == right.name && left.span == right.span);
+    resets.dedup_by(|left, right| {
+        left.name == right.name
+            && left.span == right.span
+            && left.flow_span == right.flow_span
+            && left.command_id == right.command_id
+    });
     resets
 }
 
@@ -1470,6 +1530,54 @@ fn command_runs_in_persistent_shell_context(
         .transient_ancestor_scopes_within_function(command_scope)
         .next()
         .is_none()
+}
+
+fn reset_site_control_ancestors_contain_later_use(
+    semantic: &SemanticModel,
+    command_id: CommandId,
+    later_use_span: Span,
+) -> bool {
+    let mut current = command_id;
+    while let Some(parent) = semantic.syntax_backed_command_parent_id(current) {
+        if command_kind_may_skip_child(semantic.command_kind(parent))
+            && !span_contains(semantic.command_syntax_span(parent), later_use_span)
+        {
+            return false;
+        }
+        current = parent;
+    }
+    true
+}
+
+fn command_kind_may_skip_child(kind: CommandKind) -> bool {
+    match kind {
+        CommandKind::Binary => true,
+        CommandKind::Compound(
+            CompoundCommandKind::If
+            | CompoundCommandKind::For
+            | CompoundCommandKind::Repeat
+            | CompoundCommandKind::Foreach
+            | CompoundCommandKind::ArithmeticFor
+            | CompoundCommandKind::While
+            | CompoundCommandKind::Until
+            | CompoundCommandKind::Case
+            | CompoundCommandKind::Select,
+        ) => true,
+        CommandKind::Simple
+        | CommandKind::Builtin(_)
+        | CommandKind::Decl
+        | CommandKind::Compound(
+            CompoundCommandKind::Subshell
+            | CompoundCommandKind::BraceGroup
+            | CompoundCommandKind::Arithmetic
+            | CompoundCommandKind::Time
+            | CompoundCommandKind::Conditional
+            | CompoundCommandKind::Coproc
+            | CompoundCommandKind::Always,
+        )
+        | CommandKind::Function
+        | CommandKind::AnonymousFunction => false,
+    }
 }
 
 fn build_nonpersistent_assignment_command_contexts(

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1116,7 +1116,7 @@ fn build_nonpersistent_assignment_spans(
             continue;
         }
         if suppress_zsh_nested_subshell_noise
-            && !nonpersistent_assignment_reaches_later_use(semantic, semantic_analysis, &effect)
+            && !nonpersistent_assignment_reaches_later_use(semantic, &effect)
         {
             continue;
         }
@@ -1163,7 +1163,6 @@ fn build_nonpersistent_assignment_spans(
 
 fn nonpersistent_assignment_reaches_later_use(
     semantic: &SemanticModel,
-    semantic_analysis: &SemanticAnalysis<'_>,
     effect: &shuck_semantic::NonpersistentAssignmentEffect,
 ) -> bool {
     let assignment_scope = semantic.binding(effect.assignment_binding).scope;
@@ -1174,25 +1173,7 @@ fn nonpersistent_assignment_reaches_later_use(
         return false;
     }
 
-    let assignment_blocks = semantic_analysis
-        .block_ids_for_span(effect.assignment_span)
-        .iter()
-        .copied()
-        .collect::<FxHashSet<_>>();
-    if assignment_blocks.is_empty() {
-        return true;
-    }
-
-    let later_use_blocks = semantic_analysis.block_ids_for_span(effect.later_use_span);
-    if later_use_blocks.is_empty() {
-        return true;
-    }
-
-    let entry = semantic_analysis
-        .flow_entry_block_for_binding_scopes(&[assignment_scope], effect.later_use_span.start.offset);
-    later_use_blocks.iter().copied().all(|target| {
-        semantic_analysis.blocks_cover_all_paths_to_block(entry, target, &assignment_blocks)
-    })
+    true
 }
 
 fn nonpersistent_reset_site_covers_later_use(
@@ -1431,7 +1412,6 @@ fn helper_binding_can_reset_parent_scope(semantic: &SemanticModel, binding: &Bin
         | BindingKind::ParameterDefaultAssignment
         | BindingKind::AppendAssignment
         | BindingKind::ArrayAssignment
-        | BindingKind::LoopVariable
         | BindingKind::ReadTarget
         | BindingKind::MapfileTarget
         | BindingKind::PrintfTarget
@@ -1443,7 +1423,10 @@ fn helper_binding_can_reset_parent_scope(semantic: &SemanticModel, binding: &Bin
                 .attributes
                 .contains(BindingAttributes::DECLARATION_INITIALIZED)
         }
-        BindingKind::FunctionDefinition | BindingKind::Nameref | BindingKind::Imported => false,
+        BindingKind::LoopVariable
+        | BindingKind::FunctionDefinition
+        | BindingKind::Nameref
+        | BindingKind::Imported => false,
     }
 }
 

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1397,7 +1397,7 @@ fn helper_output_names_by_scope(semantic: &SemanticModel) -> FxHashMap<ScopeId, 
     let mut names_by_scope = FxHashMap::<ScopeId, Vec<Name>>::default();
 
     for binding in semantic.bindings() {
-        if !helper_binding_can_reset_parent_scope(binding) {
+        if !helper_binding_can_reset_parent_scope(semantic, binding) {
             continue;
         }
         if !matches!(semantic.scope_kind(binding.scope), ScopeKind::Function(_)) {
@@ -1418,8 +1418,11 @@ fn helper_output_names_by_scope(semantic: &SemanticModel) -> FxHashMap<ScopeId, 
     names_by_scope
 }
 
-fn helper_binding_can_reset_parent_scope(binding: &Binding) -> bool {
+fn helper_binding_can_reset_parent_scope(semantic: &SemanticModel, binding: &Binding) -> bool {
     if binding.attributes.contains(BindingAttributes::LOCAL) {
+        return false;
+    }
+    if !binding_command_is_unconditional_in_function(semantic, binding) {
         return false;
     }
 
@@ -1442,6 +1445,31 @@ fn helper_binding_can_reset_parent_scope(binding: &Binding) -> bool {
         }
         BindingKind::FunctionDefinition | BindingKind::Nameref | BindingKind::Imported => false,
     }
+}
+
+fn binding_command_is_unconditional_in_function(
+    semantic: &SemanticModel,
+    binding: &Binding,
+) -> bool {
+    let Some(mut current) = semantic.innermost_command_id_at(binding.span.start.offset) else {
+        return true;
+    };
+
+    while let Some(parent) = semantic.syntax_backed_command_parent_id(current) {
+        if matches!(semantic.command_kind(parent), CommandKind::Function) {
+            return true;
+        }
+        if reset_site_is_always_run_binary_operand(semantic, parent, current) {
+            current = parent;
+            continue;
+        }
+        if command_kind_may_skip_child(semantic.command_kind(parent)) {
+            return false;
+        }
+        current = parent;
+    }
+
+    true
 }
 
 fn zsh_set_a_outparam_positions_by_scope(
@@ -1539,6 +1567,10 @@ fn reset_site_control_ancestors_contain_later_use(
 ) -> bool {
     let mut current = command_id;
     while let Some(parent) = semantic.syntax_backed_command_parent_id(current) {
+        if reset_site_is_always_run_binary_operand(semantic, parent, current) {
+            current = parent;
+            continue;
+        }
         if command_kind_may_skip_child(semantic.command_kind(parent))
             && !span_contains(semantic.command_syntax_span(parent), later_use_span)
         {
@@ -1547,6 +1579,18 @@ fn reset_site_control_ancestors_contain_later_use(
         current = parent;
     }
     true
+}
+
+fn reset_site_is_always_run_binary_operand(
+    semantic: &SemanticModel,
+    parent: CommandId,
+    child: CommandId,
+) -> bool {
+    if !matches!(semantic.command_kind(parent), CommandKind::Binary) {
+        return false;
+    }
+
+    semantic.command_syntax_span(parent).start == semantic.command_syntax_span(child).start
 }
 
 fn command_kind_may_skip_child(kind: CommandKind) -> bool {

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1124,7 +1124,7 @@ fn build_nonpersistent_assignment_spans(
             && extra_reset_sites.iter().any(|reset| {
                 reset.name == effect.name
                     && reset.span.start.offset > effect.assignment_span.end.offset
-                    && reset.span.start.offset < effect.later_use_span.start.offset
+                    && reset.flow_span.end.offset <= effect.later_use_span.start.offset
                     && nonpersistent_reset_site_covers_later_use(
                         semantic,
                         semantic_analysis,
@@ -1451,10 +1451,14 @@ fn binding_command_is_unconditional_in_function(
     semantic: &SemanticModel,
     binding: &Binding,
 ) -> bool {
-    let Some(mut current) = semantic.innermost_command_id_at(binding.span.start.offset) else {
+    let Some(current) = semantic.innermost_command_id_at(binding.span.start.offset) else {
         return true;
     };
 
+    command_is_unconditional_in_function(semantic, current)
+}
+
+fn command_is_unconditional_in_function(semantic: &SemanticModel, mut current: CommandId) -> bool {
     while let Some(parent) = semantic.syntax_backed_command_parent_id(current) {
         if matches!(semantic.command_kind(parent), CommandKind::Function) {
             return true;
@@ -1481,6 +1485,9 @@ fn zsh_set_a_outparam_positions_by_scope(
 
     for command in commands {
         if !command.effective_name_is("set") {
+            continue;
+        }
+        if !command_is_unconditional_in_function(semantic, command.id()) {
             continue;
         }
         let Some(function_scope) = semantic.enclosing_function_scope(command.scope()) else {

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1120,14 +1120,14 @@ fn build_nonpersistent_assignment_spans(
         {
             continue;
         }
-        if let Some(extra_reset_sites) = &extra_reset_sites {
-            if extra_reset_sites.iter().any(|reset| {
+        if let Some(extra_reset_sites) = &extra_reset_sites
+            && extra_reset_sites.iter().any(|reset| {
                 reset.name == effect.name
                     && reset.span.start.offset > effect.assignment_span.end.offset
                     && reset.span.start.offset < effect.later_use_span.start.offset
-            }) {
-                continue;
-            }
+            })
+        {
+            continue;
         }
 
         let assignment_binding = semantic.binding(effect.assignment_binding);

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1287,15 +1287,16 @@ fn build_nonpersistent_assignment_extra_reset_sites(
     commands: &[CommandFact<'_>],
     source: &str,
 ) -> Vec<NonpersistentAssignmentExtraResetSite> {
-    let helper_output_names_by_scope = helper_output_names_by_scope(semantic);
+    let helper_output_names_by_scope = helper_output_names_by_scope(semantic, semantic_analysis);
     let zsh_set_a_outparam_positions_by_scope =
-        zsh_set_a_outparam_positions_by_scope(semantic, commands, source);
+        zsh_set_a_outparam_positions_by_scope(semantic, semantic_analysis, commands, source);
     let mut resets = Vec::new();
 
     for command in commands {
-        if !command_runs_in_persistent_shell_context(semantic, command.scope()) {
+        if !command_runs_in_persistent_shell_context(semantic, command, source) {
             continue;
         }
+        let flow_span = reset_flow_span_for_command(semantic_analysis, commands, command, source);
 
         let Some((callee_scope, call_name_span)) =
             resolved_function_scope_for_command(semantic, semantic_analysis, command)
@@ -1304,13 +1305,13 @@ fn build_nonpersistent_assignment_extra_reset_sites(
                 resets.push(NonpersistentAssignmentExtraResetSite {
                     name: Name::from("REPLY"),
                     span: reset_span,
-                    flow_span: command.span(),
+                    flow_span,
                     command_id: command.id(),
                 });
                 resets.push(NonpersistentAssignmentExtraResetSite {
                     name: Name::from("reply"),
                     span: reset_span,
-                    flow_span: command.span(),
+                    flow_span,
                     command_id: command.id(),
                 });
             }
@@ -1321,7 +1322,7 @@ fn build_nonpersistent_assignment_extra_reset_sites(
             resets.extend(names.iter().cloned().map(|name| NonpersistentAssignmentExtraResetSite {
                 name,
                 span: call_name_span,
-                flow_span: command.span(),
+                flow_span,
                 command_id: command.id(),
             }));
         }
@@ -1341,7 +1342,7 @@ fn build_nonpersistent_assignment_extra_reset_sites(
                 resets.push(NonpersistentAssignmentExtraResetSite {
                     name: Name::from(name.as_ref()),
                     span: argument.span,
-                    flow_span: command.span(),
+                    flow_span,
                     command_id: command.id(),
                 });
             }
@@ -1367,6 +1368,39 @@ fn build_nonpersistent_assignment_extra_reset_sites(
     resets
 }
 
+fn reset_flow_span_for_command(
+    semantic_analysis: &SemanticAnalysis<'_>,
+    commands: &[CommandFact<'_>],
+    command: &CommandFact<'_>,
+    source: &str,
+) -> Span {
+    let command_span = command.span();
+    let pipeline_span = commands
+        .iter()
+        .filter(|candidate| candidate.id() != command.id())
+        .filter(|candidate| span_contains(candidate.span(), command_span))
+        .filter(|candidate| !semantic_analysis.block_ids_for_span(candidate.span()).is_empty())
+        .filter_map(|candidate| {
+            let Command::Binary(binary) = candidate.command() else {
+                return None;
+            };
+            matches!(binary.op, BinaryOp::Pipe | BinaryOp::PipeAll).then_some(candidate.span())
+        })
+        .filter(|span| {
+            let before_command = &source[span.start.offset..command_span.start.offset];
+            let before_command = before_command.trim_end();
+            before_command.ends_with('|') && !before_command.ends_with("||")
+        })
+        .min_by_key(|span| span.end.offset - span.start.offset)
+        .unwrap_or(command_span);
+
+    if pipeline_span != command_span {
+        return pipeline_span;
+    }
+
+    command_span
+}
+
 fn zsh_reply_helper_reset_span(command: &CommandFact<'_>) -> Option<Span> {
     let name = command.effective_or_literal_name()?;
     if !zsh_helper_name_can_set_reply(name) {
@@ -1380,11 +1414,14 @@ fn zsh_helper_name_can_set_reply(name: &str) -> bool {
     (name.starts_with('.') && name != "." && name != "..") || name.starts_with('_')
 }
 
-fn helper_output_names_by_scope(semantic: &SemanticModel) -> FxHashMap<ScopeId, Vec<Name>> {
+fn helper_output_names_by_scope(
+    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
+) -> FxHashMap<ScopeId, Vec<Name>> {
     let mut names_by_scope = FxHashMap::<ScopeId, Vec<Name>>::default();
 
     for binding in semantic.bindings() {
-        if !helper_binding_can_reset_parent_scope(semantic, binding) {
+        if !helper_binding_can_reset_parent_scope(semantic, semantic_analysis, binding) {
             continue;
         }
         if !matches!(semantic.scope_kind(binding.scope), ScopeKind::Function(_)) {
@@ -1405,11 +1442,15 @@ fn helper_output_names_by_scope(semantic: &SemanticModel) -> FxHashMap<ScopeId, 
     names_by_scope
 }
 
-fn helper_binding_can_reset_parent_scope(semantic: &SemanticModel, binding: &Binding) -> bool {
+fn helper_binding_can_reset_parent_scope(
+    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
+    binding: &Binding,
+) -> bool {
     if binding.attributes.contains(BindingAttributes::LOCAL) {
         return false;
     }
-    if !binding_command_is_unconditional_in_function(semantic, binding) {
+    if !binding_command_is_unconditional_in_function(semantic, semantic_analysis, binding) {
         return false;
     }
 
@@ -1438,16 +1479,25 @@ fn helper_binding_can_reset_parent_scope(semantic: &SemanticModel, binding: &Bin
 
 fn binding_command_is_unconditional_in_function(
     semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
     binding: &Binding,
 ) -> bool {
     let Some(current) = semantic.innermost_command_id_at(binding.span.start.offset) else {
         return true;
     };
 
-    command_is_unconditional_in_function(semantic, current)
+    command_is_unconditional_in_function(semantic, semantic_analysis, current)
 }
 
-fn command_is_unconditional_in_function(semantic: &SemanticModel, mut current: CommandId) -> bool {
+fn command_is_unconditional_in_function(
+    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
+    mut current: CommandId,
+) -> bool {
+    if !command_has_reachable_cfg_block(semantic, semantic_analysis, current) {
+        return false;
+    }
+
     while let Some(parent) = semantic.syntax_backed_command_parent_id(current) {
         if matches!(semantic.command_kind(parent), CommandKind::Function) {
             return true;
@@ -1465,8 +1515,20 @@ fn command_is_unconditional_in_function(semantic: &SemanticModel, mut current: C
     true
 }
 
+fn command_has_reachable_cfg_block(
+    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
+    command_id: CommandId,
+) -> bool {
+    semantic_analysis
+        .block_ids_for_span(semantic.command_syntax_span(command_id))
+        .iter()
+        .any(|block| !semantic_analysis.block_is_unreachable(*block))
+}
+
 fn zsh_set_a_outparam_positions_by_scope(
     semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
     source: &str,
 ) -> FxHashMap<ScopeId, Vec<usize>> {
@@ -1476,7 +1538,7 @@ fn zsh_set_a_outparam_positions_by_scope(
         if !command.effective_name_is("set") {
             continue;
         }
-        if !command_is_unconditional_in_function(semantic, command.id()) {
+        if !command_is_unconditional_in_function(semantic, semantic_analysis, command.id()) {
             continue;
         }
         let Some(function_scope) = semantic.enclosing_function_scope(command.scope()) else {
@@ -1557,12 +1619,82 @@ fn command_is_inside_function_body(semantic: &SemanticModel, scope: ScopeId) -> 
 
 fn command_runs_in_persistent_shell_context(
     semantic: &SemanticModel,
-    command_scope: ScopeId,
+    command: &CommandFact<'_>,
+    source: &str,
 ) -> bool {
-    semantic
-        .transient_ancestor_scopes_within_function(command_scope)
-        .next()
-        .is_none()
+    let transient_scopes = semantic
+        .transient_ancestor_scopes_within_function(command.scope())
+        .collect::<SmallVec<[_; 2]>>();
+    if transient_scopes.is_empty() {
+        return true;
+    }
+
+    transient_scopes
+        .iter()
+        .all(|scope| matches!(semantic.scope_kind(*scope), ScopeKind::Pipeline))
+        && zsh_pipeline_tail_runs_in_current_shell(command, semantic, source)
+}
+
+fn zsh_pipeline_tail_runs_in_current_shell(
+    command: &CommandFact<'_>,
+    semantic: &SemanticModel,
+    source: &str,
+) -> bool {
+    if command.shell_behavior().shell_dialect() != shuck_semantic::ShellDialect::Zsh {
+        return false;
+    }
+    if command
+        .shell_behavior()
+        .zsh_options()
+        .is_some_and(|options| *options == ZshOptionState::for_emulate(shuck_semantic::ZshEmulationMode::Sh))
+    {
+        return false;
+    }
+
+    command_is_pipeline_tail_operand(semantic, command.id(), source)
+        || command_is_preceded_by_pipeline_operator(command.span(), source)
+}
+
+fn command_is_pipeline_tail_operand(
+    semantic: &SemanticModel,
+    mut current: CommandId,
+    source: &str,
+) -> bool {
+    let mut saw_pipeline_parent = false;
+    while let Some(parent) = semantic.syntax_backed_command_parent_id(current) {
+        if !matches!(semantic.command_kind(parent), CommandKind::Binary) {
+            break;
+        }
+        if !binary_child_is_pipe_tail_operand(semantic, parent, current, source) {
+            return false;
+        }
+        saw_pipeline_parent = true;
+        current = parent;
+    }
+    saw_pipeline_parent
+}
+
+fn binary_child_is_pipe_tail_operand(
+    semantic: &SemanticModel,
+    parent: CommandId,
+    child: CommandId,
+    source: &str,
+) -> bool {
+    let parent_span = semantic.command_syntax_span(parent);
+    let child_span = semantic.command_syntax_span(child);
+    if child_span.start == parent_span.start {
+        return false;
+    }
+
+    let before_child = &source[parent_span.start.offset..child_span.start.offset];
+    let before_child = before_child.trim_end();
+    before_child.ends_with('|') && !before_child.ends_with("||")
+}
+
+fn command_is_preceded_by_pipeline_operator(command_span: Span, source: &str) -> bool {
+    let before_command = &source[..command_span.start.offset];
+    let before_command = before_command.trim_end();
+    before_command.ends_with('|') && !before_command.ends_with("||")
 }
 
 fn reset_site_control_ancestors_contain_later_use(
@@ -1573,6 +1705,10 @@ fn reset_site_control_ancestors_contain_later_use(
     let mut current = command_id;
     while let Some(parent) = semantic.syntax_backed_command_parent_id(current) {
         if reset_site_is_always_run_binary_operand(semantic, parent, current) {
+            current = parent;
+            continue;
+        }
+        if matches!(semantic.command_kind(parent), CommandKind::Binary) {
             current = parent;
             continue;
         }

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1615,7 +1615,11 @@ fn resolved_function_scope_for_command(
                     .find_map(|(site, binding)| {
                         (site.name_span == name_span
                             && fallback_function_binding_is_callable_from_function_body(
-                                semantic, command, name_span, binding,
+                                semantic,
+                                semantic_analysis,
+                                command,
+                                name_span,
+                                binding,
                             ))
                         .then_some(binding)
                     })
@@ -1627,6 +1631,7 @@ fn resolved_function_scope_for_command(
 
 fn fallback_function_binding_is_callable_from_function_body(
     semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
     command: &CommandFact<'_>,
     call_name_span: Span,
     binding: BindingId,
@@ -1636,7 +1641,40 @@ fn fallback_function_binding_is_callable_from_function_body(
         return true;
     }
 
-    enclosing_function_scope(semantic, command.scope()) != enclosing_function_scope(semantic, binding.scope)
+    let Some(command_function_scope) = enclosing_function_scope(semantic, command.scope()) else {
+        return false;
+    };
+    if Some(command_function_scope) == enclosing_function_scope(semantic, binding.scope) {
+        return false;
+    }
+
+    !function_scope_may_run_before_offset(
+        semantic,
+        semantic_analysis,
+        command_function_scope,
+        binding.span.start.offset,
+    )
+}
+
+fn function_scope_may_run_before_offset(
+    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
+    function_scope: ScopeId,
+    offset: usize,
+) -> bool {
+    semantic_analysis
+        .function_bindings_by_scope()
+        .find(|(scope, _)| *scope == function_scope)
+        .is_some_and(|(_, bindings)| {
+            bindings.iter().copied().any(|function_binding| {
+                let name = &semantic.binding(function_binding).name;
+                semantic_analysis
+                    .resolved_function_call_sites(name)
+                    .any(|(site, resolved_binding)| {
+                        resolved_binding == function_binding && site.name_span.start.offset < offset
+                    })
+            })
+        })
 }
 
 fn command_is_inside_function_body(semantic: &SemanticModel, scope: ScopeId) -> bool {

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1547,6 +1547,9 @@ fn zsh_set_a_outparam_positions_by_scope(
         if !command.effective_name_is("set") {
             continue;
         }
+        if !command_runs_in_persistent_shell_context(semantic, command, source) {
+            continue;
+        }
         if !command_is_unconditional_in_function(semantic, semantic_analysis, command.id()) {
             continue;
         }

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1198,9 +1198,15 @@ fn nonpersistent_reset_site_covers_later_use(
         return false;
     }
 
-    let later_use_blocks = semantic_analysis.block_ids_for_span(effect.later_use_span);
+    let Some(later_use_command) =
+        semantic.innermost_command_id_at(effect.later_use_span.start.offset)
+    else {
+        return false;
+    };
+    let later_use_blocks =
+        semantic_analysis.block_ids_for_span(semantic.command_syntax_span(later_use_command));
     if later_use_blocks.is_empty() {
-        return true;
+        return false;
     }
 
     let assignment_scope = semantic.binding(effect.assignment_binding).scope;
@@ -1292,7 +1298,7 @@ fn build_nonpersistent_assignment_extra_reset_sites(
         }
 
         let Some((callee_scope, call_name_span)) =
-            resolved_function_scope_for_command(semantic_analysis, command)
+            resolved_function_scope_for_command(semantic, semantic_analysis, command)
         else {
             if let Some(reset_span) = zsh_reply_helper_reset_span(command) {
                 resets.push(NonpersistentAssignmentExtraResetSite {
@@ -1524,6 +1530,7 @@ fn positional_outparam_index(text: &str) -> Option<usize> {
 }
 
 fn resolved_function_scope_for_command(
+    semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     command: &CommandFact<'_>,
 ) -> Option<(ScopeId, Span)> {
@@ -1532,12 +1539,20 @@ fn resolved_function_scope_for_command(
     let binding = semantic_analysis
         .visible_function_binding_at_call(&name, name_span)
         .or_else(|| {
-            semantic_analysis
-                .function_call_arity_sites(&name)
-                .find_map(|(site, binding)| (site.name_span == name_span).then_some(binding))
+            command_is_inside_function_body(semantic, command.scope()).then(|| {
+                semantic_analysis
+                    .function_call_arity_sites(&name)
+                    .find_map(|(site, binding)| (site.name_span == name_span).then_some(binding))
+            })?
         })?;
     let scope = semantic_analysis.function_scope_for_binding(binding)?;
     Some((scope, name_span))
+}
+
+fn command_is_inside_function_body(semantic: &SemanticModel, scope: ScopeId) -> bool {
+    semantic
+        .ancestor_scopes(scope)
+        .any(|scope| matches!(semantic.scope_kind(scope), ScopeKind::Function(_)))
 }
 
 fn command_runs_in_persistent_shell_context(

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1581,13 +1581,21 @@ fn zsh_set_a_outparam_positions(args: &[&Word], source: &str) -> Vec<usize> {
             continue;
         }
 
-        if let Some(position) = positional_outparam_index(text) {
+        if let Some(position) = positional_outparam_index_from_word_text(text) {
             positions.push(position);
         }
         break;
     }
 
     positions
+}
+
+fn positional_outparam_index_from_word_text(text: &str) -> Option<usize> {
+    positional_outparam_index(text).or_else(|| {
+        text.strip_prefix('"')
+            .and_then(|inner| inner.strip_suffix('"'))
+            .and_then(positional_outparam_index)
+    })
 }
 
 fn positional_outparam_index(text: &str) -> Option<usize> {
@@ -1739,30 +1747,34 @@ fn command_is_pipeline_tail_operand(
         if !matches!(semantic.command_kind(parent), CommandKind::Binary) {
             break;
         }
-        if !binary_child_is_pipe_tail_operand(semantic, parent, current, source) {
-            return false;
+        match binary_child_pipe_tail_relation(semantic, parent, current, source) {
+            Some(true) => {
+                saw_pipeline_parent = true;
+                current = parent;
+            }
+            Some(false) => return false,
+            None => break,
         }
-        saw_pipeline_parent = true;
-        current = parent;
     }
     saw_pipeline_parent
 }
 
-fn binary_child_is_pipe_tail_operand(
+fn binary_child_pipe_tail_relation(
     semantic: &SemanticModel,
     parent: CommandId,
     child: CommandId,
     source: &str,
-) -> bool {
+) -> Option<bool> {
     let parent_span = semantic.command_syntax_span(parent);
     let child_span = semantic.command_syntax_span(child);
     if child_span.start == parent_span.start {
-        return false;
+        let after_child = &source[child_span.end.offset..parent_span.end.offset];
+        return text_starts_with_pipeline_operator(after_child.trim_start()).map(|_| false);
     }
 
     let before_child = &source[parent_span.start.offset..child_span.start.offset];
     let before_child = before_child.trim_end();
-    text_ends_with_pipeline_operator(before_child)
+    text_ends_with_pipeline_operator(before_child).then_some(true)
 }
 
 fn command_is_textual_pipeline_tail_operand(command_span: Span, source: &str) -> bool {
@@ -1779,6 +1791,10 @@ fn command_is_textual_pipeline_tail_operand(command_span: Span, source: &str) ->
 
 fn text_ends_with_pipeline_operator(text: &str) -> bool {
     text.ends_with("|&") || (text.ends_with('|') && !text.ends_with("||"))
+}
+
+fn text_starts_with_pipeline_operator(text: &str) -> Option<()> {
+    (text.starts_with("|&") || (text.starts_with('|') && !text.starts_with("||"))).then_some(())
 }
 
 fn reset_site_control_ancestors_contain_later_use(

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1704,6 +1704,10 @@ fn command_runs_in_persistent_shell_context(
     command: &CommandFact<'_>,
     source: &str,
 ) -> bool {
+    if matches!(command.stmt().terminator, Some(StmtTerminator::Background(_))) {
+        return false;
+    }
+
     let transient_scopes = semantic
         .transient_ancestor_scopes_within_function(command.scope())
         .collect::<SmallVec<[_; 2]>>();

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1075,12 +1075,17 @@ fn collect_plus_equals_assignment_span(assignment: &Assignment, spans: &mut Vec<
 #[cfg_attr(shuck_profiling, inline(never))]
 fn build_nonpersistent_assignment_spans(
     semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
     source: &str,
+    suppress_zsh_nested_subshell_noise: bool,
     suppress_bash_pipefail_pipeline_side_effects: bool,
     arithmetic_only_suppressed_subscript_spans: &[Span],
 ) -> NonpersistentAssignmentSpans {
     let command_contexts = build_nonpersistent_assignment_command_contexts(commands);
+    let extra_reset_sites = suppress_zsh_nested_subshell_noise.then(|| {
+        build_nonpersistent_assignment_extra_reset_sites(semantic, semantic_analysis, commands, source)
+    });
     let prompt_runtime_reads = build_prompt_runtime_read_spans(commands, source)
         .into_iter()
         .map(|read| NonpersistentAssignmentExtraRead {
@@ -1110,6 +1115,20 @@ fn build_nonpersistent_assignment_spans(
         {
             continue;
         }
+        if suppress_zsh_nested_subshell_noise
+            && !nonpersistent_assignment_reaches_later_use(semantic, semantic_analysis, &effect)
+        {
+            continue;
+        }
+        if let Some(extra_reset_sites) = &extra_reset_sites {
+            if extra_reset_sites.iter().any(|reset| {
+                reset.name == effect.name
+                    && reset.span.start.offset > effect.assignment_span.end.offset
+                    && reset.span.start.offset < effect.later_use_span.start.offset
+            }) {
+                continue;
+            }
+        }
 
         let assignment_binding = semantic.binding(effect.assignment_binding);
         assignment_sites.push(NamedSpan {
@@ -1134,6 +1153,40 @@ fn build_nonpersistent_assignment_spans(
         subshell_assignment_sites: assignment_sites,
         subshell_later_use_sites: later_use_sites,
     }
+}
+
+fn nonpersistent_assignment_reaches_later_use(
+    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
+    effect: &shuck_semantic::NonpersistentAssignmentEffect,
+) -> bool {
+    let assignment_scope = semantic.binding(effect.assignment_binding).scope;
+    let assignment_transient = semantic.innermost_transient_scope_within_function(assignment_scope);
+    let later_use_scope = semantic.scope_at(effect.later_use_span.start.offset);
+    let later_use_transient = semantic.innermost_transient_scope_within_function(later_use_scope);
+    if later_use_transient.is_some() && later_use_transient != assignment_transient {
+        return false;
+    }
+
+    let assignment_blocks = semantic_analysis
+        .block_ids_for_span(effect.assignment_span)
+        .iter()
+        .copied()
+        .collect::<FxHashSet<_>>();
+    if assignment_blocks.is_empty() {
+        return true;
+    }
+
+    let later_use_blocks = semantic_analysis.block_ids_for_span(effect.later_use_span);
+    if later_use_blocks.is_empty() {
+        return true;
+    }
+
+    let entry = semantic_analysis
+        .flow_entry_block_for_binding_scopes(&[assignment_scope], effect.later_use_span.start.offset);
+    later_use_blocks.iter().copied().all(|target| {
+        semantic_analysis.blocks_cover_all_paths_to_block(entry, target, &assignment_blocks)
+    })
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
@@ -1189,6 +1242,234 @@ fn subshell_assignment_report_span(
 struct NonpersistentAssignmentSpans {
     subshell_assignment_sites: Vec<NamedSpan>,
     subshell_later_use_sites: Vec<NamedSpan>,
+}
+
+#[derive(Debug, Clone)]
+struct NonpersistentAssignmentExtraResetSite {
+    name: Name,
+    span: Span,
+}
+
+fn build_nonpersistent_assignment_extra_reset_sites(
+    semantic: &SemanticModel,
+    semantic_analysis: &SemanticAnalysis<'_>,
+    commands: &[CommandFact<'_>],
+    source: &str,
+) -> Vec<NonpersistentAssignmentExtraResetSite> {
+    let helper_output_names_by_scope = helper_output_names_by_scope(semantic);
+    let zsh_set_a_outparam_positions_by_scope =
+        zsh_set_a_outparam_positions_by_scope(semantic, commands, source);
+    let mut resets = Vec::new();
+
+    for command in commands {
+        if !command_runs_in_persistent_shell_context(semantic, command.scope()) {
+            continue;
+        }
+
+        let Some((callee_scope, call_name_span)) =
+            resolved_function_scope_for_command(semantic_analysis, command)
+        else {
+            if let Some(reset_span) = zsh_reply_helper_reset_span(command) {
+                resets.push(NonpersistentAssignmentExtraResetSite {
+                    name: Name::from("REPLY"),
+                    span: reset_span,
+                });
+                resets.push(NonpersistentAssignmentExtraResetSite {
+                    name: Name::from("reply"),
+                    span: reset_span,
+                });
+            }
+            continue;
+        };
+
+        if let Some(names) = helper_output_names_by_scope.get(&callee_scope) {
+            resets.extend(names.iter().cloned().map(|name| NonpersistentAssignmentExtraResetSite {
+                name,
+                span: call_name_span,
+            }));
+        }
+
+        if let Some(positions) = zsh_set_a_outparam_positions_by_scope.get(&callee_scope) {
+            for position in positions {
+                let Some(argument) = command.body_args().get(position.saturating_sub(1)).copied()
+                else {
+                    continue;
+                };
+                let Some(name) = static_word_text(argument, source) else {
+                    continue;
+                };
+                if !is_shell_variable_name(&name) {
+                    continue;
+                }
+                resets.push(NonpersistentAssignmentExtraResetSite {
+                    name: Name::from(name.as_ref()),
+                    span: argument.span,
+                });
+            }
+        }
+    }
+
+    resets.sort_by(|left, right| {
+        left.name
+            .as_str()
+            .cmp(right.name.as_str())
+            .then_with(|| left.span.start.offset.cmp(&right.span.start.offset))
+            .then_with(|| left.span.end.offset.cmp(&right.span.end.offset))
+    });
+    resets.dedup_by(|left, right| left.name == right.name && left.span == right.span);
+    resets
+}
+
+fn zsh_reply_helper_reset_span(command: &CommandFact<'_>) -> Option<Span> {
+    let name = command.effective_or_literal_name()?;
+    if !zsh_helper_name_can_set_reply(name) {
+        return None;
+    }
+
+    Some(command.body_name_word()?.span)
+}
+
+fn zsh_helper_name_can_set_reply(name: &str) -> bool {
+    (name.starts_with('.') && name != "." && name != "..") || name.starts_with('_')
+}
+
+fn helper_output_names_by_scope(semantic: &SemanticModel) -> FxHashMap<ScopeId, Vec<Name>> {
+    let mut names_by_scope = FxHashMap::<ScopeId, Vec<Name>>::default();
+
+    for binding in semantic.bindings() {
+        if !helper_binding_can_reset_parent_scope(binding) {
+            continue;
+        }
+        if !matches!(semantic.scope_kind(binding.scope), ScopeKind::Function(_)) {
+            continue;
+        }
+
+        names_by_scope
+            .entry(binding.scope)
+            .or_default()
+            .push(binding.name.clone());
+    }
+
+    for names in names_by_scope.values_mut() {
+        names.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        names.dedup();
+    }
+
+    names_by_scope
+}
+
+fn helper_binding_can_reset_parent_scope(binding: &Binding) -> bool {
+    if binding.attributes.contains(BindingAttributes::LOCAL) {
+        return false;
+    }
+
+    match binding.kind {
+        BindingKind::Assignment
+        | BindingKind::ParameterDefaultAssignment
+        | BindingKind::AppendAssignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::MapfileTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
+        | BindingKind::ArithmeticAssignment => true,
+        BindingKind::Declaration(_) => {
+            binding
+                .attributes
+                .contains(BindingAttributes::DECLARATION_INITIALIZED)
+        }
+        BindingKind::FunctionDefinition | BindingKind::Nameref | BindingKind::Imported => false,
+    }
+}
+
+fn zsh_set_a_outparam_positions_by_scope(
+    semantic: &SemanticModel,
+    commands: &[CommandFact<'_>],
+    source: &str,
+) -> FxHashMap<ScopeId, Vec<usize>> {
+    let mut positions_by_scope = FxHashMap::<ScopeId, Vec<usize>>::default();
+
+    for command in commands {
+        if !command.effective_name_is("set") {
+            continue;
+        }
+        let Some(function_scope) = semantic.enclosing_function_scope(command.scope()) else {
+            continue;
+        };
+
+        positions_by_scope
+            .entry(function_scope)
+            .or_default()
+            .extend(zsh_set_a_outparam_positions(command.body_args(), source));
+    }
+
+    for positions in positions_by_scope.values_mut() {
+        positions.sort_unstable();
+        positions.dedup();
+    }
+
+    positions_by_scope
+}
+
+fn zsh_set_a_outparam_positions(args: &[&Word], source: &str) -> Vec<usize> {
+    let mut positions = Vec::new();
+    let mut saw_array_flag = false;
+
+    for word in args {
+        let text = word.span.slice(source);
+        if !saw_array_flag {
+            if static_word_text(word, source).is_some_and(|text| text == "-A" || text == "-AArray")
+            {
+                saw_array_flag = true;
+            }
+            continue;
+        }
+
+        if let Some(position) = positional_outparam_index(text) {
+            positions.push(position);
+        }
+        break;
+    }
+
+    positions
+}
+
+fn positional_outparam_index(text: &str) -> Option<usize> {
+    let parameter = text
+        .strip_prefix("${")
+        .and_then(|inner| inner.strip_suffix('}'))
+        .or_else(|| text.strip_prefix('$'))?;
+    let index = parameter.parse::<usize>().ok()?;
+    (index > 0).then_some(index)
+}
+
+fn resolved_function_scope_for_command(
+    semantic_analysis: &SemanticAnalysis<'_>,
+    command: &CommandFact<'_>,
+) -> Option<(ScopeId, Span)> {
+    let name = Name::from(command.effective_or_literal_name()?);
+    let name_span = command.body_name_word()?.span;
+    let binding = semantic_analysis
+        .visible_function_binding_at_call(&name, name_span)
+        .or_else(|| {
+            semantic_analysis
+                .function_call_arity_sites(&name)
+                .find_map(|(site, binding)| (site.name_span == name_span).then_some(binding))
+        })?;
+    let scope = semantic_analysis.function_scope_for_binding(binding)?;
+    Some((scope, name_span))
+}
+
+fn command_runs_in_persistent_shell_context(
+    semantic: &SemanticModel,
+    command_scope: ScopeId,
+) -> bool {
+    semantic
+        .transient_ancestor_scopes_within_function(command_scope)
+        .next()
+        .is_none()
 }
 
 fn build_nonpersistent_assignment_command_contexts(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -726,8 +726,10 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         }
         let nonpersistent_assignment_spans = build_nonpersistent_assignment_spans(
             self.semantic,
+            semantic_analysis,
             &commands,
             self.source,
+            matches!(self.shell, ShellDialect::Zsh),
             matches!(self.shell, ShellDialect::Bash) && pipefail_enabled_anywhere,
             &arithmetic_only_suppressed_subscript_spans,
         );

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -66,9 +66,10 @@ use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::parser::Parser;
 use shuck_semantic::{
     ArithmeticLiteralBehavior, Binding, BindingAttributes, BindingId, BindingKind, CaseCliDispatch,
-    Declaration, DeclarationBuiltin, DeclarationOperand as SemanticDeclarationOperand,
-    FieldSplittingBehavior, FileExpansionOrderBehavior, FunctionScopeKind, GlobDotBehavior,
-    GlobFailureBehavior, GlobPatternBehavior, NonpersistentAssignmentAnalysisContext,
+    CommandKind, CompoundCommandKind, Declaration, DeclarationBuiltin,
+    DeclarationOperand as SemanticDeclarationOperand, FieldSplittingBehavior,
+    FileExpansionOrderBehavior, FunctionScopeKind, GlobDotBehavior, GlobFailureBehavior,
+    GlobPatternBehavior, NonpersistentAssignmentAnalysisContext,
     NonpersistentAssignmentAnalysisOptions, NonpersistentAssignmentCommandContext,
     NonpersistentAssignmentExtraRead, OptionValue, PathnameExpansionBehavior, Reference,
     ReferenceId, ReferenceKind, ScopeId, ScopeKind, SemanticAnalysis, SemanticModel,

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -650,6 +650,61 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_reads_in_helper_call_arguments_before_reset_runs() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper \"$REPLY\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_after_conditional_set_a_outparam_helper() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  [[ -n $cond ]] && set -A $1 ${(f)\"$(
+    shift
+    for d; do
+      print -r -- $d
+    done
+  )\"}
+}
+fill d /tmp
+print -r -- $d
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -812,6 +812,30 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_middle_pipeline_helper_reset() {
+        let source = "\
+#!/bin/zsh
+(
+  for REPLY in a; do :; done
+)
+print -r -- input | _reply-helper | cat
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn reports_zsh_reads_in_helper_call_arguments_before_reset_runs() {
         let source = "\
 #!/bin/zsh
@@ -916,6 +940,31 @@ esac
         );
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_in_parent_nested_subshell_scope() {
+        let source = "\
+#!/bin/zsh
+(
+  (
+    for REPLY in a; do :; done
+  )
+  print -r -- $REPLY
+)
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -525,6 +525,142 @@ snapshot=\"$(
     }
 
     #[test]
+    fn ignores_zsh_later_reads_after_helper_resets_name_in_parent_scope() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
+        let source = "\
+#!/bin/zsh
+case $site in
+  github)
+    (
+      for REPLY in a; do :; done
+    )
+    ;;
+  cygwin)
+    (
+      print -r -- $REPLY
+    )
+    ;;
+esac
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_later_reads_after_later_defined_helper_resets_name() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  (
+    for REPLY in a; do :; done
+  )
+  helper
+  print -r -- $REPLY
+}
+helper() {
+  REPLY=value
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_reply_reads_after_unresolved_private_helper_calls() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  (
+    for reply in a; do :; done
+  )
+  .helper-from-sourced-file input
+  print -r -- $reply
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_set_a_outparam_helpers_after_command_substitution_loop_assignments() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  set -A $1 ${(f)\"$(
+    shift
+    for d; do
+      print -r -- $d
+    done
+  )\"}
+}
+fill d /tmp
+print -r -- $d
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_process_substitution_fd_closes_after_parent_fd_assignment() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  local fd
+  sysopen -ro cloexec -u fd <(
+    (
+      local fd
+      sysopen -wo create,excl -u fd -- lock
+      exec {fd}>&-
+    ) &!
+  )
+  IFS= read -ru $fd
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_later_arithmetic_assignments_after_pipeline_updates() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -1037,6 +1037,35 @@ esac
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_subshell_set_a_outparam_helper() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  (
+    set -A $1 value
+  )
+}
+(
+  for d in /tmp; do :; done
+)
+fill d
+print -r -- $d
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_after_later_defined_helper_resets_name() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -599,6 +599,66 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_when_reset_is_in_disjoint_case_branch() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+case $site in
+  github)
+    (
+      for REPLY in a; do :; done
+    )
+    ;;
+  cygwin)
+    helper
+    ;;
+esac
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_after_top_level_helper_call_before_definition() {
+        let source = "\
+#!/bin/zsh
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+helper() {
+  REPLY=value
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn reports_zsh_later_reads_when_helper_only_resets_loop_variable() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -602,6 +602,54 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_conditional_helper_body_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  [[ -n $cond ]] && REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
+    fn ignores_zsh_later_reads_after_always_run_binary_left_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper || :
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -867,6 +867,33 @@ print -r -- $d
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_attached_set_a_helper_argument() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  set -Aresult $1
+}
+(
+  for d in /tmp; do :; done
+)
+fill d
+print -r -- $d
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -791,6 +791,33 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_background_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper &
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_after_pipeline_tail_helper_reset() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -742,6 +742,34 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_dead_helper_body_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  return
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_after_always_run_binary_left_helper_reset() {
         let source = "\
 #!/bin/zsh
@@ -752,6 +780,27 @@ helper() {
   for REPLY in a; do :; done
 )
 helper || :
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_later_reads_after_pipeline_tail_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+print -r -- input | helper
 print -r -- $REPLY
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -546,6 +546,62 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_when_helper_reset_is_conditional() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+[[ -n $cond ]] && helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_after_branch_only_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+if [[ -n $cond ]]; then
+  helper
+fi
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -573,6 +573,59 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_conditional_subshell_assignment() {
+        let source = "\
+#!/bin/zsh
+REPLY=old
+if [[ -n $cond ]]; then
+  (
+    REPLY=value
+  )
+fi
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["REPLY"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_when_helper_only_resets_loop_variable() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  for REPLY in \"$@\"; do :; done
+}
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn reports_zsh_later_reads_after_branch_only_helper_reset() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -812,6 +812,27 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn ignores_zsh_later_reads_after_pipeline_tail_helper_reset_in_or_list() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+print -r -- input | helper || :
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_after_pipe_ampersand_tail_helper_reset() {
         let source = "\
 #!/bin/zsh
@@ -1097,6 +1118,29 @@ demo() {
 #!/bin/zsh
 fill() {
   set -A $1 ${(f)\"$(
+    shift
+    for d; do
+      print -r -- $d
+    done
+  )\"}
+}
+fill d /tmp
+print -r -- $d
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_quoted_set_a_outparam_helpers_after_command_substitution_loop_assignments() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  set -A \"$1\" ${(f)\"$(
     shift
     for d; do
       print -r -- $d

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -812,6 +812,27 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn ignores_zsh_later_reads_after_pipe_ampersand_tail_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+print -r -- input |& helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_zsh_later_reads_after_middle_pipeline_helper_reset() {
         let source = "\
 #!/bin/zsh
@@ -988,6 +1009,36 @@ helper() {
         );
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_after_function_local_helper_call_before_definition() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  (
+    for REPLY in a; do :; done
+  )
+  helper
+  print -r -- $REPLY
+  helper() {
+    REPLY=value
+  }
+}
+demo
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -1042,6 +1042,36 @@ demo
     }
 
     #[test]
+    fn reports_zsh_later_reads_when_function_runs_before_later_helper_definition() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  (
+    for REPLY in a; do :; done
+  )
+  helper
+  print -r -- $REPLY
+}
+demo
+helper() {
+  REPLY=value
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["for"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_reply_reads_after_unresolved_private_helper_calls() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -616,6 +616,31 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_dead_helper_body_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  return
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_after_always_run_binary_left_helper_reset() {
         let source = "\
 #!/bin/zsh
@@ -626,6 +651,24 @@ helper() {
   for REPLY in a; do :; done
 )
 helper || :
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_later_reads_after_pipeline_tail_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+print -r -- input | helper
 print -r -- $REPLY
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -677,6 +677,27 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_middle_pipeline_helper_reset() {
+        let source = "\
+#!/bin/zsh
+(
+  for REPLY in a; do :; done
+)
+print -r -- input | _reply-helper | cat
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
     fn reports_zsh_reads_in_helper_call_arguments_before_reset_runs() {
         let source = "\
 #!/bin/zsh
@@ -769,6 +790,28 @@ esac
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_in_parent_nested_subshell_scope() {
+        let source = "\
+#!/bin/zsh
+(
+  (
+    for REPLY in a; do :; done
+  )
+  print -r -- $REPLY
+)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -726,6 +726,30 @@ print -r -- $d
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_attached_set_a_helper_argument() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  set -Aresult $1
+}
+(
+  for d in /tmp; do :; done
+)
+fill d
+print -r -- $d
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$d"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -441,6 +441,56 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_when_helper_reset_is_conditional() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+[[ -n $cond ]] && helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_after_branch_only_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+if [[ -n $cond ]]; then
+  helper
+fi
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -491,6 +491,48 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_conditional_helper_body_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  [[ -n $cond ]] && REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
+    fn ignores_zsh_later_reads_after_always_run_binary_left_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper || :
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -659,6 +659,30 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_background_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper &
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_after_pipeline_tail_helper_reset() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -677,6 +677,24 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn ignores_zsh_later_reads_after_pipeline_tail_helper_reset_in_or_list() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+print -r -- input | helper || :
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_after_pipe_ampersand_tail_helper_reset() {
         let source = "\
 #!/bin/zsh
@@ -929,6 +947,26 @@ demo() {
 #!/bin/zsh
 fill() {
   set -A $1 ${(f)\"$(
+    shift
+    for d; do
+      print -r -- $d
+    done
+  )\"}
+}
+fill d /tmp
+print -r -- $d
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_quoted_set_a_outparam_helpers_after_command_substitution_loop_assignments() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  set -A \"$1\" ${(f)\"$(
     shift
     for d; do
       print -r -- $d

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -880,6 +880,33 @@ demo
     }
 
     #[test]
+    fn reports_zsh_later_reads_when_function_runs_before_later_helper_definition() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  (
+    for REPLY in a; do :; done
+  )
+  helper
+  print -r -- $REPLY
+}
+demo
+helper() {
+  REPLY=value
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_reply_reads_after_unresolved_private_helper_calls() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -488,6 +488,60 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_when_reset_is_in_disjoint_case_branch() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+case $site in
+  github)
+    (
+      for REPLY in a; do :; done
+    )
+    ;;
+  cygwin)
+    helper
+    ;;
+esac
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_after_top_level_helper_call_before_definition() {
+        let source = "\
+#!/bin/zsh
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+helper() {
+  REPLY=value
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
     fn reports_zsh_later_reads_when_helper_only_resets_loop_variable() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -465,6 +465,53 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_conditional_subshell_assignment() {
+        let source = "\
+#!/bin/zsh
+REPLY=old
+if [[ -n $cond ]]; then
+  (
+    REPLY=value
+  )
+fi
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_when_helper_only_resets_loop_variable() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  for REPLY in \"$@\"; do :; done
+}
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
     fn reports_zsh_later_reads_after_branch_only_helper_reset() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -831,6 +831,32 @@ print -r -- $d
     }
 
     #[test]
+    fn reports_zsh_later_reads_after_subshell_set_a_outparam_helper() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  (
+    set -A $1 value
+  )
+}
+(
+  for d in /tmp; do :; done
+)
+fill d
+print -r -- $d
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$d"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -423,6 +423,124 @@ echo \"$value\"
     }
 
     #[test]
+    fn ignores_zsh_later_reads_after_helper_resets_name_in_parent_scope() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
+        let source = "\
+#!/bin/zsh
+case $site in
+  github)
+    (
+      for REPLY in a; do :; done
+    )
+    ;;
+  cygwin)
+    (
+      print -r -- $REPLY
+    )
+    ;;
+esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_later_reads_after_later_defined_helper_resets_name() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  (
+    for REPLY in a; do :; done
+  )
+  helper
+  print -r -- $REPLY
+}
+helper() {
+  REPLY=value
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_reply_reads_after_unresolved_private_helper_calls() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  (
+    for reply in a; do :; done
+  )
+  .helper-from-sourced-file input
+  print -r -- $reply
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_set_a_outparam_helpers_after_command_substitution_loop_assignments() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  set -A $1 ${(f)\"$(
+    shift
+    for d; do
+      print -r -- $d
+    done
+  )\"}
+}
+fill d /tmp
+print -r -- $d
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn ignores_zsh_process_substitution_fd_closes_after_parent_fd_assignment() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  local fd
+  sysopen -ro cloexec -u fd <(
+    (
+      local fd
+      sysopen -wo create,excl -u fd -- lock
+      exec {fd}>&-
+    ) &!
+  )
+  IFS= read -ru $fd
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_ifs_assignments_inside_pipeline_children() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -533,6 +533,55 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn reports_zsh_reads_in_helper_call_arguments_before_reset_runs() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+helper \"$REPLY\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_after_conditional_set_a_outparam_helper() {
+        let source = "\
+#!/bin/zsh
+fill() {
+  [[ -n $cond ]] && set -A $1 ${(f)\"$(
+    shift
+    for d; do
+      print -r -- $d
+    done
+  )\"}
+}
+fill d /tmp
+print -r -- $d
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$d"]
+        );
+    }
+
+    #[test]
     fn ignores_zsh_later_reads_in_sibling_nested_scopes() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -677,6 +677,24 @@ print -r -- $REPLY
     }
 
     #[test]
+    fn ignores_zsh_later_reads_after_pipe_ampersand_tail_helper_reset() {
+        let source = "\
+#!/bin/zsh
+helper() {
+  REPLY=value
+}
+(
+  for REPLY in a; do :; done
+)
+print -r -- input |& helper
+print -r -- $REPLY
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_zsh_later_reads_after_middle_pipeline_helper_reset() {
         let source = "\
 #!/bin/zsh
@@ -832,6 +850,33 @@ helper() {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_zsh_later_reads_after_function_local_helper_call_before_definition() {
+        let source = "\
+#!/bin/zsh
+demo() {
+  (
+    for REPLY in a; do :; done
+  )
+  helper
+  print -r -- $REPLY
+  helper() {
+    REPLY=value
+  }
+}
+demo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$REPLY"]
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -112,6 +112,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     }
 
     pub(super) fn add_redirect_fd_var_binding(&mut self, redirect: &shuck_ast::Redirect) {
+        if redirect.word_target().is_some_and(|target| {
+            matches!(
+                redirect.kind,
+                shuck_ast::RedirectKind::DupInput | shuck_ast::RedirectKind::DupOutput
+            ) && shuck_ast::static_word_text(target, self.source).as_deref() == Some("-")
+        }) {
+            return;
+        }
+
         if let (Some(name), Some(span)) = (&redirect.fd_var, redirect.fd_var_span) {
             self.add_binding(
                 name,


### PR DESCRIPTION
## Summary
- suppress zsh C150/C155 effects when subshell assignments cannot reach later reads in sibling nested scopes
- recognize caller-visible zsh helper resets, including later-defined helpers, private REPLY helpers, and set -A out-parameter helpers
- avoid treating fd-var close redirects like exec {fd}>&- as fresh fd assignments

## Tests
- cargo fmt --check
- cargo test -p shuck-linter subshell_local_assignment::tests -- --nocapture
- cargo test -p shuck-linter subshell_side_effect::tests -- --nocapture
- cargo run -q -p shuck-cli -- check --no-cache --exit-zero --output-format concise --select C150,C155 --per-file-shell '**:zsh' /tmp/zsh/zinit/zinit-install.zsh /tmp/zsh/ohmyzsh/plugins/scd/scd /tmp/zsh/powerlevel10k/gitstatus/mbuild\n- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C150,C155\n- cargo test -p shuck-semantic\n- cargo test -p shuck-linter