### PR TITLE
fix(linter): recognize zsh completion helper outputs

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -2029,50 +2029,6 @@ repos:
       - path: "plugins/cabal/cabal.plugin.zsh"
         code: "C001"
         severity: "warning"
-        message: "variable `context` is assigned but never used"
-        start:
-          line: 57
-          column: 5
-        end:
-          line: 57
-          column: 15
-        classification: false_positive
-      - path: "plugins/cabal/cabal.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `line` is assigned but never used"
-        start:
-          line: 57
-          column: 5
-        end:
-          line: 57
-          column: 15
-        classification: real
-      - path: "plugins/cabal/cabal.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `opt_args` is assigned but never used"
-        start:
-          line: 57
-          column: 5
-        end:
-          line: 57
-          column: 15
-        classification: false_positive
-      - path: "plugins/cabal/cabal.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `state_descr` is assigned but never used"
-        start:
-          line: 57
-          column: 5
-        end:
-          line: 57
-          column: 15
-        classification: false_positive
-      - path: "plugins/cabal/cabal.plugin.zsh"
-        code: "C001"
-        severity: "warning"
         message: "variable `ret` is assigned but never used"
         start:
           line: 87
@@ -3305,28 +3261,6 @@ repos:
       - path: "plugins/git-extras/git-extras.plugin.zsh"
         code: "C001"
         severity: "warning"
-        message: "variable `expl` is assigned but never used"
-        start:
-          line: 97
-          column: 11
-        end:
-          line: 97
-          column: 15
-        classification: false_positive
-      - path: "plugins/git-extras/git-extras.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `state_descr` is assigned but never used"
-        start:
-          line: 218
-          column: 5
-        end:
-          line: 218
-          column: 15
-        classification: false_positive
-      - path: "plugins/git-extras/git-extras.plugin.zsh"
-        code: "C001"
-        severity: "warning"
         message: "variable `ret` is assigned but never used"
         start:
           line: 228
@@ -3335,28 +3269,6 @@ repos:
           line: 228
           column: 58
         classification: real
-      - path: "plugins/git-extras/git-extras.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `context` is assigned but never used"
-        start:
-          line: 337
-          column: 5
-        end:
-          line: 337
-          column: 15
-        classification: false_positive
-      - path: "plugins/git-extras/git-extras.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `opt_args` is assigned but never used"
-        start:
-          line: 337
-          column: 5
-        end:
-          line: 337
-          column: 15
-        classification: false_positive
       - path: "plugins/git-extras/git-extras.plugin.zsh"
         code: "C006"
         severity: "error"
@@ -3446,17 +3358,6 @@ repos:
           column: 83
         classification: real
       - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `state_descr` is assigned but never used"
-        start:
-          line: 409
-          column: 5
-        end:
-          line: 409
-          column: 15
-        classification: false_positive
-      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
         code: "C005"
         severity: "warning"
         message: "shell expansion inside single quotes stays literal"
@@ -3467,39 +3368,6 @@ repos:
           line: 418
           column: 76
         classification: real
-      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `context` is assigned but never used"
-        start:
-          line: 437
-          column: 21
-        end:
-          line: 437
-          column: 31
-        classification: false_positive
-      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `opt_args` is assigned but never used"
-        start:
-          line: 437
-          column: 21
-        end:
-          line: 437
-          column: 31
-        classification: false_positive
-      - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `expl` is assigned but never used"
-        start:
-          line: 509
-          column: 11
-        end:
-          line: 509
-          column: 15
-        classification: false_positive
       - path: "plugins/git-flow-avh/git-flow-avh.plugin.zsh"
         code: "C006"
         severity: "error"
@@ -3556,17 +3424,6 @@ repos:
           column: 70
         classification: real
       - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `state_descr` is assigned but never used"
-        start:
-          line: 181
-          column: 5
-        end:
-          line: 181
-          column: 15
-        classification: false_positive
-      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
         code: "C005"
         severity: "warning"
         message: "shell expansion inside single quotes stays literal"
@@ -3577,39 +3434,6 @@ repos:
           line: 190
           column: 83
         classification: real
-      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `context` is assigned but never used"
-        start:
-          line: 257
-          column: 21
-        end:
-          line: 257
-          column: 31
-        classification: false_positive
-      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `opt_args` is assigned but never used"
-        start:
-          line: 257
-          column: 21
-        end:
-          line: 257
-          column: 31
-        classification: false_positive
-      - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `expl` is assigned but never used"
-        start:
-          line: 316
-          column: 11
-        end:
-          line: 316
-          column: 15
-        classification: false_positive
       - path: "plugins/git-hubflow/git-hubflow.plugin.zsh"
         code: "C006"
         severity: "error"
@@ -6470,17 +6294,6 @@ repos:
           line: 183
           column: 1
         classification: real
