### PR TITLE
fix(parser): handle heredoc array parameter forms

### DIFF
--- a/crates/shuck-parser/src/parser/mod.rs
+++ b/crates/shuck-parser/src/parser/mod.rs
@@ -677,7 +677,12 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn heredoc_body_part_from_word_part_node(part: WordPartNode) -> HeredocBodyPartNode {
+    fn heredoc_body_part_from_word_part_node(
+        &self,
+        part: WordPartNode,
+        source_backed: bool,
+    ) -> HeredocBodyPartNode {
+        let span = part.span;
         let kind = match part.kind {
             WordPart::Literal(text) => HeredocBodyPart::Literal(text),
             WordPart::Variable(name) => HeredocBodyPart::Variable(name),
@@ -696,10 +701,44 @@ impl<'a> Parser<'a> {
                 syntax,
             },
             WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(parameter),
-            other => panic!("unsupported heredoc body part: {other:?}"),
+            part @ (WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::Transformation { .. }) => {
+                match self.parameter_word_part_from_legacy(
+                    part,
+                    span.start,
+                    span.end,
+                    source_backed,
+                ) {
+                    WordPart::Parameter(parameter) => HeredocBodyPart::Parameter(parameter),
+                    other => self.literal_heredoc_body_part_from_word_part(other, span),
+                }
+            }
+            other => self.literal_heredoc_body_part_from_word_part(other, span),
         };
 
-        HeredocBodyPartNode::new(kind, part.span)
+        HeredocBodyPartNode::new(kind, span)
+    }
+
+    fn literal_heredoc_body_part_from_word_part(
+        &self,
+        part: WordPart,
+        span: Span,
+    ) -> HeredocBodyPart {
+        if span.end.offset <= self.input.len() {
+            return HeredocBodyPart::Literal(LiteralText::source());
+        }
+
+        let mut syntax = String::new();
+        self.push_word_part_syntax(&mut syntax, &part, span);
+        HeredocBodyPart::Literal(LiteralText::owned(syntax))
     }
 
     fn brace_syntax_from_parts(&self, parts: &[WordPartNode], offset: usize) -> Vec<BraceSyntax> {

--- a/crates/shuck-parser/src/parser/tests/heredocs.rs
+++ b/crates/shuck-parser/src/parser/tests/heredocs.rs
@@ -704,6 +704,34 @@ fn test_unquoted_heredoc_body_keeps_dollar_quoted_forms_literal() {
 }
 
 #[test]
+fn test_unquoted_heredoc_body_accepts_array_parameter_forms() {
+    let input = "cat <<EOF\n${words[1]} ${#words[@]}\nEOF\n";
+    let script = Parser::new(input).parse().unwrap().file;
+
+    let body = &script.body[0]
+        .redirects
+        .iter()
+        .find_map(|redirect| redirect.heredoc())
+        .expect("expected heredoc redirect")
+        .body;
+
+    assert!(!heredoc_body_is_literal(body));
+    assert_eq!(
+        heredoc_top_level_part_slices(body, input),
+        vec!["${words[1]}", " ", "${#words[@]}", "\n"]
+    );
+    assert!(matches!(
+        body.parts[0].kind,
+        shuck_ast::HeredocBodyPart::Parameter(_)
+    ));
+    assert!(matches!(
+        body.parts[2].kind,
+        shuck_ast::HeredocBodyPart::Parameter(_)
+    ));
+    assert_eq!(body.render(input), "${words[1]} ${#words[@]}\n");
+}
+
+#[test]
 fn test_unquoted_heredoc_body_keeps_later_expansions_live_after_quoted_lines() {
     let input = "\
 cat <<EOF > \"$archname\"

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -5748,7 +5748,7 @@ impl<'a> Parser<'a> {
         );
         let parts = parts
             .into_iter()
-            .map(Self::heredoc_body_part_from_word_part_node)
+            .map(|part| self.heredoc_body_part_from_word_part_node(part, source_backed))
             .collect();
         self.heredoc_body_with_parts(parts, span, HeredocBodyMode::Expanding, source_backed)
     }


### PR DESCRIPTION
## Summary
- Normalize legacy parameter word parts when building expanding heredoc bodies
- Avoid panicking on array-style parameter forms such as `${words[1]}` and `${#words[@]}` in heredoc content
- Add a parser regression covering array access and array length inside an unquoted heredoc

## Root Cause
The heredoc body decoder reused word parsing, which can produce structured parameter word parts like array access, array length, slices, and related legacy forms. The heredoc conversion layer only accepted literals, simple variables, command substitutions, arithmetic expansions, and already-normalized parameter expansions, so fuzzed heredoc content could hit an unsupported word-part panic.

## Validation
- Exact `recovered_parser_fuzz` artifact from scheduled fuzz run `25361779190` executes cleanly
- Exact `linter_no_panic_fuzz` artifact from scheduled fuzz run `25361779190` executes cleanly
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p shuck-parser`
- `cargo test -p shuck-linter`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

Fixes #872