### PR TITLE
fix(linter): initialize oh-my-zsh emotty emoji arrays

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -2840,28 +2840,6 @@ repos:
           line: 67
           column: 31
         classification: false_positive
-      - path: "plugins/emotty/emotty.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji` is referenced before assignment"
-        start:
-          line: 42
-          column: 9
-        end:
-          line: 42
-          column: 36
-        classification: false_positive
-      - path: "plugins/emotty/emotty.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji2` is referenced before assignment"
-        start:
-          line: 42
-          column: 36
-        end:
-          line: 42
-          column: 58
-        classification: false_positive
       - path: "plugins/emotty/emotty_emoji_set.zsh"
         code: "C006"
         severity: "error"
@@ -7393,28 +7371,6 @@ repos:
         end:
           line: 118
           column: 8
-        classification: false_positive
-      - path: "themes/emotty.zsh-theme"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji` is referenced before assignment"
-        start:
-          line: 60
-          column: 14
-        end:
-          line: 60
-          column: 20
-        classification: false_positive
-      - path: "themes/emotty.zsh-theme"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji2` is referenced before assignment"
-        start:
-          line: 63
-          column: 61
-        end:
-          line: 63
-          column: 68
         classification: false_positive
       - path: "themes/emotty.zsh-theme"
         code: "C001"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -208,6 +208,20 @@ less_termcap[me]=\"${reset_color}\"
 }
 
 #[test]
+fn zsh_runtime_contract_initializes_ohmyzsh_emotty_emoji_arrays() {
+    let path = Path::new("/tmp/zsh/ohmyzsh/plugins/emotty/emotty.plugin.zsh");
+    let source = "\
+print -r -- \"${emoji[smile]}${emoji2[emoji_style]}\"
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    for name in ["emoji", "emoji2"] {
+        assert!(has_initialized_binding(&contract, name), "{contract:?}");
+    }
+}
+
+#[test]
 fn zsh_runtime_contract_initializes_prompt_colors_after_colors_autoload() {
     let path = Path::new("/tmp/zsh/holman-dotfiles/zsh/prompt.zsh");
     let source = "\

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -71,6 +71,7 @@ fn zsh_ambient_runtime_has_signal(source: &SourceSignals<'_>, path: &PathSignals
     source.mentions_any(ZSH_INITIALIZED_SPECIAL_PARAMETERS)
         || source.mentions_any(ZSH_HOOK_ARRAY_PARAMETERS)
         || zsh_prompt_color_runtime_shape(source, path)
+        || ohmyzsh_emotty_runtime_shape(source, path)
         || !zsh_externally_consumed_names(source, path).is_empty()
         || zsh_test_fixture_consumed_prefixes(source, path)
             .next()
@@ -101,6 +102,14 @@ fn zsh_initialized_runtime_names<'a>(
                 .copied()
                 .filter(move |name| {
                     source.mentions_name(name) && zsh_runtime_path_shape(path.lower_path())
+                }),
+        )
+        .chain(
+            OHMYZSH_EMOTTY_PARAMETERS
+                .iter()
+                .copied()
+                .filter(move |name| {
+                    source.mentions_name(name) && ohmyzsh_emotty_runtime_shape(source, path)
                 }),
         )
 }
@@ -198,7 +207,17 @@ const ZSH_PROMPT_COLOR_PARAMETERS: &[&str] = &[
 const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
     &["REPLY", "compstate", "comppostfuncs", "reply"];
 
+const OHMYZSH_EMOTTY_PARAMETERS: &[&str] = &["emoji", "emoji2"];
+
 fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
     (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())
         && source.mentions_any(ZSH_PROMPT_COLOR_PARAMETERS)
+}
+
+fn ohmyzsh_emotty_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
+    (path.lower_path().contains("/ohmyzsh/plugins/emotty/")
+        || path
+            .lower_path()
+            .ends_with("/ohmyzsh/themes/emotty.zsh-theme"))
+        && source.mentions_any(OHMYZSH_EMOTTY_PARAMETERS)
 }

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1281,6 +1281,27 @@ print -r -- $chpwd_functions $still_missing
     }
 
     #[test]
+    fn ohmyzsh_emotty_reads_emoji_arrays_from_plugin_dependency() {
+        let source = "\
+#!/bin/zsh
+print -r -- \"${emoji[smile]}${emoji2[emoji_style]}\" \"$still_missing\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/plugins/emotty/emotty.plugin.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$still_missing"]
+        );
+    }
+
+    #[test]
     fn pathless_zsh_hook_array_references_stay_reportable() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
Summary:
- add a narrow oh-my-zsh emotty runtime contract for the emoji plugin arrays
- remove four C006 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter emotty --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-emotty-main`:
- `check_command_concise/all`: -1.7421%
- `check_command_full/all`: -1.3768%
- `linter_facts/all`: -1.9953% (not significant)
- `linter/all`: +0.2938%