### PR TITLE
Fix C063 zsh function reachability

### DIFF
--- a/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/overwritten_function.rs
@@ -1,7 +1,7 @@
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 use compact_str::CompactString;
 use rustc_hash::{FxHashMap, FxHashSet};
-use shuck_ast::Name;
+use shuck_ast::{Name, static_word_text};
 use shuck_semantic::{
     BindingId, BindingKind, BindingOrigin, DirectFunctionCallReachability,
     DirectFunctionCallWindow, FunctionCallCandidate, FunctionCallPersistence,
@@ -283,22 +283,103 @@ fn build_compat_structural_facts(checker: &Checker<'_>) -> CompatStructuralFacts
     }
 }
 
-fn supplemental_function_call_candidates<'checker, 'model>(
-    checker: &'checker Checker<'model>,
-) -> impl Iterator<Item = FunctionCallCandidate> + 'checker {
-    checker
+fn supplemental_function_call_candidates(checker: &Checker<'_>) -> Vec<FunctionCallCandidate> {
+    let forwarding_wrappers = first_argument_forwarding_wrappers(checker);
+    let mut candidates = Vec::new();
+
+    for fact in checker
         .facts()
         .structural_commands()
         .filter(|fact| !matches!(fact.command(), shuck_ast::Command::Function(_)))
-        .filter_map(|fact| {
-            let callee = fact.effective_name()?;
-            Some(FunctionCallCandidate {
+    {
+        if let Some(callee) = fact.effective_name() {
+            candidates.push(FunctionCallCandidate {
                 callee: Name::from(callee),
                 scope: fact.scope(),
                 name_span: fact.body_span(),
-                command_span: fact.body_span(),
-            })
+                command_span: fact.span(),
+            });
+        }
+
+        if fact.effective_name().is_some_and(|name| {
+            wrapper_call_resolves_to_forwarding_binding(
+                checker,
+                &forwarding_wrappers,
+                Name::from(name),
+                fact.scope(),
+                fact.body_word_span(),
+                fact.span(),
+            )
+        }) && let Some(first_arg) = fact.body_args().first()
+            && let Some(callee) = static_word_text(first_arg, checker.source())
+        {
+            candidates.push(FunctionCallCandidate {
+                callee: Name::from(callee.as_ref()),
+                scope: fact.scope(),
+                name_span: first_arg.span,
+                command_span: fact.span(),
+            });
+        }
+    }
+
+    candidates
+}
+
+fn first_argument_forwarding_wrappers(checker: &Checker<'_>) -> FxHashMap<Name, Vec<BindingId>> {
+    let mut wrappers = FxHashMap::<Name, Vec<BindingId>>::default();
+    checker
+        .facts()
+        .function_headers()
+        .iter()
+        .filter_map(|header| {
+            let (name, _) = header.static_name_entry()?;
+            let binding_id = header.binding_id()?;
+            let function_scope = header.function_scope()?;
+            function_body_invokes_positional_arguments(checker, function_scope)
+                .then_some((name.clone(), binding_id))
         })
+        .for_each(|(name, binding_id)| wrappers.entry(name).or_default().push(binding_id));
+    wrappers
+}
+
+fn wrapper_call_resolves_to_forwarding_binding(
+    checker: &Checker<'_>,
+    forwarding_wrappers: &FxHashMap<Name, Vec<BindingId>>,
+    name: Name,
+    call_scope: ScopeId,
+    name_span: Option<shuck_ast::Span>,
+    command_span: shuck_ast::Span,
+) -> bool {
+    let Some(name_span) = name_span else {
+        return false;
+    };
+    forwarding_wrappers.get(&name).is_some_and(|bindings| {
+        bindings.iter().any(|binding_id| {
+            checker
+                .semantic_analysis()
+                .function_call_may_resolve_to_binding(
+                    *binding_id,
+                    call_scope,
+                    name_span,
+                    command_span,
+                )
+        })
+    })
+}
+
+fn function_body_invokes_positional_arguments(
+    checker: &Checker<'_>,
+    function_scope: ScopeId,
+) -> bool {
+    checker.facts().structural_commands().any(|fact| {
+        checker.semantic().enclosing_function_scope(fact.scope()) == Some(function_scope)
+            && fact.body_word_span().is_some_and(|span| {
+                matches!(
+                    span.slice(checker.source()),
+                    "$@" | "\"$@\"" | "${@}" | "\"${@}\"" | "$*" | "${*}"
+                )
+            })
+    })
 }
 
 fn build_direct_function_call_reachability<'checker, 'model>(
@@ -807,15 +888,8 @@ fn should_suppress_unreached(
         .rule_options()
         .c063
         .report_unreached_nested_definitions;
-
     matches!(binding.kind, BindingKind::Imported)
         || (matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
-            && has_apparent_infinite_loop_after(checker, binding.span.start.offset))
-        || (compat_mode
-            && matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
-            && has_top_level_return_after(checker, binding.span.start.offset))
-        || (compat_mode
-            && matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
             && last_script_terminator_offset_after(checker, binding.span.start.offset).is_some_and(
                 |terminator_offset| {
                     has_direct_call_to_binding_before_offset(
@@ -825,6 +899,16 @@ fn should_suppress_unreached(
                     )
                 },
             ))
+        || (matches!(
+            unreached.reason,
+            UnreachedFunctionReason::UnreachableDefinition
+        ) && !has_file_scope_termination_barrier_before(checker, binding.span.start.offset)
+            && has_direct_call_to_binding_before_offset(reach, unreached.binding, usize::MAX))
+        || (matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
+            && has_apparent_infinite_loop_after(checker, binding.span.start.offset))
+        || (compat_mode
+            && matches!(unreached.reason, UnreachedFunctionReason::ScriptTerminates)
+            && has_top_level_return_after(checker, binding.span.start.offset))
         || (matches!(
             unreached.reason,
             UnreachedFunctionReason::EnclosingFunctionUnreached
@@ -860,6 +944,42 @@ fn last_script_terminator_offset_after(
                 .then_some(offset)
         })
         .max()
+}
+
+fn has_file_scope_script_terminator_before(checker: &Checker<'_>, before_offset: usize) -> bool {
+    let cfg = checker.semantic_analysis().cfg();
+    let unreachable = cfg.unreachable().iter().copied().collect::<FxHashSet<_>>();
+    cfg.script_terminators()
+        .iter()
+        .filter(|block_id| !unreachable.contains(block_id))
+        .flat_map(|block_id| cfg.block(*block_id).commands.iter())
+        .any(|span| {
+            let offset = span.start.offset;
+            offset < before_offset
+                && checker
+                    .facts()
+                    .innermost_command_at(offset)
+                    .map(|fact| scope_is_file_scope(checker, fact.scope()))
+                    .unwrap_or_else(|| {
+                        scope_is_file_scope(checker, checker.semantic().scope_at(offset))
+                    })
+        })
+}
+
+fn has_file_scope_termination_barrier_before(checker: &Checker<'_>, before_offset: usize) -> bool {
+    has_file_scope_script_terminator_before(checker, before_offset)
+        || has_file_scope_return_before(checker, before_offset)
+}
+
+fn has_file_scope_return_before(checker: &Checker<'_>, before_offset: usize) -> bool {
+    checker.facts().structural_commands().any(|fact| {
+        let offset = fact.body_span().start.offset;
+        offset < before_offset
+            && fact.effective_name_is("return")
+            && scope_is_file_scope(checker, fact.scope())
+            && !command_offset_is_under_dominance_barrier(checker, offset)
+            && !command_offset_is_unreachable(checker, offset)
+    })
 }
 
 fn has_top_level_return_after(checker: &Checker<'_>, after_offset: usize) -> bool {
@@ -2177,6 +2297,235 @@ exit 0
     }
 
     #[test]
+    fn later_anonymous_function_call_reaches_transitive_helpers_before_exit() {
+        let source = "\
+function run_command() {
+  :
+}
+
+function install_font() {
+  run_command
+}
+
+function ask_font() {
+  install_font
+}
+
+() {
+  ask_font
+  exit
+}
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn later_anonymous_function_call_reaches_conditional_helpers_before_exit() {
+        let source = "\
+if [[ $OSTYPE == cygwin ]]; then
+  function flock() {
+    :
+  }
+else
+  function flock() {
+    :
+  }
+fi
+
+function build() {
+  flock
+}
+
+function mbuild() {
+  build
+}
+
+() {
+  mbuild \"$@\"
+  exit
+}
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/mbuild.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn large_file_reachability_suppresses_later_body_calls_before_exit() {
+        let mut source = String::new();
+        for i in 0..205 {
+            source.push_str(&format!("function filler_{i}() {{ :; }}\n"));
+        }
+        source.push_str(
+            "\
+function helper() {
+  :
+}
+
+function driver() {
+  helper
+}
+
+driver
+exit
+",
+        );
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/large.zsh"),
+            &source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn first_argument_forwarding_wrapper_reaches_function_chain_before_exit() {
+        let source = "\
+function flock() {
+  :
+}
+
+function build() {
+  flock
+}
+
+function mbuild() {
+  build
+}
+
+function run_process_tree() {
+  \"$@\"
+}
+
+run_process_tree mbuild \"$@\"
+exit
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/mbuild.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn quoted_star_wrapper_does_not_reach_first_argument() {
+        let source = "\
+function helper() {
+  :
+}
+
+function other() {
+  :
+}
+
+function run_quoted_star() {
+  \"$*\"
+}
+
+function run_quoted_braced_star() {
+  \"${*}\"
+}
+
+run_quoted_star helper arg
+run_quoted_braced_star other arg
+exit
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.start.line == 1),
+            "diagnostics: {diagnostics:?}"
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.start.line == 5),
+            "diagnostics: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn nested_forwarding_body_does_not_make_outer_function_a_wrapper() {
+        let source = "\
+function helper() {
+  :
+}
+
+function outer() {
+  function inner() {
+    \"$@\"
+  }
+}
+
+outer helper
+exit
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.start.line == 1),
+            "diagnostics: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn redefined_forwarding_wrapper_does_not_reach_first_argument() {
+        let source = "\
+function helper() {
+  :
+}
+
+function run_wrapper() {
+  \"$@\"
+}
+
+function run_wrapper() {
+  :
+}
+
+run_wrapper helper
+exit
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.start.line == 1),
+            "diagnostics: {diagnostics:?}"
+        );
+    }
+
+    #[test]
     fn direct_calls_before_script_termination_do_not_report() {
         let source = "\
 myfunc() { echo hi; }
@@ -2207,6 +2556,69 @@ myfunc() { echo hi; }
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::OverwrittenFunction);
         assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn unreachable_function_definitions_report_despite_later_unreachable_body_call() {
+        let source = "\
+exit 0
+helper() { echo hi; }
+driver() { helper; }
+driver
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.start.line == 2),
+            "diagnostics: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn unreachable_function_definitions_report_after_sourceable_return() {
+        let source = "\
+return 2>/dev/null
+helper() { echo hi; }
+driver() { helper; }
+driver
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.span.start.line == 2),
+            "diagnostics: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn conditional_file_scope_return_does_not_block_later_body_call() {
+        let source = "\
+if cond; then
+  return 1
+fi
+helper() { echo hi; }
+driver() { helper; }
+driver
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::OverwrittenFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
 
     #[test]

