### PR TITLE
perf(semantic): cache zsh runtime function summaries

### DIFF
--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -800,6 +800,7 @@ pub struct SemanticModel {
     zsh_option_analysis: Option<ZshOptionAnalysis>,
     zsh_runtime_ambiguous_entry_mask: OnceLock<zsh_options::ZshOptionMask>,
     zsh_runtime_by_function: OnceLock<FxHashMap<ScopeId, OnceLock<Option<ZshOptionAnalysis>>>>,
+    zsh_runtime_function_summaries: OnceLock<zsh_options::SharedFunctionSummaryCache>,
     assoc_lookup_binding_index: OnceLock<AssocLookupBindingIndex>,
     command_topology: OnceLock<CommandTopology>,
     references_sorted_by_start: OnceLock<Vec<ReferenceId>>,
@@ -1002,6 +1003,7 @@ impl SemanticModel {
             zsh_option_analysis,
             zsh_runtime_ambiguous_entry_mask: OnceLock::new(),
             zsh_runtime_by_function: OnceLock::new(),
+            zsh_runtime_function_summaries: OnceLock::new(),
             assoc_lookup_binding_index: OnceLock::new(),
             command_topology: OnceLock::new(),
             references_sorted_by_start: OnceLock::new(),
@@ -1113,6 +1115,10 @@ impl SemanticModel {
                 indirect_targets_by_binding: &self.indirect_targets_by_binding,
                 command_references: &self.command_references,
             },
+            Some(
+                self.zsh_runtime_function_summaries
+                    .get_or_init(Default::default),
+            ),
             function_scope,
             function_entry,
         )

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -11243,3 +11243,74 @@ run_dispatcher
         ArrayReferencePolicy::Ambiguous
     );
 }
+
+#[test]
+fn semantic_runtime_zsh_option_analysis_records_cached_root_function_snapshots() {
+    let source = "\
+setopt ksh_arrays
+unsetopt ksh_arrays
+callee() {
+  print $name
+}
+caller() {
+  callee
+}
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+    let caller_call_offset = source.rfind("callee").unwrap();
+    let callee_print_offset = source.find("print $name").unwrap();
+
+    assert_eq!(
+        array_reference_policy_at(&model, caller_call_offset),
+        ArrayReferencePolicy::Ambiguous
+    );
+    assert!(
+        model
+            .shell_behavior_at(callee_print_offset)
+            .zsh_options()
+            .is_some_and(|options| options.ksh_arrays == OptionValue::Unknown),
+        "{source}"
+    );
+    assert_eq!(
+        array_reference_policy_at(&model, callee_print_offset),
+        ArrayReferencePolicy::Ambiguous
+    );
+}
+
+#[test]
+fn semantic_runtime_zsh_option_analysis_keys_summaries_by_recursion_context() {
+    let source = "\
+setopt ksh_arrays
+unsetopt ksh_arrays
+f() {
+  g
+}
+g() {
+  h
+}
+h() {
+  g
+  print $name
+  unsetopt ksh_arrays
+}
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+    let f_call_offset = source.find("  g\n").unwrap() + 2;
+    let h_print_offset = source.find("print $name").unwrap();
+
+    assert_eq!(
+        array_reference_policy_at(&model, f_call_offset),
+        ArrayReferencePolicy::Ambiguous
+    );
+    assert!(
+        model
+            .shell_behavior_at(h_print_offset)
+            .zsh_options()
+            .is_some_and(|options| options.ksh_arrays == OptionValue::Unknown),
+        "{source}"
+    );
+    assert_eq!(
+        array_reference_policy_at(&model, h_print_offset),
+        ArrayReferencePolicy::Ambiguous
+    );
+}

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -1,6 +1,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_parser::{OptionValue, ShellProfile, ZshEmulationMode, ZshOptionState};
 use smallvec::SmallVec;
