### PR TITLE
fix(linter): avoid recovered command lookup panics

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -202,12 +202,15 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 );
                 let lookup_kind = command_lookup_kind(visit.command);
                 let entries = command_ids_by_span.entry(key).or_default();
-                let previous = entries.iter().find(|entry| entry.kind == lookup_kind);
-                debug_assert!(previous.is_none(), "duplicate command lookup key");
-                entries.push(CommandLookupEntry {
-                    kind: lookup_kind,
-                    id,
-                });
+                // Recovery on malformed nested word commands can surface the same
+                // syntax-backed command more than once. Keep the first lookup target
+                // so stmt-to-fact resolution stays deterministic.
+                if !entries.iter().any(|entry| entry.kind == lookup_kind) {
+                    entries.push(CommandLookupEntry {
+                        kind: lookup_kind,
+                        id,
+                    });
+                }
 
                 if context.is_in_if_condition() {
                     if_condition_command_ids.insert(id);
@@ -252,7 +255,9 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     &normalized,
                 );
                 if let Some(name_word) = normalized.body_name_word() {
-                    command_ids_by_name_word_span.insert(FactSpan::new(name_word.span), id);
+                    command_ids_by_name_word_span
+                        .entry(FactSpan::new(name_word.span))
+                        .or_insert(id);
                 }
                 let nested_word_command = context.is_nested_word_command();
                 build_word_facts_for_command(

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -3938,3 +3938,24 @@ printf '%s\\n' `date` $(uname) <(cat /etc/hosts)
         assert!(substitutions.contains(&("<(cat /etc/hosts)".to_owned(), None, false,)));
     });
 }
+
+#[test]
+fn builds_recovered_nested_command_substitutions_without_duplicate_lookup_panics() {
+    let source = "x=${(#} {($(e";
+
+    with_facts_dialect(
+        source,
+        None,
+        shuck_parser::parser::ShellDialect::Zsh,
+        ShellDialect::Zsh,
+        |_, facts| {
+            assert!(
+                facts
+                    .commands()
+                    .iter()
+                    .any(|fact| fact.span().slice(source) == "e"),
+                "expected the recovered command substitution body to stay discoverable",
+            );
+        },
+    );
+}


### PR DESCRIPTION
## Summary
- keep recovered command lookup indexes deterministic when malformed nested word commands surface the same syntax-backed command more than once
- preserve the first command-name word lookup for duplicate recovered spans
- add a regression for the minimized fuzz reproducer

## Root cause
Malformed zsh recovery could emit duplicate syntax-backed command contexts for the same nested command-substitution body. The facts builder asserted uniqueness in the span and name lookup indexes, so the scheduled fuzz run panicked instead of finishing linting.

## Validation
- `cargo test -p shuck-linter`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `rustup run nightly cargo fuzz run --sanitizer=none linter_no_panic_fuzz /tmp/shuck-fuzz-919-min.sh`
- `rustup run nightly cargo fuzz run --sanitizer=none linter_no_panic_fuzz /tmp/shuck-fuzz-25420775837/crash-71940cea9f145ed713c6eba1b950ea1a2be2da18`

Fixes #919