### PR TITLE
fix(linter): initialize zsh functrace parameter

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -1114,17 +1114,6 @@ repos:
           column: 13
         classification: real
       - path: "lib/cli.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `functrace` is referenced before assignment"
-        start:
-          line: 125
-          column: 30
-        end:
-          line: 125
-          column: 47
-        classification: false_positive
-      - path: "lib/cli.zsh"
         code: "C132"
         severity: "warning"
         message: "this same-command expansion still sees the earlier shell value"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -142,7 +142,7 @@ ZDOT_MODULE_NAME=prompt
 fn zsh_runtime_contract_initializes_special_parameters_and_prompt_colors() {
     let path = Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh");
     let source = "\
-print -r -- \"$sysparams\" \"$history\" \"$words\" \"$compstate\"
+print -r -- \"$sysparams\" \"$history\" \"$words\" \"$compstate\" \"$functrace\"
 prompt=\"%{$fg_bold[blue]%}%{$reset_color%}\"
 ";
 
@@ -153,6 +153,7 @@ prompt=\"%{$fg_bold[blue]%}%{$reset_color%}\"
         "history",
         "words",
         "compstate",
+        "functrace",
         "fg_bold",
         "reset_color",
     ] {

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -171,6 +171,7 @@ fn zsh_test_fixture_consumed_prefixes<'a>(
 
 const ZSH_INITIALIZED_SPECIAL_PARAMETERS: &[&str] = &[
     "compstate",
+    "functrace",
     "galiases",
     "history",
     "keymaps",

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -234,7 +234,7 @@ printf '%s\\n' \"$plain_test\" \"$file_test\" \"$still_missing\"
     fn zsh_runtime_special_parameters_do_not_report_undefined() {
         let source = "\
 #!/bin/zsh
-print -r -- \"$sysparams\" \"$history\" \"$words\" \"$compstate\"
+print -r -- \"$sysparams\" \"$history\" \"$words\" \"$compstate\" \"$functrace\"
 print -r -- \"$ordinary_missing\"
 ";
         let diagnostics = test_snippet_at_path(


### PR DESCRIPTION
Summary:
- treat zsh `functrace` as an initialized runtime special parameter
- remove one C006 false positive from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter zsh_runtime_special_parameters_do_not_report_undefined --lib`
- `cargo test -p shuck-linter zsh_runtime_contract_initializes_special_parameters_and_prompt_colors --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-functrace-main`:
- `check_command_concise/all`: 433.33 ms, -1.0021%
- `check_command_full/all`: 432.28 ms, -1.0733% (not significant, p = 0.05)
- `linter_facts/all`: 36.275 ms, -0.1993% (not significant, p = 0.61)
- `linter/all`: 545.34 ms, -0.3169%