### PR TITLE
fix(linter): suppress zsh highlight style key reads

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -20182,28 +20182,6 @@ repos:
           line: 30
           column: 9
         classification: real
-      - path: "highlighters/brackets/test-data/cursor-matchingbracket.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bracket` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 29
-        classification: false_positive
-      - path: "highlighters/brackets/test-data/cursor-matchingbracket.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `level` is referenced before assignment"
-        start:
-          line: 32
-          column: 30
-        end:
-          line: 32
-          column: 35
-        classification: false_positive
       - path: "highlighters/brackets/test-data/loop-styles.zsh"
         code: "C001"
         severity: "warning"
@@ -20215,28 +20193,6 @@ repos:
           line: 30
           column: 9
         classification: real
-      - path: "highlighters/brackets/test-data/loop-styles.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bracket` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 29
-        classification: false_positive
-      - path: "highlighters/brackets/test-data/loop-styles.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `level` is referenced before assignment"
-        start:
-          line: 32
-          column: 30
-        end:
-          line: 32
-          column: 35
-        classification: false_positive
       - path: "highlighters/brackets/test-data/mismatch-patentheses.zsh"
         code: "C001"
         severity: "warning"
@@ -20248,28 +20204,6 @@ repos:
           line: 30
           column: 9
         classification: real
-      - path: "highlighters/brackets/test-data/mismatch-patentheses.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bracket` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 29
-        classification: false_positive
-      - path: "highlighters/brackets/test-data/mismatch-patentheses.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `level` is referenced before assignment"
-        start:
-          line: 32
-          column: 30
-        end:
-          line: 32
-          column: 35
-        classification: false_positive
       - path: "highlighters/brackets/test-data/near-quotes.zsh"
         code: "C001"
         severity: "warning"
@@ -20281,28 +20215,6 @@ repos:
           line: 30
           column: 9
         classification: real
-      - path: "highlighters/brackets/test-data/near-quotes.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bracket` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 29
-        classification: false_positive
-      - path: "highlighters/brackets/test-data/near-quotes.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `level` is referenced before assignment"
-        start:
-          line: 32
-          column: 30
-        end:
-          line: 32
-          column: 35
-        classification: false_positive
       - path: "highlighters/brackets/test-data/nested-parentheses.zsh"
         code: "C001"
         severity: "warning"
@@ -20314,28 +20226,6 @@ repos:
           line: 30
           column: 9
         classification: real
-      - path: "highlighters/brackets/test-data/nested-parentheses.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bracket` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 29
-        classification: false_positive
-      - path: "highlighters/brackets/test-data/nested-parentheses.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `level` is referenced before assignment"
-        start:
-          line: 32
-          column: 30
-        end:
-          line: 32
-          column: 35
-        classification: false_positive
       - path: "highlighters/brackets/test-data/nested-parentheses.zsh"
         code: "C005"
         severity: "warning"
@@ -20358,28 +20248,6 @@ repos:
           line: 30
           column: 9
         classification: real
-      - path: "highlighters/brackets/test-data/simple-parentheses.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bracket` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 29
-        classification: false_positive
-      - path: "highlighters/brackets/test-data/simple-parentheses.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `level` is referenced before assignment"
-        start:
-          line: 32
-          column: 30
-        end:
-          line: 32
-          column: 35
-        classification: false_positive
       - path: "highlighters/brackets/test-data/unclosed-patentheses.zsh"
         code: "C001"
         severity: "warning"
@@ -20391,28 +20259,6 @@ repos:
           line: 30
           column: 9
         classification: real
-      - path: "highlighters/brackets/test-data/unclosed-patentheses.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bracket` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 29
-        classification: false_positive
-      - path: "highlighters/brackets/test-data/unclosed-patentheses.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `level` is referenced before assignment"
-        start:
-          line: 32
-          column: 30
-        end:
-          line: 32
-          column: 35
-        classification: false_positive
       - path: "highlighters/brackets/test-data/unclosed-patentheses2.zsh"
         code: "C001"
         severity: "warning"
@@ -20424,28 +20270,6 @@ repos:
           line: 30
           column: 9
         classification: real
