### PR TITLE
Narrow zsh pattern diagnostics for static literals

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -2334,6 +2334,99 @@ pub fn word_is_standalone_variable_like(word: &Word) -> bool {
     }
 }
 
+/// Returns whether `span` identifies a plain scalar parameter reference in `word`.
+pub fn word_span_is_plain_parameter_reference(word: &Word, span: Span) -> bool {
+    word_parts_contain_plain_parameter_reference_span(&word.parts, span)
+}
+
+fn word_parts_contain_plain_parameter_reference_span(parts: &[WordPartNode], span: Span) -> bool {
+    parts
+        .iter()
+        .any(|part| word_part_is_plain_parameter_reference_span(part, span))
+}
+
+fn word_part_is_plain_parameter_reference_span(part: &WordPartNode, span: Span) -> bool {
+    if part.span == span {
+        return word_part_is_plain_parameter_reference(&part.kind);
+    }
+
+    match &part.kind {
+        WordPart::DoubleQuoted { parts, .. } => {
+            word_parts_contain_plain_parameter_reference_span(parts, span)
+        }
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::Parameter(_)
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn word_part_is_plain_parameter_reference(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(_) => true,
+        WordPart::Parameter(parameter) => {
+            parameter_expansion_is_plain_parameter_reference(parameter)
+        }
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::DoubleQuoted { .. }
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn parameter_expansion_is_plain_parameter_reference(parameter: &ParameterExpansion) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
+            reference.subscript.is_none()
+        }
+        ParameterExpansionSyntax::Zsh(syntax) => {
+            syntax.length_prefix.is_none()
+                && syntax.modifiers.is_empty()
+                && syntax.operation.is_none()
+                && matches!(
+                    &syntax.target,
+                    ZshExpansionTarget::Reference(reference) if reference.subscript.is_none()
+                )
+        }
+        ParameterExpansionSyntax::Bourne(
+            BourneParameterExpansion::Length { .. }
+            | BourneParameterExpansion::Indices { .. }
+            | BourneParameterExpansion::Indirect { .. }
+            | BourneParameterExpansion::PrefixMatch { .. }
+            | BourneParameterExpansion::Slice { .. }
+            | BourneParameterExpansion::Operation { .. }
+            | BourneParameterExpansion::Transformation { .. },
+        ) => false,
+    }
+}
+
 /// Returns whether a zsh parameter expansion explicitly enables pattern expansion.
 pub fn parameter_expansion_forces_zsh_globbing(parameter: &ParameterExpansion) -> bool {
     matches!(

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -380,6 +380,10 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         shuck_ast::word_span_is_zsh_force_glob_parameter(self.word(), span)
     }
 
+    pub fn expansion_span_is_plain_parameter_reference(self, span: Span) -> bool {
+        shuck_ast::word_span_is_plain_parameter_reference(self.word(), span)
+    }
+
     pub fn scalar_expansion_spans(self) -> &'facts [Span] {
         self.facts.fact_store.word_spans(self.derived().scalar_expansion_spans)
     }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
@@ -1,5 +1,6 @@
 use shuck_ast::{word_is_standalone_variable_like, word_is_standalone_zsh_force_glob_parameter};
 
