### PR TITLE
fix(cli): add top-level version flag

### DIFF
--- a/crates/shuck-cli/src/args.rs
+++ b/crates/shuck-cli/src/args.rs
@@ -139,6 +139,7 @@ impl From<ManagedShellArg> for shuck_run::Shell {
 #[derive(Debug, Parser)]
 #[command(name = "shuck")]
 #[command(about = "Shell checker CLI for shuck")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(styles = STYLES)]
 struct StableCli {
     #[command(flatten)]
@@ -150,6 +151,7 @@ struct StableCli {
 #[derive(Debug, Parser)]
 #[command(name = "shuck")]
 #[command(about = "Shell checker CLI for shuck")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(styles = STYLES)]
 struct ExperimentalCli {
     #[command(flatten)]

--- a/crates/shuck-cli/tests/shellcheck_compat.rs
+++ b/crates/shuck-cli/tests/shellcheck_compat.rs
@@ -74,6 +74,16 @@ fn plain_shuck_help_stays_on_existing_cli() {
 }
 
 #[test]
+fn plain_shuck_version_reports_release_version() {
+    let mut cmd = Command::cargo_bin("shuck").unwrap();
+    cmd.arg("--version");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")))
+        .stdout(predicate::str::contains("ShellCheck compatibility mode").not());
+}
+
+#[test]
 fn compat_reads_shellcheckrc_from_cwd() {
     let tempdir = tempdir().unwrap();
     fs::write(tempdir.path().join(".shellcheckrc"), "disable=SC2086\n").unwrap();


### PR DESCRIPTION
## Summary
- add top-level Clap version metadata for the stable and experimental `shuck` CLI parsers so `shuck --version` prints the released package version
- add a regression test confirming plain `shuck --version` stays on the normal CLI surface instead of ShellCheck compatibility mode

## Why
The CLI goes through custom top-level parser structs, but those structs were missing version metadata. That made Clap treat `--version` as an unknown argument instead of handling it as a built-in version flag.

## Validation
- `cargo test -p shuck-cli plain_shuck_version_reports_release_version -- --exact`
- `cargo test -p shuck-cli env_activation_uses_shellcheck_surface -- --exact`