### PR TITLE
fix(linter): suppress zinit state map key reads

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -17799,105 +17799,6 @@ repos:
           column: 40
         classification: real
       - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `mark` is referenced before assignment"
-        start:
-          line: 3033
-          column: 24
-        end:
-          line: 3033
-          column: 28
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `r` is referenced before assignment"
-        start:
-          line: 3034
-          column: 12
-        end:
-          line: 3034
-          column: 13
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `hook` is referenced before assignment"
-        start:
-          line: 3034
-          column: 26
-        end:
-          line: 3034
-          column: 30
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `has` is referenced before assignment"
-        start:
-          line: 3034
-          column: 31
-        end:
-          line: 3034
-          column: 34
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `been` is referenced before assignment"
-        start:
-          line: 3034
-          column: 35
-        end:
-          line: 3034
-          column: 39
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `run` is referenced before assignment"
-        start:
-          line: 3034
-          column: 40
-        end:
-          line: 3034
-          column: 43
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `annex` is referenced before assignment"
-        start:
-          line: 3075
-          column: 11
-        end:
-          line: 3075
-          column: 16
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `multi` is referenced before assignment"
-        start:
-          line: 3075
-          column: 17
-        end:
-          line: 3075
-          column: 22
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `flag` is referenced before assignment"
-        start:
-          line: 3075
-          column: 23
-        end:
-          line: 3075
-          column: 27
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
         code: "C010"
         severity: "warning"
         message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
@@ -18007,50 +17908,6 @@ repos:
           line: 3380
           column: 23
         classification: real
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `mtime` is referenced before assignment"
-        start:
-          line: 3418
-          column: 40
-        end:
-          line: 3418
-          column: 45
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `side` is referenced before assignment"
-        start:
-          line: 3418
-          column: 61
-        end:
-          line: 3418
-          column: 65
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `install` is referenced before assignment"
-        start:
-          line: 3419
-          column: 21
-        end:
-          line: 3419
-          column: 28
-        classification: false_positive
-      - path: "zinit-autoload.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `autoload` is referenced before assignment"
-        start:
-          line: 3419
-          column: 44
-        end:
-          line: 3419
-          column: 52
-        classification: false_positive
       - path: "zinit-autoload.zsh"
         code: "C003"
         severity: "warning"
@@ -18261,39 +18118,6 @@ repos:
           column: 62
         classification: real
       - path: "zinit-install.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `annex` is referenced before assignment"
-        start:
-          line: 330
-          column: 11
-        end:
-          line: 330
-          column: 16
-        classification: false_positive
-      - path: "zinit-install.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `multi` is referenced before assignment"
-        start:
-          line: 330
-          column: 17
-        end:
-          line: 330
-          column: 22
-        classification: false_positive
-      - path: "zinit-install.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `flag` is referenced before assignment"
-        start:
-          line: 330
-          column: 23
-        end:
-          line: 330
-          column: 27
-        classification: false_positive
-      - path: "zinit-install.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `pid_hl` is assigned but never used"
@@ -18447,50 +18271,6 @@ repos:
           line: 1287
           column: 9
         classification: real
-      - path: "zinit-install.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `opt` is referenced before assignment"
-        start:
-          line: 1296
-          column: 60
-        end:
-          line: 1296
-          column: 63
-        classification: false_positive
-      - path: "zinit-install.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `has` is referenced before assignment"
-        start:
-          line: 1296
-          column: 69
-        end:
-          line: 1296
-          column: 72
-        classification: false_positive
-      - path: "zinit-install.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `been` is referenced before assignment"
-        start:
-          line: 1296
-          column: 73
-        end:
-          line: 1296
-          column: 77
-        classification: false_positive
-      - path: "zinit-install.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `run` is referenced before assignment"
-        start:
-          line: 1296
-          column: 78
-        end:
-          line: 1296
-          column: 81
-        classification: false_positive
       - path: "zinit-install.zsh"
         code: "C001"
         severity: "warning"
@@ -18866,28 +18646,6 @@ repos:
           column: 26
         classification: false_positive
       - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `ice` is referenced before assignment"
