### PR TITLE
Fix zsh ambient context variable diagnostics

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts.rs
@@ -67,6 +67,10 @@ fn providers() -> &'static [AmbientContractProvider] {
             build: build_sourced_runtime_contract,
         },
         AmbientContractProvider {
+            matches: matches_zsh_ambient_runtime_contract,
+            build: build_zsh_ambient_runtime_contract,
+        },
+        AmbientContractProvider {
             matches: matches_zsh_config_contract,
             build: build_zsh_config_contract,
         },
@@ -77,6 +81,9 @@ fn merge_contract(merged: &mut FileContract, contract: FileContract) {
     merged.externally_consumed_bindings |= contract.externally_consumed_bindings;
     for name in contract.required_reads {
         merged.add_required_read(name);
+    }
+    for name in contract.externally_consumed_binding_names {
+        merged.add_externally_consumed_binding_name(name);
     }
     for binding in contract.provided_bindings {
         merged.add_provided_binding(binding);
@@ -123,6 +130,44 @@ fn build_sourced_runtime_contract(
     contract
 }
 
+fn matches_zsh_ambient_runtime_contract(
+    collector: &AmbientContractCollector<'_>,
+    path: &Path,
+    shell: ShellDialect,
+) -> bool {
+    let lower = lower_path(path);
+    shell_matches_zsh_runtime_context(shell, &lower)
+        && zsh_ambient_runtime_has_signal(collector.source, &lower)
+}
+
+fn build_zsh_ambient_runtime_contract(
+    collector: &AmbientContractCollector<'_>,
+    path: &Path,
+    _shell: ShellDialect,
+) -> FileContract {
+    let lower = lower_path(path);
+    let source = collector.source;
+    let mut contract = FileContract::default();
+
+    for name in zsh_initialized_runtime_names(source, &lower) {
+        contract.add_provided_binding(ProvidedBinding::new_file_entry_initialized(
+            Name::from(name),
+            ProvidedBindingKind::Variable,
+            ContractCertainty::Definite,
+        ));
+    }
+
+    for name in zsh_externally_consumed_names(source, &lower) {
+        contract.add_externally_consumed_binding_name(Name::from(name));
+    }
+
+    for prefix in zsh_test_fixture_consumed_prefixes(source, &lower) {
+        contract.add_externally_consumed_binding_prefix(Name::from(prefix));
+    }
+
+    contract
+}
+
 fn matches_zsh_config_contract(
     collector: &AmbientContractCollector<'_>,
     path: &Path,
@@ -152,18 +197,148 @@ fn zsh_config_consumed_prefixes<'a>(
     source: &'a str,
     lower_path: &'a str,
 ) -> impl Iterator<Item = &'static str> + 'a {
-    ["POWERLEVEL9K_", "ZDOT_"].into_iter().filter(|prefix| {
-        source.contains(prefix) && zsh_config_prefix_path_shape(prefix, lower_path)
-    })
+    [
+        "HISTORY_SUBSTRING_SEARCH_",
+        "ITERM2_",
+        "P9K_",
+        "POWERLEVEL9K_",
+        "ZDOT_",
+        "ZSH_AUTOSUGGEST_",
+        "ZSH_HIGHLIGHT_",
+    ]
+    .into_iter()
+    .filter(|prefix| source.contains(prefix) && zsh_config_prefix_path_shape(prefix, lower_path))
 }
 
 fn zsh_config_prefix_path_shape(prefix: &str, lower_path: &str) -> bool {
     match prefix {
-        "POWERLEVEL9K_" => p10k_config_path_shape(lower_path) || zsh_dotfile_path_shape(lower_path),
+        "HISTORY_SUBSTRING_SEARCH_" => {
+            lower_path.contains("/history-substring-search/")
+                || lower_path.contains("/modules/history-substring-search/")
+        }
+        "ITERM2_" => p10k_config_path_shape(lower_path) || zsh_dotfile_path_shape(lower_path),
+        "P9K_" | "POWERLEVEL9K_" => {
+            p10k_config_path_shape(lower_path) || zsh_dotfile_path_shape(lower_path)
+        }
         "ZDOT_" => zsh_dotfile_path_shape(lower_path),
+        "ZSH_AUTOSUGGEST_" => lower_path.contains("/zsh-autosuggestions/"),
+        "ZSH_HIGHLIGHT_" => lower_path.contains("/zsh-syntax-highlighting/"),
         _ => false,
     }
 }
+
+fn shell_matches_zsh_runtime_context(shell: ShellDialect, lower_path: &str) -> bool {
+    shell == ShellDialect::Zsh
+        || (shell == ShellDialect::Unknown
+            && (zsh_dotfile_path_shape(lower_path) || zsh_project_path_shape(lower_path)))
+}
+
+fn zsh_ambient_runtime_has_signal(source: &str, lower_path: &str) -> bool {
+    source_mentions_any(source, ZSH_INITIALIZED_SPECIAL_PARAMETERS)
+        || zsh_prompt_color_runtime_shape(source, lower_path)
+        || !zsh_externally_consumed_names(source, lower_path).is_empty()
+        || zsh_test_fixture_consumed_prefixes(source, lower_path)
+            .next()
+            .is_some()
+}
+
+fn zsh_initialized_runtime_names<'a>(
+    source: &'a str,
+    lower_path: &'a str,
+) -> impl Iterator<Item = &'static str> + 'a {
+    ZSH_INITIALIZED_SPECIAL_PARAMETERS
+        .iter()
+        .copied()
+        .filter(move |name| {
+            source_mentions_name(source, name)
+                && zsh_special_parameter_available(name, source, lower_path)
+        })
+        .chain(
+            ZSH_PROMPT_COLOR_PARAMETERS
+                .iter()
+                .copied()
+                .filter(move |name| {
+                    source_mentions_name(source, name)
+                        && zsh_prompt_color_runtime_shape(source, lower_path)
+                }),
+        )
+}
+
+fn zsh_special_parameter_available(name: &str, source: &str, lower_path: &str) -> bool {
+    match name {
+        "sysparams" => {
+            zsh_runtime_path_shape(lower_path) || source_loads_zsh_module(source, "zsh/system")
+        }
+        "langinfo" => {
+            zsh_runtime_path_shape(lower_path) || source_loads_zsh_module(source, "zsh/langinfo")
+        }
+        "compstate" | "words" => zsh_runtime_path_shape(lower_path),
+        "galiases" | "history" | "keymaps" | "reswords" | "saliases" => {
+            zsh_runtime_path_shape(lower_path) || source_loads_zsh_module(source, "zsh/parameter")
+        }
+        _ => true,
+    }
+}
+
+fn source_loads_zsh_module(source: &str, module: &str) -> bool {
+    source.lines().any(|line| {
+        line.split('#')
+            .next()
+            .is_some_and(|code| code.contains("zmodload") && code.contains(module))
+    })
+}
+
+fn zsh_externally_consumed_names(source: &str, lower_path: &str) -> Vec<&'static str> {
+    if !zsh_runtime_path_shape(lower_path) && !zsh_test_data_path_shape(lower_path) {
+        return Vec::new();
+    }
+
+    ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS
+        .iter()
+        .copied()
+        .filter(|name| source_assigns_name(source, name))
+        .collect()
+}
+
+fn zsh_test_fixture_consumed_prefixes<'a>(
+    source: &'a str,
+    lower_path: &'a str,
+) -> impl Iterator<Item = &'static str> + 'a {
+    ["expected_"].into_iter().filter(|prefix| {
+        zsh_test_data_path_shape(lower_path)
+            && lower_path.contains("/zsh-syntax-highlighting/")
+            && source.contains(prefix)
+    })
+}
+
+const ZSH_INITIALIZED_SPECIAL_PARAMETERS: &[&str] = &[
+    "compstate",
+    "galiases",
+    "history",
+    "keymaps",
+    "langinfo",
+    "parameters",
+    "reswords",
+    "saliases",
+    "sysparams",
+    "widgets",
+    "words",
+];
+
+const ZSH_PROMPT_COLOR_PARAMETERS: &[&str] = &[
+    "bg",
+    "bg_bold",
+    "bg_no_bold",
+    "color",
+    "colour",
+    "fg",
+    "fg_bold",
+    "fg_no_bold",
+    "reset_color",
+];
+
+const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
+    &["REPLY", "compstate", "comppostfuncs", "reply"];
 
 fn shell_matches_zsh_config_context(shell: ShellDialect, lower_path: &str) -> bool {
     shell == ShellDialect::Zsh
@@ -206,6 +381,52 @@ fn zsh_dotfile_path_shape(lower_path: &str) -> bool {
             "zdot",
         ],
     ) || lower_path.contains("/zsh/config/")
