### PR TITLE
[codex] Narrow zsh pattern policy for presence tests

### DIFF
--- a/crates/shuck-ast/src/ast.rs
+++ b/crates/shuck-ast/src/ast.rs
@@ -2464,6 +2464,48 @@ fn word_parts_contain_zsh_force_glob_span(parts: &[WordPartNode], span: Span) ->
     })
 }
 
+/// Returns whether `span` points at a zsh `${+name}` presence-test expansion.
+pub fn word_span_is_zsh_presence_test(word: &Word, span: Span) -> bool {
+    word_parts_contain_zsh_presence_test_span(&word.parts, span)
+}
+
+fn word_parts_contain_zsh_presence_test_span(parts: &[WordPartNode], span: Span) -> bool {
+    parts.iter().any(|part| match &part.kind {
+        WordPart::Parameter(parameter) => {
+            part.span == span && parameter_expansion_is_zsh_presence_test(parameter)
+        }
+        WordPart::DoubleQuoted { parts, .. } => {
+            word_parts_contain_zsh_presence_test_span(parts, span)
+        }
+        _ => false,
+    })
+}
+
+fn parameter_expansion_is_zsh_presence_test(parameter: &ParameterExpansion) -> bool {
+    matches!(
+        &parameter.syntax,
+        ParameterExpansionSyntax::Zsh(syntax)
+            if syntax.length_prefix.is_none()
+                && syntax.modifiers.is_empty()
+                && syntax.operation.is_none()
+                && matches!(
+                    &syntax.target,
+                    ZshExpansionTarget::Reference(reference)
+                        if reference
+                            .name
+                            .as_str()
+                            .strip_prefix('+')
+                            .is_some_and(is_zsh_presence_target_name)
+                )
+    )
+}
+
+fn is_zsh_presence_target_name(name: &str) -> bool {
+    is_shell_variable_name(name)
+        || name.bytes().all(|byte| byte.is_ascii_digit())
+        || matches!(name, "#" | "$" | "!" | "*" | "@" | "?" | "-")
+}
+
 /// Returns whether the word captures only the previous command status.
 pub fn word_is_standalone_status_capture(word: &Word) -> bool {
     matches!(word.parts.as_slice(), [part] if is_standalone_status_capture_part(&part.kind))

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -380,6 +380,10 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         shuck_ast::word_span_is_zsh_force_glob_parameter(self.word(), span)
     }
 
+    pub fn expansion_span_is_zsh_presence_test(self, span: Span) -> bool {
+        shuck_ast::word_span_is_zsh_presence_test(self.word(), span)
+    }
+
     pub fn expansion_span_is_plain_parameter_reference(self, span: Span) -> bool {
         shuck_ast::word_span_is_plain_parameter_reference(self.word(), span)
     }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_string_comparison.rs
@@ -159,6 +159,31 @@ if [[ $actual == $unknown ]]; then :; fi
     }
 
     #[test]
+    fn ignores_zsh_presence_test_rhs() {
+        let source = "\
+#!/usr/bin/env zsh
+if [[ 0 = ${+ICE[nocompletions]} ]]; then :; fi
+if [[ ${+left} == ${+right} ]]; then :; fi
+if [[ 1 = ${+1} ]]; then :; fi
+if [[ 1 = ${+?} ]]; then :; fi
+if [[ $actual == $unknown ]]; then :; fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInStringComparison)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$unknown"]
+        );
+    }
+
+    #[test]
     fn reports_rhs_parameter_operations_even_when_target_bindings_are_static_safe() {
         let source = "\
 #!/usr/bin/env zsh

--- a/crates/shuck-linter/src/rules/correctness/pattern_policy.rs
+++ b/crates/shuck-linter/src/rules/correctness/pattern_policy.rs
@@ -1,4 +1,7 @@
-use shuck_ast::{Span, Word, static_word_text, word_span_is_plain_parameter_reference};
+use shuck_ast::{
+    Span, Word, static_word_text, word_span_is_plain_parameter_reference,
+    word_span_is_zsh_presence_test,
+};
 use shuck_semantic::{BindingId, Reference, ReferenceKind};
 
 use crate::{Checker, ShellDialect};
@@ -11,6 +14,7 @@ pub(crate) fn word_expands_only_static_pattern_safe_literals(
         checker,
         word.span,
         word_span_is_plain_parameter_reference(word, word.span),
+        word_span_is_zsh_presence_test(word, word.span),
     )
 }
 
