### PR TITLE
Fix zsh scalar subscript array facts

### DIFF
--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -262,12 +262,18 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
     }
 
     fn reference_is_zsh_conditional_operand(&self, reference: &Reference) -> bool {
-        self.facts.shell == ShellDialect::Zsh
+        matches!(
+            self.array_reference_policy(reference),
+            shuck_semantic::ArrayReferencePolicy::NativeZshScalar
+        )
             && matches!(reference.kind, shuck_semantic::ReferenceKind::ConditionalOperand)
     }
 
     fn reference_is_zsh_presence_test(&self, reference: &Reference) -> bool {
-        self.facts.shell == ShellDialect::Zsh
+        matches!(
+            self.array_reference_policy(reference),
+            shuck_semantic::ArrayReferencePolicy::NativeZshScalar
+        )
             && self
                 .facts
                 .presence_test_references(&reference.name)

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -56,6 +56,8 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         reference: &Reference,
     ) -> Option<PlainUnindexedArrayReferenceFact> {
         if self.semantic.is_guarded_parameter_reference(reference.id)
+            || self.reference_is_zsh_conditional_operand(reference)
+            || self.reference_is_zsh_presence_test(reference)
             || self.reference_has_prior_presence_test(reference)
             || self.reference_reads_into_same_name_array_writer(reference)
             || self.reference_has_prior_zsh_scalar_local_barrier(reference)
@@ -257,6 +259,20 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
                         binding_suppresses_same_command_array_read(binding, assignment_only)
                     })
         })
