### PR TITLE
fix(linter): consume zsh theme prompt state

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -1653,28 +1653,6 @@ repos:
           column: 27
         classification: false_positive
       - path: "lib/theme-and-appearance.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ZSH_THEME_RUBY_PROMPT_PREFIX` is assigned but never used"
-        start:
-          line: 12
-          column: 1
-        end:
-          line: 12
-          column: 29
-        classification: false_positive
-      - path: "lib/theme-and-appearance.zsh"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ZSH_THEME_RUBY_PROMPT_SUFFIX` is assigned but never used"
-        start:
-          line: 13
-          column: 1
-        end:
-          line: 13
-          column: 29
-        classification: false_positive
-      - path: "lib/theme-and-appearance.zsh"
         code: "C010"
         severity: "warning"
         message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
@@ -7210,50 +7188,6 @@ repos:
       - path: "themes/adben.zsh-theme"
         code: "C001"
         severity: "warning"
-        message: "variable `ZSH_THEME_SVN_PROMPT_PREFIX` is assigned but never used"
-        start:
-          line: 51
-          column: 1
-        end:
-          line: 51
-          column: 28
-        classification: false_positive
-      - path: "themes/adben.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ZSH_THEME_SVN_PROMPT_SUFFIX` is assigned but never used"
-        start:
-          line: 52
-          column: 1
-        end:
-          line: 52
-          column: 28
-        classification: false_positive
-      - path: "themes/adben.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ZSH_THEME_SVN_PROMPT_DIRTY` is assigned but never used"
-        start:
-          line: 53
-          column: 1
-        end:
-          line: 53
-          column: 27
-        classification: false_positive
-      - path: "themes/adben.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `ZSH_THEME_SVN_PROMPT_CLEAN` is assigned but never used"
-        start:
-          line: 54
-          column: 1
-        end:
-          line: 54
-          column: 27
-        classification: false_positive
-      - path: "themes/adben.zsh-theme"
-        code: "C001"
-        severity: "warning"
         message: "variable `ZSH_THEME_GIT_PROMPT_PREFIX` is assigned but never used"
         start:
           line: 57
@@ -7381,17 +7315,6 @@ repos:
           column: 1
         end:
           line: 116
-          column: 8
-        classification: false_positive
-      - path: "themes/adben.zsh-theme"
-        code: "C001"
-        severity: "warning"
-        message: "variable `PROMPT2` is assigned but never used"
-        start:
-          line: 118
-          column: 1
-        end:
-          line: 118
           column: 8
         classification: false_positive
       - path: "themes/emotty.zsh-theme"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -139,6 +139,20 @@ ZDOT_MODULE_NAME=prompt
 }
 
 #[test]
+fn ohmyzsh_theme_prompt_namespaces_are_consumed() {
+    let path = Path::new("/tmp/zsh/ohmyzsh/themes/example.zsh-theme");
+    let source = "\
+ZSH_THEME_RUBY_PROMPT_PREFIX='('
+ZSH_THEME_SVN_PROMPT_PREFIX='svn:'
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    assert!(has_consumed_prefix(&contract, "ZSH_THEME_RUBY_PROMPT_"));
+    assert!(has_consumed_prefix(&contract, "ZSH_THEME_SVN_PROMPT_"));
+}
+
+#[test]
 fn zsh_runtime_contract_initializes_special_parameters_and_prompt_colors() {
     let path = Path::new("/tmp/zsh/ohmyzsh/plugins/example/example.plugin.zsh");
     let source = "\
@@ -386,11 +400,12 @@ fn zsh_runtime_contract_marks_exact_output_parameters_consumed() {
 reply=(one two)
 REPLY=value
 compstate[insert]=menu
+PROMPT2='> '
 ";
 
     let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
 
-    for name in ["reply", "REPLY", "compstate"] {
+    for name in ["reply", "REPLY", "compstate", "PROMPT2"] {
         assert!(has_consumed_name(&contract, name), "{contract:?}");
     }
 }

--- a/crates/shuck-linter/src/ambient_contracts/zsh_config.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_config.rs
@@ -62,6 +62,8 @@ fn zsh_config_consumed_prefixes<'a>(
         "P9K_",
         "POWERLEVEL9K_",
         "ZDOT_",
+        "ZSH_THEME_RUBY_PROMPT_",
+        "ZSH_THEME_SVN_PROMPT_",
         "ZSH_AUTOSUGGEST_",
         "ZSH_HIGHLIGHT_",
     ]