-        start:
-          line: 77
-          column: 7
-        end:
-          line: 77
-          column: 10
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `nval` is referenced before assignment"
-        start:
-          line: 98
-          column: 7
-        end:
-          line: 98
-          column: 11
-        classification: false_positive
-      - path: "zinit.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `ZINIT_2MAP` is assigned but never used"
@@ -18932,28 +18690,6 @@ repos:
           column: 23
         classification: real
       - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `BINDKEYS___dtrace` is referenced before assignment"
-        start:
-          line: 551
-          column: 45
-        end:
-          line: 551
-          column: 62
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `_dtrace` is referenced before assignment"
-        start:
-          line: 551
-          column: 63
-        end:
-          line: 551
-          column: 70
-        classification: false_positive
-      - path: "zinit.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `Nopt` is assigned but never used"
@@ -18965,17 +18701,6 @@ repos:
           column: 23
         classification: real
       - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `ZSTYLES___dtrace` is referenced before assignment"
-        start:
-          line: 620
-          column: 45
-        end:
-          line: 620
-          column: 61
-        classification: false_positive
-      - path: "zinit.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `avalue` is assigned but never used"
@@ -18986,127 +18711,6 @@ repos:
           line: 652
           column: 21
         classification: real
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `ALIASES___dtrace` is referenced before assignment"
-        start:
-          line: 677
-          column: 45
-        end:
-          line: 677
-          column: 61
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `WIDGETS_DELETE___dtrace` is referenced before assignment"
-        start:
-          line: 708
-          column: 53
-        end:
-          line: 708
-          column: 76
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `WIDGETS_SAVED___dtrace` is referenced before assignment"
-        start:
-          line: 726
-          column: 53
-        end:
-          line: 726
-          column: 75
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bkp` is referenced before assignment"
-        start:
-          line: 782
-          column: 48
-        end:
-          line: 782
-          column: 51
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `autoload` is referenced before assignment"
-        start:
-          line: 782
-          column: 52
-        end:
-          line: 782
-          column: 60
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `compdef` is referenced before assignment"
-        start:
-          line: 787
-          column: 47
-        end:
-          line: 787
-          column: 54
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `source` is referenced before assignment"
-        start:
-          line: 792
-          column: 50
-        end:
-          line: 792
-          column: 56
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bindkey` is referenced before assignment"
-        start:
-          line: 806
-          column: 47
-        end:
-          line: 806
-          column: 54
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `zstyle` is referenced before assignment"
-        start:
-          line: 813
-          column: 46
-        end:
-          line: 813
-          column: 52
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `alias` is referenced before assignment"
-        start:
-          line: 817
-          column: 45
-        end:
-          line: 817
-          column: 50
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `zle` is referenced before assignment"
-        start:
-          line: 821
-          column: 43
-        end:
-          line: 821
-          column: 46
-        classification: false_positive
       - path: "zinit.zsh"
         code: "C081"
         severity: "warning"
@@ -19316,17 +18920,6 @@ repos:
           line: 1351
           column: 40
         classification: real
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `___m_bkp` is referenced before assignment"
-        start:
-          line: 1361
-          column: 15
-        end:
-          line: 1361
-          column: 23
-        classification: false_positive
       - path: "zinit.zsh"
         code: "C108"
         severity: "warning"
@@ -19856,50 +19449,6 @@ repos:
           column: 47
         classification: real
       - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `annex` is referenced before assignment"
-        start:
-          line: 2689
-          column: 15
-        end:
-          line: 2689
-          column: 20
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `exposed` is referenced before assignment"
-        start:
-          line: 2689
-          column: 21
-        end:
-          line: 2689
-          column: 28
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `processed` is referenced before assignment"
-        start:
-          line: 2689
-          column: 29
-        end:
-          line: 2689
-          column: 38
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `IDs` is referenced before assignment"
-        start:
-          line: 2689
-          column: 39
-        end:
-          line: 2689
-          column: 42
-        classification: false_positive
-      - path: "zinit.zsh"
         code: "C099"
         severity: "warning"
         message: "all-elements array expansions collapse in scalar assignment values"
