### PR TITLE
feat(zsh): add zsh diagnostic snapshot corpus

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -518,14 +518,18 @@ jobs:
       - name: "Install Nix"
         uses: DeterminateSystems/determinate-nix-action@32cb6a5ae30bb0dfc996fa7baf8bf1ed28442fa4 # v3.17.3
       - uses: DeterminateSystems/flakehub-cache-action@77fe95416299b8d1351b57bf10a1042a0ed75708 # v3.17.3
-      - name: "Download large corpus cache"
+      - name: "Download large corpus caches"
         run: |
           gh release download v0.0.0-test-files -R ewhauser/shuck -p 'shuck-cache-v3.tar.zst' -D /tmp
+          gh release download v0.0.0-test-files -R ewhauser/shuck -p 'shuck-zsh-diagnostic-corpus-v1.tar.zst' -D /tmp
           echo "880356ce713decb75c894a488c7a5f9cbeef2e3f76e43bb04525ebab4211ccd7  /tmp/shuck-cache-v3.tar.zst" | sha256sum -c -
+          echo "6fefa7c1aea0aba37e0111a73d2dea2e0ba08df2ed1a8704a3464798ac413dda  /tmp/shuck-zsh-diagnostic-corpus-v1.tar.zst" | sha256sum -c -
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: "Extract large corpus cache"
-        run: tar --zstd -xf /tmp/shuck-cache-v3.tar.zst -C "$GITHUB_WORKSPACE"
+      - name: "Extract large corpus caches"
+        run: |
+          tar --zstd -xf /tmp/shuck-cache-v3.tar.zst -C "$GITHUB_WORKSPACE"
+          tar --zstd -xf /tmp/shuck-zsh-diagnostic-corpus-v1.tar.zst -C "$GITHUB_WORKSPACE"
       - name: "Run large corpus tests"
         id: large-corpus
         shell: bash

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -1,10 +1,10 @@
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::panic::{self, AssertUnwindSafe};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 use std::sync::{
     Arc, Mutex,
     atomic::{AtomicUsize, Ordering},
@@ -36,13 +36,17 @@ const LARGE_CORPUS_SAMPLE_PERCENT_ENV: &str = "SHUCK_LARGE_CORPUS_SAMPLE_PERCENT
 const LARGE_CORPUS_MAPPED_ONLY_ENV: &str = "SHUCK_LARGE_CORPUS_MAPPED_ONLY";
 const LARGE_CORPUS_KEEP_GOING_ENV: &str = "SHUCK_LARGE_CORPUS_KEEP_GOING";
 const LARGE_CORPUS_TIMING_ENV: &str = "SHUCK_LARGE_CORPUS_TIMING";
+const ZSH_DIAGNOSTIC_CORPUS_ROOT_ENV: &str = "SHUCK_ZSH_DIAGNOSTIC_CORPUS_ROOT";
+const ZSH_DIAGNOSTIC_CORPUS_TIMEOUT_ENV: &str = "SHUCK_ZSH_DIAGNOSTIC_CORPUS_TIMEOUT_SECS";
 
 const LARGE_CORPUS_DEFAULT_SHELLCHECK_TIMEOUT: Duration = Duration::from_secs(300);
 const LARGE_CORPUS_DEFAULT_SHUCK_TIMEOUT: Duration = Duration::from_secs(30);
+const ZSH_DIAGNOSTIC_CORPUS_DEFAULT_TIMEOUT: Duration = Duration::from_secs(300);
 const LARGE_CORPUS_AUTOSCALED_SHUCK_TIMEOUT_BUFFER: Duration = Duration::from_secs(15);
 const LARGE_CORPUS_MAX_AUTOSCALED_SHUCK_TIMEOUT: Duration = Duration::from_secs(150);
 const LARGE_CORPUS_AUTOSCALED_SHUCK_LINES_PER_SEC: usize = 175;
 const LARGE_CORPUS_CACHE_DIR_NAME: &str = ".cache/large-corpus";
+const ZSH_DIAGNOSTIC_CORPUS_CACHE_DIR_NAME: &str = ".cache/zsh-diagnostic-corpus";
 const LARGE_CORPUS_MAX_WORKER_COUNT: usize = 4;
 const LARGE_CORPUS_TIMEOUT_FAILURE_CAP: usize = 5;
 const LARGE_CORPUS_PROGRESS_PERCENT_STEP: usize = 5;
@@ -78,6 +82,7 @@ const LARGE_CORPUS_SHELLCHECK_PARSE_IGNORE_SUFFIXES: &[&str] = &[
 ];
 const SHELLCHECK_CACHE_SCHEMA: u32 = 3;
 const SHELLCHECK_CACHE_MIGRATION_VERSION: u32 = 1;
+const ZSH_DIAGNOSTIC_CORPUS_BASELINE: &str = include_str!("testdata/zsh-diagnostic-corpus.yaml");
 
 // ---------------------------------------------------------------------------
 // Config
@@ -96,6 +101,202 @@ struct LargeCorpusConfig {
     mapped_only: bool,
     keep_going: bool,
     timing_mode: bool,
+}
+
+#[derive(Debug, Clone)]
+struct ZshDiagnosticCorpusConfig {
+    corpus_dir: PathBuf,
+    timeout: Duration,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ZshDiagnosticCorpusDocument {
+    schema: u32,
+    repos: Vec<ZshDiagnosticCorpusRepo>,
+}
+
+impl ZshDiagnosticCorpusDocument {
+    fn validate(&self) -> Result<(), String> {
+        if self.schema != 1 {
+            return Err(format!(
+                "unsupported zsh diagnostic corpus schema {}, expected 1",
+                self.schema
+            ));
+        }
+        if self.repos.is_empty() {
+            return Err("zsh diagnostic corpus baseline must list at least one repo".into());
+        }
+
+        let mut seen_repos = HashSet::new();
+        for repo in &self.repos {
+            repo.validate()?;
+            if !seen_repos.insert(repo.name.as_str()) {
+                return Err(format!(
+                    "zsh diagnostic corpus baseline repeats repo `{}`",
+                    repo.name
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ZshDiagnosticCorpusRepo {
+    name: String,
+    github_url: String,
+    commit: String,
+    #[serde(default)]
+    diagnostics: Vec<ZshDiagnosticRecord>,
+}
+
+impl ZshDiagnosticCorpusRepo {
+    fn validate(&self) -> Result<(), String> {
+        if self.name.is_empty() {
+            return Err("zsh diagnostic corpus repo names cannot be empty".into());
+        }
+        if self.github_url.is_empty() {
+            return Err(format!(
+                "zsh diagnostic corpus repo `{}` must include github_url",
+                self.name
+            ));
+        }
+        if self.commit.is_empty() {
+            return Err(format!(
+                "zsh diagnostic corpus repo `{}` must include commit",
+                self.name
+            ));
+        }
+
+        for diagnostic in &self.diagnostics {
+            diagnostic.validate(&self.name)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(deny_unknown_fields)]
+struct ZshDiagnosticRecord {
+    path: String,
+    code: String,
+    severity: String,
+    message: String,
+    start: ZshDiagnosticPosition,
+    end: ZshDiagnosticPosition,
+    classification: ZshDiagnosticClassification,
+}
+
+impl ZshDiagnosticRecord {
+    fn validate(&self, repo_name: &str) -> Result<(), String> {
+        if self.path.is_empty() {
+            return Err(format!(
+                "zsh diagnostic corpus repo `{repo_name}` has a diagnostic with an empty path"
+            ));
+        }
+        if Path::new(&self.path).is_absolute() {
+            return Err(format!(
+                "zsh diagnostic corpus repo `{repo_name}` diagnostic path `{}` must be relative",
+                self.path
+            ));
+        }
+        if self.code.is_empty() {
+            return Err(format!(
+                "zsh diagnostic corpus repo `{repo_name}` path `{}` has an empty code",
+                self.path
+            ));
+        }
+        if self.severity.is_empty() {
+            return Err(format!(
+                "zsh diagnostic corpus repo `{repo_name}` path `{}` has an empty severity",
+                self.path
+            ));
+        }
+        self.start.validate(repo_name, &self.path, "start")?;
+        self.end.validate(repo_name, &self.path, "end")?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(deny_unknown_fields)]
+struct ZshDiagnosticPosition {
+    line: usize,
+    column: usize,
+}
+
+impl ZshDiagnosticPosition {
+    fn validate(&self, repo_name: &str, path: &str, label: &str) -> Result<(), String> {
+        if self.line == 0 || self.column == 0 {
+            return Err(format!(
+                "zsh diagnostic corpus repo `{repo_name}` path `{path}` has invalid {label} position {}:{}",
+                self.line, self.column
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+enum ZshDiagnosticClassification {
+    Real,
+    FalsePositive,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+struct ZshDiagnosticCorpusManifest {
+    repos: Vec<ZshDiagnosticCorpusManifestRepo>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+struct ZshDiagnosticCorpusManifestRepo {
+    name: String,
+    github_url: String,
+    commit: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+struct ZshJsonDiagnostic {
+    code: String,
+    severity: String,
+    message: String,
+    location: ZshJsonLocation,
+    end_location: ZshJsonLocation,
+    filename: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+struct ZshJsonLocation {
+    row: usize,
+    column: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ZshObservedDiagnostic {
+    path: String,
+    code: String,
+    severity: String,
+    message: String,
+    start: ZshDiagnosticPosition,
+    end: ZshDiagnosticPosition,
+}
+
+impl From<&ZshDiagnosticRecord> for ZshObservedDiagnostic {
+    fn from(record: &ZshDiagnosticRecord) -> Self {
+        Self {
+            path: record.path.clone(),
+            code: record.code.clone(),
+            severity: record.severity.clone(),
+            message: record.message.clone(),
+            start: record.start.clone(),
+            end: record.end.clone(),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1080,6 +1281,96 @@ fn large_corpus_zsh_fixtures_parse() {
     );
 }
 
+#[test]
+#[ignore = "requires the zsh diagnostic corpus; run `make test-large-corpus`"]
+fn zsh_diagnostic_corpus_matches_baseline() {
+    let cfg = match resolve_zsh_diagnostic_corpus_config() {
+        Some(cfg) => cfg,
+        None => {
+            eprintln!(
+                "zsh diagnostic corpus test skipped (set {ZSH_DIAGNOSTIC_CORPUS_ROOT_ENV} or run `make setup-large-corpus`)"
+            );
+            return;
+        }
+    };
+
+    let baseline = load_zsh_diagnostic_corpus_baseline();
+    let manifest = load_zsh_diagnostic_corpus_manifest(&cfg.corpus_dir);
+    let visible_root = tempfile::tempdir().expect("create visible zsh diagnostic corpus root");
+    let mut failures = Vec::new();
+
+    for repo in &baseline.repos {
+        if let Err(err) = validate_zsh_diagnostic_manifest_repo(&manifest, repo) {
+            failures.push(err);
+            continue;
+        }
+
+        let repo_dir = cfg.corpus_dir.join("repos").join(&repo.name);
+        if !repo_dir.is_dir() {
+            failures.push(format!(
+                "repo `{}` is missing from {}",
+                repo.name,
+                cfg.corpus_dir.join("repos").display()
+            ));
+            continue;
+        }
+
+        let visible_repo_dir =
+            match expose_zsh_diagnostic_repo(&repo_dir, visible_root.path(), &repo.name) {
+                Ok(path) => path,
+                Err(err) => {
+                    failures.push(format!("repo `{}`: {err}", repo.name));
+                    continue;
+                }
+            };
+
+        let output = match run_zsh_diagnostic_shuck_check(&visible_repo_dir, cfg.timeout) {
+            Ok(output) => output,
+            Err(err) => {
+                failures.push(format!("repo `{}`: {err}", repo.name));
+                continue;
+            }
+        };
+
+        if !matches!(output.status.code(), Some(0 | 1)) {
+            failures.push(format!(
+                "repo `{}`: shuck exited with status {:?}",
+                repo.name,
+                output.status.code()
+            ));
+            continue;
+        }
+        if !output.stderr.is_empty() {
+            failures.push(format!(
+                "repo `{}`: shuck wrote stderr:\n{}",
+                repo.name,
+                String::from_utf8_lossy(&output.stderr)
+            ));
+            continue;
+        }
+
+        let actual =
+            match parse_zsh_diagnostic_json_lines(&repo.name, &visible_repo_dir, &output.stdout) {
+                Ok(actual) => actual,
+                Err(err) => {
+                    failures.push(err);
+                    continue;
+                }
+            };
+        let expected = expected_zsh_observed_diagnostics(repo);
+        let diffs = diff_zsh_observed_diagnostics(&expected, &actual);
+        if !diffs.is_empty() {
+            failures.push(format_zsh_diagnostic_repo_diff(&repo.name, &diffs));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "zsh diagnostic corpus drifted from baseline:\n\nZsh Diagnostic Corpus Drift:\n{}",
+        failures.join("\n\n")
+    );
+}
+
 fn collect_fixture_failures<F>(
     fixtures: &[&LargeCorpusFixture],
     keep_going: bool,
@@ -1466,6 +1757,301 @@ fn probe_invalid_zsh_fixture(path: &Path, timeout: Duration) -> Result<Option<St
 fn zsh_stderr_looks_like_parse_error(stderr: &str) -> bool {
     let lower = stderr.to_ascii_lowercase();
     lower.contains("parse error") || lower.contains("unmatched ")
+}
+
+fn load_zsh_diagnostic_corpus_baseline() -> ZshDiagnosticCorpusDocument {
+    let baseline: ZshDiagnosticCorpusDocument =
+        serde_yaml::from_str(ZSH_DIAGNOSTIC_CORPUS_BASELINE)
+            .unwrap_or_else(|err| panic!("parse zsh diagnostic corpus baseline: {err}"));
+    baseline.validate().unwrap_or_else(|err| panic!("{err}"));
+    baseline
+}
+
+fn load_zsh_diagnostic_corpus_manifest(corpus_dir: &Path) -> ZshDiagnosticCorpusManifest {
+    let path = corpus_dir.join("manifest.yaml");
+    let data =
+        fs::read_to_string(&path).unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
+    serde_yaml::from_str(&data).unwrap_or_else(|err| panic!("parse {}: {err}", path.display()))
+}
+
+fn validate_zsh_diagnostic_manifest_repo(
+    manifest: &ZshDiagnosticCorpusManifest,
+    baseline_repo: &ZshDiagnosticCorpusRepo,
+) -> Result<(), String> {
+    let Some(manifest_repo) = manifest
+        .repos
+        .iter()
+        .find(|repo| repo.name == baseline_repo.name)
+    else {
+        return Err(format!(
+            "repo `{}` is missing from zsh diagnostic corpus manifest",
+            baseline_repo.name
+        ));
+    };
+
+    if manifest_repo.github_url != baseline_repo.github_url
+        || manifest_repo.commit != baseline_repo.commit
+    {
+        return Err(format!(
+            "repo `{}` manifest metadata differs from baseline: got {} @ {}, expected {} @ {}",
+            baseline_repo.name,
+            manifest_repo.github_url,
+            manifest_repo.commit,
+            baseline_repo.github_url,
+            baseline_repo.commit
+        ));
+    }
+
+    Ok(())
+}
+
+fn resolve_zsh_diagnostic_corpus_config() -> Option<ZshDiagnosticCorpusConfig> {
+    let repo_root = repo_root();
+    let default_root = repo_root.join(ZSH_DIAGNOSTIC_CORPUS_CACHE_DIR_NAME);
+    let required = env_truthy(LARGE_CORPUS_ENV, false);
+    let root = env::var(ZSH_DIAGNOSTIC_CORPUS_ROOT_ENV)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or(default_root);
+
+    if !zsh_diagnostic_corpus_dir_looks_valid(&root) {
+        if required {
+            panic!(
+                "zsh diagnostic corpus not found; set {ZSH_DIAGNOSTIC_CORPUS_ROOT_ENV} to an existing corpus directory or run scripts/corpus-download.sh to populate {}",
+                repo_root
+                    .join(ZSH_DIAGNOSTIC_CORPUS_CACHE_DIR_NAME)
+                    .display()
+            );
+        }
+        return None;
+    }
+
+    let default_timeout_secs = positive_env_int(
+        LARGE_CORPUS_SHELLCHECK_TIMEOUT_ENV,
+        ZSH_DIAGNOSTIC_CORPUS_DEFAULT_TIMEOUT.as_secs() as usize,
+    );
+    let timeout_secs = positive_env_int(ZSH_DIAGNOSTIC_CORPUS_TIMEOUT_ENV, default_timeout_secs);
+
+    Some(ZshDiagnosticCorpusConfig {
+        corpus_dir: root,
+        timeout: Duration::from_secs(timeout_secs as u64),
+    })
+}
+
+fn zsh_diagnostic_corpus_dir_looks_valid(dir: &Path) -> bool {
+    dir.join("manifest.yaml").is_file() && dir.join("repos").is_dir()
+}
+
+fn expose_zsh_diagnostic_repo(
+    source_repo_dir: &Path,
+    visible_root: &Path,
+    repo_name: &str,
+) -> Result<PathBuf, String> {
+    let visible_repo_dir = visible_root.join(repo_name);
+    expose_zsh_diagnostic_repo_impl(source_repo_dir, &visible_repo_dir)?;
+    Ok(visible_repo_dir)
+}
+
+#[cfg(unix)]
+fn expose_zsh_diagnostic_repo_impl(
+    source_repo_dir: &Path,
+    visible_repo_dir: &Path,
+) -> Result<(), String> {
+    std::os::unix::fs::symlink(source_repo_dir, visible_repo_dir).map_err(|err| {
+        format!(
+            "symlink {} -> {}: {err}",
+            visible_repo_dir.display(),
+            source_repo_dir.display()
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn expose_zsh_diagnostic_repo_impl(
+    source_repo_dir: &Path,
+    visible_repo_dir: &Path,
+) -> Result<(), String> {
+    copy_zsh_diagnostic_repo(source_repo_dir, visible_repo_dir)
+}
+
+#[cfg(not(unix))]
+fn copy_zsh_diagnostic_repo(source: &Path, dest: &Path) -> Result<(), String> {
+    fs::create_dir_all(dest).map_err(|err| format!("create {}: {err}", dest.display()))?;
+    for entry in fs::read_dir(source).map_err(|err| format!("read {}: {err}", source.display()))? {
+        let entry = entry.map_err(|err| format!("read {} entry: {err}", source.display()))?;
+        let source_path = entry.path();
+        let dest_path = dest.join(entry.file_name());
+        let file_type = entry
+            .file_type()
+            .map_err(|err| format!("stat {}: {err}", source_path.display()))?;
+        if file_type.is_dir() {
+            copy_zsh_diagnostic_repo(&source_path, &dest_path)?;
+        } else if file_type.is_file() {
+            fs::copy(&source_path, &dest_path).map_err(|err| {
+                format!(
+                    "copy {} -> {}: {err}",
+                    source_path.display(),
+                    dest_path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn run_zsh_diagnostic_shuck_check(repo_dir: &Path, timeout: Duration) -> Result<Output, String> {
+    let repo_dir = repo_dir.to_path_buf();
+    run_with_timeout("shuck", timeout, move || {
+        Command::new(assert_cmd::cargo::cargo_bin("shuck"))
+            .args(["check", "--no-cache", "--output-format", "json-lines"])
+            .arg(&repo_dir)
+            .output()
+            .map_err(|err| format!("failed to run shuck check on {}: {err}", repo_dir.display()))
+    })?
+}
+
+fn parse_zsh_diagnostic_json_lines(
+    repo_name: &str,
+    repo_dir: &Path,
+    stdout: &[u8],
+) -> Result<Vec<ZshObservedDiagnostic>, String> {
+    let text = std::str::from_utf8(stdout)
+        .map_err(|err| format!("repo `{repo_name}`: shuck stdout was not UTF-8: {err}"))?;
+    let mut diagnostics = Vec::new();
+
+    for (index, line) in text.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let diagnostic: ZshJsonDiagnostic = serde_json::from_str(line).map_err(|err| {
+            format!(
+                "repo `{repo_name}`: invalid json-lines diagnostic at line {}: {err}: {line}",
+                index + 1
+            )
+        })?;
+        diagnostics.push(zsh_observed_diagnostic_from_json(
+            repo_name, repo_dir, diagnostic,
+        )?);
+    }
+
+    diagnostics.sort();
+    Ok(diagnostics)
+}
+
+fn zsh_observed_diagnostic_from_json(
+    repo_name: &str,
+    repo_dir: &Path,
+    diagnostic: ZshJsonDiagnostic,
+) -> Result<ZshObservedDiagnostic, String> {
+    Ok(ZshObservedDiagnostic {
+        path: normalize_zsh_diagnostic_filename(repo_name, repo_dir, &diagnostic.filename)?,
+        code: diagnostic.code,
+        severity: diagnostic.severity,
+        message: diagnostic.message,
+        start: ZshDiagnosticPosition {
+            line: diagnostic.location.row,
+            column: diagnostic.location.column,
+        },
+        end: ZshDiagnosticPosition {
+            line: diagnostic.end_location.row,
+            column: diagnostic.end_location.column,
+        },
+    })
+}
+
+fn normalize_zsh_diagnostic_filename(
+    repo_name: &str,
+    repo_dir: &Path,
+    filename: &str,
+) -> Result<String, String> {
+    let path = Path::new(filename);
+    let relative = path.strip_prefix(repo_dir).map_err(|_| {
+        format!(
+            "repo `{repo_name}`: diagnostic filename `{filename}` is not under {}",
+            repo_dir.display()
+        )
+    })?;
+    Ok(normalize_cache_rel_path(relative))
+}
+
+fn expected_zsh_observed_diagnostics(repo: &ZshDiagnosticCorpusRepo) -> Vec<ZshObservedDiagnostic> {
+    let mut diagnostics = repo
+        .diagnostics
+        .iter()
+        .map(ZshObservedDiagnostic::from)
+        .collect::<Vec<_>>();
+    diagnostics.sort();
+    diagnostics
+}
+
+fn diff_zsh_observed_diagnostics(
+    expected: &[ZshObservedDiagnostic],
+    actual: &[ZshObservedDiagnostic],
+) -> Vec<String> {
+    let expected_counts = zsh_observed_diagnostic_counts(expected);
+    let actual_counts = zsh_observed_diagnostic_counts(actual);
+    let mut diffs = Vec::new();
+
+    for (diagnostic, expected_count) in &expected_counts {
+        let actual_count = actual_counts.get(diagnostic).copied().unwrap_or(0);
+        if actual_count < *expected_count {
+            diffs.push(format!(
+                "missing x{} {}",
+                expected_count - actual_count,
+                format_zsh_observed_diagnostic(diagnostic)
+            ));
+        }
+    }
+
+    for (diagnostic, actual_count) in &actual_counts {
+        let expected_count = expected_counts.get(diagnostic).copied().unwrap_or(0);
+        if expected_count < *actual_count {
+            diffs.push(format!(
+                "added x{} {}",
+                actual_count - expected_count,
+                format_zsh_observed_diagnostic(diagnostic)
+            ));
+        }
+    }
+
+    diffs
+}
+
+fn zsh_observed_diagnostic_counts(
+    diagnostics: &[ZshObservedDiagnostic],
+) -> BTreeMap<ZshObservedDiagnostic, usize> {
+    let mut counts = BTreeMap::new();
+    for diagnostic in diagnostics {
+        *counts.entry(diagnostic.clone()).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn format_zsh_diagnostic_repo_diff(repo_name: &str, diffs: &[String]) -> String {
+    let limit = 100;
+    let mut lines = diffs.iter().take(limit).cloned().collect::<Vec<_>>();
+    if diffs.len() > limit {
+        lines.push(format!(
+            "... omitted {} additional zsh diagnostic drift(s)",
+            diffs.len() - limit
+        ));
+    }
+    format!("repo `{repo_name}`:\n{}", indent_detail(&lines.join("\n")))
+}
+
+fn format_zsh_observed_diagnostic(diagnostic: &ZshObservedDiagnostic) -> String {
+    format!(
+        "{}:{}:{}-{}:{} {} {} {}",
+        diagnostic.path,
+        diagnostic.start.line,
+        diagnostic.start.column,
+        diagnostic.end.line,
+        diagnostic.end.column,
+        diagnostic.code,
+        diagnostic.severity,
+        diagnostic.message
+    )
 }
 
 fn fixture_failure_kind_for_message(message: &str, label: &str) -> FixtureFailureKind {
@@ -4818,6 +5404,138 @@ mod tests {
             cache_rel_path: cache_rel_path.to_path_buf(),
             shell: "sh".into(),
             source_hash: "source-hash".into(),
+        }
+    }
+
+    #[test]
+    fn zsh_diagnostic_diff_ignores_order() {
+        let first = zsh_observed("a.zsh", "C001", "first", 1, 1);
+        let second = zsh_observed("b.zsh", "C002", "second", 2, 1);
+
+        let diffs = diff_zsh_observed_diagnostics(
+            &[second.clone(), first.clone()],
+            &[first.clone(), second.clone()],
+        );
+
+        assert!(diffs.is_empty());
+    }
+
+    #[test]
+    fn zsh_diagnostic_diff_reports_added_and_missing_records() {
+        let expected = zsh_observed("a.zsh", "C001", "expected", 1, 1);
+        let actual = zsh_observed("a.zsh", "C002", "actual", 1, 1);
+
+        let diffs = diff_zsh_observed_diagnostics(
+            std::slice::from_ref(&expected),
+            std::slice::from_ref(&actual),
+        );
+
+        assert_eq!(diffs.len(), 2);
+        assert!(diffs.iter().any(|diff| diff.contains("missing")));
+        assert!(diffs.iter().any(|diff| diff.contains("added")));
+    }
+
+    #[test]
+    fn zsh_diagnostic_diff_treats_message_and_span_changes_as_drift() {
+        let expected = zsh_observed("a.zsh", "C001", "old message", 1, 1);
+        let changed_message = zsh_observed("a.zsh", "C001", "new message", 1, 1);
+        let changed_span = zsh_observed("a.zsh", "C001", "old message", 1, 2);
+
+        assert_eq!(
+            diff_zsh_observed_diagnostics(
+                std::slice::from_ref(&expected),
+                std::slice::from_ref(&changed_message)
+            )
+            .len(),
+            2
+        );
+        assert_eq!(
+            diff_zsh_observed_diagnostics(
+                std::slice::from_ref(&expected),
+                std::slice::from_ref(&changed_span)
+            )
+            .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn zsh_diagnostic_record_identity_includes_classification() {
+        let real = zsh_record(
+            "a.zsh",
+            "C001",
+            "message",
+            ZshDiagnosticClassification::Real,
+        );
+        let false_positive = zsh_record(
+            "a.zsh",
+            "C001",
+            "message",
+            ZshDiagnosticClassification::FalsePositive,
+        );
+
+        assert_ne!(real, false_positive);
+    }
+
+    #[test]
+    fn zsh_diagnostic_baseline_rejects_unknown_classification() {
+        let yaml = r#"
+schema: 1
+repos:
+  - name: repo
+    github_url: https://example.test/repo.git
+    commit: abc123
+    diagnostics:
+      - path: test.zsh
+        code: C001
+        severity: warning
+        message: message
+        start:
+          line: 1
+          column: 1
+        end:
+          line: 1
+          column: 2
+        classification: unclassified
+"#;
+
+        assert!(serde_yaml::from_str::<ZshDiagnosticCorpusDocument>(yaml).is_err());
+    }
+
+    fn zsh_observed(
+        path: &str,
+        code: &str,
+        message: &str,
+        line: usize,
+        column: usize,
+    ) -> ZshObservedDiagnostic {
+        ZshObservedDiagnostic {
+            path: path.into(),
+            code: code.into(),
+            severity: "warning".into(),
+            message: message.into(),
+            start: ZshDiagnosticPosition { line, column },
+            end: ZshDiagnosticPosition {
+                line,
+                column: column + 1,
+            },
+        }
+    }
+
+    fn zsh_record(
+        path: &str,
+        code: &str,
+        message: &str,
+        classification: ZshDiagnosticClassification,
+    ) -> ZshDiagnosticRecord {
+        ZshDiagnosticRecord {
+            path: path.into(),
+            code: code.into(),
+            severity: "warning".into(),
+            message: message.into(),
+            start: ZshDiagnosticPosition { line: 1, column: 1 },
+            end: ZshDiagnosticPosition { line: 1, column: 2 },
+            classification,
         }
     }
 

--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -1,0 +1,21735 @@
+# Generated from `.cache/zsh-diagnostic-corpus` with `shuck check --no-cache --output-format json-lines`.
+schema: 1
+repos:
+  - name: "dotfiler"
+    github_url: "https://github.com/georgeharker/dotfiler.git"
+    commit: "a9699e7dc18f76846d939e2f0c3a6a46a8709432"
+    diagnostics:
+      - path: "check_update.zsh"
+        code: "C085"
+        severity: "warning"
+        message: "stderr is redirected before stdout is redirected"
+        start:
+          line: 91
+          column: 28
+        end:
+          line: 91
+          column: 32
+        classification: real
+      - path: "check_update.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 167
+          column: 16
+        end:
+          line: 167
+          column: 24
+        classification: real
+      - path: "check_update.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_dotfiler_registered_hooks` is referenced before assignment"
+        start:
+          line: 168
+          column: 71
+        end:
+          line: 168
+          column: 103
+        classification: false_positive
+      - path: "check_update.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 267
+          column: 36
+        end:
+          line: 267
+          column: 55
+        classification: real
+      - path: "check_update.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 278
+          column: 36
+        end:
+          line: 278
+          column: 55
+        classification: real
+      - path: "check_update.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 287
+          column: 39
+        end:
+          line: 287
+          column: 60
+        classification: real
+      - path: "check_update.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `LAST_EPOCH` is assigned but never used"
+        start:
+          line: 383
+          column: 23
+        end:
+          line: 383
+          column: 33
+        classification: real
+      - path: "check_update.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 390
+          column: 19
+        end:
+          line: 390
+          column: 40
+        classification: real
+      - path: "example_install/02-shell-utils.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 144
+          column: 14
+        end:
+          line: 144
+          column: 102
+        classification: false_positive
+      - path: "example_install/05-editor-extras.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `module_name` is assigned but never used"
+        start:
+          line: 5
+          column: 1
+        end:
+          line: 5
+          column: 12
+        classification: real
+      - path: "example_install/05-editor-extras.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `module_description` is assigned but never used"
+        start:
+          line: 6
+          column: 1
+        end:
+          line: 6
+          column: 19
+        classification: real
+      - path: "example_install/05-editor-extras.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `module_main_function` is assigned but never used"
+        start:
+          line: 7
+          column: 1
+        end:
+          line: 7
+          column: 21
+        classification: real
+      - path: "example_install/07-ai.zsh"
+        code: "parse-error"
+        severity: "error"
+        message: "expected command"
+        start:
+          line: 25
+          column: 5
+        end:
+          line: 25
+          column: 5
+        classification: real
+      - path: "example_install/helpers.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 40
+          column: 27
+        end:
+          line: 40
+          column: 31
+        classification: real
+      - path: "example_install/helpers.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 215
+          column: 16
+        end:
+          line: 215
+          column: 35
+        classification: real
+      - path: "example_install/helpers.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 217
+          column: 40
+        end:
+          line: 217
+          column: 59
+        classification: real
+      - path: "example_install/helpers.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 321
+          column: 47
+        end:
+          line: 321
+          column: 69
+        classification: real
+      - path: "example_install/helpers.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 347
+          column: 16
+        end:
+          line: 347
+          column: 36
+        classification: real
+      - path: "example_install/helpers.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 384
+          column: 16
+        end:
+          line: 384
+          column: 28
+        classification: real
+      - path: "example_install/helpers.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 483
+          column: 16
+        end:
+          line: 483
+          column: 43
+        classification: real
+      - path: "example_install/helpers.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 486
+          column: 20
+        end:
+          line: 486
+          column: 40
+        classification: real
+      - path: "git_commands.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 200
+          column: 11
+        end:
+          line: 200
+          column: 13
+        classification: real
+      - path: "git_commands.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 206
+          column: 17
+        end:
+          line: 206
+          column: 19
+        classification: real
+      - path: "helpers.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 151
+          column: 70
+        end:
+          line: 151
+          column: 82
+        classification: real
+      - path: "helpers.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `REPLY` is assigned but never used"
+        start:
+          line: 168
+          column: 9
+        end:
+          line: 168
+          column: 14
+        classification: false_positive
+      - path: "install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `script_dir` is assigned but never used"
+        start:
+          line: 17
+          column: 1
+        end:
+          line: 17
+          column: 11
+        classification: real
+      - path: "install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `FORCE_INSTALL` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 14
+        classification: real
+      - path: "install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `dotfiles_module_descriptions` is referenced before assignment"
+        start:
+          line: 83
+          column: 29
+        end:
+          line: 83
+          column: 78
+        classification: false_positive
+      - path: "install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `dotfiles_module_functions` is referenced before assignment"
+        start:
+          line: 84
+          column: 30
+        end:
+          line: 84
+          column: 76
+        classification: false_positive
+      - path: "install_module.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `FORCE_INSTALL` is assigned but never used"
+        start:
+          line: 20
+          column: 1
+        end:
+          line: 20
+          column: 14
+        classification: real
+      - path: "install_module.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 63
+          column: 7
+        end:
+          line: 63
+          column: 9
+        classification: real
+      - path: "install_module.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 71
+          column: 8
+        end:
+          line: 71
+          column: 22
+        classification: real
+      - path: "module_helpers.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `dotfiles_module_functions` is assigned but never used"
+        start:
+          line: 48
+          column: 5
+        end:
+          line: 48
+          column: 30
+        classification: real
+      - path: "module_helpers.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 59
+          column: 20
+        end:
+          line: 59
+          column: 29
+        classification: real
+      - path: "module_helpers.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 134
+          column: 16
+        end:
+          line: 134
+          column: 30
+        classification: real
+      - path: "module_helpers.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 173
+          column: 11
+        end:
+          line: 173
+          column: 13
+        classification: real
+      - path: "setup.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 145
+          column: 28
+        end:
+          line: 145
+          column: 41
+        classification: real
+      - path: "setup.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_dotfiler_registered_hooks` is referenced before assignment"
+        start:
+          line: 167
+          column: 19
+        end:
+          line: 167
+          column: 49
+        classification: false_positive
+      - path: "setup.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 168
+          column: 12
+        end:
+          line: 168
+          column: 19
+        classification: real
+      - path: "setup.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 181
+          column: 77
+        end:
+          line: 181
+          column: 79
+        classification: real
+      - path: "setup.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 183
+          column: 51
+        end:
+          line: 183
+          column: 64
+        classification: real
+      - path: "setup.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 191
+          column: 77
+        end:
+          line: 191
+          column: 79
+        classification: real
+      - path: "setup.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 193
+          column: 51
+        end:
+          line: 193
+          column: 64
+        classification: real
+      - path: "setup.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 256
+          column: 16
+        end:
+          line: 256
+          column: 28
+        classification: real
+      - path: "setup_core.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_dotfiler_registered_hooks` is referenced before assignment"
+        start:
+          line: 163
+          column: 19
+        end:
+          line: 163
+          column: 51
+        classification: false_positive
+      - path: "setup_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 170
+          column: 27
+        end:
+          line: 170
+          column: 43
+        classification: real
+      - path: "setup_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 411
+          column: 36
+        end:
+          line: 411
+          column: 53
+        classification: real
+      - path: "setup_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 502
+          column: 32
+        end:
+          line: 502
+          column: 46
+        classification: real
+      - path: "setup_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 591
+          column: 42
+        end:
+          line: 591
+          column: 64
+        classification: real
+      - path: "setup_core.zsh"
+        code: "C103"
+        severity: "warning"
+        message: "`find` alternatives joined with `-o` should be grouped before applying actions"
+        start:
+          line: 928
+          column: 38
+        end:
+          line: 928
+          column: 44
+        classification: real
+      - path: "setup_core.zsh"
+        code: "C103"
+        severity: "warning"
+        message: "`find` alternatives joined with `-o` should be grouped before applying actions"
+        start:
+          line: 1055
+          column: 42
+        end:
+          line: 1055
+          column: 48
+        classification: real
+      - path: "setup_core.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_src` is referenced before assignment"
+        start:
+          line: 1081
+          column: 16
+        end:
+          line: 1081
+          column: 26
+        classification: false_positive
+      - path: "setup_core.zsh"
+        code: "C103"
+        severity: "warning"
+        message: "`find` alternatives joined with `-o` should be grouped before applying actions"
+        start:
+          line: 1214
+          column: 38
+        end:
+          line: 1214
+          column: 44
+        classification: real
+      - path: "setup_core.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `quiet_mode` is assigned but never used"
+        start:
+          line: 1315
+          column: 33
+        end:
+          line: 1315
+          column: 43
+        classification: real
+      - path: "update.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `quiet_mode` is assigned but never used"
+        start:
+          line: 107
+          column: 38
+        end:
+          line: 107
+          column: 48
+        classification: real
+      - path: "update.zsh"
+        code: "C128"
+        severity: "warning"
+        message: "this case pattern shadows a later pattern"
+        start:
+          line: 223
+          column: 25
+        end:
+          line: 223
+          column: 26
+        classification: real
+      - path: "update.zsh"
+        code: "C129"
+        severity: "warning"
+        message: "this case pattern is unreachable because an earlier pattern already matches it"
+        start:
+          line: 227
+          column: 13
+        end:
+          line: 227
+          column: 23
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 230
+          column: 9
+        end:
+          line: 230
+          column: 29
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 231
+          column: 9
+        end:
+          line: 231
+          column: 29
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 233
+          column: 12
+        end:
+          line: 233
+          column: 50
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 234
+          column: 13
+        end:
+          line: 234
+          column: 45
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 235
+          column: 13
+        end:
+          line: 235
+          column: 51
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 237
+          column: 13
+        end:
+          line: 237
+          column: 69
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 238
+          column: 13
+        end:
+          line: 238
+          column: 80
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 240
+          column: 9
+        end:
+          line: 240
+          column: 108
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 241
+          column: 9
+        end:
+          line: 241
+          column: 25
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 242
+          column: 9
+        end:
+          line: 242
+          column: 90
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 243
+          column: 13
+        end:
+          line: 243
+          column: 93
+        classification: real
+      - path: "update.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 244
+          column: 9
+        end:
+          line: 244
+          column: 80
+        classification: real
+      - path: "update.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `reply` is referenced before assignment"
+        start:
+          line: 266
+          column: 26
+        end:
+          line: 266
+          column: 32
+        classification: false_positive
+      - path: "update.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 377
+          column: 43
+        end:
+          line: 377
+          column: 53
+        classification: real
+      - path: "update.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 424
+          column: 39
+        end:
+          line: 424
+          column: 49
+        classification: real
+      - path: "update.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 509
+          column: 37
+        end:
+          line: 509
+          column: 47
+        classification: real
+      - path: "update.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_dotfiler_registered_hooks` is referenced before assignment"
+        start:
+          line: 688
+          column: 27
+        end:
+          line: 688
+          column: 57
+        classification: false_positive
+      - path: "update.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 689
+          column: 20
+        end:
+          line: 689
+          column: 28
+        classification: real
+      - path: "update_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 55
+          column: 36
+        end:
+          line: 55
+          column: 46
+        classification: real
+      - path: "update_core.zsh"
+        code: "C112"
+        severity: "warning"
+        message: "all-elements array expansions collapse inside `[[ ... ]]` tests"
+        start:
+          line: 278
+          column: 15
+        end:
+          line: 278
+          column: 25
+        classification: real
+      - path: "update_core.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 280
+          column: 20
+        end:
+          line: 280
+          column: 32
+        classification: real
+      - path: "update_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 575
+          column: 27
+        end:
+          line: 575
+          column: 42
+        classification: real
+      - path: "update_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 591
+          column: 23
+        end:
+          line: 591
+          column: 38
+        classification: real
+      - path: "update_core.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 1484
+          column: 17
+        end:
+          line: 1484
+          column: 26
+        classification: real
+      - path: "update_core.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 1927
+          column: 11
+        end:
+          line: 1927
+          column: 13
+        classification: real
+      - path: "update_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 2090
+          column: 34
+        end:
+          line: 2090
+          column: 51
+        classification: real
+      - path: "update_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 2102
+          column: 40
+        end:
+          line: 2102
+          column: 57
+        classification: real
+      - path: "update_core.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 2110
+          column: 44
+        end:
+          line: 2110
+          column: 61
+        classification: real
+  - name: "holman-dotfiles"
+    github_url: "https://github.com/holman/dotfiles.git"
+    commit: "af5071cd804b63dc59caeb21f7d0d0d0d1f55efa"
+    diagnostics:
+      - path: "bin/dot"
+        code: "X019"
+        severity: "warning"
+        message: "array references are not portable in `sh`"
+        start:
+          line: 10
+          column: 36
+        end:
+          line: 10
+          column: 53
+        classification: real
+      - path: "bin/dot"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 38
+          column: 2
+        end:
+          line: 38
+          column: 7
+        classification: real
+      - path: "bin/git-up"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 17
+          column: 11
+        end:
+          line: 17
+          column: 15
+        classification: real
+      - path: "git/completion.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 4
+          column: 12
+        end:
+          line: 4
+          column: 60
+        classification: real
+      - path: "git/completion.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 8
+          column: 10
+        end:
+          line: 8
+          column: 21
+        classification: real
+      - path: "homebrew/install.sh"
+        code: "C120"
+        severity: "warning"
+        message: "this uses an `expr` string helper instead of shell string operations"
+        start:
+          line: 17
+          column: 21
+        end:
+          line: 17
+          column: 27
+        classification: real
+      - path: "ruby/completion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `reply` is assigned but never used"
+        start:
+          line: 21
+          column: 3
+        end:
+          line: 21
+          column: 8
+        classification: false_positive
+      - path: "script/bootstrap"
+        code: "C013"
+        severity: "warning"
+        message: "expanding `find` output in a `for` loop splits paths on whitespace"
+        start:
+          line: 133
+          column: 14
+        end:
+          line: 133
+          column: 91
+        classification: real
+      - path: "script/bootstrap"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 147
+          column: 13
+        end:
+          line: 147
+          column: 20
+        classification: real
+      - path: "system/aliases.zsh"
+        code: "C092"
+        severity: "warning"
+        message: "use the command's exit status directly instead of executing the output from `$(...)`"
+        start:
+          line: 4
+          column: 4
+        end:
+          line: 4
+          column: 22
+        classification: real
+      - path: "system/grc.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 4
+          column: 10
+        end:
+          line: 4
+          column: 40
+        classification: real
+      - path: "zsh/fpath.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 2
+          column: 19
+        end:
+          line: 2
+          column: 23
+        classification: real
+      - path: "zsh/prompt.zsh"
+        code: "C092"
+        severity: "warning"
+        message: "use the command's exit status directly instead of executing the output from `$(...)`"
+        start:
+          line: 17
+          column: 6
+        end:
+          line: 17
+          column: 38
+        classification: real
+  - name: "ohmyzsh"
+    github_url: "https://github.com/ohmyzsh/ohmyzsh.git"
+    commit: "e64912e0c1eaa32181c3b5e5e4bf8042ecd0e8a7"
+    diagnostics:
+      - path: "lib/async_prompt.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 90
+          column: 7
+        end:
+          line: 90
+          column: 15
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `args` is assigned but never used"
+        start:
+          line: 104
+          column: 9
+        end:
+          line: 104
+          column: 13
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `functrace` is referenced before assignment"
+        start:
+          line: 125
+          column: 30
+        end:
+          line: 125
+          column: 47
+        classification: false_positive
+      - path: "lib/cli.zsh"
+        code: "C132"
+        severity: "warning"
+        message: "this same-command expansion still sees the earlier shell value"
+        start:
+          line: 202
+          column: 30
+        end:
+          line: 202
+          column: 34
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `dis_p` is referenced before assignment"
+        start:
+          line: 252
+          column: 11
+        end:
+          line: 252
+          column: 31
+        classification: false_positive
+      - path: "lib/cli.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 304
+          column: 6
+        end:
+          line: 304
+          column: 8
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C056"
+        severity: "warning"
+        message: "`$?` here refers to a condition result, not an earlier command"
+        start:
+          line: 305
+          column: 15
+        end:
+          line: 305
+          column: 17
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 398
+          column: 6
+        end:
+          line: 398
+          column: 8
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C056"
+        severity: "warning"
+        message: "`$?` here refers to a condition result, not an earlier command"
+        start:
+          line: 399
+          column: 15
+        end:
+          line: 399
+          column: 17
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C021"
+        severity: "warning"
+        message: "this `case` statement switches on a fixed literal"
+        start:
+          line: 437
+          column: 12
+        end:
+          line: 437
+          column: 13
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 438
+          column: 9
+        end:
+          line: 438
+          column: 27
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 439
+          column: 9
+        end:
+          line: 439
+          column: 26
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 440
+          column: 9
+        end:
+          line: 440
+          column: 27
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `comp_files` is assigned but never used"
+        start:
+          line: 521
+          column: 5
+        end:
+          line: 521
+          column: 15
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 526
+          column: 14
+        end:
+          line: 526
+          column: 40
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_comp_dumpfile` is referenced before assignment"
+        start:
+          line: 537
+          column: 21
+        end:
+          line: 537
+          column: 36
+        classification: false_positive
+      - path: "lib/cli.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 704
+          column: 6
+        end:
+          line: 704
+          column: 8
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 742
+          column: 33
+        end:
+          line: 742
+          column: 35
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 842
+          column: 6
+        end:
+          line: 842
+          column: 8
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C056"
+        severity: "warning"
+        message: "`$?` here refers to a condition result, not an earlier command"
+        start:
+          line: 843
+          column: 15
+        end:
+          line: 843
+          column: 17
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 870
+          column: 12
+        end:
+          line: 870
+          column: 38
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 872
+          column: 12
+        end:
+          line: 872
+          column: 45
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 874
+          column: 12
+        end:
+          line: 874
+          column: 38
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 900
+          column: 6
+        end:
+          line: 900
+          column: 8
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C132"
+        severity: "warning"
+        message: "this same-command expansion still sees the earlier shell value"
+        start:
+          line: 907
+          column: 30
+        end:
+          line: 907
+          column: 34
+        classification: real
+      - path: "lib/cli.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 920
+          column: 35
+        end:
+          line: 920
+          column: 37
+        classification: real
+      - path: "lib/completion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `WORDCHARS` is assigned but never used"
+        start:
+          line: 4
+          column: 1
+        end:
+          line: 4
+          column: 10
+        classification: false_positive
+      - path: "lib/diagnostics.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `opts` is assigned but never used"
+        start:
+          line: 68
+          column: 25
+        end:
+          line: 68
+          column: 29
+        classification: real
+      - path: "lib/diagnostics.zsh"
+        code: "C086"
+        severity: "warning"
+        message: "use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons"
+        start:
+          line: 72
+          column: 15
+        end:
+          line: 72
+          column: 16
+        classification: real
+      - path: "lib/diagnostics.zsh"
+        code: "C086"
+        severity: "warning"
+        message: "use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons"
+        start:
+          line: 75
+          column: 15
+        end:
+          line: 75
+          column: 16
+        classification: real
+      - path: "lib/diagnostics.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 86
+          column: 9
+        end:
+          line: 86
+          column: 11
+        classification: real
+      - path: "lib/diagnostics.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `md5` is assigned but never used"
+        start:
+          line: 103
+          column: 35
+        end:
+          line: 103
+          column: 38
+        classification: real
+      - path: "lib/diagnostics.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 127
+          column: 11
+        end:
+          line: 127
+          column: 13
+        classification: real
+      - path: "lib/diagnostics.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 185
+          column: 16
+        end:
+          line: 185
+          column: 37
+        classification: false_positive
+      - path: "lib/diagnostics.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `builtins_fatal` is assigned but never used"
+        start:
+          line: 278
+          column: 3
+        end:
+          line: 278
+          column: 17
+        classification: real
+      - path: "lib/functions.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 23
+          column: 49
+        end:
+          line: 23
+          column: 51
+        classification: real
+      - path: "lib/functions.zsh"
+        code: "C130"
+        severity: "warning"
+        message: "quotes or backslashes stored in this value will stay literal on reuse"
+        start:
+          line: 30
+          column: 24
+        end:
+          line: 30
+          column: 34
+        classification: real
+      - path: "lib/functions.zsh"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 43
+          column: 3
+        end:
+          line: 43
+          column: 15
+        classification: real
+      - path: "lib/functions.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 183
+          column: 16
+        end:
+          line: 183
+          column: 20
+        classification: real
+      - path: "lib/functions.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 195
+          column: 11
+        end:
+          line: 195
+          column: 13
+        classification: real
+      - path: "lib/functions.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 277
+          column: 11
+        end:
+          line: 277
+          column: 13
+        classification: real
+      - path: "lib/git.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `statuses_seen` is assigned but never used"
+        start:
+          line: 125
+          column: 7
+        end:
+          line: 125
+          column: 38
+        classification: real
+      - path: "lib/git.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `hook_com` is referenced before assignment"
+        start:
+          line: 241
+          column: 43
+        end:
+          line: 241
+          column: 62
+        classification: false_positive
+      - path: "lib/grep.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 12
+        end:
+          line: 6
+          column: 32
+        classification: real
+      - path: "lib/history.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `list` is assigned but never used"
+        start:
+          line: 5
+          column: 30
+        end:
+          line: 5
+          column: 34
+        classification: real
+      - path: "lib/spectrum.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `FX` is assigned but never used"
+        start:
+          line: 7
+          column: 1
+        end:
+          line: 7
+          column: 3
+        classification: real
+      - path: "lib/tests/cli.test.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `dis_p` is referenced before assignment"
+        start:
+          line: 11
+          column: 13
+        end:
+          line: 11
+          column: 33
+        classification: false_positive
+      - path: "lib/theme-and-appearance.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_PREFIX` is assigned but never used"
+        start:
+          line: 8
+          column: 1
+        end:
+          line: 8
+          column: 28
+        classification: false_positive
+      - path: "lib/theme-and-appearance.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_SUFFIX` is assigned but never used"
+        start:
+          line: 9
+          column: 1
+        end:
+          line: 9
+          column: 28
+        classification: false_positive
+      - path: "lib/theme-and-appearance.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_DIRTY` is assigned but never used"
+        start:
+          line: 10
+          column: 1
+        end:
+          line: 10
+          column: 27
+        classification: false_positive
+      - path: "lib/theme-and-appearance.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_CLEAN` is assigned but never used"
+        start:
+          line: 11
+          column: 1
+        end:
+          line: 11
+          column: 27
+        classification: false_positive
+      - path: "lib/theme-and-appearance.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_RUBY_PROMPT_PREFIX` is assigned but never used"
+        start:
+          line: 12
+          column: 1
+        end:
+          line: 12
+          column: 29
+        classification: false_positive
+      - path: "lib/theme-and-appearance.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_RUBY_PROMPT_SUFFIX` is assigned but never used"
+        start:
+          line: 13
+          column: 1
+        end:
+          line: 13
+          column: 29
+        classification: false_positive
+      - path: "lib/theme-and-appearance.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 35
+          column: 7
+        end:
+          line: 35
+          column: 9
+        classification: real
+      - path: "lib/theme-and-appearance.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 35
+          column: 17
+        end:
+          line: 35
+          column: 51
+        classification: real
+      - path: "lib/theme-and-appearance.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 36
+          column: 17
+        end:
+          line: 36
+          column: 32
+        classification: real
+      - path: "lib/vcs_info.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PATCH` is assigned but never used"
+        start:
+          line: 44
+          column: 9
+        end:
+          line: 44
+          column: 14
+        classification: real
+      - path: "oh-my-zsh.sh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 26
+          column: 7
+        end:
+          line: 26
+          column: 9
+        classification: real
+      - path: "oh-my-zsh.sh"
+        code: "C006"
+        severity: "error"
+        message: "variable `plugins` is referenced before assignment"
+        start:
+          line: 90
+          column: 13
+        end:
+          line: 90
+          column: 21
+        classification: false_positive
+      - path: "oh-my-zsh.sh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 175
+          column: 12
+        end:
+          line: 175
+          column: 35
+        classification: real
+      - path: "oh-my-zsh.sh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 177
+          column: 12
+        end:
+          line: 177
+          column: 28
+        classification: real
+      - path: "oh-my-zsh.sh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 210
+          column: 10
+        end:
+          line: 210
+          column: 24
+        classification: real
+      - path: "oh-my-zsh.sh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 223
+          column: 12
+        end:
+          line: 223
+          column: 46
+        classification: real
+      - path: "oh-my-zsh.sh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 225
+          column: 12
+        end:
+          line: 225
+          column: 53
+        classification: real
+      - path: "oh-my-zsh.sh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 227
+          column: 12
+        end:
+          line: 227
+          column: 46
+        classification: real
+      - path: "plugins/alias-finder/alias-finder.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 26
+          column: 72
+        end:
+          line: 26
+          column: 98
+        classification: false_positive
+      - path: "plugins/alias-finder/alias-finder.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 64
+          column: 50
+        end:
+          line: 64
+          column: 52
+        classification: real
+      - path: "plugins/alias-finder/tests/test_run.sh"
+        code: "C006"
+        severity: "error"
+        message: "variable `lines` is referenced before assignment"
+        start:
+          line: 20
+          column: 11
+        end:
+          line: 20
+          column: 23
+        classification: false_positive
+      - path: "plugins/archlinux/archlinux.plugin.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 37
+          column: 16
+        end:
+          line: 37
+          column: 24
+        classification: real
+      - path: "plugins/archlinux/archlinux.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bold_color` is referenced before assignment"
+        start:
+          line: 68
+          column: 17
+        end:
+          line: 68
+          column: 28
+        classification: false_positive
+      - path: "plugins/autoenv/autoenv.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 54
+          column: 12
+        end:
+          line: 54
+          column: 33
+        classification: real
+      - path: "plugins/autoenv/autoenv.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 56
+          column: 12
+        end:
+          line: 56
+          column: 36
+        classification: real
+      - path: "plugins/autoenv/autoenv.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 60
+          column: 4
+        end:
+          line: 60
+          column: 6
+        classification: real
+      - path: "plugins/autoenv/autoenv.plugin.zsh"
+        code: "C056"
+        severity: "warning"
+        message: "`$?` here refers to a condition result, not an earlier command"
+        start:
+          line: 60
+          column: 25
+        end:
+          line: 60
+          column: 27
+        classification: real
+      - path: "plugins/autojump/autojump.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 24
+          column: 12
+        end:
+          line: 24
+          column: 19
+        classification: real
+      - path: "plugins/autojump/autojump.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 34
+          column: 12
+        end:
+          line: 34
+          column: 19
+        classification: real
+      - path: "plugins/aws/aws.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `yn` is referenced before assignment"
+        start:
+          line: 206
+          column: 8
+        end:
+          line: 206
+          column: 11
+        classification: false_positive
+      - path: "plugins/aws/aws.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 274
+          column: 53
+        end:
+          line: 274
+          column: 73
+        classification: false_positive
+      - path: "plugins/aws/aws.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 335
+          column: 47
+        end:
+          line: 335
+          column: 71
+        classification: real
+      - path: "plugins/azure/azure.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 59
+          column: 91
+        end:
+          line: 59
+          column: 114
+        classification: real
+      - path: "plugins/bgnotify/bgnotify.plugin.zsh"
+        code: "P004"
+        severity: "warning"
+        message: "use braces to group these tests instead of a subshell"
+        start:
+          line: 67
+          column: 37
+        end:
+          line: 67
+          column: 77
+        classification: real
+      - path: "plugins/bgnotify/bgnotify.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bgnotify_extraargs` is referenced before assignment"
+        start:
+          line: 132
+          column: 120
+        end:
+          line: 132
+          column: 144
+        classification: false_positive
+      - path: "plugins/bower/bower.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `expl` is assigned but never used"
+        start:
+          line: 13
+          column: 11
+        end:
+          line: 13
+          column: 15
+        classification: false_positive
+      - path: "plugins/bundler/bundler.plugin.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `BUNDLED_COMMANDS` looks like it may mean `bundled_commands`"
+        start:
+          line: 56
+          column: 20
+        end:
+          line: 56
+          column: 37
+        classification: real
+      - path: "plugins/cabal/cabal.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `cabal_files` is assigned but never used"
+        start:
+          line: 2
+          column: 5
+        end:
+          line: 2
+          column: 16
+        classification: real
+      - path: "plugins/cabal/cabal.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `context` is assigned but never used"
+        start:
+          line: 57
+          column: 5
+        end:
+          line: 57
+          column: 15
+        classification: false_positive
+      - path: "plugins/cabal/cabal.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `line` is assigned but never used"
+        start:
+          line: 57
+          column: 5
+        end:
+          line: 57
+          column: 15
+        classification: real
+      - path: "plugins/cabal/cabal.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `opt_args` is assigned but never used"
+        start:
+          line: 57
+          column: 5
+        end:
+          line: 57
+          column: 15
+        classification: false_positive
+      - path: "plugins/cabal/cabal.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `state_descr` is assigned but never used"
+        start:
+          line: 57
+          column: 5
+        end:
+          line: 57
+          column: 15
+        classification: false_positive
+      - path: "plugins/cabal/cabal.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ret` is assigned but never used"
+        start:
+          line: 87
+          column: 67
+        end:
+          line: 87
+          column: 70
+        classification: real
+      - path: "plugins/cask/cask.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 22
+          column: 14
+        end:
+          line: 22
+          column: 18
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X052"
+        severity: "warning"
+        message: "`function` with trailing `()` is not portable in `sh` scripts"
+        start:
+          line: 14
+          column: 1
+        end:
+          line: 17
+          column: 2
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "P001"
+        severity: "warning"
+        message: "use shell arithmetic instead of `expr` for numeric operations"
+        start:
+          line: 46
+          column: 10
+        end:
+          line: 46
+          column: 14
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X027"
+        severity: "warning"
+        message: "echo flags are not portable in `sh` scripts"
+        start:
+          line: 46
+          column: 39
+        end:
+          line: 46
+          column: 41
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "P001"
+        severity: "warning"
+        message: "use shell arithmetic instead of `expr` for numeric operations"
+        start:
+          line: 48
+          column: 10
+        end:
+          line: 48
+          column: 14
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X027"
+        severity: "warning"
+        message: "echo flags are not portable in `sh` scripts"
+        start:
+          line: 48
+          column: 33
+        end:
+          line: 48
+          column: 35
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `f` is assigned but never used"
+        start:
+          line: 68
+          column: 18
+        end:
+          line: 68
+          column: 19
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X008"
+        severity: "warning"
+        message: "standalone `(( ))` arithmetic is not portable in `sh` scripts"
+        start:
+          line: 71
+          column: 7
+        end:
+          line: 74
+          column: 9
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X062"
+        severity: "warning"
+        message: "arithmetic `++` and `--` operators are not portable in `sh` scripts"
+        start:
+          line: 72
+          column: 8
+        end:
+          line: 72
+          column: 10
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X008"
+        severity: "warning"
+        message: "standalone `(( ))` arithmetic is not portable in `sh` scripts"
+        start:
+          line: 76
+          column: 7
+        end:
+          line: 82
+          column: 9
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X062"
+        severity: "warning"
+        message: "arithmetic `++` and `--` operators are not portable in `sh` scripts"
+        start:
+          line: 77
+          column: 8
+        end:
+          line: 77
+          column: 10
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X027"
+        severity: "warning"
+        message: "echo flags are not portable in `sh` scripts"
+        start:
+          line: 85
+          column: 10
+        end:
+          line: 85
+          column: 13
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X008"
+        severity: "warning"
+        message: "standalone `(( ))` arithmetic is not portable in `sh` scripts"
+        start:
+          line: 87
+          column: 5
+        end:
+          line: 87
+          column: 14
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X062"
+        severity: "warning"
+        message: "arithmetic `++` and `--` operators are not portable in `sh` scripts"
+        start:
+          line: 87
+          column: 9
+        end:
+          line: 87
+          column: 11
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X027"
+        severity: "warning"
+        message: "echo flags are not portable in `sh` scripts"
+        start:
+          line: 88
+          column: 10
+        end:
+          line: 88
+          column: 13
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X008"
+        severity: "warning"
+        message: "standalone `(( ))` arithmetic is not portable in `sh` scripts"
+        start:
+          line: 91
+          column: 3
+        end:
+          line: 91
+          column: 20
+        classification: real
+      - path: "plugins/catimg/catimg.sh"
+        code: "X027"
+        severity: "warning"
+        message: "echo flags are not portable in `sh` scripts"
+        start:
+          line: 91
+          column: 29
+        end:
+          line: 91
+          column: 31
+        classification: real
+      - path: "plugins/chruby/chruby.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 10
+          column: 12
+        end:
+          line: 10
+          column: 27
+        classification: real
+      - path: "plugins/chruby/chruby.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 14
+          column: 12
+        end:
+          line: 14
+          column: 27
+        classification: real
+      - path: "plugins/chruby/chruby.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 21
+          column: 10
+        end:
+          line: 21
+          column: 43
+        classification: real
+      - path: "plugins/chruby/chruby.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 22
+          column: 10
+        end:
+          line: 22
+          column: 41
+        classification: real
+      - path: "plugins/chruby/chruby.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 42
+          column: 10
+        end:
+          line: 42
+          column: 46
+        classification: real
+      - path: "plugins/chruby/chruby.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 43
+          column: 10
+        end:
+          line: 43
+          column: 44
+        classification: real
+      - path: "plugins/command-not-found/command-not-found.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 18
+          column: 12
+        end:
+          line: 18
+          column: 19
+        classification: real
+      - path: "plugins/command-not-found/command-not-found.plugin.zsh"
+        code: "C063"
+        severity: "warning"
+        message: "function `command_not_found_handler` is overwritten before any direct call can reach it"
+        start:
+          line: 66
+          column: 3
+        end:
+          line: 68
+          column: 4
+        classification: real
+      - path: "plugins/compleat/compleat.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 18
+          column: 12
+        end:
+          line: 18
+          column: 20
+        classification: real
+      - path: "plugins/composer/composer.plugin.zsh"
+        code: "C071"
+        severity: "warning"
+        message: "double parentheses are used to group commands instead of arithmetic"
+        start:
+          line: 9
+          column: 32
+        end:
+          line: 9
+          column: 32
+        classification: real
+      - path: "plugins/debian/debian.plugin.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 80
+          column: 13
+        end:
+          line: 80
+          column: 51
+        classification: real
+      - path: "plugins/debian/debian.plugin.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 91
+          column: 13
+        end:
+          line: 91
+          column: 49
+        classification: real
+      - path: "plugins/debian/debian.plugin.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 96
+          column: 13
+        end:
+          line: 96
+          column: 47
+        classification: real
+      - path: "plugins/debian/debian.plugin.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 101
+          column: 13
+        end:
+          line: 101
+          column: 52
+        classification: real
+      - path: "plugins/debian/debian.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `fb` is assigned but never used"
+        start:
+          line: 121
+          column: 13
+        end:
+          line: 121
+          column: 15
+        classification: real
+      - path: "plugins/debian/debian.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 160
+          column: 9
+        end:
+          line: 160
+          column: 28
+        classification: false_positive
+      - path: "plugins/debian/debian.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 211
+          column: 11
+        end:
+          line: 211
+          column: 31
+        classification: false_positive
+      - path: "plugins/dirhistory/dirhistory.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `dirhistory_futuret` is referenced before assignment"
+        start:
+          line: 55
+          column: 38
+        end:
+          line: 55
+          column: 78
+        classification: false_positive
+      - path: "plugins/dotenv/dotenv.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 61
+          column: 10
+        end:
+          line: 61
+          column: 26
+        classification: real
+      - path: "plugins/dotnet/dotnet.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `completions` is assigned but never used"
+        start:
+          line: 6
+          column: 12
+        end:
+          line: 6
+          column: 23
+        classification: real
+      - path: "plugins/drush/drush.complete.sh"
+        code: "X012"
+        severity: "warning"
+        message: "use of `&>` is not portable in `sh`"
+        start:
+          line: 16
+          column: 40
+        end:
+          line: 16
+          column: 52
+        classification: real
+      - path: "plugins/drush/drush.complete.sh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `DRUPAL_SITE` looks like it may mean `__DRUPAL_SITE`"
+        start:
+          line: 24
+          column: 20
+        end:
+          line: 24
+          column: 32
+        classification: real
+      - path: "plugins/drush/drush.complete.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 34
+          column: 3
+        end:
+          line: 34
+          column: 28
+        classification: real
+      - path: "plugins/drush/drush.complete.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 42
+          column: 3
+        end:
+          line: 42
+          column: 12
+        classification: real
+      - path: "plugins/drush/drush.complete.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 42
+          column: 13
+        end:
+          line: 42
+          column: 18
+        classification: real
+      - path: "plugins/drush/drush.complete.sh"
+        code: "X013"
+        severity: "warning"
+        message: "array assignment is not portable in `sh`"
+        start:
+          line: 46
+          column: 13
+        end:
+          line: 46
+          column: 99
+        classification: real
+      - path: "plugins/drush/drush.complete.sh"
+        code: "X019"
+        severity: "warning"
+        message: "array references are not portable in `sh`"
+        start:
+          line: 46
+          column: 54
+        end:
+          line: 46
+          column: 70
+        classification: real
+      - path: "plugins/drush/drush.complete.sh"
+        code: "X016"
+        severity: "warning"
+        message: "`complete` is not portable in `sh` scripts"
+        start:
+          line: 50
+          column: 1
+        end:
+          line: 50
+          column: 116
+        classification: real
+      - path: "plugins/drush/drush.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 107
+          column: 8
+        end:
+          line: 107
+          column: 39
+        classification: real
+      - path: "plugins/eecms/eecms.plugin.zsh"
+        code: "C093"
+        severity: "warning"
+        message: "run the command directly instead of executing backtick output as a command name"
+        start:
+          line: 8
+          column: 5
+        end:
+          line: 8
+          column: 21
+        classification: real
+      - path: "plugins/eecms/eecms.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 15
+          column: 16
+        end:
+          line: 15
+          column: 34
+        classification: false_positive
+      - path: "plugins/emacs/emacsclient.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 4
+          column: 3
+        end:
+          line: 4
+          column: 19
+        classification: real
+      - path: "plugins/emacs/emacsclient.sh"
+        code: "C128"
+        severity: "warning"
+        message: "this case pattern shadows a later pattern"
+        start:
+          line: 9
+          column: 3
+        end:
+          line: 9
+          column: 7
+        classification: real
+      - path: "plugins/emacs/emacsclient.sh"
+        code: "C129"
+        severity: "warning"
+        message: "this case pattern is unreachable because an earlier pattern already matches it"
+        start:
+          line: 9
+          column: 8
+        end:
+          line: 9
+          column: 15
+        classification: real
+      - path: "plugins/emacs/emacsclient.sh"
+        code: "X023"
+        severity: "warning"
+        message: "substring expansion is not portable in `sh`"
+        start:
+          line: 35
+          column: 28
+        end:
+          line: 35
+          column: 34
+        classification: real
+      - path: "plugins/emoji/emoji-char-definitions.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `emoji_mod` is assigned but never used"
+        start:
+          line: 2681
+          column: 1
+        end:
+          line: 2681
+          column: 16
+        classification: real
+      - path: "plugins/emoji/emoji-char-definitions.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `emoji` is assigned but never used"
+        start:
+          line: 4250
+          column: 1
+        end:
+          line: 4250
+          column: 27
+        classification: real
+      - path: "plugins/emoji/emoji-char-definitions.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `emoji_flags` is assigned but never used"
+        start:
+          line: 5282
+          column: 1
+        end:
+          line: 5282
+          column: 19
+        classification: real
+      - path: "plugins/emoji/emoji-char-definitions.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `emoji_groups` is assigned but never used"
+        start:
+          line: 7005
+          column: 1
+        end:
+          line: 7005
+          column: 20
+        classification: real
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_d_regional_indicator_symbol_letter_e` is referenced before assignment"
+        start:
+          line: 31
+          column: 7
+        end:
+          line: 31
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_g_regional_indicator_symbol_letter_b` is referenced before assignment"
+        start:
+          line: 32
+          column: 7
+        end:
+          line: 32
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_c_regional_indicator_symbol_letter_n` is referenced before assignment"
+        start:
+          line: 33
+          column: 7
+        end:
+          line: 33
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_j_regional_indicator_symbol_letter_p` is referenced before assignment"
+        start:
+          line: 34
+          column: 7
+        end:
+          line: 34
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_k_regional_indicator_symbol_letter_r` is referenced before assignment"
+        start:
+          line: 35
+          column: 7
+        end:
+          line: 35
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_f_regional_indicator_symbol_letter_r` is referenced before assignment"
+        start:
+          line: 36
+          column: 7
+        end:
+          line: 36
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_e_regional_indicator_symbol_letter_s` is referenced before assignment"
+        start:
+          line: 37
+          column: 7
+        end:
+          line: 37
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_i_regional_indicator_symbol_letter_t` is referenced before assignment"
+        start:
+          line: 38
+          column: 7
+        end:
+          line: 38
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_u_regional_indicator_symbol_letter_s` is referenced before assignment"
+        start:
+          line: 39
+          column: 7
+        end:
+          line: 39
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `regional_indicator_symbol_letter_r_regional_indicator_symbol_letter_u` is referenced before assignment"
+        start:
+          line: 40
+          column: 7
+        end:
+          line: 40
+          column: 76
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `emoji_skintone` is assigned but never used"
+        start:
+          line: 47
+          column: 1
+        end:
+          line: 47
+          column: 18
+        classification: real
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `emoji_groups` is referenced before assignment"
+        start:
+          line: 60
+          column: 9
+        end:
+          line: 60
+          column: 33
+        classification: false_positive
+      - path: "plugins/emoji/emoji.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `emoji_flags` is referenced before assignment"
+        start:
+          line: 67
+          column: 10
+        end:
+          line: 67
+          column: 31
+        classification: false_positive
+      - path: "plugins/emotty/emotty.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `emoji` is referenced before assignment"
+        start:
+          line: 42
+          column: 9
+        end:
+          line: 42
+          column: 36
+        classification: false_positive
+      - path: "plugins/emotty/emotty.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `emoji2` is referenced before assignment"
+        start:
+          line: 42
+          column: 36
+        end:
+          line: 42
+          column: 58
+        classification: false_positive
+      - path: "plugins/emotty/emotty_emoji_set.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `emoji` is referenced before assignment"
+        start:
+          line: 4
+          column: 14
+        end:
+          line: 4
+          column: 19
+        classification: false_positive
+      - path: "plugins/emotty/emotty_floral_set.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `floral` is referenced before assignment"
+        start:
+          line: 4
+          column: 14
+        end:
+          line: 4
+          column: 20
+        classification: false_positive
+      - path: "plugins/emotty/emotty_love_set.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `love` is referenced before assignment"
+        start:
+          line: 6
+          column: 14
+        end:
+          line: 6
+          column: 18
+        classification: false_positive
+      - path: "plugins/emotty/emotty_nature_set.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `nature` is referenced before assignment"
+        start:
+          line: 4
+          column: 14
+        end:
+          line: 4
+          column: 20
+        classification: false_positive
+      - path: "plugins/emotty/emotty_stellar_set.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `stellar` is referenced before assignment"
+        start:
+          line: 9
+          column: 14
+        end:
+          line: 9
+          column: 21
+        classification: false_positive
+      - path: "plugins/emotty/emotty_zodiac_set.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `zodiac` is referenced before assignment"
+        start:
+          line: 4
+          column: 14
+        end:
+          line: 4
+          column: 20
+        classification: false_positive
+      - path: "plugins/extract/extract.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 52
+          column: 32
+        end:
+          line: 52
+          column: 34
+        classification: real
+      - path: "plugins/extract/extract.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 54
+          column: 34
+        end:
+          line: 54
+          column: 36
+        classification: real
+      - path: "plugins/extract/extract.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 56
+          column: 32
+        end:
+          line: 56
+          column: 34
+        classification: real
+      - path: "plugins/extract/extract.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 58
+          column: 9
+        end:
+          line: 58
+          column: 11
+        classification: real
+      - path: "plugins/extract/extract.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 62
+          column: 9
+        end:
+          line: 62
+          column: 11
+        classification: real
+      - path: "plugins/extract/extract.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 66
+          column: 9
+        end:
+          line: 66
+          column: 11
+        classification: real
+      - path: "plugins/extract/extract.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 72
+          column: 37
+        end:
+          line: 72
+          column: 39
+        classification: real
+      - path: "plugins/extract/extract.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 73
+          column: 40
+        end:
+          line: 73
+          column: 42
+        classification: real
+      - path: "plugins/extract/extract.plugin.zsh"
+        code: "C012"
+        severity: "warning"
+        message: "wildcard arguments should be guarded with `./` or `--`"
+        start:
+          line: 97
+          column: 38
+        end:
+          line: 97
+          column: 39
+        classification: real
+      - path: "plugins/fasd/fasd.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 11
+          column: 8
+        end:
+          line: 11
+          column: 21
+        classification: real
+      - path: "plugins/forklift/forklift.plugin.zsh"
+        code: "C085"
+        severity: "warning"
+        message: "stderr is redirected before stdout is redirected"
+        start:
+          line: 27
+          column: 13
+        end:
+          line: 27
+          column: 17
+        classification: real
+      - path: "plugins/frontend-search/frontend-search.plugin.zsh"
+        code: "C021"
+        severity: "warning"
+        message: "this `case` statement switches on a fixed literal"
+        start:
+          line: 34
+          column: 10
+        end:
+          line: 34
+          column: 14
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `FZF_BASE` looks like it may mean `fzf_base`"
+        start:
+          line: 17
+          column: 12
+        end:
+          line: 17
+          column: 23
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 66
+          column: 12
+        end:
+          line: 66
+          column: 41
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 71
+          column: 12
+        end:
+          line: 71
+          column: 43
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 111
+          column: 12
+        end:
+          line: 111
+          column: 24
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 116
+          column: 12
+        end:
+          line: 116
+          column: 25
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 140
+          column: 12
+        end:
+          line: 140
+          column: 26
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 145
+          column: 12
+        end:
+          line: 145
+          column: 27
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 162
+          column: 12
+        end:
+          line: 162
+          column: 26
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 166
+          column: 12
+        end:
+          line: 166
+          column: 27
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 185
+          column: 12
+        end:
+          line: 185
+          column: 26
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 190
+          column: 12
+        end:
+          line: 190
+          column: 27
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 209
+          column: 12
+        end:
+          line: 209
+          column: 26
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 214
+          column: 12
+        end:
+          line: 214
+          column: 27
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 235
+          column: 12
+        end:
+          line: 235
+          column: 26
+        classification: real
+      - path: "plugins/fzf/fzf.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 240
+          column: 12
+        end:
+          line: 240
+          column: 27
+        classification: real
+      - path: "plugins/gcloud/gcloud.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 36
+          column: 12
+        end:
+          line: 36
+          column: 43
+        classification: real
+      - path: "plugins/gcloud/gcloud.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 45
+          column: 14
+        end:
+          line: 45
+          column: 28
+        classification: real
+      - path: "plugins/genpass/genpass-monkey"
+        code: "C001"
+        severity: "warning"
+        message: "variable `c` is assigned but never used"
+        start:
+          line: 23
+          column: 9
+        end:
+          line: 23
+          column: 10
+        classification: real
+      - path: "plugins/genpass/genpass-xkcd"
+        code: "C001"
+        severity: "warning"
+        message: "variable `c` is assigned but never used"
+        start:
+          line: 49
+          column: 9
+        end:
+          line: 49
+          column: 10
+        classification: real
+      - path: "plugins/git-commit/git-commit.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 32
+          column: 15
+        end:
+          line: 54
+          column: 17
+        classification: real
+      - path: "plugins/git-commit/git-commit.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 54
+          column: 23
+        end:
+          line: 55
+          column: 6
+        classification: real
+      - path: "plugins/git-extras/git-extras.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `*:#0` is referenced before assignment"
+        start:
+          line: 32
+          column: 9
+        end:
+          line: 32
+          column: 17
+        classification: false_positive
+      - path: "plugins/git-extras/git-extras.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `expl` is assigned but never used"
+        start:
+          line: 97
+          column: 11
+        end:
+          line: 97
+          column: 15
+        classification: false_positive
+      - path: "plugins/git-extras/git-extras.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `state_descr` is assigned but never used"
+        start:
+          line: 218
+          column: 5
+        end:
+          line: 218
+          column: 15
+        classification: false_positive
+      - path: "plugins/git-extras/git-extras.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ret` is assigned but never used"
+        start:
+          line: 228
+          column: 55
+        end:
+          line: 228
+          column: 58
+        classification: real
+      - path: "plugins/git-extras/git-extras.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `context` is assigned but never used"
+        start:
+          line: 337
+          column: 5
+        end:
+          line: 337
+          column: 15
+        classification: false_positive
+      - path: "plugins/git-extras/git-extras.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `opt_args` is assigned but never used"
+        start:
+          line: 337
+          column: 5
+        end:
+          line: 337
+          column: 15
+        classification: false_positive
+      - path: "plugins/git-extras/git-extras.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `existing_user_commands` is referenced before assignment"
+        start:
+          line: 344
+          column: 46
+        end:
+          line: 344
+          column: 69
+        classification: false_positive
+      - path: "plugins/git-extras/git-extras.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 404
+          column: 9
+        end:
+          line: 404
+          column: 52
+        classification: real
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 82
+          column: 17
+        end:
+          line: 82
+          column: 85
+        classification: real
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 108
+          column: 27
+        end:
+          line: 108
+          column: 70
+        classification: real
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 162
+          column: 17
+        end:
+          line: 162
+          column: 83
+        classification: real
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 186
+          column: 27
+        end:
+          line: 186
+          column: 70
+        classification: real
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 229
+          column: 17
+        end:
+          line: 229
+          column: 85
+        classification: real
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 325
+          column: 17
+        end:
+          line: 325
+          column: 83
+        classification: real
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `state_descr` is assigned but never used"
+        start:
+          line: 409
+          column: 5
+        end:
+          line: 409
+          column: 15
+        classification: false_positive
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 418
+          column: 17
+        end:
+          line: 418
+          column: 76
+        classification: real
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `context` is assigned but never used"
+        start:
+          line: 437
+          column: 21
+        end:
+          line: 437
+          column: 31
+        classification: false_positive
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `opt_args` is assigned but never used"
+        start:
+          line: 437
+          column: 21
+        end:
+          line: 437
+          column: 31
+        classification: false_positive
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `expl` is assigned but never used"
+        start:
+          line: 509
+          column: 11
+        end:
+          line: 509
+          column: 15
+        classification: false_positive
+      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `pipestatus:#0` is referenced before assignment"
+        start:
+          line: 519
+          column: 11
+        end:
+          line: 519
+          column: 28
+        classification: false_positive
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 76
+          column: 17
+        end:
+          line: 76
+          column: 83
+        classification: real
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 102
+          column: 27
+        end:
+          line: 102
+          column: 70
+        classification: real
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 133
+          column: 17
+        end:
+          line: 133
+          column: 81
+        classification: real
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 161
+          column: 27
+        end:
+          line: 161
+          column: 70
+        classification: real
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `state_descr` is assigned but never used"
+        start:
+          line: 181
+          column: 5
+        end:
+          line: 181
+          column: 15
+        classification: false_positive
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 190
+          column: 17
+        end:
+          line: 190
+          column: 83
+        classification: real
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `context` is assigned but never used"
+        start:
+          line: 257
+          column: 21
+        end:
+          line: 257
+          column: 31
+        classification: false_positive
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `opt_args` is assigned but never used"
+        start:
+          line: 257
+          column: 21
+        end:
+          line: 257
+          column: 31
+        classification: false_positive
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `expl` is assigned but never used"
+        start:
+          line: 316
+          column: 11
+        end:
+          line: 316
+          column: 15
+        classification: false_positive
+      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `pipestatus:#0` is referenced before assignment"
+        start:
+          line: 326
+          column: 11
+        end:
+          line: 326
+          column: 28
+        classification: false_positive
+      - path: "plugins/git-prompt/git-prompt.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `RPROMPT` is assigned but never used"
+        start:
+          line: 113
+          column: 1
+        end:
+          line: 113
+          column: 8
+        classification: false_positive
+      - path: "plugins/git/git.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 183
+          column: 17
+        end:
+          line: 183
+          column: 19
+        classification: real
+      - path: "plugins/git/git.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 227
+          column: 3
+        end:
+          line: 227
+          column: 5
+        classification: real
+      - path: "plugins/git/git.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 312
+          column: 3
+        end:
+          line: 312
+          column: 5
+        classification: real
+      - path: "plugins/git/git.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 324
+          column: 3
+        end:
+          line: 324
+          column: 5
+        classification: real
+      - path: "plugins/git/git.plugin.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 389
+          column: 3
+        end:
+          line: 389
+          column: 5
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "X044"
+        severity: "warning"
+        message: "nested zsh substitutions are not portable to this shell"
+        start:
+          line: 326
+          column: 8
+        end:
+          line: 326
+          column: 54
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "X028"
+        severity: "warning"
+        message: "use `[:lower:]` instead of `a-z` in `tr` for locale-aware lower-case matching"
+        start:
+          line: 600
+          column: 31
+        end:
+          line: 600
+          column: 34
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "X029"
+        severity: "warning"
+        message: "use `[:upper:]` instead of `A-Z` in `tr` for locale-aware upper-case matching"
+        start:
+          line: 600
+          column: 35
+        end:
+          line: 600
+          column: 38
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C021"
+        severity: "warning"
+        message: "this `case` statement switches on a fixed literal"
+        start:
+          line: 653
+          column: 9
+        end:
+          line: 653
+          column: 15
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C021"
+        severity: "warning"
+        message: "this `case` statement switches on a fixed literal"
+        start:
+          line: 662
+          column: 9
+        end:
+          line: 662
+          column: 15
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C001"
+        severity: "warning"
+        message: "variable `hash` is assigned but never used"
+        start:
+          line: 765
+          column: 16
+        end:
+          line: 765
+          column: 20
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 993
+          column: 13
+        end:
+          line: 993
+          column: 21
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2386
+          column: 62
+        end:
+          line: 2386
+          column: 64
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "X029"
+        severity: "warning"
+        message: "use `[:upper:]` instead of `A-Z` in `tr` for locale-aware upper-case matching"
+        start:
+          line: 2416
+          column: 34
+        end:
+          line: 2416
+          column: 37
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "X028"
+        severity: "warning"
+        message: "use `[:lower:]` instead of `a-z` in `tr` for locale-aware lower-case matching"
+        start:
+          line: 2416
+          column: 38
+        end:
+          line: 2416
+          column: 41
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 2886
+          column: 11
+        end:
+          line: 2886
+          column: 24
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X022"
+        severity: "warning"
+        message: "this builtin option is not portable in `sh` scripts"
+        start:
+          line: 112
+          column: 8
+        end:
+          line: 112
+          column: 10
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 118
+          column: 2
+        end:
+          line: 118
+          column: 17
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 119
+          column: 2
+        end:
+          line: 119
+          column: 42
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 120
+          column: 2
+        end:
+          line: 120
+          column: 51
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X013"
+        severity: "warning"
+        message: "array assignment is not portable in `sh`"
+        start:
+          line: 122
+          column: 13
+        end:
+          line: 122
+          column: 15
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 124
+          column: 2
+        end:
+          line: 124
+          column: 14
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 129
+          column: 7
+        end:
+          line: 129
+          column: 41
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X011"
+        severity: "warning"
+        message: "here-strings are not portable in `sh`"
+        start:
+          line: 140
+          column: 7
+        end:
+          line: 140
+          column: 10
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 143
+          column: 2
+        end:
+          line: 143
+          column: 14
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 159
+          column: 3
+        end:
+          line: 159
+          column: 24
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X013"
+        severity: "warning"
+        message: "array assignment is not portable in `sh`"
+        start:
+          line: 160
+          column: 16
+        end:
+          line: 161
+          column: 67
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 162
+          column: 6
+        end:
+          line: 162
+          column: 37
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X041"
+        severity: "warning"
+        message: "array-style subscripts in `[[ ... ]]` are not portable to POSIX sh"
+        start:
+          line: 162
+          column: 15
+        end:
+          line: 162
+          column: 34
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 163
+          column: 4
+        end:
+          line: 163
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X019"
+        severity: "warning"
+        message: "array references are not portable in `sh`"
+        start:
+          line: 163
+          column: 17
+        end:
+          line: 163
+          column: 57
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 164
+          column: 4
+        end:
+          line: 164
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 165
+          column: 4
+        end:
+          line: 165
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X056"
+        severity: "warning"
+        message: "C-style `for ((...))` loops are not portable in `sh` scripts"
+        start:
+          line: 166
+          column: 4
+        end:
+          line: 166
+          column: 7
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X062"
+        severity: "warning"
+        message: "arithmetic `++` and `--` operators are not portable in `sh` scripts"
+        start:
+          line: 166
+          column: 29
+        end:
+          line: 166
+          column: 31
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 167
+          column: 5
+        end:
+          line: 167
+          column: 17
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 167
+          column: 33
+        end:
+          line: 167
+          column: 50
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X019"
+        severity: "warning"
+        message: "array references are not portable in `sh`"
+        start:
+          line: 167
+          column: 33
+        end:
+          line: 167
+          column: 50
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 170
+          column: 7
+        end:
+          line: 170
+          column: 31
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 170
+          column: 14
+        end:
+          line: 170
+          column: 27
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 176
+          column: 8
+        end:
+          line: 176
+          column: 42
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X033"
+        severity: "warning"
+        message: "`elif` uses `[[ ... ]]`, which is not available in POSIX sh"
+        start:
+          line: 176
+          column: 8
+        end:
+          line: 176
+          column: 42
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 183
+          column: 5
+        end:
+          line: 183
+          column: 23
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 188
+          column: 3
+        end:
+          line: 188
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 191
+          column: 4
+        end:
+          line: 191
+          column: 31
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X008"
+        severity: "warning"
+        message: "standalone `(( ))` arithmetic is not portable in `sh` scripts"
+        start:
+          line: 195
+          column: 11
+        end:
+          line: 195
+          column: 23
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X062"
+        severity: "warning"
+        message: "arithmetic `++` and `--` operators are not portable in `sh` scripts"
+        start:
+          line: 195
+          column: 19
+        end:
+          line: 195
+          column: 21
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X008"
+        severity: "warning"
+        message: "standalone `(( ))` arithmetic is not portable in `sh` scripts"
+        start:
+          line: 196
+          column: 11
+        end:
+          line: 196
+          column: 22
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X062"
+        severity: "warning"
+        message: "arithmetic `++` and `--` operators are not portable in `sh` scripts"
+        start:
+          line: 196
+          column: 18
+        end:
+          line: 196
+          column: 20
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 206
+          column: 5
+        end:
+          line: 206
+          column: 24
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 232
+          column: 6
+        end:
+          line: 232
+          column: 37
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 254
+          column: 5
+        end:
+          line: 254
+          column: 29
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 255
+          column: 3
+        end:
+          line: 255
+          column: 14
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 256
+          column: 3
+        end:
+          line: 256
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 257
+          column: 3
+        end:
+          line: 257
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 258
+          column: 3
+        end:
+          line: 258
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 262
+          column: 3
+        end:
+          line: 262
+          column: 14
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 262
+          column: 15
+        end:
+          line: 262
+          column: 32
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 263
+          column: 3
+        end:
+          line: 263
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 263
+          column: 17
+        end:
+          line: 263
+          column: 34
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 264
+          column: 3
+        end:
+          line: 264
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 264
+          column: 17
+        end:
+          line: 264
+          column: 36
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 265
+          column: 3
+        end:
+          line: 265
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 265
+          column: 17
+        end:
+          line: 265
+          column: 33
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 267
+          column: 2
+        end:
+          line: 267
+          column: 17
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 268
+          column: 2
+        end:
+          line: 268
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 269
+          column: 2
+        end:
+          line: 269
+          column: 19
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 271
+          column: 2
+        end:
+          line: 271
+          column: 20
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 301
+          column: 22
+        end:
+          line: 301
+          column: 29
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 310
+          column: 2
+        end:
+          line: 310
+          column: 12
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 349
+          column: 2
+        end:
+          line: 349
+          column: 12
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 350
+          column: 2
+        end:
+          line: 350
+          column: 14
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 351
+          column: 2
+        end:
+          line: 351
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 352
+          column: 2
+        end:
+          line: 352
+          column: 19
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 353
+          column: 2
+        end:
+          line: 353
+          column: 17
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 354
+          column: 2
+        end:
+          line: 354
+          column: 21
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 405
+          column: 2
+        end:
+          line: 405
+          column: 20
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 406
+          column: 30
+        end:
+          line: 406
+          column: 51
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X073"
+        severity: "warning"
+        message: "`-o` option tests are not available in POSIX sh"
+        start:
+          line: 406
+          column: 33
+        end:
+          line: 406
+          column: 35
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X016"
+        severity: "warning"
+        message: "`shopt` is not portable in `sh` scripts"
+        start:
+          line: 407
+          column: 31
+        end:
+          line: 407
+          column: 50
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 409
+          column: 2
+        end:
+          line: 409
+          column: 37
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 419
+          column: 2
+        end:
+          line: 419
+          column: 17
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 421
+          column: 28
+        end:
+          line: 421
+          column: 33
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 422
+          column: 26
+        end:
+          line: 422
+          column: 31
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 424
+          column: 2
+        end:
+          line: 424
+          column: 23
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 424
+          column: 39
+        end:
+          line: 424
+          column: 44
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 425
+          column: 25
+        end:
+          line: 425
+          column: 30
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 426
+          column: 2
+        end:
+          line: 426
+          column: 17
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 426
+          column: 33
+        end:
+          line: 426
+          column: 38
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 427
+          column: 25
+        end:
+          line: 427
+          column: 30
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 428
+          column: 2
+        end:
+          line: 428
+          column: 21
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 428
+          column: 37
+        end:
+          line: 428
+          column: 42
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 429
+          column: 2
+        end:
+          line: 429
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 429
+          column: 23
+        end:
+          line: 429
+          column: 28
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 439
+          column: 2
+        end:
+          line: 439
+          column: 14
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 446
+          column: 2
+        end:
+          line: 446
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 447
+          column: 2
+        end:
+          line: 447
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 448
+          column: 2
+        end:
+          line: 448
+          column: 12
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 449
+          column: 2
+        end:
+          line: 449
+          column: 13
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 481
+          column: 4
+        end:
+          line: 481
+          column: 14
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "C128"
+        severity: "warning"
+        message: "this case pattern shadows a later pattern"
+        start:
+          line: 499
+          column: 6
+        end:
+          line: 499
+          column: 7
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "C129"
+        severity: "warning"
+        message: "this case pattern is unreachable because an earlier pattern already matches it"
+        start:
+          line: 499
+          column: 10
+        end:
+          line: 499
+          column: 17
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 513
+          column: 2
+        end:
+          line: 513
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 514
+          column: 5
+        end:
+          line: 514
+          column: 50
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X002"
+        severity: "warning"
+        message: "use `=` instead of `==` in POSIX test expressions"
+        start:
+          line: 514
+          column: 39
+        end:
+          line: 514
+          column: 41
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X001"
+        severity: "warning"
+        message: "`[[ ... ]]` is not available in POSIX sh"
+        start:
+          line: 515
+          column: 5
+        end:
+          line: 515
+          column: 49
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 519
+          column: 2
+        end:
+          line: 519
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 520
+          column: 2
+        end:
+          line: 520
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 521
+          column: 2
+        end:
+          line: 521
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 522
+          column: 2
+        end:
+          line: 522
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 523
+          column: 2
+        end:
+          line: 523
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 524
+          column: 2
+        end:
+          line: 524
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 525
+          column: 2
+        end:
+          line: 525
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 526
+          column: 2
+        end:
+          line: 526
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 567
+          column: 2
+        end:
+          line: 567
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 579
+          column: 2
+        end:
+          line: 579
+          column: 9
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 580
+          column: 2
+        end:
+          line: 580
+          column: 17
+        classification: real
+      - path: "plugins/gitfast/git-prompt.sh"
+        code: "X022"
+        severity: "warning"
+        message: "this builtin option is not portable in `sh` scripts"
+        start:
+          line: 586
+          column: 11
+        end:
+          line: 586
+          column: 13
+        classification: real
+      - path: "plugins/grc/grc.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 15
+          column: 12
+        end:
+          line: 15
+          column: 19
+        classification: real
+      - path: "plugins/grunt/grunt.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `cache_path` is assigned but never used"
+        start:
+          line: 120
+          column: 40
+        end:
+          line: 120
+          column: 50
+        classification: real
+      - path: "plugins/grunt/grunt.plugin.zsh"
+        code: "C071"
+        severity: "warning"
+        message: "double parentheses are used to group commands instead of arithmetic"
+        start:
+          line: 126
+          column: 12
+        end:
+          line: 126
+          column: 12
+        classification: real
+      - path: "plugins/grunt/grunt.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 133
+          column: 25
+        end:
+          line: 133
+          column: 43
+        classification: real
+      - path: "plugins/grunt/grunt.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 137
+          column: 30
+        end:
+          line: 137
+          column: 41
+        classification: real
+      - path: "plugins/grunt/grunt.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 149
+          column: 26
+        end:
+          line: 149
+          column: 37
+        classification: real
+      - path: "plugins/grunt/grunt.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 198
+          column: 24
+        end:
+          line: 198
+          column: 28
+        classification: real
+      - path: "plugins/grunt/grunt.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 201
+          column: 23
+        end:
+          line: 201
+          column: 31
+        classification: real
+      - path: "plugins/grunt/grunt.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `oldp` is assigned but never used"
+        start:
+          line: 251
+          column: 5
+        end:
+          line: 251
+          column: 9
+        classification: real
+      - path: "plugins/hasura/hasura.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 9
+          column: 10
+        end:
+          line: 9
+          column: 46
+        classification: real
+      - path: "plugins/hasura/hasura.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 11
+          column: 10
+        end:
+          line: 11
+          column: 46
+        classification: real
+      - path: "plugins/helm/helm.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 9
+          column: 10
+        end:
+          line: 9
+          column: 44
+        classification: real
+      - path: "plugins/helm/helm.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 11
+          column: 10
+        end:
+          line: 11
+          column: 44
+        classification: real
+      - path: "plugins/heroku/heroku.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 8
+          column: 34
+        end:
+          line: 8
+          column: 45
+        classification: real
+      - path: "plugins/history-substring-search/history-substring-search.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 218
+          column: 11
+        end:
+          line: 218
+          column: 27
+        classification: real
+      - path: "plugins/history-substring-search/history-substring-search.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 259
+          column: 34
+        end:
+          line: 259
+          column: 71
+        classification: real
+      - path: "plugins/history-substring-search/history-substring-search.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `BUFFER:$highlight_start_index` is referenced before assignment"
+        start:
+          line: 397
+          column: 41
+        end:
+          line: 397
+          column: 74
+        classification: false_positive
+      - path: "plugins/history-substring-search/history-substring-search.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `xlbuflines` is assigned but never used"
+        start:
+          line: 451
+          column: 3
+        end:
+          line: 451
+          column: 13
+        classification: real
+      - path: "plugins/history-substring-search/history-substring-search.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `buflines` is assigned but never used"
+        start:
+          line: 478
+          column: 3
+        end:
+          line: 478
+          column: 11
+        classification: real
+      - path: "plugins/history-substring-search/history-substring-search.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `xrbuflines` is assigned but never used"
+        start:
+          line: 480
+          column: 3
+        end:
+          line: 480
+          column: 13
+        classification: real
+      - path: "plugins/history-substring-search/history-substring-search.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 757
+          column: 44
+        end:
+          line: 757
+          column: 77
+        classification: real
+      - path: "plugins/history-substring-search/history-substring-search.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 837
+          column: 44
+        end:
+          line: 837
+          column: 77
+        classification: real
+      - path: "plugins/invoke/invoke.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 4
+          column: 10
+        end:
+          line: 4
+          column: 49
+        classification: real
+      - path: "plugins/istioctl/istioctl.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 2
+          column: 10
+        end:
+          line: 2
+          column: 36
+        classification: real
+      - path: "plugins/iterm2/iterm2.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ITERM_PROFILE` is assigned but never used"
+        start:
+          line: 58
+          column: 5
+        end:
+          line: 58
+          column: 18
+        classification: real
+      - path: "plugins/iterm2/iterm2_shell_integration.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 38
+          column: 10
+        end:
+          line: 38
+          column: 12
+        classification: real
+      - path: "plugins/iterm2/iterm2_shell_integration.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 163
+          column: 14
+        end:
+          line: 163
+          column: 16
+        classification: real
+      - path: "plugins/jira/jira.plugin.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `JIRA_NAME` looks like it may mean `jira_name`"
+        start:
+          line: 112
+          column: 21
+        end:
+          line: 112
+          column: 31
+        classification: real
+      - path: "plugins/juju/juju.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 10
+          column: 39
+        end:
+          line: 10
+          column: 57
+        classification: real
+      - path: "plugins/jump/jump.plugin.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 35
+          column: 14
+        end:
+          line: 35
+          column: 23
+        classification: real
+      - path: "plugins/jump/jump.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `link:t` is referenced before assignment"
+        start:
+          line: 36
+          column: 9
+        end:
+          line: 36
+          column: 19
+        classification: false_positive
+      - path: "plugins/jump/jump.plugin.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 41
+          column: 14
+        end:
+          line: 41
+          column: 23
+        classification: real
+      - path: "plugins/jump/jump.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 57
+          column: 26
+        end:
+          line: 57
+          column: 71
+        classification: false_positive
+      - path: "plugins/keychain/keychain.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 38
+          column: 38
+        end:
+          line: 38
+          column: 57
+        classification: real
+      - path: "plugins/keychain/keychain.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 39
+          column: 38
+        end:
+          line: 39
+          column: 61
+        classification: real
+      - path: "plugins/kn/kn.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 10
+        end:
+          line: 6
+          column: 30
+        classification: real
+      - path: "plugins/kompose/kompose.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 2
+          column: 10
+        end:
+          line: 2
+          column: 35
+        classification: real
+      - path: "plugins/kops/kops.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 2
+          column: 10
+        end:
+          line: 2
+          column: 32
+        classification: real
+      - path: "plugins/kube-ps1/kube-ps1.plugin.zsh"
+        code: "C017"
+        severity: "warning"
+        message: "this comparison only checks fixed literals"
+        start:
+          line: 189
+          column: 56
+        end:
+          line: 189
+          column: 58
+        classification: real
+      - path: "plugins/laravel/laravel.plugin.zsh"
+        code: "C060"
+        severity: "warning"
+        message: "shebang should use an absolute path or `/usr/bin/env`"
+        start:
+          line: 1
+          column: 1
+        end:
+          line: 1
+          column: 6
+        classification: real
+      - path: "plugins/lxd/lxd.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_comp_command1` is referenced before assignment"
+        start:
+          line: 2
+          column: 5
+        end:
+          line: 2
+          column: 20
+        classification: false_positive
+      - path: "plugins/macos/macos.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `i` is referenced before assignment"
+        start:
+          line: 306
+          column: 90
+        end:
+          line: 306
+          column: 92
+        classification: false_positive
+      - path: "plugins/macos/music"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 54
+          column: 15
+        end:
+          line: 54
+          column: 17
+        classification: real
+      - path: "plugins/macos/spotify"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 36
+          column: 8
+        end:
+          line: 36
+          column: 29
+        classification: real
+      - path: "plugins/macos/spotify"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `USER_CONFG_FILE` looks like it may mean `USER_CONFIG_FILE`"
+        start:
+          line: 197
+          column: 67
+        end:
+          line: 197
+          column: 85
+        classification: real
+      - path: "plugins/macos/spotify"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 231
+          column: 31
+        end:
+          line: 231
+          column: 49
+        classification: real
+      - path: "plugins/macos/spotify"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 256
+          column: 31
+        end:
+          line: 256
+          column: 49
+        classification: real
+      - path: "plugins/macos/spotify"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 260
+          column: 42
+        end:
+          line: 260
+          column: 60
+        classification: real
+      - path: "plugins/macos/spotify"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 263
+          column: 31
+        end:
+          line: 263
+          column: 49
+        classification: real
+      - path: "plugins/macos/spotify"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 447
+          column: 23
+        end:
+          line: 447
+          column: 30
+        classification: real
+      - path: "plugins/mercurial/mercurial.plugin.zsh"
+        code: "P002"
+        severity: "warning"
+        message: "use `grep -c` instead of piping `grep` into `wc -l`"
+        start:
+          line: 25
+          column: 22
+        end:
+          line: 25
+          column: 38
+        classification: real
+      - path: "plugins/mercurial/mercurial.plugin.zsh"
+        code: "P002"
+        severity: "warning"
+        message: "use `grep -c` instead of piping `grep` into `wc -l`"
+        start:
+          line: 29
+          column: 22
+        end:
+          line: 29
+          column: 38
+        classification: real
+      - path: "plugins/microk8s/microk8s.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 13
+          column: 29
+        end:
+          line: 13
+          column: 35
+        classification: real
+      - path: "plugins/mvn/mvn.plugin.zsh"
+        code: "C012"
+        severity: "warning"
+        message: "wildcard arguments should be guarded with `./` or `--`"
+        start:
+          line: 128
+          column: 23
+        end:
+          line: 128
+          column: 24
+        classification: real
+      - path: "plugins/n98-magerun/n98-magerun.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_comp_command1` is referenced before assignment"
+        start:
+          line: 11
+          column: 3
+        end:
+          line: 11
+          column: 18
+        classification: false_positive
+      - path: "plugins/nvm/nvm.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 32
+          column: 27
+        end:
+          line: 32
+          column: 45
+        classification: real
+      - path: "plugins/nvm/nvm.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 96
+          column: 10
+        end:
+          line: 96
+          column: 27
+        classification: real
+      - path: "plugins/oc/oc.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 10
+        end:
+          line: 6
+          column: 30
+        classification: real
+      - path: "plugins/operator-sdk/operator-sdk.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 2
+          column: 10
+        end:
+          line: 2
+          column: 40
+        classification: real
+      - path: "plugins/otp/otp.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `COPY_CMD` is assigned but never used"
+        start:
+          line: 15
+          column: 3
+        end:
+          line: 15
+          column: 11
+        classification: real
+      - path: "plugins/otp/otp.plugin.zsh"
+        code: "C007"
+        severity: "warning"
+        message: "raw `find` output piped to `xargs` can break on whitespace"
+        start:
+          line: 42
+          column: 12
+        end:
+          line: 42
+          column: 43
+        classification: real
+      - path: "plugins/perl/perl.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 62
+          column: 12
+        end:
+          line: 62
+          column: 37
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `use_slow_mode` is assigned but never used"
+        start:
+          line: 23
+          column: 52
+        end:
+          line: 23
+          column: 65
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C086"
+        severity: "warning"
+        message: "use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons"
+        start:
+          line: 25
+          column: 12
+        end:
+          line: 25
+          column: 13
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 71
+          column: 11
+        end:
+          line: 71
+          column: 13
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C056"
+        severity: "warning"
+        message: "`$?` here refers to a condition result, not an earlier command"
+        start:
+          line: 71
+          column: 41
+        end:
+          line: 71
+          column: 43
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 73
+          column: 11
+        end:
+          line: 73
+          column: 13
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C056"
+        severity: "warning"
+        message: "`$?` here refers to a condition result, not an earlier command"
+        start:
+          line: 73
+          column: 41
+        end:
+          line: 73
+          column: 43
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 76
+          column: 11
+        end:
+          line: 76
+          column: 13
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C056"
+        severity: "warning"
+        message: "`$?` here refers to a condition result, not an earlier command"
+        start:
+          line: 76
+          column: 41
+        end:
+          line: 76
+          column: 43
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 78
+          column: 11
+        end:
+          line: 78
+          column: 13
+        classification: real
+      - path: "plugins/perms/perms.plugin.zsh"
+        code: "C056"
+        severity: "warning"
+        message: "`$?` here refers to a condition result, not an earlier command"
+        start:
+          line: 78
+          column: 41
+        end:
+          line: 78
+          column: 43
+        classification: real
+      - path: "plugins/pip/pip.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 63
+          column: 22
+        end:
+          line: 63
+          column: 31
+        classification: real
+      - path: "plugins/pip/pip.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 78
+          column: 22
+        end:
+          line: 78
+          column: 31
+        classification: real
+      - path: "plugins/pipenv/pipenv.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 32
+          column: 16
+        end:
+          line: 32
+          column: 47
+        classification: real
+      - path: "plugins/please/please.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 2
+          column: 12
+        end:
+          line: 2
+          column: 38
+        classification: real
+      - path: "plugins/poetry-env/poetry-env.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 26
+          column: 14
+        end:
+          line: 26
+          column: 40
+        classification: real
+      - path: "plugins/pow/pow.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 54
+          column: 5
+        end:
+          line: 54
+          column: 7
+        classification: real
+      - path: "plugins/profiles/profiles.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 10
+          column: 12
+        end:
+          line: 10
+          column: 17
+        classification: real
+      - path: "plugins/pyenv/pyenv.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 64
+          column: 26
+        end:
+          line: 64
+          column: 60
+        classification: real
+      - path: "plugins/pyenv/pyenv.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 78
+          column: 26
+        end:
+          line: 78
+          column: 56
+        classification: real
+      - path: "plugins/python/python.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 86
+          column: 5
+        end:
+          line: 86
+          column: 31
+        classification: real
+      - path: "plugins/python/python.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 110
+          column: 19
+        end:
+          line: 110
+          column: 35
+        classification: real
+      - path: "plugins/python/python.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 115
+          column: 16
+        end:
+          line: 115
+          column: 21
+        classification: real
+      - path: "plugins/rbenv/rbenv.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `current_ruby` is referenced before assignment"
+        start:
+          line: 45
+          column: 13
+        end:
+          line: 45
+          column: 26
+        classification: false_positive
+      - path: "plugins/rbenv/rbenv.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `current_gemset` is referenced before assignment"
+        start:
+          line: 46
+          column: 26
+        end:
+          line: 46
+          column: 41
+        classification: false_positive
+      - path: "plugins/rvm/rvm.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `rvm_path` is referenced before assignment"
+        start:
+          line: 2
+          column: 10
+        end:
+          line: 2
+          column: 21
+        classification: false_positive
+      - path: "plugins/scd/scd"
+        code: "C130"
+        severity: "warning"
+        message: "quotes or backslashes stored in this value will stay literal on reuse"
+        start:
+          line: 12
+          column: 11
+        end:
+          line: 40
+          column: 2
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 91
+          column: 11
+        end:
+          line: 91
+          column: 15
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 96
+          column: 31
+        end:
+          line: 96
+          column: 41
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 129
+          column: 29
+        end:
+          line: 129
+          column: 31
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 150
+          column: 39
+        end:
+          line: 150
+          column: 49
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 166
+          column: 24
+        end:
+          line: 166
+          column: 34
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C006"
+        severity: "error"
+        message: "variable `nameddirs` is referenced before assignment"
+        start:
+          line: 168
+          column: 24
+        end:
+          line: 168
+          column: 40
+        classification: false_positive
+      - path: "plugins/scd/scd"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 195
+          column: 20
+        end:
+          line: 195
+          column: 30
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 278
+          column: 42
+        end:
+          line: 278
+          column: 57
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 317
+          column: 5
+        end:
+          line: 317
+          column: 6
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 463
+          column: 21
+        end:
+          line: 463
+          column: 34
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C001"
+        severity: "warning"
+        message: "variable `threshold` is assigned but never used"
+        start:
+          line: 482
+          column: 9
+        end:
+          line: 482
+          column: 18
+        classification: real
+      - path: "plugins/scd/scd"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 484
+          column: 34
+        end:
+          line: 484
+          column: 71
+        classification: real
+      - path: "plugins/scd/scd.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 16
+          column: 12
+        end:
+          line: 16
+          column: 27
+        classification: real
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 9
+          column: 15
+        end:
+          line: 9
+          column: 82
+        classification: false_positive
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 12
+          column: 15
+        end:
+          line: 12
+          column: 44
+        classification: false_positive
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 16
+          column: 34
+        end:
+          line: 16
+          column: 39
+        classification: false_positive
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 16
+          column: 49
+        end:
+          line: 16
+          column: 82
+        classification: false_positive
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 19
+          column: 20
+        end:
+          line: 19
+          column: 30
+        classification: false_positive
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 22
+          column: 18
+        end:
+          line: 22
+          column: 29
+        classification: false_positive
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 29
+          column: 25
+        end:
+          line: 29
+          column: 35
+        classification: false_positive
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 32
+          column: 23
+        end:
+          line: 32
+          column: 29
+        classification: false_positive
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `cmd` is assigned but never used"
+        start:
+          line: 46
+          column: 19
+        end:
+          line: 46
+          column: 22
+        classification: real
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `tab_title` is referenced before assignment"
+        start:
+          line: 49
+          column: 16
+        end:
+          line: 49
+          column: 26
+        classification: false_positive
+      - path: "plugins/screen/screen.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `tab_hardstatus` is referenced before assignment"
+        start:
+          line: 49
+          column: 27
+        end:
+          line: 49
+          column: 42
+        classification: false_positive
+      - path: "plugins/shrink-path/shrink-path.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `elllen` is assigned but never used"
+        start:
+          line: 138
+          column: 20
+        end:
+          line: 138
+          column: 26
+        classification: real
+      - path: "plugins/shrink-path/shrink-path.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `nameddirs` is referenced before assignment"
+        start:
+          line: 151
+          column: 29
+        end:
+          line: 151
+          column: 44
+        classification: false_positive
+      - path: "plugins/shrink-path/shrink-path.plugin.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 173
+          column: 44
+        end:
+          line: 173
+          column: 46
+        classification: real
+      - path: "plugins/shrink-path/shrink-path.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ellen` is referenced before assignment"
+        start:
+          line: 173
+          column: 68
+        end:
+          line: 173
+          column: 73
+        classification: false_positive
+      - path: "plugins/shrink-path/shrink-path.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 173
+          column: 87
+        end:
+          line: 173
+          column: 92
+        classification: real
+      - path: "plugins/shrink-path/shrink-path.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 173
+          column: 130
+        end:
+          line: 173
+          column: 135
+        classification: real
+      - path: "plugins/ssh-agent/ssh-agent.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 7
+          column: 7
+        end:
+          line: 7
+          column: 23
+        classification: real
+      - path: "plugins/ssh-agent/ssh-agent.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 29
+          column: 5
+        end:
+          line: 29
+          column: 21
+        classification: real
+      - path: "plugins/stack/stack.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 4
+          column: 8
+        end:
+          line: 4
+          column: 47
+        classification: real
+      - path: "plugins/sublime-merge/sublime-merge.plugin.zsh"
+        code: "C122"
+        severity: "warning"
+        message: "use `-e` or `&&` instead of `-a` inside `[[ ... ]]`"
+        start:
+          line: 17
+          column: 10
+        end:
+          line: 17
+          column: 12
+        classification: real
+      - path: "plugins/sublime-merge/sublime-merge.plugin.zsh"
+        code: "C122"
+        severity: "warning"
+        message: "use `-e` or `&&` instead of `-a` inside `[[ ... ]]`"
+        start:
+          line: 33
+          column: 10
+        end:
+          line: 33
+          column: 12
+        classification: real
+      - path: "plugins/sublime-merge/sublime-merge.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `sublime_merge_cygwin_paths` is assigned but never used"
+        start:
+          line: 41
+          column: 3
+        end:
+          line: 41
+          column: 29
+        classification: real
+      - path: "plugins/sublime-merge/sublime-merge.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ProgramW6432` is referenced before assignment"
+        start:
+          line: 42
+          column: 15
+        end:
+          line: 42
+          column: 28
+        classification: false_positive
+      - path: "plugins/sublime-merge/sublime-merge.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_sublime_merge_cygwin_paths` is referenced before assignment"
+        start:
+          line: 44
+          column: 30
+        end:
+          line: 44
+          column: 58
+        classification: false_positive
+      - path: "plugins/sublime-merge/sublime-merge.plugin.zsh"
+        code: "C122"
+        severity: "warning"
+        message: "use `-e` or `&&` instead of `-a` inside `[[ ... ]]`"
+        start:
+          line: 45
+          column: 10
+        end:
+          line: 45
+          column: 12
+        classification: real
+      - path: "plugins/sublime/sublime.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ProgramW6432` is referenced before assignment"
+        start:
+          line: 51
+          column: 19
+        end:
+          line: 51
+          column: 32
+        classification: false_positive
+      - path: "plugins/sublime/sublime.plugin.zsh"
+        code: "C122"
+        severity: "warning"
+        message: "use `-e` or `&&` instead of `-a` inside `[[ ... ]]`"
+        start:
+          line: 63
+          column: 11
+        end:
+          line: 63
+          column: 13
+        classification: real
+      - path: "plugins/sudo/sudo.plugin.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 24
+          column: 36
+        end:
+          line: 24
+          column: 40
+        classification: real
+      - path: "plugins/sudo/sudo.plugin.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 28
+          column: 38
+        end:
+          line: 28
+          column: 42
+        classification: real
+      - path: "plugins/sudo/sudo.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 89
+          column: 42
+        end:
+          line: 89
+          column: 51
+        classification: real
+      - path: "plugins/svcat/svcat.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 5
+          column: 10
+        end:
+          line: 5
+          column: 33
+        classification: real
+      - path: "plugins/symfony2/symfony2.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 15
+          column: 19
+        end:
+          line: 15
+          column: 39
+        classification: false_positive
+      - path: "plugins/symfony6/symfony6.plugin.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 32
+          column: 24
+        end:
+          line: 32
+          column: 39
+        classification: real
+      - path: "plugins/symfony6/symfony6.plugin.zsh"
+        code: "C101"
+        severity: "warning"
+        message: "backslashes in IFS stay literal"
+        start:
+          line: 64
+          column: 15
+        end:
+          line: 64
+          column: 19
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C012"
+        severity: "warning"
+        message: "wildcard arguments should be guarded with `./` or `--`"
+        start:
+          line: 47
+          column: 12
+        end:
+          line: 47
+          column: 13
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "P002"
+        severity: "warning"
+        message: "use `grep -c` instead of piping `grep` into `wc -l`"
+        start:
+          line: 76
+          column: 7
+        end:
+          line: 76
+          column: 26
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C025"
+        severity: "warning"
+        message: "use braces for positional parameters above 9"
+        start:
+          line: 141
+          column: 14
+        end:
+          line: 141
+          column: 49
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C046"
+        severity: "warning"
+        message: "piping data into `kill` has no effect"
+        start:
+          line: 182
+          column: 3
+        end:
+          line: 183
+          column: 1
+        classification: real
+      - path: "plugins/term_tab/term_tab.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `expl` is assigned but never used"
+        start:
+          line: 18
+          column: 12
+        end:
+          line: 18
+          column: 16
+        classification: false_positive
+      - path: "plugins/thefuck/thefuck.plugin.zsh"
+        code: "C122"
+        severity: "warning"
+        message: "use `-e` or `&&` instead of `-a` inside `[[ ... ]]`"
+        start:
+          line: 8
+          column: 6
+        end:
+          line: 8
+          column: 8
+        classification: real
+      - path: "plugins/thefuck/thefuck.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 9
+          column: 8
+        end:
+          line: 9
+          column: 32
+        classification: real
+      - path: "plugins/themes/themes.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 5
+          column: 16
+        end:
+          line: 5
+          column: 42
+        classification: real
+      - path: "plugins/themes/themes.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 7
+          column: 16
+        end:
+          line: 7
+          column: 49
+        classification: real
+      - path: "plugins/themes/themes.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 9
+          column: 16
+        end:
+          line: 9
+          column: 42
+        classification: real
+      - path: "plugins/timer/timer.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `dec` is assigned but never used"
+        start:
+          line: 9
+          column: 52
+        end:
+          line: 9
+          column: 55
+        classification: real
+      - path: "plugins/tmux/tmux.plugin.zsh"
+        code: "K003"
+        severity: "warning"
+        message: "array expansion passed to `eval` is reinterpreted as shell text"
+        start:
+          line: 70
+          column: 17
+        end:
+          line: 70
+          column: 23
+        classification: real
+      - path: "plugins/tmux/tmux.plugin.zsh"
+        code: "C112"
+        severity: "warning"
+        message: "all-elements array expansions collapse inside `[[ ... ]]` tests"
+        start:
+          line: 112
+          column: 12
+        end:
+          line: 112
+          column: 16
+        classification: real
+      - path: "plugins/tmux/tmux.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 145
+          column: 9
+        end:
+          line: 145
+          column: 11
+        classification: real
+      - path: "plugins/ubuntu/ubuntu.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 122
+          column: 9
+        end:
+          line: 122
+          column: 29
+        classification: false_positive
+      - path: "plugins/vi-mode/vi-mode.plugin.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 57
+          column: 28
+        end:
+          line: 57
+          column: 52
+        classification: real
+      - path: "plugins/vim-interaction/vim-interaction.plugin.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 52
+          column: 27
+        end:
+          line: 52
+          column: 50
+        classification: real
+      - path: "plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 13
+          column: 20
+        end:
+          line: 13
+          column: 40
+        classification: real
+      - path: "plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 22
+          column: 1
+        end:
+          line: 26
+          column: 3
+        classification: real
+      - path: "plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 22
+          column: 7
+        end:
+          line: 22
+          column: 9
+        classification: real
+      - path: "plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 28
+          column: 1
+        end:
+          line: 30
+          column: 3
+        classification: real
+      - path: "plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 32
+          column: 1
+        end:
+          line: 93
+          column: 3
+        classification: real
+      - path: "plugins/virtualenvwrapper/virtualenvwrapper.plugin.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 74
+          column: 20
+        end:
+          line: 74
+          column: 42
+        classification: real
+      - path: "plugins/wd/_wd.sh"
+        code: "C006"
+        severity: "error"
+        message: "variable `mapfile` is referenced before assignment"
+        start:
+          line: 17
+          column: 18
+        end:
+          line: 17
+          column: 52
+        classification: false_positive
+      - path: "plugins/wd/_wd.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `context` is assigned but never used"
+        start:
+          line: 49
+          column: 3
+        end:
+          line: 49
+          column: 13
+        classification: false_positive
+      - path: "plugins/wd/_wd.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `opt_args` is assigned but never used"
+        start:
+          line: 49
+          column: 3
+        end:
+          line: 49
+          column: 13
+        classification: false_positive
+      - path: "plugins/wd/_wd.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `state_descr` is assigned but never used"
+        start:
+          line: 49
+          column: 3
+        end:
+          line: 49
+          column: 13
+        classification: false_positive
+      - path: "plugins/wd/wd.sh"
+        code: "C018"
+        severity: "error"
+        message: "`break` is only valid inside a loop"
+        start:
+          line: 127
+          column: 9
+        end:
+          line: 127
+          column: 14
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C018"
+        severity: "error"
+        message: "`break` is only valid inside a loop"
+        start:
+          line: 130
+          column: 9
+        end:
+          line: 130
+          column: 14
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C086"
+        severity: "warning"
+        message: "use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons"
+        start:
+          line: 143
+          column: 19
+        end:
+          line: 143
+          column: 20
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 354
+          column: 5
+        end:
+          line: 354
+          column: 12
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `WD_QUIET` is assigned but never used"
+        start:
+          line: 500
+          column: 7
+        end:
+          line: 500
+          column: 15
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `args` is assigned but never used"
+        start:
+          line: 555
+          column: 1
+        end:
+          line: 555
+          column: 5
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C128"
+        severity: "warning"
+        message: "this case pattern shadows a later pattern"
+        start:
+          line: 576
+          column: 13
+        end:
+          line: 576
+          column: 17
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C129"
+        severity: "warning"
+        message: "this case pattern is unreachable because an earlier pattern already matches it"
+        start:
+          line: 613
+          column: 13
+        end:
+          line: 613
+          column: 17
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C128"
+        severity: "warning"
+        message: "this case pattern shadows a later pattern"
+        start:
+          line: 617
+          column: 13
+        end:
+          line: 617
+          column: 14
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C129"
+        severity: "warning"
+        message: "this case pattern is unreachable because an earlier pattern already matches it"
+        start:
+          line: 621
+          column: 13
+        end:
+          line: 621
+          column: 15
+        classification: real
+      - path: "plugins/wd/wd.sh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 622
+          column: 17
+        end:
+          line: 622
+          column: 22
+        classification: real
+      - path: "plugins/xcode/xcode.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `file` is assigned but never used"
+        start:
+          line: 100
+          column: 9
+        end:
+          line: 100
+          column: 13
+        classification: real
+      - path: "plugins/xcode/xcode.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 141
+          column: 44
+        end:
+          line: 141
+          column: 56
+        classification: real
+      - path: "plugins/xcode/xcode.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 163
+          column: 13
+        end:
+          line: 163
+          column: 15
+        classification: real
+      - path: "plugins/xcode/xcode.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `width_i` is assigned but never used"
+        start:
+          line: 175
+          column: 17
+        end:
+          line: 175
+          column: 24
+        classification: real
+      - path: "plugins/yarn/yarn.plugin.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 6
+          column: 6
+        end:
+          line: 6
+          column: 8
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 217
+          column: 16
+        end:
+          line: 217
+          column: 21
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 223
+          column: 11
+        end:
+          line: 223
+          column: 21
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `lockfd` is assigned but never used"
+        start:
+          line: 234
+          column: 13
+        end:
+          line: 234
+          column: 19
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 277
+          column: 31
+        end:
+          line: 277
+          column: 37
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 357
+          column: 17
+        end:
+          line: 357
+          column: 23
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 361
+          column: 33
+        end:
+          line: 361
+          column: 37
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 372
+          column: 17
+        end:
+          line: 372
+          column: 23
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 380
+          column: 28
+        end:
+          line: 380
+          column: 37
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 421
+          column: 17
+        end:
+          line: 421
+          column: 23
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 553
+          column: 18
+        end:
+          line: 553
+          column: 34
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 628
+          column: 17
+        end:
+          line: 628
+          column: 23
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 632
+          column: 33
+        end:
+          line: 632
+          column: 37
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 643
+          column: 17
+        end:
+          line: 643
+          column: 23
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 674
+          column: 48
+        end:
+          line: 674
+          column: 50
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C112"
+        severity: "warning"
+        message: "all-elements array expansions collapse inside `[[ ... ]]` tests"
+        start:
+          line: 830
+          column: 9
+        end:
+          line: 830
+          column: 17
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C112"
+        severity: "warning"
+        message: "all-elements array expansions collapse inside `[[ ... ]]` tests"
+        start:
+          line: 832
+          column: 11
+        end:
+          line: 832
+          column: 19
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `cd:h` is referenced before assignment"
+        start:
+          line: 868
+          column: 36
+        end:
+          line: 868
+          column: 43
+        classification: false_positive
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 923
+          column: 7
+        end:
+          line: 923
+          column: 17
+        classification: real
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ie` is referenced before assignment"
+        start:
+          line: 967
+          column: 13
+        end:
+          line: 967
+          column: 15
+        classification: false_positive
+      - path: "plugins/z/z.plugin.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 1004
+          column: 27
+        end:
+          line: 1004
+          column: 33
+        classification: real
+      - path: "plugins/zbell/zbell.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 75
+          column: 30
+        end:
+          line: 75
+          column: 46
+        classification: real
+      - path: "plugins/zsh-interactive-cd/zsh-interactive-cd.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `zic_case_insensitive` is referenced before assignment"
+        start:
+          line: 46
+          column: 15
+        end:
+          line: 46
+          column: 36
+        classification: false_positive
+      - path: "plugins/zsh-interactive-cd/zsh-interactive-cd.plugin.zsh"
+        code: "C092"
+        severity: "warning"
+        message: "use the command's exit status directly instead of executing the output from `$(...)`"
+        start:
+          line: 84
+          column: 6
+        end:
+          line: 84
+          column: 50
+        classification: real
+      - path: "plugins/zsh-navigation-tools/doc/install.sh"
+        code: "C004"
+        severity: "warning"
+        message: "`cd` should check whether the directory change succeeded"
+        start:
+          line: 23
+          column: 5
+        end:
+          line: 23
+          column: 42
+        classification: real
+      - path: "plugins/zsh-navigation-tools/doc/install.sh"
+        code: "C004"
+        severity: "warning"
+        message: "`cd` should check whether the directory change succeeded"
+        start:
+          line: 26
+          column: 5
+        end:
+          line: 26
+          column: 21
+        classification: real
+      - path: "plugins/zsh-navigation-tools/doc/install.sh"
+        code: "C004"
+        severity: "warning"
+        message: "`cd` should check whether the directory change succeeded"
+        start:
+          line: 37
+          column: 1
+        end:
+          line: 37
+          column: 17
+        classification: real
+      - path: "plugins/zsh-navigation-tools/zsh-navigation-tools.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `zsh_loaded_plugins` is referenced before assignment"
+        start:
+          line: 24
+          column: 7
+        end:
+          line: 24
+          column: 32
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `RED_END` is assigned but never used"
+        start:
+          line: 41
+          column: 1
+        end:
+          line: 41
+          column: 8
+        classification: real
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_SVN_PROMPT_PREFIX` is assigned but never used"
+        start:
+          line: 51
+          column: 1
+        end:
+          line: 51
+          column: 28
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_SVN_PROMPT_SUFFIX` is assigned but never used"
+        start:
+          line: 52
+          column: 1
+        end:
+          line: 52
+          column: 28
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_SVN_PROMPT_DIRTY` is assigned but never used"
+        start:
+          line: 53
+          column: 1
+        end:
+          line: 53
+          column: 27
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_SVN_PROMPT_CLEAN` is assigned but never used"
+        start:
+          line: 54
+          column: 1
+        end:
+          line: 54
+          column: 27
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_PREFIX` is assigned but never used"
+        start:
+          line: 57
+          column: 1
+        end:
+          line: 57
+          column: 28
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_SUFFIX` is assigned but never used"
+        start:
+          line: 58
+          column: 1
+        end:
+          line: 58
+          column: 28
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_DIRTY` is assigned but never used"
+        start:
+          line: 59
+          column: 1
+        end:
+          line: 59
+          column: 27
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_CLEAN` is assigned but never used"
+        start:
+          line: 60
+          column: 1
+        end:
+          line: 60
+          column: 27
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_ADDED` is assigned but never used"
+        start:
+          line: 61
+          column: 1
+        end:
+          line: 61
+          column: 27
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_MODIFIED` is assigned but never used"
+        start:
+          line: 62
+          column: 1
+        end:
+          line: 62
+          column: 30
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_DELETED` is assigned but never used"
+        start:
+          line: 63
+          column: 1
+        end:
+          line: 63
+          column: 29
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_RENAMED` is assigned but never used"
+        start:
+          line: 64
+          column: 1
+        end:
+          line: 64
+          column: 29
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_UNMERGED` is assigned but never used"
+        start:
+          line: 65
+          column: 1
+        end:
+          line: 65
+          column: 30
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_UNTRACKED` is assigned but never used"
+        start:
+          line: 66
+          column: 1
+        end:
+          line: 66
+          column: 31
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT` is assigned but never used"
+        start:
+          line: 112
+          column: 1
+        end:
+          line: 112
+          column: 7
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `RPROMPT` is assigned but never used"
+        start:
+          line: 116
+          column: 1
+        end:
+          line: 116
+          column: 8
+        classification: false_positive
+      - path: "themes/adben.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT2` is assigned but never used"
+        start:
+          line: 118
+          column: 1
+        end:
+          line: 118
+          column: 8
+        classification: false_positive
+      - path: "themes/emotty.zsh-theme"
+        code: "C006"
+        severity: "error"
+        message: "variable `emoji` is referenced before assignment"
+        start:
+          line: 60
+          column: 14
+        end:
+          line: 60
+          column: 20
+        classification: false_positive
+      - path: "themes/emotty.zsh-theme"
+        code: "C006"
+        severity: "error"
+        message: "variable `emoji2` is referenced before assignment"
+        start:
+          line: 63
+          column: 61
+        end:
+          line: 63
+          column: 68
+        classification: false_positive
+      - path: "themes/emotty.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `cyan` is assigned but never used"
+        start:
+          line: 71
+          column: 1
+        end:
+          line: 71
+          column: 5
+        classification: real
+      - path: "themes/emotty.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `red_if_root` is assigned but never used"
+        start:
+          line: 101
+          column: 1
+        end:
+          line: 101
+          column: 12
+        classification: real
+      - path: "themes/emotty.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `sshuser_on_host` is assigned but never used"
+        start:
+          line: 102
+          column: 1
+        end:
+          line: 102
+          column: 16
+        classification: real
+      - path: "themes/emotty.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT` is assigned but never used"
+        start:
+          line: 104
+          column: 1
+        end:
+          line: 104
+          column: 7
+        classification: false_positive
+      - path: "themes/emotty.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `RPROMPT` is assigned but never used"
+        start:
+          line: 105
+          column: 1
+        end:
+          line: 105
+          column: 8
+        classification: false_positive
+      - path: "themes/nicoulaj.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT` is assigned but never used"
+        start:
+          line: 42
+          column: 1
+        end:
+          line: 42
+          column: 7
+        classification: false_positive
+      - path: "themes/nicoulaj.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `RPROMPT` is assigned but never used"
+        start:
+          line: 43
+          column: 1
+        end:
+          line: 43
+          column: 8
+        classification: false_positive
+      - path: "themes/refined.zsh-theme"
+        code: "C006"
+        severity: "error"
+        message: "variable `vcs_info_msg_0_` is referenced before assignment"
+        start:
+          line: 52
+          column: 19
+        end:
+          line: 52
+          column: 41
+        classification: false_positive
+      - path: "themes/refined.zsh-theme"
+        code: "C006"
+        severity: "error"
+        message: "variable `vcs_info_msg_1_` is referenced before assignment"
+        start:
+          line: 52
+          column: 47
+        end:
+          line: 52
+          column: 63
+        classification: false_positive
+      - path: "themes/refined.zsh-theme"
+        code: "C006"
+        severity: "error"
+        message: "variable `vcs_info_msg_2_` is referenced before assignment"
+        start:
+          line: 52
+          column: 75
+        end:
+          line: 52
+          column: 91
+        classification: false_positive
+      - path: "themes/refined.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT` is assigned but never used"
+        start:
+          line: 81
+          column: 1
+        end:
+          line: 81
+          column: 7
+        classification: false_positive
+      - path: "themes/refined.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `RPROMPT` is assigned but never used"
+        start:
+          line: 82
+          column: 1
+        end:
+          line: 82
+          column: 8
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ROOT_ICON_COLOR` is assigned but never used"
+        start:
+          line: 7
+          column: 1
+        end:
+          line: 7
+          column: 16
+        classification: real
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `MACHINE_NAME_COLOR` is assigned but never used"
+        start:
+          line: 8
+          column: 1
+        end:
+          line: 8
+          column: 19
+        classification: real
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT_SUCCESS_COLOR` is assigned but never used"
+        start:
+          line: 9
+          column: 1
+        end:
+          line: 9
+          column: 21
+        classification: real
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT_FAILURE_COLOR` is assigned but never used"
+        start:
+          line: 10
+          column: 1
+        end:
+          line: 10
+          column: 21
+        classification: real
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT_VCS_INFO_COLOR` is assigned but never used"
+        start:
+          line: 11
+          column: 1
+        end:
+          line: 11
+          column: 22
+        classification: real
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT_PROMPT` is assigned but never used"
+        start:
+          line: 12
+          column: 1
+        end:
+          line: 12
+          column: 14
+        classification: real
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ROOT_ICON` is assigned but never used"
+        start:
+          line: 20
+          column: 2
+        end:
+          line: 20
+          column: 11
+        classification: real
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PROMPT` is assigned but never used"
+        start:
+          line: 23
+          column: 1
+        end:
+          line: 23
+          column: 7
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_PREFIX` is assigned but never used"
+        start:
+          line: 27
+          column: 1
+        end:
+          line: 27
+          column: 28
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_SUFFIX` is assigned but never used"
+        start:
+          line: 28
+          column: 1
+        end:
+          line: 28
+          column: 28
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_DIRTY` is assigned but never used"
+        start:
+          line: 29
+          column: 1
+        end:
+          line: 29
+          column: 27
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_CLEAN` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 27
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_ADDED` is assigned but never used"
+        start:
+          line: 32
+          column: 1
+        end:
+          line: 32
+          column: 27
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_MODIFIED` is assigned but never used"
+        start:
+          line: 33
+          column: 1
+        end:
+          line: 33
+          column: 30
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_DELETED` is assigned but never used"
+        start:
+          line: 34
+          column: 1
+        end:
+          line: 34
+          column: 29
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_RENAMED` is assigned but never used"
+        start:
+          line: 35
+          column: 1
+        end:
+          line: 35
+          column: 29
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_UNMERGED` is assigned but never used"
+        start:
+          line: 36
+          column: 1
+        end:
+          line: 36
+          column: 30
+        classification: false_positive
+      - path: "themes/sonicradish.zsh-theme"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME_GIT_PROMPT_UNTRACKED` is assigned but never used"
+        start:
+          line: 37
+          column: 1
+        end:
+          line: 37
+          column: 31
+        classification: false_positive
+      - path: "tools/changelog.sh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 310
+          column: 16
+        end:
+          line: 310
+          column: 70
+        classification: false_positive
+      - path: "tools/changelog.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `raw_commit` is assigned but never used"
+        start:
+          line: 541
+          column: 3
+        end:
+          line: 541
+          column: 6
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C085"
+        severity: "warning"
+        message: "stderr is redirected before stdout is redirected"
+        start:
+          line: 31
+          column: 31
+        end:
+          line: 31
+          column: 35
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `remote_repo` is assigned but never used"
+        start:
+          line: 46
+          column: 27
+        end:
+          line: 46
+          column: 38
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 93
+          column: 15
+        end:
+          line: 93
+          column: 27
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C072"
+        severity: "warning"
+        message: "a unicode smart quote appears inside a shell string"
+        start:
+          line: 107
+          column: 20
+        end:
+          line: 107
+          column: 21
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C132"
+        severity: "warning"
+        message: "this same-command expansion still sees the earlier shell value"
+        start:
+          line: 121
+          column: 33
+        end:
+          line: 121
+          column: 37
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C132"
+        severity: "warning"
+        message: "this same-command expansion still sees the earlier shell value"
+        start:
+          line: 127
+          column: 39
+        end:
+          line: 127
+          column: 43
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 191
+          column: 23
+        end:
+          line: 191
+          column: 27
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 196
+          column: 17
+        end:
+          line: 196
+          column: 47
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 273
+          column: 11
+        end:
+          line: 273
+          column: 39
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C006"
+        severity: "error"
+        message: "variable `fg` is referenced before assignment"
+        start:
+          line: 283
+          column: 21
+        end:
+          line: 283
+          column: 34
+        classification: false_positive
+      - path: "tools/check_for_upgrade.sh"
+        code: "C006"
+        severity: "error"
+        message: "variable `reset_color` is referenced before assignment"
+        start:
+          line: 283
+          column: 36
+        end:
+          line: 283
+          column: 50
+        classification: false_positive
+      - path: "tools/install.sh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 318
+          column: 3
+        end:
+          line: 318
+          column: 5
+        classification: real
+      - path: "tools/install.sh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 483
+          column: 8
+        end:
+          line: 483
+          column: 10
+        classification: real
+      - path: "tools/require_tool.sh"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 91
+          column: 3
+        end:
+          line: 91
+          column: 16
+        classification: real
+      - path: "tools/theme_chooser.sh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 12
+          column: 8
+        end:
+          line: 12
+          column: 25
+        classification: real
+      - path: "tools/theme_chooser.sh"
+        code: "C006"
+        severity: "error"
+        message: "variable `a` is referenced before assignment"
+        start:
+          line: 16
+          column: 11
+        end:
+          line: 16
+          column: 13
+        classification: false_positive
+      - path: "tools/theme_chooser.sh"
+        code: "C006"
+        severity: "error"
+        message: "variable `fg` is referenced before assignment"
+        start:
+          line: 25
+          column: 12
+        end:
+          line: 25
+          column: 15
+        classification: false_positive
+      - path: "tools/theme_chooser.sh"
+        code: "C006"
+        severity: "error"
+        message: "variable `reset_color` is referenced before assignment"
+        start:
+          line: 25
+          column: 63
+        end:
+          line: 25
+          column: 75
+        classification: false_positive
+      - path: "tools/theme_chooser.sh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 26
+          column: 12
+        end:
+          line: 26
+          column: 32
+        classification: real
+      - path: "tools/theme_chooser.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `cols` is assigned but never used"
+        start:
+          line: 27
+          column: 5
+        end:
+          line: 27
+          column: 9
+        classification: real
+      - path: "tools/uninstall.sh"
+        code: "X022"
+        severity: "warning"
+        message: "this builtin option is not portable in `sh` scripts"
+        start:
+          line: 13
+          column: 9
+        end:
+          line: 13
+          column: 11
+        classification: real
+      - path: "tools/upgrade.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `GREEN` is assigned but never used"
+        start:
+          line: 187
+          column: 3
+        end:
+          line: 187
+          column: 8
+        classification: real
+      - path: "tools/upgrade.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `YELLOW` is assigned but never used"
+        start:
+          line: 188
+          column: 3
+        end:
+          line: 188
+          column: 9
+        classification: real
+      - path: "tools/upgrade.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `extra` is assigned but never used"
+        start:
+          line: 195
+          column: 39
+        end:
+          line: 195
+          column: 44
+        classification: real
+      - path: "tools/upgrade.sh"
+        code: "C132"
+        severity: "warning"
+        message: "this same-command expansion still sees the earlier shell value"
+        start:
+          line: 257
+          column: 34
+        end:
+          line: 257
+          column: 38
+        classification: real
+  - name: "powerlevel10k"
+    github_url: "https://github.com/romkatv/powerlevel10k.git"
+    commit: "604f19a9eaa18e76db2e60b8d446d5f879065f90"
+    diagnostics:
+      - path: "config/p10k-classic.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `my_git_format` is assigned but never used"
+        start:
+          line: 470
+          column: 16
+        end:
+          line: 470
+          column: 29
+        classification: real
+      - path: "config/p10k-lean-8colors.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `my_git_format` is assigned but never used"
+        start:
+          line: 461
+          column: 16
+        end:
+          line: 461
+          column: 29
+        classification: real
+      - path: "config/p10k-lean.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `my_git_format` is assigned but never used"
+        start:
+          line: 461
+          column: 16
+        end:
+          line: 461
+          column: 29
+        classification: real
+      - path: "config/p10k-rainbow.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `my_git_format` is assigned but never used"
+        start:
+          line: 471
+          column: 16
+        end:
+          line: 471
+          column: 29
+        classification: real
+      - path: "gitstatus/build"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 563
+          column: 16
+        end:
+          line: 563
+          column: 58
+        classification: false_positive
+      - path: "gitstatus/build"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 597
+          column: 22
+        end:
+          line: 597
+          column: 66
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C086"
+        severity: "warning"
+        message: "use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons"
+        start:
+          line: 44
+          column: 25
+        end:
+          line: 44
+          column: 26
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 49
+          column: 16
+        end:
+          line: 49
+          column: 74
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 51
+          column: 16
+        end:
+          line: 51
+          column: 103
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C094"
+        severity: "warning"
+        message: "this command reads and writes the same file"
+        start:
+          line: 145
+          column: 12
+        end:
+          line: 145
+          column: 35
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C004"
+        severity: "warning"
+        message: "`cd` should check whether the directory change succeeded"
+        start:
+          line: 146
+          column: 9
+        end:
+          line: 146
+          column: 21
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 185
+          column: 26
+        end:
+          line: 185
+          column: 35
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 185
+          column: 42
+        end:
+          line: 185
+          column: 46
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 214
+          column: 24
+        end:
+          line: 214
+          column: 33
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 214
+          column: 40
+        end:
+          line: 214
+          column: 44
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C094"
+        severity: "warning"
+        message: "this command reads and writes the same file"
+        start:
+          line: 220
+          column: 21
+        end:
+          line: 220
+          column: 44
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_WORKDIR` is assigned but never used"
+        start:
+          line: 394
+          column: 5
+        end:
+          line: 394
+          column: 23
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMIT` is assigned but never used"
+        start:
+          line: 395
+          column: 5
+        end:
+          line: 395
+          column: 22
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_LOCAL_BRANCH` is assigned but never used"
+        start:
+          line: 396
+          column: 5
+        end:
+          line: 396
+          column: 28
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_REMOTE_BRANCH` is assigned but never used"
+        start:
+          line: 397
+          column: 5
+        end:
+          line: 397
+          column: 29
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_REMOTE_NAME` is assigned but never used"
+        start:
+          line: 398
+          column: 5
+        end:
+          line: 398
+          column: 27
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_REMOTE_URL` is assigned but never used"
+        start:
+          line: 399
+          column: 5
+        end:
+          line: 399
+          column: 26
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_ACTION` is assigned but never used"
+        start:
+          line: 400
+          column: 5
+        end:
+          line: 400
+          column: 22
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMITS_AHEAD` is assigned but never used"
+        start:
+          line: 406
+          column: 5
+        end:
+          line: 406
+          column: 29
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMITS_BEHIND` is assigned but never used"
+        start:
+          line: 407
+          column: 5
+        end:
+          line: 407
+          column: 30
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_STASHES` is assigned but never used"
+        start:
+          line: 408
+          column: 5
+        end:
+          line: 408
+          column: 23
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_TAG` is assigned but never used"
+        start:
+          line: 409
+          column: 5
+        end:
+          line: 409
+          column: 19
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_UNSTAGED_DELETED` is assigned but never used"
+        start:
+          line: 410
+          column: 5
+        end:
+          line: 410
+          column: 36
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_STAGED_NEW` is assigned but never used"
+        start:
+          line: 411
+          column: 5
+        end:
+          line: 411
+          column: 30
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_STAGED_DELETED` is assigned but never used"
+        start:
+          line: 412
+          column: 5
+        end:
+          line: 412
+          column: 34
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_PUSH_REMOTE_NAME` is assigned but never used"
+        start:
+          line: 413
+          column: 5
+        end:
+          line: 413
+          column: 32
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_PUSH_REMOTE_URL` is assigned but never used"
+        start:
+          line: 414
+          column: 5
+        end:
+          line: 414
+          column: 31
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_PUSH_COMMITS_AHEAD` is assigned but never used"
+        start:
+          line: 415
+          column: 5
+        end:
+          line: 415
+          column: 34
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_PUSH_COMMITS_BEHIND` is assigned but never used"
+        start:
+          line: 416
+          column: 5
+        end:
+          line: 416
+          column: 35
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_SKIP_WORKTREE` is assigned but never used"
+        start:
+          line: 417
+          column: 5
+        end:
+          line: 417
+          column: 33
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_ASSUME_UNCHANGED` is assigned but never used"
+        start:
+          line: 418
+          column: 5
+        end:
+          line: 418
+          column: 36
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMIT_ENCODING` is assigned but never used"
+        start:
+          line: 419
+          column: 5
+        end:
+          line: 419
+          column: 31
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMIT_SUMMARY` is assigned but never used"
+        start:
+          line: 420
+          column: 5
+        end:
+          line: 420
+          column: 30
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_HAS_STAGED` is assigned but never used"
+        start:
+          line: 421
+          column: 5
+        end:
+          line: 421
+          column: 26
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_GITSTATUS_DIRTY_MAX_INDEX_SIZE_` looks like it may mean `_GITSTATUS_DIRTY_MAX_INDEX_SIZE`"
+        start:
+          line: 423
+          column: 35
+        end:
+          line: 423
+          column: 67
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_HAS_UNSTAGED` is assigned but never used"
+        start:
+          line: 428
+          column: 7
+        end:
+          line: 428
+          column: 30
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_HAS_CONFLICTED` is assigned but never used"
+        start:
+          line: 429
+          column: 7
+        end:
+          line: 429
+          column: 32
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_HAS_UNTRACKED` is assigned but never used"
+        start:
+          line: 430
+          column: 7
+        end:
+          line: 430
+          column: 31
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_RESULT` is assigned but never used"
+        start:
+          line: 433
+          column: 5
+        end:
+          line: 433
+          column: 22
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C135"
+        severity: "warning"
+        message: "this case arm does not match any option declared by getopts"
+        start:
+          line: 157
+          column: 7
+        end:
+          line: 157
+          column: 9
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 287
+          column: 20
+        end:
+          line: 287
+          column: 417
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_ACTION` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMITS_AHEAD` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMITS_BEHIND` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMIT_ENCODING` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMIT_SUMMARY` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_COMMIT` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_LOCAL_BRANCH` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_ASSUME_UNCHANGED` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_SKIP_WORKTREE` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_STAGED_DELETED` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_STAGED_NEW` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_NUM_UNSTAGED_DELETED` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_PUSH_COMMITS_AHEAD` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_PUSH_COMMITS_BEHIND` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_PUSH_REMOTE_NAME` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_PUSH_REMOTE_URL` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_REMOTE_BRANCH` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_REMOTE_NAME` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_REMOTE_URL` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_STASHES` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_TAG` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_WORKDIR` is assigned but never used"
+        start:
+          line: 324
+          column: 7
+        end:
+          line: 324
+          column: 10
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 352
+          column: 30
+        end:
+          line: 352
+          column: 265
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_HAS_STAGED` is assigned but never used"
+        start:
+          line: 353
+          column: 19
+        end:
+          line: 353
+          column: 40
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_HAS_UNSTAGED` is assigned but never used"
+        start:
+          line: 361
+          column: 11
+        end:
+          line: 361
+          column: 34
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_HAS_CONFLICTED` is assigned but never used"
+        start:
+          line: 362
+          column: 11
+        end:
+          line: 362
+          column: 36
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VCS_STATUS_HAS_UNTRACKED` is assigned but never used"
+        start:
+          line: 363
+          column: 11
+        end:
+          line: 363
+          column: 35
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `userdirs` is referenced before assignment"
+        start:
+          line: 438
+          column: 20
+        end:
+          line: 438
+          column: 38
+        classification: false_positive
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C135"
+        severity: "warning"
+        message: "this case arm does not match any option declared by getopts"
+        start:
+          line: 528
+          column: 7
+        end:
+          line: 528
+          column: 9
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 727
+          column: 23
+        end:
+          line: 727
+          column: 32
+        classification: real
+      - path: "gitstatus/gitstatus.plugin.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_intro_base` is referenced before assignment"
+        start:
+          line: 734
+          column: 65
+        end:
+          line: 734
+          column: 82
+        classification: false_positive
+      - path: "gitstatus/gitstatus.prompt.sh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 10
+        end:
+          line: 6
+          column: 26
+        classification: real
+      - path: "gitstatus/gitstatus.prompt.sh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 8
+          column: 10
+        end:
+          line: 8
+          column: 52
+        classification: real
+      - path: "gitstatus/gitstatus.prompt.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 5
+          column: 8
+        end:
+          line: 5
+          column: 64
+        classification: real
+      - path: "gitstatus/gitstatus.prompt.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `GITSTATUS_PROMPT_LEN` is assigned but never used"
+        start:
+          line: 84
+          column: 3
+        end:
+          line: 84
+          column: 23
+        classification: false_positive
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 6
+          column: 3
+        end:
+          line: 6
+          column: 18
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 18
+          column: 3
+        end:
+          line: 18
+          column: 14
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 21
+          column: 3
+        end:
+          line: 21
+          column: 76
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 22
+          column: 3
+        end:
+          line: 22
+          column: 28
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 145
+          column: 3
+        end:
+          line: 145
+          column: 15
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 146
+          column: 3
+        end:
+          line: 146
+          column: 18
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 157
+          column: 7
+        end:
+          line: 157
+          column: 47
+        classification: real
+      - path: "gitstatus/install"
+        code: "C001"
+        severity: "warning"
+        message: "variable `libgit2_version` is assigned but never used"
+        start:
+          line: 157
+          column: 32
+        end:
+          line: 157
+          column: 47
+        classification: real
+      - path: "gitstatus/install"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 158
+          column: 14
+        end:
+          line: 158
+          column: 41
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 166
+          column: 7
+        end:
+          line: 166
+          column: 20
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 176
+          column: 5
+        end:
+          line: 176
+          column: 60
+        classification: real
+      - path: "gitstatus/install"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 189
+          column: 7
+        end:
+          line: 189
+          column: 20
+        classification: real
+      - path: "gitstatus/install"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 193
+          column: 7
+        end:
+          line: 193
+          column: 20
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 201
+          column: 7
+        end:
+          line: 201
+          column: 19
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 219
+          column: 5
+        end:
+          line: 219
+          column: 17
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 226
+          column: 7
+        end:
+          line: 226
+          column: 16
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 249
+          column: 7
+        end:
+          line: 249
+          column: 16
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 251
+          column: 7
+        end:
+          line: 251
+          column: 16
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 258
+          column: 11
+        end:
+          line: 258
+          column: 22
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 260
+          column: 11
+        end:
+          line: 260
+          column: 22
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 287
+          column: 9
+        end:
+          line: 287
+          column: 35
+        classification: real
+      - path: "gitstatus/install"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 296
+          column: 17
+        end:
+          line: 296
+          column: 21
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 307
+          column: 9
+        end:
+          line: 307
+          column: 24
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 308
+          column: 9
+        end:
+          line: 308
+          column: 24
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 309
+          column: 9
+        end:
+          line: 309
+          column: 19
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 336
+          column: 7
+        end:
+          line: 336
+          column: 17
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 337
+          column: 7
+        end:
+          line: 337
+          column: 17
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 338
+          column: 7
+        end:
+          line: 338
+          column: 16
+        classification: real
+      - path: "gitstatus/install"
+        code: "X027"
+        severity: "warning"
+        message: "echo flags are not portable in `sh` scripts"
+        start:
+          line: 343
+          column: 18
+        end:
+          line: 343
+          column: 20
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 347
+          column: 9
+        end:
+          line: 347
+          column: 31
+        classification: real
+      - path: "gitstatus/install"
+        code: "X027"
+        severity: "warning"
+        message: "echo flags are not portable in `sh` scripts"
+        start:
+          line: 370
+          column: 14
+        end:
+          line: 370
+          column: 16
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 374
+          column: 7
+        end:
+          line: 374
+          column: 20
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 377
+          column: 7
+        end:
+          line: 377
+          column: 17
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 379
+          column: 7
+        end:
+          line: 379
+          column: 17
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 381
+          column: 7
+        end:
+          line: 381
+          column: 16
+        classification: real
+      - path: "gitstatus/install"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 382
+          column: 13
+        end:
+          line: 382
+          column: 17
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 385
+          column: 7
+        end:
+          line: 385
+          column: 14
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 395
+          column: 11
+        end:
+          line: 395
+          column: 20
+        classification: real
+      - path: "gitstatus/install"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 408
+          column: 19
+        end:
+          line: 408
+          column: 23
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 412
+          column: 11
+        end:
+          line: 412
+          column: 20
+        classification: real
+      - path: "gitstatus/install"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 425
+          column: 19
+        end:
+          line: 425
+          column: 23
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 444
+          column: 7
+        end:
+          line: 444
+          column: 20
+        classification: real
+      - path: "gitstatus/install"
+        code: "X003"
+        severity: "warning"
+        message: "`local` is not portable in `sh` scripts"
+        start:
+          line: 458
+          column: 5
+        end:
+          line: 458
+          column: 14
+        classification: real
+      - path: "gitstatus/mbuild"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 167
+          column: 79
+        end:
+          line: 178
+          column: 22
+        classification: false_positive
+      - path: "gitstatus/mbuild"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 185
+          column: 26
+        end:
+          line: 185
+          column: 58
+        classification: false_positive
+      - path: "gitstatus/mbuild"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 186
+          column: 26
+        end:
+          line: 186
+          column: 55
+        classification: false_positive
+      - path: "gitstatus/mbuild"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 197
+          column: 19
+        end:
+          line: 197
+          column: 23
+        classification: false_positive
+      - path: "gitstatus/mbuild"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 218
+          column: 14
+        end:
+          line: 218
+          column: 87
+        classification: false_positive
+      - path: "gitstatus/mbuild"
+        code: "K002"
+        severity: "warning"
+        message: "ssh command text is expanded locally before the remote shell sees it"
+        start:
+          line: 223
+          column: 32
+        end:
+          line: 223
+          column: 34
+        classification: real
+      - path: "gitstatus/mbuild"
+        code: "C006"
+        severity: "error"
+        message: "variable `patchars` is referenced before assignment"
+        start:
+          line: 351
+          column: 17
+        end:
+          line: 351
+          column: 31
+        classification: false_positive
+      - path: "gitstatus/mbuild"
+        code: "C006"
+        severity: "error"
+        message: "variable `dis_patchars` is referenced before assignment"
+        start:
+          line: 352
+          column: 21
+        end:
+          line: 352
+          column: 39
+        classification: false_positive
+      - path: "gitstatus/mbuild"
+        code: "C001"
+        severity: "warning"
+        message: "variable `REPLY` is assigned but never used"
+        start:
+          line: 362
+          column: 19
+        end:
+          line: 362
+          column: 24
+        classification: false_positive
+      - path: "gitstatus/mbuild"
+        code: "C001"
+        severity: "warning"
+        message: "variable `gid` is assigned but never used"
+        start:
+          line: 367
+          column: 16
+        end:
+          line: 367
+          column: 19
+        classification: real
+      - path: "gitstatus/mbuild"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 391
+          column: 18
+        end:
+          line: 391
+          column: 22
+        classification: real
+      - path: "internal/configure.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_root_dir` is referenced before assignment"
+        start:
+          line: 9
+          column: 30
+        end:
+          line: 9
+          column: 98
+        classification: false_positive
+      - path: "internal/configure.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 27
+          column: 35
+        end:
+          line: 27
+          column: 43
+        classification: real
+      - path: "internal/configure.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_intro` is referenced before assignment"
+        start:
+          line: 72
+          column: 9
+        end:
+          line: 72
+          column: 21
+        classification: false_positive
+      - path: "internal/icons.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `langinfo` is referenced before assignment"
+        start:
+          line: 4
+          column: 34
+        end:
+          line: 4
+          column: 54
+        classification: false_positive
+      - path: "internal/icons.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_intro` is referenced before assignment"
+        start:
+          line: 1145
+          column: 9
+        end:
+          line: 1145
+          column: 21
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_sourced` is referenced before assignment"
+        start:
+          line: 1
+          column: 7
+        end:
+          line: 1
+          column: 21
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 29
+          column: 28
+        end:
+          line: 29
+          column: 50
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 30
+          column: 21
+        end:
+          line: 30
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 30
+          column: 45
+        end:
+          line: 30
+          column: 49
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 34
+          column: 38
+        end:
+          line: 34
+          column: 78
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 35
+          column: 35
+        end:
+          line: 35
+          column: 57
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 36
+          column: 40
+        end:
+          line: 36
+          column: 52
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 38
+          column: 34
+        end:
+          line: 38
+          column: 44
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 41
+          column: 64
+        end:
+          line: 41
+          column: 70
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_root_dir` is referenced before assignment"
+        start:
+          line: 52
+          column: 17
+        end:
+          line: 52
+          column: 34
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_intro` is referenced before assignment"
+        start:
+          line: 116
+          column: 9
+        end:
+          line: 116
+          column: 21
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 148
+          column: 31
+        end:
+          line: 148
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 165
+          column: 17
+        end:
+          line: 165
+          column: 19
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 168
+          column: 17
+        end:
+          line: 168
+          column: 19
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 171
+          column: 17
+        end:
+          line: 171
+          column: 19
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 175
+          column: 15
+        end:
+          line: 175
+          column: 16
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 229
+          column: 47
+        end:
+          line: 229
+          column: 65
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 233
+          column: 26
+        end:
+          line: 233
+          column: 48
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 330
+          column: 14
+        end:
+          line: 330
+          column: 32
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 434
+          column: 35
+        end:
+          line: 434
+          column: 57
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 598
+          column: 34
+        end:
+          line: 598
+          column: 41
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 684
+          column: 40
+        end:
+          line: 684
+          column: 49
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 685
+          column: 26
+        end:
+          line: 685
+          column: 38
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 721
+          column: 31
+        end:
+          line: 721
+          column: 35
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 725
+          column: 31
+        end:
+          line: 725
+          column: 35
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 728
+          column: 27
+        end:
+          line: 728
+          column: 55
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 729
+          column: 30
+        end:
+          line: 729
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 735
+          column: 25
+        end:
+          line: 735
+          column: 53
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 736
+          column: 10
+        end:
+          line: 736
+          column: 24
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 738
+          column: 24
+        end:
+          line: 738
+          column: 52
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 749
+          column: 8
+        end:
+          line: 749
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 749
+          column: 35
+        end:
+          line: 749
+          column: 61
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 750
+          column: 8
+        end:
+          line: 750
+          column: 32
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 752
+          column: 10
+        end:
+          line: 752
+          column: 77
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 754
+          column: 10
+        end:
+          line: 754
+          column: 44
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 759
+          column: 8
+        end:
+          line: 759
+          column: 49
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 759
+          column: 52
+        end:
+          line: 759
+          column: 66
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 759
+          column: 68
+        end:
+          line: 759
+          column: 80
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 774
+          column: 29
+        end:
+          line: 774
+          column: 36
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 775
+          column: 24
+        end:
+          line: 775
+          column: 36
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 778
+          column: 14
+        end:
+          line: 778
+          column: 26
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 785
+          column: 14
+        end:
+          line: 785
+          column: 37
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 791
+          column: 10
+        end:
+          line: 791
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 799
+          column: 10
+        end:
+          line: 799
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 807
+          column: 14
+        end:
+          line: 807
+          column: 37
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 814
+          column: 26
+        end:
+          line: 814
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 815
+          column: 12
+        end:
+          line: 815
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 826
+          column: 8
+        end:
+          line: 826
+          column: 16
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 844
+          column: 12
+        end:
+          line: 844
+          column: 14
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 952
+          column: 31
+        end:
+          line: 952
+          column: 35
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 956
+          column: 31
+        end:
+          line: 956
+          column: 35
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 959
+          column: 27
+        end:
+          line: 959
+          column: 55
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 960
+          column: 30
+        end:
+          line: 960
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 966
+          column: 25
+        end:
+          line: 966
+          column: 53
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 969
+          column: 24
+        end:
+          line: 969
+          column: 52
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 980
+          column: 8
+        end:
+          line: 980
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 980
+          column: 35
+        end:
+          line: 980
+          column: 61
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 981
+          column: 8
+        end:
+          line: 981
+          column: 32
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 983
+          column: 10
+        end:
+          line: 983
+          column: 77
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 985
+          column: 10
+        end:
+          line: 985
+          column: 44
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 990
+          column: 8
+        end:
+          line: 990
+          column: 47
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 990
+          column: 49
+        end:
+          line: 990
+          column: 61
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1000
+          column: 10
+        end:
+          line: 1000
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1008
+          column: 14
+        end:
+          line: 1008
+          column: 37
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1015
+          column: 26
+        end:
+          line: 1015
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1016
+          column: 12
+        end:
+          line: 1016
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1030
+          column: 29
+        end:
+          line: 1030
+          column: 36
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1031
+          column: 24
+        end:
+          line: 1031
+          column: 36
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1034
+          column: 14
+        end:
+          line: 1034
+          column: 26
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1041
+          column: 14
+        end:
+          line: 1041
+          column: 37
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1047
+          column: 10
+        end:
+          line: 1047
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1055
+          column: 8
+        end:
+          line: 1055
+          column: 16
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1057
+          column: 40
+        end:
+          line: 1057
+          column: 49
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1058
+          column: 26
+        end:
+          line: 1058
+          column: 38
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1069
+          column: 8
+        end:
+          line: 1069
+          column: 24
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1093
+          column: 12
+        end:
+          line: 1093
+          column: 14
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 1109
+          column: 5
+        end:
+          line: 1109
+          column: 41
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 1162
+          column: 15
+        end:
+          line: 1162
+          column: 21
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 1198
+          column: 27
+        end:
+          line: 1198
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 1202
+          column: 36
+        end:
+          line: 1202
+          column: 43
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1239
+          column: 11
+        end:
+          line: 1239
+          column: 23
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1241
+          column: 11
+        end:
+          line: 1241
+          column: 29
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1265
+          column: 33
+        end:
+          line: 1265
+          column: 115
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1360
+          column: 41
+        end:
+          line: 1360
+          column: 46
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 1412
+          column: 18
+        end:
+          line: 1412
+          column: 23
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1413
+          column: 39
+        end:
+          line: 1413
+          column: 41
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1450
+          column: 30
+        end:
+          line: 1450
+          column: 32
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1500
+          column: 12
+        end:
+          line: 1500
+          column: 63
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1556
+          column: 26
+        end:
+          line: 1556
+          column: 29
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1575
+          column: 20
+        end:
+          line: 1575
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1594
+          column: 28
+        end:
+          line: 1594
+          column: 47
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1594
+          column: 53
+        end:
+          line: 1594
+          column: 72
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1613
+          column: 25
+        end:
+          line: 1613
+          column: 38
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1624
+          column: 25
+        end:
+          line: 1624
+          column: 38
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1646
+          column: 65
+        end:
+          line: 1646
+          column: 78
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1653
+          column: 65
+        end:
+          line: 1653
+          column: 78
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `zsh_directory_name_functions` is referenced before assignment"
+        start:
+          line: 1776
+          column: 38
+        end:
+          line: 1776
+          column: 67
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C086"
+        severity: "warning"
+        message: "use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons"
+        start:
+          line: 1831
+          column: 69
+        end:
+          line: 1831
+          column: 70
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 1874
+          column: 27
+        end:
+          line: 1874
+          column: 29
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1909
+          column: 74
+        end:
+          line: 1909
+          column: 93
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `rtail` is assigned but never used"
+        start:
+          line: 1910
+          column: 15
+        end:
+          line: 1910
+          column: 20
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `real_delim_len` is assigned but never used"
+        start:
+          line: 1913
+          column: 18
+        end:
+          line: 1913
+          column: 32
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `matching` is assigned but never used"
+        start:
+          line: 1935
+          column: 26
+        end:
+          line: 1935
+          column: 34
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1941
+          column: 28
+        end:
+          line: 1941
+          column: 59
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1941
+          column: 76
+        end:
+          line: 1941
+          column: 92
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1942
+          column: 75
+        end:
+          line: 1942
+          column: 91
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1944
+          column: 28
+        end:
+          line: 1944
+          column: 50
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1944
+          column: 87
+        end:
+          line: 1944
+          column: 103
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ib` is referenced before assignment"
+        start:
+          line: 1959
+          column: 29
+        end:
+          line: 1959
+          column: 31
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1970
+          column: 25
+        end:
+          line: 1970
+          column: 36
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1977
+          column: 75
+        end:
+          line: 1977
+          column: 86
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C091"
+        severity: "warning"
+        message: "quoted `~/...` stays literal; use `$HOME` or an unquoted tilde"
+        start:
+          line: 2054
+          column: 92
+        end:
+          line: 2054
+          column: 96
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C086"
+        severity: "warning"
+        message: "use `-lt`/`-gt` instead of `<`/`>` for numeric comparisons"
+        start:
+          line: 2058
+          column: 89
+        end:
+          line: 2058
+          column: 90
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2152
+          column: 26
+        end:
+          line: 2152
+          column: 50
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 2254
+          column: 10
+        end:
+          line: 2254
+          column: 31
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2295
+          column: 11
+        end:
+          line: 2295
+          column: 31
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 2303
+          column: 65
+        end:
+          line: 2303
+          column: 87
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2443
+          column: 21
+        end:
+          line: 2443
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 2459
+          column: 95
+        end:
+          line: 2459
+          column: 105
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2581
+          column: 22
+        end:
+          line: 2581
+          column: 30
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2632
+          column: 21
+        end:
+          line: 2632
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 2729
+          column: 53
+        end:
+          line: 2729
+          column: 55
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_RBENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
+        start:
+          line: 2794
+          column: 8
+        end:
+          line: 2794
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2802
+          column: 21
+        end:
+          line: 2802
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
+        start:
+          line: 2823
+          column: 10
+        end:
+          line: 2823
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_RBENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
+        start:
+          line: 2835
+          column: 10
+        end:
+          line: 2835
+          column: 41
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C063"
+        severity: "warning"
+        message: "function `_p9k_phpenv_global_version` is overwritten before any direct call can reach it"
+        start:
+          line: 2846
+          column: 1
+        end:
+          line: 2848
+          column: 2
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2865
+          column: 21
+        end:
+          line: 2865
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_PHPENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
+        start:
+          line: 2915
+          column: 8
+        end:
+          line: 2915
+          column: 49
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2923
+          column: 21
+        end:
+          line: 2923
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_PHPENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
+        start:
+          line: 2944
+          column: 10
+        end:
+          line: 2944
+          column: 49
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_PHPENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
+        start:
+          line: 2956
+          column: 10
+        end:
+          line: 2956
+          column: 42
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2984
+          column: 21
+        end:
+          line: 2984
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_JENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
+        start:
+          line: 3037
+          column: 8
+        end:
+          line: 3037
+          column: 47
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 3045
+          column: 21
+        end:
+          line: 3045
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_JENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
+        start:
+          line: 3066
+          column: 10
+        end:
+          line: 3066
+          column: 47
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_JENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
+        start:
+          line: 3078
+          column: 10
+        end:
+          line: 3078
+          column: 40
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_PLENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
+        start:
+          line: 3098
+          column: 8
+        end:
+          line: 3098
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 3106
+          column: 21
+        end:
+          line: 3106
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_PLENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
+        start:
+          line: 3127
+          column: 10
+        end:
+          line: 3127
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_PLENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
+        start:
+          line: 3139
+          column: 10
+        end:
+          line: 3139
+          column: 41
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 3233
+          column: 12
+        end:
+          line: 3233
+          column: 29
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `tests` is assigned but never used"
+        start:
+          line: 3251
+          column: 11
+        end:
+          line: 3251
+          column: 16
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ruby_string` is referenced before assignment"
+        start:
+          line: 3259
+          column: 28
+        end:
+          line: 3259
+          column: 40
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `rvm_path` is referenced before assignment"
+        start:
+          line: 3259
+          column: 44
+        end:
+          line: 3259
+          column: 53
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 3261
+          column: 49
+        end:
+          line: 3261
+          column: 75
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 3297
+          column: 24
+        end:
+          line: 3297
+          column: 26
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 3404
+          column: 52
+        end:
+          line: 3404
+          column: 54
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `code` is assigned but never used"
+        start:
+          line: 3458
+          column: 14
+        end:
+          line: 3458
+          column: 18
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_instant_prompt_time_format` is referenced before assignment"
+        start:
+          line: 3495
+          column: 51
+        end:
+          line: 3495
+          column: 84
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 3495
+          column: 88
+        end:
+          line: 3495
+          column: 114
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_instant_prompt_time` is referenced before assignment"
+        start:
+          line: 3496
+          column: 20
+        end:
+          line: 3496
+          column: 55
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_instant_prompt_date_format` is referenced before assignment"
+        start:
+          line: 3543
+          column: 49
+        end:
+          line: 3543
+          column: 82
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 3543
+          column: 86
+        end:
+          line: 3543
+          column: 112
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_instant_prompt_date` is referenced before assignment"
+        start:
+          line: 3544
+          column: 18
+        end:
+          line: 3544
+          column: 53
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `unstaged` is referenced before assignment"
+        start:
+          line: 3619
+          column: 12
+        end:
+          line: 3619
+          column: 20
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `misc` is referenced before assignment"
+        start:
+          line: 3637
+          column: 12
+        end:
+          line: 3637
+          column: 16
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C112"
+        severity: "warning"
+        message: "all-elements array expansions collapse inside `[[ ... ]]` tests"
+        start:
+          line: 3713
+          column: 12
+        end:
+          line: 3713
+          column: 28
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `hg` is referenced before assignment"
+        start:
+          line: 3714
+          column: 14
+        end:
+          line: 3714
+          column: 16
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bookmark` is referenced before assignment"
+        start:
+          line: 3714
+          column: 17
+        end:
+          line: 3714
+          column: 25
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `string` is referenced before assignment"
+        start:
+          line: 3714
+          column: 26
+        end:
+          line: 3714
+          column: 32
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 3714
+          column: 34
+        end:
+          line: 3714
+          column: 84
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_VCS_MAX_SYNC_LATENCY_SECONDS` looks like it may mean `POWERLEVEL9K_VCS_MAX_SYNC_LATENCY_SECONDS`"
+        start:
+          line: 4058
+          column: 21
+        end:
+          line: 4058
+          column: 63
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 4178
+          column: 33
+        end:
+          line: 4178
+          column: 44
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `vcs_info_msg_0_` is referenced before assignment"
+        start:
+          line: 4180
+          column: 23
+        end:
+          line: 4180
+          column: 41
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `PYENV_VERSION` looks like it may mean `PLENV_VERSION`"
+        start:
+          line: 4364
+          column: 11
+        end:
+          line: 4364
+          column: 56
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 4373
+          column: 21
+        end:
+          line: 4373
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `GOENV_VERSION` looks like it may mean `NODENV_VERSION`"
+        start:
+          line: 4444
+          column: 11
+        end:
+          line: 4444
+          column: 52
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_GOENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
+        start:
+          line: 4446
+          column: 8
+        end:
+          line: 4446
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 4453
+          column: 21
+        end:
+          line: 4453
+          column: 33
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_GOENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
+        start:
+          line: 4474
+          column: 10
+        end:
+          line: 4474
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `_POWERLEVEL9K_GOENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
+        start:
+          line: 4486
+          column: 10
+        end:
+          line: 4486
+          column: 41
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 4732
+          column: 38
+        end:
+          line: 4732
+          column: 64
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 4733
+          column: 32
+        end:
+          line: 4733
+          column: 52
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 4734
+          column: 35
+        end:
+          line: 4734
+          column: 58
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 4776
+          column: 12
+        end:
+          line: 4776
+          column: 37
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 4777
+          column: 12
+        end:
+          line: 4777
+          column: 31
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 4778
+          column: 12
+        end:
+          line: 4778
+          column: 34
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 4779
+          column: 12
+        end:
+          line: 4779
+          column: 36
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 4780
+          column: 15
+        end:
+          line: 4780
+          column: 17
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `reset` is assigned but never used"
+        start:
+          line: 4783
+          column: 3
+        end:
+          line: 4783
+          column: 8
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 4929
+          column: 3
+        end:
+          line: 4929
+          column: 52
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 4929
+          column: 9
+        end:
+          line: 4929
+          column: 27
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 4932
+          column: 3
+        end:
+          line: 4934
+          column: 5
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 4935
+          column: 3
+        end:
+          line: 4947
+          column: 7
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 5061
+          column: 13
+        end:
+          line: 5061
+          column: 15
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `all_proxy` is referenced before assignment"
+        start:
+          line: 5095
+          column: 5
+        end:
+          line: 5095
+          column: 15
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `http_proxy` is referenced before assignment"
+        start:
+          line: 5095
+          column: 16
+        end:
+          line: 5095
+          column: 27
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `https_proxy` is referenced before assignment"
+        start:
+          line: 5095
+          column: 28
+        end:
+          line: 5095
+          column: 40
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ftp_proxy` is referenced before assignment"
+        start:
+          line: 5095
+          column: 41
+        end:
+          line: 5095
+          column: 51
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5140
+          column: 14
+        end:
+          line: 5140
+          column: 35
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5143
+          column: 23
+        end:
+          line: 5143
+          column: 50
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5143
+          column: 66
+        end:
+          line: 5143
+          column: 94
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5155
+          column: 21
+        end:
+          line: 5155
+          column: 48
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 5215
+          column: 31
+        end:
+          line: 5215
+          column: 59
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 5220
+          column: 11
+        end:
+          line: 5220
+          column: 13
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 5252
+          column: 29
+        end:
+          line: 5252
+          column: 57
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 5324
+          column: 102
+        end:
+          line: 5324
+          column: 104
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 5392
+          column: 19
+        end:
+          line: 5392
+          column: 25
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5429
+          column: 37
+        end:
+          line: 5429
+          column: 50
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5430
+          column: 37
+        end:
+          line: 5430
+          column: 42
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5431
+          column: 37
+        end:
+          line: 5431
+          column: 47
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5432
+          column: 37
+        end:
+          line: 5432
+          column: 42
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5433
+          column: 37
+        end:
+          line: 5433
+          column: 43
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 5506
+          column: 21
+        end:
+          line: 5506
+          column: 26
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 5536
+          column: 31
+        end:
+          line: 5536
+          column: 52
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 5542
+          column: 11
+        end:
+          line: 5542
+          column: 13
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 5578
+          column: 9
+        end:
+          line: 5578
+          column: 10
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 5579
+          column: 58
+        end:
+          line: 5579
+          column: 60
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 5592
+          column: 19
+        end:
+          line: 5592
+          column: 25
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 5603
+          column: 27
+        end:
+          line: 5603
+          column: 41
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 5640
+          column: 17
+        end:
+          line: 5640
+          column: 23
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5679
+          column: 23
+        end:
+          line: 5679
+          column: 41
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5743
+          column: 14
+        end:
+          line: 5743
+          column: 24
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_per_directory_history_is_global` is referenced before assignment"
+        start:
+          line: 5793
+          column: 9
+        end:
+          line: 5793
+          column: 42
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C061"
+        severity: "warning"
+        message: "this token is being treated as a command name, but it looks more like stray text"
+        start:
+          line: 5870
+          column: 68
+        end:
+          line: 5870
+          column: 74
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 5904
+          column: 35
+        end:
+          line: 5904
+          column: 37
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5953
+          column: 20
+        end:
+          line: 5953
+          column: 26
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5954
+          column: 27
+        end:
+          line: 5954
+          column: 40
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5955
+          column: 26
+        end:
+          line: 5955
+          column: 38
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5956
+          column: 26
+        end:
+          line: 5956
+          column: 38
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5957
+          column: 25
+        end:
+          line: 5957
+          column: 36
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 5958
+          column: 25
+        end:
+          line: 5958
+          column: 36
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 6004
+          column: 8
+        end:
+          line: 6004
+          column: 14
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 6006
+          column: 21
+        end:
+          line: 6006
+          column: 27
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `right_idx` is assigned but never used"
+        start:
+          line: 6064
+          column: 7
+        end:
+          line: 6064
+          column: 16
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `left_idx` is assigned but never used"
+        start:
+          line: 6110
+          column: 5
+        end:
+          line: 6110
+          column: 13
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6132
+          column: 27
+        end:
+          line: 6132
+          column: 54
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_dump_file` is referenced before assignment"
+        start:
+          line: 6174
+          column: 18
+        end:
+          line: 6174
+          column: 38
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6197
+          column: 25
+        end:
+          line: 6198
+          column: 119
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C039"
+        severity: "warning"
+        message: "quoted string looks unterminated"
+        start:
+          line: 6199
+          column: 25
+        end:
+          line: 6199
+          column: 25
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_intro_no_locale` is referenced before assignment"
+        start:
+          line: 6200
+          column: 3
+        end:
+          line: 6200
+          column: 25
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6220
+          column: 25
+        end:
+          line: 6229
+          column: 35
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6229
+          column: 57
+        end:
+          line: 6238
+          column: 27
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6238
+          column: 49
+        end:
+          line: 6246
+          column: 47
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6246
+          column: 76
+        end:
+          line: 6252
+          column: 47
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6252
+          column: 76
+        end:
+          line: 6257
+          column: 73
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6261
+          column: 27
+        end:
+          line: 6267
+          column: 37
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6271
+          column: 25
+        end:
+          line: 6274
+          column: 29
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6277
+          column: 18
+        end:
+          line: 6327
+          column: 5
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6329
+          column: 27
+        end:
+          line: 6329
+          column: 110
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6332
+          column: 27
+        end:
+          line: 6332
+          column: 103
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6382
+          column: 31
+        end:
+          line: 6402
+          column: 35
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6402
+          column: 98
+        end:
+          line: 6414
+          column: 6
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6417
+          column: 25
+        end:
+          line: 6417
+          column: 91
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6420
+          column: 25
+        end:
+          line: 6497
+          column: 6
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6497
+          column: 28
+        end:
+          line: 6523
+          column: 6
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6523
+          column: 18
+        end:
+          line: 6536
+          column: 80
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 6536
+          column: 109
+        end:
+          line: 6537
+          column: 79
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 6660
+          column: 35
+        end:
+          line: 6660
+          column: 51
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 6660
+          column: 82
+        end:
+          line: 6660
+          column: 98
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_instant_prompt_param_sig` is referenced before assignment"
+        start:
+          line: 6672
+          column: 13
+        end:
+          line: 6672
+          column: 44
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 6672
+          column: 48
+        end:
+          line: 6672
+          column: 64
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_fd_0` is referenced before assignment"
+        start:
+          line: 6682
+          column: 13
+        end:
+          line: 6682
+          column: 24
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_fd_1` is referenced before assignment"
+        start:
+          line: 6685
+          column: 11
+        end:
+          line: 6685
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_fd_2` is referenced before assignment"
+        start:
+          line: 6685
+          column: 26
+        end:
+          line: 6685
+          column: 37
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_instant_prompt_output` is referenced before assignment"
+        start:
+          line: 6692
+          column: 12
+        end:
+          line: 6692
+          column: 40
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `fill` is assigned but never used"
+        start:
+          line: 6698
+          column: 16
+        end:
+          line: 6698
+          column: 20
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_z4h_can_save_restore_screen` is referenced before assignment"
+        start:
+          line: 6701
+          column: 13
+        end:
+          line: 6701
+          column: 41
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_instant_prompt_sourced` is referenced before assignment"
+        start:
+          line: 6701
+          column: 50
+        end:
+          line: 6701
+          column: 78
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 6838
+          column: 59
+        end:
+          line: 6838
+          column: 61
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_intro_locale` is referenced before assignment"
+        start:
+          line: 6873
+          column: 9
+        end:
+          line: 6873
+          column: 28
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 6881
+          column: 23
+        end:
+          line: 6881
+          column: 25
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `instant_prompt_disabled` is assigned but never used"
+        start:
+          line: 7034
+          column: 15
+        end:
+          line: 7034
+          column: 38
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_cfg_path` is referenced before assignment"
+        start:
+          line: 7036
+          column: 31
+        end:
+          line: 7036
+          column: 46
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 7157
+          column: 9
+        end:
+          line: 7157
+          column: 23
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `POWERLEVEL9K_BATTERY_STAGES` looks like it may mean `_POWERLEVEL9K_BATTERY_STAGES`"
+        start:
+          line: 7518
+          column: 57
+        end:
+          line: 7518
+          column: 101
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 7825
+          column: 34
+        end:
+          line: 7825
+          column: 54
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 7827
+          column: 26
+        end:
+          line: 7827
+          column: 52
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `parameters[_$MATCH]-$MATCH` is referenced before assignment"
+        start:
+          line: 7855
+          column: 58
+        end:
+          line: 7855
+          column: 102
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 7871
+          column: 19
+        end:
+          line: 7871
+          column: 39
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 7901
+          column: 70
+        end:
+          line: 7901
+          column: 92
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 7934
+          column: 30
+        end:
+          line: 7934
+          column: 32
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 7936
+          column: 20
+        end:
+          line: 7936
+          column: 22
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 7985
+          column: 22
+        end:
+          line: 7985
+          column: 43
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 8002
+          column: 29
+        end:
+          line: 8002
+          column: 31
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 8090
+          column: 17
+        end:
+          line: 8090
+          column: 29
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8174
+          column: 52
+        end:
+          line: 8174
+          column: 64
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8176
+          column: 39
+        end:
+          line: 8176
+          column: 61
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8177
+          column: 14
+        end:
+          line: 8177
+          column: 26
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8177
+          column: 28
+        end:
+          line: 8177
+          column: 61
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8178
+          column: 17
+        end:
+          line: 8178
+          column: 29
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8179
+          column: 16
+        end:
+          line: 8179
+          column: 23
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8179
+          column: 25
+        end:
+          line: 8179
+          column: 41
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8181
+          column: 16
+        end:
+          line: 8181
+          column: 37
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8181
+          column: 39
+        end:
+          line: 8181
+          column: 55
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8182
+          column: 16
+        end:
+          line: 8182
+          column: 23
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 8223
+          column: 38
+        end:
+          line: 8223
+          column: 40
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 8224
+          column: 40
+        end:
+          line: 8224
+          column: 42
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8229
+          column: 28
+        end:
+          line: 8229
+          column: 38
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8229
+          column: 40
+        end:
+          line: 8229
+          column: 98
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8230
+          column: 28
+        end:
+          line: 8230
+          column: 50
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8234
+          column: 29
+        end:
+          line: 8234
+          column: 39
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8234
+          column: 41
+        end:
+          line: 8234
+          column: 97
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8235
+          column: 29
+        end:
+          line: 8235
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 8239
+          column: 26
+        end:
+          line: 8239
+          column: 53
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8247
+          column: 15
+        end:
+          line: 8247
+          column: 22
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8268
+          column: 19
+        end:
+          line: 8268
+          column: 39
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 8269
+          column: 9
+        end:
+          line: 8269
+          column: 30
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8278
+          column: 19
+        end:
+          line: 8278
+          column: 29
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 8279
+          column: 9
+        end:
+          line: 8279
+          column: 30
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8286
+          column: 34
+        end:
+          line: 8286
+          column: 53
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 8287
+          column: 7
+        end:
+          line: 8287
+          column: 34
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8293
+          column: 35
+        end:
+          line: 8293
+          column: 45
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 8296
+          column: 26
+        end:
+          line: 8296
+          column: 53
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 8306
+          column: 13
+        end:
+          line: 8306
+          column: 34
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8306
+          column: 38
+        end:
+          line: 8306
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8315
+          column: 38
+        end:
+          line: 8315
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 8317
+          column: 9
+        end:
+          line: 8317
+          column: 36
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 8326
+          column: 21
+        end:
+          line: 8326
+          column: 23
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8358
+          column: 16
+        end:
+          line: 8358
+          column: 96
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8360
+          column: 19
+        end:
+          line: 8360
+          column: 58
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8361
+          column: 19
+        end:
+          line: 8361
+          column: 108
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8362
+          column: 19
+        end:
+          line: 8362
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8363
+          column: 19
+        end:
+          line: 8363
+          column: 48
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8365
+          column: 17
+        end:
+          line: 8365
+          column: 66
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8368
+          column: 27
+        end:
+          line: 8368
+          column: 77
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8369
+          column: 28
+        end:
+          line: 8369
+          column: 38
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8369
+          column: 63
+        end:
+          line: 8369
+          column: 114
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8370
+          column: 27
+        end:
+          line: 8370
+          column: 56
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8371
+          column: 28
+        end:
+          line: 8371
+          column: 58
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8374
+          column: 30
+        end:
+          line: 8374
+          column: 78
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8378
+          column: 30
+        end:
+          line: 8378
+          column: 87
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8392
+          column: 30
+        end:
+          line: 8392
+          column: 135
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8393
+          column: 32
+        end:
+          line: 8393
+          column: 65
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8396
+          column: 30
+        end:
+          line: 8396
+          column: 84
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8423
+          column: 30
+        end:
+          line: 8423
+          column: 63
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8425
+          column: 30
+        end:
+          line: 8425
+          column: 63
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8439
+          column: 16
+        end:
+          line: 8439
+          column: 26
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8439
+          column: 51
+        end:
+          line: 8439
+          column: 61
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8442
+          column: 30
+        end:
+          line: 8442
+          column: 46
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8459
+          column: 12
+        end:
+          line: 8459
+          column: 19
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8459
+          column: 23
+        end:
+          line: 8459
+          column: 58
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8461
+          column: 14
+        end:
+          line: 8461
+          column: 42
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8463
+          column: 14
+        end:
+          line: 8463
+          column: 44
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8469
+          column: 30
+        end:
+          line: 8469
+          column: 61
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8471
+          column: 30
+        end:
+          line: 8471
+          column: 61
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8478
+          column: 16
+        end:
+          line: 8478
+          column: 30
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8480
+          column: 27
+        end:
+          line: 8480
+          column: 41
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 8489
+          column: 38
+        end:
+          line: 8489
+          column: 42
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `NAME` looks like it may mean `name`"
+        start:
+          line: 8522
+          column: 32
+        end:
+          line: 8522
+          column: 37
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 8534
+          column: 16
+        end:
+          line: 8534
+          column: 32
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `cmds` is assigned but never used"
+        start:
+          line: 8586
+          column: 13
+        end:
+          line: 8586
+          column: 17
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8600
+          column: 28
+        end:
+          line: 8600
+          column: 54
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8602
+          column: 28
+        end:
+          line: 8602
+          column: 35
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8607
+          column: 28
+        end:
+          line: 8607
+          column: 54
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8609
+          column: 28
+        end:
+          line: 8609
+          column: 35
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8615
+          column: 17
+        end:
+          line: 8615
+          column: 24
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C091"
+        severity: "warning"
+        message: "quoted `~/...` stays literal; use `$HOME` or an unquoted tilde"
+        start:
+          line: 8750
+          column: 35
+        end:
+          line: 8750
+          column: 40
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 8771
+          column: 17
+        end:
+          line: 8771
+          column: 41
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 8972
+          column: 30
+        end:
+          line: 8972
+          column: 98
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C130"
+        severity: "warning"
+        message: "quotes or backslashes stored in this value will stay literal on reuse"
+        start:
+          line: 9168
+          column: 39
+        end:
+          line: 9235
+          column: 51
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C130"
+        severity: "warning"
+        message: "quotes or backslashes stored in this value will stay literal on reuse"
+        start:
+          line: 9249
+          column: 39
+        end:
+          line: 9306
+          column: 1
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_intro_no_reply` is referenced before assignment"
+        start:
+          line: 9316
+          column: 9
+        end:
+          line: 9316
+          column: 30
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 9336
+          column: 29
+        end:
+          line: 9336
+          column: 36
+        classification: false_positive
+      - path: "internal/p10k.zsh"
+        code: "C135"
+        severity: "warning"
+        message: "this case arm does not match any option declared by getopts"
+        start:
+          line: 9340
+          column: 11
+        end:
+          line: 9340
+          column: 13
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C135"
+        severity: "warning"
+        message: "this case arm does not match any option declared by getopts"
+        start:
+          line: 9341
+          column: 11
+        end:
+          line: 9341
+          column: 13
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 9342
+          column: 27
+        end:
+          line: 9342
+          column: 52
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 9343
+          column: 27
+        end:
+          line: 9343
+          column: 52
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 9347
+          column: 22
+        end:
+          line: 9347
+          column: 47
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 9368
+          column: 22
+        end:
+          line: 9368
+          column: 47
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 9384
+          column: 27
+        end:
+          line: 9384
+          column: 52
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 9385
+          column: 27
+        end:
+          line: 9385
+          column: 52
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 9407
+          column: 32
+        end:
+          line: 9407
+          column: 40
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 9412
+          column: 18
+        end:
+          line: 9412
+          column: 21
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 9414
+          column: 41
+        end:
+          line: 9414
+          column: 49
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 9418
+          column: 41
+        end:
+          line: 9418
+          column: 45
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 9424
+          column: 32
+        end:
+          line: 9424
+          column: 34
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 9427
+          column: 32
+        end:
+          line: 9427
+          column: 34
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 9493
+          column: 41
+        end:
+          line: 9493
+          column: 43
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 9509
+          column: 27
+        end:
+          line: 9509
+          column: 58
+        classification: real
+      - path: "internal/parser.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_intro` is referenced before assignment"
+        start:
+          line: 146
+          column: 9
+        end:
+          line: 146
+          column: 21
+        classification: false_positive
+      - path: "internal/parser.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `galiases` is referenced before assignment"
+        start:
+          line: 183
+          column: 13
+        end:
+          line: 183
+          column: 22
+        classification: false_positive
+      - path: "internal/parser.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `saliases` is referenced before assignment"
+        start:
+          line: 194
+          column: 13
+        end:
+          line: 194
+          column: 32
+        classification: false_positive
+      - path: "internal/parser.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 211
+          column: 60
+        end:
+          line: 211
+          column: 64
+        classification: false_positive
+      - path: "internal/parser.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 211
+          column: 76
+        end:
+          line: 211
+          column: 81
+        classification: false_positive
+      - path: "internal/parser.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 224
+          column: 27
+        end:
+          line: 224
+          column: 32
+        classification: real
+      - path: "internal/parser.zsh"
+        code: "C133"
+        severity: "warning"
+        message: "a variable name switches from array-like use to a plain scalar assignment"
+        start:
+          line: 312
+          column: 13
+        end:
+          line: 312
+          column: 14
+        classification: real
+      - path: "internal/parser.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 344
+          column: 15
+        end:
+          line: 344
+          column: 25
+        classification: real
+      - path: "internal/parser.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 347
+          column: 15
+        end:
+          line: 347
+          column: 21
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C135"
+        severity: "warning"
+        message: "this case arm does not match any option declared by getopts"
+        start:
+          line: 7
+          column: 5
+        end:
+          line: 7
+          column: 7
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `prompt_indent` is assigned but never used"
+        start:
+          line: 26
+          column: 11
+        end:
+          line: 26
+          column: 24
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `lean_left` is assigned but never used"
+        start:
+          line: 51
+          column: 11
+        end:
+          line: 51
+          column: 20
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 52
+          column: 3
+        end:
+          line: 52
+          column: 30
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 52
+          column: 31
+        end:
+          line: 52
+          column: 157
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 53
+          column: 3
+        end:
+          line: 53
+          column: 29
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 53
+          column: 30
+        end:
+          line: 53
+          column: 69
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `lean_right` is assigned but never used"
+        start:
+          line: 56
+          column: 11
+        end:
+          line: 56
+          column: 21
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 57
+          column: 3
+        end:
+          line: 57
+          column: 90
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 57
+          column: 91
+        end:
+          line: 57
+          column: 120
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 58
+          column: 6
+        end:
+          line: 58
+          column: 35
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `lean_8colors_left` is assigned but never used"
+        start:
+          line: 61
+          column: 11
+        end:
+          line: 61
+          column: 28
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 62
+          column: 3
+        end:
+          line: 62
+          column: 30
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 62
+          column: 31
+        end:
+          line: 62
+          column: 138
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 63
+          column: 3
+        end:
+          line: 63
+          column: 29
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 63
+          column: 30
+        end:
+          line: 63
+          column: 68
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `lean_8colors_right` is assigned but never used"
+        start:
+          line: 66
+          column: 11
+        end:
+          line: 66
+          column: 29
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 67
+          column: 3
+        end:
+          line: 67
+          column: 87
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 67
+          column: 88
+        end:
+          line: 67
+          column: 117
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 68
+          column: 6
+        end:
+          line: 68
+          column: 35
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `classic_left` is assigned but never used"
+        start:
+          line: 71
+          column: 11
+        end:
+          line: 71
+          column: 23
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 72
+          column: 3
+        end:
+          line: 72
+          column: 29
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 72
+          column: 30
+        end:
+          line: 72
+          column: 376
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 73
+          column: 3
+        end:
+          line: 73
+          column: 29
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 73
+          column: 30
+        end:
+          line: 73
+          column: 53
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `classic_right` is assigned but never used"
+        start:
+          line: 76
+          column: 11
+        end:
+          line: 76
+          column: 24
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 77
+          column: 3
+        end:
+          line: 77
+          column: 256
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 77
+          column: 257
+        end:
+          line: 77
+          column: 285
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 78
+          column: 6
+        end:
+          line: 78
+          column: 34
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `pure_left` is assigned but never used"
+        start:
+          line: 81
+          column: 11
+        end:
+          line: 81
+          column: 20
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 82
+          column: 6
+        end:
+          line: 82
+          column: 116
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 83
+          column: 6
+        end:
+          line: 83
+          column: 65
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `pure_right` is assigned but never used"
+        start:
+          line: 86
+          column: 11
+        end:
+          line: 86
+          column: 21
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 87
+          column: 3
+        end:
+          line: 87
+          column: 101
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `rainbow_left` is assigned but never used"
+        start:
+          line: 91
+          column: 11
+        end:
+          line: 91
+          column: 23
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 92
+          column: 3
+        end:
+          line: 92
+          column: 29
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 92
+          column: 30
+        end:
+          line: 92
+          column: 274
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 93
+          column: 3
+        end:
+          line: 93
+          column: 29
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 93
+          column: 30
+        end:
+          line: 93
+          column: 53
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `rainbow_right` is assigned but never used"
+        start:
+          line: 96
+          column: 11
+        end:
+          line: 96
+          column: 24
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 97
+          column: 3
+        end:
+          line: 97
+          column: 144
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 97
+          column: 145
+        end:
+          line: 97
+          column: 173
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 98
+          column: 6
+        end:
+          line: 98
+          column: 34
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `gap` is assigned but never used"
+        start:
+          line: 158
+          column: 14
+        end:
+          line: 158
+          column: 17
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 159
+          column: 36
+        end:
+          line: 159
+          column: 38
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `fill` is assigned but never used"
+        start:
+          line: 159
+          column: 69
+        end:
+          line: 159
+          column: 73
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_p9k_term_has_href` is referenced before assignment"
+        start:
+          line: 169
+          column: 9
+        end:
+          line: 169
+          column: 27
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `indentation` is assigned but never used"
+        start:
+          line: 182
+          column: 11
+        end:
+          line: 182
+          column: 22
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C135"
+        severity: "warning"
+        message: "this case arm does not match any option declared by getopts"
+        start:
+          line: 184
+          column: 7
+        end:
+          line: 184
+          column: 9
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `key` is assigned but never used"
+        start:
+          line: 237
+          column: 17
+        end:
+          line: 237
+          column: 20
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_zshrc_u` is referenced before assignment"
+        start:
+          line: 268
+          column: 85
+        end:
+          line: 268
+          column: 99
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_wizard_columns` is referenced before assignment"
+        start:
+          line: 317
+          column: 32
+        end:
+          line: 317
+          column: 52
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_wizard_lines` is referenced before assignment"
+        start:
+          line: 322
+          column: 32
+        end:
+          line: 322
+          column: 50
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `columns` is assigned but never used"
+        start:
+          line: 399
+          column: 7
+        end:
+          line: 399
+          column: 14
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 478
+          column: 18
+        end:
+          line: 478
+          column: 24
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 487
+          column: 6
+        end:
+          line: 487
+          column: 24
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 489
+          column: 1
+        end:
+          line: 505
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 493
+          column: 13
+        end:
+          line: 493
+          column: 15
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 507
+          column: 1
+        end:
+          line: 585
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 587
+          column: 1
+        end:
+          line: 612
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C063"
+        severity: "warning"
+        message: "function `print_file_path` cannot be reached by a direct call before the script terminates"
+        start:
+          line: 614
+          column: 1
+        end:
+          line: 620
+          column: 2
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 614
+          column: 1
+        end:
+          line: 620
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 622
+          column: 1
+        end:
+          line: 669
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 671
+          column: 1
+        end:
+          line: 698
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 700
+          column: 1
+        end:
+          line: 722
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 724
+          column: 1
+        end:
+          line: 745
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 747
+          column: 1
+        end:
+          line: 767
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 769
+          column: 1
+        end:
+          line: 796
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C063"
+        severity: "warning"
+        message: "function `print_indented` cannot be reached by a direct call before the script terminates"
+        start:
+          line: 798
+          column: 1
+        end:
+          line: 803
+          column: 2
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 798
+          column: 1
+        end:
+          line: 803
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `max_width` is assigned but never used"
+        start:
+          line: 799
+          column: 12
+        end:
+          line: 799
+          column: 21
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `indent` is assigned but never used"
+        start:
+          line: 801
+          column: 12
+        end:
+          line: 801
+          column: 18
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 805
+          column: 1
+        end:
+          line: 829
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 831
+          column: 1
+        end:
+          line: 875
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `icons` is referenced before assignment"
+        start:
+          line: 838
+          column: 13
+        end:
+          line: 838
+          column: 38
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 877
+          column: 1
+        end:
+          line: 912
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 914
+          column: 1
+        end:
+          line: 958
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 960
+          column: 1
+        end:
+          line: 1005
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1007
+          column: 1
+        end:
+          line: 1028
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C063"
+        severity: "warning"
+        message: "function `print_frame_marker` cannot be reached by a direct call before the script terminates"
+        start:
+          line: 1030
+          column: 1
+        end:
+          line: 1037
+          column: 2
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1030
+          column: 1
+        end:
+          line: 1037
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1039
+          column: 1
+        end:
+          line: 1071
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1073
+          column: 1
+        end:
+          line: 1093
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1095
+          column: 1
+        end:
+          line: 1112
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `pure_use_rprompt` is assigned but never used"
+        start:
+          line: 1109
+          column: 8
+        end:
+          line: 1109
+          column: 24
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1114
+          column: 1
+        end:
+          line: 1175
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C128"
+        severity: "warning"
+        message: "this case pattern shadows a later pattern"
+        start:
+          line: 1135
+          column: 11
+        end:
+          line: 1135
+          column: 21
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C129"
+        severity: "warning"
+        message: "this case pattern is unreachable because an earlier pattern already matches it"
+        start:
+          line: 1143
+          column: 11
+        end:
+          line: 1143
+          column: 21
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1177
+          column: 1
+        end:
+          line: 1205
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1207
+          column: 1
+        end:
+          line: 1228
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1230
+          column: 1
+        end:
+          line: 1285
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1287
+          column: 1
+        end:
+          line: 1344
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C063"
+        severity: "warning"
+        message: "function `print_tail_marker` cannot be reached by a direct call before the script terminates"
+        start:
+          line: 1346
+          column: 1
+        end:
+          line: 1353
+          column: 2
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1346
+          column: 1
+        end:
+          line: 1353
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `m` is assigned but never used"
+        start:
+          line: 1349
+          column: 12
+        end:
+          line: 1349
+          column: 13
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1355
+          column: 1
+        end:
+          line: 1404
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1406
+          column: 1
+        end:
+          line: 1422
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1424
+          column: 1
+        end:
+          line: 1451
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1453
+          column: 1
+        end:
+          line: 1478
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1480
+          column: 1
+        end:
+          line: 1507
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C063"
+        severity: "warning"
+        message: "function `print_instant_prompt_link` cannot be reached by a direct call before the script terminates"
+        start:
+          line: 1509
+          column: 1
+        end:
+          line: 1514
+          column: 2
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1509
+          column: 1
+        end:
+          line: 1514
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1516
+          column: 1
+        end:
+          line: 1552
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1554
+          column: 1
+        end:
+          line: 1592
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1594
+          column: 1
+        end:
+          line: 1626
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_cfg_path` is referenced before assignment"
+        start:
+          line: 1597
+          column: 14
+        end:
+          line: 1597
+          column: 29
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_cfg_path_u` is referenced before assignment"
+        start:
+          line: 1601
+          column: 47
+        end:
+          line: 1601
+          column: 75
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1612
+          column: 24
+        end:
+          line: 1612
+          column: 33
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_cfg_basename` is referenced before assignment"
+        start:
+          line: 1618
+          column: 43
+        end:
+          line: 1618
+          column: 62
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1628
+          column: 1
+        end:
+          line: 1707
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_zd` is referenced before assignment"
+        start:
+          line: 1650
+          column: 14
+        end:
+          line: 1650
+          column: 23
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_zd_u` is referenced before assignment"
+        start:
+          line: 1652
+          column: 46
+        end:
+          line: 1652
+          column: 68
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_zshrc` is referenced before assignment"
+        start:
+          line: 1654
+          column: 14
+        end:
+          line: 1654
+          column: 26
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 1685
+          column: 26
+        end:
+          line: 1685
+          column: 35
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1709
+          column: 1
+        end:
+          line: 1964
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_root_dir` is referenced before assignment"
+        start:
+          line: 1710
+          column: 26
+        end:
+          line: 1710
+          column: 41
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1930
+          column: 20
+        end:
+          line: 1930
+          column: 22
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 1966
+          column: 1
+        end:
+          line: 2011
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 2013
+          column: 1
+        end:
+          line: 2045
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_cfg_path_o` is referenced before assignment"
+        start:
+          line: 2019
+          column: 12
+        end:
+          line: 2019
+          column: 29
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2025
+          column: 12
+        end:
+          line: 2025
+          column: 37
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2026
+          column: 12
+        end:
+          line: 2026
+          column: 41
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2027
+          column: 12
+        end:
+          line: 2027
+          column: 43
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2028
+          column: 12
+        end:
+          line: 2028
+          column: 43
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2029
+          column: 12
+        end:
+          line: 2029
+          column: 34
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2030
+          column: 12
+        end:
+          line: 2030
+          column: 36
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2031
+          column: 12
+        end:
+          line: 2031
+          column: 36
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2032
+          column: 12
+        end:
+          line: 2032
+          column: 32
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2033
+          column: 12
+        end:
+          line: 2033
+          column: 34
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2034
+          column: 12
+        end:
+          line: 2034
+          column: 34
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2035
+          column: 13
+        end:
+          line: 2035
+          column: 40
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2036
+          column: 13
+        end:
+          line: 2036
+          column: 42
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 2040
+          column: 13
+        end:
+          line: 2040
+          column: 81
+        classification: false_positive
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 2071
+          column: 1
+        end:
+          line: 2078
+          column: 3
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 2080
+          column: 1
+        end:
+          line: 2257
+          column: 2
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `langinfo` is referenced before assignment"
+        start:
+          line: 2119
+          column: 50
+        end:
+          line: 2119
+          column: 68
+        classification: false_positive
+      - path: "internal/worker.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `sysparams` is referenced before assignment"
+        start:
+          line: 94
+          column: 33
+        end:
+          line: 94
+          column: 48
+        classification: false_positive
+      - path: "internal/worker.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 94
+          column: 33
+        end:
+          line: 94
+          column: 48
+        classification: real
+      - path: "internal/worker.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `__p9k_intro` is referenced before assignment"
+        start:
+          line: 116
+          column: 9
+        end:
+          line: 116
+          column: 21
+        classification: false_positive
+  - name: "prezto"
+    github_url: "https://github.com/sorin-ionescu/prezto.git"
+    commit: "cff2d01871425b1b80710f8ec6a475c5a53145b4"
+    diagnostics:
+      - path: "init.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 40
+          column: 23
+        end:
+          line: 40
+          column: 30
+        classification: real
+      - path: "init.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 43
+          column: 25
+        end:
+          line: 43
+          column: 30
+        classification: real
+      - path: "init.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 54
+          column: 26
+        end:
+          line: 54
+          column: 31
+        classification: real
+      - path: "init.zsh"
+        code: "C124"
+        severity: "warning"
+        message: "code is unreachable"
+        start:
+          line: 66
+          column: 5
+        end:
+          line: 66
+          column: 13
+        classification: real
+      - path: "init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 130
+          column: 16
+        end:
+          line: 130
+          column: 46
+        classification: real
+      - path: "init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 132
+          column: 16
+        end:
+          line: 132
+          column: 59
+        classification: real
+      - path: "init.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 135
+          column: 13
+        end:
+          line: 135
+          column: 15
+        classification: real
+      - path: "init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 172
+          column: 10
+        end:
+          line: 172
+          column: 40
+        classification: real
+      - path: "modules/autosuggestions/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE` is assigned but never used"
+        start:
+          line: 24
+          column: 3
+        end:
+          line: 24
+          column: 34
+        classification: false_positive
+      - path: "modules/command-not-found/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 11
+          column: 10
+        end:
+          line: 11
+          column: 36
+        classification: real
+      - path: "modules/command-not-found/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 14
+          column: 10
+        end:
+          line: 14
+          column: 54
+        classification: real
+      - path: "modules/command-not-found/init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 22
+          column: 14
+        end:
+          line: 22
+          column: 31
+        classification: real
+      - path: "modules/completion/init.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_comps` is referenced before assignment"
+        start:
+          line: 132
+          column: 66
+        end:
+          line: 132
+          column: 91
+        classification: false_positive
+      - path: "modules/editor/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `WORDCHARS` is assigned but never used"
+        start:
+          line: 25
+          column: 6
+        end:
+          line: 25
+          column: 15
+        classification: false_positive
+      - path: "modules/editor/init.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `KEYMAP` looks like it may mean `keymap`"
+        start:
+          line: 102
+          column: 12
+        end:
+          line: 102
+          column: 19
+        classification: real
+      - path: "modules/editor/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `editor_info` is assigned but never used"
+        start:
+          line: 114
+          column: 9
+        end:
+          line: 114
+          column: 31
+        classification: real
+      - path: "modules/emacs/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 16
+          column: 8
+        end:
+          line: 16
+          column: 45
+        classification: real
+      - path: "modules/environment/init.zsh"
+        code: "C094"
+        severity: "warning"
+        message: "this command reads and writes the same file"
+        start:
+          line: 41
+          column: 74
+        end:
+          line: 41
+          column: 78
+        classification: real
+      - path: "modules/environment/init.zsh"
+        code: "C094"
+        severity: "warning"
+        message: "this command reads and writes the same file"
+        start:
+          line: 41
+          column: 80
+        end:
+          line: 41
+          column: 84
+        classification: real
+      - path: "modules/fasd/init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 39
+          column: 8
+        end:
+          line: 39
+          column: 21
+        classification: real
+      - path: "modules/gpg/init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 18
+          column: 8
+        end:
+          line: 18
+          column: 25
+        classification: real
+      - path: "modules/homebrew/init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 33
+          column: 10
+        end:
+          line: 33
+          column: 23
+        classification: real
+      - path: "modules/node/init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 26
+          column: 10
+        end:
+          line: 26
+          column: 31
+        classification: real
+      - path: "modules/node/init.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `nvm_path` is referenced before assignment"
+        start:
+          line: 30
+          column: 17
+        end:
+          line: 30
+          column: 70
+        classification: false_positive
+      - path: "modules/node/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 31
+          column: 10
+        end:
+          line: 31
+          column: 28
+        classification: real
+      - path: "modules/node/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `N_PREFIX` is assigned but never used"
+        start:
+          line: 45
+          column: 1
+        end:
+          line: 45
+          column: 9
+        classification: real
+      - path: "modules/ocaml/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 14
+          column: 8
+        end:
+          line: 14
+          column: 40
+        classification: real
+      - path: "modules/perl/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 22
+          column: 10
+        end:
+          line: 22
+          column: 61
+        classification: real
+      - path: "modules/perl/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 26
+          column: 12
+        end:
+          line: 26
+          column: 81
+        classification: real
+      - path: "modules/perl/init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 54
+          column: 12
+        end:
+          line: 54
+          column: 25
+        classification: real
+      - path: "modules/python/init.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `local_pyenv` is referenced before assignment"
+        start:
+          line: 22
+          column: 11
+        end:
+          line: 22
+          column: 65
+        classification: false_positive
+      - path: "modules/python/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 84
+          column: 16
+        end:
+          line: 84
+          column: 38
+        classification: real
+      - path: "modules/python/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `VIRTUALENVWRAPPER_PYTHON` is assigned but never used"
+        start:
+          line: 135
+          column: 7
+        end:
+          line: 135
+          column: 31
+        classification: real
+      - path: "modules/python/init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 143
+          column: 14
+        end:
+          line: 143
+          column: 45
+        classification: real
+      - path: "modules/ruby/init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 29
+          column: 10
+        end:
+          line: 29
+          column: 31
+        classification: real
+      - path: "modules/ruby/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 34
+          column: 12
+        end:
+          line: 34
+          column: 65
+        classification: real
+      - path: "modules/ruby/init.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 39
+          column: 14
+        end:
+          line: 39
+          column: 65
+        classification: real
+      - path: "modules/spectrum/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `FG` is assigned but never used"
+        start:
+          line: 70
+          column: 3
+        end:
+          line: 70
+          column: 13
+        classification: real
+      - path: "modules/spectrum/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `BG` is assigned but never used"
+        start:
+          line: 71
+          column: 3
+        end:
+          line: 71
+          column: 13
+        classification: real
+      - path: "modules/ssh/init.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 25
+          column: 10
+        end:
+          line: 25
+          column: 27
+        classification: real
+      - path: "modules/syntax-highlighting/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_HIGHLIGHT_STYLES` is assigned but never used"
+        start:
+          line: 26
+          column: 3
+        end:
+          line: 26
+          column: 51
+        classification: real
+      - path: "modules/syntax-highlighting/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_HIGHLIGHT_PATTERNS` is assigned but never used"
+        start:
+          line: 34
+          column: 3
+        end:
+          line: 34
+          column: 48
+        classification: real
+      - path: "modules/terminal/init.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `title_formatted` is referenced before assignment"
+        start:
+          line: 19
+          column: 23
+        end:
+          line: 19
+          column: 45
+        classification: false_positive
+      - path: "modules/terminal/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `jobtexts_from_parent_shell` is assigned but never used"
+        start:
+          line: 50
+          column: 5
+        end:
+          line: 50
+          column: 31
+        classification: real
+      - path: "modules/terminal/init.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `discarded` is assigned but never used"
+        start:
+          line: 53
+          column: 18
+        end:
+          line: 53
+          column: 27
+        classification: real
+  - name: "thoughtbot-dotfiles"
+    github_url: "https://github.com/thoughtbot/dotfiles.git"
+    commit: "317ba3a479e4b104328150070b71e1a89d5bd532"
+    diagnostics:
+      - path: "bin/bundler-search"
+        code: "X012"
+        severity: "warning"
+        message: "use of `&>` is not portable in `sh`"
+        start:
+          line: 15
+          column: 18
+        end:
+          line: 15
+          column: 29
+        classification: real
+      - path: "bin/clear-port"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 9
+          column: 8
+        end:
+          line: 9
+          column: 10
+        classification: real
+      - path: "bin/git-merge-branch"
+        code: "C006"
+        severity: "error"
+        message: "variable `main_branch` is referenced before assignment"
+        start:
+          line: 18
+          column: 30
+        end:
+          line: 18
+          column: 42
+        classification: false_positive
+      - path: "bin/replace"
+        code: "X012"
+        severity: "warning"
+        message: "use of `&>` is not portable in `sh`"
+        start:
+          line: 12
+          column: 18
+        end:
+          line: 12
+          column: 29
+        classification: real
+      - path: "bin/replace"
+        code: "X007"
+        severity: "warning"
+        message: "ANSI-C quoting is not portable in `sh`"
+        start:
+          line: 19
+          column: 5
+        end:
+          line: 19
+          column: 10
+        classification: real
+      - path: "git_template/hooks/commit-msg"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 5
+        end:
+          line: 6
+          column: 18
+        classification: real
+      - path: "git_template/hooks/post-checkout"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 5
+        end:
+          line: 6
+          column: 18
+        classification: real
+      - path: "git_template/hooks/post-commit"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 5
+        end:
+          line: 6
+          column: 18
+        classification: real
+      - path: "git_template/hooks/post-merge"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 5
+        end:
+          line: 6
+          column: 18
+        classification: real
+      - path: "git_template/hooks/pre-commit"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 5
+        end:
+          line: 6
+          column: 18
+        classification: real
+      - path: "git_template/hooks/pre-push"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 5
+        end:
+          line: 6
+          column: 18
+        classification: real
+      - path: "git_template/hooks/prepare-commit-msg"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 5
+        end:
+          line: 6
+          column: 18
+        classification: real
+      - path: "zsh/configs/fzf.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 4
+          column: 10
+        end:
+          line: 4
+          column: 22
+        classification: real
+      - path: "zsh/configs/fzf.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 6
+          column: 10
+        end:
+          line: 6
+          column: 33
+        classification: real
+      - path: "zsh/configs/options.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `DIRSTACKSIZE` is assigned but never used"
+        start:
+          line: 3
+          column: 1
+        end:
+          line: 3
+          column: 13
+        classification: real
+      - path: "zsh/configs/post/path.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 6
+          column: 5
+        end:
+          line: 6
+          column: 26
+        classification: real
+      - path: "zsh/configs/post/path.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 8
+          column: 5
+        end:
+          line: 8
+          column: 44
+        classification: real
+  - name: "zdot"
+    github_url: "https://github.com/georgeharker/zdot.git"
+    commit: "a27c23ff0180520c92ad61d0cc7c0becfa112396"
+    diagnostics:
+      - path: "core/cache.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 196
+          column: 12
+        end:
+          line: 196
+          column: 26
+        classification: real
+      - path: "core/cache.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `compiled_plan` is assigned but never used"
+        start:
+          line: 456
+          column: 11
+        end:
+          line: 456
+          column: 24
+        classification: real
+      - path: "core/cache.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 546
+          column: 12
+        end:
+          line: 546
+          column: 24
+        classification: real
+      - path: "core/compinit.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 186
+          column: 52
+        end:
+          line: 186
+          column: 79
+        classification: real
+      - path: "core/dotfiler-hook.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 49
+          column: 8
+        end:
+          line: 49
+          column: 42
+        classification: real
+      - path: "core/functions.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 122
+          column: 16
+        end:
+          line: 122
+          column: 23
+        classification: real
+      - path: "core/functions.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 135
+          column: 20
+        end:
+          line: 135
+          column: 24
+        classification: real
+      - path: "core/functions/zdot_hooks_graph"
+        code: "C001"
+        severity: "warning"
+        message: "variable `deps` is assigned but never used"
+        start:
+          line: 391
+          column: 19
+        end:
+          line: 391
+          column: 23
+        classification: real
+      - path: "core/functions/zdot_hooks_list"
+        code: "C112"
+        severity: "warning"
+        message: "all-elements array expansions collapse inside `[[ ... ]]` tests"
+        start:
+          line: 227
+          column: 23
+        end:
+          line: 227
+          column: 49
+        classification: real
+      - path: "core/functions/zdot_module_hooks"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 54
+          column: 47
+        end:
+          line: 54
+          column: 52
+        classification: real
+      - path: "core/functions/zdot_update_plugin"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 64
+          column: 74
+        end:
+          line: 64
+          column: 76
+        classification: real
+      - path: "core/functions/zdot_update_plugin"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 93
+          column: 81
+        end:
+          line: 93
+          column: 83
+        classification: real
+      - path: "core/hooks.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `defer_mark` is assigned but never used"
+        start:
+          line: 1641
+          column: 25
+        end:
+          line: 1641
+          column: 35
+        classification: real
+      - path: "core/plugin-bundles/omz.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 52
+          column: 60
+        end:
+          line: 52
+          column: 95
+        classification: real
+      - path: "core/plugin-bundles/omz.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 80
+          column: 16
+        end:
+          line: 80
+          column: 29
+        classification: real
+      - path: "core/plugin-bundles/omz.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 103
+          column: 66
+        end:
+          line: 103
+          column: 95
+        classification: real
+      - path: "core/plugin-bundles/omz.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 105
+          column: 78
+        end:
+          line: 105
+          column: 103
+        classification: real
+      - path: "core/plugin-bundles/omz.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 107
+          column: 63
+        end:
+          line: 107
+          column: 100
+        classification: real
+      - path: "core/plugin-bundles/omz.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 108
+          column: 61
+        end:
+          line: 108
+          column: 86
+        classification: real
+      - path: "core/plugin-bundles/omz.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 157
+          column: 50
+        end:
+          line: 157
+          column: 71
+        classification: real
+      - path: "core/plugin-bundles/omz.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `omz` is referenced before assignment"
+        start:
+          line: 274
+          column: 26
+        end:
+          line: 274
+          column: 29
+        classification: false_positive
+      - path: "core/plugin-bundles/omz.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 337
+          column: 12
+        end:
+          line: 337
+          column: 26
+        classification: real
+      - path: "core/plugin-bundles/pz.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 126
+          column: 16
+        end:
+          line: 126
+          column: 40
+        classification: real
+      - path: "core/plugins.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 56
+          column: 51
+        end:
+          line: 56
+          column: 77
+        classification: real
+      - path: "core/plugins.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 127
+          column: 18
+        end:
+          line: 127
+          column: 23
+        classification: real
+      - path: "core/plugins.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 259
+          column: 22
+        end:
+          line: 259
+          column: 54
+        classification: false_positive
+      - path: "core/plugins.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 259
+          column: 69
+        end:
+          line: 259
+          column: 91
+        classification: false_positive
+      - path: "core/plugins.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 476
+          column: 12
+        end:
+          line: 476
+          column: 26
+        classification: real
+      - path: "core/update.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 36
+          column: 8
+        end:
+          line: 36
+          column: 42
+        classification: real
+      - path: "core/update.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `reply` is referenced before assignment"
+        start:
+          line: 52
+          column: 34
+        end:
+          line: 52
+          column: 45
+        classification: false_positive
+      - path: "core/update.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 140
+          column: 20
+        end:
+          line: 140
+          column: 35
+        classification: real
+      - path: "core/update.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 148
+          column: 20
+        end:
+          line: 148
+          column: 34
+        classification: real
+      - path: "core/utils.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 67
+          column: 12
+        end:
+          line: 67
+          column: 26
+        classification: real
+      - path: "modules/apt/apt.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `reply` is referenced before assignment"
+        start:
+          line: 15
+          column: 6
+        end:
+          line: 15
+          column: 17
+        classification: false_positive
+      - path: "modules/autocompletion/autocompletion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_AUTOSUGGEST_STRATEGY` is assigned but never used"
+        start:
+          line: 10
+          column: 5
+        end:
+          line: 10
+          column: 29
+        classification: false_positive
+      - path: "modules/autocompletion/autocompletion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_AUTOLOAD` is assigned but never used"
+        start:
+          line: 13
+          column: 5
+        end:
+          line: 13
+          column: 18
+        classification: false_positive
+      - path: "modules/autocompletion/autocompletion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_SET_EXPANSION_CURSOR` is assigned but never used"
+        start:
+          line: 14
+          column: 5
+        end:
+          line: 14
+          column: 30
+        classification: false_positive
+      - path: "modules/autocompletion/autocompletion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_SET_LINE_CURSOR` is assigned but never used"
+        start:
+          line: 15
+          column: 5
+        end:
+          line: 15
+          column: 25
+        classification: false_positive
+      - path: "modules/autocompletion/autocompletion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_GET_AVAILABLE_ABBREVIATION` is assigned but never used"
+        start:
+          line: 16
+          column: 5
+        end:
+          line: 16
+          column: 36
+        classification: false_positive
+      - path: "modules/autocompletion/autocompletion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_USER_ABBREVIATIONS_FILE` is assigned but never used"
+        start:
+          line: 17
+          column: 5
+        end:
+          line: 17
+          column: 33
+        classification: false_positive
+      - path: "modules/brew/brew.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `reply` is referenced before assignment"
+        start:
+          line: 29
+          column: 46
+        end:
+          line: 29
+          column: 57
+        classification: false_positive
+      - path: "modules/dotfiler/dotfiler.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 47
+          column: 16
+        end:
+          line: 47
+          column: 55
+        classification: real
+      - path: "modules/dotfiler/dotfiler.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 51
+          column: 16
+        end:
+          line: 51
+          column: 54
+        classification: real
+      - path: "modules/fzf/functions/fzf_ripgrep"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 8
+          column: 19
+        end:
+          line: 8
+          column: 33
+        classification: real
+      - path: "modules/fzf/functions/fzf_ripgrep"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 12
+          column: 16
+        end:
+          line: 14
+          column: 132
+        classification: false_positive
+      - path: "modules/fzf/fzf.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 45
+          column: 73
+        end:
+          line: 45
+          column: 114
+        classification: false_positive
+      - path: "modules/fzf/fzf.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 89
+          column: 62
+        end:
+          line: 89
+          column: 77
+        classification: real
+      - path: "modules/fzf/fzf.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 93
+          column: 16
+        end:
+          line: 93
+          column: 65
+        classification: real
+      - path: "modules/history/history.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `HISTORY_BASE` is assigned but never used"
+        start:
+          line: 21
+          column: 9
+        end:
+          line: 21
+          column: 21
+        classification: real
+      - path: "modules/history/history.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `HISTORY_START_WITH_GLOBAL` is assigned but never used"
+        start:
+          line: 25
+          column: 13
+        end:
+          line: 25
+          column: 38
+        classification: real
+      - path: "modules/history/history.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PER_DIRECTORY_HISTORY_TOGGLE` is assigned but never used"
+        start:
+          line: 28
+          column: 13
+        end:
+          line: 28
+          column: 41
+        classification: real
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `FAST_WORK_DIR` is assigned but never used"
+        start:
+          line: 33
+          column: 5
+        end:
+          line: 33
+          column: 18
+        classification: real
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_AUTOSUGGEST_STRATEGY` is assigned but never used"
+        start:
+          line: 36
+          column: 5
+        end:
+          line: 36
+          column: 29
+        classification: false_positive
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_AUTOLOAD` is assigned but never used"
+        start:
+          line: 39
+          column: 5
+        end:
+          line: 39
+          column: 18
+        classification: false_positive
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_SET_EXPANSION_CURSOR` is assigned but never used"
+        start:
+          line: 40
+          column: 5
+        end:
+          line: 40
+          column: 30
+        classification: false_positive
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_SET_LINE_CURSOR` is assigned but never used"
+        start:
+          line: 41
+          column: 5
+        end:
+          line: 41
+          column: 25
+        classification: false_positive
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_GET_AVAILABLE_ABBREVIATION` is assigned but never used"
+        start:
+          line: 42
+          column: 5
+        end:
+          line: 42
+          column: 36
+        classification: false_positive
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ABBR_USER_ABBREVIATIONS_FILE` is assigned but never used"
+        start:
+          line: 43
+          column: 5
+        end:
+          line: 43
+          column: 33
+        classification: false_positive
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 51
+          column: 16
+        end:
+          line: 51
+          column: 76
+        classification: real
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `plugins` is assigned but never used"
+        start:
+          line: 76
+          column: 9
+        end:
+          line: 76
+          column: 16
+        classification: real
+      - path: "modules/old-plugins/old-plugins.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 78
+          column: 16
+        end:
+          line: 78
+          column: 37
+        classification: real
+      - path: "modules/omz-prompt/omz-prompt.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_THEME` is assigned but never used"
+        start:
+          line: 28
+          column: 5
+        end:
+          line: 28
+          column: 14
+        classification: real
+      - path: "modules/omz-prompt/omz-prompt.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 33
+          column: 16
+        end:
+          line: 33
+          column: 30
+        classification: real
+      - path: "modules/rust/rust.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 6
+          column: 41
+        end:
+          line: 6
+          column: 59
+        classification: real
+      - path: "modules/secrets/functions/op_get_vault_config"
+        code: "C001"
+        severity: "warning"
+        message: "variable `op_svc_vault` is assigned but never used"
+        start:
+          line: 20
+          column: 12
+        end:
+          line: 20
+          column: 24
+        classification: real
+      - path: "modules/secrets/functions/op_get_vault_config"
+        code: "C001"
+        severity: "warning"
+        message: "variable `op_svc_grants` is assigned but never used"
+        start:
+          line: 30
+          column: 9
+        end:
+          line: 30
+          column: 22
+        classification: real
+      - path: "modules/secrets/functions/op_refresh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `op_api_vault` is assigned but never used"
+        start:
+          line: 19
+          column: 24
+        end:
+          line: 19
+          column: 36
+        classification: real
+      - path: "modules/secrets/functions/op_refresh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `op_ssh_vault` is assigned but never used"
+        start:
+          line: 19
+          column: 37
+        end:
+          line: 19
+          column: 49
+        classification: real
+      - path: "modules/secrets/functions/op_refresh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 87
+          column: 19
+        end:
+          line: 87
+          column: 21
+        classification: real
+      - path: "modules/secrets/functions/refresh_shell_secrets"
+        code: "C001"
+        severity: "warning"
+        message: "variable `op_config_dir` is assigned but never used"
+        start:
+          line: 14
+          column: 5
+        end:
+          line: 14
+          column: 18
+        classification: real
+      - path: "modules/secrets/functions/refresh_shell_secrets"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 23
+          column: 11
+        end:
+          line: 23
+          column: 13
+        classification: real
+      - path: "modules/secrets/functions/refresh_shell_secrets"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 24
+          column: 16
+        end:
+          line: 24
+          column: 54
+        classification: real
+      - path: "modules/secrets/secrets.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `op_config` is assigned but never used"
+        start:
+          line: 121
+          column: 5
+        end:
+          line: 121
+          column: 14
+        classification: real
+      - path: "modules/secrets/secrets.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 135
+          column: 16
+        end:
+          line: 135
+          column: 57
+        classification: real
+      - path: "modules/secrets/secrets.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 151
+          column: 20
+        end:
+          line: 151
+          column: 58
+        classification: real
+      - path: "modules/sudo/sudo.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_TMUX_AUTOSTART` is assigned but never used"
+        start:
+          line: 9
+          column: 9
+        end:
+          line: 9
+          column: 27
+        classification: real
+      - path: "modules/sudo/sudo.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_TMUX_AUTOQUIT` is assigned but never used"
+        start:
+          line: 10
+          column: 9
+        end:
+          line: 10
+          column: 26
+        classification: real
+      - path: "modules/syntax-highlight/syntax-highlight.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `FAST_WORK_DIR` is assigned but never used"
+        start:
+          line: 16
+          column: 5
+        end:
+          line: 16
+          column: 18
+        classification: real
+      - path: "modules/tmux/tmux.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_TMUX_UNICODE` is assigned but never used"
+        start:
+          line: 6
+          column: 5
+        end:
+          line: 6
+          column: 21
+        classification: real
+      - path: "modules/tmux/tmux.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_TMUX_AUTOQUIT` is assigned but never used"
+        start:
+          line: 13
+          column: 13
+        end:
+          line: 13
+          column: 30
+        classification: real
+      - path: "modules/tmux/tmux.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_TMUX_AUTOSTART` is assigned but never used"
+        start:
+          line: 15
+          column: 13
+        end:
+          line: 15
+          column: 31
+        classification: real
+      - path: "modules/tmux/tmux.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_TMUX_AUTOSTART_ONCE` is assigned but never used"
+        start:
+          line: 16
+          column: 13
+        end:
+          line: 16
+          column: 36
+        classification: real
+      - path: "modules/tmux/tmux.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH_TMUX_AUTOCONNECT` is assigned but never used"
+        start:
+          line: 17
+          column: 13
+        end:
+          line: 17
+          column: 33
+        classification: real
+      - path: "modules/uv/uv.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 8
+          column: 16
+        end:
+          line: 8
+          column: 38
+        classification: real
+      - path: "modules/uv/uv.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 12
+          column: 43
+        end:
+          line: 12
+          column: 63
+        classification: real
+      - path: "modules/venv/functions/avenv"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 7
+          column: 16
+        end:
+          line: 7
+          column: 36
+        classification: real
+      - path: "modules/venv/functions/defvenv"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 7
+          column: 16
+        end:
+          line: 7
+          column: 36
+        classification: real
+      - path: "modules/venv/functions/rvenv"
+        code: "C006"
+        severity: "error"
+        message: "variable `python` is referenced before assignment"
+        start:
+          line: 29
+          column: 15
+        end:
+          line: 29
+          column: 24
+        classification: false_positive
+      - path: "modules/venv/venv.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `DEFAULT_PYTHON_VERSION` is assigned but never used"
+        start:
+          line: 32
+          column: 16
+        end:
+          line: 32
+          column: 38
+        classification: real
+      - path: "modules/venv/venv.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 44
+          column: 43
+        end:
+          line: 44
+          column: 63
+        classification: real
+      - path: "scripts/benchmark.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `n` is assigned but never used"
+        start:
+          line: 82
+          column: 11
+        end:
+          line: 82
+          column: 12
+        classification: real
+      - path: "scripts/benchmark.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `TIMEFMT` is assigned but never used"
+        start:
+          line: 136
+          column: 18
+        end:
+          line: 136
+          column: 25
+        classification: false_positive
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 17
+          column: 8
+        end:
+          line: 17
+          column: 34
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 20
+          column: 8
+        end:
+          line: 20
+          column: 38
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 23
+          column: 8
+        end:
+          line: 23
+          column: 35
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 24
+          column: 8
+        end:
+          line: 24
+          column: 36
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 25
+          column: 8
+        end:
+          line: 25
+          column: 36
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 26
+          column: 8
+        end:
+          line: 26
+          column: 38
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 27
+          column: 8
+        end:
+          line: 27
+          column: 40
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 28
+          column: 8
+        end:
+          line: 28
+          column: 42
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 29
+          column: 8
+        end:
+          line: 29
+          column: 36
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 30
+          column: 8
+        end:
+          line: 30
+          column: 38
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 31
+          column: 8
+        end:
+          line: 31
+          column: 35
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 32
+          column: 8
+        end:
+          line: 32
+          column: 37
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 35
+          column: 8
+        end:
+          line: 35
+          column: 39
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 36
+          column: 8
+        end:
+          line: 36
+          column: 49
+        classification: real
+      - path: "zdot.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 37
+          column: 8
+        end:
+          line: 37
+          column: 48
+        classification: real
+      - path: "zdot.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `zdot` is referenced before assignment"
+        start:
+          line: 77
+          column: 22
+        end:
+          line: 77
+          column: 26
+        classification: false_positive
+  - name: "zinit"
+    github_url: "https://github.com/zdharma-continuum/zinit.git"
+    commit: "6c9ac1c4bc9bcaede64cb473759ac2c5b9187f98"
+    diagnostics:
+      - path: ".github/workflows/linting.yaml"
+        code: "C012"
+        severity: "warning"
+        message: "jobs.mdlint.steps[3].run: wildcard arguments should be guarded with `./` or `--`"
+        start:
+          line: 35
+          column: 14
+        end:
+          line: 35
+          column: 15
+        classification: real
+      - path: ".github/workflows/linting.yaml"
+        code: "C012"
+        severity: "warning"
+        message: "jobs.mdlint.steps[3].run: wildcard arguments should be guarded with `./` or `--`"
+        start:
+          line: 35
+          column: 19
+        end:
+          line: 35
+          column: 20
+        classification: real
+      - path: "docker/utils.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 4
+          column: 10
+        end:
+          line: 4
+          column: 24
+        classification: real
+      - path: "docker/utils.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 11
+          column: 12
+        end:
+          line: 11
+          column: 17
+        classification: real
+      - path: "share/git-process-output.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `first` is assigned but never used"
+        start:
+          line: 38
+          column: 7
+        end:
+          line: 38
+          column: 12
+        classification: real
+      - path: "tests/_support/annex_test_assertions"
+        code: "C006"
+        severity: "error"
+        message: "variable `state` is referenced before assignment"
+        start:
+          line: 6
+          column: 10
+        end:
+          line: 6
+          column: 18
+        classification: false_positive
+      - path: "tests/_support/bootstrap"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 49
+          column: 7
+        end:
+          line: 49
+          column: 9
+        classification: real
+      - path: "tests/_support/bootstrap"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 61
+          column: 4
+        end:
+          line: 61
+          column: 6
+        classification: real
+      - path: "tests/_support/bootstrap"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 67
+          column: 8
+        end:
+          line: 67
+          column: 44
+        classification: real
+      - path: "tests/_support/bootstrap"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 68
+          column: 4
+        end:
+          line: 68
+          column: 6
+        classification: real
+      - path: "zi-browse-symbol"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 81
+          column: 37
+        end:
+          line: 81
+          column: 92
+        classification: real
+      - path: "zi-browse-symbol"
+        code: "C001"
+        severity: "warning"
+        message: "variable `page_start_idx` is assigned but never used"
+        start:
+          line: 184
+          column: 13
+        end:
+          line: 184
+          column: 27
+        classification: real
+      - path: "zi-browse-symbol"
+        code: "C001"
+        severity: "warning"
+        message: "variable `redrawbkp` is assigned but never used"
+        start:
+          line: 405
+          column: 11
+        end:
+          line: 405
+          column: 20
+        classification: real
+      - path: "zi-browse-symbol"
+        code: "C001"
+        severity: "warning"
+        message: "variable `cd_at_edit` is assigned but never used"
+        start:
+          line: 413
+          column: 85
+        end:
+          line: 413
+          column: 95
+        classification: real
+      - path: "zinit-additional.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `ZSRV_PID` looks like it may mean `ZSRV_ID`"
+        start:
+          line: 70
+          column: 59
+        end:
+          line: 70
+          column: 68
+        classification: real
+      - path: "zinit-additional.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `sysparams` is referenced before assignment"
+        start:
+          line: 72
+          column: 57
+        end:
+          line: 72
+          column: 74
+        classification: false_positive
+      - path: "zinit-additional.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 150
+          column: 11
+        end:
+          line: 150
+          column: 13
+        classification: real
+      - path: "zinit-additional.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 159
+          column: 25
+        end:
+          line: 159
+          column: 27
+        classification: real
+      - path: "zinit-additional.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 173
+          column: 15
+        end:
+          line: 173
+          column: 17
+        classification: real
+      - path: "zinit-additional.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `o_help` is assigned but never used"
+        start:
+          line: 202
+          column: 19
+        end:
+          line: 202
+          column: 25
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 234
+          column: 43
+        end:
+          line: 234
+          column: 45
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 307
+          column: 32
+        end:
+          line: 307
+          column: 34
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 638
+          column: 21
+        end:
+          line: 638
+          column: 23
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 816
+          column: 31
+        end:
+          line: 816
+          column: 33
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 1075
+          column: 29
+        end:
+          line: 1075
+          column: 39
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 1175
+          column: 18
+        end:
+          line: 1175
+          column: 31
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `compcontext` is assigned but never used"
+        start:
+          line: 1242
+          column: 11
+        end:
+          line: 1242
+          column: 22
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `o_all` is assigned but never used"
+        start:
+          line: 1369
+          column: 18
+        end:
+          line: 1369
+          column: 23
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `o_clean` is assigned but never used"
+        start:
+          line: 1370
+          column: 20
+        end:
+          line: 1370
+          column: 27
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `o_debug` is assigned but never used"
+        start:
+          line: 1371
+          column: 20
+        end:
+          line: 1371
+          column: 27
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `o_help` is assigned but never used"
+        start:
+          line: 1372
+          column: 19
+        end:
+          line: 1372
+          column: 25
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `o_quiet` is assigned but never used"
+        start:
+          line: 1373
+          column: 20
+        end:
+          line: 1373
+          column: 27
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `o_yes` is assigned but never used"
+        start:
+          line: 1374
+          column: 18
+        end:
+          line: 1374
+          column: 23
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ld_snips` is assigned but never used"
+        start:
+          line: 1392
+          column: 9
+        end:
+          line: 1392
+          column: 17
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1402
+          column: 58
+        end:
+          line: 1402
+          column: 60
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1464
+          column: 34
+        end:
+          line: 1464
+          column: 36
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `seqno` is referenced before assignment"
+        start:
+          line: 1634
+          column: 41
+        end:
+          line: 1634
+          column: 46
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1638
+          column: 44
+        end:
+          line: 1638
+          column: 46
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1809
+          column: 25
+        end:
+          line: 1809
+          column: 27
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 1871
+          column: 15
+        end:
+          line: 1871
+          column: 17
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C071"
+        severity: "warning"
+        message: "double parentheses are used to group commands instead of arithmetic"
+        start:
+          line: 1887
+          column: 13
+        end:
+          line: 1887
+          column: 13
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1887
+          column: 38
+        end:
+          line: 1887
+          column: 40
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `adjust_ec` is assigned but never used"
+        start:
+          line: 1957
+          column: 21
+        end:
+          line: 1957
+          column: 30
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 2041
+          column: 16
+        end:
+          line: 2041
+          column: 41
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `flmax` is referenced before assignment"
+        start:
+          line: 2121
+          column: 27
+        end:
+          line: 2121
+          column: 32
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `msg` is assigned but never used"
+        start:
+          line: 2183
+          column: 11
+        end:
+          line: 2183
+          column: 14
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `tmp__` is referenced before assignment"
+        start:
+          line: 2184
+          column: 40
+        end:
+          line: 2184
+          column: 63
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2270
+          column: 37
+        end:
+          line: 2270
+          column: 39
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2440
+          column: 47
+        end:
+          line: 2440
+          column: 49
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `correct` is assigned but never used"
+        start:
+          line: 2481
+          column: 30
+        end:
+          line: 2481
+          column: 37
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `LASTREPORT` is assigned but never used"
+        start:
+          line: 2493
+          column: 5
+        end:
+          line: 2493
+          column: 15
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `comp_wid` is assigned but never used"
+        start:
+          line: 2696
+          column: 19
+        end:
+          line: 2696
+          column: 27
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `oth_prefix_uspl2_X` is referenced before assignment"
+        start:
+          line: 2756
+          column: 90
+        end:
+          line: 2756
+          column: 109
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2888
+          column: 97
+        end:
+          line: 2888
+          column: 100
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C095"
+        severity: "warning"
+        message: "assignment value looks like arithmetic subtraction"
+        start:
+          line: 2937
+          column: 26
+        end:
+          line: 2937
+          column: 40
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C095"
+        severity: "warning"
+        message: "assignment value looks like arithmetic subtraction"
+        start:
+          line: 2993
+          column: 26
+        end:
+          line: 2993
+          column: 40
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `mark` is referenced before assignment"
+        start:
+          line: 3033
+          column: 24
+        end:
+          line: 3033
+          column: 28
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `r` is referenced before assignment"
+        start:
+          line: 3034
+          column: 12
+        end:
+          line: 3034
+          column: 13
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `hook` is referenced before assignment"
+        start:
+          line: 3034
+          column: 26
+        end:
+          line: 3034
+          column: 30
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `has` is referenced before assignment"
+        start:
+          line: 3034
+          column: 31
+        end:
+          line: 3034
+          column: 34
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `been` is referenced before assignment"
+        start:
+          line: 3034
+          column: 35
+        end:
+          line: 3034
+          column: 39
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `run` is referenced before assignment"
+        start:
+          line: 3034
+          column: 40
+        end:
+          line: 3034
+          column: 43
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `annex` is referenced before assignment"
+        start:
+          line: 3075
+          column: 11
+        end:
+          line: 3075
+          column: 16
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `multi` is referenced before assignment"
+        start:
+          line: 3075
+          column: 17
+        end:
+          line: 3075
+          column: 22
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `flag` is referenced before assignment"
+        start:
+          line: 3075
+          column: 23
+        end:
+          line: 3075
+          column: 27
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 3107
+          column: 41
+        end:
+          line: 3107
+          column: 43
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 3142
+          column: 25
+        end:
+          line: 3142
+          column: 31
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 3145
+          column: 55
+        end:
+          line: 3145
+          column: 61
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 3163
+          column: 52
+        end:
+          line: 3163
+          column: 54
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 3218
+          column: 62
+        end:
+          line: 3218
+          column: 64
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 3247
+          column: 58
+        end:
+          line: 3247
+          column: 60
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `INSTALLED_EXECS` is assigned but never used"
+        start:
+          line: 3370
+          column: 7
+        end:
+          line: 3370
+          column: 22
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `INSTALLED_COMPS` is assigned but never used"
+        start:
+          line: 3374
+          column: 11
+        end:
+          line: 3374
+          column: 26
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `SKIPPED_COMPS` is assigned but never used"
+        start:
+          line: 3375
+          column: 11
+        end:
+          line: 3375
+          column: 24
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ADD_COMPILED` is assigned but never used"
+        start:
+          line: 3380
+          column: 11
+        end:
+          line: 3380
+          column: 23
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `mtime` is referenced before assignment"
+        start:
+          line: 3418
+          column: 40
+        end:
+          line: 3418
+          column: 45
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `side` is referenced before assignment"
+        start:
+          line: 3418
+          column: 61
+        end:
+          line: 3418
+          column: 65
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `install` is referenced before assignment"
+        start:
+          line: 3419
+          column: 21
+        end:
+          line: 3419
+          column: 28
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `autoload` is referenced before assignment"
+        start:
+          line: 3419
+          column: 44
+        end:
+          line: 3419
+          column: 52
+        classification: false_positive
+      - path: "zinit-autoload.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 3423
+          column: 16
+        end:
+          line: 3423
+          column: 41
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 3424
+          column: 16
+        end:
+          line: 3424
+          column: 46
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 3425
+          column: 16
+        end:
+          line: 3425
+          column: 49
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 3426
+          column: 16
+        end:
+          line: 3426
+          column: 50
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 3463
+          column: 20
+        end:
+          line: 3463
+          column: 42
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 3490
+          column: 17
+        end:
+          line: 3490
+          column: 38
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 3504
+          column: 44
+        end:
+          line: 3504
+          column: 46
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 3526
+          column: 41
+        end:
+          line: 3526
+          column: 43
+        classification: real
+      - path: "zinit-autoload.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `value` is referenced before assignment"
+        start:
+          line: 3588
+          column: 26
+        end:
+          line: 3588
+          column: 31
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `+varname` is referenced before assignment"
+        start:
+          line: 49
+          column: 8
+        end:
+          line: 49
+          column: 22
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 80
+          column: 17
+        end:
+          line: 80
+          column: 35
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 81
+          column: 17
+        end:
+          line: 81
+          column: 35
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C043"
+        severity: "warning"
+        message: "use a standard descriptor redirection form like `2>&1`"
+        start:
+          line: 94
+          column: 58
+        end:
+          line: 94
+          column: 60
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `subscribe` is referenced before assignment"
+        start:
+          line: 150
+          column: 42
+        end:
+          line: 150
+          column: 51
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `jsondata` is assigned but never used"
+        start:
+          line: 246
+          column: 22
+        end:
+          line: 246
+          column: 30
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 312
+          column: 17
+        end:
+          line: 312
+          column: 35
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 312
+          column: 44
+        end:
+          line: 312
+          column: 62
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 313
+          column: 17
+        end:
+          line: 313
+          column: 35
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 313
+          column: 44
+        end:
+          line: 313
+          column: 62
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `annex` is referenced before assignment"
+        start:
+          line: 330
+          column: 11
+        end:
+          line: 330
+          column: 16
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `multi` is referenced before assignment"
+        start:
+          line: 330
+          column: 17
+        end:
+          line: 330
+          column: 22
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `flag` is referenced before assignment"
+        start:
+          line: 330
+          column: 23
+        end:
+          line: 330
+          column: 27
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `pid_hl` is assigned but never used"
+        start:
+          line: 346
+          column: 19
+        end:
+          line: 346
+          column: 25
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `action` is assigned but never used"
+        start:
+          line: 642
+          column: 9
+        end:
+          line: 642
+          column: 15
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `usr` is referenced before assignment"
+        start:
+          line: 677
+          column: 23
+        end:
+          line: 677
+          column: 26
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `local` is referenced before assignment"
+        start:
+          line: 677
+          column: 27
+        end:
+          line: 677
+          column: 32
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bin` is referenced before assignment"
+        start:
+          line: 677
+          column: 33
+        end:
+          line: 677
+          column: 36
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_comps` is referenced before assignment"
+        start:
+          line: 813
+          column: 16
+        end:
+          line: 813
+          column: 36
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 841
+          column: 25
+        end:
+          line: 841
+          column: 42
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 841
+          column: 43
+        end:
+          line: 841
+          column: 58
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ICE[svn]+\" (with Subversion)\"` is referenced before assignment"
+        start:
+          line: 906
+          column: 93
+        end:
+          line: 906
+          column: 125
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1140
+          column: 51
+        end:
+          line: 1140
+          column: 73
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `INSTALLED_EXECS` is assigned but never used"
+        start:
+          line: 1251
+          column: 7
+        end:
+          line: 1251
+          column: 22
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ADD_COMPILED` is assigned but never used"
+        start:
+          line: 1267
+          column: 11
+        end:
+          line: 1267
+          column: 23
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `correct` is assigned but never used"
+        start:
+          line: 1286
+          column: 27
+        end:
+          line: 1286
+          column: 34
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `opts` is assigned but never used"
+        start:
+          line: 1287
+          column: 5
+        end:
+          line: 1287
+          column: 9
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `opt` is referenced before assignment"
+        start:
+          line: 1296
+          column: 60
+        end:
+          line: 1296
+          column: 63
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `has` is referenced before assignment"
+        start:
+          line: 1296
+          column: 69
+        end:
+          line: 1296
+          column: 72
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `been` is referenced before assignment"
+        start:
+          line: 1296
+          column: 73
+        end:
+          line: 1296
+          column: 77
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `run` is referenced before assignment"
+        start:
+          line: 1296
+          column: 78
+        end:
+          line: 1296
+          column: 81
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH` is assigned but never used"
+        start:
+          line: 1326
+          column: 109
+        end:
+          line: 1326
+          column: 112
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 1389
+          column: 58
+        end:
+          line: 1389
+          column: 65
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 1406
+          column: 13
+        end:
+          line: 1406
+          column: 15
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `bpick_error` is assigned but never used"
+        start:
+          line: 1479
+          column: 15
+        end:
+          line: 1479
+          column: 26
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1583
+          column: 44
+        end:
+          line: 1583
+          column: 50
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1588
+          column: 46
+        end:
+          line: 1588
+          column: 54
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C012"
+        severity: "warning"
+        message: "wildcard arguments should be guarded with `./` or `--`"
+        start:
+          line: 1618
+          column: 23
+        end:
+          line: 1618
+          column: 24
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `zi_was_renamed` is assigned but never used"
+        start:
+          line: 1664
+          column: 25
+        end:
+          line: 1664
+          column: 39
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C012"
+        severity: "warning"
+        message: "wildcard arguments should be guarded with `./` or `--`"
+        start:
+          line: 1809
+          column: 27
+        end:
+          line: 1809
+          column: 28
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C012"
+        severity: "warning"
+        message: "wildcard arguments should be guarded with `./` or `--`"
+        start:
+          line: 1811
+          column: 31
+        end:
+          line: 1811
+          column: 32
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C012"
+        severity: "warning"
+        message: "wildcard arguments should be guarded with `./` or `--`"
+        start:
+          line: 1813
+          column: 31
+        end:
+          line: 1813
+          column: 32
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `svn` is referenced before assignment"
+        start:
+          line: 2011
+          column: 25
+        end:
+          line: 2011
+          column: 28
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `skip_pull` is referenced before assignment"
+        start:
+          line: 2012
+          column: 23
+        end:
+          line: 2012
+          column: 33
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2040
+          column: 64
+        end:
+          line: 2040
+          column: 66
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `is_release` is referenced before assignment"
+        start:
+          line: 2048
+          column: 19
+        end:
+          line: 2048
+          column: 29
+        classification: false_positive
+      - path: "zinit-install.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 2094
+          column: 28
+        end:
+          line: 2094
+          column: 34
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `aflags` is assigned but never used"
+        start:
+          line: 2096
+          column: 5
+        end:
+          line: 2096
+          column: 11
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2097
+          column: 19
+        end:
+          line: 2097
+          column: 22
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 2156
+          column: 18
+        end:
+          line: 2156
+          column: 25
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2157
+          column: 15
+        end:
+          line: 2157
+          column: 22
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `src` is assigned but never used"
+        start:
+          line: 2163
+          column: 11
+        end:
+          line: 2163
+          column: 14
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `TRY_BLOCK_ERROR` is assigned but never used"
+        start:
+          line: 2200
+          column: 12
+        end:
+          line: 2200
+          column: 27
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2251
+          column: 25
+        end:
+          line: 2251
+          column: 27
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2280
+          column: 25
+        end:
+          line: 2280
+          column: 27
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2298
+          column: 25
+        end:
+          line: 2298
+          column: 27
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2384
+          column: 25
+        end:
+          line: 2384
+          column: 27
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2410
+          column: 26
+        end:
+          line: 2410
+          column: 28
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2433
+          column: 25
+        end:
+          line: 2433
+          column: 27
+        classification: real
+      - path: "zinit-install.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `subtype` is assigned but never used"
+        start:
+          line: 2435
+          column: 47
+        end:
+          line: 2435
+          column: 54
+        classification: real
+      - path: "zinit-side.zsh"
+        code: "C008"
+        severity: "warning"
+        message: "double-quoted trap handlers expand variables when the trap is set"
+        start:
+          line: 202
+          column: 47
+        end:
+          line: 202
+          column: 51
+        classification: real
+      - path: "zinit-side.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `spec3` is assigned but never used"
+        start:
+          line: 252
+          column: 15
+        end:
+          line: 252
+          column: 20
+        classification: real
+      - path: "zinit-side.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 261
+          column: 35
+        end:
+          line: 261
+          column: 41
+        classification: real
+      - path: "zinit-side.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `mode` is assigned but never used"
+        start:
+          line: 315
+          column: 18
+        end:
+          line: 315
+          column: 22
+        classification: real
+      - path: "zinit-side.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `+___var_name` is referenced before assignment"
+        start:
+          line: 338
+          column: 8
+        end:
+          line: 338
+          column: 26
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ice` is referenced before assignment"
+        start:
+          line: 77
+          column: 7
+        end:
+          line: 77
+          column: 10
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `nval` is referenced before assignment"
+        start:
+          line: 98
+          column: 7
+        end:
+          line: 98
+          column: 11
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZINIT_2MAP` is assigned but never used"
+        start:
+          line: 202
+          column: 1
+        end:
+          line: 202
+          column: 11
+        classification: real
+      - path: "zinit.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 218
+          column: 71
+        end:
+          line: 218
+          column: 73
+        classification: real
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `opts2` is assigned but never used"
+        start:
+          line: 321
+          column: 60
+        end:
+          line: 321
+          column: 65
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 449
+          column: 21
+        end:
+          line: 449
+          column: 23
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `BINDKEYS___dtrace` is referenced before assignment"
+        start:
+          line: 551
+          column: 45
+        end:
+          line: 551
+          column: 62
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `_dtrace` is referenced before assignment"
+        start:
+          line: 551
+          column: 63
+        end:
+          line: 551
+          column: 70
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `Nopt` is assigned but never used"
+        start:
+          line: 574
+          column: 19
+        end:
+          line: 574
+          column: 23
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ZSTYLES___dtrace` is referenced before assignment"
+        start:
+          line: 620
+          column: 45
+        end:
+          line: 620
+          column: 61
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `avalue` is assigned but never used"
+        start:
+          line: 652
+          column: 15
+        end:
+          line: 652
+          column: 21
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ALIASES___dtrace` is referenced before assignment"
+        start:
+          line: 677
+          column: 45
+        end:
+          line: 677
+          column: 61
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `WIDGETS_DELETE___dtrace` is referenced before assignment"
+        start:
+          line: 708
+          column: 53
+        end:
+          line: 708
+          column: 76
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `WIDGETS_SAVED___dtrace` is referenced before assignment"
+        start:
+          line: 726
+          column: 53
+        end:
+          line: 726
+          column: 75
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bkp` is referenced before assignment"
+        start:
+          line: 782
+          column: 48
+        end:
+          line: 782
+          column: 51
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `autoload` is referenced before assignment"
+        start:
+          line: 782
+          column: 52
+        end:
+          line: 782
+          column: 60
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `compdef` is referenced before assignment"
+        start:
+          line: 787
+          column: 47
+        end:
+          line: 787
+          column: 54
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `source` is referenced before assignment"
+        start:
+          line: 792
+          column: 50
+        end:
+          line: 792
+          column: 56
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bindkey` is referenced before assignment"
+        start:
+          line: 806
+          column: 47
+        end:
+          line: 806
+          column: 54
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `zstyle` is referenced before assignment"
+        start:
+          line: 813
+          column: 46
+        end:
+          line: 813
+          column: 52
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `alias` is referenced before assignment"
+        start:
+          line: 817
+          column: 45
+        end:
+          line: 817
+          column: 50
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `zle` is referenced before assignment"
+        start:
+          line: 821
+          column: 43
+        end:
+          line: 821
+          column: 46
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 836
+          column: 65
+        end:
+          line: 836
+          column: 70
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 842
+          column: 39
+        end:
+          line: 842
+          column: 41
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 846
+          column: 34
+        end:
+          line: 846
+          column: 36
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 849
+          column: 33
+        end:
+          line: 849
+          column: 35
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 850
+          column: 28
+        end:
+          line: 850
+          column: 30
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 858
+          column: 34
+        end:
+          line: 858
+          column: 36
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 864
+          column: 33
+        end:
+          line: 864
+          column: 35
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 866
+          column: 32
+        end:
+          line: 866
+          column: 34
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 868
+          column: 30
+        end:
+          line: 868
+          column: 32
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 936
+          column: 22
+        end:
+          line: 936
+          column: 24
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 961
+          column: 22
+        end:
+          line: 961
+          column: 24
+        classification: real
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ret` is assigned but never used"
+        start:
+          line: 1127
+          column: 9
+        end:
+          line: 1127
+          column: 12
+        classification: real
+      - path: "zinit.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1202
+          column: 59
+        end:
+          line: 1202
+          column: 72
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `on` is referenced before assignment"
+        start:
+          line: 1263
+          column: 12
+        end:
+          line: 1263
+          column: 14
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `unload` is referenced before assignment"
+        start:
+          line: 1263
+          column: 15
+        end:
+          line: 1263
+          column: 21
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `update` is referenced before assignment"
+        start:
+          line: 1269
+          column: 15
+        end:
+          line: 1269
+          column: 21
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 1333
+          column: 60
+        end:
+          line: 1333
+          column: 66
+        classification: real
+      - path: "zinit.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 1349
+          column: 29
+        end:
+          line: 1349
+          column: 36
+        classification: real
+      - path: "zinit.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 1351
+          column: 33
+        end:
+          line: 1351
+          column: 40
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `___m_bkp` is referenced before assignment"
+        start:
+          line: 1361
+          column: 15
+        end:
+          line: 1361
+          column: 23
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C108"
+        severity: "warning"
+        message: "quote `unset` array-subscript operands so bracket text stays literal"
+        start:
+          line: 1371
+          column: 26
+        end:
+          line: 1371
+          column: 38
+        classification: real
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZSH` is assigned but never used"
+        start:
+          line: 1429
+          column: 105
+        end:
+          line: 1429
+          column: 108
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ICE[svn]+svn` is referenced before assignment"
+        start:
+          line: 1461
+          column: 39
+        end:
+          line: 1461
+          column: 54
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1472
+          column: 80
+        end:
+          line: 1472
+          column: 82
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1488
+          column: 42
+        end:
+          line: 1488
+          column: 44
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1519
+          column: 35
+        end:
+          line: 1519
+          column: 37
+        classification: real
+      - path: "zinit.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 1521
+          column: 85
+        end:
+          line: 1521
+          column: 87
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1523
+          column: 120
+        end:
+          line: 1523
+          column: 122
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1524
+          column: 363
+        end:
+          line: 1524
+          column: 365
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1539
+          column: 203
+        end:
+          line: 1539
+          column: 205
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1541
+          column: 127
+        end:
+          line: 1541
+          column: 129
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1566
+          column: 46
+        end:
+          line: 1566
+          column: 48
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1576
+          column: 35
+        end:
+          line: 1576
+          column: 37
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1578
+          column: 363
+        end:
+          line: 1578
+          column: 365
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1593
+          column: 203
+        end:
+          line: 1593
+          column: 205
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1596
+          column: 131
+        end:
+          line: 1596
+          column: 133
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1602
+          column: 151
+        end:
+          line: 1602
+          column: 153
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1610
+          column: 84
+        end:
+          line: 1610
+          column: 86
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1707
+          column: 110
+        end:
+          line: 1707
+          column: 112
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1718
+          column: 87
+        end:
+          line: 1718
+          column: 89
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1789
+          column: 46
+        end:
+          line: 1789
+          column: 48
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1798
+          column: 88
+        end:
+          line: 1798
+          column: 90
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1799
+          column: 114
+        end:
+          line: 1799
+          column: 116
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1800
+          column: 363
+        end:
+          line: 1800
+          column: 365
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1815
+          column: 200
+        end:
+          line: 1815
+          column: 202
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1818
+          column: 131
+        end:
+          line: 1818
+          column: 133
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1848
+          column: 88
+        end:
+          line: 1848
+          column: 90
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1849
+          column: 31
+        end:
+          line: 1849
+          column: 33
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1850
+          column: 114
+        end:
+          line: 1850
+          column: 116
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1851
+          column: 347
+        end:
+          line: 1851
+          column: 349
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1866
+          column: 200
+        end:
+          line: 1866
+          column: 202
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1875
+          column: 143
+        end:
+          line: 1875
+          column: 145
+        classification: real
+      - path: "zinit.zsh"
+        code: "C107"
+        severity: "warning"
+        message: "test the command directly instead of reading its status back from `$?`"
+        start:
+          line: 1969
+          column: 11
+        end:
+          line: 1969
+          column: 13
+        classification: real
+      - path: "zinit.zsh"
+        code: "K003"
+        severity: "warning"
+        message: "array expansion passed to `eval` is reinterpreted as shell text"
+        start:
+          line: 1972
+          column: 15
+        end:
+          line: 1972
+          column: 33
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 1986
+          column: 38
+        end:
+          line: 1986
+          column: 40
+        classification: real
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `hasw` is assigned but never used"
+        start:
+          line: 1992
+          column: 26
+        end:
+          line: 1992
+          column: 30
+        classification: real
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `i` is assigned but never used"
+        start:
+          line: 2003
+          column: 21
+        end:
+          line: 2003
+          column: 22
+        classification: real
+      - path: "zinit.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 2022
+          column: 67
+        end:
+          line: 2022
+          column: 69
+        classification: real
+      - path: "zinit.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 2078
+          column: 47
+        end:
+          line: 2078
+          column: 79
+        classification: real
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ch` is assigned but never used"
+        start:
+          line: 2106
+          column: 9
+        end:
+          line: 2106
+          column: 11
+        classification: real
+      - path: "zinit.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 2235
+          column: 28
+        end:
+          line: 2235
+          column: 32
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2279
+          column: 64
+        end:
+          line: 2279
+          column: 66
+        classification: real
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `fts_arr` is assigned but never used"
+        start:
+          line: 2373
+          column: 20
+        end:
+          line: 2373
+          column: 27
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `fts` is referenced before assignment"
+        start:
+          line: 2375
+          column: 24
+        end:
+          line: 2375
+          column: 27
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2434
+          column: 24
+        end:
+          line: 2434
+          column: 33
+        classification: real
+      - path: "zinit.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 2434
+          column: 67
+        end:
+          line: 2434
+          column: 75
+        classification: real
+      - path: "zinit.zsh"
+        code: "C088"
+        severity: "warning"
+        message: "mixing `&&` and `||` inside `[[ ... ]]` needs parentheses to stay clear"
+        start:
+          line: 2647
+          column: 80
+        end:
+          line: 2647
+          column: 82
+        classification: real
+      - path: "zinit.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 2673
+          column: 31
+        end:
+          line: 2673
+          column: 47
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `annex` is referenced before assignment"
+        start:
+          line: 2689
+          column: 15
+        end:
+          line: 2689
+          column: 20
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `exposed` is referenced before assignment"
+        start:
+          line: 2689
+          column: 21
+        end:
+          line: 2689
+          column: 28
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `processed` is referenced before assignment"
+        start:
+          line: 2689
+          column: 29
+        end:
+          line: 2689
+          column: 38
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `IDs` is referenced before assignment"
+        start:
+          line: 2689
+          column: 39
+        end:
+          line: 2689
+          column: 42
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C099"
+        severity: "warning"
+        message: "all-elements array expansions collapse in scalar assignment values"
+        start:
+          line: 2697
+          column: 35
+        end:
+          line: 2697
+          column: 51
+        classification: real
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `ZINIT_ICE` is assigned but never used"
+        start:
+          line: 2701
+          column: 21
+        end:
+          line: 2701
+          column: 30
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2768
+          column: 64
+        end:
+          line: 2768
+          column: 66
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ICE[light-mode]+light` is referenced before assignment"
+        start:
+          line: 2809
+          column: 88
+        end:
+          line: 2809
+          column: 112
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2845
+          column: 45
+        end:
+          line: 2845
+          column: 47
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 2939
+          column: 49
+        end:
+          line: 2939
+          column: 51
+        classification: real
+      - path: "zinit.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 3091
+          column: 44
+        end:
+          line: 3091
+          column: 52
+        classification: real
+      - path: "zinit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `all` is assigned but never used"
+        start:
+          line: 3091
+          column: 53
+        end:
+          line: 3091
+          column: 56
+        classification: real
+      - path: "zinit.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 3091
+          column: 57
+        end:
+          line: 3091
+          column: 66
+        classification: real
+      - path: "zinit.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 3091
+          column: 72
+        end:
+          line: 3091
+          column: 82
+        classification: real
+      - path: "zinit.zsh"
+        code: "C010"
+        severity: "warning"
+        message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
+        start:
+          line: 3133
+          column: 65
+        end:
+          line: 3133
+          column: 67
+        classification: real
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `STATES___local` is referenced before assignment"
+        start:
+          line: 3255
+          column: 7
+        end:
+          line: 3255
+          column: 21
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `zinit` is referenced before assignment"
+        start:
+          line: 3255
+          column: 22
+        end:
+          line: 3255
+          column: 27
+        classification: false_positive
+      - path: "zinit.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 3284
+          column: 22
+        end:
+          line: 3284
+          column: 59
+        classification: real
+  - name: "zsh-autosuggestions"
+    github_url: "https://github.com/zsh-users/zsh-autosuggestions.git"
+    commit: "85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5"
+    diagnostics:
+      - path: "src/strategies/completion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `REPLY` is assigned but never used"
+        start:
+          line: 104
+          column: 13
+        end:
+          line: 104
+          column: 18
+        classification: false_positive
+      - path: "src/strategies/completion.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `suggestion` is assigned but never used"
+        start:
+          line: 132
+          column: 3
+        end:
+          line: 132
+          column: 13
+        classification: false_positive
+      - path: "src/strategies/history.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `suggestion` is assigned but never used"
+        start:
+          line: 31
+          column: 13
+        end:
+          line: 31
+          column: 23
+        classification: false_positive
+      - path: "src/strategies/match_prev_cmd.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `suggestion` is assigned but never used"
+        start:
+          line: 65
+          column: 13
+        end:
+          line: 65
+          column: 23
+        classification: false_positive
+      - path: "src/widgets.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 103
+          column: 29
+        end:
+          line: 103
+          column: 36
+        classification: real
+      - path: "zsh-autosuggestions.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 367
+          column: 29
+        end:
+          line: 367
+          column: 36
+        classification: real
+      - path: "zsh-autosuggestions.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `REPLY` is assigned but never used"
+        start:
+          line: 599
+          column: 13
+        end:
+          line: 599
+          column: 18
+        classification: false_positive
+  - name: "zsh-syntax-highlighting"
+    github_url: "https://github.com/zsh-users/zsh-syntax-highlighting.git"
+    commit: "1d85c692615a25fe2293bdd44b34c217d5d2bf04"
+    diagnostics:
+      - path: "highlighters/brackets/brackets-highlighter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `style` is assigned but never used"
+        start:
+          line: 49
+          column: 14
+        end:
+          line: 49
+          column: 19
+        classification: real
+      - path: "highlighters/brackets/brackets-highlighter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `buflen` is assigned but never used"
+        start:
+          line: 50
+          column: 76
+        end:
+          line: 50
+          column: 82
+        classification: real
+      - path: "highlighters/brackets/test-data/cursor-matchingbracket-line-finish.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 32
+          column: 8
+        end:
+          line: 32
+          column: 21
+        classification: real
+      - path: "highlighters/brackets/test-data/cursor-matchingbracket.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `unsorted` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 9
+        classification: real
+      - path: "highlighters/brackets/test-data/cursor-matchingbracket.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bracket` is referenced before assignment"
+        start:
+          line: 32
+          column: 22
+        end:
+          line: 32
+          column: 29
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/cursor-matchingbracket.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `level` is referenced before assignment"
+        start:
+          line: 32
+          column: 30
+        end:
+          line: 32
+          column: 35
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/loop-styles.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `unsorted` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 9
+        classification: real
+      - path: "highlighters/brackets/test-data/loop-styles.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bracket` is referenced before assignment"
+        start:
+          line: 32
+          column: 22
+        end:
+          line: 32
+          column: 29
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/loop-styles.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `level` is referenced before assignment"
+        start:
+          line: 32
+          column: 30
+        end:
+          line: 32
+          column: 35
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/mismatch-patentheses.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `unsorted` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 9
+        classification: real
+      - path: "highlighters/brackets/test-data/mismatch-patentheses.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bracket` is referenced before assignment"
+        start:
+          line: 32
+          column: 22
+        end:
+          line: 32
+          column: 29
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/mismatch-patentheses.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `level` is referenced before assignment"
+        start:
+          line: 32
+          column: 30
+        end:
+          line: 32
+          column: 35
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/near-quotes.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `unsorted` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 9
+        classification: real
+      - path: "highlighters/brackets/test-data/near-quotes.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bracket` is referenced before assignment"
+        start:
+          line: 32
+          column: 22
+        end:
+          line: 32
+          column: 29
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/near-quotes.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `level` is referenced before assignment"
+        start:
+          line: 32
+          column: 30
+        end:
+          line: 32
+          column: 35
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/nested-parentheses.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `unsorted` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 9
+        classification: real
+      - path: "highlighters/brackets/test-data/nested-parentheses.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bracket` is referenced before assignment"
+        start:
+          line: 32
+          column: 22
+        end:
+          line: 32
+          column: 29
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/nested-parentheses.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `level` is referenced before assignment"
+        start:
+          line: 32
+          column: 30
+        end:
+          line: 32
+          column: 35
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/nested-parentheses.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 36
+          column: 8
+        end:
+          line: 36
+          column: 34
+        classification: real
+      - path: "highlighters/brackets/test-data/simple-parentheses.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `unsorted` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 9
+        classification: real
+      - path: "highlighters/brackets/test-data/simple-parentheses.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bracket` is referenced before assignment"
+        start:
+          line: 32
+          column: 22
+        end:
+          line: 32
+          column: 29
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/simple-parentheses.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `level` is referenced before assignment"
+        start:
+          line: 32
+          column: 30
+        end:
+          line: 32
+          column: 35
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/unclosed-patentheses.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `unsorted` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 9
+        classification: real
+      - path: "highlighters/brackets/test-data/unclosed-patentheses.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bracket` is referenced before assignment"
+        start:
+          line: 32
+          column: 22
+        end:
+          line: 32
+          column: 29
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/unclosed-patentheses.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `level` is referenced before assignment"
+        start:
+          line: 32
+          column: 30
+        end:
+          line: 32
+          column: 35
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/unclosed-patentheses2.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `unsorted` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 9
+        classification: real
+      - path: "highlighters/brackets/test-data/unclosed-patentheses2.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `bracket` is referenced before assignment"
+        start:
+          line: 32
+          column: 22
+        end:
+          line: 32
+          column: 29
+        classification: false_positive
+      - path: "highlighters/brackets/test-data/unclosed-patentheses2.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `level` is referenced before assignment"
+        start:
+          line: 32
+          column: 30
+        end:
+          line: 32
+          column: 35
+        classification: false_positive
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `fallback_of` is assigned but never used"
+        start:
+          line: 108
+          column: 25
+        end:
+          line: 108
+          column: 36
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 135
+          column: 27
+        end:
+          line: 135
+          column: 48
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 136
+          column: 37
+        end:
+          line: 136
+          column: 58
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 138
+          column: 27
+        end:
+          line: 138
+          column: 40
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 139
+          column: 27
+        end:
+          line: 139
+          column: 40
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 140
+          column: 27
+        end:
+          line: 140
+          column: 40
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 294
+          column: 29
+        end:
+          line: 294
+          column: 31
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `zsyh_user_options` is referenced before assignment"
+        start:
+          line: 382
+          column: 9
+        end:
+          line: 382
+          column: 41
+        classification: false_positive
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `X_ZSH_HIGHLIGHT_DIRS_BLACKLIST` looks like it may mean `ZSH_HIGHLIGHT_DIRS_BLACKLIST`"
+        start:
+          line: 421
+          column: 35
+        end:
+          line: 421
+          column: 66
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 429
+          column: 27
+        end:
+          line: 429
+          column: 33
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 434
+          column: 47
+        end:
+          line: 434
+          column: 53
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `histchars` is referenced before assignment"
+        start:
+          line: 693
+          column: 71
+        end:
+          line: 693
+          column: 84
+        classification: false_positive
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 693
+          column: 71
+        end:
+          line: 693
+          column: 84
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1052
+          column: 45
+        end:
+          line: 1052
+          column: 60
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1055
+          column: 46
+        end:
+          line: 1055
+          column: 61
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 1158
+          column: 39
+        end:
+          line: 1158
+          column: 54
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `tmp` is assigned but never used"
+        start:
+          line: 1294
+          column: 7
+        end:
+          line: 1294
+          column: 10
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 1456
+          column: 50
+        end:
+          line: 1456
+          column: 61
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C130"
+        severity: "warning"
+        message: "quotes or backslashes stored in this value will stay literal on reuse"
+        start:
+          line: 1470
+          column: 21
+        end:
+          line: 1470
+          column: 23
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 1471
+          column: 22
+        end:
+          line: 1471
+          column: 24
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C131"
+        severity: "warning"
+        message: "unquoted expansion will not honor quotes or escapes stored in this variable"
+        start:
+          line: 1478
+          column: 23
+        end:
+          line: 1478
+          column: 25
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 1565
+          column: 8
+        end:
+          line: 1565
+          column: 21
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 1588
+          column: 14
+        end:
+          line: 1588
+          column: 21
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `highlight_zone` is assigned but never used"
+        start:
+          line: 1660
+          column: 12
+        end:
+          line: 1660
+          column: 26
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C096"
+        severity: "warning"
+        message: "bracket globs only match one character at a time; quote word-like ones"
+        start:
+          line: 1665
+          column: 25
+        end:
+          line: 1665
+          column: 33
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `offsets` is assigned but never used"
+        start:
+          line: 1689
+          column: 7
+        end:
+          line: 1689
+          column: 29
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C100"
+        severity: "warning"
+        message: "array references should choose an explicit element or selector"
+        start:
+          line: 1698
+          column: 31
+        end:
+          line: 1698
+          column: 37
+        classification: real
+      - path: "highlighters/main/main-highlighter.zsh"
+        code: "C048"
+        severity: "warning"
+        message: "case patterns should be literal instead of built from expansions"
+        start:
+          line: 1784
+          column: 8
+        end:
+          line: 1784
+          column: 21
+        classification: real
+      - path: "highlighters/main/test-data/alias-parameter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `foo` is assigned but never used"
+        start:
+          line: 32
+          column: 12
+        end:
+          line: 32
+          column: 15
+        classification: real
+      - path: "highlighters/main/test-data/alias-parameter.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 34
+          column: 8
+        end:
+          line: 34
+          column: 14
+        classification: real
+      - path: "highlighters/main/test-data/alias-reuse4.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 33
+          column: 8
+        end:
+          line: 33
+          column: 16
+        classification: real
+      - path: "highlighters/main/test-data/arithmetic-unfinished.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 39
+          column: 23
+        end:
+          line: 39
+          column: 28
+        classification: real
+      - path: "highlighters/main/test-data/back-quoted-argument.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 30
+          column: 8
+        end:
+          line: 30
+          column: 65
+        classification: real
+      - path: "highlighters/main/test-data/backslash-continuation.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PREBUFFER` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 10
+        classification: false_positive
+      - path: "highlighters/main/test-data/brackets-mismatch7.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 31
+          column: 8
+        end:
+          line: 31
+          column: 37
+        classification: real
+      - path: "highlighters/main/test-data/cmdpos-elision-partial.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `x` is assigned but never used"
+        start:
+          line: 33
+          column: 13
+        end:
+          line: 33
+          column: 14
+        classification: real
+      - path: "highlighters/main/test-data/command-substitution-adjacent.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 31
+          column: 8
+        end:
+          line: 31
+          column: 30
+        classification: real
+      - path: "highlighters/main/test-data/command-substitution-unclosed.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 42
+          column: 23
+        end:
+          line: 42
+          column: 28
+        classification: real
+      - path: "highlighters/main/test-data/commmand-parameter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `x` is assigned but never used"
+        start:
+          line: 30
+          column: 7
+        end:
+          line: 30
+          column: 8
+        classification: real
+      - path: "highlighters/main/test-data/commmand-parameter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `y` is assigned but never used"
+        start:
+          line: 31
+          column: 7
+        end:
+          line: 31
+          column: 8
+        classification: real
+      - path: "highlighters/main/test-data/commmand-parameter.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `z` is assigned but never used"
+        start:
+          line: 32
+          column: 13
+        end:
+          line: 32
+          column: 14
+        classification: real
+      - path: "highlighters/main/test-data/commmand-parameter.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 35
+          column: 8
+        end:
+          line: 35
+          column: 31
+        classification: real
+      - path: "highlighters/main/test-data/dollar-dollar.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 31
+          column: 8
+        end:
+          line: 31
+          column: 22
+        classification: real
+      - path: "highlighters/main/test-data/dollar-paren.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 31
+          column: 8
+        end:
+          line: 31
+          column: 30
+        classification: real
+      - path: "highlighters/main/test-data/double-quoted.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 30
+          column: 8
+        end:
+          line: 30
+          column: 30
+        classification: real
+      - path: "highlighters/main/test-data/double-quoted2.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 32
+          column: 8
+        end:
+          line: 32
+          column: 20
+        classification: real
+      - path: "highlighters/main/test-data/double-quoted3.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 30
+          column: 8
+        end:
+          line: 30
+          column: 24
+        classification: real
+      - path: "highlighters/main/test-data/double-quoted4.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 30
+          column: 8
+        end:
+          line: 30
+          column: 23
+        classification: real
+      - path: "highlighters/main/test-data/multiline-string.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PREBUFFER` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 10
+        classification: false_positive
+      - path: "highlighters/main/test-data/opt-shwordsplit1.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `EDITOR` is assigned but never used"
+        start:
+          line: 32
+          column: 7
+        end:
+          line: 32
+          column: 13
+        classification: real
+      - path: "highlighters/main/test-data/option-path_dirs.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `skip_test` is assigned but never used"
+        start:
+          line: 31
+          column: 3
+        end:
+          line: 31
+          column: 12
+        classification: real
+      - path: "highlighters/main/test-data/order-path-after-dollar.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 31
+          column: 7
+        end:
+          line: 31
+          column: 13
+        classification: real
+      - path: "highlighters/main/test-data/order-path-after-dollar.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 32
+          column: 8
+        end:
+          line: 32
+          column: 22
+        classification: real
+      - path: "highlighters/main/test-data/param-precommand-option-argument1.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `sudo_u` is assigned but never used"
+        start:
+          line: 32
+          column: 18
+        end:
+          line: 32
+          column: 24
+        classification: real
+      - path: "highlighters/main/test-data/param-precommand-option-argument1.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 35
+          column: 8
+        end:
+          line: 35
+          column: 34
+        classification: real
+      - path: "highlighters/main/test-data/param-precommand-option-argument3.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `sudo_u` is assigned but never used"
+        start:
+          line: 32
+          column: 18
+        end:
+          line: 32
+          column: 24
+        classification: real
+      - path: "highlighters/main/test-data/param-precommand-option-argument3.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 35
+          column: 8
+        end:
+          line: 35
+          column: 32
+        classification: real
+      - path: "highlighters/main/test-data/parameter-elision-command-word.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 31
+          column: 8
+        end:
+          line: 31
+          column: 15
+        classification: real
+      - path: "highlighters/main/test-data/parameter-expansion-shwordsplit.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `foo` is assigned but never used"
+        start:
+          line: 32
+          column: 7
+        end:
+          line: 32
+          column: 10
+        classification: real
+      - path: "highlighters/main/test-data/parameter-expansion-shwordsplit.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 34
+          column: 8
+        end:
+          line: 34
+          column: 14
+        classification: real
+      - path: "highlighters/main/test-data/parameter-expansion-untokenized1.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `x` is assigned but never used"
+        start:
+          line: 31
+          column: 7
+        end:
+          line: 31
+          column: 8
+        classification: real
+      - path: "highlighters/main/test-data/parameter-expansion-untokenized2.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `x` is assigned but never used"
+        start:
+          line: 31
+          column: 7
+        end:
+          line: 31
+          column: 8
+        classification: real
+      - path: "highlighters/main/test-data/parameter-to-global-alias.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `skip_test` is assigned but never used"
+        start:
+          line: 32
+          column: 3
+        end:
+          line: 32
+          column: 12
+        classification: real
+      - path: "highlighters/main/test-data/parameter-to-global-alias.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `s` is assigned but never used"
+        start:
+          line: 36
+          column: 7
+        end:
+          line: 36
+          column: 8
+        classification: real
+      - path: "highlighters/main/test-data/parameter-value-contains-command-position1.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `foobar` is assigned but never used"
+        start:
+          line: 31
+          column: 7
+        end:
+          line: 31
+          column: 13
+        classification: real
+      - path: "highlighters/main/test-data/parameter-value-contains-command-position1.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 31
+          column: 14
+        end:
+          line: 31
+          column: 23
+        classification: real
+      - path: "highlighters/main/test-data/parameter-value-contains-command-position2.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `y` is assigned but never used"
+        start:
+          line: 31
+          column: 7
+        end:
+          line: 31
+          column: 8
+        classification: real
+      - path: "highlighters/main/test-data/parameter-value-contains-command-position2.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 31
+          column: 9
+        end:
+          line: 31
+          column: 18
+        classification: real
+      - path: "highlighters/main/test-data/path-broken-symlink.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `skip_test` is assigned but never used"
+        start:
+          line: 31
+          column: 3
+        end:
+          line: 31
+          column: 12
+        classification: real
+      - path: "highlighters/main/test-data/path-dollared-word.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `skip_test` is assigned but never used"
+        start:
+          line: 31
+          column: 3
+        end:
+          line: 31
+          column: 12
+        classification: real
+      - path: "highlighters/main/test-data/path-dollared-word.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 38
+          column: 10
+        end:
+          line: 38
+          column: 32
+        classification: real
+      - path: "highlighters/main/test-data/path-dollared-word2.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `lambda` is assigned but never used"
+        start:
+          line: 30
+          column: 7
+        end:
+          line: 30
+          column: 13
+        classification: real
+      - path: "highlighters/main/test-data/path-dollared-word2.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 32
+          column: 8
+        end:
+          line: 32
+          column: 20
+        classification: real
+      - path: "highlighters/main/test-data/path-dollared-word3.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 34
+          column: 8
+        end:
+          line: 34
+          column: 22
+        classification: real
+      - path: "highlighters/main/test-data/path-dollared-word4.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 32
+          column: 8
+        end:
+          line: 32
+          column: 12
+        classification: real
+      - path: "highlighters/main/test-data/path-separators.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `path_pathseparator` is referenced before assignment"
+        start:
+          line: 32
+          column: 22
+        end:
+          line: 32
+          column: 40
+        classification: false_positive
+      - path: "highlighters/main/test-data/path-separators.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `path_prefix_pathseparator` is referenced before assignment"
+        start:
+          line: 33
+          column: 22
+        end:
+          line: 33
+          column: 47
+        classification: false_positive
+      - path: "highlighters/main/test-data/path-separators2.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `path_pathseparator` is referenced before assignment"
+        start:
+          line: 33
+          column: 22
+        end:
+          line: 33
+          column: 40
+        classification: false_positive
+      - path: "highlighters/main/test-data/path_prefix3.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PREBUFFER` is assigned but never used"
+        start:
+          line: 33
+          column: 1
+        end:
+          line: 33
+          column: 10
+        classification: false_positive
+      - path: "highlighters/main/test-data/process-substitution2.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 48
+          column: 23
+        end:
+          line: 48
+          column: 28
+        classification: real
+      - path: "highlighters/main/test-data/quoted-command-substitution-empty.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 31
+          column: 8
+        end:
+          line: 31
+          column: 22
+        classification: real
+      - path: "highlighters/main/test-data/quoted-command-substitution-empty.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 41
+          column: 23
+        end:
+          line: 41
+          column: 28
+        classification: real
+      - path: "highlighters/main/test-data/redirection-from-param.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `fn` is assigned but never used"
+        start:
+          line: 32
+          column: 7
+        end:
+          line: 32
+          column: 9
+        classification: real
+      - path: "highlighters/main/test-data/vanilla-newline.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PREBUFFER` is assigned but never used"
+        start:
+          line: 30
+          column: 1
+        end:
+          line: 30
+          column: 10
+        classification: false_positive
+      - path: "highlighters/main/test-data/vi-linewise-mode.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `REGION_ACTIVE` is assigned but never used"
+        start:
+          line: 32
+          column: 1
+        end:
+          line: 32
+          column: 14
+        classification: false_positive
+      - path: "highlighters/main/test-data/vi-linewise-mode.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `MARK` is assigned but never used"
+        start:
+          line: 34
+          column: 1
+        end:
+          line: 34
+          column: 5
+        classification: false_positive
+      - path: "highlighters/regexp/test-data/word-boundary.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `skip_test` is assigned but never used"
+        start:
+          line: 41
+          column: 3
+        end:
+          line: 41
+          column: 12
+        classification: real
+      - path: "tests/generate.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 51
+          column: 3
+        end:
+          line: 51
+          column: 41
+        classification: real
+      - path: "tests/generate.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PREBUFFER` is assigned but never used"
+        start:
+          line: 91
+          column: 3
+        end:
+          line: 91
+          column: 12
+        classification: false_positive
+      - path: "tests/test-highlighting.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 80
+          column: 3
+        end:
+          line: 80
+          column: 36
+        classification: real
+      - path: "tests/test-highlighting.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `MARK` is assigned but never used"
+        start:
+          line: 124
+          column: 23
+        end:
+          line: 124
+          column: 27
+        classification: false_positive
+      - path: "tests/test-highlighting.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `REGION_ACTIVE` is assigned but never used"
+        start:
+          line: 124
+          column: 46
+        end:
+          line: 124
+          column: 59
+        classification: false_positive
+      - path: "tests/test-highlighting.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 135
+          column: 14
+        end:
+          line: 135
+          column: 30
+        classification: real
+      - path: "tests/test-highlighting.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 194
+          column: 20
+        end:
+          line: 194
+          column: 30
+        classification: real
+      - path: "tests/test-highlighting.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 195
+          column: 18
+        end:
+          line: 195
+          column: 26
+        classification: real
+      - path: "tests/test-highlighting.zsh"
+        code: "C081"
+        severity: "warning"
+        message: "quote the right-hand side so string comparisons do not turn into glob matches"
+        start:
+          line: 196
+          column: 36
+        end:
+          line: 196
+          column: 65
+        classification: real
+      - path: "tests/test-highlighting.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 285
+          column: 18
+        end:
+          line: 285
+          column: 23
+        classification: real
+      - path: "tests/test-highlighting.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 285
+          column: 37
+        end:
+          line: 285
+          column: 39
+        classification: real
+      - path: "tests/test-perfs.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 55
+          column: 3
+        end:
+          line: 55
+          column: 39
+        classification: real
+      - path: "tests/test-perfs.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `highlight_zone` is assigned but never used"
+        start:
+          line: 63
+          column: 12
+        end:
+          line: 63
+          column: 26
+        classification: real
+      - path: "tests/test-perfs.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 71
+          column: 5
+        end:
+          line: 71
+          column: 19
+        classification: real
+      - path: "tests/test-perfs.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `TIMEFMT` is assigned but never used"
+        start:
+          line: 97
+          column: 1
+        end:
+          line: 97
+          column: 8
+        classification: false_positive
+      - path: "tests/test-perfs.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 98
+          column: 26
+        end:
+          line: 98
+          column: 34
+        classification: real
+      - path: "tests/test-perfs.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 98
+          column: 48
+        end:
+          line: 98
+          column: 50
+        classification: real
+      - path: "tests/test-zprof.zsh"
+        code: "C003"
+        severity: "warning"
+        message: "sourced file is not available to this analysis"
+        start:
+          line: 33
+          column: 3
+        end:
+          line: 33
+          column: 39
+        classification: real
+      - path: "tests/test-zprof.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `highlight_zone` is assigned but never used"
+        start:
+          line: 45
+          column: 12
+        end:
+          line: 45
+          column: 26
+        classification: real
+      - path: "tests/test-zprof.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `PREBUFFER` is assigned but never used"
+        start:
+          line: 52
+          column: 3
+        end:
+          line: 52
+          column: 12
+        classification: false_positive
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `histchars` is referenced before assignment"
+        start:
+          line: 59
+          column: 50
+        end:
+          line: 59
+          column: 63
+        classification: false_positive
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C005"
+        severity: "warning"
+        message: "shell expansion inside single quotes stays literal"
+        start:
+          line: 127
+          column: 14
+        end:
+          line: 127
+          column: 80
+        classification: real
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `onoff` is assigned but never used"
+        start:
+          line: 189
+          column: 29
+        end:
+          line: 189
+          column: 34
+        classification: real
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C001"
+        severity: "warning"
+        message: "variable `REPLY` is assigned but never used"
+        start:
+          line: 207
+          column: 9
+        end:
+          line: 207
+          column: 14
+        classification: false_positive
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `Ib` is referenced before assignment"
+        start:
+          line: 273
+          column: 28
+        end:
+          line: 273
+          column: 30
+        classification: false_positive
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C006"
+        severity: "error"
+        message: "variable `ib` is referenced before assignment"
+        start:
+          line: 274
+          column: 28
+        end:
+          line: 274
+          column: 30
+        classification: false_positive
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C055"
+        severity: "warning"
+        message: "pattern expressions should not expand variables"
+        start:
+          line: 321
+          column: 22
+        end:
+          line: 321
+          column: 30
+        classification: real
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C114"
+        severity: "warning"
+        message: "quote expansion prefixes when combining them with loop globs"
+        start:
+          line: 517
+          column: 24
+        end:
+          line: 517
+          column: 26
+        classification: real
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C002"
+        severity: "warning"
+        message: "source path is built at runtime"
+        start:
+          line: 520
+          column: 9
+        end:
+          line: 520
+          column: 57
+        classification: real
+      - path: "zsh-syntax-highlighting.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `X_ZSH_HIGHLIGHT_DIRS_BLACKLIST` looks like it may mean `ZSH_HIGHLIGHT_DIRS_BLACKLIST`"
+        start:
+          line: 578
+          column: 33
+        end:
+          line: 578
+          column: 64
+        classification: real

--- a/scripts/compact_large_corpus_log.py
+++ b/scripts/compact_large_corpus_log.py
@@ -14,9 +14,10 @@ SECTION_HEADERS = {
     "Reviewed Divergence:",
     "Harness Warnings:",
     "Harness Failures:",
+    "Zsh Diagnostic Corpus Drift:",
 }
 MAX_BLOCKS_PER_SECTION = 8
-FIXTURE_HEADER_RE = re.compile(r"^/.*$")
+FIXTURE_HEADER_RE = re.compile(r"^(?:/.*|repo `.*`:\s*)$")
 IMPORTANT_LINE_RES = [
     re.compile(r"^running \d+ tests$"),
     re.compile(r"^large corpus: processed \d+/\d+ fixtures"),
@@ -25,8 +26,12 @@ IMPORTANT_LINE_RES = [
     re.compile(r"^large corpus .* had \d+ blocking issue\(s\) "),
     re.compile(r"^large corpus test skipped "),
     re.compile(r"^large corpus zsh parse skipped "),
+    re.compile(r"^zsh diagnostic corpus test skipped "),
+    re.compile(r"^zsh diagnostic corpus drifted "),
     re.compile(r"^thread 'large_corpus"),
+    re.compile(r"^thread 'zsh_diagnostic_corpus_matches_baseline"),
     re.compile(r"^test large_corpus_"),
+    re.compile(r"^test zsh_diagnostic_"),
     re.compile(r"^failures:$"),
     re.compile(r"^test result: "),
     re.compile(r"^error: test failed"),

--- a/scripts/corpus-download.sh
+++ b/scripts/corpus-download.sh
@@ -6,14 +6,55 @@ default_corpus_dir="$repo_root/.cache/large-corpus"
 archive_file="${SHUCK_LARGE_CORPUS_ARCHIVE_FILE:-shuck-cache-v3.tar.zst}"
 archive_url="${SHUCK_LARGE_CORPUS_ARCHIVE_URL:-https://github.com/ewhauser/shuck/releases/download/v0.0.0-test-files/$archive_file}"
 sha256="${SHUCK_LARGE_CORPUS_ARCHIVE_SHA256:-880356ce713decb75c894a488c7a5f9cbeef2e3f76e43bb04525ebab4211ccd7}"
-tmp_file="/tmp/$archive_file"
+default_zsh_diagnostic_corpus_dir="$repo_root/.cache/zsh-diagnostic-corpus"
+zsh_diagnostic_archive_file="${SHUCK_ZSH_DIAGNOSTIC_CORPUS_ARCHIVE_FILE:-shuck-zsh-diagnostic-corpus-v1.tar.zst}"
+zsh_diagnostic_archive_url="${SHUCK_ZSH_DIAGNOSTIC_CORPUS_ARCHIVE_URL:-https://github.com/ewhauser/shuck/releases/download/v0.0.0-test-files/$zsh_diagnostic_archive_file}"
+zsh_diagnostic_sha256="${SHUCK_ZSH_DIAGNOSTIC_CORPUS_ARCHIVE_SHA256:-6fefa7c1aea0aba37e0111a73d2dea2e0ba08df2ed1a8704a3464798ac413dda}"
+zsh_diagnostic_corpus_dir="${SHUCK_ZSH_DIAGNOSTIC_CORPUS_ROOT:-$default_zsh_diagnostic_corpus_dir}"
 
 usage() {
   echo "Usage: $0 [-c] [-l] [corpus-dir]"
   echo "  -c  Clone repos from GitHub instead of downloading pre-built archive"
   echo "  -l  List repos only (dry run, only with -c)"
   echo "  corpus-dir defaults to $default_corpus_dir"
+  echo "  zsh diagnostic corpus defaults to $default_zsh_diagnostic_corpus_dir"
   exit 1
+}
+
+download_archive() {
+  corpus_dir=$1
+  marker_dir=$2
+  archive_file=$3
+  archive_url=$4
+  sha256=$5
+  label=$6
+  tmp_file="/tmp/$archive_file"
+
+  if [ -d "$marker_dir" ]; then
+    count=$(find "$marker_dir" -type f | wc -l | tr -d ' ')
+    echo "$label already exists ($count files in $marker_dir)"
+    echo "To re-download, remove $corpus_dir and re-run."
+    return 0
+  fi
+
+  echo "Downloading $label archive..."
+  curl -L --fail --retry 3 -o "$tmp_file" "$archive_url"
+
+  echo "Verifying $label checksum..."
+  if command -v sha256sum >/dev/null 2>&1; then
+    echo "$sha256  $tmp_file" | sha256sum -c -
+  elif command -v shasum >/dev/null 2>&1; then
+    echo "$sha256  $tmp_file" | shasum -a 256 -c -
+  else
+    echo "WARNING: no sha256sum or shasum found, skipping checksum verification"
+  fi
+
+  echo "Extracting $label to $repo_root..."
+  tar --zstd -xf "$tmp_file" -C "$repo_root"
+  rm -f "$tmp_file"
+
+  count=$(find "$marker_dir" -type f | wc -l | tr -d ' ')
+  echo "Done. $count files in $marker_dir"
 }
 
 clone_mode=false
@@ -43,32 +84,8 @@ if [ "$clone_mode" = false ]; then
     exit 1
   fi
 
-  scripts_dir="$corpus_dir/scripts"
-  if [ -d "$scripts_dir" ]; then
-    count=$(find "$scripts_dir" -type f | wc -l | tr -d ' ')
-    echo "Large corpus already exists ($count scripts in $scripts_dir)"
-    echo "To re-download, remove $corpus_dir and re-run."
-    exit 0
-  fi
-
-  echo "Downloading large corpus archive..."
-  curl -L --fail --retry 3 -o "$tmp_file" "$archive_url"
-
-  echo "Verifying checksum..."
-  if command -v sha256sum >/dev/null 2>&1; then
-    echo "$sha256  $tmp_file" | sha256sum -c -
-  elif command -v shasum >/dev/null 2>&1; then
-    echo "$sha256  $tmp_file" | shasum -a 256 -c -
-  else
-    echo "WARNING: no sha256sum or shasum found, skipping checksum verification"
-  fi
-
-  echo "Extracting to $repo_root..."
-  tar --zstd -xf "$tmp_file" -C "$repo_root"
-  rm -f "$tmp_file"
-
-  count=$(find "$scripts_dir" -type f | wc -l | tr -d ' ')
-  echo "Done. $count scripts in $scripts_dir"
+  download_archive "$corpus_dir" "$corpus_dir/scripts" "$archive_file" "$archive_url" "$sha256" "Large corpus"
+  download_archive "$zsh_diagnostic_corpus_dir" "$zsh_diagnostic_corpus_dir/repos" "$zsh_diagnostic_archive_file" "$zsh_diagnostic_archive_url" "$zsh_diagnostic_sha256" "Zsh diagnostic corpus"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- add a repo-shaped zsh diagnostic corpus baseline with `real` / `false_positive` classifications
- wire an ignored large-corpus test that fails on any zsh diagnostic drift, with grouped diff output
- download and verify the new zsh diagnostic corpus tarball in setup and CI

## Release Asset
- uploaded `shuck-zsh-diagnostic-corpus-v1.tar.zst` to `v0.0.0-test-files`
- SHA256: `6fefa7c1aea0aba37e0111a73d2dea2e0ba08df2ed1a8704a3464798ac413dda`

## Validation
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic -- --nocapture`
- `cargo test -p shuck-cli --test large_corpus -- --nocapture`
- `python3 -m unittest scripts/test_compact_large_corpus_log.py`
- `make NIX_DEVELOP= test-large-corpus`
- `cargo test --workspace --all-features`
- verified release asset download/checksum for `shuck-zsh-diagnostic-corpus-v1.tar.zst`