### PR TITLE
fix(linter): initialize zsh histchars parameter

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -20568,17 +20568,6 @@ repos:
           column: 53
         classification: real
       - path: "highlighters/main/main-highlighter.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `histchars` is referenced before assignment"
-        start:
-          line: 693
-          column: 71
-        end:
-          line: 693
-          column: 84
-        classification: false_positive
-      - path: "highlighters/main/main-highlighter.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -21622,17 +21611,6 @@ repos:
         end:
           line: 52
           column: 12
-        classification: false_positive
-      - path: "zsh-syntax-highlighting.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `histchars` is referenced before assignment"
-        start:
-          line: 59
-          column: 50
-        end:
-          line: 59
-          column: 63
         classification: false_positive
       - path: "zsh-syntax-highlighting.zsh"
         code: "C005"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -150,6 +150,7 @@ prompt=\"%{$fg_bold[blue]%}%{$reset_color%}\"
 
     for name in [
         "sysparams",
+        "histchars",
         "history",
         "words",
         "compstate",

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -118,7 +118,7 @@ fn zsh_special_parameter_available(
             zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_module("zsh/langinfo")
         }
         "compstate" | "words" => zsh_runtime_path_shape(path.lower_path()),
-        "galiases" | "history" | "keymaps" | "reswords" | "saliases" => {
+        "galiases" | "histchars" | "history" | "keymaps" | "reswords" | "saliases" => {
             zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_module("zsh/parameter")
         }
         _ => true,
@@ -172,6 +172,7 @@ fn zsh_test_fixture_consumed_prefixes<'a>(
 const ZSH_INITIALIZED_SPECIAL_PARAMETERS: &[&str] = &[
     "compstate",
     "galiases",
+    "histchars",
     "history",
     "keymaps",
     "langinfo",

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1281,6 +1281,27 @@ print -r -- $chpwd_functions $still_missing
     }
 
     #[test]
+    fn zsh_runtime_special_parameters_include_history_characters() {
+        let source = "\
+#!/bin/zsh
+print -r -- $histchars $still_missing
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$still_missing"]
+        );
+    }
+
+    #[test]
     fn pathless_zsh_hook_array_references_stay_reportable() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
Summary:
- add `histchars` to the zsh initialized special-parameter contract
- remove two C006 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter history_characters --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-histchars-main`:
- `check_command_concise/all`: -1.2149%
- `check_command_full/all`: -0.4945%
- `linter_facts/all`: -1.0243%
- `linter/all`: +0.3415% (not significant)