### PR TITLE
fix: zsh subshell return side-effect pairing

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1103,6 +1103,7 @@ fn build_nonpersistent_assignment_spans(
         &NonpersistentAssignmentAnalysisContext {
             options: NonpersistentAssignmentAnalysisOptions {
                 suppress_bash_pipefail_pipeline_side_effects,
+                require_return_use_same_execution_context: suppress_zsh_nested_subshell_noise,
                 ignored_names: vec![Name::from("IFS")],
             },
             commands: command_contexts,

--- a/crates/shuck-linter/src/facts/tests/assignments.rs
+++ b/crates/shuck-linter/src/facts/tests/assignments.rs
@@ -958,6 +958,96 @@ demo() {
     );
 }
 
+#[test]
+fn zsh_status_capture_inside_subshell_is_not_connected_to_parent_return() {
+    let source = "\
+#!/bin/zsh
+demo() {
+  local retval=0
+  (
+    ( return 2 )
+    retval=$?
+    print -r -- $retval
+  ) || return $?
+  return $retval
+}
+";
+
+    assert!(subshell_assignment_slices(source, ShellDialect::Zsh).is_empty());
+    assert!(subshell_later_use_slices(source, ShellDialect::Zsh).is_empty());
+}
+
+#[test]
+fn zsh_subshell_loop_local_assignment_is_not_connected_to_parent_return() {
+    let source = "\
+#!/bin/zsh
+demo() {
+  local retval=0
+  for pair in \"$@\"; do
+    (
+      retval=1
+      continue
+    )
+  done
+  return $retval
+}
+";
+
+    assert!(subshell_assignment_slices(source, ShellDialect::Zsh).is_empty());
+    assert!(subshell_later_use_slices(source, ShellDialect::Zsh).is_empty());
+}
+
+#[test]
+fn zsh_sh_emulation_return_read_still_reports_subshell_assignment() {
+    let source = "\
+#!/bin/zsh
+demo() {
+  emulate sh
+  local retval=0
+  (
+    retval=1
+  )
+  return $retval
+}
+demo
+";
+
+    assert_eq!(
+        subshell_assignment_slices(source, ShellDialect::Zsh),
+        vec!["retval"]
+    );
+    assert_eq!(
+        subshell_later_use_slices(source, ShellDialect::Zsh),
+        vec!["$retval"]
+    );
+}
+
+#[test]
+fn zsh_sh_emulation_return_read_survives_later_option_updates() {
+    let source = "\
+#!/bin/zsh
+demo() {
+  emulate sh
+  setopt ksh_arrays
+  local retval=0
+  (
+    retval=1
+  )
+  return $retval
+}
+demo
+";
+
+    assert_eq!(
+        subshell_assignment_slices(source, ShellDialect::Zsh),
+        vec!["retval"]
+    );
+    assert_eq!(
+        subshell_later_use_slices(source, ShellDialect::Zsh),
+        vec!["$retval"]
+    );
+}
+
 fn subshell_assignment_slices(source: &str, shell: ShellDialect) -> Vec<&str> {
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -127,6 +127,7 @@ pub struct ShellBehaviorAt<'model> {
     shell: ShellDialect,
     zsh_options: Option<&'model ZshOptionState>,
     runtime_options: Option<ZshOptionState>,
+    zsh_sh_emulation: Option<bool>,
 }
 
 impl ShellBehaviorAt<'_> {
@@ -144,12 +145,18 @@ impl ShellBehaviorAt<'_> {
         self.shell
     }
 
+    /// Returns whether this offset is in zsh's `emulate sh`-style compatibility behavior.
+    pub fn zsh_sh_emulation(&self) -> bool {
+        self.shell == ShellDialect::Zsh && self.zsh_sh_emulation.unwrap_or(false)
+    }
+
     /// Creates behavior for a shell dialect without source-local option state.
     pub fn for_dialect(shell: ShellDialect) -> Self {
         Self {
             shell,
             zsh_options: None,
             runtime_options: None,
+            zsh_sh_emulation: None,
         }
     }
 
@@ -1035,12 +1042,20 @@ impl SemanticModel {
             .and_then(|analysis| analysis.options_at(&self.scopes, offset))
     }
 
