### PR TITLE
fix(linter): consume zsh TIMEFMT assignments

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -16991,17 +16991,6 @@ repos:
           line: 82
           column: 12
         classification: real
-      - path: "scripts/benchmark.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `TIMEFMT` is assigned but never used"
-        start:
-          line: 136
-          column: 18
-        end:
-          line: 136
-          column: 25
-        classification: false_positive
       - path: "zdot.zsh"
         code: "C003"
         severity: "warning"
@@ -21557,17 +21546,6 @@ repos:
           line: 71
           column: 19
         classification: real
-      - path: "tests/test-perfs.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `TIMEFMT` is assigned but never used"
-        start:
-          line: 97
-          column: 1
-        end:
-          line: 97
-          column: 8
-        classification: false_positive
       - path: "tests/test-perfs.zsh"
         code: "C114"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -386,11 +386,12 @@ fn zsh_runtime_contract_marks_exact_output_parameters_consumed() {
 reply=(one two)
 REPLY=value
 compstate[insert]=menu
+TIMEFMT='%E'
 ";
 
     let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
 
-    for name in ["reply", "REPLY", "compstate"] {
+    for name in ["reply", "REPLY", "compstate", "TIMEFMT"] {
         assert!(has_consumed_name(&contract, name), "{contract:?}");
     }
 }

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -196,7 +196,7 @@ const ZSH_PROMPT_COLOR_PARAMETERS: &[&str] = &[
 ];
 
 const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
-    &["REPLY", "compstate", "comppostfuncs", "reply"];
+    &["REPLY", "TIMEFMT", "compstate", "comppostfuncs", "reply"];
 
 fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
     (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1468,6 +1468,7 @@ runner() {
 reply=(one two)
 REPLY=value
 compstate[insert]=menu
+TIMEFMT='%E'
 ordinary=1
 ";
         let diagnostics = test_snippet_at_path(


### PR DESCRIPTION
## Summary
- treat zsh `TIMEFMT` assignments as shell-consumed timing format state
- cover the existing ambient contract and unused-assignment regression tests
- remove two C001 entries from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-linter zsh_runtime_contract_marks_exact_output_parameters_consumed --lib`
- `cargo test -p shuck-linter zsh_ambient_output_parameters_are_external_consumers --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- `git diff --check`

## Performance
Compared against `origin/main` with Criterion (`linter` and `check_command` benches):
- `check_command_concise/all`: +0.91% median time
- `check_command_full/all`: +1.28% median time
- `linter_facts/all`: -2.17% median time
- `linter/all`: -1.32% median time