@@ -82,10 +84,19 @@ fn zsh_config_prefix_path_shape(prefix: &str, path: &PathSignals) -> bool {
             p10k_config_path_shape(path.lower_path()) || zsh_dotfile_path_shape(path.lower_path())
         }
         "ZDOT_" => zsh_dotfile_path_shape(path.lower_path()),
+        "ZSH_THEME_RUBY_PROMPT_" | "ZSH_THEME_SVN_PROMPT_" => {
+            ohmyzsh_theme_path_shape(path.lower_path())
+        }
         "ZSH_AUTOSUGGEST_" => path.contains("/zsh-autosuggestions/"),
         "ZSH_HIGHLIGHT_" => path.contains("/zsh-syntax-highlighting/"),
         _ => false,
     }
+}
+
+fn ohmyzsh_theme_path_shape(lower_path: &str) -> bool {
+    lower_path.contains("/ohmyzsh/lib/")
+        || lower_path.contains("/ohmyzsh/themes/")
+        || lower_path.ends_with(".zsh-theme")
 }
 
 const ZSH_CONFIG_EXTERNALLY_CONSUMED_NAMES: &[&str] = &["HISTFILE", "HISTSIZE", "SAVEHIST"];

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -196,7 +196,7 @@ const ZSH_PROMPT_COLOR_PARAMETERS: &[&str] = &[
 ];
 
 const ZSH_EXTERNALLY_CONSUMED_OUTPUT_PARAMETERS: &[&str] =
-    &["REPLY", "compstate", "comppostfuncs", "reply"];
+    &["PROMPT2", "REPLY", "compstate", "comppostfuncs", "reply"];
 
 fn zsh_prompt_color_runtime_shape(source: &SourceSignals<'_>, path: &PathSignals) -> bool {
     (zsh_runtime_path_shape(path.lower_path()) || source.loads_zsh_colors())

--- a/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_assignment.rs
@@ -1314,6 +1314,25 @@ ordinary=1
     }
 
     #[test]
+    fn ohmyzsh_theme_prompt_namespaces_are_external_consumers() {
+        let source = "\
+#!/usr/bin/env zsh
+ZSH_THEME_RUBY_PROMPT_PREFIX='('
+ZSH_THEME_SVN_PROMPT_PREFIX='svn:'
+PROMPT2='> '
+ordinary=1
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/themes/example.zsh-theme"),
+            source,
+            &LinterSettings::for_rule(Rule::UnusedAssignment).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "ordinary");
+    }
+
+    #[test]
     fn zsh_plugin_config_namespaces_are_external_consumers() {
         let source = "\
 #!/usr/bin/env zsh


### PR DESCRIPTION
## Summary
- treat oh-my-zsh Ruby and SVN theme prompt namespaces as externally consumed theme config
- mark zsh `PROMPT2` assignments as shell-consumed prompt state
- remove seven C001 entries from the zsh diagnostic corpus baseline

## Validation
- `cargo test -p shuck-linter ohmyzsh_theme_prompt_namespaces --lib`
- `cargo test -p shuck-linter zsh_runtime_contract_marks_exact_output_parameters_consumed --lib`
- `cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- `git diff --check`

## Performance
Compared against `origin/main` with Criterion (`linter` and `check_command` benches):
- `check_command_concise/all`: -0.12% median time, p=0.88, within noise
- `check_command_full/all`: -0.05% median time, p=0.63, within noise
- `linter_facts/all`: -0.98% median time
- `linter/all`: +0.72% median time
