### PR TITLE
fix(linter): recognize Windows ProgramW6432 environment

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -6297,17 +6297,6 @@ repos:
       - path: "plugins/sublime-merge/sublime-merge.plugin.zsh"
         code: "C006"
         severity: "error"
-        message: "variable `ProgramW6432` is referenced before assignment"
-        start:
-          line: 42
-          column: 15
-        end:
-          line: 42
-          column: 28
-        classification: false_positive
-      - path: "plugins/sublime-merge/sublime-merge.plugin.zsh"
-        code: "C006"
-        severity: "error"
         message: "variable `_sublime_merge_cygwin_paths` is referenced before assignment"
         start:
           line: 44
@@ -6327,17 +6316,6 @@ repos:
           line: 45
           column: 12
         classification: real
-      - path: "plugins/sublime/sublime.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `ProgramW6432` is referenced before assignment"
-        start:
-          line: 51
-          column: 19
-        end:
-          line: 51
-          column: 32
-        classification: false_positive
       - path: "plugins/sublime/sublime.plugin.zsh"
         code: "C122"
         severity: "warning"

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1281,6 +1281,26 @@ print -r -- $chpwd_functions $still_missing
     }
 
     #[test]
+    fn known_mixed_case_environment_names_follow_default_environment_suppression() {
+        let source = "\
+#!/bin/zsh
+print -r -- \"$ProgramW6432\" \"$still_missing\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$still_missing"]
+        );
+    }
+
+    #[test]
     fn pathless_zsh_hook_array_references_stay_reportable() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
+++ b/crates/shuck-linter/src/rules/correctness/variable_reference_common.rs
@@ -56,10 +56,11 @@ pub(super) fn is_reportable_variable_reference(
 }
 
 pub(super) fn is_environment_style_name(name: &str) -> bool {
-    !name.is_empty()
-        && name
-            .chars()
-            .all(|char| char.is_ascii_uppercase() || char.is_ascii_digit() || char == '_')
+    matches!(name, "ProgramW6432")
+        || (!name.is_empty()
+            && name
+                .chars()
+                .all(|char| char.is_ascii_uppercase() || char.is_ascii_digit() || char == '_'))
 }
 
 pub(super) fn is_sc2154_defining_binding(kind: BindingKind) -> bool {


### PR DESCRIPTION
Summary:
- recognize the known mixed-case Windows `ProgramW6432` environment variable under the default C006 environment-name suppression
- remove two C006 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter known_mixed_case_environment_names --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-programw-main`:
- `check_command_concise/all`: -1.3955%
- `check_command_full/all`: -0.6937%
- `linter_facts/all`: -0.5776% (not significant)
- `linter/all`: -0.2382% (not significant)