+    /// Returns whether `offset` is in a definite zsh `emulate sh` region.
+    pub fn zsh_sh_emulation_at(&self, offset: usize) -> Option<bool> {
+        self.zsh_option_analysis
+            .as_ref()
+            .and_then(|analysis| analysis.sh_emulation_at(&self.scopes, offset))
+    }
+
     /// Returns option-sensitive shell behavior visible at `offset`.
     pub fn shell_behavior_at(&self, offset: usize) -> ShellBehaviorAt<'_> {
         ShellBehaviorAt {
             shell: self.shell_profile.dialect,
             zsh_options: self.zsh_options_at(offset),
             runtime_options: self.zsh_runtime_options_at(offset),
+            zsh_sh_emulation: self.zsh_sh_emulation_at(offset),
         }
     }
 

--- a/crates/shuck-semantic/src/nonpersistent.rs
+++ b/crates/shuck-semantic/src/nonpersistent.rs
@@ -2,8 +2,8 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Name, Span};
 
 use crate::{
-    Binding, BindingAttributes, BindingId, BindingKind, DeclarationBuiltin, ReferenceKind, ScopeId,
-    ScopeKind, SemanticModel,
+    Binding, BindingAttributes, BindingId, BindingKind, BuiltinCommandKind, CommandKind,
+    DeclarationBuiltin, ReferenceKind, ScopeId, ScopeKind, SemanticModel,
 };
 
 /// Options for nonpersistent assignment analysis.
