### PR TITLE
fix(linter): allow zsh function REPLY outputs

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -269,17 +269,6 @@ repos:
           line: 151
           column: 82
         classification: real
-      - path: "helpers.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `REPLY` is assigned but never used"
-        start:
-          line: 168
-          column: 9
-        end:
-          line: 168
-          column: 14
-        classification: false_positive
       - path: "install.zsh"
         code: "C001"
         severity: "warning"
@@ -9498,17 +9487,6 @@ repos:
         end:
           line: 352
           column: 39
-        classification: false_positive
-      - path: "gitstatus/mbuild"
-        code: "C001"
-        severity: "warning"
-        message: "variable `REPLY` is assigned but never used"
-        start:
-          line: 362
-          column: 19
-        end:
-          line: 362
-          column: 24
         classification: false_positive
       - path: "gitstatus/mbuild"
         code: "C001"
@@ -20060,17 +20038,6 @@ repos:
       - path: "src/strategies/completion.zsh"
         code: "C001"
         severity: "warning"
-        message: "variable `REPLY` is assigned but never used"
-        start:
-          line: 104
-          column: 13
-        end:
-          line: 104
-          column: 18
-        classification: false_positive
-      - path: "src/strategies/completion.zsh"
-        code: "C001"
-        severity: "warning"
         message: "variable `suggestion` is assigned but never used"
         start:
           line: 132
@@ -20123,17 +20090,6 @@ repos:
           line: 367
           column: 36
         classification: real
-      - path: "zsh-autosuggestions.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `REPLY` is assigned but never used"
-        start:
-          line: 599
-          column: 13
-        end:
-          line: 599
-          column: 18
-        classification: false_positive
   - name: "zsh-syntax-highlighting"
     github_url: "https://github.com/zsh-users/zsh-syntax-highlighting.git"
     commit: "1d85c692615a25fe2293bdd44b34c217d5d2bf04"
@@ -21656,17 +21612,6 @@ repos:
           line: 189
           column: 34
         classification: real
-      - path: "zsh-syntax-highlighting.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `REPLY` is assigned but never used"
-        start:
-          line: 207
-          column: 9
-        end:
-          line: 207
-          column: 14
-        classification: false_positive
       - path: "zsh-syntax-highlighting.zsh"
         code: "C006"
         severity: "error"

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -115,6 +115,10 @@ pub fn unused_assignment(checker: &mut Checker) {
             continue;
         }
 
+        if is_zsh_function_scoped_reply_binding(checker, binding) {
+            continue;
+        }
+
         if !is_reportable_unused_assignment(binding.kind, binding.attributes) {
             continue;
         }
@@ -268,6 +272,15 @@ fn is_zsh_arguments_context_name(name: &str) -> bool {
         name,
         "context" | "line" | "opt_args" | "state" | "state_descr"
     )
+}
+
+fn is_zsh_function_scoped_reply_binding(checker: &Checker<'_>, binding: &Binding) -> bool {
+    checker.shell() == crate::ShellDialect::Zsh
+        && binding.name.as_str() == "REPLY"
+        && checker
+            .semantic_analysis()
+            .enclosing_function_scope_at(binding.span.start.offset)
+            .is_some()
 }
 
 fn function_has_zsh_arguments_target_for_name(
@@ -1547,9 +1560,31 @@ helper() {
             &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
         );
 
-        assert_eq!(diagnostics.len(), 2);
+        assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "reply");
-        assert_eq!(diagnostics[1].span.slice(source), "REPLY");
+    }
+
+    #[test]
+    fn zsh_function_reply_outputs_are_not_unused() {
+        let source = "\
+#!/usr/bin/env zsh
+relative_path() {
+  if [[ -z $1 ]]; then
+    REPLY=.
+  else
+    REPLY=$1
+  fi
+}
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/dotfiler/helpers.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- stop reporting function-scoped zsh `REPLY` bindings as unused assignments
- keep lowercase `reply` function locals reportable
- remove five C001 false positives from the zsh diagnostic corpus

Validation:
- `cargo test -p shuck-linter zsh_function_reply_outputs_are_not_unused --lib`
- `cargo test -p shuck-linter zsh_ambient_output_parameters_do_not_consume_function_locals --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`

Performance vs `zsh-reply-c001-main`:
- `check_command_concise/all`: 431.90 ms, -1.0094%
- `check_command_full/all`: 431.27 ms, -0.6744%
- `linter_facts/all`: 36.237 ms, -0.6471% (not significant, p = 0.08)
- `linter/all`: 553.78 ms, +1.2760% (not significant, p = 0.22)