### PR TITLE
fix(linter): initialize dotfiler hook registry

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -28,17 +28,6 @@ repos:
           column: 24
         classification: real
       - path: "check_update.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `_dotfiler_registered_hooks` is referenced before assignment"
-        start:
-          line: 168
-          column: 71
-        end:
-          line: 168
-          column: 103
-        classification: false_positive
-      - path: "check_update.zsh"
         code: "C008"
         severity: "warning"
         message: "double-quoted trap handlers expand variables when the trap is set"
@@ -413,17 +402,6 @@ repos:
           column: 41
         classification: real
       - path: "setup.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `_dotfiler_registered_hooks` is referenced before assignment"
-        start:
-          line: 167
-          column: 19
-        end:
-          line: 167
-          column: 49
-        classification: false_positive
-      - path: "setup.zsh"
         code: "C002"
         severity: "warning"
         message: "source path is built at runtime"
@@ -489,17 +467,6 @@ repos:
           line: 256
           column: 28
         classification: real
-      - path: "setup_core.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `_dotfiler_registered_hooks` is referenced before assignment"
-        start:
-          line: 163
-          column: 19
-        end:
-          line: 163
-          column: 51
-        classification: false_positive
       - path: "setup_core.zsh"
         code: "C055"
         severity: "warning"
@@ -808,17 +775,6 @@ repos:
           line: 509
           column: 47
         classification: real
-      - path: "update.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `_dotfiler_registered_hooks` is referenced before assignment"
-        start:
-          line: 688
-          column: 27
-        end:
-          line: 688
-          column: 57
-        classification: false_positive
       - path: "update.zsh"
         code: "C002"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -396,6 +396,24 @@ compstate[insert]=menu
 }
 
 #[test]
+fn zsh_runtime_contract_initializes_dotfiler_hook_registry() {
+    let path = Path::new("/tmp/zsh/dotfiler/setup.zsh");
+    let source = "\
+local _before=${#_dotfiler_registered_hooks}
+for name in \"${_dotfiler_registered_hooks[@]}\"; do
+  print -r -- \"$name\"
+done
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    assert!(has_initialized_binding(
+        &contract,
+        "_dotfiler_registered_hooks"
+    ));
+}
+
+#[test]
 fn pathless_zsh_hook_arrays_do_not_get_ambient_contracts() {
     let source = "precmd_functions=(${precmd_functions:#_example_precmd})\n";
 

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -71,6 +71,7 @@ fn zsh_ambient_runtime_has_signal(source: &SourceSignals<'_>, path: &PathSignals
     source.mentions_any(ZSH_INITIALIZED_SPECIAL_PARAMETERS)
         || source.mentions_any(ZSH_HOOK_ARRAY_PARAMETERS)
         || zsh_prompt_color_runtime_shape(source, path)
+        || dotfiler_runtime_shape(source, path)
         || !zsh_externally_consumed_names(source, path).is_empty()
         || zsh_test_fixture_consumed_prefixes(source, path)
             .next()
@@ -101,6 +102,14 @@ fn zsh_initialized_runtime_names<'a>(
                 .copied()
                 .filter(move |name| {
                     source.mentions_name(name) && zsh_runtime_path_shape(path.lower_path())
+                }),
+        )
+        .chain(
+            DOTFILER_RUNTIME_PARAMETERS
+                .iter()
+                .copied()
+                .filter(move |name| {
+                    source.mentions_name(name) && dotfiler_runtime_shape(source, path)
                 }),
         )
 }
@@ -198,7 +207,13 @@ const ZSH_PROMPT_COLOR_PARAMETERS: &[&str] = &[
 const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
     &["REPLY", "compstate", "comppostfuncs", "reply"];
 
+const DOTFILER_RUNTIME_PARAMETERS: &[&str] = &["_dotfiler_registered_hooks"];
+
 fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
     (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())
         && source.mentions_any(ZSH_PROMPT_COLOR_PARAMETERS)
+}
+
+fn dotfiler_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
+    path.lower_path().contains("/dotfiler/") && source.mentions_any(DOTFILER_RUNTIME_PARAMETERS)
 }

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1281,6 +1281,31 @@ print -r -- $chpwd_functions $still_missing
     }
 
     #[test]
+    fn dotfiler_hook_registry_is_initialized_by_dotfiler_runtime() {
+        let source = "\
+#!/bin/zsh
+local _before=${#_dotfiler_registered_hooks}
+for name in \"${_dotfiler_registered_hooks[@]}\"; do
+  print -r -- \"$name\"
+done
+print -r -- $still_missing
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/dotfiler/setup.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$still_missing"]
+        );
+    }
+
+    #[test]
     fn pathless_zsh_hook_array_references_stay_reportable() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
Summary:
- add a path-scoped Dotfiler ambient binding for `_dotfiler_registered_hooks`
- remove four resolved C006 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter dotfiler --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-dotfiler-main`:
- `check_command_concise/all`: -1.2535%
- `check_command_full/all`: -0.6492%
- `linter_facts/all`: +0.2847% (not significant)
- `linter/all`: -0.6395%