### PR TITLE
fix(linter): consume zsh autosuggestion outputs

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -20068,39 +20068,6 @@ repos:
           line: 104
           column: 18
         classification: false_positive
-      - path: "src/strategies/completion.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `suggestion` is assigned but never used"
-        start:
-          line: 132
-          column: 3
-        end:
-          line: 132
-          column: 13
-        classification: false_positive
-      - path: "src/strategies/history.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `suggestion` is assigned but never used"
-        start:
-          line: 31
-          column: 13
-        end:
-          line: 31
-          column: 23
-        classification: false_positive
-      - path: "src/strategies/match_prev_cmd.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `suggestion` is assigned but never used"
-        start:
-          line: 65
-          column: 13
-        end:
-          line: 65
-          column: 23
-        classification: false_positive
       - path: "src/widgets.zsh"
         code: "C055"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -451,6 +451,16 @@ fn zsh_autosuggestion_config_namespace_is_consumed_on_project_paths() {
 }
 
 #[test]
+fn zsh_autosuggestion_strategy_output_is_consumed_on_strategy_paths() {
+    let path = Path::new("/tmp/zsh/zsh-autosuggestions/src/strategies/history.zsh");
+    let source = "typeset -g suggestion=value\n";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    assert!(has_consumed_name(&contract, "suggestion"));
+}
+
+#[test]
 fn zsh_config_prefix_contracts_are_zsh_only() {
     let path = Path::new("/tmp/project/script.sh");
     let source = "POWERLEVEL9K_DIR_FOREGROUND=31\n";

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -147,6 +147,11 @@ fn zsh_externally_consumed_names(
                 .filter(|name| source.assigns_name(name)),
         );
     }
+    if zsh_autosuggestions_strategy_path_shape(path.lower_path())
+        && source.assigns_name("suggestion")
+    {
+        consumed.push("suggestion");
+    }
     consumed
 }
 
@@ -201,4 +206,8 @@ const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
 fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
     (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())
         && source.mentions_any(ZSH_PROMPT_COLOR_PARAMETERS)
+}
+
+fn zsh_autosuggestions_strategy_path_shape(lower_path: &str) -> bool {
+    lower_path.contains("/zsh-autosuggestions/src/strategies/")
 }

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1332,6 +1332,23 @@ ordinary=1
     }
 
     #[test]
+    fn zsh_autosuggestion_strategy_output_is_external_consumer() {
+        let source = "\
+#!/usr/bin/env zsh
+typeset -g suggestion=value
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/zsh-autosuggestions/src/strategies/history.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
     fn zsh_test_data_expected_outputs_are_external_consumers() {
         let source = "\
 #!/usr/bin/env zsh


### PR DESCRIPTION
## Summary
- treat zsh-autosuggestions strategy `suggestion` assignments as strategy output state
- scope the ambient consumer to `zsh-autosuggestions/src/strategies/` paths
- remove three C001 entries from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-linter zsh_autosuggestion_strategy_output --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- `git diff --check`

## Performance
Compared against `origin/main` with Criterion (`linter` and `check_command` benches):
- `check_command_concise/all`: -0.52% median time, p=0.43, within noise
- `check_command_full/all`: +0.23% median time, p=0.08, within noise
- `linter_facts/all`: +0.26% median time, p=0.31, within noise
- `linter/all`: -0.15% median time, p=0.76, within noise