+        || lower_path.contains("/zsh/configs/")
+}
+
+fn zsh_runtime_path_shape(lower_path: &str) -> bool {
+    zsh_dotfile_path_shape(lower_path)
+        || path_matches_any(
+            lower_path,
+            &[
+                "/completion/",
+                "/completions/",
+                "/functions/",
+                "/highlighters/",
+                "/lib/",
+                "/modules/",
+                "/plugins/",
+                "/plugin/",
+                "/themes/",
+                ".plugin.zsh",
+                ".theme.zsh",
+                "/zsh-autosuggestions/",
+                "/zsh-syntax-highlighting/",
+            ],
+        )
+}
+
+fn zsh_project_path_shape(lower_path: &str) -> bool {
+    path_matches_any(
+        lower_path,
+        &[
+            "/ohmyzsh/",
+            "/powerlevel10k/",
+            "/prezto/",
+            "/zinit/",
+            "/zsh-autosuggestions/",
+            "/zsh-syntax-highlighting/",
+        ],
+    )
+}
+
+fn zsh_test_data_path_shape(lower_path: &str) -> bool {
+    path_matches_any(lower_path, &["/test-data/", "/testdata/", "/fixtures/"])
+}
+
+fn zsh_prompt_color_runtime_shape(source: &str, lower_path: &str) -> bool {
+    (zsh_runtime_path_shape(lower_path) || source.contains("autoload -Uz colors"))
+        && source_mentions_any(source, ZSH_PROMPT_COLOR_PARAMETERS)
 }
 
 fn path_has_component(lower_path: &str, names: &[&str]) -> bool {
@@ -461,6 +682,20 @@ fn source_mentions_name(source: &str, name: &str) -> bool {
         || source.contains(&format!("${{{name}:"))
 }
 
+fn source_assigns_name(source: &str, name: &str) -> bool {
+    source.match_indices(name).any(|(offset, _)| {
+        let before = source[..offset].chars().next_back();
+        let after = source[offset + name.len()..].chars().next();
+        let starts_token = before.is_none_or(|ch| !is_shell_name_char(ch));
+        let assignment_like = matches!(after, Some('=') | Some('['));
+        starts_token && assignment_like
+    })
+}
+
+fn is_shell_name_char(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -476,10 +711,18 @@ mod tests {
     }
 
     fn contract_for_shell(path: &Path, source: &str, shell: ShellDialect) -> Option<FileContract> {
+        contract_for_optional_path(Some(path), source, shell)
+    }
+
+    fn contract_for_optional_path(
+        path: Option<&Path>,
+        source: &str,
+        shell: ShellDialect,
+    ) -> Option<FileContract> {
         let output = Parser::new(source).parse().unwrap();
         let indexer = Indexer::new(source, &output);
         let mut observer = NoopTraversalObserver;
-        let mut collector = AmbientContractCollector::new(source, Some(path), shell);
+        let mut collector = AmbientContractCollector::new(source, path, shell);
         let _semantic = build_with_observer_with_options(
             &output.file,
             source,
@@ -514,6 +757,13 @@ mod tests {
             .externally_consumed_binding_prefixes
             .iter()
             .any(|consumed_prefix| consumed_prefix.as_str() == prefix)
+    }
+
+    fn has_consumed_name(contract: &FileContract, name: &str) -> bool {
+        contract
+            .externally_consumed_binding_names
+            .iter()
+            .any(|consumed_name| consumed_name.as_str() == name)
     }
 
     #[test]
@@ -582,6 +832,92 @@ ZDOT_MODULE_NAME=prompt
         assert!(has_consumed_prefix(&contract, "POWERLEVEL9K_"));
         assert!(has_consumed_prefix(&contract, "ZDOT_"));
         assert!(!contract.externally_consumed_bindings);
+    }
+
+    #[test]
+    fn zsh_runtime_contract_initializes_special_parameters_and_prompt_colors() {
+        let path = Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh");
+        let source = "\
+print -r -- \"$sysparams\" \"$history\" \"$words\" \"$compstate\"
+prompt=\"%{$fg_bold[blue]%}%{$reset_color%}\"
+";
+
+        let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+        for name in [
+            "sysparams",
+            "history",
+            "words",
+            "compstate",
+            "fg_bold",
+            "reset_color",
+        ] {
+            assert!(has_initialized_binding(&contract, name), "{contract:?}");
+        }
+    }
+
+    #[test]
+    fn unknown_generic_runtime_paths_do_not_get_zsh_runtime_contracts() {
+        let path = Path::new("/tmp/project/plugins/example");
+        let source = "print -r -- \"$history\" \"$words\"\n";
+
+        assert!(contract_for_shell(path, source, ShellDialect::Unknown).is_none());
+    }
+
+    #[test]
+    fn pathless_zsh_sources_do_not_get_ambient_runtime_contracts() {
+        let source = "print -r -- \"$history\" \"$words\" \"$fg_bold\"\n";
+
+        assert!(contract_for_optional_path(None, source, ShellDialect::Zsh).is_none());
+    }
+
+    #[test]
+    fn zsh_runtime_contract_marks_exact_output_parameters_consumed() {
+        let path = Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh");
+        let source = "\
+reply=(one two)
+REPLY=value
+compstate[insert]=menu
+";
+
+        let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+        for name in ["reply", "REPLY", "compstate"] {
+            assert!(has_consumed_name(&contract, name), "{contract:?}");
+        }
+    }
+
+    #[test]
+    fn zsh_runtime_contract_does_not_consume_read_only_output_parameters() {
+        let path = Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh");
+        let source = "print -r -- \"$reply\" \"$REPLY\" \"$compstate\"\n";
+
+        let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+        for name in ["reply", "REPLY", "compstate"] {
+            assert!(!has_consumed_name(&contract, name), "{contract:?}");
+        }
+    }
+
+    #[test]
+    fn zsh_syntax_highlighting_test_data_expected_values_are_consumed() {
+        let path =
+            Path::new("/tmp/zsh/zsh-syntax-highlighting/highlighters/main/test-data/example.zsh");
+        let source = "expected_region_highlight=('1 4 fg=red')\n";
+
+        let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+        assert!(has_consumed_prefix(&contract, "expected_"));
+    }
+
+    #[test]
+    fn zsh_autosuggestion_config_namespace_is_consumed_on_project_paths() {
+        let path = Path::new("/tmp/zsh/zsh-autosuggestions/src/config.zsh");
+        let source = "ZSH_AUTOSUGGEST_STRATEGY=(history)\n";
+
+        let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+        assert!(has_consumed_prefix(&contract, "ZSH_AUTOSUGGEST_"));
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -92,7 +92,9 @@ pub fn undefined_variable(checker: &mut Checker) {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
+    use std::path::Path;
+
+    use crate::test::{test_snippet, test_snippet_at_path};
     use crate::{LinterSettings, Rule, ShellDialect};
 
     #[test]
@@ -195,6 +197,168 @@ printf '%s\\n' \"$plain_test\" \"$file_test\" \"$still_missing\"
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$plain_test", "$file_test", "$still_missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_runtime_special_parameters_do_not_report_undefined() {
+        let source = "\
+#!/bin/zsh
+print -r -- \"$sysparams\" \"$history\" \"$words\" \"$compstate\"
+print -r -- \"$ordinary_missing\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$ordinary_missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_special_associative_parameter_keys_do_not_report_undefined() {
+        let source = "\
+#!/bin/zsh
+compstate[insert]=menu
+print -r -- \"$sysparams[pid]\" \"$history[1]\"
+print -r -- \"$ordinary_missing\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$ordinary_missing"]
+        );
+    }
+
+    #[test]
+    fn ordinary_zsh_scripts_do_not_get_context_backed_special_parameters() {
+        let source = "\
+#!/bin/zsh
+print -r -- \"$compstate\" \"$sysparams\" \"$history\" \"$words\" \"$ordinary_missing\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/script.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "$compstate",
+                "$sysparams",
+                "$history",
+                "$words",
+                "$ordinary_missing",
+            ]
+        );
+    }
+
+    #[test]
+    fn pathless_zsh_snippets_do_not_get_context_backed_special_parameters() {
+        let source = "\
+#!/bin/zsh
+print -r -- \"$compstate\" \"$sysparams\" \"$history\" \"$words\" \"$ordinary_missing\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "$compstate",
+                "$sysparams",
+                "$history",
+                "$words",
+                "$ordinary_missing",
+            ]
+        );
+    }
+
+    #[test]
+    fn zsh_prompt_color_runtime_bindings_do_not_report_undefined_on_runtime_paths() {
+        let source = "\
+#!/usr/bin/env zsh
+prompt_fragment=\"%{$fg_bold[blue]%}branch%{$reset_color%}\"
+print -r -- \"$ordinary_missing\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$ordinary_missing"]
+        );
+    }
+
+    #[test]
+    fn unknown_generic_runtime_paths_do_not_get_zsh_special_parameters() {
+        let source = "\
+print -r -- \"$history\" \"$words\" \"$ordinary_missing\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/plugins/example"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Unknown),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$history", "$words", "$ordinary_missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_prompt_color_runtime_bindings_do_not_report_undefined_on_config_paths() {
+        let source = "\
+#!/usr/bin/env zsh
+PS1='%{$fg_bold[blue]%}%n%{$reset_color%}'
+print -r -- \"$ordinary_missing\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/thoughtbot-dotfiles/zsh/configs/prompt.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$ordinary_missing"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1246,6 +1246,97 @@ ordinary=1
     }
 
     #[test]
