### PR TITLE
fix(linter): suppress zsh literal map key reads

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -2698,116 +2698,6 @@ repos:
           column: 20
         classification: real
       - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_d_regional_indicator_symbol_letter_e` is referenced before assignment"
-        start:
-          line: 31
-          column: 7
-        end:
-          line: 31
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_g_regional_indicator_symbol_letter_b` is referenced before assignment"
-        start:
-          line: 32
-          column: 7
-        end:
-          line: 32
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_c_regional_indicator_symbol_letter_n` is referenced before assignment"
-        start:
-          line: 33
-          column: 7
-        end:
-          line: 33
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_j_regional_indicator_symbol_letter_p` is referenced before assignment"
-        start:
-          line: 34
-          column: 7
-        end:
-          line: 34
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_k_regional_indicator_symbol_letter_r` is referenced before assignment"
-        start:
-          line: 35
-          column: 7
-        end:
-          line: 35
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_f_regional_indicator_symbol_letter_r` is referenced before assignment"
-        start:
-          line: 36
-          column: 7
-        end:
-          line: 36
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_e_regional_indicator_symbol_letter_s` is referenced before assignment"
-        start:
-          line: 37
-          column: 7
-        end:
-          line: 37
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_i_regional_indicator_symbol_letter_t` is referenced before assignment"
-        start:
-          line: 38
-          column: 7
-        end:
-          line: 38
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_u_regional_indicator_symbol_letter_s` is referenced before assignment"
-        start:
-          line: 39
-          column: 7
-        end:
-          line: 39
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `regional_indicator_symbol_letter_r_regional_indicator_symbol_letter_u` is referenced before assignment"
-        start:
-          line: 40
-          column: 7
-        end:
-          line: 40
-          column: 76
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `emoji_skintone` is assigned but never used"
@@ -19317,17 +19207,6 @@ repos:
           column: 40
         classification: real
       - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `___m_bkp` is referenced before assignment"
-        start:
-          line: 1361
-          column: 15
-        end:
-          line: 1361
-          column: 23
-        classification: false_positive
-      - path: "zinit.zsh"
         code: "C108"
         severity: "warning"
         message: "quote `unset` array-subscript operands so bracket text stays literal"
@@ -21271,39 +21150,6 @@ repos:
           line: 32
           column: 12
         classification: real
-      - path: "highlighters/main/test-data/path-separators.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `path_pathseparator` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 40
-        classification: false_positive
-      - path: "highlighters/main/test-data/path-separators.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `path_prefix_pathseparator` is referenced before assignment"
-        start:
-          line: 33
-          column: 22
-        end:
-          line: 33
-          column: 47
-        classification: false_positive
-      - path: "highlighters/main/test-data/path-separators2.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `path_pathseparator` is referenced before assignment"
-        start:
-          line: 33
-          column: 22
-        end:
-          line: 33
-          column: 40
-        classification: false_positive
       - path: "highlighters/main/test-data/path_prefix3.zsh"
         code: "C001"
         severity: "warning"

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2245,7 +2245,12 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             Some(assignment.target.name_span),
             assignment.target.subscript.as_deref(),
         );
-        if !indexed_semantics {
+        let bare_zsh_literal_key = Self::zsh_assignment_target_subscript_is_bare_literal_key(
+            self.semantic.shell_profile().dialect,
+            assignment.target.subscript.as_deref(),
+            self.source,
+        );
+        if !indexed_semantics || bare_zsh_literal_key {
             self.surface
                 .record_arithmetic_only_suppressed_subscript(assignment.target.subscript.as_deref());
         }
@@ -3033,6 +3038,31 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }
 
         true
+    }
+
+    fn zsh_assignment_target_subscript_is_bare_literal_key(
+        dialect: shuck_parser::parser::ShellDialect,
+        subscript: Option<&Subscript>,
+        source: &str,
+    ) -> bool {
+        if dialect != shuck_parser::parser::ShellDialect::Zsh {
+            return false;
+        }
+        let Some(subscript) = subscript else {
+            return false;
+        };
+        if subscript.selector().is_some() {
+            return false;
+        }
+        let text = subscript.syntax_text(source);
+        text.contains('_')
+            && text
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_')
+            && text
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
     }
 
     fn assoc_binding_visible_for_subscript(

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -624,6 +624,28 @@ print -r -- ${functions[iterm2_precmd]}
     }
 
     #[test]
+    fn suppresses_zsh_assignment_target_literal_map_keys_with_imported_declarations() {
+        let source = "\
+#!/bin/zsh
+emoji[regional_indicator_symbol_letter_d_regional_indicator_symbol_letter_e]=x
+arr[i]=x
+arr[plain_key]=x
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["i"]
+        );
+    }
+
+    #[test]
     fn zparseopts_targets_initialize_option_arrays() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
## Summary
- suppress zsh underscore-style assignment target subscripts as literal map keys instead of fake arithmetic reads
- keep ordinary indexed writes like `arr[i]=...` reportable for C006
- remove 14 C006 false positives from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-linter suppresses_zsh_assignment_target_literal_map_keys_with_imported_declarations --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

## Performance
Compared impacted Criterion groups against `origin/main` baseline `zsh-c006-main`:
- `check_command_concise/all`: -1.77%
- `check_command_full/all`: -1.10%
- `linter_facts/all`: -2.11%
- `linter/all`: -2.80%