+    }
+
+    fn reference_is_zsh_conditional_operand(&self, reference: &Reference) -> bool {
+        self.facts.shell == ShellDialect::Zsh
+            && matches!(reference.kind, shuck_semantic::ReferenceKind::ConditionalOperand)
+    }
+
+    fn reference_is_zsh_presence_test(&self, reference: &Reference) -> bool {
+        self.facts.shell == ShellDialect::Zsh
+            && self
+                .facts
+                .presence_test_references(&reference.name)
+                .iter()
+                .any(|test| test.reference_id() == reference.id)
     }
 
     fn reference_has_prior_presence_test(&mut self, reference: &Reference) -> bool {

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -40,6 +40,7 @@ pub struct BindingValueFact<'a> {
     standalone_status_or_pid_capture: bool,
     conditional_assignment_shortcut: bool,
     one_sided_short_circuit_assignment: bool,
+    zsh_scalar_subscript_value: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -49,19 +50,25 @@ enum BindingValueKind<'a> {
 }
 
 impl<'a> BindingValueFact<'a> {
-    fn scalar(word: &'a Word) -> Self {
-        Self::scalar_with_status_or_pid_capture(word, word_is_standalone_status_or_pid_capture(word))
+    fn scalar(word: &'a Word, source: &str) -> Self {
+        Self::scalar_with_status_or_pid_capture(
+            word,
+            word_is_standalone_status_or_pid_capture(word),
+            source,
+        )
     }
 
     fn scalar_with_status_or_pid_capture(
         word: &'a Word,
         standalone_status_or_pid_capture: bool,
+        source: &str,
     ) -> Self {
         Self {
             kind: BindingValueKind::Scalar(word),
             standalone_status_or_pid_capture,
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
+            zsh_scalar_subscript_value: word_is_zsh_scalar_subscript_value(word, source),
         }
     }
 
@@ -71,6 +78,7 @@ impl<'a> BindingValueFact<'a> {
             standalone_status_or_pid_capture: false,
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
+            zsh_scalar_subscript_value: false,
         }
     }
 
@@ -98,6 +106,10 @@ impl<'a> BindingValueFact<'a> {
 
     pub fn standalone_status_or_pid_capture(&self) -> bool {
         self.standalone_status_or_pid_capture
+    }
+
+    pub fn zsh_scalar_subscript_value(&self) -> bool {
+        self.zsh_scalar_subscript_value
     }
 
     fn mark_conditional_assignment_shortcut(&mut self) {
@@ -1561,6 +1573,130 @@ fn word_has_command_substitution(
         .has_command_substitution()
 }
 
+fn word_is_zsh_scalar_subscript_value(word: &Word, source: &str) -> bool {
+    let mut saw_scalar_subscript = false;
+    word_part_nodes_are_zsh_scalar_subscript_value(&word.parts, source, &mut saw_scalar_subscript)
+        && saw_scalar_subscript
+}
+
+fn word_part_nodes_are_zsh_scalar_subscript_value(
+    parts: &[WordPartNode],
+    source: &str,
+    saw_scalar_subscript: &mut bool,
+) -> bool {
+    for (index, part) in parts.iter().enumerate() {
+        if let WordPart::Variable(_) = &part.kind
+            && parts.get(index + 1).is_some_and(|next| {
+                matches!(
+                    &next.kind,
+                    WordPart::Literal(text) if literal_starts_with_zsh_subscript(text.as_str(source, next.span))
+                )
+            })
+        {
+            *saw_scalar_subscript = true;
+            continue;
+        }
+        if !word_part_is_zsh_scalar_subscript_value(&part.kind, source, saw_scalar_subscript) {
+            return false;
+        }
+    }
+    true
+}
+
+fn word_part_is_zsh_scalar_subscript_value(
+    part: &WordPart,
+    source: &str,
+    saw_scalar_subscript: &mut bool,
+) -> bool {
+    match part {
+        WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
+        WordPart::DoubleQuoted { parts, .. } => {
+            word_part_nodes_are_zsh_scalar_subscript_value(parts, source, saw_scalar_subscript)
+        }
+        WordPart::Parameter(parameter) => {
+            parameter_is_zsh_scalar_subscript_value(parameter, saw_scalar_subscript)
+        }
+        WordPart::ArrayAccess(reference) | WordPart::ArraySlice { reference, .. } => {
+            if !var_ref_is_zsh_scalar_subscript(reference) {
+                return false;
+            }
+            *saw_scalar_subscript = true;
+            true
+        }
+        WordPart::ZshQualifiedGlob(_)
+        | WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn literal_starts_with_zsh_subscript(text: &str) -> bool {
+    let Some(rest) = text.strip_prefix('[') else {
+        return false;
+    };
+    rest.contains(']')
+}
+
+fn parameter_is_zsh_scalar_subscript_value(
+    parameter: &ParameterExpansion,
+    saw_scalar_subscript: &mut bool,
+) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
+            if !var_ref_is_zsh_scalar_subscript(reference) {
+                return false;
+            }
+            *saw_scalar_subscript = true;
+            true
+        }
+        ParameterExpansionSyntax::Bourne(
+            BourneParameterExpansion::Operation { .. }
+            | BourneParameterExpansion::Length { .. }
+            | BourneParameterExpansion::Indices { .. }
+            | BourneParameterExpansion::Indirect { .. }
+            | BourneParameterExpansion::PrefixMatch { .. }
+            | BourneParameterExpansion::Slice { .. }
+            | BourneParameterExpansion::Transformation { .. },
+        ) => false,
+        ParameterExpansionSyntax::Zsh(syntax)
+            if syntax.length_prefix.is_none()
+                && syntax.operation.is_none()
+                && syntax.modifiers.is_empty() =>
+        {
+            match &syntax.target {
+                ZshExpansionTarget::Reference(reference) => {
+                    if !var_ref_is_zsh_scalar_subscript(reference) {
+                        return false;
+                    }
+                    *saw_scalar_subscript = true;
+                    true
+                }
+                ZshExpansionTarget::Nested(parameter) => {
+                    parameter_is_zsh_scalar_subscript_value(parameter, saw_scalar_subscript)
+                }
+                ZshExpansionTarget::Word(_) | ZshExpansionTarget::Empty => false,
+            }
+        }
+        ParameterExpansionSyntax::Zsh(_) => false,
+    }
+}
+
+fn var_ref_is_zsh_scalar_subscript(reference: &VarRef) -> bool {
+    reference
+        .subscript
+        .as_deref()
+        .is_some_and(|subscript| subscript.selector().is_none())
+}
+
 fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
     let next = start + '\\'.len_utf8();
     if next >= text.len() {
@@ -1593,7 +1729,7 @@ fn collect_binding_values<'a>(
         if let Some(binding_id) =
             binding_value_definition_id_for_span(semantic, assignment.target.name_span)
         {
-            binding_values.insert(binding_id, BindingValueFact::scalar(word));
+            binding_values.insert(binding_id, BindingValueFact::scalar(word, source));
         }
     }
 
@@ -1607,7 +1743,7 @@ fn collect_binding_values<'a>(
         if let Some(binding_id) =
             binding_value_definition_id_for_span(semantic, assignment.target.name_span)
         {
-            binding_values.insert(binding_id, BindingValueFact::scalar(word));
+            binding_values.insert(binding_id, BindingValueFact::scalar(word, source));
         }
     }
 
@@ -1635,6 +1771,7 @@ fn collect_binding_values<'a>(
                     BindingValueFact::scalar_with_status_or_pid_capture(
                         word,
                         standalone_status_or_pid_capture,
+                        source,
                     ),
                 );
             }

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -40,7 +40,7 @@ pub struct BindingValueFact<'a> {
     standalone_status_or_pid_capture: bool,
     conditional_assignment_shortcut: bool,
     one_sided_short_circuit_assignment: bool,
