### PR TITLE
fix(linter): initialize zsh nameddirs parameter

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -5954,17 +5954,6 @@ repos:
           column: 34
         classification: real
       - path: "plugins/scd/scd"
-        code: "C006"
-        severity: "error"
-        message: "variable `nameddirs` is referenced before assignment"
-        start:
-          line: 168
-          column: 24
-        end:
-          line: 168
-          column: 40
-        classification: false_positive
-      - path: "plugins/scd/scd"
         code: "C002"
         severity: "warning"
         message: "source path is built at runtime"
@@ -6173,17 +6162,6 @@ repos:
           line: 138
           column: 26
         classification: real
-      - path: "plugins/shrink-path/shrink-path.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `nameddirs` is referenced before assignment"
-        start:
-          line: 151
-          column: 29
-        end:
-          line: 151
-          column: 44
-        classification: false_positive
       - path: "plugins/shrink-path/shrink-path.plugin.zsh"
         code: "C088"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -153,6 +153,7 @@ prompt=\"%{$fg_bold[blue]%}%{$reset_color%}\"
         "history",
         "words",
         "compstate",
+        "nameddirs",
         "fg_bold",
         "reset_color",
     ] {

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -118,7 +118,7 @@ fn zsh_special_parameter_available(
             zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_module("zsh/langinfo")
         }
         "compstate" | "words" => zsh_runtime_path_shape(path.lower_path()),
-        "galiases" | "history" | "keymaps" | "reswords" | "saliases" => {
+        "galiases" | "history" | "keymaps" | "nameddirs" | "reswords" | "saliases" => {
             zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_module("zsh/parameter")
         }
         _ => true,
@@ -175,6 +175,7 @@ const ZSH_INITIALIZED_SPECIAL_PARAMETERS: &[&str] = &[
     "history",
     "keymaps",
     "langinfo",
+    "nameddirs",
     "parameters",
     "reswords",
     "saliases",

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1281,6 +1281,27 @@ print -r -- $chpwd_functions $still_missing
     }
 
     #[test]
+    fn zsh_runtime_special_parameters_include_named_directories() {
+        let source = "\
+#!/bin/zsh
+print -r -- $nameddirs $still_missing
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/plugins/scd/scd"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$still_missing"]
+        );
+    }
+
+    #[test]
     fn pathless_zsh_hook_array_references_stay_reportable() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
Summary:
- add `nameddirs` to the zsh initialized special-parameter contract
- remove two C006 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter named_directories --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-nameddirs-main`:
- `check_command_concise/all`: -0.7980%
- `check_command_full/all`: -0.4486%
- `linter_facts/all`: -1.5290%
- `linter/all`: -1.4421%