+    fn zsh_plugin_config_namespaces_are_external_consumers() {
+        let source = "\
+#!/usr/bin/env zsh
+typeset -g ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=8'
+ZSH_AUTOSUGGEST_STRATEGY=(history completion)
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/zsh-autosuggestions/src/config.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
+    fn zsh_test_data_expected_outputs_are_external_consumers() {
+        let source = "\
+#!/usr/bin/env zsh
+expected_region_highlight=('1 4 fg=red')
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/zsh-syntax-highlighting/highlighters/main/test-data/example.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
+    fn zsh_ambient_output_parameters_are_external_consumers() {
+        let source = "\
+#!/usr/bin/env zsh
+reply=(one two)
+REPLY=value
+compstate[insert]=menu
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
+    fn pathless_zsh_output_parameters_still_report_unused() {
+        let source = "\
+#!/usr/bin/env zsh
+reply=(one two)
+ordinary=1
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "reply");
+        assert_eq!(diagnostics[1].span.slice(source), "ordinary");
+    }
+
+    #[test]
+    fn zsh_ambient_output_parameters_do_not_consume_function_locals() {
+        let source = "\
+#!/usr/bin/env zsh
+helper() {
+  local reply=(one two)
+  local REPLY=value
+}
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics[0].span.slice(source), "reply");
+        assert_eq!(diagnostics[1].span.slice(source), "REPLY");
+    }
+
+    #[test]
     fn zsh_config_namespace_names_still_report_on_ordinary_paths() {
         let source = "\
 #!/usr/bin/env zsh

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -6828,6 +6828,7 @@ printf '%s\\n' $pkgname
                     )],
                     provided_functions: Vec::new(),
                     externally_consumed_bindings: false,