-    zsh_scalar_subscript_value: bool,
+    zsh_selectorless_subscript_value: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -68,7 +68,9 @@ impl<'a> BindingValueFact<'a> {
             standalone_status_or_pid_capture,
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
-            zsh_scalar_subscript_value: word_is_zsh_scalar_subscript_value(word, source),
+            zsh_selectorless_subscript_value: word_is_zsh_selectorless_subscript_value(
+                word, source,
+            ),
         }
     }
 
@@ -78,7 +80,7 @@ impl<'a> BindingValueFact<'a> {
             standalone_status_or_pid_capture: false,
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
-            zsh_scalar_subscript_value: false,
+            zsh_selectorless_subscript_value: false,
         }
     }
 
@@ -108,8 +110,8 @@ impl<'a> BindingValueFact<'a> {
         self.standalone_status_or_pid_capture
     }
 
-    pub fn zsh_scalar_subscript_value(&self) -> bool {
-        self.zsh_scalar_subscript_value
+    pub fn zsh_selectorless_subscript_value(&self) -> bool {
+        self.zsh_selectorless_subscript_value
     }
 
     fn mark_conditional_assignment_shortcut(&mut self) {
@@ -1573,16 +1575,19 @@ fn word_has_command_substitution(
         .has_command_substitution()
 }
 
-fn word_is_zsh_scalar_subscript_value(word: &Word, source: &str) -> bool {
-    let mut saw_scalar_subscript = false;
-    word_part_nodes_are_zsh_scalar_subscript_value(&word.parts, source, &mut saw_scalar_subscript)
-        && saw_scalar_subscript
+fn word_is_zsh_selectorless_subscript_value(word: &Word, source: &str) -> bool {
+    let mut saw_selectorless_subscript = false;
+    word_part_nodes_are_zsh_selectorless_subscript_value(
+        &word.parts,
+        source,
+        &mut saw_selectorless_subscript,
+    ) && saw_selectorless_subscript
 }
 
-fn word_part_nodes_are_zsh_scalar_subscript_value(
+fn word_part_nodes_are_zsh_selectorless_subscript_value(
     parts: &[WordPartNode],
     source: &str,
-    saw_scalar_subscript: &mut bool,
+    saw_selectorless_subscript: &mut bool,
 ) -> bool {
     for (index, part) in parts.iter().enumerate() {
         if let WordPart::Variable(_) = &part.kind
@@ -1593,34 +1598,42 @@ fn word_part_nodes_are_zsh_scalar_subscript_value(
                 )
             })
         {
-            *saw_scalar_subscript = true;
+            *saw_selectorless_subscript = true;
             continue;
         }
-        if !word_part_is_zsh_scalar_subscript_value(&part.kind, source, saw_scalar_subscript) {
+        if !word_part_is_zsh_selectorless_subscript_value(
+            &part.kind,
+            source,
+            saw_selectorless_subscript,
+        ) {
             return false;
         }
     }
     true
 }
 
-fn word_part_is_zsh_scalar_subscript_value(
+fn word_part_is_zsh_selectorless_subscript_value(
     part: &WordPart,
     source: &str,
-    saw_scalar_subscript: &mut bool,
+    saw_selectorless_subscript: &mut bool,
 ) -> bool {
     match part {
         WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
         WordPart::DoubleQuoted { parts, .. } => {
-            word_part_nodes_are_zsh_scalar_subscript_value(parts, source, saw_scalar_subscript)
+            word_part_nodes_are_zsh_selectorless_subscript_value(
+                parts,
+                source,
+                saw_selectorless_subscript,
+            )
         }
         WordPart::Parameter(parameter) => {
-            parameter_is_zsh_scalar_subscript_value(parameter, saw_scalar_subscript)
+            parameter_is_zsh_selectorless_subscript_value(parameter, saw_selectorless_subscript)
         }
         WordPart::ArrayAccess(reference) | WordPart::ArraySlice { reference, .. } => {
-            if !var_ref_is_zsh_scalar_subscript(reference) {
+            if !var_ref_has_selectorless_subscript(reference) {
                 return false;
             }
-            *saw_scalar_subscript = true;
+            *saw_selectorless_subscript = true;
             true
         }
         WordPart::ZshQualifiedGlob(_)
@@ -1646,16 +1659,16 @@ fn literal_starts_with_zsh_subscript(text: &str) -> bool {
     rest.contains(']')
 }
 
-fn parameter_is_zsh_scalar_subscript_value(
+fn parameter_is_zsh_selectorless_subscript_value(
     parameter: &ParameterExpansion,
-    saw_scalar_subscript: &mut bool,
+    saw_selectorless_subscript: &mut bool,
 ) -> bool {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
-            if !var_ref_is_zsh_scalar_subscript(reference) {
+            if !var_ref_has_selectorless_subscript(reference) {
                 return false;
             }
-            *saw_scalar_subscript = true;
+            *saw_selectorless_subscript = true;
             true
         }
         ParameterExpansionSyntax::Bourne(
@@ -1674,14 +1687,17 @@ fn parameter_is_zsh_scalar_subscript_value(
         {
             match &syntax.target {
                 ZshExpansionTarget::Reference(reference) => {
-                    if !var_ref_is_zsh_scalar_subscript(reference) {
+                    if !var_ref_has_selectorless_subscript(reference) {
                         return false;
                     }
-                    *saw_scalar_subscript = true;
+                    *saw_selectorless_subscript = true;
                     true
                 }
                 ZshExpansionTarget::Nested(parameter) => {
-                    parameter_is_zsh_scalar_subscript_value(parameter, saw_scalar_subscript)
+                    parameter_is_zsh_selectorless_subscript_value(
+                        parameter,
+                        saw_selectorless_subscript,
+                    )
                 }
                 ZshExpansionTarget::Word(_) | ZshExpansionTarget::Empty => false,
             }
@@ -1690,7 +1706,7 @@ fn parameter_is_zsh_scalar_subscript_value(
     }
 }
 
-fn var_ref_is_zsh_scalar_subscript(reference: &VarRef) -> bool {
+fn var_ref_has_selectorless_subscript(reference: &VarRef) -> bool {
     reference
         .subscript
         .as_deref()

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use shuck_ast::Name;
+use shuck_ast::{
+    BourneParameterExpansion, Name, ParameterExpansion, ParameterExpansionSyntax, VarRef, Word,
+    WordPart, WordPartNode, ZshExpansionTarget,
+};
 use shuck_semantic::{
     Binding, BindingAttributes, BindingKind, Declaration, DeclarationBuiltin, DeclarationOperand,
     ScopeId,
@@ -88,6 +91,15 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
             }
 
             checker.facts().binding_value(binding.id)?.scalar_word()?;
+
+            if zsh_scalar_subscript_value_assignment(checker, binding) {
+                push_array_history(
+                    &mut array_history,
+                    name,
+                    ArrayHistoryState::from_binding(checker, binding, false, None),
+                );
+                return None;
+            }
 
             if binding_establishes_array_history(binding, &builtin_history) {
                 let prior = latest_array_history(&array_history, &name);
@@ -196,6 +208,127 @@ impl ArrayHistoryState {
         !self.local
             || self.function_scope == checker.semantic().enclosing_function_scope(binding.scope)
     }
+}
+
+fn zsh_scalar_subscript_value_assignment(checker: &Checker<'_>, binding: &Binding) -> bool {
+    if checker.shell() != ShellDialect::Zsh {
+        return false;
+    }
+    let Some(word) = checker
+        .facts()
+        .binding_value(binding.id)
+        .and_then(|value| value.scalar_word())
+    else {
+        return false;
+    };
+    let mut saw_scalar_subscript = false;
+    word_is_zsh_scalar_subscript_value(word, checker.source(), &mut saw_scalar_subscript)
+        && saw_scalar_subscript
+}
+
+fn word_is_zsh_scalar_subscript_value(
+    word: &Word,
+    source: &str,
+    saw_scalar_subscript: &mut bool,
+) -> bool {
+    word_part_nodes_are_zsh_scalar_subscript_value(&word.parts, source, saw_scalar_subscript)
+}
+
+fn word_part_nodes_are_zsh_scalar_subscript_value(
+    parts: &[WordPartNode],
+    source: &str,
+    saw_scalar_subscript: &mut bool,
+) -> bool {
+    for (index, part) in parts.iter().enumerate() {
+        if let WordPart::Variable(_) = &part.kind
+            && parts.get(index + 1).is_some_and(|next| {
+                matches!(
+                    &next.kind,
+                    WordPart::Literal(text) if literal_starts_with_zsh_subscript(text.as_str(source, next.span))
+                )
+            })
+        {
+            *saw_scalar_subscript = true;
+            continue;
+        }
+        if !word_part_is_zsh_scalar_subscript_value(&part.kind, source, saw_scalar_subscript) {
+            return false;
+        }
+    }
+    true
+}
+
+fn word_part_is_zsh_scalar_subscript_value(
+    part: &WordPart,
+    source: &str,
+    saw_scalar_subscript: &mut bool,
+) -> bool {
+    match part {
+        WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
+        WordPart::DoubleQuoted { parts, .. } => {
+            word_part_nodes_are_zsh_scalar_subscript_value(parts, source, saw_scalar_subscript)
+        }
+        WordPart::Parameter(parameter) => {
+            parameter_is_zsh_scalar_subscript_value(parameter, saw_scalar_subscript)
+        }
+        WordPart::ArrayAccess(reference) | WordPart::ArraySlice { reference, .. } => {
+            if !var_ref_is_zsh_scalar_subscript(reference) {
+                return false;
+            }
+            *saw_scalar_subscript = true;
+            true
+        }
+        _ => false,
+    }
+}
+
+fn literal_starts_with_zsh_subscript(text: &str) -> bool {
+    let Some(rest) = text.strip_prefix('[') else {
+        return false;
+    };
+    rest.contains(']')
+}
+
+fn parameter_is_zsh_scalar_subscript_value(
+    parameter: &ParameterExpansion,
+    saw_scalar_subscript: &mut bool,
+) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
+            if !var_ref_is_zsh_scalar_subscript(reference) {
+                return false;
+            }
+            *saw_scalar_subscript = true;
+            true
+        }
+        ParameterExpansionSyntax::Zsh(syntax)
+            if syntax.length_prefix.is_none()
+                && syntax.operation.is_none()
+                && syntax.modifiers.is_empty() =>
+        {
+            match &syntax.target {
+                ZshExpansionTarget::Reference(reference) => {
+                    if !var_ref_is_zsh_scalar_subscript(reference) {
+                        return false;
+                    }
+                    *saw_scalar_subscript = true;
+                    true
+                }
+                ZshExpansionTarget::Nested(parameter) => {
+                    parameter_is_zsh_scalar_subscript_value(parameter, saw_scalar_subscript)
+                }
+                ZshExpansionTarget::Word(_) | ZshExpansionTarget::Empty => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn var_ref_is_zsh_scalar_subscript(reference: &VarRef) -> bool {
+    reference
+        .subscript
+        .as_deref()
+        .is_some_and(|subscript| subscript.selector().is_none())
 }
 
 fn array_history_events(
@@ -1517,6 +1650,25 @@ exts+=\" ${exts^^}\"
             vec!["exts"],
             "{diagnostics:#?}"
         );
+    }
+
+    #[test]
+    fn zsh_scalar_string_slices_do_not_create_array_to_string_history() {
+        let source = "\
+#!/bin/zsh
+ret=abcdef
+ret[-1,-1]=''
+ret=${ret[2,-1]}
+items=(one two)
+items=$items[1]
+echo \"$ret\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -1,9 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use shuck_ast::{
-    BourneParameterExpansion, Name, ParameterExpansion, ParameterExpansionSyntax, VarRef, Word,
-    WordPart, WordPartNode, ZshExpansionTarget,
-};
+use shuck_ast::Name;
 use shuck_semantic::{
     Binding, BindingAttributes, BindingKind, Declaration, DeclarationBuiltin, DeclarationOperand,
     ScopeId,
@@ -92,7 +89,12 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
 
             checker.facts().binding_value(binding.id)?.scalar_word()?;
 
-            if zsh_scalar_subscript_value_assignment(checker, binding) {
+            if checker.shell() == ShellDialect::Zsh
+                && checker
+                    .facts()
+                    .binding_value(binding.id)
+                    .is_some_and(|value| value.zsh_scalar_subscript_value())
+            {
                 push_array_history(
                     &mut array_history,
                     name,
@@ -208,127 +210,6 @@ impl ArrayHistoryState {
         !self.local
             || self.function_scope == checker.semantic().enclosing_function_scope(binding.scope)
     }
-}
-
-fn zsh_scalar_subscript_value_assignment(checker: &Checker<'_>, binding: &Binding) -> bool {
-    if checker.shell() != ShellDialect::Zsh {
-        return false;
-    }
-    let Some(word) = checker
-        .facts()
-        .binding_value(binding.id)
-        .and_then(|value| value.scalar_word())
-    else {
-        return false;
-    };
-    let mut saw_scalar_subscript = false;
-    word_is_zsh_scalar_subscript_value(word, checker.source(), &mut saw_scalar_subscript)
-        && saw_scalar_subscript
-}
-
-fn word_is_zsh_scalar_subscript_value(
-    word: &Word,
-    source: &str,
-    saw_scalar_subscript: &mut bool,
-) -> bool {
-    word_part_nodes_are_zsh_scalar_subscript_value(&word.parts, source, saw_scalar_subscript)
-}
-
-fn word_part_nodes_are_zsh_scalar_subscript_value(
-    parts: &[WordPartNode],
-    source: &str,
-    saw_scalar_subscript: &mut bool,
-) -> bool {
-    for (index, part) in parts.iter().enumerate() {
-        if let WordPart::Variable(_) = &part.kind
-            && parts.get(index + 1).is_some_and(|next| {
-                matches!(
-                    &next.kind,
-                    WordPart::Literal(text) if literal_starts_with_zsh_subscript(text.as_str(source, next.span))
-                )
-            })
-        {
-            *saw_scalar_subscript = true;
-            continue;
-        }
-        if !word_part_is_zsh_scalar_subscript_value(&part.kind, source, saw_scalar_subscript) {
-            return false;
-        }
-    }
-    true
-}
-
-fn word_part_is_zsh_scalar_subscript_value(
-    part: &WordPart,
-    source: &str,
-    saw_scalar_subscript: &mut bool,
-) -> bool {
-    match part {
-        WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
-        WordPart::DoubleQuoted { parts, .. } => {
-            word_part_nodes_are_zsh_scalar_subscript_value(parts, source, saw_scalar_subscript)
-        }
-        WordPart::Parameter(parameter) => {
-            parameter_is_zsh_scalar_subscript_value(parameter, saw_scalar_subscript)
-        }
-        WordPart::ArrayAccess(reference) | WordPart::ArraySlice { reference, .. } => {
-            if !var_ref_is_zsh_scalar_subscript(reference) {
-                return false;
-            }
-            *saw_scalar_subscript = true;
-            true
-        }
-        _ => false,
-    }
-}
-
-fn literal_starts_with_zsh_subscript(text: &str) -> bool {
-    let Some(rest) = text.strip_prefix('[') else {
-        return false;
-    };
-    rest.contains(']')
-}
-
-fn parameter_is_zsh_scalar_subscript_value(
-    parameter: &ParameterExpansion,
-    saw_scalar_subscript: &mut bool,
-) -> bool {
-    match &parameter.syntax {
-        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
-            if !var_ref_is_zsh_scalar_subscript(reference) {
-                return false;
-            }
-            *saw_scalar_subscript = true;
-            true
-        }
-        ParameterExpansionSyntax::Zsh(syntax)
-            if syntax.length_prefix.is_none()
-                && syntax.operation.is_none()
-                && syntax.modifiers.is_empty() =>
-        {
-            match &syntax.target {
-                ZshExpansionTarget::Reference(reference) => {
-                    if !var_ref_is_zsh_scalar_subscript(reference) {
-                        return false;
-                    }
-                    *saw_scalar_subscript = true;
-                    true
-                }
-                ZshExpansionTarget::Nested(parameter) => {
-                    parameter_is_zsh_scalar_subscript_value(parameter, saw_scalar_subscript)
-                }
-                ZshExpansionTarget::Word(_) | ZshExpansionTarget::Empty => false,
-            }
-        }
-        _ => false,
-    }
-}
-
-fn var_ref_is_zsh_scalar_subscript(reference: &VarRef) -> bool {
-    reference
-        .subscript
-        .as_deref()
-        .is_some_and(|subscript| subscript.selector().is_none())
 }
 
 fn array_history_events(

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -2,8 +2,8 @@ use std::collections::{HashMap, HashSet};
 
 use shuck_ast::Name;
 use shuck_semantic::{
-    Binding, BindingAttributes, BindingKind, Declaration, DeclarationBuiltin, DeclarationOperand,
-    ScopeId,
+    ArrayReferencePolicy, Binding, BindingAttributes, BindingKind, Declaration, DeclarationBuiltin,
+    DeclarationOperand, ScopeId,
 };
 
 use crate::{Checker, ComparableNameUseKind, Rule, ShellDialect, Violation, WrapperKind};
@@ -89,12 +89,11 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
 
             checker.facts().binding_value(binding.id)?.scalar_word()?;
 
-            if checker.shell() == ShellDialect::Zsh
-                && checker
-                    .facts()
-                    .binding_value(binding.id)
-                    .is_some_and(|value| value.zsh_scalar_subscript_value())
-            {
+            if zsh_selectorless_subscript_value_resets_scalar_history(
+                checker,
+                binding,
+                saw_array_history,
+            ) {
                 push_array_history(
                     &mut array_history,
                     name,
@@ -210,6 +209,26 @@ impl ArrayHistoryState {
         !self.local
             || self.function_scope == checker.semantic().enclosing_function_scope(binding.scope)
     }
+}
+
+fn zsh_selectorless_subscript_value_resets_scalar_history(
+    checker: &Checker<'_>,
+    binding: &Binding,
+    saw_array_history: bool,
+) -> bool {
+    checker.shell() == ShellDialect::Zsh
+        && !saw_array_history
+        && matches!(
+            checker
+                .semantic()
+                .shell_behavior_at(binding.span.start.offset)
+                .array_reference_policy(),
+            ArrayReferencePolicy::NativeZshScalar
+        )
+        && checker
+            .facts()
+            .binding_value(binding.id)
+            .is_some_and(|value| value.zsh_selectorless_subscript_value())
 }
 
 fn array_history_events(
@@ -1534,7 +1553,7 @@ exts+=\" ${exts^^}\"
     }
 
     #[test]
-    fn zsh_scalar_string_slices_do_not_create_array_to_string_history() {
+    fn zsh_scalar_string_slices_do_not_hide_array_element_conversions() {
         let source = "\
 #!/bin/zsh
 ret=abcdef
@@ -1542,6 +1561,9 @@ ret[-1,-1]=''
 ret=${ret[2,-1]}
 items=(one two)
 items=$items[1]
+setopt ksh_arrays
+kitems=(one two)
+kitems=$kitems[1]
 echo \"$ret\"
 ";
         let diagnostics = test_snippet(
@@ -1549,7 +1571,14 @@ echo \"$ret\"
             &LinterSettings::for_rule(Rule::ArrayToStringConversion),
         );
 
-        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["items", "kitems"],
+            "{diagnostics:#?}"
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -143,14 +143,31 @@ printf '%s\\n' \"$ret\" \"${ret}\"
     fn zsh_array_presence_tests_do_not_require_explicit_selectors() {
         let source = "\
 #!/bin/zsh
-opt=ksh_arrays
-setopt \"$opt\"
 precm=(builtin emulate zsh)
 [[ -n $precm ]] && builtin ${precm[@]} 'source \"$ZERO\"'
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::QuotedBashSource));
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_ksh_array_presence_tests_require_explicit_selectors() {
+        let source = "\
+#!/bin/zsh
+setopt ksh_arrays
+precm=(builtin emulate zsh)
+[[ -n $precm ]] && builtin ${precm[@]} 'source \"$ZERO\"'
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::QuotedBashSource));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$precm"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -124,6 +124,36 @@ printf '%s\\n' \"$MAPFILE\"
     }
 
     #[test]
+    fn zsh_scalar_string_slices_do_not_create_array_reference_history() {
+        let source = "\
+#!/bin/zsh
+opt=ksh_arrays
+setopt \"$opt\"
+ret=abcdef
+ret[-1,-1]=''
+ret=${ret[2,-1]}
+printf '%s\\n' \"$ret\" \"${ret}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::QuotedBashSource));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_array_presence_tests_do_not_require_explicit_selectors() {
+        let source = "\
+#!/bin/zsh
+opt=ksh_arrays
+setopt \"$opt\"
+precm=(builtin emulate zsh)
+[[ -n $precm ]] && builtin ${precm[@]} 'source \"$ZERO\"'
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::QuotedBashSource));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn ignores_follow_up_loop_headers_after_presence_guard() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-semantic/src/builder/bindings.rs
+++ b/crates/shuck-semantic/src/builder/bindings.rs
@@ -27,11 +27,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     ) {
         let reference_start = self.references.len();
         self.visit_assignment_reads_into(assignment, flow, nested_regions);
+        let zsh_scalar_subscript_assignment =
+            self.assignment_target_uses_zsh_scalar_subscript(assignment);
         let (kind, scope) = declaration_kind.unwrap_or_else(|| {
             let kind = if assignment.append {
                 BindingKind::AppendAssignment
             } else if matches!(assignment.value, AssignmentValue::Compound(_))
-                || assignment.target.subscript.is_some()
+                || (assignment.target.subscript.is_some() && !zsh_scalar_subscript_assignment)
             {
                 BindingKind::ArrayAssignment
             } else {
@@ -40,6 +42,9 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             (kind, self.current_scope())
         });
         attributes |= assignment_binding_attributes(assignment);
+        if zsh_scalar_subscript_assignment {
+            attributes.remove(BindingAttributes::ARRAY | BindingAttributes::ASSOC);
+        }
         if assignment_has_empty_initializer(assignment, self.source) {
             attributes |= BindingAttributes::EMPTY_INITIALIZER;
         }
@@ -80,6 +85,26 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         if let Some(hint) = indirect_target_hint(assignment, self.source) {
             self.indirect_target_hints.insert(binding, hint);
         }
+    }
+
+    fn assignment_target_uses_zsh_scalar_subscript(&self, assignment: &Assignment) -> bool {
+        if self.shell_profile.dialect != ShellDialect::Zsh {
+            return false;
+        }
+        let Some(subscript) = assignment.target.subscript.as_deref() else {
+            return false;
+        };
+        if subscript.selector().is_some() {
+            return false;
+        }
+        self.resolve_reference(
+            &assignment.target.name,
+            self.current_scope(),
+            assignment.target.name_span.start.offset,
+        )
+        .is_some_and(|binding_id| {
+            !crate::binding::is_array_like_binding(&self.bindings[binding_id.index()])
+        })
     }
 
     pub(super) fn record_prompt_assignment_references(&mut self, assignment: &'a Assignment) {

--- a/crates/shuck-semantic/src/builder/bindings.rs
+++ b/crates/shuck-semantic/src/builder/bindings.rs
@@ -29,6 +29,8 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         self.visit_assignment_reads_into(assignment, flow, nested_regions);
         let zsh_scalar_subscript_assignment =
             self.assignment_target_uses_zsh_scalar_subscript(assignment);
+        let explicit_array_declaration = declaration_kind.is_some()
+            && attributes.intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC);
         let (kind, scope) = declaration_kind.unwrap_or_else(|| {
             let kind = if assignment.append {
                 BindingKind::AppendAssignment
@@ -42,7 +44,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             (kind, self.current_scope())
         });
         attributes |= assignment_binding_attributes(assignment);
-        if zsh_scalar_subscript_assignment {
+        if zsh_scalar_subscript_assignment && !explicit_array_declaration {
             attributes.remove(BindingAttributes::ARRAY | BindingAttributes::ASSOC);
         }
         if assignment_has_empty_initializer(assignment, self.source) {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9976,6 +9976,56 @@ print -r -- ${functions[iterm2_precmd]}
 }
 
 #[test]
+fn zsh_subscript_declarations_preserve_explicit_array_flags() {
+    let source = "\
+#!/bin/zsh
+indexed=scalar
+assoc=scalar
+plain=scalar
+typeset -a indexed[1]=x
+typeset -A assoc[key]=x
+typeset plain[1]=x
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+
+    let indexed = model
+        .bindings()
+        .iter()
+        .rev()
+        .find(|binding| {
+            binding.name == "indexed"
+                && binding.kind == BindingKind::Declaration(DeclarationBuiltin::Typeset)
+        })
+        .expect("expected typed indexed declaration");
+    assert!(indexed.attributes.contains(BindingAttributes::ARRAY));
+    assert!(!indexed.attributes.contains(BindingAttributes::ASSOC));
+
+    let assoc = model
+        .bindings()
+        .iter()
+        .rev()
+        .find(|binding| {
+            binding.name == "assoc"
+                && binding.kind == BindingKind::Declaration(DeclarationBuiltin::Typeset)
+        })
+        .expect("expected typed associative declaration");
+    assert!(assoc.attributes.contains(BindingAttributes::ARRAY));
+    assert!(assoc.attributes.contains(BindingAttributes::ASSOC));
+
+    let plain = model
+        .bindings()
+        .iter()
+        .rev()
+        .find(|binding| {
+            binding.name == "plain"
+                && binding.kind == BindingKind::Declaration(DeclarationBuiltin::Typeset)
+        })
+        .expect("expected plain declaration");
+    assert!(!plain.attributes.contains(BindingAttributes::ARRAY));
+    assert!(!plain.attributes.contains(BindingAttributes::ASSOC));
+}
+
+#[test]
 fn arithmetic_indexed_writes_preserve_associative_attributes() {
     let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary

- Treat zsh subscript assignments to existing scalar parameters as scalar string updates instead of array bindings.
- Reset C133 array history for zsh scalar assignments built from ordinary scalar/index/slice subscripts, including unbraced `$name[1]` forms.
- Suppress C100 for zsh conditional/presence operands where a plain array expansion is being used as a scalar test.

## Validation

- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-scalar-subscripts/shuck/Cargo.toml -p shuck-linter zsh_scalar_string_slices_do_not_create_array_reference_history -- --nocapture`
- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-scalar-subscripts/shuck/Cargo.toml -p shuck-linter zsh_scalar_string_slices_do_not_create_array_to_string_history -- --nocapture`
- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-scalar-subscripts/shuck/Cargo.toml -p shuck-linter rules::correctness::tests::rules -- --nocapture`
- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-scalar-subscripts/shuck/Cargo.toml -p shuck-semantic zsh -- --nocapture`
- `make -C /Users/ewhauser/.codex/worktrees/zsh-scalar-subscripts/shuck test-large-corpus SHUCK_LARGE_CORPUS_RULES=C100,C133`