### PR TITLE
fix(semantic): bound zsh runtime summary reuse

### DIFF
--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -11314,3 +11314,35 @@ h() {
         ArrayReferencePolicy::Ambiguous
     );
 }
+
+#[test]
+fn semantic_runtime_zsh_option_summary_cache_keeps_recursive_context_local() {
+    let source = "\
+unsetopt ksh_arrays
+f() {
+  g
+  setopt ksh_arrays
+}
+g() {
+  f
+}
+f
+unsetopt ksh_arrays
+g
+print $name
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+    let offset = source.find("print $name").unwrap();
+
+    assert!(
+        model
+            .shell_behavior_at(offset)
+            .zsh_options()
+            .is_some_and(|options| options.ksh_arrays == OptionValue::On),
+        "{source}"
+    );
+    assert_eq!(
+        array_reference_policy_at(&model, offset),
+        ArrayReferencePolicy::RequiresExplicitSelector
+    );
+}

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -56,6 +56,7 @@ struct FunctionSummary {
 struct FunctionSummaryKey {
     scope: ScopeId,
     entry: InternalState,
+    active_function_scopes: SmallVec<[ScopeId; 4]>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -931,6 +932,7 @@ impl<'a> Analyzer<'a> {
         let cache_key = FunctionSummaryKey {
             scope,
             entry: entry.current.clone(),
+            active_function_scopes: self.active_function_summary_context(),
         };
         let recursive_context = !self.active_function_scopes.is_empty();
         if let Some(summary) = self.function_summaries.get(&cache_key) {
@@ -962,6 +964,13 @@ impl<'a> Analyzer<'a> {
             shared_summaries.insert(cache_key, summary.clone());
         }
         summary
+    }
+
+    fn active_function_summary_context(&self) -> SmallVec<[ScopeId; 4]> {
+        let mut active: SmallVec<[ScopeId; 4]> =
+            self.active_function_scopes.iter().copied().collect();
+        active.sort_by_key(|scope| scope.0);
+        active
     }
 
     fn resolve_visible_function_scope(

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -56,7 +56,6 @@ struct FunctionSummary {
 struct FunctionSummaryKey {
     scope: ScopeId,
     entry: InternalState,
-    active_scopes: SmallVec<[ScopeId; 4]>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -929,11 +928,16 @@ impl<'a> Analyzer<'a> {
             };
         }
 
-        let cache_key = self.function_summary_key(scope, &entry.current);
+        let cache_key = FunctionSummaryKey {
+            scope,
+            entry: entry.current.clone(),
+        };
+        let recursive_context = !self.active_function_scopes.is_empty();
         if let Some(summary) = self.function_summaries.get(&cache_key) {
             return summary.clone();
         }
-        if allow_shared_reuse
+        if !recursive_context
+            && allow_shared_reuse
             && let Some(summary) = self
                 .shared_function_summaries
                 .and_then(|summaries| summaries.get(&cache_key))
@@ -952,21 +956,12 @@ impl<'a> Analyzer<'a> {
         };
         self.function_summaries
             .insert(cache_key.clone(), summary.clone());
-        if let Some(shared_summaries) = self.shared_function_summaries {
+        // Recursive-context summaries are useful inside this analyzer, but they may have cut a
+        // call through `active_function_scopes`, so do not publish them across root analyses.
+        if !recursive_context && let Some(shared_summaries) = self.shared_function_summaries {
             shared_summaries.insert(cache_key, summary.clone());
         }
         summary
-    }
-
-    fn function_summary_key(&self, scope: ScopeId, entry: &InternalState) -> FunctionSummaryKey {
-        let mut active_scopes: SmallVec<[ScopeId; 4]> =
-            self.active_function_scopes.iter().copied().collect();
-        active_scopes.sort_by_key(|scope| scope.index());
-        FunctionSummaryKey {
-            scope,
-            entry: entry.clone(),
-            active_scopes,
-        }
     }
 
     fn resolve_visible_function_scope(


### PR DESCRIPTION
## Summary

- Remove `active_scopes` from the zsh runtime function-summary cache key to avoid recursive cache-context explosion
- Keep local analyzer memoization for recursive contexts, but do not publish recursion-cut summaries into the shared cross-root cache
- Preserve the existing recursion guard behavior for active function calls

## Regression

On current `main`, profiling `romkatv__powerlevel10k__internal__p10k.zsh` exposed a runaway zsh runtime option analysis path:

- 1 direct iteration timed out at 90s and grew to roughly 30GB RSS
- 12-iteration sampled run had to be killed after growing much larger
- Stack sample was dominated by `zsh_options::Analyzer::analyze_function_scope_with_shared_summary_reuse` under `SemanticModel::shell_behavior_at` while building linter facts

After this fix:

- 1 direct iteration completes in 119.266ms with about 156MB max RSS
- Warm sampled profile completes at 108.396ms avg over 12 iterations

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-semantic zsh_option --lib`
- `cargo test -p shuck-linter array_to_string_conversion --lib`
- `cargo test -p shuck-linter quoted_bash_source --lib`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C100,C133,C150,C155`
  - `blocking=0`
  - `implementation_diffs=0`
  - `harness_failures=0`