### PR TITLE
fix(parser): handle zsh length parameter operations

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -3292,17 +3292,6 @@ repos:
           column: 6
         classification: real
       - path: "plugins/git-extras/git-extras.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `*:#0` is referenced before assignment"
-        start:
-          line: 32
-          column: 9
-        end:
-          line: 32
-          column: 17
-        classification: false_positive
-      - path: "plugins/git-extras/git-extras.plugin.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `expl` is assigned but never used"
@@ -3500,17 +3489,6 @@ repos:
           line: 509
           column: 15
         classification: false_positive
-      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `pipestatus:#0` is referenced before assignment"
-        start:
-          line: 519
-          column: 11
-        end:
-          line: 519
-          column: 28
-        classification: false_positive
       - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
         code: "C005"
         severity: "warning"
@@ -3609,17 +3587,6 @@ repos:
         end:
           line: 316
           column: 15
-        classification: false_positive
-      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `pipestatus:#0` is referenced before assignment"
-        start:
-          line: 326
-          column: 11
-        end:
-          line: 326
-          column: 28
         classification: false_positive
       - path: "plugins/git-prompt/git-prompt.plugin.zsh"
         code: "C001"
@@ -5107,17 +5074,6 @@ repos:
           column: 71
         classification: real
       - path: "plugins/history-substring-search/history-substring-search.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `BUFFER:$highlight_start_index` is referenced before assignment"
-        start:
-          line: 397
-          column: 41
-        end:
-          line: 397
-          column: 74
-        classification: false_positive
-      - path: "plugins/history-substring-search/history-substring-search.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `xlbuflines` is assigned but never used"
@@ -5260,17 +5216,6 @@ repos:
           line: 35
           column: 23
         classification: real
-      - path: "plugins/jump/jump.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `link:t` is referenced before assignment"
-        start:
-          line: 36
-          column: 9
-        end:
-          line: 36
-          column: 19
-        classification: false_positive
       - path: "plugins/jump/jump.plugin.zsh"
         code: "C114"
         severity: "warning"
@@ -7075,17 +7020,6 @@ repos:
           line: 832
           column: 19
         classification: real
-      - path: "plugins/z/z.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `cd:h` is referenced before assignment"
-        start:
-          line: 868
-          column: 36
-        end:
-          line: 868
-          column: 43
-        classification: false_positive
       - path: "plugins/z/z.plugin.zsh"
         code: "C048"
         severity: "warning"

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1281,6 +1281,30 @@ print -r -- $chpwd_functions $still_missing
     }
 
     #[test]