@@ -20020,28 +19569,6 @@ repos:
           line: 3133
           column: 67
         classification: real
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `STATES___local` is referenced before assignment"
-        start:
-          line: 3255
-          column: 7
-        end:
-          line: 3255
-          column: 21
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `zinit` is referenced before assignment"
-        start:
-          line: 3255
-          column: 22
-        end:
-          line: 3255
-          column: 27
-        classification: false_positive
       - path: "zinit.zsh"
         code: "C005"
         severity: "warning"

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -201,7 +201,7 @@ fn arithmetic_index_uses_zsh_option_map_key_semantics(
         {
             return true;
         }
-        if !zsh_option_map_binding_origin(owner_name, binding, source)
+        if !zsh_implicit_assoc_binding_origin(owner_name, binding, source)
             || zsh_option_map_binding_has_prior_assoc_lookup_blocker(
                 semantic, owner_name, binding, source,
             )
@@ -217,7 +217,8 @@ fn arithmetic_index_uses_zsh_option_map_key_semantics(
         source,
     )
         && semantic.shell_profile().dialect == shuck_parser::parser::ShellDialect::Zsh
-        && zsh_option_map_subscript_key(owner_name.as_str(), index.span.slice(source))
+        && (zsh_option_map_subscript_key(owner_name.as_str(), index.span.slice(source))
+            || zsh_external_assoc_subscript_key(owner_name.as_str(), index.span.slice(source)))
 }
 
 fn zsh_option_map_binding_permits_implicit_assoc_key(
@@ -233,10 +234,15 @@ fn zsh_option_map_binding_permits_implicit_assoc_key(
         return true;
     }
 
-    zsh_option_map_binding_origin(owner_name, binding, source)
+    zsh_implicit_assoc_binding_origin(owner_name, binding, source)
         && !zsh_option_map_binding_has_prior_assoc_lookup_blocker(
             semantic, owner_name, binding, source,
         )
+}
+
+fn zsh_implicit_assoc_binding_origin(owner_name: &Name, binding: &Binding, source: &str) -> bool {
+    zsh_option_map_binding_origin(owner_name, binding, source)
+        || zsh_external_assoc_binding_origin(owner_name, binding, source)
 }
 
 fn zsh_option_map_binding_origin(owner_name: &Name, binding: &Binding, source: &str) -> bool {
@@ -246,6 +252,24 @@ fn zsh_option_map_binding_origin(owner_name: &Name, binding: &Binding, source: &
         } => zsh_option_map_assignment_target(owner_name, definition_span.slice(source)),
         shuck_semantic::BindingOrigin::ArithmeticAssignment { target_span, .. } => {
             zsh_option_map_assignment_target(owner_name, target_span.slice(source))
+        }
+        shuck_semantic::BindingOrigin::ParameterDefaultAssignment { .. }
+        | shuck_semantic::BindingOrigin::LoopVariable { .. }
+        | shuck_semantic::BindingOrigin::Imported { .. }
+        | shuck_semantic::BindingOrigin::FunctionDefinition { .. }
+        | shuck_semantic::BindingOrigin::BuiltinTarget { .. }
+        | shuck_semantic::BindingOrigin::Declaration { .. }
+        | shuck_semantic::BindingOrigin::Nameref { .. } => false,
+    }
+}
+
+fn zsh_external_assoc_binding_origin(owner_name: &Name, binding: &Binding, source: &str) -> bool {
+    match &binding.origin {
+        shuck_semantic::BindingOrigin::Assignment {
+            definition_span, ..
+        } => zsh_external_assoc_assignment_target(owner_name, definition_span.slice(source)),
+        shuck_semantic::BindingOrigin::ArithmeticAssignment { target_span, .. } => {
+            zsh_external_assoc_assignment_target(owner_name, target_span.slice(source))
         }
         shuck_semantic::BindingOrigin::ParameterDefaultAssignment { .. }
         | shuck_semantic::BindingOrigin::LoopVariable { .. }
@@ -268,7 +292,7 @@ fn zsh_option_map_binding_has_prior_assoc_lookup_blocker(
         candidate.scope == binding.scope
             && candidate.span.start.offset < binding.span.start.offset
             && zsh_option_map_binding_blocks_assoc_lookup(candidate)
-            && !zsh_option_map_binding_origin(owner_name, candidate, source)
+            && !zsh_implicit_assoc_binding_origin(owner_name, candidate, source)
     })
 }
 