--- a/crates/shuck-semantic/src/function_call_reachability.rs
+++ b/crates/shuck-semantic/src/function_call_reachability.rs
@@ -743,7 +743,7 @@ impl<'analysis, 'model> DirectFunctionCallReachability<'analysis, 'model> {
     }
 
     fn enclosing_function_scope(&self, scope: ScopeId) -> Option<ScopeId> {
-        self.model().enclosing_function_scope(scope)
+        self.analysis.enclosing_function_scope(scope)
     }
 
     fn call_is_inside_scope(&self, scope: ScopeId, ancestor_scope: ScopeId) -> bool {

--- a/crates/shuck-semantic/src/reachability.rs
+++ b/crates/shuck-semantic/src/reachability.rs
@@ -166,6 +166,45 @@ impl<'model> SemanticAnalysis<'model> {
                             .ancestor_scopes(call_scope)
                             .any(|scope| scope == other_binding.scope)
                 });
+        let unreachable = self.unreachable_blocks();
+        let shadow_blocks =
+            self.shadow_function_blocks_from_cfg(&binding.name, binding_id, unreachable);
+        if !shadow_blocks.is_empty()
+            && self
+                .model
+                .ancestor_scopes(call_scope)
+                .any(|scope| scope == binding.scope)
+            && let Some(function_scope) = self.enclosing_function_scope(call_scope)
+            && function_scope != binding.scope
+        {
+            let binding_blocks = self
+                .blocks_containing_binding(binding_id)
+                .iter()
+                .copied()
+                .filter(|block| !unreachable.contains(block))
+                .collect::<Vec<_>>();
+            if binding_blocks.is_empty() {
+                return false;
+            }
+            if self.binding_can_reach_natural_exit_avoiding_shadow(
+                &binding_blocks,
+                &shadow_blocks,
+                unreachable,
+                &FxHashSet::default(),
+            ) {
+                return true;
+            }
+            let empty_script_terminators = FxHashSet::default();
+            let mut visiting_scopes = FxHashSet::default();
+            return self.function_scope_can_run_on_path_before_shadow(
+                function_scope,
+                &binding_blocks,
+                &shadow_blocks,
+                unreachable,
+                &empty_script_terminators,
+                &mut visiting_scopes,
+            );
+        }
         if !has_visible_shadow {
             return true;
         }
