### PR TITLE
[codex] Ignore zsh subscript flags for subshell side effects

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1120,6 +1120,11 @@ fn build_nonpersistent_assignment_spans(
         {
             continue;
         }
+        if suppress_zsh_nested_subshell_noise
+            && zsh_later_use_is_parameter_subscript_flag(source, effect.later_use_span)
+        {
+            continue;
+        }
         if let Some(extra_reset_sites) = &extra_reset_sites
             && extra_reset_sites.iter().any(|reset| {
                 reset.name == effect.name
@@ -1180,6 +1185,37 @@ fn nonpersistent_assignment_reaches_later_use(
         {
             return false;
         }
+    }
+
+    true
+}
+
+fn zsh_later_use_is_parameter_subscript_flag(source: &str, span: Span) -> bool {
+    if span.start.offset + 1 != span.end.offset {
+        return false;
+    }
+
+    let bytes = source.as_bytes();
+    let start = span.start.offset;
+    let end = span.end.offset;
+    if start == 0
+        || end >= bytes.len()
+        || bytes[start - 1] != b'('
+        || bytes[end] != b')'
+        || !bytes[start].is_ascii_alphabetic()
+    {
+        return false;
+    }
+
+    let Some(open_subscript_offset) = source[..start - 1].rfind('[') else {
+        return false;
+    };
+    if open_subscript_offset > 0 && bytes[open_subscript_offset - 1] == b'$' {
+        return false;
+    }
+    let subscript_prefix = &source[open_subscript_offset + 1..start - 1];
+    if !subscript_prefix.is_empty() || subscript_prefix.contains(']') {
+        return false;
     }
 
     true

--- a/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_local_assignment.rs
@@ -238,6 +238,103 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn ignores_zsh_parameter_index_flags_after_subshell_loop_variables() {
+        let source = "\
+#!/bin/zsh
+forget() {
+  local -a opts zsh_loaded_plugins
+  local user plugin
+  (
+    for i in \"${opts[@]}\"; do
+      print -r -- \"$i\"
+    done
+  )
+  zsh_loaded_plugins[${zsh_loaded_plugins[(i)$user${${user:#(%|/)*}:+/}$plugin]}]=()
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_parenthesized_zsh_arithmetic_reads_after_unmatched_brackets() {
+        let source = "\
+#!/bin/zsh
+i=0
+(
+  i=1
+)
+print -r -- \"[\"
+: $((i))
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["i"]
+        );
+    }
+
+    #[test]
+    fn reports_legacy_zsh_arithmetic_reads_after_subshell_assignments() {
+        let source = "\
+#!/bin/zsh
+i=0
+(
+  i=1
+)
+: $[ (i) ]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["i"]
+        );
+    }
+
+    #[test]
+    fn reports_spaced_zsh_subscript_reads_after_subshell_assignments() {
+        let source = "\
+#!/bin/zsh
+i=0
+typeset -a values
+(
+  i=1
+)
+print -r -- ${values[ (i) ]}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellLocalAssignment),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["i"]
+        );
+    }
+
+    #[test]
     fn reports_zsh_always_body_sh_emulation_final_pipeline_component_assignments() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subshell_side_effect.rs
@@ -211,6 +211,91 @@ print -r -- \"$header\"
     }
 
     #[test]
+    fn ignores_zsh_parameter_index_flags_after_subshell_loop_variables() {
+        let source = "\
+#!/bin/zsh
+forget() {
+  local -a opts zsh_loaded_plugins
+  local user plugin
+  (
+    for i in \"${opts[@]}\"; do
+      print -r -- \"$i\"
+    done
+  )
+  zsh_loaded_plugins[${zsh_loaded_plugins[(i)$user${${user:#(%|/)*}:+/}$plugin]}]=()
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn reports_parenthesized_zsh_arithmetic_reads_after_unmatched_brackets() {
+        let source = "\
+#!/bin/zsh
+i=0
+(
+  i=1
+)
+print -r -- \"[\"
+: $((i))
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["i"]
+        );
+    }
+
+    #[test]
+    fn reports_legacy_zsh_arithmetic_reads_after_subshell_assignments() {
+        let source = "\
+#!/bin/zsh
+i=0
+(
+  i=1
+)
+: $[ (i) ]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["i"]
+        );
+    }
+
+    #[test]
+    fn reports_spaced_zsh_subscript_reads_after_subshell_assignments() {
+        let source = "\
+#!/bin/zsh
+i=0
+typeset -a values
+(
+  i=1
+)
+print -r -- ${values[ (i) ]}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SubshellSideEffect));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["i"]
+        );
+    }
+
+    #[test]
     fn reports_zsh_always_body_sh_emulation_final_pipeline_component_assignments() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
## Summary

- Ignore zsh parenthesized parameter subscript flags like `[(i)...]` as later reads in C150/C155 nonpersistent assignment modeling.
- Add focused C150 and C155 regressions for a subshell loop variable named `i` followed by zinit-style `[(i)...]` indexing.

## Root Cause

The semantic reference stream can surface the `i` in zsh's `[(i)...]` parameter subscript flag as a normal variable reference. When a prior subshell loop also used `i`, C150/C155 connected that loop binding to the flag character and reported a false subshell side-effect pair.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p shuck-linter ignores_zsh_parameter_index_flags_after_subshell_loop_variables -- --nocapture`
- `cargo test -p shuck-linter subshell -- --nocapture`
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C150,C155`
- Direct zinit evidence check: `zinit-autoload.zsh:2437/2914` no longer reports; `zinit-install.zsh` `retval` pairs remain because they are genuine writes inside an outer subshell read later outside it.