### PR TITLE
[codex] fix zsh alias C005 literals

### DIFF
--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -1009,7 +1009,7 @@ pub(super) fn single_quoted_literal_exempt_argument(
     };
 
     match command_name {
-        "alias" => static_word_text(word, source).is_some_and(|text| text.contains('=')),
+        "alias" => alias_definition_argument(word, source),
         "builtin" if shell_dialect == shuck_parser::ShellDialect::Zsh => {
             zsh_builtin_dynamic_wrapper_argument(body_args, relative_arg_index, word, source)
         }
@@ -1068,6 +1068,11 @@ pub(super) fn single_quoted_literal_exempt_argument(
         }
         _ => false,
     }
+}
+
+fn alias_definition_argument(word: &Word, source: &str) -> bool {
+    static_word_text(word, source).is_some_and(|text| text.contains('='))
+        || word_contains_literal_equals(word, source)
 }
 
 fn gh_graphql_query_argument(args: &[Word], relative_arg_index: usize, word: &Word, source: &str) -> bool {

--- a/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
+++ b/crates/shuck-linter/src/rules/correctness/single_quoted_literal.rs
@@ -469,6 +469,9 @@ mod tests {
     #[test]
     fn corpus_regression_alias_wrapper_is_exempt() {
         assert_eq!(c005("alias hosts='sudo $EDITOR /etc/hosts'\n"), 0);
+        assert_eq!(c005_zsh("alias -s $ft='$BROWSER'\n"), 0);
+        assert_eq!(c005_zsh("alias -s $ft '$BROWSER'\n"), 1);
+        assert_eq!(c005_zsh("alias ${name:=foo}'$HOME'\n"), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat zsh `alias` definition operands with dynamic names as delayed-eval literal contexts for C005
- keep non-definition alias arguments reportable so arbitrary single-quoted strings are not blanket-exempted
- add focused regression coverage for `alias -s $ft='$BROWSER'`

## Root Cause
C005 already exempted alias definitions when the whole operand could be decoded statically, such as `alias hosts='sudo $EDITOR /etc/hosts'`. In zsh suffix aliases like `alias -s $ft='$BROWSER'`, the dynamic alias name makes the operand non-static, so the single-quoted RHS was incorrectly treated as a literal shell bug instead of delayed alias text.

## Validation
- `cargo test -p shuck-linter corpus_regression_alias_wrapper_is_exempt -- --nocapture` failed before the fix and passes after it
- `cargo test -p shuck-linter rules::correctness::single_quoted_literal -- --nocapture`
- `cargo test -p shuck-linter`
- `cargo fmt`
- `target/debug/shuck check --no-cache --output-format json-lines /tmp/zsh/ohmyzsh/plugins/common-aliases/common-aliases.plugin.zsh`

## Corpus Note
The targeted `common-aliases.plugin.zsh` suffix-alias C005 rows at lines 60, 64, and 68 now clear. Other residual C005 buckets remain intentionally out of scope.