@@ -179,7 +218,6 @@ impl<'model> SemanticAnalysis<'model> {
 
         let mut avoid = self.shadow_function_blocks_for_binding(binding_id);
         avoid.extend(self.cfg().script_terminators().iter().copied());
-        let unreachable = self.unreachable_blocks();
         let binding_blocks = self
             .blocks_containing_binding(binding_id)
             .iter()
@@ -198,6 +236,142 @@ impl<'model> SemanticAnalysis<'model> {
         }
 
         self.blocks_have_path_avoiding(&binding_blocks, &call_blocks, &avoid)
+    }
+
+    fn binding_can_reach_natural_exit_avoiding_shadow(
+        &self,
+        binding_blocks: &[BlockId],
+        shadow_blocks: &FxHashSet<BlockId>,
+        unreachable: &FxHashSet<BlockId>,
+        script_terminators: &FxHashSet<BlockId>,
+    ) -> bool {
+        if shadow_blocks.is_empty() {
+            return true;
+        }
+        let mut endpoints = self
+            .cfg()
+            .natural_exits()
+            .iter()
+            .copied()
+            .filter(|block| !unreachable.contains(block))
+            .collect::<Vec<_>>();
+        let shadow_offset = shadow_blocks
+            .iter()
+            .flat_map(|block| block_min_offset(self.cfg().block(*block), self.model))
+            .max();
+        if let Some(shadow_offset) = shadow_offset {
+            endpoints.extend(self.cfg().blocks().iter().filter_map(|block| {
+                (!unreachable.contains(&block.id)
+                    && !shadow_blocks.contains(&block.id)
+                    && block_min_offset(block, self.model)
+                        .is_some_and(|offset| offset > shadow_offset))
+                .then_some(block.id)
+            }));
+        }
+        endpoints.sort_by_key(|block| block.index());
+        endpoints.dedup();
+        !endpoints.is_empty()
+            && blocks_have_path_avoiding_many(
+                self.cfg(),
+                binding_blocks,
+                &endpoints,
+                shadow_blocks,
+                script_terminators,
+            )
+    }
+
+    fn function_scope_can_run_on_path_before_shadow(
+        &self,
+        function_scope: ScopeId,
+        binding_blocks: &[BlockId],
+        shadow_blocks: &FxHashSet<BlockId>,
+        unreachable: &FxHashSet<BlockId>,
+        script_terminators: &FxHashSet<BlockId>,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        if !visiting_scopes.insert(function_scope) {
+            return false;
+        }
+        let can_run = self
+            .model
+            .recorded_program
+            .function_body_scopes
+            .iter()
+            .filter_map(|(function_binding, body_scope)| {
+                (*body_scope == function_scope).then_some(*function_binding)
+            })
+            .any(|function_binding| {
+                let function = self.model.binding(function_binding);
+                self.model
+                    .call_sites_for(&function.name)
+                    .iter()
+                    .any(|caller| {
+                        self.call_site_can_run_on_path_before_shadow(
+                            &function.name,
+                            caller,
+                            function_binding,
+                            function.span.start.offset,
+                            binding_blocks,
+                            shadow_blocks,
+                            unreachable,
+                            script_terminators,
+                            visiting_scopes,
+                        )
+                    })
+            });
+        visiting_scopes.remove(&function_scope);
+        can_run
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn call_site_can_run_on_path_before_shadow(
+        &self,
+        function_name: &Name,
+        caller: &CallSite,
+        function_binding: BindingId,
+        function_offset: usize,
+        binding_blocks: &[BlockId],
+        shadow_blocks: &FxHashSet<BlockId>,
+        unreachable: &FxHashSet<BlockId>,
+        script_terminators: &FxHashSet<BlockId>,
+        visiting_scopes: &mut FxHashSet<ScopeId>,
+    ) -> bool {
+        if !self.overwrite_call_site_resolves_to_binding(function_name, caller, function_binding)
+            || !self.call_site_can_execute_after_function_definition(caller, function_offset)
+        {
+            return false;
+        }
+
+        let caller_blocks = self.reachable_call_site_blocks_in_cfg(self.cfg(), caller, unreachable);
+        if caller_blocks.is_empty() {
+            return false;
+        }
+
+        let Some(caller_function_scope) = self.enclosing_function_scope(caller.scope) else {
+            return blocks_have_path_avoiding_many(
+                self.cfg(),
+                binding_blocks,
+                &caller_blocks,
+                shadow_blocks,
+                script_terminators,
+            );
+        };
+        let Some(scope_entry) = self.cfg().scope_entry(caller_function_scope) else {
+            return false;
+        };
+        blocks_have_path_avoiding(
+            self.cfg(),
+            &[scope_entry],
+            &caller_blocks,
+            script_terminators,
+        ) && self.function_scope_can_run_on_path_before_shadow(
+            caller_function_scope,
+            binding_blocks,
+            shadow_blocks,
+            unreachable,
+            script_terminators,
+            visiting_scopes,
+        )
     }
 
     fn overwrite_call_site_resolves_to_binding(
@@ -875,12 +1049,70 @@ impl<'model> SemanticAnalysis<'model> {
             return false;
         }
 
-        if site.scope == binding.scope
-            || self
-                .model
-                .ancestor_scopes(site.scope)
-                .any(|scope| scope == binding.scope)
+        if site.scope == binding.scope {
+            let binding_blocks: Vec<BlockId> = self
+                .blocks_containing_binding(binding_id)
+                .iter()
+                .copied()
+                .filter(|block| !unreachable.contains(block))
+                .collect();
+            if binding_blocks.is_empty() {
+                return false;
+            }
+            let shadow_blocks = self.shadow_function_blocks_from_cfg(name, binding_id, unreachable);
+            return blocks_have_path_avoiding_many(
+                cfg,
+                &binding_blocks,
+                &site_blocks,
+                &shadow_blocks,
+                script_terminators,
+            );
+        }
+
+        if self
+            .model
+            .ancestor_scopes(site.scope)
+            .any(|scope| scope == binding.scope)
         {
+            if let Some(function_scope) = self.enclosing_function_scope(site.scope)
+                && function_scope != binding.scope
+            {
+                let Some(scope_entry) = cfg.scope_entry(function_scope) else {
+                    return false;
+                };
+                if !blocks_have_path_avoiding(cfg, &[scope_entry], &site_blocks, script_terminators)
+                {
+                    return false;
+                }
+                let binding_blocks: Vec<BlockId> = self
+                    .blocks_containing_binding(binding_id)
+                    .iter()
+                    .copied()
+                    .filter(|block| !unreachable.contains(block))
+                    .collect();
+                if binding_blocks.is_empty() {
+                    return false;
+                }
+                let shadow_blocks =
+                    self.shadow_function_blocks_from_cfg(name, binding_id, unreachable);
+                if self.binding_can_reach_natural_exit_avoiding_shadow(
+                    &binding_blocks,
+                    &shadow_blocks,
+                    unreachable,
+                    script_terminators,
+                ) {
+                    return true;
+                }
+                return self.function_scope_can_run_on_path_before_shadow(
+                    function_scope,
+                    &binding_blocks,
+                    &shadow_blocks,
+                    unreachable,
+                    script_terminators,
+                    &mut FxHashSet::default(),
+                );
+            }
+
             let binding_blocks: Vec<BlockId> = self
                 .blocks_containing_binding(binding_id)
                 .iter()
@@ -1465,6 +1697,20 @@ fn blocks_have_path_avoiding(
             .copied()
             .any(|end| block_reaches_avoiding(cfg, start, end, avoid))
     })
+}
+
+fn block_min_offset(block: &BasicBlock, model: &SemanticModel) -> Option<usize> {
+    block
+        .commands
+        .iter()
+        .map(|span| span.start.offset)
+        .chain(
+            block
+                .bindings
+                .iter()
+                .map(|binding| model.binding(*binding).span.start.offset),
+        )
+        .min()
 }
 
 fn blocks_have_path_avoiding_many(

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -2680,6 +2680,32 @@ target
 }
 
 #[test]
+fn function_call_reachability_blocks_prior_binding_called_from_later_wrapper() {
+    let source = "\
+target() { : old; }
+wrapper() {
+  target
+}
+target() { : new; }
+wrapper
+";
+    let model = model(source);
+    let first = function_binding_id(&model, "target", 0);
+    let second = function_binding_id(&model, "target", 1);
+    let analysis = model.analysis();
+    let mut reachability = analysis.direct_function_call_reachability(Vec::new());
+
+    assert!(!reachability.binding_has_reachable_direct_call(
+        first,
+        DirectFunctionCallWindow::before_offset(source.len())
+    ));
+    assert!(reachability.binding_has_reachable_direct_call(
+        second,
+        DirectFunctionCallWindow::before_offset(source.len())
+    ));
+}
+
+#[test]
 fn function_call_reachability_uses_supplemental_call_candidates() {
     let source = "\
 target() { :; }


### PR DESCRIPTION
## Summary
- teach C063 reachability to follow later direct function-body calls back to reachable function definitions
- preserve script-terminator cutoffs so calls only appearing after termination still report
- add zsh regressions for later anonymous calls, conditional helper chains, large-file fallback behavior, and first-argument forwarding wrappers

## Verification
- `cargo fmt --check`
- `cargo test -p shuck-linter overwritten_function -- --nocapture`
- `cargo test -p shuck-semantic unreached_functions -- --nocapture`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter`
- `cargo run -q -p shuck-cli -- check --isolated --no-cache --select C063 --output-format concise --exit-zero /tmp/zsh/powerlevel10k/internal/wizard.zsh /tmp/zsh/powerlevel10k/gitstatus/mbuild`

## Target corpus result
The cited false positives cleared:
- `/tmp/zsh/powerlevel10k/internal/wizard.zsh:489` `run_command`
- `/tmp/zsh/powerlevel10k/internal/wizard.zsh:507` `install_font`
- `/tmp/zsh/powerlevel10k/gitstatus/mbuild:279/301` `flock`
- `/tmp/zsh/powerlevel10k/gitstatus/mbuild:307` `build`

The targeted two-file C063 run still reports five unrelated `print_*` functions in `wizard.zsh`.