@@ -18,9 +22,13 @@ pub(crate) fn span_expands_only_static_pattern_safe_literals(
     checker: &Checker<'_>,
     span: Span,
     is_plain_parameter_reference: bool,
+    is_zsh_presence_test: bool,
 ) -> bool {
     if checker.shell() != ShellDialect::Zsh {
         return false;
+    }
+    if is_zsh_presence_test {
+        return true;
     }
     if !is_plain_parameter_reference {
         return false;

--- a/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/pattern_with_variable.rs
@@ -57,6 +57,7 @@ pub fn pattern_with_variable(checker: &mut Checker) {
                         checker,
                         *span,
                         fact.expansion_span_is_plain_parameter_reference(*span),
+                        fact.expansion_span_is_zsh_presence_test(*span),
                     )
                 })
                 .map(|span| {
@@ -195,6 +196,31 @@ unknown_trimmed=${path#$unknown}
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
             vec!["$pattern", "$unknown"]
+        );
+    }
+
+    #[test]
+    fn ignores_zsh_presence_tests_in_pattern_operands() {
+        let source = "\
+#!/usr/bin/env zsh
+trimmed=${value#${+ICE[nocompletions]}}
+also_trimmed=${value#${+enabled}}
+positional_trimmed=${value#${+1}}
+status_trimmed=${value#${+?}}
+unknown_trimmed=${value#$unknown}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::PatternWithVariable)
+                .with_shell(crate::ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$unknown"]
         );
     }
 

--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -4991,6 +4991,12 @@ impl<'a> Parser<'a> {
         matches!(name, "#" | "$" | "!" | "*" | "@" | "?" | "-") || name == "0"
     }
 
+    fn is_plain_parameter_access_name(name: &str) -> bool {
+        Self::is_valid_identifier(name)
+            || name.bytes().all(|byte| byte.is_ascii_digit())
+            || Self::is_plain_special_parameter_name(name)
+    }
+
     fn looks_like_plain_parameter_access(text: &str) -> bool {
         let trimmed = text.trim();
         if trimmed.is_empty() {
@@ -5006,12 +5012,10 @@ impl<'a> Parser<'a> {
             trimmed
         };
 
-        Self::is_valid_identifier(name)
+        Self::is_plain_parameter_access_name(name)
             || name
                 .strip_prefix('+')
-                .is_some_and(Self::is_valid_identifier)
-            || name.bytes().all(|byte| byte.is_ascii_digit())
-            || Self::is_plain_special_parameter_name(name)
+                .is_some_and(Self::is_plain_parameter_access_name)
     }
 
     fn parse_nested_parameter_target(&mut self, text: &str, base: Position) -> ZshExpansionTarget {

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -4926,6 +4926,25 @@ impl<'a> Parser<'a> {
                     var_name.push(Self::next_word_char_unwrap(&mut chars, &mut cursor));
                 }
 
+                if var_name.is_empty()
+                    && self.dialect.features().zsh_parameter_modifiers
+                    && chars.peek() == Some(&'+')
+                {
+                    let mut lookahead = chars.clone();
+                    lookahead.next();
+                    if lookahead
+                        .peek()
+                        .is_some_and(|next| Self::zsh_bare_parameter_target_start(*next))
+                    {
+                        let raw_body =
+                            self.read_brace_operand(&mut chars, &mut cursor, source_backed);
+                        let parameter = self.zsh_parameter_word_part(raw_body, part_start, cursor);
+                        Self::push_word_part(parts, parameter, part_start, cursor);
+                        current_start = cursor;
+                        continue;
+                    }
+                }
+
                 if Self::consume_word_char_if(&mut chars, &mut cursor, '[') {
                     let (index, raw_index) =
                         self.read_array_index(&mut chars, &mut cursor, source_backed);


### PR DESCRIPTION
## Summary

- Treat zsh `${+param}` and `${+array[key]}` presence tests as pattern-safe for C081/C055 policy checks.
- Add focused regressions for C081 string-comparison RHS operands and C055 parameter-pattern operands.

## Root Cause

C081/C055 shared a helper that already suppresses zsh pattern operands known to expand only to static pattern-safe literals, but `${+...}` was not modeled. In zsh this presence-test form expands only to `0` or `1`, so it cannot inject glob metacharacters into a pattern expression.

## Validation

- First ran `cargo test -p shuck-linter ignores_zsh_presence -- --nocapture` before the fix and confirmed both new tests failed.
- `cargo fmt --check`
- `cargo test -p shuck-linter ignores_zsh_presence -- --nocapture`
- `cargo test -p shuck-linter glob_in_string_comparison -- --nocapture`
- `cargo test -p shuck-linter pattern_with_variable -- --nocapture`
- `cargo test -p shuck-linter`
- `target/debug/shuck --isolated check --select C081,C055 --output-format json-lines -e` over the cited evidence files plus `zinit-install.zsh`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C081,C055` with `implementation_diffs=0`, `mapping_issues=0`, `reviewed_divergences=0`

## Notes

The cited prefix/suffix-removal and ordinary dynamic comparison examples still report. I treated those as valid diagnostics because zsh uses pattern semantics for those operands unless the dynamic text is quoted or otherwise escaped.