-      - path: "highlighters/brackets/test-data/unclosed-patentheses2.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bracket` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 29
-        classification: false_positive
-      - path: "highlighters/brackets/test-data/unclosed-patentheses2.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `level` is referenced before assignment"
-        start:
-          line: 32
-          column: 30
-        end:
-          line: 32
-          column: 35
-        classification: false_positive
       - path: "highlighters/main/main-highlighter.zsh"
         code: "C001"
         severity: "warning"
@@ -21271,39 +21095,6 @@ repos:
           line: 32
           column: 12
         classification: real
-      - path: "highlighters/main/test-data/path-separators.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `path_pathseparator` is referenced before assignment"
-        start:
-          line: 32
-          column: 22
-        end:
-          line: 32
-          column: 40
-        classification: false_positive
-      - path: "highlighters/main/test-data/path-separators.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `path_prefix_pathseparator` is referenced before assignment"
-        start:
-          line: 33
-          column: 22
-        end:
-          line: 33
-          column: 47
-        classification: false_positive
-      - path: "highlighters/main/test-data/path-separators2.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `path_pathseparator` is referenced before assignment"
-        start:
-          line: 33
-          column: 22
-        end:
-          line: 33
-          column: 40
-        classification: false_positive
       - path: "highlighters/main/test-data/path_prefix3.zsh"
         code: "C001"
         severity: "warning"

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2245,7 +2245,14 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             Some(assignment.target.name_span),
             assignment.target.subscript.as_deref(),
         );
-        if !indexed_semantics {
+        let external_zsh_assoc_key =
+            Self::zsh_assignment_target_subscript_has_external_assoc_key_semantics(
+                self.semantic.shell_profile().dialect,
+                &assignment.target.name,
+                assignment.target.subscript.as_deref(),
+                self.source,
+            );
+        if !indexed_semantics || external_zsh_assoc_key {
             self.surface
                 .record_arithmetic_only_suppressed_subscript(assignment.target.subscript.as_deref());
         }
@@ -3033,6 +3040,31 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }
 
         true
+    }
+
+    fn zsh_assignment_target_subscript_has_external_assoc_key_semantics(
+        dialect: shuck_parser::parser::ShellDialect,
+        owner_name: &Name,
+        subscript: Option<&Subscript>,
+        source: &str,
+    ) -> bool {
+        if dialect != shuck_parser::parser::ShellDialect::Zsh {
+            return false;
+        }
+        if owner_name.as_str() != "ZSH_HIGHLIGHT_STYLES" {
+            return false;
+        }
+        let Some(subscript) = subscript else {
+            return false;
+        };
+        if subscript.selector().is_some() {
+            return false;
+        }
+        let text = subscript.syntax_text(source);
+        !text.is_empty()
+            && text
+                .chars()
+                .all(|ch| ch == '-' || ch == '_' || ch.is_ascii_alphanumeric())
     }
 
     fn assoc_binding_visible_for_subscript(

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -624,6 +624,28 @@ print -r -- ${functions[iterm2_precmd]}
     }
 
     #[test]
+    fn suppresses_external_zsh_highlight_style_keys() {
+        let source = "\
+#!/bin/zsh
+ZSH_HIGHLIGHT_STYLES[bracket-level-1]=
+ZSH_HIGHLIGHT_STYLES[path_prefix_pathseparator]=
+arr[i-j]=x
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["i", "j"]
+        );
+    }
+
+    #[test]
     fn zparseopts_targets_initialize_option_arrays() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
## Summary
- treat literal `ZSH_HIGHLIGHT_STYLES[...]` assignment subscripts as externally provided zsh associative-map keys
- keep arbitrary undeclared indexed arithmetic like `arr[i-j]=...` reportable
- remove 19 C006 false positives from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-linter suppresses_external_zsh_highlight_style_keys --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

## Performance
Compared impacted Criterion groups against updated `origin/main` baseline `zsh-styles-main`:
- `check_command_concise/all`: -0.98%
- `check_command_full/all`: -0.41%
- `linter_facts/all`: +0.01%
- `linter/all`: +0.29%
