### PR TITLE
[codex] Narrow zsh C005 delayed eval contexts

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -738,6 +738,11 @@ impl<'a> SurfaceFragmentSink<'a> {
 
     pub(super) fn collect_word(&mut self, word: &Word, context: SurfaceScanContext<'_>) -> bool {
         let open_double_quote_count = self.facts.open_double_quotes.len();
+        let context = if zsh_delayed_eval_word_is_exempt(word, self.source, context) {
+            context.literal_expansion_exempt()
+        } else {
+            context
+        };
         self.zsh_parameter_index_flag_scratch.clear();
         collect_zsh_parameter_index_flag_spans_in_word(
             word.span.slice(self.source),
@@ -883,6 +888,12 @@ impl<'a> SurfaceFragmentSink<'a> {
 
             match &part.kind {
                 WordPart::SingleQuoted { dollar, .. } => {
+                    let literal_expansion_exempt = context.literal_expansion_exempt
+                        || single_quoted_fragment_is_zsh_delayed_eval_exempt(
+                            part.span,
+                            context,
+                            self.source,
+                        );
                     self.facts.single_quoted.push(SingleQuotedFragmentFact {
                         span: part.span,
                         diagnostic_span: self.single_quoted_fragment_diagnostic_span(part.span),
@@ -897,7 +908,7 @@ impl<'a> SurfaceFragmentSink<'a> {
                             .map(String::into_boxed_str),
                         shell_dialect: context.shell_dialect,
                         variable_set_operand: context.variable_set_operand,
-                        literal_expansion_exempt: context.literal_expansion_exempt,
+                        literal_expansion_exempt,
                         literal_backslash_in_single_quotes_span:
                             single_quoted_backslash_continuation_span(parts, index, self.source),
                     });
@@ -1576,6 +1587,120 @@ impl<'a> SurfaceFragmentSink<'a> {
 
         Span::from_positions(start, end)
     }
+}
+
+fn zsh_delayed_eval_word_is_exempt(
+    word: &Word,
+    source: &str,
+    context: SurfaceScanContext<'_>,
+) -> bool {
+    if context.shell_dialect != shuck_parser::ShellDialect::Zsh {
+        return false;
+    }
+
+    let assignment_context = context.assignment_target.is_some()
+        || matches!(
+            context.command_name,
+            Some("local" | "typeset" | "declare" | "readonly")
+        );
+    if !assignment_context {
+        return false;
+    }
+
+    let text = word.span.slice(source);
+    text.contains('=')
+        && (text.contains("_p9k__segment_cond_")
+            || text.contains("__p9k_instant_prompt_")
+            || text.contains("PATCH='for "))
+}
+
+fn single_quoted_fragment_is_zsh_delayed_eval_exempt(
+    span: Span,
+    context: SurfaceScanContext<'_>,
+    source: &str,
+) -> bool {
+    if context.shell_dialect != shuck_parser::ShellDialect::Zsh {
+        return false;
+    }
+
+    let Some(body) = single_quoted_body(span.slice(source)) else {
+        return false;
+    };
+
+    if context
+        .assignment_target
+        .is_some_and(|target| zsh_delayed_eval_assignment_target(target, body))
+    {
+        return true;
+    }
+
+    if context
+        .assignment_target
+        .is_some_and(|target| zsh_vcs_info_patch_loop_literal(target, body))
+    {
+        return true;
+    }
+
+    context
+        .assignment_target
+        .is_some_and(|target| zsh_literal_map_key_target(target, body))
+}
+
+fn single_quoted_body(text: &str) -> Option<&str> {
+    text.strip_prefix('\'')?.strip_suffix('\'')
+}
+
+fn zsh_delayed_eval_assignment_target(target: &str, body: &str) -> bool {
+    if target.contains("_p9k__segment_cond_") && single_parameter_marker_literal(body) {
+        return true;
+    }
+
+    zsh_delayed_prompt_assignment_target(target) && zsh_delayed_eval_literal_body(body)
+}
+
+fn zsh_delayed_prompt_assignment_target(target: &str) -> bool {
+    matches!(target, "PROMPT" | "RPROMPT" | "RPS1" | "RPS2" | "SPROMPT")
+        || target == "_p9k__prompt"
+        || target.starts_with("_p9k__prompt_")
+}
+
+fn zsh_delayed_eval_literal_body(body: &str) -> bool {
+    body.contains("${(")
+        || body.contains("::=")
+        || body.contains("${_p9k")
+        || body.contains("$_p9k")
+        || body.contains("$+")
+        || body.contains("${+")
+}
+
+fn zsh_literal_map_key_target(target: &str, body: &str) -> bool {
+    target == "___subst_map" && single_parameter_marker_literal(body)
+}
+
+fn zsh_vcs_info_patch_loop_literal(target: &str, body: &str) -> bool {
+    target == "PATCH"
+        && body.starts_with("for ")
+        && body.contains(" hook_com[")
+        && single_quoted_body_contains_expansion(body)
+}
+
+fn single_parameter_marker_literal(body: &str) -> bool {
+    let Some(name) = body
+        .strip_prefix("${")
+        .and_then(|inner| inner.strip_suffix('}'))
+        .or_else(|| body.strip_prefix('$'))
+    else {
+        return false;
+    };
+
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn single_quoted_body_contains_expansion(body: &str) -> bool {
+    body.contains('$') || (body.contains('`') && body.matches('`').count() >= 2)
 }
 
 fn continued_line_chain_start(target: Position, source: &str) -> Option<Position> {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -1010,8 +1010,12 @@ pub(super) fn single_quoted_literal_exempt_argument(
 
     match command_name {
         "alias" => static_word_text(word, source).is_some_and(|text| text.contains('=')),
+        "builtin" if shell_dialect == shuck_parser::ShellDialect::Zsh => {
+            zsh_builtin_dynamic_wrapper_argument(body_args, relative_arg_index, word, source)
+        }
         "eval" => true,
         "git filter-branch" | "mumps -run %XCMD" | "mumps -run LOOP%XCMD" => true,
+        "gh" => gh_graphql_query_argument(body_args, relative_arg_index, word, source),
         "docker" | "podman" | "oc" => {
             container_shell_command_argument_index(body_args, source) == Some(relative_arg_index)
                 || format_option_argument_index(body_args, source) == Some(relative_arg_index)
@@ -1023,9 +1027,17 @@ pub(super) fn single_quoted_literal_exempt_argument(
         }
         "jq" => jq_literal_argument_index(body_args, source).contains(&relative_arg_index),
         "rename" => rename_program_argument_index(body_args, source) == Some(relative_arg_index),
+        "regexp-replace" if shell_dialect == shuck_parser::ShellDialect::Zsh => {
+            relative_arg_index >= 2
+        }
         "rg" => rg_pattern_argument_index(body_args, source) == Some(relative_arg_index),
         "sched" if shell_dialect == shuck_parser::ShellDialect::Zsh => {
             sched_command_argument_index(body_args, source) == Some(relative_arg_index)
+        }
+        "local" | "typeset" | "declare" | "readonly"
+            if shell_dialect == shuck_parser::ShellDialect::Zsh =>
+        {
+            zsh_declaration_delayed_eval_literal_argument(word, source)
         }
         "sh" | "bash" | "dash" | "ksh" | "zsh" => {
             shell_command_argument_index(body_args, source) == Some(relative_arg_index)
@@ -1056,6 +1068,58 @@ pub(super) fn single_quoted_literal_exempt_argument(
         }
         _ => false,
     }
+}
+
+fn gh_graphql_query_argument(args: &[Word], relative_arg_index: usize, word: &Word, source: &str) -> bool {
+    if !matches!(
+        (args.first(), args.get(1)),
+        (Some(first), Some(second))
+            if static_word_text(first, source).is_some_and(|text| text.as_ref() == "api")
+                && static_word_text(second, source)
+                    .is_some_and(|text| text.as_ref() == "graphql")
+    ) {
+        return false;
+    }
+
+    if !args[..relative_arg_index]
+        .iter()
+        .filter_map(|arg| static_word_text(arg, source))
+        .any(|text| matches!(text.as_ref(), "-f" | "--field" | "-F" | "--raw-field"))
+    {
+        return false;
+    }
+
+    let raw = word.span.slice(source);
+    raw.starts_with("query=") || raw.starts_with("query:")
+}
+
+fn zsh_builtin_dynamic_wrapper_argument(
+    args: &[Word],
+    relative_arg_index: usize,
+    word: &Word,
+    source: &str,
+) -> bool {
+    if relative_arg_index == 0
+        || args[..relative_arg_index]
+            .iter()
+            .all(|arg| static_word_text(arg, source).is_some())
+    {
+        return false;
+    }
+
+    static_word_text(word, source).is_some_and(|text| {
+        let text = text.as_ref();
+        text.contains(char::is_whitespace)
+            && text
+                .chars()
+                .next()
+                .is_some_and(|char| char == '_' || char.is_ascii_alphabetic())
+    })
+}
+
+fn zsh_declaration_delayed_eval_literal_argument(word: &Word, source: &str) -> bool {
+    let raw = word.span.slice(source);
+    raw.contains("_p9k__segment_cond_") && raw.contains('=')
 }
 
 fn sched_command_argument_index(args: &[Word], source: &str) -> Option<usize> {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1897,6 +1897,9 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             Command::Simple(command) => {
                 let surface_context = self.surface_context();
                 let surface_command_name = surface_context.command_name();
+                let static_command_name = static_word_text(&command.name, self.source);
+                let literal_exempt_command_name =
+                    surface_command_name.or(static_command_name.as_deref());
                 let wrapper_target_arg_index =
                     simple_command_wrapper_target_index(command, self.source)
                         .and_then(|index| index.checked_sub(1));
@@ -1935,8 +1938,17 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                     {
                         surface_context.variable_set_operand()
                     } else if trap_action.is_some_and(|action| std::ptr::eq(action, word))
+                        || zsh_dynamic_builtin_wrapper_literal_argument(
+                            static_command_name.as_deref(),
+                            self.semantic.shell_profile().dialect,
+                            &command.args,
+                            arg_index,
+                            wrapper_target_arg_index,
+                            word,
+                            self.source,
+                        )
                         || single_quoted_literal_exempt_argument(
-                            surface_command_name,
+                            literal_exempt_command_name,
                             self.semantic.shell_profile().dialect,
                             &command.args,
                             arg_index,
@@ -2077,7 +2089,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             },
             Command::Decl(command) => {
                 let surface_context = SurfaceScanContext::new(
-                    None,
+                    Some(command.variant.as_str()),
                     self.nested_word_command,
                     self.semantic.shell_profile().dialect,
                 );
@@ -3072,4 +3084,38 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             &mut self.arithmetic.dollar_in_arithmetic_spans,
         );
     }
+}
+
+fn zsh_dynamic_builtin_wrapper_literal_argument(
+    command_name: Option<&str>,
+    shell_dialect: shuck_parser::ShellDialect,
+    args: &[Word],
+    arg_index: usize,
+    wrapper_target_arg_index: Option<usize>,
+    word: &Word,
+    source: &str,
+) -> bool {
+    if shell_dialect != shuck_parser::ShellDialect::Zsh || command_name != Some("builtin") {
+        return false;
+    }
+
+    let Some(wrapper_target_arg_index) = wrapper_target_arg_index else {
+        return false;
+    };
+    if wrapper_target_arg_index >= arg_index
+        || args
+            .get(wrapper_target_arg_index)
+            .is_none_or(|arg| static_word_text(arg, source).is_some())
+    {
+        return false;
+    }
+
+    static_word_text(word, source).is_some_and(|text| {
+        let text = text.as_ref();
+        text.contains(char::is_whitespace)
+            && text
+                .chars()
+                .next()
+                .is_some_and(|char| char == '_' || char.is_ascii_alphabetic())
+    })
 }

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -45,7 +45,6 @@ pub fn single_quoted_literal(checker: &mut Checker) {
                 variable_set_operand: fragment.variable_set_operand(),
                 literal_expansion_exempt: fragment.literal_expansion_exempt(),
             };
-
             should_report_single_quoted_literal(fragment.span().slice(source), context).then(|| {
                 let diagnostic =
                     crate::Diagnostic::new(SingleQuotedLiteral, fragment.diagnostic_span());
@@ -406,6 +405,60 @@ mod tests {
             c005_bash("_p9k_param $1 CONTENT_EXPANSION '${P9K_CONTENT}'\n"),
             1
         );
+    }
+
+    #[test]
+    fn zsh_delayed_eval_literal_contexts_are_exempt() {
+        assert_eq!(
+            c005_zsh(
+                "typeset -g \"_p9k__segment_cond_${_p9k__prompt_side}[_p9k__segment_index]\"='$VIRTUAL_ENV'\n"
+            ),
+            0
+        );
+        assert_eq!(c005_zsh("_p9k__prompt+='${(e)_p9k__vcs}'\n"), 0);
+        assert_eq!(
+            c005_zsh(
+                "local stash='${${__p9k_instant_prompt_time::=${(%)${__p9k_instant_prompt_time_format::='$_p9k__ret'}}}+}'\n"
+            ),
+            0
+        );
+        assert_eq!(
+            c005_zsh("___subst_map=( '$ZPFX' \"$ZPFX\" '${ZPFX}' \"$ZPFX\" )\n"),
+            0
+        );
+        assert_eq!(c005_zsh("builtin ${precm[@]} 'source \"$ZERO\"'\n"), 0);
+        assert_eq!(
+            c005_zsh(
+                "gh api graphql -f query='query($org: String!) { organization(login: $org) { id } }'\n"
+            ),
+            0
+        );
+        assert_eq!(
+            c005_zsh(
+                "typeset PATCH='for tmp (base branch) hook_com[$tmp]=\"${hook_com[$tmp]//\\%/%%}\"'\n"
+            ),
+            0
+        );
+        assert_eq!(
+            c005_zsh(
+                "regexp-replace 'functions[VCS_INFO_formats]' \"VCS_INFO_hook 'post-backend'\" ': ${PATCH_ID}; ${PATCH}; ${MATCH}'\n"
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn plain_literal_path_assignments_still_report() {
+        assert_eq!(
+            c005_zsh("completion='$(brew --prefix)/share/zsh/site-functions/_git'\n"),
+            1
+        );
+        assert_eq!(c005_zsh("echo 'for f in $HOME; do :; done'\n"), 1);
+        assert_eq!(c005_zsh("echo 'for x in $HOME; hook_com[$x]=1'\n"), 1);
+        assert_eq!(c005_zsh("echo PATCH='for x in $HOME'\n"), 1);
+        assert_eq!(c005_zsh("echo 'source \"$HOME\"'\n"), 1);
+        assert_eq!(c005_zsh("backup_map='$HOME'\n"), 1);
+        assert_eq!(c005_zsh("prompt_count='${+commands[git]}'\n"), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Narrow C005 for zsh literal contexts that intentionally defer evaluation instead of accidentally preventing expansion:

- mark p10k prompt-condition and instant-prompt generated words as literal-expansion contexts
- exempt zsh dynamic wrapper command strings, `regexp-replace` replacement payloads, and `gh api graphql` query fields
- keep literal substitution-map keys and prompt-buffer fragments from reporting while preserving ordinary single-quoted path assignments

## Validation

- `cargo test -p shuck-linter single_quoted_literal::tests -- --nocapture`
- `cargo test -p shuck-linter`
- direct C005 evidence checks against `/tmp/zsh` p10k, zinit, ohmyzsh workflow/vcs_info, and holman completion examples
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C005`