### PR TITLE
perf(semantic): pre-size zsh option analysis caches

### DIFF
--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -396,6 +396,7 @@ pub(crate) fn function_runtime_analysis_with_entry(
         .collect();
     scope_index.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| b.end.cmp(&a.end)));
     let scope_capacity = scope_index.len();
+    let function_count = recorded_program.function_body_scopes.len();
 
     let mut analyzer = Analyzer {
         scopes,
@@ -406,8 +407,11 @@ pub(crate) fn function_runtime_analysis_with_entry(
         scope_entries: FxHashMap::with_capacity_and_hasher(scope_capacity, Default::default()),
         snapshots: FxHashMap::with_capacity_and_hasher(scope_capacity, Default::default()),
         active_function_scopes: FxHashSet::default(),
-        function_summaries: FxHashMap::default(),
-        direct_function_callees: FxHashMap::default(),
+        function_summaries: FxHashMap::with_capacity_and_hasher(function_count, Default::default()),
+        direct_function_callees: FxHashMap::with_capacity_and_hasher(
+            function_count,
+            Default::default(),
+        ),
         shared_function_summaries: shared_summaries,
     };
     analyzer.analyze_function_scope_with_shared_summary_reuse(


### PR DESCRIPTION
## Summary
- Pre-size zsh option analysis caches from the number of recorded function bodies.
- Avoid an avoidable resize/rehash path while semantic zsh runtime option analysis summarizes function scopes.

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-semantic`

## Notes
- The borrowed-name `visible_name_is_array_like` experiment was reverted because the profile did not show a meaningful improvement; this PR keeps only the cache-sizing change that was already committed.