### PR TITLE
fix: narrow zsh array scalar diagnostics

### DIFF
--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -150,7 +150,13 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
 
         self.facts.word_facts().any(|word| {
             self.facts.is_compound_assignment_value_word(word)
-                && span_is_within(word.span(), reference.span)
+                && self
+                    .semantic
+                    .references_in_command_span(
+                        self.facts.command(word.command_id()).span(),
+                        word.span(),
+                    )
+                    .any(|direct_reference| direct_reference.id == reference.id)
         })
     }
 

--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -114,6 +114,10 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
             ));
         }
 
+        if self.reference_is_zsh_array_assignment_list_value(reference) {
+            return None;
+        }
+
         Some(match self.array_reference_policy(reference) {
             shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector => {
                 PlainUnindexedArrayReferenceFact::SelectorRequired(
@@ -131,6 +135,22 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
                     reference.span,
                 ))
             }
+        })
+    }
+
+    fn reference_is_zsh_array_assignment_list_value(&mut self, reference: &Reference) -> bool {
+        if self.facts.shell != ShellDialect::Zsh
+            || matches!(
+                self.array_reference_policy(reference),
+                shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector
+            )
+        {
+            return false;
+        }
+
+        self.facts.word_facts().any(|word| {
+            self.facts.is_compound_assignment_value_word(word)
+                && span_is_within(word.span(), reference.span)
         })
     }
 
@@ -262,17 +282,17 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
     }
 
     fn reference_is_zsh_conditional_operand(&self, reference: &Reference) -> bool {
-        matches!(
+        !matches!(
             self.array_reference_policy(reference),
-            shuck_semantic::ArrayReferencePolicy::NativeZshScalar
+            shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector
         )
             && matches!(reference.kind, shuck_semantic::ReferenceKind::ConditionalOperand)
     }
 
     fn reference_is_zsh_presence_test(&self, reference: &Reference) -> bool {
-        matches!(
+        !matches!(
             self.array_reference_policy(reference),
-            shuck_semantic::ArrayReferencePolicy::NativeZshScalar
+            shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector
         )
             && self
                 .facts

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -40,7 +40,7 @@ pub struct BindingValueFact<'a> {
     standalone_status_or_pid_capture: bool,
     conditional_assignment_shortcut: bool,
     one_sided_short_circuit_assignment: bool,
-    zsh_selectorless_subscript_value: bool,
+    zsh_selectorless_subscript_value_base_names: Box<[Name]>,
 }
 
 #[derive(Debug, Clone)]
@@ -68,9 +68,8 @@ impl<'a> BindingValueFact<'a> {
             standalone_status_or_pid_capture,
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
-            zsh_selectorless_subscript_value: word_is_zsh_selectorless_subscript_value(
-                word, source,
-            ),
+            zsh_selectorless_subscript_value_base_names:
+                word_zsh_selectorless_subscript_value_base_names(word, source),
         }
     }
 
@@ -80,7 +79,7 @@ impl<'a> BindingValueFact<'a> {
             standalone_status_or_pid_capture: false,
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
-            zsh_selectorless_subscript_value: false,
+            zsh_selectorless_subscript_value_base_names: Box::default(),
         }
     }
 