-      - path: "plugins/term_tab/term_tab.plugin.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `expl` is assigned but never used"
-        start:
-          line: 18
-          column: 12
-        end:
-          line: 18
-          column: 16
-        classification: false_positive
       - path: "plugins/thefuck/thefuck.plugin.zsh"
         code: "C122"
         severity: "warning"
@@ -6689,39 +6502,6 @@ repos:
         end:
           line: 17
           column: 52
-        classification: false_positive
-      - path: "plugins/wd/_wd.sh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `context` is assigned but never used"
-        start:
-          line: 49
-          column: 3
-        end:
-          line: 49
-          column: 13
-        classification: false_positive
-      - path: "plugins/wd/_wd.sh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `opt_args` is assigned but never used"
-        start:
-          line: 49
-          column: 3
-        end:
-          line: 49
-          column: 13
-        classification: false_positive
-      - path: "plugins/wd/_wd.sh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `state_descr` is assigned but never used"
-        start:
-          line: 49
-          column: 3
-        end:
-          line: 49
-          column: 13
         classification: false_positive
       - path: "plugins/wd/wd.sh"
         code: "C018"

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -244,9 +244,6 @@ fn is_zsh_arguments_context_binding_in_completion_function(
     else {
         return false;
     };
-    if !checker.facts().function_is_completion_registered(scope) {
-        return false;
-    }
 
     if matches!(
         binding.origin,
@@ -1611,6 +1608,54 @@ fi
     }
 
     #[test]
+    fn zsh_arguments_targets_are_not_unused_in_completion_helpers() {
+        let source = "\
+#!/bin/zsh
+function _cab_commands() {
+  local state
+  _arguments ':subcommand:->subcommand'
+  ordinary=1
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["ordinary"]
+        );
+    }
+
+    #[test]
+    fn zsh_wanted_explanation_operand_counts_as_use() {
+        let source = "\
+#!/bin/zsh
+function _term_list() {
+  local -a expl
+  _wanted directories expl 'current directory from other shell' compadd
+  ordinary=1
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["ordinary"]
+        );
+    }
+
+    #[test]
     fn zsh_arguments_targets_ignore_branch_words_in_comments_between_registration() {
         let source = "\
 #!/bin/zsh
@@ -1684,19 +1729,12 @@ fi
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec![
-                "_arguments",
-                "_arguments",
-                "_arguments",
-                "_arguments",
-                "_arguments",
-                "ordinary"
-            ]
+            vec!["ordinary"]
         );
     }
 
     #[test]
-    fn zsh_arguments_targets_keep_case_boundaries_after_parameter_hash() {
+    fn zsh_arguments_targets_are_not_unused_with_branch_separated_compdef() {
         let source = "\
 #!/bin/zsh
 case $service in
@@ -1720,19 +1758,12 @@ esac
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec![
-                "_arguments",
-                "_arguments",
-                "_arguments",
-                "_arguments",
-                "_arguments",
-                "ordinary"
-            ]
+            vec!["ordinary"]
         );
     }
 
     #[test]
-    fn zsh_arguments_targets_stay_unused_for_short_circuit_compdef() {
+    fn zsh_arguments_targets_are_not_unused_with_short_circuit_compdef() {
         let source = "\
 #!/bin/zsh
 function _composer() {
@@ -1750,14 +1781,7 @@ function _composer() {
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec![
-                "_arguments",
-                "_arguments",
-                "_arguments",
-                "_arguments",
-                "_arguments",
-                "ordinary"
-            ]
+            vec!["ordinary"]
         );
     }
 

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -157,6 +157,13 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                     self.add_reference_if_bound(&argument, ReferenceKind::ImplicitRead, span);
                 }
             }
+            "_wanted" if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh => {
+                if let Some((argument, span)) =
+                    args.get(1).and_then(|word| named_target_word(word, self.source))
+                {
+                    self.add_reference_if_bound(&argument, ReferenceKind::ImplicitRead, span);
+                }
+            }
             "_arguments" if self.shell_profile.dialect == shuck_parser::ShellDialect::Zsh => {
                 for (argument, attributes) in
                     zsh_arguments_targets(zsh_arguments_has_state_action(args, self.source))


### PR DESCRIPTION
## Summary
- treat zsh `_arguments` context/state targets as completion-owned when the same function calls `_arguments`, even when static registration is conditional or branch-separated
- mark `_wanted` static explanation array operands as implicit reads
- remove twenty C001 entries from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-linter zsh_ --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- `git diff --check`

## Performance
Compared against `origin/main` with Criterion (`linter` and `check_command` benches):
- `linter/all`: -0.81% median time
- `linter_facts/all`: +0.52% median time, p=0.39, within noise
- `check_command_concise/all`: +0.32% median time
- `check_command_full/all`: +0.76% median time
