### PR TITLE
fix(linter): consume zsh highlighting fixture state

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -20809,17 +20809,6 @@ repos:
           line: 30
           column: 65
         classification: real
-      - path: "highlighters/main/test-data/backslash-continuation.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `PREBUFFER` is assigned but never used"
-        start:
-          line: 30
-          column: 1
-        end:
-          line: 30
-          column: 10
-        classification: false_positive
       - path: "highlighters/main/test-data/brackets-mismatch7.zsh"
         code: "C005"
         severity: "warning"
@@ -20974,17 +20963,6 @@ repos:
           line: 30
           column: 23
         classification: real
-      - path: "highlighters/main/test-data/multiline-string.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `PREBUFFER` is assigned but never used"
-        start:
-          line: 30
-          column: 1
-        end:
-          line: 30
-          column: 10
-        classification: false_positive
       - path: "highlighters/main/test-data/opt-shwordsplit1.zsh"
         code: "C001"
         severity: "warning"
@@ -21304,17 +21282,6 @@ repos:
           line: 33
           column: 40
         classification: false_positive
-      - path: "highlighters/main/test-data/path_prefix3.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `PREBUFFER` is assigned but never used"
-        start:
-          line: 33
-          column: 1
-        end:
-          line: 33
-          column: 10
-        classification: false_positive
       - path: "highlighters/main/test-data/process-substitution2.zsh"
         code: "C005"
         severity: "warning"
@@ -21359,39 +21326,6 @@ repos:
           line: 32
           column: 9
         classification: real
-      - path: "highlighters/main/test-data/vanilla-newline.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `PREBUFFER` is assigned but never used"
-        start:
-          line: 30
-          column: 1
-        end:
-          line: 30
-          column: 10
-        classification: false_positive
-      - path: "highlighters/main/test-data/vi-linewise-mode.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `REGION_ACTIVE` is assigned but never used"
-        start:
-          line: 32
-          column: 1
-        end:
-          line: 32
-          column: 14
-        classification: false_positive
-      - path: "highlighters/main/test-data/vi-linewise-mode.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `MARK` is assigned but never used"
-        start:
-          line: 34
-          column: 1
-        end:
-          line: 34
-          column: 5
-        classification: false_positive
       - path: "highlighters/regexp/test-data/word-boundary.zsh"
         code: "C001"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -426,6 +426,23 @@ fn zsh_syntax_highlighting_test_data_expected_values_are_consumed() {
 }
 
 #[test]
+fn zsh_syntax_highlighting_test_data_zle_state_is_consumed() {
+    let path =
+        Path::new("/tmp/zsh/zsh-syntax-highlighting/highlighters/main/test-data/example.zsh");
+    let source = "\
+PREBUFFER=$'echo foo\\n'
+MARK=1
+REGION_ACTIVE=1
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    for name in ["PREBUFFER", "MARK", "REGION_ACTIVE"] {
+        assert!(has_consumed_name(&contract, name), "{contract:?}");
+    }
+}
+
+#[test]
 fn zsh_syntax_highlighting_test_harness_expected_values_are_consumed() {
     let path = Path::new("/tmp/zsh/zsh-syntax-highlighting/tests/test-zprof.zsh");
     let source = "\

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -53,6 +53,10 @@ pub(super) fn build_zsh_ambient_runtime_contract(
         contract.add_externally_consumed_binding_name(Name::from(name));
     }
 
+    for name in zsh_test_fixture_consumed_names(source, path) {
+        contract.add_externally_consumed_binding_name(Name::from(name));
+    }
+
     for prefix in zsh_test_fixture_consumed_prefixes(source, path) {
         contract.add_externally_consumed_binding_prefix(Name::from(prefix));
     }
@@ -72,6 +76,9 @@ fn zsh_ambient_runtime_has_signal(source: &SourceSignals<'_>, path: &PathSignals
         || source.mentions_any(ZSH_HOOK_ARRAY_PARAMETERS)
         || zsh_prompt_color_runtime_shape(source, path)
         || !zsh_externally_consumed_names(source, path).is_empty()
+        || zsh_test_fixture_consumed_names(source, path)
+            .next()
+            .is_some()
         || zsh_test_fixture_consumed_prefixes(source, path)
             .next()
             .is_some()
@@ -159,6 +166,17 @@ const ZSH_HOOK_ARRAY_PARAMETERS: &[&str] = &[
     "zshaddhistory_functions",
     "zshexit_functions",
 ];
+
+fn zsh_test_fixture_consumed_names<'a>(
+    source: &'a SourceSignals<'_>,
+    path: &'a PathSignals,
+) -> impl Iterator<Item = &'static str> + 'a {
+    ["MARK", "PREBUFFER", "REGION_ACTIVE"].into_iter().filter(|name| {
+        zsh_syntax_highlighting_test_path_shape(path.lower_path())
+            && zsh_test_data_path_shape(path.lower_path())
+            && source.assigns_name(name)
+    })
+}
 
 fn zsh_test_fixture_consumed_prefixes<'a>(
     source: &'a SourceSignals<'_>,

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1349,6 +1349,25 @@ ordinary=1
     }
 
     #[test]
+    fn zsh_test_data_zle_state_assignments_are_consumed() {
+        let source = "\
+#!/usr/bin/env zsh
+PREBUFFER=$'echo foo\\n'
+MARK=1
+REGION_ACTIVE=1
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/zsh-syntax-highlighting/highlighters/main/test-data/example.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
     fn zsh_test_harness_expected_outputs_are_external_consumers() {
         let source = "\
 #!/usr/bin/env zsh


### PR DESCRIPTION
Summary:
- mark zsh-syntax-highlighting test-data zle state assignments as consumed by the fixture harness
- remove six C001 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter zsh_test_data_zle_state --lib`
- `cargo test -p shuck-linter zsh_syntax_highlighting_test_data_zle_state_is_consumed --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-zlefixture-main`:
- `check_command_concise/all`: 434.55 ms, -0.6782%
- `check_command_full/all`: 433.19 ms, -0.4149%
- `linter_facts/all`: 36.697 ms, +1.9566% (not significant, p = 0.60)
- `linter/all`: 548.19 ms, -0.3315% (not significant, p = 0.15)