### PR TITLE
fix(linter): consume zsh plugin config prefixes

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -15388,17 +15388,6 @@ repos:
           line: 172
           column: 40
         classification: real
-      - path: "modules/autosuggestions/init.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE` is assigned but never used"
-        start:
-          line: 24
-          column: 3
-        end:
-          line: 24
-          column: 34
-        classification: false_positive
       - path: "modules/command-not-found/init.zsh"
         code: "C003"
         severity: "warning"
@@ -16364,72 +16353,6 @@ repos:
           line: 15
           column: 17
         classification: false_positive
-      - path: "modules/autocompletion/autocompletion.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ZSH_AUTOSUGGEST_STRATEGY` is assigned but never used"
-        start:
-          line: 10
-          column: 5
-        end:
-          line: 10
-          column: 29
-        classification: false_positive
-      - path: "modules/autocompletion/autocompletion.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_AUTOLOAD` is assigned but never used"
-        start:
-          line: 13
-          column: 5
-        end:
-          line: 13
-          column: 18
-        classification: false_positive
-      - path: "modules/autocompletion/autocompletion.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_SET_EXPANSION_CURSOR` is assigned but never used"
-        start:
-          line: 14
-          column: 5
-        end:
-          line: 14
-          column: 30
-        classification: false_positive
-      - path: "modules/autocompletion/autocompletion.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_SET_LINE_CURSOR` is assigned but never used"
-        start:
-          line: 15
-          column: 5
-        end:
-          line: 15
-          column: 25
-        classification: false_positive
-      - path: "modules/autocompletion/autocompletion.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_GET_AVAILABLE_ABBREVIATION` is assigned but never used"
-        start:
-          line: 16
-          column: 5
-        end:
-          line: 16
-          column: 36
-        classification: false_positive
-      - path: "modules/autocompletion/autocompletion.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_USER_ABBREVIATIONS_FILE` is assigned but never used"
-        start:
-          line: 17
-          column: 5
-        end:
-          line: 17
-          column: 33
-        classification: false_positive
       - path: "modules/brew/brew.zsh"
         code: "C006"
         severity: "error"
@@ -16562,72 +16485,6 @@ repos:
           line: 33
           column: 18
         classification: real
-      - path: "modules/old-plugins/old-plugins.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ZSH_AUTOSUGGEST_STRATEGY` is assigned but never used"
-        start:
-          line: 36
-          column: 5
-        end:
-          line: 36
-          column: 29
-        classification: false_positive
-      - path: "modules/old-plugins/old-plugins.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_AUTOLOAD` is assigned but never used"
-        start:
-          line: 39
-          column: 5
-        end:
-          line: 39
-          column: 18
-        classification: false_positive
-      - path: "modules/old-plugins/old-plugins.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_SET_EXPANSION_CURSOR` is assigned but never used"
-        start:
-          line: 40
-          column: 5
-        end:
-          line: 40
-          column: 30
-        classification: false_positive
-      - path: "modules/old-plugins/old-plugins.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_SET_LINE_CURSOR` is assigned but never used"
-        start:
-          line: 41
-          column: 5
-        end:
-          line: 41
-          column: 25
-        classification: false_positive
-      - path: "modules/old-plugins/old-plugins.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_GET_AVAILABLE_ABBREVIATION` is assigned but never used"
-        start:
-          line: 42
-          column: 5
-        end:
-          line: 42
-          column: 36
-        classification: false_positive
-      - path: "modules/old-plugins/old-plugins.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ABBR_USER_ABBREVIATIONS_FILE` is assigned but never used"
-        start:
-          line: 43
-          column: 5
-        end:
-          line: 43
-          column: 33
-        classification: false_positive
       - path: "modules/old-plugins/old-plugins.zsh"
         code: "C003"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -451,6 +451,20 @@ fn zsh_autosuggestion_config_namespace_is_consumed_on_project_paths() {
 }
 
 #[test]
+fn zsh_dotfile_framework_plugin_config_namespaces_are_consumed() {
+    let path = Path::new("/tmp/zdot/modules/autocompletion/autocompletion.zsh");
+    let source = "\
+ZSH_AUTOSUGGEST_STRATEGY=(history completion)
+ABBR_AUTOLOAD=1
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    assert!(has_consumed_prefix(&contract, "ZSH_AUTOSUGGEST_"));
+    assert!(has_consumed_prefix(&contract, "ABBR_"));
+}
+
+#[test]
 fn zsh_config_prefix_contracts_are_zsh_only() {
     let path = Path::new("/tmp/project/script.sh");
     let source = "POWERLEVEL9K_DIR_FOREGROUND=31\n";

--- a/crates/shuck-linter/src/ambient_contracts/zsh_config.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_config.rs
@@ -57,6 +57,7 @@ fn zsh_config_consumed_prefixes<'a>(
     path: &'a PathSignals,
 ) -> impl Iterator<Item = &'static str> + 'a {
     [
+        "ABBR_",
         "HISTORY_SUBSTRING_SEARCH_",
         "ITERM2_",
         "P9K_",
@@ -71,6 +72,7 @@ fn zsh_config_consumed_prefixes<'a>(
 
 fn zsh_config_prefix_path_shape(prefix: &str, path: &PathSignals) -> bool {
     match prefix {
+        "ABBR_" => zsh_dotfile_path_shape(path.lower_path()) || path.contains("/zsh-abbr/"),
         "HISTORY_SUBSTRING_SEARCH_" => {
             path.contains("/history-substring-search/")
                 || path.contains("/modules/history-substring-search/")
@@ -82,7 +84,11 @@ fn zsh_config_prefix_path_shape(prefix: &str, path: &PathSignals) -> bool {
             p10k_config_path_shape(path.lower_path()) || zsh_dotfile_path_shape(path.lower_path())
         }
         "ZDOT_" => zsh_dotfile_path_shape(path.lower_path()),
-        "ZSH_AUTOSUGGEST_" => path.contains("/zsh-autosuggestions/"),
+        "ZSH_AUTOSUGGEST_" => {
+            path.contains("/zsh-autosuggestions/")
+                || path.contains("/modules/autosuggestions/")
+                || zsh_dotfile_path_shape(path.lower_path())
+        }
         "ZSH_HIGHLIGHT_" => path.contains("/zsh-syntax-highlighting/"),
         _ => false,
     }

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1332,6 +1332,24 @@ ordinary=1
     }
 
     #[test]
+    fn zsh_dotfile_framework_plugin_config_namespaces_are_external_consumers() {
+        let source = "\
+#!/usr/bin/env zsh
+ZSH_AUTOSUGGEST_STRATEGY=(history completion)
+ABBR_AUTOLOAD=1
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zdot/modules/autocompletion/autocompletion.zsh"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
     fn zsh_test_data_expected_outputs_are_external_consumers() {
         let source = "\
 #!/usr/bin/env zsh


### PR DESCRIPTION
## Summary
- treat zsh-abbr `ABBR_` settings as consumed in zsh dotfile framework paths
- allow zsh-autosuggestions config prefixes in dotfile framework and module paths
- remove thirteen C001 entries from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-linter zsh_dotfile_framework_plugin_config_namespaces --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- `git diff --check`

## Performance
Compared against `origin/main` with Criterion (`linter` and `check_command` benches):
- `check_command_concise/all`: +0.17% median time, p=0.08, within noise
- `check_command_full/all`: +0.12% median time, p=0.36, within noise
- `linter_facts/all`: +0.27% median time, p=0.82, within noise
- `linter/all`: +0.24% median time
