### PR TITLE
perf(linter): speed up zsh array fanout facts

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -63,6 +63,33 @@ fn compute_array_like_capable_names(semantic: &SemanticModel) -> FxHashSet<Name>
     names
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
+fn compute_single_array_like_bindings(semantic: &SemanticModel) -> FxHashMap<Name, BindingId> {
+    let mut bindings_by_name = FxHashMap::default();
+    for binding in semantic.bindings() {
+        let array_like = binding
+            .attributes
+            .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+            || matches!(
+                binding.kind,
+                BindingKind::ArrayAssignment | BindingKind::MapfileTarget
+            );
+        match bindings_by_name.entry(binding.name.clone()) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(array_like.then_some(binding.id));
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                entry.insert(None);
+            }
+        }
+    }
+
+    bindings_by_name
+        .into_iter()
+        .filter_map(|(name, binding_id)| binding_id.map(|binding_id| (name, binding_id)))
+        .collect()
+}
+
 impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
     fn new(
         file: &'a File,
@@ -130,6 +157,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let mut seen_pending_arithmetic_word_occurrences = FxHashSet::default();
         let mut assoc_binding_visibility_memo = FxHashMap::default();
         let array_like_capable_names = compute_array_like_capable_names(self.semantic);
+        let single_array_like_bindings = compute_single_array_like_bindings(self.semantic);
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut case_pattern_expansions = Vec::new();
         let mut pattern_literal_spans = Vec::new();
@@ -255,6 +283,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                             &mut seen_pending_arithmetic_word_occurrences,
                         assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
                         array_like_capable_names: &array_like_capable_names,
+                        single_array_like_bindings: &single_array_like_bindings,
                         semantic_analysis: self.semantic_analysis,
                         case_pattern_expansions: &mut case_pattern_expansions,
                         pattern_literal_spans: &mut pattern_literal_spans,

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1025,6 +1025,7 @@ struct ZshArrayFanoutContext<'a, 'flow> {
     scope: ScopeId,
     options: Option<&'a ZshOptionState>,
     array_like_capable_names: &'a FxHashSet<Name>,
+    single_array_like_bindings: &'a FxHashMap<Name, BindingId>,
 }
 
 fn apply_zsh_array_fanout(
@@ -1041,6 +1042,7 @@ fn apply_zsh_array_fanout(
             context.value_flow,
             context.scope,
             context.array_like_capable_names,
+            context.single_array_like_bindings,
         )
     {
         return;
@@ -1064,6 +1066,7 @@ fn word_has_unquoted_visible_array_reference(
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
     array_like_capable_names: &FxHashSet<Name>,
+    single_array_like_bindings: &FxHashMap<Name, BindingId>,
 ) -> bool {
     parts_have_unquoted_visible_array_reference(
         &word.parts,
@@ -1073,6 +1076,7 @@ fn word_has_unquoted_visible_array_reference(
         scope,
         false,
         array_like_capable_names,
+        single_array_like_bindings,
     )
 }
 
@@ -1084,6 +1088,7 @@ fn parts_have_unquoted_visible_array_reference(
     scope: ScopeId,
     in_double_quotes: bool,
     array_like_capable_names: &FxHashSet<Name>,
+    single_array_like_bindings: &FxHashMap<Name, BindingId>,
 ) -> bool {
     for part in parts {
         match &part.kind {
@@ -1096,6 +1101,7 @@ fn parts_have_unquoted_visible_array_reference(
                     scope,
                     true,
                     array_like_capable_names,
+                    single_array_like_bindings,
                 ) {
                     return true;
                 }
@@ -1109,6 +1115,7 @@ fn parts_have_unquoted_visible_array_reference(
                     value_flow,
                     scope,
                     array_like_capable_names,
+                    single_array_like_bindings,
                 ) {
                     return true;
                 }
@@ -1121,6 +1128,7 @@ fn parts_have_unquoted_visible_array_reference(
                     value_flow,
                     scope,
                     array_like_capable_names,
+                    single_array_like_bindings,
                 ) {
                     return true;
                 }
@@ -1139,6 +1147,7 @@ fn zsh_parameter_targets_visible_array(
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
     array_like_capable_names: &FxHashSet<Name>,
+    single_array_like_bindings: &FxHashMap<Name, BindingId>,
 ) -> bool {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
@@ -1154,6 +1163,7 @@ fn zsh_parameter_targets_visible_array(
             value_flow,
             scope,
             array_like_capable_names,
+            single_array_like_bindings,
         ),
         _ => false,
     }
@@ -1167,9 +1177,15 @@ fn visible_name_is_array_like(
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
     array_like_capable_names: &FxHashSet<Name>,
+    single_array_like_bindings: &FxHashMap<Name, BindingId>,
 ) -> bool {
     if !array_like_capable_names.contains(name) {
         return false;
+    }
+    if let Some(binding_id) = single_array_like_bindings.get(name)
+        && semantic.binding_visible_at(*binding_id, span)
+    {
+        return true;
     }
     let synthetic_use_block = if semantic_analysis.reference_id_for_name_at(name, span).is_none() {
         Some(semantic_analysis.flow_entry_block_for_binding_scopes(&[scope], span.start.offset))
@@ -1245,6 +1261,7 @@ pub(super) struct WordFactOutputs<'out, 'a> {
     pub(super) assoc_binding_visibility_memo:
         &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     pub(super) array_like_capable_names: &'out FxHashSet<Name>,
+    pub(super) single_array_like_bindings: &'out FxHashMap<Name, BindingId>,
     pub(super) semantic_analysis: &'out SemanticAnalysis<'a>,
     pub(super) case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
     pub(super) pattern_literal_spans: &'out mut Vec<Span>,
@@ -1556,6 +1573,7 @@ pub(super) struct WordFactCollector<'out, 'a, 'norm> {
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     assoc_binding_visibility_memo: &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     array_like_capable_names: &'out FxHashSet<Name>,
+    single_array_like_bindings: &'out FxHashMap<Name, BindingId>,
     semantic_analysis: &'out SemanticAnalysis<'a>,
     value_flow: SemanticValueFlow<'out, 'a>,
     seen: &'out mut FxHashSet<WordOccurrenceSeenKey>,
@@ -1649,6 +1667,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             array_assignment_split_word_ids: outputs.array_assignment_split_word_ids,
             assoc_binding_visibility_memo: outputs.assoc_binding_visibility_memo,
             array_like_capable_names: outputs.array_like_capable_names,
+            single_array_like_bindings: outputs.single_array_like_bindings,
             semantic_analysis: outputs.semantic_analysis,
             value_flow,
             seen: {
@@ -2608,6 +2627,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 scope: self.command_scope,
                 options: self.command_shell_behavior.zsh_options(),
                 array_like_capable_names: self.array_like_capable_names,
+                single_array_like_bindings: self.single_array_like_bindings,
             },
             &mut analysis,
         );

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1024,6 +1024,11 @@ struct ZshArrayFanoutContext<'a, 'flow> {
     value_flow: &'flow SemanticValueFlow<'flow, 'a>,
     scope: ScopeId,
     options: Option<&'a ZshOptionState>,
+    lookups: ZshArrayFanoutLookups<'a>,
+}
+
+#[derive(Clone, Copy)]
+struct ZshArrayFanoutLookups<'a> {
     array_like_capable_names: &'a FxHashSet<Name>,
     single_array_like_bindings: &'a FxHashMap<Name, BindingId>,
 }
@@ -1041,8 +1046,7 @@ fn apply_zsh_array_fanout(
             context.semantic_analysis,
             context.value_flow,
             context.scope,
-            context.array_like_capable_names,
-            context.single_array_like_bindings,
+            context.lookups,
         )
     {
         return;
@@ -1065,8 +1069,7 @@ fn word_has_unquoted_visible_array_reference(
     semantic_analysis: &SemanticAnalysis<'_>,
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
-    array_like_capable_names: &FxHashSet<Name>,
-    single_array_like_bindings: &FxHashMap<Name, BindingId>,
+    lookups: ZshArrayFanoutLookups<'_>,
 ) -> bool {
     parts_have_unquoted_visible_array_reference(
         &word.parts,
@@ -1075,8 +1078,7 @@ fn word_has_unquoted_visible_array_reference(
         value_flow,
         scope,
         false,
-        array_like_capable_names,
-        single_array_like_bindings,
+        lookups,
     )
 }
 
@@ -1087,8 +1089,7 @@ fn parts_have_unquoted_visible_array_reference(
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
     in_double_quotes: bool,
-    array_like_capable_names: &FxHashSet<Name>,
-    single_array_like_bindings: &FxHashMap<Name, BindingId>,
+    lookups: ZshArrayFanoutLookups<'_>,
 ) -> bool {
     for part in parts {
         match &part.kind {
@@ -1100,8 +1101,7 @@ fn parts_have_unquoted_visible_array_reference(
                     value_flow,
                     scope,
                     true,
-                    array_like_capable_names,
-                    single_array_like_bindings,
+                    lookups,
                 ) {
                     return true;
                 }
@@ -1114,8 +1114,7 @@ fn parts_have_unquoted_visible_array_reference(
                     semantic_analysis,
                     value_flow,
                     scope,
-                    array_like_capable_names,
-                    single_array_like_bindings,
+                    lookups,
                 ) {
                     return true;
                 }
@@ -1127,8 +1126,7 @@ fn parts_have_unquoted_visible_array_reference(
                     semantic_analysis,
                     value_flow,
                     scope,
-                    array_like_capable_names,
-                    single_array_like_bindings,
+                    lookups,
                 ) {
                     return true;
                 }
@@ -1146,8 +1144,7 @@ fn zsh_parameter_targets_visible_array(
     semantic_analysis: &SemanticAnalysis<'_>,
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
-    array_like_capable_names: &FxHashSet<Name>,
-    single_array_like_bindings: &FxHashMap<Name, BindingId>,
+    lookups: ZshArrayFanoutLookups<'_>,
 ) -> bool {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
@@ -1162,8 +1159,7 @@ fn zsh_parameter_targets_visible_array(
             semantic_analysis,
             value_flow,
             scope,
-            array_like_capable_names,
-            single_array_like_bindings,
+            lookups,
         ),
         _ => false,
     }
@@ -1176,13 +1172,12 @@ fn visible_name_is_array_like(
     semantic_analysis: &SemanticAnalysis<'_>,
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
-    array_like_capable_names: &FxHashSet<Name>,
-    single_array_like_bindings: &FxHashMap<Name, BindingId>,
+    lookups: ZshArrayFanoutLookups<'_>,
 ) -> bool {
-    if !array_like_capable_names.contains(name) {
+    if !lookups.array_like_capable_names.contains(name) {
         return false;
     }
-    if let Some(binding_id) = single_array_like_bindings.get(name)
+    if let Some(binding_id) = lookups.single_array_like_bindings.get(name)
         && semantic.binding_visible_at(*binding_id, span)
     {
         return true;
@@ -2626,8 +2621,10 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 value_flow: &self.value_flow,
                 scope: self.command_scope,
                 options: self.command_shell_behavior.zsh_options(),
-                array_like_capable_names: self.array_like_capable_names,
-                single_array_like_bindings: self.single_array_like_bindings,
+                lookups: ZshArrayFanoutLookups {
+                    array_like_capable_names: self.array_like_capable_names,
+                    single_array_like_bindings: self.single_array_like_bindings,
+                },
             },
             &mut analysis,
         );

--- a/crates/shuck-semantic/src/zsh_options.rs
+++ b/crates/shuck-semantic/src/zsh_options.rs
@@ -396,6 +396,7 @@ pub(crate) fn function_runtime_analysis_with_entry(
         .collect();
     scope_index.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| b.end.cmp(&a.end)));
     let scope_capacity = scope_index.len();
+    let function_count = recorded_program.function_body_scopes.len();
 
     let mut analyzer = Analyzer {
         scopes,
@@ -406,8 +407,11 @@ pub(crate) fn function_runtime_analysis_with_entry(
         scope_entries: FxHashMap::with_capacity_and_hasher(scope_capacity, Default::default()),
         snapshots: FxHashMap::with_capacity_and_hasher(scope_capacity, Default::default()),
         active_function_scopes: FxHashSet::default(),
-        function_summaries: FxHashMap::default(),
-        direct_function_callees: FxHashMap::default(),
+        function_summaries: FxHashMap::with_capacity_and_hasher(function_count, Default::default()),
+        direct_function_callees: FxHashMap::with_capacity_and_hasher(
+            function_count,
+            Default::default(),
+        ),
         shared_function_summaries: shared_summaries,
     };
     analyzer.analyze_function_scope_with_shared_summary_reuse(


### PR DESCRIPTION
## Summary

- pre-size zsh option analysis caches by the recorded function count
- add a single-array-like-binding index for word facts
- skip expensive value-flow for zsh array fanout when a name has exactly one visible array-like binding

## Profiling

Profiled the large-corpus fixture `romkatv__powerlevel10k__internal__p10k.zsh` with:

```shell
SHUCK_LARGE_CORPUS_ROOT=/Users/ewhauser/working/shuck/.cache/large-corpus scripts/profiling/profile_large_corpus.sh romkatv__powerlevel10k__internal__p10k.zsh .cache/profiles 2000 1 12
```

Observed warm fixture average improved from roughly `98.221ms` to `96.787ms` with diagnostics unchanged at `403`. Earlier rebuild/warm runs were noisy on a hot machine, so I kept only the variants that improved the measured wall time and reverted the experiments that did not.

## Validation

- `cargo fmt --check`
- `cargo test -p shuck-semantic`
- `cargo test -p shuck-linter`