@@ -11,6 +11,8 @@ use crate::{
 pub struct NonpersistentAssignmentAnalysisOptions {
     /// Whether Bash pipeline side effects should be treated as persistent.
     pub suppress_bash_pipefail_pipeline_side_effects: bool,
+    /// Whether later `return` operands must run in the same transient shell context.
+    pub require_return_use_same_execution_context: bool,
     /// Names that callers do not want analyzed for this effect.
     pub ignored_names: Vec<Name>,
 }
@@ -86,6 +88,7 @@ struct CandidateNonpersistentAssignment {
     binding_id: BindingId,
     effective_local: bool,
     enclosing_function_scope: Option<ScopeId>,
+    execution_context: Option<ScopeId>,
     assignment_span: Span,
     subshell_start: usize,
     subshell_end: usize,
@@ -168,6 +171,8 @@ impl SemanticModel {
                     binding_id: binding.id,
                     effective_local: binding_effectively_targets_local(self, binding),
                     enclosing_function_scope: self.enclosing_function_scope(binding.scope),
+                    execution_context: self
+                        .innermost_transient_scope_within_function(binding.scope),
                     assignment_span: binding.span,
                     subshell_start: nonpersistent_scope.span.start.offset,
                     subshell_end: nonpersistent_scope.span.end.offset,
@@ -291,6 +296,11 @@ impl SemanticModel {
                         candidate,
                         reference.span.start.offset,
                         reference_function_scope,
+                    )
+                    && self.return_later_use_allows_candidate(
+                        candidate,
+                        reference.span.start.offset,
+                        context.options.require_return_use_same_execution_context,
                     )
             }) {
                 effects.push(effect_for_candidate(
@@ -434,6 +444,35 @@ impl SemanticModel {
         });
 
         NonpersistentAssignmentAnalysis { effects }
+    }
+}
+
+impl SemanticModel {
+    fn return_later_use_allows_candidate(
+        &self,
+        candidate: &CandidateNonpersistentAssignment,
+        later_offset: usize,
+        require_same_execution_context: bool,
+    ) -> bool {
+        if !require_same_execution_context {
+            return true;
+        }
+        let Some(command_id) = self.innermost_command_id_at(later_offset) else {
+            return true;
+        };
+        if !matches!(
+            self.command_kind(command_id),
+            CommandKind::Builtin(BuiltinCommandKind::Return)
+        ) {
+            return true;
+        }
+        if self.shell_behavior_at(later_offset).zsh_sh_emulation() {
+            return true;
+        }
+
+        let later_scope = self.scope_at(later_offset);
+        let later_context = self.innermost_transient_scope_within_function(later_scope);
+        later_context == candidate.execution_context
     }
 }
 

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[derive(Debug, Clone)]
 pub(crate) struct ZshOptionAnalysis {
-    scope_entries: FxHashMap<ScopeId, ZshOptionState>,
+    scope_entries: FxHashMap<ScopeId, ZshOptionEntry>,
     snapshots: FxHashMap<ScopeId, Vec<ZshOptionSnapshot>>,
     /// Scopes sorted by `(span.start.offset ASC, span.end.offset DESC)` so a binary search by
     /// start offset followed by a backward walk yields the deepest containing scope under
@@ -43,7 +43,7 @@ struct ScopeIndexEntry {
 #[derive(Debug, Clone)]
 struct ZshOptionSnapshot {
     offset: usize,
-    state: ZshOptionState,
+    entry: ZshOptionEntry,
 }
 
 #[derive(Debug, Clone)]
@@ -99,6 +99,28 @@ struct InternalState {
     public: ZshOptionState,
     local_options: OptionValue,
     emulation: EmulationState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ZshOptionEntry {
+    public: ZshOptionState,
+    emulation: EmulationState,
+}
+
+impl ZshOptionEntry {
+    fn from_internal(state: &InternalState) -> Self {
+        Self {
+            public: state.public,
+            emulation: state.emulation,
+        }
+    }
+
+    fn merge(&self, other: &Self) -> Self {
+        Self {
+            public: self.public.merge(&other.public),
+            emulation: self.emulation.merge(other.emulation),
+        }
+    }
 }
 
 impl InternalState {
@@ -432,11 +454,7 @@ impl SharedFunctionSummaryCache {
 }
 
 impl ZshOptionAnalysis {
-    pub(crate) fn options_at<'a>(
-        &'a self,
-        scopes: &[Scope],
-        offset: usize,
-    ) -> Option<&'a ZshOptionState> {
+    fn entry_at<'a>(&'a self, scopes: &[Scope], offset: usize) -> Option<&'a ZshOptionEntry> {
         let upper = self
             .scope_index
             .partition_point(|entry| entry.start <= offset);
@@ -450,7 +468,7 @@ impl ZshOptionAnalysis {
             if let Some(snapshots) = self.snapshots.get(&scope_id) {
                 let upper = snapshots.partition_point(|snapshot| snapshot.offset <= offset);
                 if upper > 0 {
-                    return Some(&snapshots[upper - 1].state);
+                    return Some(&snapshots[upper - 1].entry);
                 }
             }
 
@@ -463,6 +481,19 @@ impl ZshOptionAnalysis {
 
         None
     }
+
+    pub(crate) fn options_at<'a>(
+        &'a self,
+        scopes: &[Scope],
+        offset: usize,
+    ) -> Option<&'a ZshOptionState> {
+        self.entry_at(scopes, offset).map(|entry| &entry.public)
+    }
+
+    pub(crate) fn sh_emulation_at(&self, scopes: &[Scope], offset: usize) -> Option<bool> {
+        self.entry_at(scopes, offset)
+            .map(|entry| entry.emulation.is_definitely_sh())
+    }
 }
 
 struct Analyzer<'a> {
@@ -471,7 +502,7 @@ struct Analyzer<'a> {
     dynamic_calls: DynamicCallAnalysisContext<'a>,
     recorded_program: &'a RecordedProgram,
     treat_unknown_dispatch_bindings_as_ambiguous_in_functions: bool,
-    scope_entries: FxHashMap<ScopeId, ZshOptionState>,
+    scope_entries: FxHashMap<ScopeId, ZshOptionEntry>,
     snapshots: FxHashMap<ScopeId, Vec<ZshOptionSnapshot>>,
     active_function_scopes: FxHashSet<ScopeId>,
     function_summaries: FxHashMap<FunctionSummaryKey, FunctionSummary>,
@@ -644,9 +675,9 @@ impl<'a> Analyzer<'a> {
         state: EvalState,
         leak: LeakBehavior,
     ) -> EvalState {
-        self.record_scope_entry(scope, state.current.public);
+        self.record_scope_entry(scope, &state.current);
         let recorded = self.recorded_program.command(command);
-        self.record_snapshot(scope, recorded.span.start.offset, state.current.public);
+        self.record_snapshot(scope, recorded.span.start.offset, &state.current);
         self.analyze_command(scope, command, state, leak)
     }
 
@@ -657,10 +688,10 @@ impl<'a> Analyzer<'a> {
         mut state: EvalState,
         leak: LeakBehavior,
     ) -> EvalState {
-        self.record_scope_entry(scope, state.current.public);
+        self.record_scope_entry(scope, &state.current);
         for &command in self.recorded_program.commands_in(commands) {
             let recorded = self.recorded_program.command(command);
-            self.record_snapshot(scope, recorded.span.start.offset, state.current.public);
+            self.record_snapshot(scope, recorded.span.start.offset, &state.current);
             state = self.analyze_command(scope, command, state, leak);
         }
         state
@@ -1182,18 +1213,20 @@ impl<'a> Analyzer<'a> {
         }
     }
 
-    fn record_scope_entry(&mut self, scope: ScopeId, state: ZshOptionState) {
+    fn record_scope_entry(&mut self, scope: ScopeId, state: &InternalState) {
+        let entry = ZshOptionEntry::from_internal(state);
         self.scope_entries
             .entry(scope)
-            .and_modify(|current| *current = current.merge(&state))
-            .or_insert(state);
+            .and_modify(|current| *current = current.merge(&entry))
+            .or_insert(entry);
     }
 
-    fn record_snapshot(&mut self, scope: ScopeId, offset: usize, state: ZshOptionState) {
+    fn record_snapshot(&mut self, scope: ScopeId, offset: usize, state: &InternalState) {
+        let entry = ZshOptionEntry::from_internal(state);
         let snapshots = self.snapshots.entry(scope).or_default();
         if let Some(last) = snapshots.last()
             && last.offset <= offset
-            && last.state == state
+            && last.entry == entry
         {
             return;
         }
@@ -1201,11 +1234,11 @@ impl<'a> Analyzer<'a> {
             .iter_mut()
             .find(|snapshot| snapshot.offset == offset)
         {
-            existing.state = existing.state.merge(&state);
+            existing.entry = existing.entry.merge(&entry);
             return;
         }
 
-        snapshots.push(ZshOptionSnapshot { offset, state });
+        snapshots.push(ZshOptionSnapshot { offset, entry });
     }
 }
 


### PR DESCRIPTION
## Summary

- Add zsh regressions for C150/C155 `retval` pairs where a subshell-local write was being matched to a later parent `return` operand.
- Thread a semantic option through nonpersistent assignment analysis so zsh return operands only pair with assignments in the same transient shell execution context.
- Keep the existing C150/C155 behavior for non-return reads and for non-zsh shells.

## Root Cause

The nonpersistent assignment analysis treated a later `return $name` like any other read. In nested zsh flows this could connect an assignment that only existed in a subshell copy to a parent-shell return operand, even though those `return` reads execute in a different shell context.

## Validation

- `cargo test -p shuck-linter zsh_status_capture_inside_subshell_is_not_connected_to_parent_return -- --nocapture` (failed before the fix, passed after)
- `cargo test -p shuck-linter zsh_subshell_loop_local_assignment_is_not_connected_to_parent_return -- --nocapture` (failed before the fix, passed after)
- `cargo fmt --all`
- `cargo test -p shuck-linter subshell_local_assignment -- --nocapture`
- `cargo test -p shuck-linter subshell_side_effect -- --nocapture`
- `cargo test -p shuck-linter facts::tests::assignments -- --nocapture`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter`
- `cargo run -q -p shuck-cli -- check --no-cache --isolated --extend-per-file-shell '/tmp/zsh/**/*.zsh:zsh' --select C150,C155 --output-format json-lines /tmp/zsh/zinit/zinit-install.zsh`
- `cargo run -q -p shuck-cli -- check --no-cache --isolated --extend-per-file-shell '/tmp/zsh/**/*.zsh:zsh' --select C150,C155 --output-format json-lines /tmp/zsh/zinit`