### PR TITLE
fix(linter): initialize oh-my-zsh tool colors

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -7867,28 +7867,6 @@ repos:
           line: 273
           column: 39
         classification: real
-      - path: "tools/check_for_upgrade.sh"
-        code: "C006"
-        severity: "error"
-        message: "variable `fg` is referenced before assignment"
-        start:
-          line: 283
-          column: 21
-        end:
-          line: 283
-          column: 34
-        classification: false_positive
-      - path: "tools/check_for_upgrade.sh"
-        code: "C006"
-        severity: "error"
-        message: "variable `reset_color` is referenced before assignment"
-        start:
-          line: 283
-          column: 36
-        end:
-          line: 283
-          column: 50
-        classification: false_positive
       - path: "tools/install.sh"
         code: "C010"
         severity: "warning"
@@ -7943,28 +7921,6 @@ repos:
         end:
           line: 16
           column: 13
-        classification: false_positive
-      - path: "tools/theme_chooser.sh"
-        code: "C006"
-        severity: "error"
-        message: "variable `fg` is referenced before assignment"
-        start:
-          line: 25
-          column: 12
-        end:
-          line: 25
-          column: 15
-        classification: false_positive
-      - path: "tools/theme_chooser.sh"
-        code: "C006"
-        severity: "error"
-        message: "variable `reset_color` is referenced before assignment"
-        start:
-          line: 25
-          column: 63
-        end:
-          line: 25
-          column: 75
         classification: false_positive
       - path: "tools/theme_chooser.sh"
         code: "C002"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -208,6 +208,20 @@ less_termcap[me]=\"${reset_color}\"
 }
 
 #[test]
+fn zsh_runtime_contract_initializes_ohmyzsh_tool_prompt_colors() {
+    let path = Path::new("/tmp/zsh/ohmyzsh/tools/theme_chooser.sh");
+    let source = "\
+print \"$fg[blue]${reset_color}\"
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    for name in ["fg", "reset_color"] {
+        assert!(has_initialized_binding(&contract, name), "{contract:?}");
+    }
+}
+
+#[test]
 fn zsh_runtime_contract_initializes_prompt_colors_after_colors_autoload() {
     let path = Path::new("/tmp/zsh/holman-dotfiles/zsh/prompt.zsh");
     let source = "\

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -199,6 +199,12 @@ const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
     &["REPLY", "compstate", "comppostfuncs", "reply"];
 
 fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
-    (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())
+    (zsh_runtime_path_shape(path.lower_path())
+        || source.loads_zsh_colors()
+        || ohmyzsh_tools_path_shape(path))
         && source.mentions_any(ZSH_PROMPT_COLOR_PARAMETERS)
+}
+
+fn ohmyzsh_tools_path_shape(path: &PathSignals) -> bool {
+    path.lower_path().contains("/ohmyzsh/tools/")
 }

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1281,6 +1281,27 @@ print -r -- $chpwd_functions $still_missing
     }
 
     #[test]
+    fn ohmyzsh_tools_read_prompt_colors_from_framework_runtime() {
+        let source = "\
+#!/bin/zsh
+print \"$fg[blue]${reset_color}\" \"$still_missing\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/tools/theme_chooser.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$still_missing"]
+        );
+    }
+
+    #[test]
     fn pathless_zsh_hook_array_references_stay_reportable() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
Summary:
- treat oh-my-zsh tools as framework runtime context for prompt color arrays
- remove four C006 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter ohmyzsh_tool --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-tools-colors-main`:
- `check_command_concise/all`: -0.7000%
- `check_command_full/all`: -0.6433%
- `linter_facts/all`: +0.1881% (not significant)
- `linter/all`: +0.8118%