@@ -296,6 +320,17 @@ fn zsh_option_map_assignment_target(owner_name: &Name, text: &str) -> bool {
     zsh_option_map_subscript_key(owner_name.as_str(), subscript)
 }
 
+fn zsh_external_assoc_assignment_target(owner_name: &Name, text: &str) -> bool {
+    let Some(rest) = text.strip_prefix(owner_name.as_str()) else {
+        return false;
+    };
+    let Some(subscript) = rest.strip_prefix('[').and_then(|rest| rest.strip_suffix(']')) else {
+        return false;
+    };
+
+    zsh_external_assoc_subscript_key(owner_name.as_str(), subscript)
+}
+
 fn zsh_option_map_subscript_key(owner_name: &str, text: &str) -> bool {
     if owner_name != "OPTS" {
         return false;
@@ -320,6 +355,18 @@ fn zsh_option_map_subscript_key(owner_name: &str, text: &str) -> bool {
         && long_option
             .chars()
             .all(|ch| ch == '-' || ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn zsh_external_assoc_subscript_key(owner_name: &str, text: &str) -> bool {
+    if owner_name != "ZINIT" {
+        return false;
+    }
+
+    let text = text.trim();
+    !text.is_empty()
+        && text.chars().all(|ch| {
+            ch == '-' || ch == '_' || ch == '/' || ch == ':' || ch.is_ascii_alphanumeric()
+        })
 }
 
 fn collect_base_prefix_spans_in_command_parts(

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -2245,7 +2245,14 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             Some(assignment.target.name_span),
             assignment.target.subscript.as_deref(),
         );
-        if !indexed_semantics {
+        let external_zsh_assoc_key =
+            Self::zsh_assignment_target_subscript_has_external_assoc_key_semantics(
+                self.semantic.shell_profile().dialect,
+                &assignment.target.name,
+                assignment.target.subscript.as_deref(),
+                self.source,
+            );
+        if !indexed_semantics || external_zsh_assoc_key {
             self.surface
                 .record_arithmetic_only_suppressed_subscript(assignment.target.subscript.as_deref());
         }
@@ -3033,6 +3040,24 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }
 
         true
+    }
+
+    fn zsh_assignment_target_subscript_has_external_assoc_key_semantics(
+        dialect: shuck_parser::parser::ShellDialect,
+        owner_name: &Name,
+        subscript: Option<&Subscript>,
+        source: &str,
+    ) -> bool {
+        if dialect != shuck_parser::parser::ShellDialect::Zsh {
+            return false;
+        }
+        let Some(subscript) = subscript else {
+            return false;
+        };
+        if subscript.selector().is_some() {
+            return false;
+        }
+        super::zsh_external_assoc_subscript_key(owner_name.as_str(), subscript.syntax_text(source))
     }
 
     fn assoc_binding_visible_for_subscript(

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -624,6 +624,29 @@ print -r -- ${functions[iterm2_precmd]}
     }
 
     #[test]
+    fn suppresses_external_zinit_state_map_keys() {
+        let source = "\
+#!/bin/zsh
+ZINIT[annex-multi-flag:pull-active]=0
+ZINIT[BINDKEYS___dtrace/_dtrace]+=x
+(( ZINIT[-r/--reset-opt-hook-has-been-run] == 0 ))
+arr[annex-multi-flag]=0
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["annex", "multi", "flag"]
+        );
+    }
+
+    #[test]
     fn zparseopts_targets_initialize_option_arrays() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
## Summary
- treat literal `ZINIT[...]` subscripts as keys in zinit's externally provided associative state map
- apply that suppression in assignment targets and arithmetic expressions while keeping arbitrary indexed arithmetic like `arr[annex-multi-flag]` reportable
- remove 43 C006 false positives from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-linter suppresses_external_zinit_state_map_keys --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

## Performance
Compared impacted Criterion groups against updated `origin/main` baseline `zsh-zinit-main`:
- `check_command_concise/all`: -1.41%
- `check_command_full/all`: -0.86%
- `linter_facts/all`: +0.37%
- `linter/all`: -0.22%
