### PR TITLE
fix(linter): initialize zsh completion tables

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -15432,17 +15432,6 @@ repos:
           line: 22
           column: 31
         classification: real
-      - path: "modules/completion/init.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `_comps` is referenced before assignment"
-        start:
-          line: 132
-          column: 66
-        end:
-          line: 132
-          column: 91
-        classification: false_positive
       - path: "modules/editor/init.zsh"
         code: "C001"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -191,6 +191,20 @@ chpwd_functions+=(_async_prompt_chpwd)
 }
 
 #[test]
+fn zsh_runtime_contract_initializes_completion_system_tables() {
+    let path = Path::new("/tmp/zsh/prezto/modules/completion/init.zsh");
+    let source = "\
+autoload -Uz compinit
+compinit
+print -r -- ${_comps[(I)-value-*]}
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    assert!(has_initialized_binding(&contract, "_comps"), "{contract:?}");
+}
+
+#[test]
 fn zsh_runtime_contract_initializes_braced_prompt_color_arrays() {
     let path = Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh");
     let source = "\

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -70,6 +70,7 @@ fn shell_matches_zsh_runtime_context(shell: ShellDialect, path: &PathSignals) ->
 fn zsh_ambient_runtime_has_signal(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
     source.mentions_any(ZSH_INITIALIZED_SPECIAL_PARAMETERS)
         || source.mentions_any(ZSH_HOOK_ARRAY_PARAMETERS)
+        || zsh_completion_system_runtime_shape(source)
         || zsh_prompt_color_runtime_shape(source, path)
         || !zsh_externally_consumed_names(source, path).is_empty()
         || zsh_test_fixture_consumed_prefixes(source, path)
@@ -101,6 +102,14 @@ fn zsh_initialized_runtime_names<'a>(
                 .copied()
                 .filter(move |name| {
                     source.mentions_name(name) && zsh_runtime_path_shape(path.lower_path())
+                }),
+        )
+        .chain(
+            ZSH_COMPLETION_SYSTEM_PARAMETERS
+                .iter()
+                .copied()
+                .filter(move |name| {
+                    source.mentions_name(name) && zsh_completion_system_runtime_shape(source)
                 }),
         )
 }
@@ -198,7 +207,13 @@ const ZSH_PROMPT_COLOR_PARAMETERS: &[&str] = &[
 const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
     &["REPLY", "compstate", "comppostfuncs", "reply"];
 
+const ZSH_COMPLETION_SYSTEM_PARAMETERS: &[&str] = &["_comps"];
+
 fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
     (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())
         && source.mentions_any(ZSH_PROMPT_COLOR_PARAMETERS)
+}
+
+fn zsh_completion_system_runtime_shape(source: &SourceSignals<'_>) -> bool {
+    source.mentions_any(ZSH_COMPLETION_SYSTEM_PARAMETERS) && source.contains("compinit")
 }

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -1281,6 +1281,29 @@ print -r -- $chpwd_functions $still_missing
     }
 
     #[test]
+    fn zsh_completion_tables_are_initialized_after_compinit() {
+        let source = "\
+#!/bin/zsh
+autoload -Uz compinit
+compinit
+print -r -- ${_comps[(I)-value-*]} $still_missing
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/prezto/modules/completion/init.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$still_missing"]
+        );
+    }
+
+    #[test]
     fn pathless_zsh_hook_array_references_stay_reportable() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
Summary:
- initialize zsh completion-system table `_comps` after `compinit`
- remove one C006 false positive from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter completion_system --lib`
- `cargo test -p shuck-linter completion_tables --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-comps-main`:
- `check_command_concise/all`: 431.56 ms, -1.1354%
- `check_command_full/all`: 431.33 ms, -0.6063%
- `linter_facts/all`: 36.506 ms, -0.1519% (not significant, p = 0.57)
- `linter/all`: 554.53 ms, +1.4199%