### PR TITLE
fix(linter): recognize zsh reply helper outputs

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -765,17 +765,6 @@ repos:
           column: 80
         classification: real
       - path: "update.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `reply` is referenced before assignment"
-        start:
-          line: 266
-          column: 26
-        end:
-          line: 266
-          column: 32
-        classification: false_positive
-      - path: "update.zsh"
         code: "C055"
         severity: "warning"
         message: "pattern expressions should not expand variables"
@@ -16310,17 +16299,6 @@ repos:
           column: 42
         classification: real
       - path: "core/update.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `reply` is referenced before assignment"
-        start:
-          line: 52
-          column: 34
-        end:
-          line: 52
-          column: 45
-        classification: false_positive
-      - path: "core/update.zsh"
         code: "C002"
         severity: "warning"
         message: "source path is built at runtime"
@@ -16353,17 +16331,6 @@ repos:
           line: 67
           column: 26
         classification: real
-      - path: "modules/apt/apt.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `reply` is referenced before assignment"
-        start:
-          line: 15
-          column: 6
-        end:
-          line: 15
-          column: 17
-        classification: false_positive
       - path: "modules/autocompletion/autocompletion.zsh"
         code: "C001"
         severity: "warning"
@@ -16429,17 +16396,6 @@ repos:
         end:
           line: 17
           column: 33
-        classification: false_positive
-      - path: "modules/brew/brew.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `reply` is referenced before assignment"
-        start:
-          line: 29
-          column: 46
-        end:
-          line: 29
-          column: 57
         classification: false_positive
       - path: "modules/dotfiler/dotfiler.zsh"
         code: "C003"

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -1531,7 +1531,9 @@ fn zsh_reply_helper_reset_span(command: &CommandFact<'_>) -> Option<Span> {
 }
 
 fn zsh_helper_name_can_set_reply(name: &str) -> bool {
-    (name.starts_with('.') && name != "." && name != "..") || name.starts_with('_')
+    (name.starts_with('.') && name != "." && name != "..")
+        || name.starts_with('_')
+        || matches!(name, "zdot_provides_tool_args")
 }
 
 fn helper_output_names_by_scope(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -924,6 +924,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 &command_fact_indices_by_id,
                 &innermost_command_ids_by_offset,
                 &subscript_later_suppression_spans,
+                self.source,
             );
 
         let mut backtick_substitution_spans = word_spans::backtick_substitution_spans(locator);
@@ -1186,6 +1187,7 @@ fn build_c006_suppressing_reference_offsets_by_name(
     command_fact_indices_by_id: &[Option<usize>],
     innermost_command_ids_by_offset: &CommandOffsetLookup,
     subscript_later_suppression_spans: &[Span],
+    source: &str,
 ) -> FxHashMap<Name, Vec<usize>> {
     let mut offsets_by_name = semantic
         .guarded_or_defaulting_reference_offsets_by_name()
@@ -1205,6 +1207,21 @@ fn build_c006_suppressing_reference_offsets_by_name(
                     .entry(reference.name.clone())
                     .or_default()
                     .push(reference.span.start.offset);
+            }
+        }
+    }
+
+    for command in commands {
+        if command.shell_behavior().shell_dialect() == shuck_semantic::ShellDialect::Zsh
+            && zsh_reply_helper_reset_span(command).is_some()
+            && command_runs_in_persistent_shell_context(semantic, command, source)
+            && let Some(name_word) = command.body_name_word()
+        {
+            for name in ["REPLY", "reply"] {
+                offsets_by_name
+                    .entry(Name::from(name))
+                    .or_default()
+                    .push(name_word.span.start.offset);
             }
         }
     }

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -832,6 +832,30 @@ _update_core_safe_rm() {
     }
 
     #[test]
+    fn zsh_reply_helpers_initialize_reply_for_later_reads() {
+        let source = "\
+#!/bin/zsh
+_update_core_resolve_subtree_spec repo spec
+remote=$reply[1]
+zdot_provides_tool_args ':zdot:brew' op eza gh
+zdot_simple_hook brew \"${reply[@]}\"
+print -r -- $missing
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
     fn zsh_sourced_hook_helpers_accept_caller_scoped_option_arrays() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
## Summary
- treat zsh helper commands that populate `reply` as suppressing later C006 reports for `reply`/`REPLY`
- include `zdot_provides_tool_args` in the reply-helper classifier alongside existing underscore and dot helper conventions
- remove 4 C006 false positives from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-linter zsh_reply_helpers_initialize_reply_for_later_reads --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

## Performance
Compared impacted Criterion groups against updated `origin/main` baseline `zsh-reply-main`:
- `check_command_concise/all`: -1.47%
- `check_command_full/all`: -0.87%
- `linter_facts/all`: -3.14%
- `linter/all`: -0.41%