+    fn zsh_length_prefixed_parameter_operations_do_not_merge_into_variable_names() {
+        let source = "\
+#!/bin/zsh
+link=/tmp/file
+BUFFER=abcdef
+highlight_start_index=2
+printf '%s\\n' ${#link:t} ${#*:#0} ${#BUFFER:$highlight_start_index} $missing
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("fixture.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
     fn pathless_zsh_hook_array_references_stay_reportable() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-parser/src/parser/tests/words.rs
+++ b/crates/shuck-parser/src/parser/tests/words.rs
@@ -7715,6 +7715,66 @@ fn test_zsh_parameter_colon_modifiers_preserve_targets_without_bourne_slice_offs
 }
 
 #[test]
+fn test_zsh_length_prefix_preserves_colon_modifier_targets() {
+    let source = "print ${#link:t} ${#*:#0} ${#BUFFER:$highlight_start_index}\n";
+    let output = Parser::with_dialect(source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let command = expect_simple(&output.file.body[0]);
+
+    let link = expect_parameter(&command.args[0]);
+    let ParameterExpansionSyntax::Zsh(link) = &link.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    assert_eq!(
+        link.length_prefix.expect("expected length").slice(source),
+        "#"
+    );
+    let ZshExpansionTarget::Reference(reference) = &link.target else {
+        panic!("expected reference target");
+    };
+    assert_eq!(reference.name.as_str(), "link");
+    assert!(matches!(
+        link.operation,
+        Some(ZshExpansionOperation::Unknown { ref text, .. }) if text.slice(source) == ":t"
+    ));
+
+    let filtered_args = expect_parameter(&command.args[1]);
+    let ParameterExpansionSyntax::Zsh(filtered_args) = &filtered_args.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    let ZshExpansionTarget::Reference(reference) = &filtered_args.target else {
+        panic!("expected reference target");
+    };
+    assert_eq!(reference.name.as_str(), "*");
+    assert!(matches!(
+        filtered_args.operation,
+        Some(ZshExpansionOperation::PatternOperation {
+            kind: ZshPatternOp::Filter,
+            ref operand,
+            ..
+        }) if operand.slice(source) == "0"
+    ));
+
+    let sliced = expect_parameter(&command.args[2]);
+    let ParameterExpansionSyntax::Zsh(sliced) = &sliced.syntax else {
+        panic!("expected zsh parameter syntax");
+    };
+    let ZshExpansionTarget::Reference(reference) = &sliced.target else {
+        panic!("expected reference target");
+    };
+    assert_eq!(reference.name.as_str(), "BUFFER");
+    assert!(matches!(
+        sliced.operation,
+        Some(ZshExpansionOperation::Slice {
+            ref offset,
+            length: None,
+            ..
+        }) if offset.slice(source) == "$highlight_start_index"
+    ));
+}
+
+#[test]
 fn test_zsh_parameter_colon_modifiers_with_digits_preserve_targets() {
     let source = "print ${path:A:h3} ${path:t2}\n";
     let output = Parser::with_dialect(source, ShellDialect::Zsh)

--- a/crates/shuck-parser/src/parser/words.rs
+++ b/crates/shuck-parser/src/parser/words.rs
@@ -3141,6 +3141,24 @@ impl<'a> Parser<'a> {
         Self::zsh_modifier_suffix_candidate_chars(&mut lookahead)
     }
 
+    fn zsh_length_parameter_requires_fallback(
+        &self,
+        chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+        cursor: &Position,
+        source_backed: bool,
+    ) -> bool {
+        if !self.dialect.features().zsh_parameter_modifiers {
+            return false;
+        }
+
+        let mut lookahead = chars.clone();
+        let mut lookahead_cursor = *cursor;
+        let tail = self.read_brace_operand(&mut lookahead, &mut lookahead_cursor, source_backed);
+        let raw_body = self.prefixed_parameter_raw_body("#", *cursor, tail, source_backed);
+        self.find_zsh_operation_start(raw_body.slice(self.input))
+            .is_some()
+    }
+
     fn parse_zsh_bare_prefixed_parameter(
         &mut self,
         chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
@@ -4542,6 +4560,24 @@ impl<'a> Parser<'a> {
                     }
 
                     if self.zsh_parameter_requires_fallback(&mut chars) {
+                        let tail = self.read_brace_operand(&mut chars, &mut cursor, source_backed);
+                        let raw_body = self.prefixed_parameter_raw_body(
+                            "#",
+                            brace_body_start,
+                            tail,
+                            source_backed,
+                        );
+                        let parameter = self.zsh_parameter_word_part(raw_body, part_start, cursor);
+                        Self::push_word_part(parts, parameter, part_start, cursor);
+                        current_start = cursor;
+                        continue;
+                    }
+
+                    if self.zsh_length_parameter_requires_fallback(
+                        &mut chars,
+                        &cursor,
+                        source_backed,
+                    ) {
                         let tail = self.read_brace_operand(&mut chars, &mut cursor, source_backed);
                         let raw_body = self.prefixed_parameter_raw_body(
                             "#",


### PR DESCRIPTION
## Summary
- parse zsh length-prefixed parameter expansions with top-level operations through the zsh parameter parser
- add parser and C006 regression coverage for `0`, `0`, and `0`
- remove six fixed C006 false positives from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-parser test_zsh_length_prefix_preserves_colon_modifier_targets --lib`
- `cargo test -p shuck-linter zsh_length_prefixed_parameter_operations_do_not_merge_into_variable_names --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-parser -p shuck-linter --all-targets -- -D warnings`

## Performance
- Compared impacted Criterion groups against local `origin/main`: parser/all -0.17%, semantic/all -0.89%, linter/all -1.45%, check_command_concise/all -0.27%, check_command_full/all +0.61%; no aggregate regression over +3%.