### PR TITLE
Handle optional zsh function arguments

### DIFF
--- a/crates/shuck-linter/src/facts/conditionals.rs
+++ b/crates/shuck-linter/src/facts/conditionals.rs
@@ -28,6 +28,11 @@ impl<'a> ConditionalOperandFact<'a> {
         self.word
     }
 
+    pub fn is_optional_first_positional_parameter(self) -> bool {
+        self.word
+            .is_some_and(word_is_optional_first_positional_parameter)
+    }
+
     pub fn word_classification(&self) -> Option<WordClassification> {
         self.word_classification
     }
@@ -36,6 +41,95 @@ impl<'a> ConditionalOperandFact<'a> {
         self.word_classification
             .map(|classification| classification.quote)
     }
+}
+
+fn word_is_optional_first_positional_parameter(word: &Word) -> bool {
+    let [part] = word.parts.as_slice() else {
+        return false;
+    };
+
+    word_part_is_optional_first_positional_parameter(&part.kind)
+}
+
+fn word_part_is_optional_first_positional_parameter(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => name.as_str() == "1",
+        WordPart::DoubleQuoted { parts, .. } => {
+            let [part] = parts.as_slice() else {
+                return false;
+            };
+            word_part_is_optional_first_positional_parameter(&part.kind)
+        }
+        WordPart::Parameter(parameter) => parameter_is_optional_first_positional(parameter),
+        WordPart::ParameterExpansion {
+            reference,
+            operator,
+            ..
+        } => reference_is_first_positional_parameter(reference)
+            && matches!(operator.as_ref(), ParameterOp::UseDefault),
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn parameter_is_optional_first_positional(parameter: &ParameterExpansion) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
+            reference_is_first_positional_parameter(reference)
+        }
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+            reference,
+            operator,
+            ..
+        }) => {
+            reference_is_first_positional_parameter(reference)
+                && matches!(operator.as_ref(), ParameterOp::UseDefault)
+        }
+        ParameterExpansionSyntax::Zsh(syntax) => {
+            matches!(
+                &syntax.target,
+                ZshExpansionTarget::Reference(reference)
+                    if reference_is_first_positional_parameter(reference)
+            ) && match &syntax.operation {
+                None => true,
+                Some(ZshExpansionOperation::Defaulting { kind, .. }) => {
+                    matches!(kind, shuck_ast::ZshDefaultingOp::UseDefault)
+                }
+                Some(
+                    ZshExpansionOperation::PatternOperation { .. }
+                    | ZshExpansionOperation::TrimOperation { .. }
+                    | ZshExpansionOperation::ReplacementOperation { .. }
+                    | ZshExpansionOperation::Slice { .. }
+                    | ZshExpansionOperation::Unknown { .. },
+                ) => false,
+            }
+        }
+        ParameterExpansionSyntax::Bourne(
+            BourneParameterExpansion::Length { .. }
+            | BourneParameterExpansion::Indices { .. }
+            | BourneParameterExpansion::Indirect { .. }
+            | BourneParameterExpansion::PrefixMatch { .. }
+            | BourneParameterExpansion::Slice { .. }
+            | BourneParameterExpansion::Transformation { .. },
+        ) => false,
+    }
+}
+
+fn reference_is_first_positional_parameter(reference: &VarRef) -> bool {
+    reference.subscript.is_none() && reference.name.as_str() == "1"
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -77,6 +171,11 @@ impl<'a> ConditionalUnaryFact<'a> {
 
     pub fn op(&self) -> ConditionalUnaryOp {
         self.op
+    }
+
+    pub fn is_empty_string_test(&self) -> bool {
+        self.operator_family == ConditionalOperatorFamily::StringUnary
+            && self.op == ConditionalUnaryOp::EmptyString
     }
 
     pub fn operator_family(&self) -> ConditionalOperatorFamily {

--- a/crates/shuck-linter/src/rules/correctness/function_arity.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_arity.rs
@@ -1,0 +1,67 @@
+use shuck_semantic::ScopeId;
+
+use crate::facts::conditionals::{
+    ConditionalNodeFact, ConditionalOperandFact, ConditionalOperatorFamily,
+};
+use crate::{Checker, ShellDialect};
+
+pub(crate) fn zsh_function_arity_is_externally_defined(
+    checker: &Checker<'_>,
+    function_scope: ScopeId,
+) -> bool {
+    checker.shell() == ShellDialect::Zsh
+        && (checker
+            .facts()
+            .function_is_external_entrypoint(function_scope)
+            || checker
+                .facts()
+                .function_positional_parameter_facts(function_scope)
+                .required_arg_count()
+                == 0
+            || zsh_function_has_optional_first_positional_parameter(checker, function_scope))
+}
+
+fn zsh_function_has_optional_first_positional_parameter(
+    checker: &Checker<'_>,
+    function_scope: ScopeId,
+) -> bool {
+    let positional = checker
+        .facts()
+        .function_positional_parameter_facts(function_scope);
+    if positional.required_arg_count() != 1 {
+        return false;
+    }
+
+    checker.facts().commands().iter().any(|command| {
+        checker.semantic().enclosing_function_scope(command.scope()) == Some(function_scope)
+            && command
+                .conditional()
+                .is_some_and(conditional_mentions_optional_first_positional_parameter)
+    })
+}
+
+fn conditional_mentions_optional_first_positional_parameter(
+    conditional: &crate::facts::conditionals::ConditionalFact<'_>,
+) -> bool {
+    conditional.nodes().iter().any(|node| match node {
+        ConditionalNodeFact::BareWord(fact) => {
+            operand_is_optional_first_positional_parameter(fact.operand())
+        }
+        ConditionalNodeFact::Unary(fact) if fact.is_empty_string_test() => {
+            operand_is_optional_first_positional_parameter(fact.operand())
+        }
+        ConditionalNodeFact::Binary(fact)
+            if fact.operator_family() == ConditionalOperatorFamily::StringBinary =>
+        {
+            operand_is_optional_first_positional_parameter(fact.left())
+                || operand_is_optional_first_positional_parameter(fact.right())
+        }
+        ConditionalNodeFact::Unary(_)
+        | ConditionalNodeFact::Binary(_)
+        | ConditionalNodeFact::Other(_) => false,
+    })
+}
+
+fn operand_is_optional_first_positional_parameter(operand: ConditionalOperandFact<'_>) -> bool {
+    operand.is_optional_first_positional_parameter()
+}

--- a/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_called_without_args.rs
@@ -3,7 +3,8 @@ use rustc_hash::FxHashSet;
 use shuck_ast::Span;
 use shuck_semantic::BindingId;
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use super::function_arity::zsh_function_arity_is_externally_defined;
+use crate::{Checker, Rule, Violation};
 
 pub struct FunctionCalledWithoutArgs {
     pub name: CompactString,
@@ -64,21 +65,6 @@ pub fn function_called_without_args(checker: &mut Checker) {
     for (span, name) in violations {
         checker.report(FunctionCalledWithoutArgs { name }, span);
     }
-}
-
-fn zsh_function_arity_is_externally_defined(
-    checker: &Checker<'_>,
-    function_scope: shuck_semantic::ScopeId,
-) -> bool {
-    checker.shell() == ShellDialect::Zsh
-        && (checker
-            .facts()
-            .function_is_external_entrypoint(function_scope)
-            || checker
-                .facts()
-                .function_positional_parameter_facts(function_scope)
-                .required_arg_count()
-                == 0)
 }
 
 #[cfg(test)]
@@ -328,6 +314,59 @@ _zsh_autosuggest_toggle
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_zsh_functions_with_optional_first_positional_parameter() {
+        let source = "\
+#!/bin/zsh
+retlog() {
+  if [[ -z $1 ]]; then
+    print -r -- /var/log/nginx/access.log
+  else
+    print -r -- \"$1\"
+  fi
+}
+phase() {
+  local mode=components
+  [[ \"${1:-}\" == --phase=* ]] && mode=\"${1#--phase=}\"
+  print -r -- \"$mode\"
+}
+retlog
+phase
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_zsh_required_argument_after_first_positional_validation() {
+        let source = "\
+#!/bin/zsh
+requires_name() {
+  if [[ -n \"$1\" ]]; then
+    print -r -- ok
+  fi
+  print -r -- \"$2\"
+}
+requires_name
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionCalledWithoutArgs)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "requires_name() {\n  if [[ -n \"$1\" ]]; then\n    print -r -- ok\n  fi\n  print -r -- \"$2\"\n}"
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -3,7 +3,8 @@ use rustc_hash::FxHashSet;
 use shuck_ast::Span;
 use shuck_semantic::BindingId;
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use super::function_arity::zsh_function_arity_is_externally_defined;
+use crate::{Checker, Rule, Violation};
 
 pub struct FunctionReferencesUnsetParam {
     pub name: CompactString,
@@ -70,21 +71,6 @@ pub fn function_references_unset_param(checker: &mut Checker) {
     for (span, name) in violations {
         checker.report(FunctionReferencesUnsetParam { name }, span);
     }
-}
-
-fn zsh_function_arity_is_externally_defined(
-    checker: &Checker<'_>,
-    function_scope: shuck_semantic::ScopeId,
-) -> bool {
-    checker.shell() == ShellDialect::Zsh
-        && (checker
-            .facts()
-            .function_is_external_entrypoint(function_scope)
-            || checker
-                .facts()
-                .function_positional_parameter_facts(function_scope)
-                .required_arg_count()
-                == 0)
 }
 
 #[cfg(test)]
@@ -212,6 +198,57 @@ precmd_refresh
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_zsh_call_sites_for_optional_first_positional_parameter() {
+        let source = "\
+#!/bin/zsh
+retlog() {
+  if [[ -z $1 ]]; then
+    print -r -- /var/log/nginx/access.log
+  else
+    print -r -- \"$1\"
+  fi
+}
+phase() {
+  local mode=components
+  [[ \"${1:-}\" == --phase=* ]] && mode=\"${1#--phase=}\"
+  print -r -- \"$mode\"
+}
+retlog
+phase
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_zsh_required_argument_after_first_positional_validation() {
+        let source = "\
+#!/bin/zsh
+requires_name() {
+  if [[ -n \"$1\" ]]; then
+    print -r -- ok
+  fi
+  print -r -- \"$2\"
+}
+requires_name
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam)
+                .with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "requires_name");
+        assert_eq!(diagnostics[0].span.start.line, 8);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -44,6 +44,7 @@ pub mod expr_substr_in_test;
 pub mod find_or_without_grouping;
 pub mod find_output_loop;
 pub mod find_output_to_xargs;
+mod function_arity;
 pub mod function_called_without_args;
 pub mod function_references_unset_param;
 pub mod getopts_option_not_in_case;


### PR DESCRIPTION
## Summary
- share the zsh C097/C123 arity policy between the paired rules
- treat zsh functions with an explicitly optional first positional parameter as externally safe for zero-argument calls
- add focused regression coverage for optional `$1` branches and `${1:-...}` dispatch checks

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter function_called_without_args -- --nocapture`
- `cargo test -p shuck-linter function_references_unset_param -- --nocapture`
- `cargo test -p shuck-linter`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `/Users/ewhauser/.codex/worktrees/zsh-function-arity/shuck/target/debug/shuck check --isolated --select C097,C123 --per-file-shell '**/*.zsh:zsh' --output-format concise -e ohmyzsh/plugins/systemadmin/systemadmin.plugin.zsh`
- `/Users/ewhauser/.codex/worktrees/zsh-function-arity/shuck/target/debug/shuck check --isolated --select C097,C123 --per-file-shell '**/*.zsh:zsh' --output-format concise -e powerlevel10k/internal/configure.zsh`
- `/Users/ewhauser/.codex/worktrees/zsh-function-arity/shuck/target/debug/shuck check --isolated --select C097,C123 --per-file-shell '**/*.zsh:zsh' --output-format concise -e zdot/core/update-impl.zsh`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C097,C123`