### PR TITLE
fix(linter): consume zsh WORDCHARS assignments

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -1377,17 +1377,6 @@ repos:
           line: 920
           column: 37
         classification: real
-      - path: "lib/completion.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `WORDCHARS` is assigned but never used"
-        start:
-          line: 4
-          column: 1
-        end:
-          line: 4
-          column: 10
-        classification: false_positive
       - path: "lib/diagnostics.zsh"
         code: "C001"
         severity: "warning"
@@ -15442,17 +15431,6 @@ repos:
         end:
           line: 132
           column: 91
-        classification: false_positive
-      - path: "modules/editor/init.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `WORDCHARS` is assigned but never used"
-        start:
-          line: 25
-          column: 6
-        end:
-          line: 25
-          column: 15
         classification: false_positive
       - path: "modules/editor/init.zsh"
         code: "C156"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -385,12 +385,13 @@ fn zsh_runtime_contract_marks_exact_output_parameters_consumed() {
     let source = "\
 reply=(one two)
 REPLY=value
+WORDCHARS=''
 compstate[insert]=menu
 ";
 
     let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
 
-    for name in ["reply", "REPLY", "compstate"] {
+    for name in ["reply", "REPLY", "WORDCHARS", "compstate"] {
         assert!(has_consumed_name(&contract, name), "{contract:?}");
     }
 }

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -196,7 +196,7 @@ const ZSH_PROMPT_COLOR_PARAMETERS: &[&str] = &[
 ];
 
 const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
-    &["REPLY", "compstate", "comppostfuncs", "reply"];
+    &["REPLY", "WORDCHARS", "compstate", "comppostfuncs", "reply"];
 
 fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
     (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1332,6 +1332,23 @@ ordinary=1
     }
 
     #[test]
+    fn zsh_runtime_consumes_wordchars_assignments() {
+        let source = "\
+#!/usr/bin/env zsh
+WORDCHARS=''
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/lib/completion.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
     fn zsh_test_data_expected_outputs_are_external_consumers() {
         let source = "\
 #!/usr/bin/env zsh


### PR DESCRIPTION
Summary:
- mark zsh `WORDCHARS` assignments as consumed by the runtime
- remove two C001 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter zsh_runtime_contract_marks_exact_output_parameters_consumed --lib`
- `cargo test -p shuck-linter zsh_runtime_consumes_wordchars_assignments --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-wordchars-main`:
- `check_command_concise/all`: 433.05 ms, -1.3910%
- `check_command_full/all`: 431.93 ms, -0.8089%
- `linter_facts/all`: 36.154 ms, -0.8448%
- `linter/all`: 547.96 ms, +0.3532%