### PR TITLE
fix(linter): consume zsh prompt assignments

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -3621,17 +3621,6 @@ repos:
           line: 326
           column: 28
         classification: false_positive
-      - path: "plugins/git-prompt/git-prompt.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `RPROMPT` is assigned but never used"
-        start:
-          line: 113
-          column: 1
-        end:
-          line: 113
-          column: 8
-        classification: false_positive
       - path: "plugins/git/git.plugin.zsh"
         code: "C010"
         severity: "warning"
@@ -7364,28 +7353,6 @@ repos:
       - path: "themes/adben.zsh-theme"
         code: "C001"
         severity: "warning"
-        message: "variable `PROMPT` is assigned but never used"
-        start:
-          line: 112
-          column: 1
-        end:
-          line: 112
-          column: 7
-        classification: false_positive
-      - path: "themes/adben.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `RPROMPT` is assigned but never used"
-        start:
-          line: 116
-          column: 1
-        end:
-          line: 116
-          column: 8
-        classification: false_positive
-      - path: "themes/adben.zsh-theme"
-        code: "C001"
-        severity: "warning"
         message: "variable `PROMPT2` is assigned but never used"
         start:
           line: 118
@@ -7449,50 +7416,6 @@ repos:
           line: 102
           column: 16
         classification: real
-      - path: "themes/emotty.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `PROMPT` is assigned but never used"
-        start:
-          line: 104
-          column: 1
-        end:
-          line: 104
-          column: 7
-        classification: false_positive
-      - path: "themes/emotty.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `RPROMPT` is assigned but never used"
-        start:
-          line: 105
-          column: 1
-        end:
-          line: 105
-          column: 8
-        classification: false_positive
-      - path: "themes/nicoulaj.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `PROMPT` is assigned but never used"
-        start:
-          line: 42
-          column: 1
-        end:
-          line: 42
-          column: 7
-        classification: false_positive
-      - path: "themes/nicoulaj.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `RPROMPT` is assigned but never used"
-        start:
-          line: 43
-          column: 1
-        end:
-          line: 43
-          column: 8
-        classification: false_positive
       - path: "themes/refined.zsh-theme"
         code: "C006"
         severity: "error"
@@ -7525,28 +7448,6 @@ repos:
         end:
           line: 52
           column: 91
-        classification: false_positive
-      - path: "themes/refined.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `PROMPT` is assigned but never used"
-        start:
-          line: 81
-          column: 1
-        end:
-          line: 81
-          column: 7
-        classification: false_positive
-      - path: "themes/refined.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `RPROMPT` is assigned but never used"
-        start:
-          line: 82
-          column: 1
-        end:
-          line: 82
-          column: 8
         classification: false_positive
       - path: "themes/sonicradish.zsh-theme"
         code: "C001"
@@ -7625,17 +7526,6 @@ repos:
           line: 20
           column: 11
         classification: real
-      - path: "themes/sonicradish.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `PROMPT` is assigned but never used"
-        start:
-          line: 23
-          column: 1
-        end:
-          line: 23
-          column: 7
-        classification: false_positive
       - path: "themes/sonicradish.zsh-theme"
         code: "C001"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -383,6 +383,8 @@ fn pathless_zsh_sources_do_not_get_ambient_runtime_contracts() {
 fn zsh_runtime_contract_marks_exact_output_parameters_consumed() {
     let path = Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh");
     let source = "\
+PROMPT='%n@%m'
+RPROMPT='%~'
 reply=(one two)
 REPLY=value
 compstate[insert]=menu
@@ -390,7 +392,7 @@ compstate[insert]=menu
 
     let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
 
-    for name in ["reply", "REPLY", "compstate"] {
+    for name in ["PROMPT", "RPROMPT", "reply", "REPLY", "compstate"] {
         assert!(has_consumed_name(&contract, name), "{contract:?}");
     }
 }

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -196,7 +196,7 @@ const ZSH_PROMPT_COLOR_PARAMETERS: &[&str] = &[
 ];
 
 const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
-    &["REPLY", "compstate", "comppostfuncs", "reply"];
+    &["PROMPT", "REPLY", "RPROMPT", "compstate", "comppostfuncs", "reply"];
 
 fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
     (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1332,6 +1332,24 @@ ordinary=1
     }
 
     #[test]
+    fn zsh_runtime_consumes_prompt_assignments() {
+        let source = "\
+#!/usr/bin/env zsh
+PROMPT='%n@%m'
+RPROMPT='%~'
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/themes/example.zsh-theme"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
     fn zsh_test_data_expected_outputs_are_external_consumers() {
         let source = "\
 #!/usr/bin/env zsh


### PR DESCRIPTION
Summary:
- mark zsh `PROMPT` and `RPROMPT` assignments as consumed by the runtime
- remove ten C001 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter zsh_runtime_contract_marks_exact_output_parameters_consumed --lib`
- `cargo test -p shuck-linter zsh_runtime_consumes_prompt_assignments --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-prompt-main`:
- `check_command_concise/all`: 432.23 ms, -1.4779%
- `check_command_full/all`: 445.67 ms, +2.4633%
- `linter_facts/all`: 36.399 ms, -0.7592%
- `linter/all`: 550.38 ms, +0.7255%