### PR TITLE
perf(linter): cache ambient contract signals

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts/mod.rs
+++ b/crates/shuck-linter/src/ambient_contracts/mod.rs
@@ -38,6 +38,7 @@ use shuck_semantic::{FileContract, FileEntryContractCollector};
 use crate::ShellDialect;
 
 mod path;
+mod signals;
 mod source_scan;
 mod sourced_runtime;
 #[cfg(test)]
@@ -49,14 +50,14 @@ mod zsh_paths;
 mod zsh_runtime;
 
 struct AmbientContractProvider {
-    matches: fn(&AmbientContractCollector<'_>, &Path, ShellDialect) -> bool,
-    build: fn(&AmbientContractCollector<'_>, &Path, ShellDialect) -> FileContract,
+    matches: fn(&AmbientContractCollector<'_>, ShellDialect) -> bool,
+    build: fn(&AmbientContractCollector<'_>, ShellDialect) -> FileContract,
 }
 
 pub(crate) struct AmbientContractCollector<'a> {
     source: &'a str,
-    path: Option<&'a Path>,
     shell: ShellDialect,
+    signals: signals::AmbientSignals<'a>,
     completion_initializer_invoked: bool,
     caller_scoped_array_length_names: BTreeSet<Name>,
 }
@@ -73,26 +74,36 @@ impl<'a> AmbientContractCollector<'a> {
 
         Self {
             source,
-            path,
             shell,
+            signals: signals::AmbientSignals::new(source, path),
             completion_initializer_invoked: false,
             caller_scoped_array_length_names,
         }
     }
 
     fn file_entry_contract(&self) -> Option<FileContract> {
-        let path = self.path?;
+        self.signals.path()?;
         let mut merged = FileContract::default();
         let mut matched = false;
 
         for provider in providers() {
-            if (provider.matches)(self, path, self.shell) {
+            if (provider.matches)(self, self.shell) {
                 matched = true;
-                merge_contract(&mut merged, (provider.build)(self, path, self.shell));
+                merge_contract(&mut merged, (provider.build)(self, self.shell));
             }
         }
 
         matched.then_some(merged)
+    }
+
+    fn source_signals(&self) -> &signals::SourceSignals<'a> {
+        self.signals.source()
+    }
+
+    fn path_signals(&self) -> &signals::PathSignals {
+        self.signals
+            .path()
+            .expect("ambient contracts are only built for path-backed files")
     }
 }
 

--- a/crates/shuck-linter/src/ambient_contracts/path.rs
+++ b/crates/shuck-linter/src/ambient_contracts/path.rs
@@ -4,12 +4,6 @@
 //! providers are heuristics for repository layout conventions, not filesystem
 //! identity checks.
 
-use std::path::Path;
-
-pub(super) fn lower_path(path: &Path) -> String {
-    path.to_string_lossy().to_ascii_lowercase()
-}
-
 pub(super) fn path_matches_any(lower_path: &str, patterns: &[&str]) -> bool {
     patterns.iter().any(|pattern| lower_path.contains(pattern))
 }

--- a/crates/shuck-linter/src/ambient_contracts/signals.rs
+++ b/crates/shuck-linter/src/ambient_contracts/signals.rs
@@ -372,4 +372,18 @@ mod tests {
         assert!(signals.assigns_name("HISTFILE"));
         assert!(signals.assigns_name("HISTSIZE"));
     }
+
+    #[test]
+    fn zmodload_signal_ignores_separator_comments() {
+        let signals = SourceSignals::new("true;# zmodload zsh/parameter\n");
+
+        assert!(!signals.loads_zsh_module("zsh/parameter"));
+    }
+
+    #[test]
+    fn zmodload_signal_keeps_executed_segments_after_separators() {
+        let signals = SourceSignals::new("true; zmodload zsh/parameter\n");
+
+        assert!(signals.loads_zsh_module("zsh/parameter"));
+    }
 }

--- a/crates/shuck-linter/src/ambient_contracts/signals.rs
+++ b/crates/shuck-linter/src/ambient_contracts/signals.rs
@@ -1,0 +1,375 @@
+//! Cached source and path signals shared by ambient contract providers.
+//!
+//! Ambient providers are intentionally heuristic: they answer questions such as
+//! "does this zsh-shaped file mention `$history`?" or "does this config file
+//! assign `POWERLEVEL9K_...` names?" The old provider code answered those
+//! questions with repeated raw `contains()` and line scans. `AmbientSignals`
+//! centralizes the one-file facts that are cheap to compute once and expensive
+//! to rediscover for each provider.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+
+use super::source_scan::{code_before_shell_comment, parse_shell_name_at};
+
+pub(super) struct AmbientSignals<'a> {
+    source: SourceSignals<'a>,
+    path: Option<PathSignals>,
+}
+
+impl<'a> AmbientSignals<'a> {
+    pub(super) fn new(source: &'a str, path: Option<&Path>) -> Self {
+        Self {
+            source: SourceSignals::new(source),
+            path: path.map(PathSignals::new),
+        }
+    }
+
+    pub(super) fn source(&self) -> &SourceSignals<'a> {
+        &self.source
+    }
+
+    pub(super) fn path(&self) -> Option<&PathSignals> {
+        self.path.as_ref()
+    }
+}
+
+pub(super) struct PathSignals {
+    lower_path: String,
+}
+
+impl PathSignals {
+    fn new(path: &Path) -> Self {
+        Self {
+            lower_path: path.to_string_lossy().to_ascii_lowercase(),
+        }
+    }
+
+    pub(super) fn lower_path(&self) -> &str {
+        &self.lower_path
+    }
+
+    pub(super) fn contains(&self, pattern: &str) -> bool {
+        self.lower_path.contains(pattern)
+    }
+
+    pub(super) fn matches_any(&self, patterns: &[&str]) -> bool {
+        patterns.iter().any(|pattern| self.contains(pattern))
+    }
+
+    pub(super) fn file_name(&self) -> &str {
+        self.lower_path
+            .rsplit('/')
+            .next()
+            .unwrap_or(&self.lower_path)
+    }
+}
+
+pub(super) struct SourceSignals<'a> {
+    source: &'a str,
+    mentioned_names: BTreeSet<String>,
+    assigned_names: BTreeSet<String>,
+    code_lines: Vec<&'a str>,
+    zmodload_lines: Vec<&'a str>,
+    has_probable_function_definition: bool,
+    has_source_command: bool,
+    loads_zsh_colors: bool,
+}
+
+impl<'a> SourceSignals<'a> {
+    fn new(source: &'a str) -> Self {
+        let mut code_lines = Vec::new();
+        let mut zmodload_lines = Vec::new();
+        let mut has_probable_function_definition = false;
+        let mut has_source_command = false;
+        let mut loads_zsh_colors = false;
+
+        for line in source.lines() {
+            let code = code_before_shell_comment(line);
+            let trimmed = code.trim();
+            let trim_start = code.trim_start();
+            code_lines.push(trimmed);
+            has_probable_function_definition |= probable_function_definition(trimmed);
+            has_source_command |= source_command_line(trimmed);
+            loads_zsh_colors |= line_autoloads_zsh_colors(trim_start);
+            if code.contains("zmodload") {
+                zmodload_lines.push(code);
+            }
+        }
+
+        Self {
+            source,
+            mentioned_names: collect_parameter_mentions(source),
+            assigned_names: collect_assignment_names(source),
+            code_lines,
+            zmodload_lines,
+            has_probable_function_definition,
+            has_source_command,
+            loads_zsh_colors,
+        }
+    }
+
+    pub(super) fn contains(&self, pattern: &str) -> bool {
+        self.source.contains(pattern)
+    }
+
+    pub(super) fn mentions_name(&self, name: &str) -> bool {
+        self.mentioned_names.contains(name)
+    }
+
+    pub(super) fn mentions_any(&self, names: &[&str]) -> bool {
+        names.iter().any(|name| self.mentions_name(name))
+    }
+
+    pub(super) fn assigns_name(&self, name: &str) -> bool {
+        self.assigned_names.contains(name)
+    }
+
+    pub(super) fn has_probable_function_definition(&self) -> bool {
+        self.has_probable_function_definition
+    }
+
+    pub(super) fn has_source_command(&self) -> bool {
+        self.has_source_command
+    }
+
+    pub(super) fn loads_zsh_module(&self, module: &str) -> bool {
+        self.zmodload_lines.iter().any(|code| code.contains(module))
+    }
+
+    pub(super) fn loads_zsh_colors(&self) -> bool {
+        self.loads_zsh_colors
+    }
+
+    pub(super) fn static_assignment_value(&self, name: &str) -> Option<String> {
+        for code in &self.code_lines {
+            let Some(rest) = code.strip_prefix(name) else {
+                continue;
+            };
+            let rest = rest.trim_start();
+            let Some(value) = rest.strip_prefix('=') else {
+                continue;
+            };
+            let value = value.trim_start();
+            if value.is_empty() {
+                continue;
+            }
+
+            let (raw_value, quoted) = if let Some(rest) = value.strip_prefix('"') {
+                (rest.split('"').next()?, true)
+            } else if let Some(rest) = value.strip_prefix('\'') {
+                (rest.split('\'').next()?, true)
+            } else {
+                (
+                    value
+                        .split(|ch: char| ch.is_whitespace() || ch == ';')
+                        .next()?,
+                    false,
+                )
+            };
+
+            if raw_value.is_empty() || raw_value.contains('$') {
+                continue;
+            }
+            if quoted || is_shell_variable_name(raw_value) {
+                return Some(raw_value.to_owned());
+            }
+        }
+
+        None
+    }
+
+    pub(super) fn defines_function(&self, name: &str) -> bool {
+        self.code_lines.iter().enumerate().any(|(index, line)| {
+            let Some(candidate) = source_function_definition_candidate(line, name) else {
+                return false;
+            };
+
+            function_definition_rest_opens_body(candidate.rest)
+                || (candidate.allows_next_line_body
+                    && self
+                        .code_lines
+                        .iter()
+                        .skip(index + 1)
+                        .find(|next| !next.is_empty())
+                        .is_some_and(|next| next.starts_with('{')))
+        })
+    }
+}
+
+fn collect_parameter_mentions(source: &str) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    let bytes = source.as_bytes();
+    let mut cursor = 0;
+    while let Some(relative) = source[cursor..].find('$') {
+        let dollar = cursor + relative;
+        let after_dollar = dollar + 1;
+        if bytes.get(after_dollar) == Some(&b'{') {
+            let name_start = after_dollar + 1;
+            if let Some((name, after_name)) = parse_shell_name_at(source, name_start) {
+                if matches!(bytes.get(after_name), Some(b'}' | b'[' | b':')) {
+                    names.insert(name.to_owned());
+                }
+                cursor = after_name;
+            } else {
+                cursor = name_start;
+            }
+        } else if let Some((name, after_name)) = parse_shell_name_at(source, after_dollar) {
+            insert_unbraced_name_prefixes(name, &mut names);
+            cursor = after_name;
+        } else {
+            cursor = after_dollar;
+        }
+    }
+    names
+}
+
+fn insert_unbraced_name_prefixes(name: &str, names: &mut BTreeSet<String>) {
+    for (offset, ch) in name.char_indices() {
+        let end = if offset == 0 {
+            ch.len_utf8()
+        } else {
+            offset + ch.len_utf8()
+        };
+        names.insert(name[..end].to_owned());
+    }
+}
+
+fn collect_assignment_names(source: &str) -> BTreeSet<String> {
+    let mut names = BTreeSet::new();
+    for (offset, ch) in source.char_indices() {
+        if !(ch == '_' || ch.is_ascii_alphabetic()) {
+            continue;
+        }
+        if source[..offset]
+            .chars()
+            .next_back()
+            .is_some_and(is_shell_name_char)
+        {
+            continue;
+        }
+        let Some((name, after_name)) = parse_shell_name_at(source, offset) else {
+            continue;
+        };
+        let after = source[after_name..].chars().next();
+        let assignment_like = matches!(after, Some('=') | Some('['))
+            || (after == Some('+') && source[after_name..].chars().nth(1) == Some('='));
+        if assignment_like {
+            names.insert(name.to_owned());
+        }
+    }
+    names
+}
+
+fn probable_function_definition(trimmed: &str) -> bool {
+    if trimmed.starts_with('#') || trimmed.is_empty() {
+        return false;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("function ") {
+        return rest.contains('{');
+    }
+
+    trimmed.contains("() {") || trimmed.contains("(){")
+}
+
+fn source_command_line(trimmed: &str) -> bool {
+    trimmed.starts_with("source ")
+        || trimmed.starts_with(". ")
+        || trimmed.starts_with("\\source ")
+        || trimmed.starts_with("\\. ")
+}
+
+fn line_autoloads_zsh_colors(code: &str) -> bool {
+    let code = first_shell_command_segment(code);
+    let mut words = code.split_whitespace();
+    let mut command = words.next();
+    while matches!(command, Some("builtin" | "command")) {
+        command = words.next();
+    }
+    if command != Some("autoload") {
+        return false;
+    }
+
+    words.any(|word| word == "colors")
+}
+
+fn first_shell_command_segment(code: &str) -> &str {
+    ["&&", "||", ";", "|"]
+        .iter()
+        .filter_map(|separator| code.find(separator))
+        .min()
+        .map_or(code, |index| &code[..index])
+}
+
+struct FunctionDefinitionCandidate<'a> {
+    rest: &'a str,
+    allows_next_line_body: bool,
+}
+
+fn source_function_definition_candidate<'a>(
+    source: &'a str,
+    name: &str,
+) -> Option<FunctionDefinitionCandidate<'a>> {
+    let (source, has_function_keyword) = source
+        .strip_prefix("function ")
+        .map_or((source, false), |rest| (rest, true));
+    let (candidate, after_name) = parse_shell_name_at(source, 0)?;
+    if candidate != name {
+        return None;
+    }
+
+    let rest = source[after_name..].trim();
+    Some(FunctionDefinitionCandidate {
+        rest,
+        allows_next_line_body: (has_function_keyword && rest.is_empty()) || rest == "()",
+    })
+}
+
+fn function_definition_rest_opens_body(rest: &str) -> bool {
+    rest.starts_with('{') || (rest.starts_with("()") && rest.contains('{'))
+}
+
+fn is_shell_variable_name(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn is_shell_name_char(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SourceSignals;
+
+    #[test]
+    fn unbraced_mentions_preserve_prefix_matching() {
+        let signals = SourceSignals::new("printf '%s\\n' \"$fg_bold\"\n");
+
+        assert!(signals.mentions_name("fg"));
+        assert!(signals.mentions_name("fg_bold"));
+    }
+
+    #[test]
+    fn braced_mentions_remain_exact() {
+        let signals = SourceSignals::new("printf '%s\\n' \"${fg_bold}\"\n");
+
+        assert!(!signals.mentions_name("fg"));
+        assert!(signals.mentions_name("fg_bold"));
+    }
+
+    #[test]
+    fn assignment_signals_match_shell_name_boundaries() {
+        let signals =
+            SourceSignals::new("XHISTFILE=bad\n$HISTFILE=odd-but-old-shape\nHISTSIZE+=1\n");
+
+        assert!(!signals.assigns_name("XHIST"));
+        assert!(signals.assigns_name("HISTFILE"));
+        assert!(signals.assigns_name("HISTSIZE"));
+    }
+}

--- a/crates/shuck-linter/src/ambient_contracts/source_scan.rs
+++ b/crates/shuck-linter/src/ambient_contracts/source_scan.rs
@@ -35,75 +35,12 @@ pub(super) fn parse_shell_name_at(source: &str, start: usize) -> Option<(&str, u
     Some((&source[start..end], end))
 }
 
-pub(super) fn has_probable_function_definition(source: &str) -> bool {
-    source
-        .lines()
-        .map(str::trim)
-        .any(probable_function_definition)
-}
-
-pub(super) fn has_source_command(source: &str) -> bool {
-    source.lines().map(str::trim).any(|trimmed| {
-        trimmed.starts_with("source ")
-            || trimmed.starts_with(". ")
-            || trimmed.starts_with("\\source ")
-            || trimmed.starts_with("\\. ")
-    })
-}
-
-fn probable_function_definition(trimmed: &str) -> bool {
-    if trimmed.starts_with('#') || trimmed.is_empty() {
-        return false;
-    }
-
-    if let Some(rest) = trimmed.strip_prefix("function ") {
-        return rest.contains('{');
-    }
-
-    trimmed.contains("() {") || trimmed.contains("(){")
-}
-
-pub(super) fn source_mentions_any(source: &str, names: &[&str]) -> bool {
-    names.iter().any(|name| source_mentions_name(source, name))
-}
-
-pub(super) fn source_mentions_name(source: &str, name: &str) -> bool {
-    source.contains(&format!("${name}"))
-        || source.contains(&format!("${{{name}}}"))
-        || source.contains(&format!("${{{name}["))
-        || source.contains(&format!("${{{name}:"))
-}
-
-pub(super) fn source_assigns_name(source: &str, name: &str) -> bool {
-    source.match_indices(name).any(|(offset, _)| {
-        let before = source[..offset].chars().next_back();
-        let after = source[offset + name.len()..].chars().next();
-        let starts_token = before.is_none_or(|ch| !is_shell_name_char(ch));
-        let assignment_like = matches!(after, Some('=') | Some('['))
-            || (after == Some('+') && source[offset + name.len()..].chars().nth(1) == Some('='));
-        starts_token && assignment_like
-    })
-}
-
-fn is_shell_name_char(ch: char) -> bool {
-    ch == '_' || ch.is_ascii_alphanumeric()
-}
-
 pub(super) fn shell_assignment_token(token: &str) -> bool {
     let Some((name, _value)) = token.split_once('=') else {
         return false;
     };
 
     let mut chars = name.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    (first == '_' || first.is_ascii_alphabetic())
-        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-}
-
-pub(super) fn is_shell_variable_name(value: &str) -> bool {
-    let mut chars = value.chars();
     let Some(first) = chars.next() else {
         return false;
     };

--- a/crates/shuck-linter/src/ambient_contracts/source_scan.rs
+++ b/crates/shuck-linter/src/ambient_contracts/source_scan.rs
@@ -6,14 +6,18 @@
 //! should come from parser, indexer, semantic, or linter facts instead.
 
 pub(super) fn code_before_shell_comment(line: &str) -> &str {
-    let mut previous_was_whitespace = true;
+    let mut previous = None;
     for (index, ch) in line.char_indices() {
-        if ch == '#' && previous_was_whitespace {
+        if ch == '#' && shell_comment_can_start_after(previous) {
             return &line[..index];
         }
-        previous_was_whitespace = ch.is_whitespace();
+        previous = Some(ch);
     }
     line
+}
+
+fn shell_comment_can_start_after(previous: Option<char>) -> bool {
+    previous.is_none_or(|ch| ch.is_whitespace() || matches!(ch, ';' | '&' | '|' | '<' | '>'))
 }
 
 pub(super) fn parse_shell_name_at(source: &str, start: usize) -> Option<(&str, usize)> {

--- a/crates/shuck-linter/src/ambient_contracts/sourced_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/sourced_runtime.rs
@@ -25,7 +25,6 @@
 //! ```
 
 use std::collections::BTreeSet;
-use std::path::Path;
 
 use shuck_ast::{
     Name, NormalizedCommand, Word, WrapperKind, normalize_command_words, static_word_text,
@@ -33,31 +32,24 @@ use shuck_ast::{
 use shuck_semantic::{ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind};
 
 use super::AmbientContractCollector;
-use super::path::{lower_path, path_matches_any};
-use super::source_scan::{
-    has_probable_function_definition, has_source_command, shell_assignment_token,
-    source_mentions_any,
-};
+use super::signals::PathSignals;
+use super::source_scan::shell_assignment_token;
 use crate::ShellDialect;
 
 pub(super) fn matches_sourced_runtime_contract(
     collector: &AmbientContractCollector<'_>,
-    path: &Path,
     _shell: ShellDialect,
 ) -> bool {
-    let lower = lower_path(path);
-    sourced_runtime_path_shape(&lower) && sourced_runtime_source_shape(collector, &lower)
+    sourced_runtime_path_shape(collector.path_signals()) && sourced_runtime_source_shape(collector)
 }
 
 pub(super) fn build_sourced_runtime_contract(
     collector: &AmbientContractCollector<'_>,
-    path: &Path,
     _shell: ShellDialect,
 ) -> FileContract {
-    let lower = lower_path(path);
     let mut names = BTreeSet::new();
 
-    for name in runtime_names_for_source_path(collector, &lower) {
+    for name in runtime_names_for_source_path(collector) {
         names.insert((*name).to_owned());
     }
 
@@ -74,51 +66,43 @@ pub(super) fn build_sourced_runtime_contract(
     contract
 }
 
-fn sourced_runtime_path_shape(lower: &str) -> bool {
-    path_matches_any(
-        lower,
-        &[
-            "/completion/",
-            "/completions/",
-            ".completion.",
-            "bash_autocomplete",
-            "/themes/",
-            ".theme.",
-            "/plugins/",
-            "/plugin/",
-            "/modules/",
-            "/scriptmodules/",
-            "/scripts/functions/",
-            "/rvm/scripts/",
-            "/lgsm/modules/",
-            "/common/environment/setup/",
-            "/common/chroot-style/",
-            "/common/hooks/",
-            "termux-packages/packages/",
-        ],
-    )
+fn sourced_runtime_path_shape(path: &PathSignals) -> bool {
+    path.matches_any(&[
+        "/completion/",
+        "/completions/",
+        ".completion.",
+        "bash_autocomplete",
+        "/themes/",
+        ".theme.",
+        "/plugins/",
+        "/plugin/",
+        "/modules/",
+        "/scriptmodules/",
+        "/scripts/functions/",
+        "/rvm/scripts/",
+        "/lgsm/modules/",
+        "/common/environment/setup/",
+        "/common/chroot-style/",
+        "/common/hooks/",
+        "termux-packages/packages/",
+    ])
 }
 
-fn sourced_runtime_source_shape(
-    collector: &AmbientContractCollector<'_>,
-    lower_path: &str,
-) -> bool {
-    let source = collector.source;
-    has_probable_function_definition(source)
-        || has_source_command(source)
+fn sourced_runtime_source_shape(collector: &AmbientContractCollector<'_>) -> bool {
+    let source = collector.source_signals();
+    source.has_probable_function_definition()
+        || source.has_source_command()
         || source.contains("PROMPT_COMMAND")
         || source.contains("COMPREPLY")
         || source.contains("about-completion")
-        || (lower_path.contains("termux-packages") && source.contains("TERMUX_"))
+        || (collector.path_signals().contains("termux-packages") && source.contains("TERMUX_"))
         || collector.completion_initializer_invoked
 }
 
 fn runtime_names_for_source_path(
     collector: &AmbientContractCollector<'_>,
-    lower: &str,
 ) -> &'static [&'static str] {
-    let source = collector.source;
-    if bash_it_theme_runtime_shape(source, lower) {
+    if bash_it_theme_runtime_shape(collector) {
         return &[
             "black",
             "red",
@@ -143,60 +127,58 @@ fn runtime_names_for_source_path(
         ];
     }
 
-    if completion_runtime_shape(collector, lower) {
+    if completion_runtime_shape(collector) {
         return &["cur", "prev", "words", "cword", "comp_args", "split"];
     }
 
     &[]
 }
 
-fn bash_it_theme_runtime_shape(source: &str, lower: &str) -> bool {
-    path_matches_any(lower, &["/bash-it/themes/", "/bash-it/theme/"])
+fn bash_it_theme_runtime_shape(collector: &AmbientContractCollector<'_>) -> bool {
+    let source = collector.source_signals();
+    collector
+        .path_signals()
+        .matches_any(&["/bash-it/themes/", "/bash-it/theme/"])
         && (source.contains("PROMPT_COMMAND")
             || source.contains("SCM_THEME_PROMPT")
-            || source_mentions_any(
-                source,
-                &[
-                    "black",
-                    "red",
-                    "green",
-                    "yellow",
-                    "blue",
-                    "purple",
-                    "cyan",
-                    "white",
-                    "normal",
-                    "default",
-                    "reset_color",
-                    "bold_black",
-                    "bold_red",
-                    "bold_green",
-                    "bold_yellow",
-                    "bold_blue",
-                    "bold_purple",
-                    "bold_cyan",
-                    "bold_white",
-                    "italic",
-                ],
-            ))
+            || source.mentions_any(&[
+                "black",
+                "red",
+                "green",
+                "yellow",
+                "blue",
+                "purple",
+                "cyan",
+                "white",
+                "normal",
+                "default",
+                "reset_color",
+                "bold_black",
+                "bold_red",
+                "bold_green",
+                "bold_yellow",
+                "bold_blue",
+                "bold_purple",
+                "bold_cyan",
+                "bold_white",
+                "italic",
+            ]))
 }
 
-fn completion_runtime_shape(collector: &AmbientContractCollector<'_>, lower: &str) -> bool {
-    completion_runtime_path_shape(lower) && collector.completion_initializer_invoked
+fn completion_runtime_shape(collector: &AmbientContractCollector<'_>) -> bool {
+    completion_runtime_path_shape(collector.path_signals())
+        && collector.completion_initializer_invoked
 }
 
-fn completion_runtime_path_shape(lower: &str) -> bool {
-    path_matches_any(
-        lower,
-        &[
-            "/bash-completion/",
-            "/bash_completion/",
-            "/bash-it/completion/",
-            "/bash-it/completions/",
-            "/bash-progcomp/",
-            "bash_autocomplete",
-        ],
-    )
+fn completion_runtime_path_shape(path: &PathSignals) -> bool {
+    path.matches_any(&[
+        "/bash-completion/",
+        "/bash_completion/",
+        "/bash-it/completion/",
+        "/bash-it/completions/",
+        "/bash-progcomp/",
+        "bash_autocomplete",
+    ])
 }
 
 pub(super) fn normalized_command_invokes_completion_initializer(

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -161,6 +161,19 @@ prompt=\"%{$fg_bold[blue]%}%{$reset_color%}\"
 }
 
 #[test]
+fn commented_zmodload_does_not_initialize_module_parameters() {
+    let path = Path::new("/tmp/project/scripts/example.zsh");
+    let source = "\
+true;# zmodload zsh/parameter
+print -r -- \"$history\"
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    assert!(!has_initialized_binding(&contract, "history"));
+}
+
+#[test]
 fn zsh_runtime_contract_initializes_hook_arrays() {
     let path = Path::new("/tmp/zsh/ohmyzsh/lib/async_prompt.zsh");
     let source = "\

--- a/crates/shuck-linter/src/ambient_contracts/zsh_caller_arrays.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_caller_arrays.rs
@@ -16,7 +16,6 @@
 //! parsed word parts observed during semantic traversal.
 
 use std::collections::BTreeSet;
-use std::path::Path;
 
 use shuck_ast::{
     Name, ParameterExpansionSyntax, Word, WordPart, ZshExpansionOperation, ZshExpansionTarget,
@@ -24,24 +23,22 @@ use shuck_ast::{
 use shuck_semantic::{ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind};
 
 use super::AmbientContractCollector;
-use super::source_scan::{
-    code_before_shell_comment, has_probable_function_definition, parse_shell_name_at,
-};
+use super::source_scan::{code_before_shell_comment, parse_shell_name_at};
 use crate::ShellDialect;
 
 pub(super) fn matches_zsh_caller_scoped_array_contract(
     collector: &AmbientContractCollector<'_>,
-    _path: &Path,
     shell: ShellDialect,
 ) -> bool {
     shell == ShellDialect::Zsh
-        && has_probable_function_definition(collector.source)
+        && collector
+            .source_signals()
+            .has_probable_function_definition()
         && !collector.caller_scoped_array_length_names.is_empty()
 }
 
 pub(super) fn build_zsh_caller_scoped_array_contract(
     collector: &AmbientContractCollector<'_>,
-    _path: &Path,
     _shell: ShellDialect,
 ) -> FileContract {
     let mut contract = FileContract::default();

--- a/crates/shuck-linter/src/ambient_contracts/zsh_config.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_config.rs
@@ -10,55 +10,51 @@
 //! HISTSIZE=10000
 //! ```
 
-use std::path::Path;
-
 use shuck_ast::Name;
 use shuck_semantic::FileContract;
 
 use super::AmbientContractCollector;
-use super::path::{lower_path, path_file_name};
-use super::source_scan::source_assigns_name;
+use super::signals::{PathSignals, SourceSignals};
 use super::zsh_paths::{p10k_config_path_shape, zsh_dotfile_path_shape};
 use crate::ShellDialect;
 
 pub(super) fn matches_zsh_config_contract(
     collector: &AmbientContractCollector<'_>,
-    path: &Path,
     shell: ShellDialect,
 ) -> bool {
-    let lower = lower_path(path);
-    shell_matches_zsh_config_context(shell, &lower)
-        && (zsh_config_consumed_prefixes(collector.source, &lower)
-            .next()
-            .is_some()
-            || !zsh_config_consumed_names(collector.source, &lower).is_empty())
+    let path = collector.path_signals();
+    let source = collector.source_signals();
+    shell_matches_zsh_config_context(shell, path)
+        && (zsh_config_consumed_prefixes(source, path).next().is_some()
+            || !zsh_config_consumed_names(source, path).is_empty())
 }
 
 pub(super) fn build_zsh_config_contract(
     collector: &AmbientContractCollector<'_>,
-    path: &Path,
     _shell: ShellDialect,
 ) -> FileContract {
-    let lower = lower_path(path);
+    let path = collector.path_signals();
+    let source = collector.source_signals();
     let mut contract = FileContract::default();
-    for prefix in zsh_config_consumed_prefixes(collector.source, &lower) {
+    for prefix in zsh_config_consumed_prefixes(source, path) {
         contract.add_externally_consumed_binding_prefix(Name::from(prefix));
     }
-    for name in zsh_config_consumed_names(collector.source, &lower) {
+    for name in zsh_config_consumed_names(source, path) {
         contract.add_externally_consumed_binding_name(Name::from(name));
     }
     contract
 }
 
-fn shell_matches_zsh_config_context(shell: ShellDialect, lower_path: &str) -> bool {
+fn shell_matches_zsh_config_context(shell: ShellDialect, path: &PathSignals) -> bool {
     shell == ShellDialect::Zsh
         || (shell == ShellDialect::Unknown
-            && (p10k_config_path_shape(lower_path) || zsh_dotfile_path_shape(lower_path)))
+            && (p10k_config_path_shape(path.lower_path())
+                || zsh_dotfile_path_shape(path.lower_path())))
 }
 
 fn zsh_config_consumed_prefixes<'a>(
-    source: &'a str,
-    lower_path: &'a str,
+    source: &'a SourceSignals<'_>,
+    path: &'a PathSignals,
 ) -> impl Iterator<Item = &'static str> + 'a {
     [
         "HISTORY_SUBSTRING_SEARCH_",
@@ -70,50 +66,49 @@ fn zsh_config_consumed_prefixes<'a>(
         "ZSH_HIGHLIGHT_",
     ]
     .into_iter()
-    .filter(|prefix| source.contains(prefix) && zsh_config_prefix_path_shape(prefix, lower_path))
+    .filter(|prefix| source.contains(prefix) && zsh_config_prefix_path_shape(prefix, path))
 }
 
-fn zsh_config_prefix_path_shape(prefix: &str, lower_path: &str) -> bool {
+fn zsh_config_prefix_path_shape(prefix: &str, path: &PathSignals) -> bool {
     match prefix {
         "HISTORY_SUBSTRING_SEARCH_" => {
-            lower_path.contains("/history-substring-search/")
-                || lower_path.contains("/modules/history-substring-search/")
+            path.contains("/history-substring-search/")
+                || path.contains("/modules/history-substring-search/")
         }
-        "ITERM2_" => p10k_config_path_shape(lower_path) || zsh_dotfile_path_shape(lower_path),
+        "ITERM2_" => {
+            p10k_config_path_shape(path.lower_path()) || zsh_dotfile_path_shape(path.lower_path())
+        }
         "P9K_" | "POWERLEVEL9K_" => {
-            p10k_config_path_shape(lower_path) || zsh_dotfile_path_shape(lower_path)
+            p10k_config_path_shape(path.lower_path()) || zsh_dotfile_path_shape(path.lower_path())
         }
-        "ZDOT_" => zsh_dotfile_path_shape(lower_path),
-        "ZSH_AUTOSUGGEST_" => lower_path.contains("/zsh-autosuggestions/"),
-        "ZSH_HIGHLIGHT_" => lower_path.contains("/zsh-syntax-highlighting/"),
+        "ZDOT_" => zsh_dotfile_path_shape(path.lower_path()),
+        "ZSH_AUTOSUGGEST_" => path.contains("/zsh-autosuggestions/"),
+        "ZSH_HIGHLIGHT_" => path.contains("/zsh-syntax-highlighting/"),
         _ => false,
     }
 }
 
 const ZSH_CONFIG_EXTERNALLY_CONSUMED_NAMES: &[&str] = &["HISTFILE", "HISTSIZE", "SAVEHIST"];
 
-fn zsh_config_consumed_names(source: &str, lower_path: &str) -> Vec<&'static str> {
+fn zsh_config_consumed_names(source: &SourceSignals<'_>, path: &PathSignals) -> Vec<&'static str> {
     ZSH_CONFIG_EXTERNALLY_CONSUMED_NAMES
         .iter()
         .copied()
-        .filter(|name| {
-            source_assigns_name(source, name)
-                && zsh_config_consumed_name_path_shape(name, lower_path)
-        })
+        .filter(|name| source.assigns_name(name) && zsh_config_consumed_name_path_shape(name, path))
         .collect()
 }
 
-fn zsh_config_consumed_name_path_shape(name: &str, lower_path: &str) -> bool {
+fn zsh_config_consumed_name_path_shape(name: &str, path: &PathSignals) -> bool {
     match name {
-        "HISTFILE" | "HISTSIZE" | "SAVEHIST" => zsh_history_config_path_shape(lower_path),
+        "HISTFILE" | "HISTSIZE" | "SAVEHIST" => zsh_history_config_path_shape(path),
         _ => false,
     }
 }
 
-fn zsh_history_config_path_shape(lower_path: &str) -> bool {
-    let file_name = path_file_name(lower_path);
-    zsh_dotfile_path_shape(lower_path)
-        || lower_path.contains("/zsh/")
-        || lower_path.contains("/modules/history/")
+fn zsh_history_config_path_shape(path: &PathSignals) -> bool {
+    let file_name = path.file_name();
+    zsh_dotfile_path_shape(path.lower_path())
+        || path.contains("/zsh/")
+        || path.contains("/modules/history/")
         || matches!(file_name, "config.zsh" | "history.zsh" | "init.zsh")
 }

--- a/crates/shuck-linter/src/ambient_contracts/zsh_module_metadata.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_module_metadata.rs
@@ -14,28 +14,22 @@
 //! }
 //! ```
 
-use std::path::Path;
-
 use shuck_ast::Name;
 use shuck_semantic::FileContract;
 
 use super::AmbientContractCollector;
-use super::source_scan::{
-    code_before_shell_comment, is_shell_variable_name, parse_shell_name_at, source_assigns_name,
-};
+use super::signals::SourceSignals;
 use crate::ShellDialect;
 
 pub(super) fn matches_zsh_module_metadata_contract(
     collector: &AmbientContractCollector<'_>,
-    _path: &Path,
     shell: ShellDialect,
 ) -> bool {
-    shell == ShellDialect::Zsh && zsh_module_metadata_source_shape(collector.source)
+    shell == ShellDialect::Zsh && zsh_module_metadata_source_shape(collector.source_signals())
 }
 
 pub(super) fn build_zsh_module_metadata_contract(
     _collector: &AmbientContractCollector<'_>,
-    _path: &Path,
     _shell: ShellDialect,
 ) -> FileContract {
     let mut contract = FileContract::default();
@@ -48,97 +42,11 @@ pub(super) fn build_zsh_module_metadata_contract(
 const ZSH_MODULE_METADATA_NAMES: &[&str] =
     &["module_name", "module_description", "module_main_function"];
 
-fn zsh_module_metadata_source_shape(source: &str) -> bool {
+fn zsh_module_metadata_source_shape(source: &SourceSignals<'_>) -> bool {
     ZSH_MODULE_METADATA_NAMES
         .iter()
-        .all(|name| source_assigns_name(source, name))
-        && source_static_assignment_value(source, "module_main_function")
-            .is_some_and(|function_name| source_defines_function(source, &function_name))
-}
-
-fn source_static_assignment_value(source: &str, name: &str) -> Option<String> {
-    for line in source.lines() {
-        let code = code_before_shell_comment(line).trim_start();
-        let Some(rest) = code.strip_prefix(name) else {
-            continue;
-        };
-        let rest = rest.trim_start();
-        let Some(value) = rest.strip_prefix('=') else {
-            continue;
-        };
-        let value = value.trim_start();
-        if value.is_empty() {
-            continue;
-        }
-
-        let (raw_value, quoted) = if let Some(rest) = value.strip_prefix('"') {
-            (rest.split('"').next()?, true)
-        } else if let Some(rest) = value.strip_prefix('\'') {
-            (rest.split('\'').next()?, true)
-        } else {
-            (
-                value
-                    .split(|ch: char| ch.is_whitespace() || ch == ';')
-                    .next()?,
-                false,
-            )
-        };
-
-        if raw_value.is_empty() || raw_value.contains('$') {
-            continue;
-        }
-        if quoted || is_shell_variable_name(raw_value) {
-            return Some(raw_value.to_owned());
-        }
-    }
-
-    None
-}
-
-fn source_defines_function(source: &str, name: &str) -> bool {
-    let lines: Vec<_> = source
-        .lines()
-        .map(|line| code_before_shell_comment(line).trim())
-        .collect();
-    lines.iter().enumerate().any(|(index, line)| {
-        let Some(candidate) = source_function_definition_candidate(line, name) else {
-            return false;
-        };
-
-        function_definition_rest_opens_body(candidate.rest)
-            || (candidate.allows_next_line_body
-                && lines
-                    .iter()
-                    .skip(index + 1)
-                    .find(|next| !next.is_empty())
-                    .is_some_and(|next| next.starts_with('{')))
-    })
-}
-
-struct FunctionDefinitionCandidate<'a> {
-    rest: &'a str,
-    allows_next_line_body: bool,
-}
-
-fn source_function_definition_candidate<'a>(
-    source: &'a str,
-    name: &str,
-) -> Option<FunctionDefinitionCandidate<'a>> {
-    let (source, has_function_keyword) = source
-        .strip_prefix("function ")
-        .map_or((source, false), |rest| (rest, true));
-    let (candidate, after_name) = parse_shell_name_at(source, 0)?;
-    if candidate != name {
-        return None;
-    }
-
-    let rest = source[after_name..].trim();
-    Some(FunctionDefinitionCandidate {
-        rest,
-        allows_next_line_body: (has_function_keyword && rest.is_empty()) || rest == "()",
-    })
-}
-
-fn function_definition_rest_opens_body(rest: &str) -> bool {
-    rest.starts_with('{') || (rest.starts_with("()") && rest.contains('{'))
+        .all(|name| source.assigns_name(name))
+        && source
+            .static_assignment_value("module_main_function")
+            .is_some_and(|function_name| source.defines_function(&function_name))
 }

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -13,14 +13,11 @@
 //! The provider only applies to zsh-shaped paths or zsh projects so ordinary
 //! scripts do not inherit interactive-runtime assumptions.
 
-use std::path::Path;
-
 use shuck_ast::Name;
 use shuck_semantic::{ContractCertainty, FileContract, ProvidedBinding, ProvidedBindingKind};
 
 use super::AmbientContractCollector;
-use super::path::lower_path;
-use super::source_scan::{source_assigns_name, source_mentions_any, source_mentions_name};
+use super::signals::{PathSignals, SourceSignals};
 use super::zsh_paths::{
     zsh_dotfile_path_shape, zsh_project_path_shape, zsh_runtime_path_shape,
     zsh_syntax_highlighting_test_path_shape, zsh_test_data_path_shape,
@@ -29,24 +26,22 @@ use crate::ShellDialect;
 
 pub(super) fn matches_zsh_ambient_runtime_contract(
     collector: &AmbientContractCollector<'_>,
-    path: &Path,
     shell: ShellDialect,
 ) -> bool {
-    let lower = lower_path(path);
-    shell_matches_zsh_runtime_context(shell, &lower)
-        && zsh_ambient_runtime_has_signal(collector.source, &lower)
+    let path = collector.path_signals();
+    shell_matches_zsh_runtime_context(shell, path)
+        && zsh_ambient_runtime_has_signal(collector.source_signals(), path)
 }
 
 pub(super) fn build_zsh_ambient_runtime_contract(
     collector: &AmbientContractCollector<'_>,
-    path: &Path,
     _shell: ShellDialect,
 ) -> FileContract {
-    let lower = lower_path(path);
-    let source = collector.source;
+    let path = collector.path_signals();
+    let source = collector.source_signals();
     let mut contract = FileContract::default();
 
-    for name in zsh_initialized_runtime_names(source, &lower) {
+    for name in zsh_initialized_runtime_names(source, path) {
         contract.add_provided_binding(ProvidedBinding::new_file_entry_initialized(
             Name::from(name),
             ProvidedBindingKind::Variable,
@@ -54,51 +49,50 @@ pub(super) fn build_zsh_ambient_runtime_contract(
         ));
     }
 
-    for name in zsh_externally_consumed_names(source, &lower) {
+    for name in zsh_externally_consumed_names(source, path) {
         contract.add_externally_consumed_binding_name(Name::from(name));
     }
 
-    for prefix in zsh_test_fixture_consumed_prefixes(source, &lower) {
+    for prefix in zsh_test_fixture_consumed_prefixes(source, path) {
         contract.add_externally_consumed_binding_prefix(Name::from(prefix));
     }
 
     contract
 }
 
-fn shell_matches_zsh_runtime_context(shell: ShellDialect, lower_path: &str) -> bool {
+fn shell_matches_zsh_runtime_context(shell: ShellDialect, path: &PathSignals) -> bool {
     shell == ShellDialect::Zsh
         || (shell == ShellDialect::Unknown
-            && (zsh_dotfile_path_shape(lower_path) || zsh_project_path_shape(lower_path)))
+            && (zsh_dotfile_path_shape(path.lower_path())
+                || zsh_project_path_shape(path.lower_path())))
 }
 
-fn zsh_ambient_runtime_has_signal(source: &str, lower_path: &str) -> bool {
-    source_mentions_any(source, ZSH_INITIALIZED_SPECIAL_PARAMETERS)
-        || source_mentions_any(source, ZSH_HOOK_ARRAY_PARAMETERS)
-        || zsh_prompt_color_runtime_shape(source, lower_path)
-        || !zsh_externally_consumed_names(source, lower_path).is_empty()
-        || zsh_test_fixture_consumed_prefixes(source, lower_path)
+fn zsh_ambient_runtime_has_signal(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
+    source.mentions_any(ZSH_INITIALIZED_SPECIAL_PARAMETERS)
+        || source.mentions_any(ZSH_HOOK_ARRAY_PARAMETERS)
+        || zsh_prompt_color_runtime_shape(source, path)
+        || !zsh_externally_consumed_names(source, path).is_empty()
+        || zsh_test_fixture_consumed_prefixes(source, path)
             .next()
             .is_some()
 }
 
 fn zsh_initialized_runtime_names<'a>(
-    source: &'a str,
-    lower_path: &'a str,
+    source: &'a SourceSignals<'_>,
+    path: &'a PathSignals,
 ) -> impl Iterator<Item = &'static str> + 'a {
     ZSH_INITIALIZED_SPECIAL_PARAMETERS
         .iter()
         .copied()
         .filter(move |name| {
-            source_mentions_name(source, name)
-                && zsh_special_parameter_available(name, source, lower_path)
+            source.mentions_name(name) && zsh_special_parameter_available(name, source, path)
         })
         .chain(
             ZSH_PROMPT_COLOR_PARAMETERS
                 .iter()
                 .copied()
                 .filter(move |name| {
-                    source_mentions_name(source, name)
-                        && zsh_prompt_color_runtime_shape(source, lower_path)
+                    source.mentions_name(name) && zsh_prompt_color_runtime_shape(source, path)
                 }),
         )
         .chain(
@@ -106,52 +100,51 @@ fn zsh_initialized_runtime_names<'a>(
                 .iter()
                 .copied()
                 .filter(move |name| {
-                    source_mentions_name(source, name) && zsh_runtime_path_shape(lower_path)
+                    source.mentions_name(name) && zsh_runtime_path_shape(path.lower_path())
                 }),
         )
 }
 
-fn zsh_special_parameter_available(name: &str, source: &str, lower_path: &str) -> bool {
+fn zsh_special_parameter_available(
+    name: &str,
+    source: &SourceSignals<'_>,
+    path: &PathSignals,
+) -> bool {
     match name {
         "sysparams" => {
-            zsh_runtime_path_shape(lower_path) || source_loads_zsh_module(source, "zsh/system")
+            zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_module("zsh/system")
         }
         "langinfo" => {
-            zsh_runtime_path_shape(lower_path) || source_loads_zsh_module(source, "zsh/langinfo")
+            zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_module("zsh/langinfo")
         }
-        "compstate" | "words" => zsh_runtime_path_shape(lower_path),
+        "compstate" | "words" => zsh_runtime_path_shape(path.lower_path()),
         "galiases" | "history" | "keymaps" | "reswords" | "saliases" => {
-            zsh_runtime_path_shape(lower_path) || source_loads_zsh_module(source, "zsh/parameter")
+            zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_module("zsh/parameter")
         }
         _ => true,
     }
 }
 
-fn source_loads_zsh_module(source: &str, module: &str) -> bool {
-    source.lines().any(|line| {
-        line.split('#')
-            .next()
-            .is_some_and(|code| code.contains("zmodload") && code.contains(module))
-    })
-}
-
-fn zsh_externally_consumed_names(source: &str, lower_path: &str) -> Vec<&'static str> {
-    let runtime_path = zsh_runtime_path_shape(lower_path);
-    if !runtime_path && !zsh_test_data_path_shape(lower_path) {
+fn zsh_externally_consumed_names(
+    source: &SourceSignals<'_>,
+    path: &PathSignals,
+) -> Vec<&'static str> {
+    let runtime_path = zsh_runtime_path_shape(path.lower_path());
+    if !runtime_path && !zsh_test_data_path_shape(path.lower_path()) {
         return Vec::new();
     }
 
     let mut consumed = ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS
         .iter()
         .copied()
-        .filter(|name| source_assigns_name(source, name))
+        .filter(|name| source.assigns_name(name))
         .collect::<Vec<_>>();
     if runtime_path {
         consumed.extend(
             ZSH_HOOK_ARRAY_PARAMETERS
                 .iter()
                 .copied()
-                .filter(|name| source_assigns_name(source, name)),
+                .filter(|name| source.assigns_name(name)),
         );
     }
     consumed
@@ -168,11 +161,11 @@ const ZSH_HOOK_ARRAY_PARAMETERS: &[&str] = &[
 ];
 
 fn zsh_test_fixture_consumed_prefixes<'a>(
-    source: &'a str,
-    lower_path: &'a str,
+    source: &'a SourceSignals<'_>,
+    path: &'a PathSignals,
 ) -> impl Iterator<Item = &'static str> + 'a {
     ["expected_"].into_iter().filter(|prefix| {
-        zsh_syntax_highlighting_test_path_shape(lower_path) && source.contains(prefix)
+        zsh_syntax_highlighting_test_path_shape(path.lower_path()) && source.contains(prefix)
     })
 }
 
@@ -205,38 +198,7 @@ const ZSH_PROMPT_COLOR_PARAMETERS: &[&str] = &[
 const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
     &["REPLY", "compstate", "comppostfuncs", "reply"];
 
-fn zsh_prompt_color_runtime_shape(source: &str, lower_path: &str) -> bool {
-    (zsh_runtime_path_shape(lower_path) || source_loads_zsh_colors(source))
-        && source_mentions_any(source, ZSH_PROMPT_COLOR_PARAMETERS)
-}
-
-fn source_loads_zsh_colors(source: &str) -> bool {
-    source.lines().any(|line| {
-        line.split('#')
-            .next()
-            .map(str::trim_start)
-            .is_some_and(line_autoloads_zsh_colors)
-    })
-}
-
-fn line_autoloads_zsh_colors(code: &str) -> bool {
-    let code = first_shell_command_segment(code);
-    let mut words = code.split_whitespace();
-    let mut command = words.next();
-    while matches!(command, Some("builtin" | "command")) {
-        command = words.next();
-    }
-    if command != Some("autoload") {
-        return false;
-    }
-
-    words.any(|word| word == "colors")
-}
-
-fn first_shell_command_segment(code: &str) -> &str {
-    ["&&", "||", ";", "|"]
-        .iter()
-        .filter_map(|separator| code.find(separator))
-        .min()
-        .map_or(code, |index| &code[..index])
+fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
+    (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())
+        && source.mentions_any(ZSH_PROMPT_COLOR_PARAMETERS)
 }


### PR DESCRIPTION
## Summary

- Add `ambient_contracts::signals` to precompute source and path signals once per analyzed file.
- Thread cached signals through sourced-runtime, zsh-runtime, zsh-config, zsh-module-metadata, and zsh caller-array providers.
- Remove repeated raw source/path scans from provider-specific code.
- Add focused tests for compatibility-sensitive mention and assignment signal behavior.

## Validation

- `cargo fmt`
- `cargo test -p shuck-linter ambient_contracts`
- `cargo test -p shuck-linter`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`