+use std::sync::Mutex;
 
 use crate::cfg::{
     CommandId, RecordedCaseArmRange, RecordedCommand, RecordedCommandKind, RecordedCommandRange,
@@ -274,6 +275,7 @@ pub(crate) fn analyze(
             Default::default(),
         ),
         function_summaries: FxHashMap::with_capacity_and_hasher(function_count, Default::default()),
+        shared_function_summaries: None,
     };
 
     analyzer.analyze_sequence(
@@ -342,6 +344,7 @@ pub(crate) fn function_runtime_analysis_with_entry(
     bindings: &[Binding],
     recorded_program: &RecordedProgram,
     dynamic_calls: DynamicCallAnalysisContext<'_>,
+    shared_summaries: Option<&SharedFunctionSummaryCache>,
     function_scope: ScopeId,
     entry: ZshOptionState,
 ) -> Option<ZshOptionAnalysis> {
@@ -371,6 +374,7 @@ pub(crate) fn function_runtime_analysis_with_entry(
         snapshots: FxHashMap::with_capacity_and_hasher(scope_capacity, Default::default()),
         active_function_scopes: FxHashSet::default(),
         function_summaries: FxHashMap::default(),
+        shared_function_summaries: shared_summaries,
     };
     analyzer.analyze_function_scope(
         function_scope,
@@ -394,6 +398,29 @@ pub(crate) fn set_public_option_field(
     value: OptionValue,
 ) {
     set_option_field(state, field, value);
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SharedFunctionSummaryCache {
+    summaries: Mutex<FxHashMap<(ScopeId, InternalState), FunctionSummary>>,
+}
+
+impl SharedFunctionSummaryCache {
+    fn get(&self, key: &(ScopeId, InternalState)) -> Option<FunctionSummary> {
+        let summaries = match self.summaries.lock() {
+            Ok(summaries) => summaries,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        summaries.get(key).cloned()
+    }
+
+    fn insert(&self, key: (ScopeId, InternalState), summary: FunctionSummary) {
+        let mut summaries = match self.summaries.lock() {
+            Ok(summaries) => summaries,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        summaries.insert(key, summary);
+    }
 }
 
 impl ZshOptionAnalysis {
@@ -440,6 +467,7 @@ struct Analyzer<'a> {
     snapshots: FxHashMap<ScopeId, Vec<ZshOptionSnapshot>>,
     active_function_scopes: FxHashSet<ScopeId>,
     function_summaries: FxHashMap<(ScopeId, InternalState), FunctionSummary>,
+    shared_function_summaries: Option<&'a SharedFunctionSummaryCache>,
 }
 
 impl<'a> Analyzer<'a> {
@@ -881,6 +909,13 @@ impl<'a> Analyzer<'a> {
         if let Some(summary) = self.function_summaries.get(&cache_key) {
             return summary.clone();
         }
+        if let Some(summary) = self
+            .shared_function_summaries
+            .and_then(|summaries| summaries.get(&cache_key))
+        {
+            self.function_summaries.insert(cache_key, summary.clone());
+            return summary;
+        }
 
         if !self.active_function_scopes.insert(scope) {
             return FunctionSummary {
@@ -896,7 +931,11 @@ impl<'a> Analyzer<'a> {
             final_outward: result.outward,
             outward_touched: result.outward_touched,
         };
-        self.function_summaries.insert(cache_key, summary.clone());
+        self.function_summaries
+            .insert(cache_key.clone(), summary.clone());
+        if let Some(shared_summaries) = self.shared_function_summaries {
+            shared_summaries.insert(cache_key, summary.clone());
+        }
         summary
     }
 

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -52,6 +52,13 @@ struct FunctionSummary {
     outward_touched: ZshOptionMask,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FunctionSummaryKey {
+    scope: ScopeId,
+    entry: InternalState,
+    active_scopes: SmallVec<[ScopeId; 4]>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LeakBehavior {
     Always,
@@ -376,9 +383,10 @@ pub(crate) fn function_runtime_analysis_with_entry(
         function_summaries: FxHashMap::default(),
         shared_function_summaries: shared_summaries,
     };
-    analyzer.analyze_function_scope(
+    analyzer.analyze_function_scope_with_shared_summary_reuse(
         function_scope,
         EvalState::new(InternalState::from_public(entry)),
+        false,
     );
 
     for snapshots in analyzer.snapshots.values_mut() {
@@ -402,11 +410,11 @@ pub(crate) fn set_public_option_field(
 
 #[derive(Debug, Default)]
 pub(crate) struct SharedFunctionSummaryCache {
-    summaries: Mutex<FxHashMap<(ScopeId, InternalState), FunctionSummary>>,
+    summaries: Mutex<FxHashMap<FunctionSummaryKey, FunctionSummary>>,
 }
 
 impl SharedFunctionSummaryCache {
-    fn get(&self, key: &(ScopeId, InternalState)) -> Option<FunctionSummary> {
+    fn get(&self, key: &FunctionSummaryKey) -> Option<FunctionSummary> {
         let summaries = match self.summaries.lock() {
             Ok(summaries) => summaries,
             Err(poisoned) => poisoned.into_inner(),
@@ -414,7 +422,7 @@ impl SharedFunctionSummaryCache {
         summaries.get(key).cloned()
     }
 
-    fn insert(&self, key: (ScopeId, InternalState), summary: FunctionSummary) {
+    fn insert(&self, key: FunctionSummaryKey, summary: FunctionSummary) {
         let mut summaries = match self.summaries.lock() {
             Ok(summaries) => summaries,
             Err(poisoned) => poisoned.into_inner(),
@@ -466,7 +474,7 @@ struct Analyzer<'a> {
     scope_entries: FxHashMap<ScopeId, ZshOptionState>,
     snapshots: FxHashMap<ScopeId, Vec<ZshOptionSnapshot>>,
     active_function_scopes: FxHashSet<ScopeId>,
-    function_summaries: FxHashMap<(ScopeId, InternalState), FunctionSummary>,
+    function_summaries: FxHashMap<FunctionSummaryKey, FunctionSummary>,
     shared_function_summaries: Option<&'a SharedFunctionSummaryCache>,
 }
 
@@ -905,25 +913,36 @@ impl<'a> Analyzer<'a> {
     }
 
     fn analyze_function_scope(&mut self, scope: ScopeId, entry: EvalState) -> FunctionSummary {
-        let cache_key = (scope, entry.current.clone());
-        if let Some(summary) = self.function_summaries.get(&cache_key) {
-            return summary.clone();
-        }
-        if let Some(summary) = self
-            .shared_function_summaries
-            .and_then(|summaries| summaries.get(&cache_key))
-        {
-            self.function_summaries.insert(cache_key, summary.clone());
-            return summary;
-        }
+        self.analyze_function_scope_with_shared_summary_reuse(scope, entry, true)
+    }
 
-        if !self.active_function_scopes.insert(scope) {
+    fn analyze_function_scope_with_shared_summary_reuse(
+        &mut self,
+        scope: ScopeId,
+        entry: EvalState,
+        allow_shared_reuse: bool,
+    ) -> FunctionSummary {
+        if self.active_function_scopes.contains(&scope) {
             return FunctionSummary {
                 final_outward: entry.outward,
                 outward_touched: ZshOptionMask::default(),
             };
         }
 
+        let cache_key = self.function_summary_key(scope, &entry.current);
+        if let Some(summary) = self.function_summaries.get(&cache_key) {
+            return summary.clone();
+        }
+        if allow_shared_reuse
+            && let Some(summary) = self
+                .shared_function_summaries
+                .and_then(|summaries| summaries.get(&cache_key))
+        {
+            self.function_summaries.insert(cache_key, summary.clone());
+            return summary;
+        }
+
+        self.active_function_scopes.insert(scope);
         let body = self.recorded_program.function_body(scope);
         let result = self.analyze_sequence(scope, body, entry, LeakBehavior::Function);
         self.active_function_scopes.remove(&scope);
@@ -937,6 +956,17 @@ impl<'a> Analyzer<'a> {
             shared_summaries.insert(cache_key, summary.clone());
         }
         summary
+    }
+
+    fn function_summary_key(&self, scope: ScopeId, entry: &InternalState) -> FunctionSummaryKey {
+        let mut active_scopes: SmallVec<[ScopeId; 4]> =
+            self.active_function_scopes.iter().copied().collect();
+        active_scopes.sort_by_key(|scope| scope.index());
+        FunctionSummaryKey {
+            scope,
+            entry: entry.clone(),
+            active_scopes,
+        }
     }
 
     fn resolve_visible_function_scope(


### PR DESCRIPTION
## Summary

- Share zsh runtime function summaries across lazy per-function analyses on a semantic model
- Keep the existing per-analyzer cache and recursion guard behavior, publishing only completed summaries to the shared cache
- Wire the shared cache through `SemanticModel::build_zsh_runtime_analysis_for_function`

## Performance

Profiled `romkatv__powerlevel10k__internal__p10k.zsh` with the large-corpus profiling harness:

- Previous post-fix baseline: ~104ms avg
- This change, warm run: 91.194ms avg
- `zsh_options::Analyzer::analyze_command` drilldown fell from ~12.5% of samples to 0.8%

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-semantic zsh_option --lib`
- `cargo test -p shuck-linter subshell_side_effect --lib`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C150,C155`