@@ -111,7 +110,13 @@ impl<'a> BindingValueFact<'a> {
     }
 
     pub fn zsh_selectorless_subscript_value(&self) -> bool {
-        self.zsh_selectorless_subscript_value
+        !self.zsh_selectorless_subscript_value_base_names.is_empty()
+    }
+
+    pub fn zsh_selectorless_subscript_value_references_base_name(&self, name: &Name) -> bool {
+        self.zsh_selectorless_subscript_value_base_names
+            .iter()
+            .any(|base_name| base_name == name)
     }
 
     fn mark_conditional_assignment_shortcut(&mut self) {
@@ -2256,22 +2261,27 @@ fn word_has_command_substitution(
         .has_command_substitution()
 }
 
-fn word_is_zsh_selectorless_subscript_value(word: &Word, source: &str) -> bool {
-    let mut saw_selectorless_subscript = false;
-    word_part_nodes_are_zsh_selectorless_subscript_value(
+fn word_zsh_selectorless_subscript_value_base_names(word: &Word, source: &str) -> Box<[Name]> {
+    let mut base_names = Vec::new();
+    if word_part_nodes_are_zsh_selectorless_subscript_value(
         &word.parts,
         source,
-        &mut saw_selectorless_subscript,
-    ) && saw_selectorless_subscript
+        &mut base_names,
+    ) && !base_names.is_empty()
+    {
+        base_names.into_boxed_slice()
+    } else {
+        Box::default()
+    }
 }
 
 fn word_part_nodes_are_zsh_selectorless_subscript_value(
     parts: &[WordPartNode],
     source: &str,
-    saw_selectorless_subscript: &mut bool,
+    base_names: &mut Vec<Name>,
 ) -> bool {
     for (index, part) in parts.iter().enumerate() {
-        if let WordPart::Variable(_) = &part.kind
+        if let WordPart::Variable(name) = &part.kind
             && parts.get(index + 1).is_some_and(|next| {
                 matches!(
                     &next.kind,
@@ -2279,13 +2289,13 @@ fn word_part_nodes_are_zsh_selectorless_subscript_value(
                 )
             })
         {
-            *saw_selectorless_subscript = true;
+            base_names.push(name.clone());
             continue;
         }
         if !word_part_is_zsh_selectorless_subscript_value(
             &part.kind,
             source,
-            saw_selectorless_subscript,
+            base_names,
         ) {
             return false;
         }
@@ -2296,25 +2306,21 @@ fn word_part_nodes_are_zsh_selectorless_subscript_value(
 fn word_part_is_zsh_selectorless_subscript_value(
     part: &WordPart,
     source: &str,
-    saw_selectorless_subscript: &mut bool,
+    base_names: &mut Vec<Name>,
 ) -> bool {
     match part {
         WordPart::Literal(_) | WordPart::SingleQuoted { .. } => true,
         WordPart::DoubleQuoted { parts, .. } => {
-            word_part_nodes_are_zsh_selectorless_subscript_value(
-                parts,
-                source,
-                saw_selectorless_subscript,
-            )
+            word_part_nodes_are_zsh_selectorless_subscript_value(parts, source, base_names)
         }
         WordPart::Parameter(parameter) => {
-            parameter_is_zsh_selectorless_subscript_value(parameter, saw_selectorless_subscript)
+            parameter_is_zsh_selectorless_subscript_value(parameter, base_names)
         }
         WordPart::ArrayAccess(reference) | WordPart::ArraySlice { reference, .. } => {
             if !var_ref_has_selectorless_subscript(reference) {
                 return false;
             }
-            *saw_selectorless_subscript = true;
+            base_names.push(reference.name.clone());
             true
         }
         WordPart::ZshQualifiedGlob(_)
@@ -2342,14 +2348,14 @@ fn literal_starts_with_zsh_subscript(text: &str) -> bool {
 
 fn parameter_is_zsh_selectorless_subscript_value(
     parameter: &ParameterExpansion,
-    saw_selectorless_subscript: &mut bool,
+    base_names: &mut Vec<Name>,
 ) -> bool {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
             if !var_ref_has_selectorless_subscript(reference) {
                 return false;
             }
-            *saw_selectorless_subscript = true;
+            base_names.push(reference.name.clone());
             true
         }
         ParameterExpansionSyntax::Bourne(
@@ -2371,14 +2377,11 @@ fn parameter_is_zsh_selectorless_subscript_value(
                     if !var_ref_has_selectorless_subscript(reference) {
                         return false;
                     }
-                    *saw_selectorless_subscript = true;
+                    base_names.push(reference.name.clone());
                     true
                 }
                 ZshExpansionTarget::Nested(parameter) => {
-                    parameter_is_zsh_selectorless_subscript_value(
-                        parameter,
-                        saw_selectorless_subscript,
-                    )
+                    parameter_is_zsh_selectorless_subscript_value(parameter, base_names)
                 }
                 ZshExpansionTarget::Word(_) | ZshExpansionTarget::Empty => false,
             }

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -89,11 +89,7 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
 
             checker.facts().binding_value(binding.id)?.scalar_word()?;
 
-            if zsh_selectorless_subscript_value_resets_scalar_history(
-                checker,
-                binding,
-                saw_array_history,
-            ) {
+            if zsh_selectorless_subscript_value_resets_scalar_history(checker, binding) {
                 push_array_history(
                     &mut array_history,
                     name,
@@ -214,16 +210,14 @@ impl ArrayHistoryState {
 fn zsh_selectorless_subscript_value_resets_scalar_history(
     checker: &Checker<'_>,
     binding: &Binding,
-    saw_array_history: bool,
 ) -> bool {
     checker.shell() == ShellDialect::Zsh
-        && !saw_array_history
-        && matches!(
+        && !matches!(
             checker
                 .semantic()
                 .shell_behavior_at(binding.span.start.offset)
                 .array_reference_policy(),
-            ArrayReferencePolicy::NativeZshScalar
+            ArrayReferencePolicy::RequiresExplicitSelector
         )
         && checker
             .facts()
@@ -1112,6 +1106,44 @@ fi
     }
 
     #[test]
+    fn zsh_selected_element_scalar_reassignment_clears_array_history() {
+        let source = "\
+#!/bin/zsh
+for program in $programs; do
+  sha_str=($(command shasum $program))
+  sha_str=$sha_str[1]
+done
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_split_then_selected_element_scalar_reassignment_is_intentional() {
+        let source = "\
+#!/bin/zsh
+issue_arg=${issue_arg##*/}
+issue_arg=(${(s:_:)issue_arg})
+if [[ ${#issue_arg[@]} = 1 && ${issue_arg} == *-* ]]; then
+  issue_arg=(${(s:-:)issue_arg})
+  issue_arg=\"${issue_arg[1]}-${issue_arg[2]}\"
+else
+  issue_arg=${issue_arg[1]}
+fi
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn reports_scalar_reassignments_after_read_array_targets() {
         let source = "\
 #!/bin/bash
@@ -1244,6 +1276,31 @@ g() {
   local fuzzer=$1
 }
 fuzzer=$1
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_local_array_collapse_does_not_escape_to_later_local_scalars() {
+        let source = "\
+#!/bin/zsh
+upglob() {
+  local cached=$_cache[$1]
+  if [[ -n $cached ]]; then
+    cached=(${(s: :)cached})
+  fi
+}
+read_pyenv() {
+  local -a stat
+  zstat -A stat +mtime -- $1 2>/dev/null || stat=(-1)
+  local cached=$_other_cache[$1:$2]
+  print -r -- $cached
+}
 ";
         let diagnostics = test_snippet(
             source,
@@ -1576,7 +1633,7 @@ echo \"$ret\"
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["items", "kitems"],
+            vec!["kitems"],
             "{diagnostics:#?}"
         );
     }

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -44,7 +44,10 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
             }
 
             let name = binding.name.clone();
-            let saw_array_history = visible_array_history(&array_history, &name, checker, binding)
+            let visible_array_state =
+                visible_array_history(&array_history, &name, checker, binding);
+            let saw_array_history = visible_array_state
+                .map(|state| state.array_like)
                 .unwrap_or_else(|| binding_uses_builtin_array_history(checker, binding));
 
             if declaration_resets_array_history(binding) {
@@ -89,7 +92,12 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
 
             checker.facts().binding_value(binding.id)?.scalar_word()?;
 
-            if zsh_selectorless_subscript_value_resets_scalar_history(checker, binding) {
+            if zsh_selectorless_subscript_value_resets_scalar_history(
+                checker,
+                binding,
+                saw_array_history,
+                visible_array_state,
+            ) {
                 push_array_history(
                     &mut array_history,
                     name,
@@ -145,13 +153,13 @@ fn visible_array_history(
     name: &Name,
     checker: &Checker<'_>,
     binding: &Binding,
-) -> Option<bool> {
+) -> Option<ArrayHistoryState> {
     array_history.get(name).and_then(|history| {
         history
             .iter()
             .rev()
             .find(|state| state.visible_to_binding(checker, binding))
-            .map(|state| state.array_like)
+            .copied()
     })
 }
 
@@ -210,6 +218,8 @@ impl ArrayHistoryState {
 fn zsh_selectorless_subscript_value_resets_scalar_history(
     checker: &Checker<'_>,
     binding: &Binding,
+    saw_array_history: bool,
+    visible_array_state: Option<ArrayHistoryState>,
 ) -> bool {
     checker.shell() == ShellDialect::Zsh
         && !matches!(
@@ -222,7 +232,14 @@ fn zsh_selectorless_subscript_value_resets_scalar_history(
         && checker
             .facts()
             .binding_value(binding.id)
-            .is_some_and(|value| value.zsh_selectorless_subscript_value())
+            .is_some_and(|value| {
+                value.zsh_selectorless_subscript_value()
+                    && (!saw_array_history
+                        || (binding_establishes_local_scalar_history(binding)
+                            && !visible_array_state.is_some_and(|state| state.local))
+                        || value
+                            .zsh_selectorless_subscript_value_references_base_name(&binding.name))
+            })
 }
 
 fn array_history_events(
@@ -1120,6 +1137,74 @@ done
         );
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn zsh_cross_variable_selected_element_assignment_preserves_array_history() {
+        let source = "\
+#!/bin/zsh
+src=(one two)
+dst=(old new)
+dst=$src[1]
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["dst"]
+        );
+    }
+
+    #[test]
+    fn zsh_cross_variable_subscript_index_reads_do_not_clear_array_history() {
+        let source = "\
+#!/bin/zsh
+src=(one two)
+dst=(old new)
+dst=${src[$dst]}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["dst"]
+        );
+    }
+
+    #[test]
+    fn zsh_local_cross_variable_selected_element_assignment_preserves_array_history() {
+        let source = "\
+#!/bin/zsh
+f() {
+  local src=(one two)
+  local dst=(old new)
+  local dst=$src[1]
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayToStringConversion),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["dst"]
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -551,6 +551,31 @@ out=($arr) copy=$arr
     }
 
     #[test]
+    fn zsh_array_assignment_suppression_does_not_hide_nested_reads() {
+        let source = "\
+#!/bin/zsh
+maybe_ksh_arrays() {
+  [[ -n $flag ]] && setopt ksharrays
+}
+maybe_ksh_arrays
+arr=(one two)
+out=($(print -r -- $arr))
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedBashSource).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$arr"]
+        );
+    }
+
+    #[test]
     fn read_option_values_do_not_become_array_targets() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -152,6 +152,22 @@ precm=(builtin emulate zsh)
     }
 
     #[test]
+    fn zsh_ambiguous_presence_tests_do_not_require_explicit_selectors() {
+        let source = "\
+#!/bin/zsh
+maybe() {
+  [[ -n $flag ]] && setopt ksh_arrays
+}
+maybe
+precm=(builtin emulate zsh)
+[[ -n $precm ]] && builtin ${precm[@]} 'source \"$ZERO\"'
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::QuotedBashSource));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
     fn zsh_ksh_array_presence_tests_require_explicit_selectors() {
         let source = "\
 #!/bin/zsh
@@ -510,6 +526,31 @@ arr=(new1 new2) printf '%s\\n' \"$arr\"
     }
 
     #[test]
+    fn zsh_array_assignment_suppression_does_not_hide_later_scalar_assignments() {
+        let source = "\
+#!/bin/zsh
+maybe_ksh_arrays() {
+  [[ -n $flag ]] && setopt ksharrays
+}
+maybe_ksh_arrays
+arr=(one two)
+out=($arr) copy=$arr
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedBashSource).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$arr"]
+        );
+    }
+
+    #[test]
     fn read_option_values_do_not_become_array_targets() {
         let source = "\
 #!/bin/bash
@@ -788,6 +829,43 @@ OPTS[k]=1
 local -a ___opt
 ___opt=(-a -b)
 .zinit-load-snippet $___opt foo
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedBashSource).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn zsh_native_array_expansion_stays_clean_after_localoptions_dispatcher() {
+        let source = "\
+#!/bin/zsh
+function omz {
+  setopt localoptions noksharrays
+  [[ $# -gt 0 ]] || return 1
+  local command=\"$1\"
+  shift
+  (( ${+functions[_omz::$command]} )) || return 1
+  _omz::$command \"$@\"
+}
+
+function _omz {
+  local -a cmds subcmds
+  if (( CURRENT == 4 )); then
+    case \"${words[2]}::${words[3]}\" in
+      plugin::(disable|enable|load))
+        local -aU valid_plugins
+        if [[ \"${words[3]}\" = disable ]]; then
+          valid_plugins=($plugins)
+        else
+          valid_plugins=(\"$ZSH\"/plugins/*/{_*,*.plugin.zsh}(-.N:h:t))
+        fi
+        _describe 'plugin' valid_plugins ;;
+    esac
+  fi
+}
 ";
         let diagnostics = test_snippet(
             source,


### PR DESCRIPTION
## Summary

- Narrow C100 for zsh selectorless array references in array-construction and presence-test contexts unless the active behavior definitely requires ksh-style explicit selectors.
- Narrow C133 for zsh scalar assignments that intentionally collapse an array through selectorless subscript selection, while preserving reports when ksh array behavior is definitely active.
- Add focused zsh regression coverage for the ohmyzsh, jira, diagnostics, zinit, and powerlevel10k-shaped cases.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-linter`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C100,C133`
- Read-only `/tmp/zsh` C100/C133 sweep: before `93 C100 / 20 C133`; after `60 C100 / 15 C133` with two pre-existing parse errors in unrelated files.