+                    externally_consumed_binding_names: Vec::new(),
                     externally_consumed_binding_prefixes: Vec::new(),
                 }),
                 ..SemanticBuildOptions::default()

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -199,6 +199,8 @@ pub struct FileContract {
     pub provided_functions: Vec<FunctionContract>,
     /// Whether the file may consume bindings through external runtime behavior.
     pub externally_consumed_bindings: bool,
+    /// Exact binding names consumed through external runtime behavior.
+    pub externally_consumed_binding_names: Vec<Name>,
     /// Binding name prefixes consumed through external runtime behavior.
     pub externally_consumed_binding_prefixes: Vec<Name>,
 }
@@ -240,6 +242,17 @@ impl FileContract {
 
         if !merged {
             self.provided_bindings.push(binding);
+        }
+    }
+
+    /// Marks an exact binding name as externally consumed by this file.
+    pub fn add_externally_consumed_binding_name(&mut self, name: Name) {
+        if !self
+            .externally_consumed_binding_names
+            .iter()
+            .any(|existing| existing == &name)
+        {
+            self.externally_consumed_binding_names.push(name);
         }
     }
 
@@ -290,6 +303,9 @@ impl FileContract {
 
         for contract in contracts {
             merged.externally_consumed_bindings |= contract.externally_consumed_bindings;
+            for name in &contract.externally_consumed_binding_names {
+                merged.add_externally_consumed_binding_name(name.clone());
+            }
             for prefix in &contract.externally_consumed_binding_prefixes {
                 merged.add_externally_consumed_binding_prefix(prefix.clone());
             }

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -1952,6 +1952,7 @@ impl SemanticModel {
             && contract.provided_bindings.is_empty()
             && contract.provided_functions.is_empty()
             && !contract.externally_consumed_bindings
+            && contract.externally_consumed_binding_names.is_empty()
             && contract.externally_consumed_binding_prefixes.is_empty()
         {
             return;
@@ -1959,6 +1960,11 @@ impl SemanticModel {
 
         if contract.externally_consumed_bindings {
             self.mark_file_entry_consumed_bindings();
+        }
+        if !contract.externally_consumed_binding_names.is_empty() {
+            self.mark_file_entry_consumed_binding_names(
+                &contract.externally_consumed_binding_names,
+            );
         }
         if !contract.externally_consumed_binding_prefixes.is_empty() {
             self.mark_file_entry_consumed_binding_prefixes(
@@ -2020,6 +2026,19 @@ impl SemanticModel {
     fn mark_file_entry_consumed_bindings(&mut self) {
         for binding in &mut self.bindings {
             if file_entry_contract_can_consume_binding(binding) {
+                binding.attributes |= BindingAttributes::EXTERNALLY_CONSUMED;
+            }
+        }
+        self.heuristic_unused_assignments.retain(|binding_id| {
+            !self.bindings[binding_id.index()]
+                .attributes
+                .contains(BindingAttributes::EXTERNALLY_CONSUMED)
+        });
+    }
+
+    fn mark_file_entry_consumed_binding_names(&mut self, names: &[Name]) {
+        for binding in &mut self.bindings {
+            if file_entry_contract_can_consume_binding(binding) && names.contains(&binding.name) {
                 binding.attributes |= BindingAttributes::EXTERNALLY_CONSUMED;
             }
         }
@@ -2591,6 +2610,10 @@ fn file_entry_contract_can_consume_binding(binding: &Binding) -> bool {
         return false;
     }
 
+    file_entry_contract_can_consume_exact_binding(binding)
+}
+
+fn file_entry_contract_can_consume_exact_binding(binding: &Binding) -> bool {
     matches!(
         binding.kind,
         BindingKind::Assignment

--- a/crates/shuck-semantic/src/runtime.rs
+++ b/crates/shuck-semantic/src/runtime.rs
@@ -222,6 +222,7 @@ const ZSH_PREINITIALIZED_ARRAYS: &[&str] = &[
 
 const ZSH_PREINITIALIZED_ASSOCIATIVE_ARRAYS: &[&str] = &[
     "aliases",
+    "compstate",
     "commands",
     "functions",
     "jobdirs",

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -895,6 +895,7 @@ printf '%s\\n' \"$pkgname\"
                 )],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_names: Vec::new(),
                 externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
@@ -3718,6 +3719,7 @@ echo $value
                 )],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_names: Vec::new(),
                 externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
@@ -9465,6 +9467,7 @@ fn file_entry_contracts_seed_multiple_first_command_reads_as_imported_bindings()
                 ],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_names: Vec::new(),
                 externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
@@ -9531,6 +9534,7 @@ build() {
                 ],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_names: Vec::new(),
                 externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
@@ -9608,6 +9612,7 @@ hook() {
                 ],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_names: Vec::new(),
                 externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
@@ -9665,6 +9670,7 @@ fn initialized_file_entry_bindings_suppress_uninitialized_reads() {
                 )],
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: false,
+                externally_consumed_binding_names: Vec::new(),
                 externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
@@ -9700,6 +9706,7 @@ fn file_entry_contracts_can_mark_assignments_as_caller_consumed() {
                 provided_bindings: Vec::new(),
                 provided_functions: Vec::new(),
                 externally_consumed_bindings: true,
+                externally_consumed_binding_names: Vec::new(),
                 externally_consumed_binding_prefixes: Vec::new(),
             }),
             ..SemanticBuildOptions::default()
@@ -9713,6 +9720,63 @@ fn file_entry_contracts_can_mark_assignments_as_caller_consumed() {
             .contains(BindingAttributes::EXTERNALLY_CONSUMED)
     );
     assert!(model.analysis().unused_assignments().is_empty());
+}
+
+#[test]
+fn file_entry_contracts_can_mark_exact_nonlocal_assignments_as_caller_consumed() {
+    let source = "\
+published=1
+unpublished=1
+helper() {
+  local published=2
+}
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let model = SemanticModel::build_with_options(
+        &output.file,
+        source,
+        &indexer,
+        SemanticBuildOptions {
+            file_entry_contract: Some(FileContract {
+                required_reads: Vec::new(),
+                provided_bindings: Vec::new(),
+                provided_functions: Vec::new(),
+                externally_consumed_bindings: false,
+                externally_consumed_binding_names: vec![Name::from("published")],
+                externally_consumed_binding_prefixes: Vec::new(),
+            }),
+            ..SemanticBuildOptions::default()
+        },
+    );
+
+    let published_bindings = model
+        .bindings()
+        .iter()
+        .filter(|binding| binding.name == "published")
+        .collect::<Vec<_>>();
+    assert_eq!(published_bindings.len(), 2);
+    assert!(
+        published_bindings[0]
+            .attributes
+            .contains(BindingAttributes::EXTERNALLY_CONSUMED),
+        "{published_bindings:?}"
+    );
+    assert!(
+        !published_bindings[1]
+            .attributes
+            .contains(BindingAttributes::EXTERNALLY_CONSUMED),
+        "{published_bindings:?}"
+    );
+    assert!(
+        !binding_for_name(&model, "unpublished")
+            .attributes
+            .contains(BindingAttributes::EXTERNALLY_CONSUMED)
+    );
+    assert_eq!(
+        binding_names(&model, model.analysis().unused_assignments()),
+        vec!["unpublished", "published"]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- model zsh runtime special parameters and associative parameter maps so C006 does not flag ambient names like `sysparams`, `history`, `words`, and `compstate`
- add exact external-consumer file contracts for zsh output parameters such as `REPLY`, `reply`, `compstate`, and `comppostfuncs`
- expand zsh ambient contracts for plugin config namespaces, syntax-highlighting expected fixtures, and prompt color globals

## Tests
- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-ambient-context-vars/shuck/Cargo.toml -p shuck-linter ambient_contracts::tests -- --nocapture`
- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-ambient-context-vars/shuck/Cargo.toml -p shuck-semantic file_entry_contracts_can_mark_exact_assignments_as_caller_consumed -- --nocapture`
- focused C001/C006 zsh regression tests in `shuck-linter` and `shuck-semantic`
- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-ambient-context-vars/shuck/Cargo.toml -p shuck-semantic`
- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-ambient-context-vars/shuck/Cargo.toml -p shuck-linter rules::correctness::tests::rules -- --nocapture`
- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-ambient-context-vars/shuck/Cargo.toml -p shuck-linter`
- `cargo clippy --manifest-path /Users/ewhauser/.codex/worktrees/zsh-ambient-context-vars/shuck/Cargo.toml --workspace --all-targets --all-features -- -D warnings`
- `cargo test --manifest-path /Users/ewhauser/.codex/worktrees/zsh-ambient-context-vars/shuck/Cargo.toml --workspace --all-targets --all-features`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001,C006`

## Residuals
Some C001/C006 findings in the sampled zsh corpus still look like separate local-flow or parser/string-expansion issues, not ambient context: for example `suggestion` in zsh-autosuggestions completion strategy and a few non-ambient buffer/highlight locals in syntax-highlighting fixtures. This PR keeps the policy scoped to proven zsh ambient runtime/config/test-fixture mechanisms.