+use super::pattern_policy;
 use crate::{
     Checker, ConditionalNodeFact, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation,
     WordQuote, conditional_binary_op_is_string_match,
@@ -50,6 +51,9 @@ pub fn glob_in_string_comparison(checker: &mut Checker) {
 
             let word = right.word()?;
             if word_is_standalone_zsh_force_glob_parameter(word) {
+                return None;
+            }
+            if pattern_policy::word_expands_only_static_pattern_safe_literals(checker, word) {
                 return None;
             }
 
@@ -126,6 +130,53 @@ if [[ foo == ${~~literal} ]]; then :; fi
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${~~literal}"]
+        );
+    }
+
+    #[test]
+    fn ignores_rhs_variables_with_static_pattern_safe_values() {
+        let source = "\
+#!/usr/bin/env zsh
+expected=ready
+pattern='r*'
+if [[ $actual == $expected ]]; then :; fi
+if [[ $actual == $pattern ]]; then :; fi
+if [[ $actual == $unknown ]]; then :; fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInStringComparison)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$pattern", "$unknown"]
+        );
+    }
+
+    #[test]
+    fn reports_rhs_parameter_operations_even_when_target_bindings_are_static_safe() {
+        let source = "\
+#!/usr/bin/env zsh
+expected=ready
+if [[ $actual == ${expected//ready/*} ]]; then :; fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInStringComparison)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${expected//ready/*}"]
         );
     }
 

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -83,6 +83,7 @@ pub mod non_absolute_shebang;
 pub mod non_shell_syntax_in_script;
 pub mod open_double_quote;
 pub mod overwritten_function;
+mod pattern_policy;
 pub mod pattern_with_variable;
 pub mod pipe_to_kill;
 pub mod plus_prefix_in_assignment;

--- a/crates/shuck-linter/src/rules/correctness/pattern_policy.rs
+++ b/crates/shuck-linter/src/rules/correctness/pattern_policy.rs
@@ -1,0 +1,87 @@
+use shuck_ast::{Span, Word, static_word_text, word_span_is_plain_parameter_reference};
+use shuck_semantic::{BindingId, Reference, ReferenceKind};
+
+use crate::{Checker, ShellDialect};
+
+pub(crate) fn word_expands_only_static_pattern_safe_literals(
+    checker: &Checker<'_>,
+    word: &Word,
+) -> bool {
+    span_expands_only_static_pattern_safe_literals(
+        checker,
+        word.span,
+        word_span_is_plain_parameter_reference(word, word.span),
+    )
+}
+
+pub(crate) fn span_expands_only_static_pattern_safe_literals(
+    checker: &Checker<'_>,
+    span: Span,
+    is_plain_parameter_reference: bool,
+) -> bool {
+    if checker.shell() != ShellDialect::Zsh {
+        return false;
+    }
+    if !is_plain_parameter_reference {
+        return false;
+    }
+
+    let mut references = checker
+        .semantic()
+        .references_in_span(span)
+        .filter(|reference| reference_kind_can_name_pattern_operand_value(reference.kind));
+    let Some(reference) = references.next() else {
+        return false;
+    };
+    if references.next().is_some() {
+        return false;
+    }
+
+    reference_expands_only_static_pattern_safe_literals(checker, reference)
+}
+
+fn reference_kind_can_name_pattern_operand_value(kind: ReferenceKind) -> bool {
+    matches!(
+        kind,
+        ReferenceKind::Expansion
+            | ReferenceKind::ParameterExpansion
+            | ReferenceKind::ArrayAccess
+            | ReferenceKind::ParameterPattern
+            | ReferenceKind::ConditionalOperand
+    )
+}
+
+fn reference_expands_only_static_pattern_safe_literals(
+    checker: &Checker<'_>,
+    reference: &Reference,
+) -> bool {
+    let bindings = checker
+        .semantic_analysis()
+        .reaching_bindings_for_name(&reference.name, reference.span);
+    !bindings.is_empty()
+        && bindings
+            .iter()
+            .all(|binding_id| binding_expands_to_static_pattern_safe_literal(checker, *binding_id))
+}
+
+fn binding_expands_to_static_pattern_safe_literal(
+    checker: &Checker<'_>,
+    binding_id: BindingId,
+) -> bool {
+    checker
+        .facts()
+        .binding_value(binding_id)
+        .and_then(|value| value.scalar_word())
+        .and_then(|word| static_word_text(word, checker.source()))
+        .is_some_and(|text| static_literal_is_pattern_safe(&text))
+}
+
+fn static_literal_is_pattern_safe(text: &str) -> bool {
+    text.bytes().all(|byte| {
+        byte.is_ascii_alphanumeric()
+            || matches!(
+                byte,
+                b' ' | b'_' | b'-' | b'.' | b'/' | b':' | b',' | b'=' | b'@'
+            )
+    })
+}

--- a/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
@@ -1,5 +1,6 @@
 use shuck_ast::Span;
 
+use super::pattern_policy;
 use crate::{Checker, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation};
 
 pub struct PatternWithVariable;
@@ -51,6 +52,13 @@ pub fn pattern_with_variable(checker: &mut Checker) {
                 .copied()
                 .filter(|span| !span_is_within_any(*span, quoted_expansion_spans))
                 .filter(|span| !fact.expansion_span_is_zsh_force_glob_parameter(*span))
+                .filter(|span| {
+                    !pattern_policy::span_expands_only_static_pattern_safe_literals(
+                        checker,
+                        *span,
+                        fact.expansion_span_is_plain_parameter_reference(*span),
+                    )
+                })
                 .map(|span| {
                     crate::Diagnostic::new(PatternWithVariable, span).with_fix(Fix::unsafe_edit(
                         Edit::replacement(format!("\"{}\"", span.slice(source)), span),
@@ -162,6 +170,75 @@ literal_trimmed=${value#${~~literal}}
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["${~~literal}"]
+        );
+    }
+
+    #[test]
+    fn ignores_pattern_variables_with_static_pattern_safe_values() {
+        let source = "\
+#!/usr/bin/env zsh
+prefix='src/lib/'
+pattern='src/*'
+trimmed=${path#$prefix}
+pattern_trimmed=${path#$pattern}
+unknown_trimmed=${path#$unknown}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PatternWithVariable)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$pattern", "$unknown"]
+        );
+    }
+
+    #[test]
+    fn reports_command_substitutions_even_when_nested_references_are_static_safe() {
+        let source = "\
+#!/usr/bin/env zsh
+prefix='src/lib/'
+trimmed=${path#$(printf '%s' \"$prefix\")}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PatternWithVariable)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$(printf '%s' \"$prefix\")"]
+        );
+    }
+
+    #[test]
+    fn reports_parameter_operations_even_when_target_bindings_are_static_safe() {
+        let source = "\
+#!/usr/bin/env zsh
+prefix='src'
+trimmed=${path#${prefix:-*}}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PatternWithVariable)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${prefix:-*}"]
         );
     }
 


### PR DESCRIPTION
## Summary
- add a shared C055/C081 zsh pattern-policy helper that consults semantic references and reaching binding values
- suppress pattern-expression diagnostics only when the operand expands from a known static scalar literal with conservative pattern-safe characters
- keep unknown, dynamic, and glob-bearing values reportable, including the cited `/tmp/zsh` examples

## Notes
- The cited examples in `dotfiler/setup.zsh`, `zinit/zi-browse-symbol`, and `zsh-autosuggestions/src/widgets.zsh` remain diagnostics because their pattern operands are dynamic runtime values. Quoting those operands would make the intended prefix removal/string comparison literal instead of pattern-sensitive.

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter glob_in_string_comparison -- --nocapture`
- `cargo test -p shuck-linter pattern_with_variable -- --nocapture`
- `cargo test -p shuck-linter`
- `cargo clippy --workspace --all-targets --all-features --offline -- -D warnings`
- `/Users/ewhauser/.codex/worktrees/zsh-pattern-policy/shuck/target/debug/shuck check --isolated --select C081,C055 --per-file-shell '**/*.zsh:zsh' --output-format concise -e dotfiler/setup.zsh`
- `/Users/ewhauser/.codex/worktrees/zsh-pattern-policy/shuck/target/debug/shuck check --isolated --select C081,C055 --per-file-shell '**/*:zsh' --output-format concise -e zinit/zi-browse-symbol`
- `/Users/ewhauser/.codex/worktrees/zsh-pattern-policy/shuck/target/debug/shuck check --isolated --select C081,C055 --per-file-shell '**/*.zsh:zsh' --output-format concise -e zsh-autosuggestions/src/widgets.zsh`
- `/Users/ewhauser/.codex/worktrees/zsh-pattern-policy/shuck/target/debug/shuck check --isolated --select C081,C055 --per-file-shell '**/*.zsh:zsh' --per-file-shell 'zinit/zi-browse-symbol:zsh' --output-format json-lines .`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C081,C055`