### PR TITLE
fix(zsh): resolve plugin framework sources

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -577,7 +577,7 @@ impl PluginResolver for ResolvedZshPluginSettings {
         requests
     }
 
-    fn resolve_source_path(&self, _source_path: &Path, candidate: &str) -> Vec<PathBuf> {
+    fn resolve_source_path(&self, source_path: &Path, candidate: &str) -> Vec<PathBuf> {
         if !self.enabled {
             return Vec::new();
         }
@@ -585,7 +585,7 @@ impl PluginResolver for ResolvedZshPluginSettings {
         let Some(root) = self.roots.get("oh-my-zsh") else {
             return Vec::new();
         };
-        oh_my_zsh_source_suffix(candidate)
+        oh_my_zsh_source_suffix(root, source_path, candidate)
             .map(|suffix| vec![root.join(suffix)])
             .unwrap_or_default()
     }
@@ -716,10 +716,17 @@ fn plugin_root_for_request(
     settings.roots.get(key).cloned()
 }
 
-fn oh_my_zsh_source_suffix(candidate: &str) -> Option<PathBuf> {
+fn oh_my_zsh_source_suffix(root: &Path, source_path: &Path, candidate: &str) -> Option<PathBuf> {
     let normalized = candidate.replace('\\', "/");
     if normalized == "oh-my-zsh.sh" || normalized.ends_with("/oh-my-zsh.sh") {
         return Some(PathBuf::from("oh-my-zsh.sh"));
+    }
+
+    let source_in_framework = source_path.starts_with(root);
+    let candidate_has_framework_anchor = path_text_has_oh_my_zsh_anchor(&normalized)
+        || path_text_starts_with_path(&normalized, root);
+    if !source_in_framework && !candidate_has_framework_anchor {
+        return None;
     }
 
     for marker in ["/plugins/", "/themes/", "/lib/"] {
@@ -732,6 +739,18 @@ fn oh_my_zsh_source_suffix(candidate: &str) -> Option<PathBuf> {
     }
 
     None
+}
+
+fn path_text_has_oh_my_zsh_anchor(path: &str) -> bool {
+    path.contains("/.oh-my-zsh/") || path.contains("/oh-my-zsh/")
+}
+
+fn path_text_starts_with_path(path: &str, root: &Path) -> bool {
+    let root_text = root.to_string_lossy().replace('\\', "/");
+    path == root_text
+        || path
+            .strip_prefix(&root_text)
+            .is_some_and(|tail| tail.starts_with('/'))
 }
 
 fn normalize_zsh_plugin_path(project_root: &Path, value: &str) -> Result<PathBuf> {
@@ -1773,6 +1792,48 @@ mod tests {
         assert!(settings.plugin_loads.is_empty());
         assert!(settings.theme_loads.is_empty());
         assert!(settings.entrypoints.is_empty());
+    }
+
+    #[test]
+    fn oh_my_zsh_source_suffix_rewrites_framework_paths_only() {
+        let root = Path::new("/workspace/.oh-my-zsh");
+
+        assert_eq!(
+            oh_my_zsh_source_suffix(
+                root,
+                Path::new("/workspace/.oh-my-zsh/oh-my-zsh.sh"),
+                "/opt/app/plugins/git/git.plugin.zsh",
+            ),
+            Some(PathBuf::from("plugins/git/git.plugin.zsh"))
+        );
+        assert_eq!(
+            oh_my_zsh_source_suffix(
+                root,
+                Path::new("/workspace/script.zsh"),
+                "/tmp/.oh-my-zsh/plugins/git/git.plugin.zsh",
+            ),
+            Some(PathBuf::from("plugins/git/git.plugin.zsh"))
+        );
+        assert_eq!(
+            oh_my_zsh_source_suffix(
+                root,
+                Path::new("/workspace/script.zsh"),
+                "/opt/app/plugins/git/git.plugin.zsh",
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn oh_my_zsh_source_suffix_still_resolves_framework_entrypoint() {
+        assert_eq!(
+            oh_my_zsh_source_suffix(
+                Path::new("/workspace/.oh-my-zsh"),
+                Path::new("/workspace/script.zsh"),
+                "/not-installed/.oh-my-zsh/oh-my-zsh.sh",
+            ),
+            Some(PathBuf::from("oh-my-zsh.sh"))
+        );
     }
 
     #[test]

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -577,6 +577,19 @@ impl PluginResolver for ResolvedZshPluginSettings {
         requests
     }
 
+    fn resolve_source_path(&self, _source_path: &Path, candidate: &str) -> Vec<PathBuf> {
+        if !self.enabled {
+            return Vec::new();
+        }
+
+        let Some(root) = self.roots.get("oh-my-zsh") else {
+            return Vec::new();
+        };
+        oh_my_zsh_source_suffix(candidate)
+            .map(|suffix| vec![root.join(suffix)])
+            .unwrap_or_default()
+    }
+
     fn resolve_plugin_request(
         &self,
         _source_path: &Path,
@@ -701,6 +714,24 @@ fn plugin_root_for_request(
         PluginFramework::Other(other) => other.as_str(),
     };
     settings.roots.get(key).cloned()
+}
+
+fn oh_my_zsh_source_suffix(candidate: &str) -> Option<PathBuf> {
+    let normalized = candidate.replace('\\', "/");
+    if normalized == "oh-my-zsh.sh" || normalized.ends_with("/oh-my-zsh.sh") {
+        return Some(PathBuf::from("oh-my-zsh.sh"));
+    }
+
+    for marker in ["/plugins/", "/themes/", "/lib/"] {
+        if let Some(index) = normalized.rfind(marker) {
+            let suffix = &normalized[index + 1..];
+            if !suffix.is_empty() {
+                return Some(PathBuf::from(suffix));
+            }
+        }
+    }
+
+    None
 }
 
 fn normalize_zsh_plugin_path(project_root: &Path, value: &str) -> Result<PathBuf> {

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -83,6 +83,49 @@ const LARGE_CORPUS_SHELLCHECK_PARSE_IGNORE_SUFFIXES: &[&str] = &[
 const SHELLCHECK_CACHE_SCHEMA: u32 = 3;
 const SHELLCHECK_CACHE_MIGRATION_VERSION: u32 = 1;
 const ZSH_DIAGNOSTIC_CORPUS_BASELINE: &str = include_str!("testdata/zsh-diagnostic-corpus.yaml");
+const ZSH_DIAGNOSTIC_OH_MY_ZSH_REPO: &str = "ohmyzsh";
+const ZSH_DIAGNOSTIC_PLUGIN_ENTRYPOINTS: &[(&str, &str)] = &[
+    (
+        "zdot/modules/autocompletion/autocompletion.zsh",
+        "ohmyzsh/plugins/zoxide/zoxide.plugin.zsh",
+    ),
+    (
+        "zdot/modules/autocompletion/autocompletion.zsh",
+        "zsh-autosuggestions/zsh-autosuggestions.plugin.zsh",
+    ),
+    (
+        "zdot/modules/fzf/fzf.zsh",
+        "ohmyzsh/plugins/fzf/fzf.plugin.zsh",
+    ),
+    (
+        "zdot/modules/old-plugins/old-plugins.zsh",
+        "zsh-autosuggestions/zsh-autosuggestions.plugin.zsh",
+    ),
+    (
+        "zdot/modules/shell-extras/shell-extras.zsh",
+        "ohmyzsh/plugins/debian/debian.plugin.zsh",
+    ),
+    (
+        "zdot/modules/shell-extras/shell-extras.zsh",
+        "ohmyzsh/plugins/eza/eza.plugin.zsh",
+    ),
+    (
+        "zdot/modules/shell-extras/shell-extras.zsh",
+        "ohmyzsh/plugins/git/git.plugin.zsh",
+    ),
+    (
+        "zdot/modules/shell-extras/shell-extras.zsh",
+        "ohmyzsh/plugins/ssh/ssh.plugin.zsh",
+    ),
+    (
+        "prezto/modules/autosuggestions/init.zsh",
+        "zsh-autosuggestions/zsh-autosuggestions.plugin.zsh",
+    ),
+    (
+        "prezto/modules/syntax-highlighting/init.zsh",
+        "zsh-syntax-highlighting/zsh-syntax-highlighting.plugin.zsh",
+    ),
+];
 
 // ---------------------------------------------------------------------------
 // Config
@@ -1298,6 +1341,9 @@ fn zsh_diagnostic_corpus_matches_baseline() {
     let manifest = load_zsh_diagnostic_corpus_manifest(&cfg.corpus_dir);
     let visible_root = tempfile::tempdir().expect("create visible zsh diagnostic corpus root");
     let mut failures = Vec::new();
+    let (visible_repos, expose_failures) =
+        expose_zsh_diagnostic_repos(&cfg.corpus_dir, visible_root.path(), &manifest);
+    failures.extend(expose_failures);
 
     for repo in &baseline.repos {
         if let Err(err) = validate_zsh_diagnostic_manifest_repo(&manifest, repo) {
@@ -1305,26 +1351,19 @@ fn zsh_diagnostic_corpus_matches_baseline() {
             continue;
         }
 
-        let repo_dir = cfg.corpus_dir.join("repos").join(&repo.name);
-        if !repo_dir.is_dir() {
+        let Some(visible_repo_dir) = visible_repos.get(&repo.name) else {
             failures.push(format!(
-                "repo `{}` is missing from {}",
-                repo.name,
-                cfg.corpus_dir.join("repos").display()
+                "repo `{}` was not exposed in the visible corpus",
+                repo.name
             ));
             continue;
-        }
+        };
 
-        let visible_repo_dir =
-            match expose_zsh_diagnostic_repo(&repo_dir, visible_root.path(), &repo.name) {
-                Ok(path) => path,
-                Err(err) => {
-                    failures.push(format!("repo `{}`: {err}", repo.name));
-                    continue;
-                }
-            };
-
-        let output = match run_zsh_diagnostic_shuck_check(&visible_repo_dir, cfg.timeout) {
+        let output = match run_zsh_diagnostic_shuck_check(
+            visible_root.path(),
+            visible_repo_dir,
+            cfg.timeout,
+        ) {
             Ok(output) => output,
             Err(err) => {
                 failures.push(format!("repo `{}`: {err}", repo.name));
@@ -1843,6 +1882,37 @@ fn zsh_diagnostic_corpus_dir_looks_valid(dir: &Path) -> bool {
     dir.join("manifest.yaml").is_file() && dir.join("repos").is_dir()
 }
 
+fn expose_zsh_diagnostic_repos(
+    corpus_dir: &Path,
+    visible_root: &Path,
+    manifest: &ZshDiagnosticCorpusManifest,
+) -> (HashMap<String, PathBuf>, Vec<String>) {
+    let source_root = corpus_dir.join("repos");
+    let mut visible_repos = HashMap::new();
+    let mut failures = Vec::new();
+
+    for repo in &manifest.repos {
+        let source_repo_dir = source_root.join(&repo.name);
+        if !source_repo_dir.is_dir() {
+            failures.push(format!(
+                "repo `{}` is missing from {}",
+                repo.name,
+                source_root.display()
+            ));
+            continue;
+        }
+
+        match expose_zsh_diagnostic_repo(&source_repo_dir, visible_root, &repo.name) {
+            Ok(visible_repo_dir) => {
+                visible_repos.insert(repo.name.clone(), visible_repo_dir);
+            }
+            Err(err) => failures.push(format!("repo `{}`: {err}", repo.name)),
+        }
+    }
+
+    (visible_repos, failures)
+}
+
 fn expose_zsh_diagnostic_repo(
     source_repo_dir: &Path,
     visible_root: &Path,
@@ -1900,15 +1970,45 @@ fn copy_zsh_diagnostic_repo(source: &Path, dest: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn run_zsh_diagnostic_shuck_check(repo_dir: &Path, timeout: Duration) -> Result<Output, String> {
+fn run_zsh_diagnostic_shuck_check(
+    visible_root: &Path,
+    repo_dir: &Path,
+    timeout: Duration,
+) -> Result<Output, String> {
+    let plugin_args = zsh_diagnostic_plugin_args(visible_root);
     let repo_dir = repo_dir.to_path_buf();
     run_with_timeout("shuck", timeout, move || {
         Command::new(assert_cmd::cargo::cargo_bin("shuck"))
             .args(["check", "--no-cache", "--output-format", "json-lines"])
+            .args(&plugin_args)
             .arg(&repo_dir)
             .output()
             .map_err(|err| format!("failed to run shuck check on {}: {err}", repo_dir.display()))
     })?
+}
+
+fn zsh_diagnostic_plugin_args(visible_root: &Path) -> Vec<String> {
+    let mut args = Vec::new();
+    let oh_my_zsh_root = visible_root.join(ZSH_DIAGNOSTIC_OH_MY_ZSH_REPO);
+    if oh_my_zsh_root.join("oh-my-zsh.sh").is_file() {
+        args.push("--zsh-plugin-root".into());
+        args.push(format!("oh-my-zsh={}", path_arg(&oh_my_zsh_root)));
+    }
+
+    for (source_pattern, entrypoint) in ZSH_DIAGNOSTIC_PLUGIN_ENTRYPOINTS {
+        let pattern = visible_root.join(source_pattern);
+        let entrypoint = visible_root.join(entrypoint);
+        if entrypoint.is_file() {
+            args.push("--extend-zsh-plugin-entrypoint".into());
+            args.push(format!("{}:{}", path_arg(&pattern), path_arg(&entrypoint)));
+        }
+    }
+
+    args
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
 }
 
 fn parse_zsh_diagnostic_json_lines(
@@ -5502,6 +5602,85 @@ repos:
         assert!(serde_yaml::from_str::<ZshDiagnosticCorpusDocument>(yaml).is_err());
     }
 
+    #[test]
+    fn zsh_diagnostic_plugin_args_include_available_corpus_plugins() {
+        let visible_root = tempfile::tempdir().expect("create visible root");
+        write_file(
+            visible_root.path().join("ohmyzsh/oh-my-zsh.sh"),
+            "source plugins/git/git.plugin.zsh\n",
+        );
+        write_file(
+            visible_root
+                .path()
+                .join("ohmyzsh/plugins/git/git.plugin.zsh"),
+            "git plugin\n",
+        );
+        write_file(
+            visible_root
+                .path()
+                .join("zsh-autosuggestions/zsh-autosuggestions.plugin.zsh"),
+            "autosuggestions plugin\n",
+        );
+
+        let args = zsh_diagnostic_plugin_args(visible_root.path());
+
+        assert!(args.windows(2).any(|window| {
+            window[0] == "--zsh-plugin-root"
+                && window[1]
+                    == format!(
+                        "oh-my-zsh={}",
+                        visible_root.path().join("ohmyzsh").display()
+                    )
+        }));
+        assert!(args.windows(2).any(|window| {
+            window[0] == "--extend-zsh-plugin-entrypoint"
+                && window[1].ends_with(&format!(
+                    "zdot/modules/autocompletion/autocompletion.zsh:{}",
+                    visible_root
+                        .path()
+                        .join("zsh-autosuggestions/zsh-autosuggestions.plugin.zsh")
+                        .display()
+                ))
+        }));
+        assert!(!args.iter().any(|arg| arg.contains("zoxide.plugin.zsh")));
+    }
+
+    #[test]
+    fn expose_zsh_diagnostic_repos_exposes_manifest_repos_together() {
+        let corpus_root = tempfile::tempdir().expect("create corpus root");
+        write_file(
+            corpus_root.path().join("repos/app/app.zsh"),
+            "source app.zsh\n",
+        );
+        write_file(
+            corpus_root.path().join("repos/plugin/plugin.plugin.zsh"),
+            "plugin\n",
+        );
+        let visible_root = tempfile::tempdir().expect("create visible root");
+        let manifest = ZshDiagnosticCorpusManifest {
+            repos: vec![
+                ZshDiagnosticCorpusManifestRepo {
+                    name: "app".into(),
+                    github_url: "https://example.test/app.git".into(),
+                    commit: "abc123".into(),
+                },
+                ZshDiagnosticCorpusManifestRepo {
+                    name: "plugin".into(),
+                    github_url: "https://example.test/plugin.git".into(),
+                    commit: "def456".into(),
+                },
+            ],
+        };
+
+        let (visible, failures) =
+            expose_zsh_diagnostic_repos(corpus_root.path(), visible_root.path(), &manifest);
+
+        assert!(failures.is_empty());
+        assert_eq!(visible.len(), 2);
+        assert!(visible["app"].join("app.zsh").is_file());
+        assert!(visible["plugin"].join("plugin.plugin.zsh").is_file());
+    }
+
     fn zsh_observed(
         path: &str,
         code: &str,
@@ -5574,6 +5753,14 @@ repos:
             fs::create_dir_all(parent).unwrap();
         }
         fs::write(path, cache_file_data(label)).unwrap();
+    }
+
+    fn write_file(path: impl AsRef<Path>, contents: &str) {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
     }
 
     fn cache_file_data(label: &str) -> String {

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -1389,7 +1389,7 @@ fn zsh_diagnostic_corpus_matches_baseline() {
         }
 
         let actual =
-            match parse_zsh_diagnostic_json_lines(&repo.name, &visible_repo_dir, &output.stdout) {
+            match parse_zsh_diagnostic_json_lines(&repo.name, visible_repo_dir, &output.stdout) {
                 Ok(actual) => actual,
                 Err(err) => {
                     failures.push(err);

--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -7340,17 +7340,6 @@ repos:
           column: 16
         classification: real
       - path: "tools/theme_chooser.sh"
-        code: "C003"
-        severity: "warning"
-        message: "sourced file is not available to this analysis"
-        start:
-          line: 12
-          column: 8
-        end:
-          line: 12
-          column: 25
-        classification: real
-      - path: "tools/theme_chooser.sh"
         code: "C006"
         severity: "error"
         message: "variable `a` is referenced before assignment"

--- a/crates/shuck-semantic/src/dataflow/unused.rs
+++ b/crates/shuck-semantic/src/dataflow/unused.rs
@@ -725,7 +725,14 @@ fn build_unused_assignment_events(
     }
 
     for (read_index, synthetic_read) in context.synthetic_reads.iter().enumerate() {
-        let Some(block_id) = command_block_for_span(context.cfg, synthetic_read.span) else {
+        let Some(block_id) =
+            command_block_for_span(context.cfg, synthetic_read.span).or_else(|| {
+                context
+                    .cfg
+                    .scope_exits(synthetic_read.scope)
+                    .and_then(|exits| exits.last().copied())
+            })
+        else {
             continue;
         };
         events[block_id.index()].push(UnusedAssignmentEvent {

--- a/crates/shuck-semantic/src/dataflow/unused.rs
+++ b/crates/shuck-semantic/src/dataflow/unused.rs
@@ -725,21 +725,25 @@ fn build_unused_assignment_events(
     }
 
     for (read_index, synthetic_read) in context.synthetic_reads.iter().enumerate() {
-        let Some(block_id) =
-            command_block_for_span(context.cfg, synthetic_read.span).or_else(|| {
-                context
-                    .cfg
-                    .scope_exits(synthetic_read.scope)
-                    .and_then(|exits| exits.last().copied())
-            })
-        else {
+        let mut push_synthetic_read = |block_id: BlockId| {
+            events[block_id.index()].push(UnusedAssignmentEvent {
+                offset: synthetic_read.span.start.offset,
+                order: 0,
+                kind: UnusedAssignmentEventKind::SyntheticRead(read_index),
+            });
+        };
+
+        if let Some(block_id) = command_block_for_span(context.cfg, synthetic_read.span) {
+            push_synthetic_read(block_id);
             continue;
         };
-        events[block_id.index()].push(UnusedAssignmentEvent {
-            offset: synthetic_read.span.start.offset,
-            order: 0,
-            kind: UnusedAssignmentEventKind::SyntheticRead(read_index),
-        });
+
+        let Some(exits) = context.cfg.scope_exits(synthetic_read.scope) else {
+            continue;
+        };
+        for block_id in exits {
+            push_synthetic_read(*block_id);
+        }
     }
 
     for plan in read_plans {

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -544,6 +544,11 @@ pub trait PluginResolver {
         Vec::new()
     }
 
+    /// Resolves a zsh `source` candidate through plugin/framework roots.
+    fn resolve_source_path(&self, _source_path: &Path, _candidate: &str) -> Vec<PathBuf> {
+        Vec::new()
+    }
+
     /// Resolves one plugin request into entrypoint paths and optional contracts.
     fn resolve_plugin_request(
         &self,

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -57,7 +57,7 @@ struct SourceClosureLookupContext<'a> {
     plugin_resolver: Option<&'a (dyn PluginResolver + Send + Sync)>,
     analyzed_paths: Option<&'a FxHashSet<PathBuf>>,
     shell_profile: ShellProfile,
-    resolved_helper_paths: RefCell<FxHashMap<HelperPathResolutionKey, Vec<PathBuf>>>,
+    resolved_helper_paths: RefCell<FxHashMap<HelperPathResolutionKey, HelperPathResolution>>,
     dependency_paths: RefCell<FxHashSet<PathBuf>>,
 }
 
@@ -65,6 +65,12 @@ struct SourceClosureLookupContext<'a> {
 struct HelperPathResolutionKey {
     source_path: PathBuf,
     candidate: compact_str::CompactString,
+}
+
+#[derive(Debug, Clone, Default)]
+struct HelperPathResolution {
+    paths: Vec<PathBuf>,
+    plugin_resolved: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -384,12 +390,14 @@ fn merge_contracts_for_candidates(
     let mut resolved = false;
     let mut explicit = false;
     for candidate in candidates {
-        let resolved_paths = resolve_helper_paths_cached(source_path, &candidate, context);
-        resolved |= !resolved_paths.is_empty();
-        explicit |= resolved_paths
-            .iter()
-            .any(|path| path_is_explicitly_analyzed(path, context.analyzed_paths));
-        for resolved_path in resolved_paths {
+        let resolution = resolve_helper_paths_cached(source_path, &candidate, context);
+        resolved |= !resolution.paths.is_empty();
+        explicit |= resolution.plugin_resolved
+            || resolution
+                .paths
+                .iter()
+                .any(|path| path_is_explicitly_analyzed(path, context.analyzed_paths));
+        for resolved_path in resolution.paths {
             contracts.push(summarize_helper(&resolved_path, summaries, active, context));
         }
     }
@@ -408,11 +416,13 @@ fn source_ref_metadata_for_candidates(
     let mut resolved = false;
     let mut explicit = false;
     for candidate in candidates {
-        let resolved_paths = resolve_helper_paths_cached(source_path, &candidate, context);
-        resolved |= !resolved_paths.is_empty();
-        explicit |= resolved_paths
-            .iter()
-            .any(|path| path_is_explicitly_analyzed(path, context.analyzed_paths));
+        let resolution = resolve_helper_paths_cached(source_path, &candidate, context);
+        resolved |= !resolution.paths.is_empty();
+        explicit |= resolution.plugin_resolved
+            || resolution
+                .paths
+                .iter()
+                .any(|path| path_is_explicitly_analyzed(path, context.analyzed_paths));
     }
 
     (resolved, explicit)
@@ -943,7 +953,10 @@ fn anchor_configured_plugin_requests(
     for request in requests {
         if request.kind == PluginRequestKind::Entrypoint {
             anchored.push(PluginRequest {
-                span: file_span,
+                // Configured entrypoints are not tied to a source command. Treat
+                // them as late file-scope loads so their contract can consume
+                // setup assignments made earlier in the file.
+                span: Span::at(file_span.end),
                 ..request
             });
             continue;
@@ -1829,38 +1842,63 @@ fn resolve_literal_call_args_by_scope(
 fn resolve_helper_paths(
     source_path: &Path,
     candidate: &str,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-) -> Vec<PathBuf> {
+    context: &SourceClosureLookupContext<'_>,
+) -> HelperPathResolution {
     for candidate_path in candidate_path_variants(candidate) {
         if candidate_path.is_absolute() {
             if candidate_path.is_file() {
-                return vec![candidate_path];
+                return HelperPathResolution {
+                    paths: vec![candidate_path],
+                    plugin_resolved: false,
+                };
             }
             continue;
         }
 
         let Some(base_dir) = source_path.parent() else {
-            return Vec::new();
+            return HelperPathResolution::default();
         };
 
         let direct = base_dir.join(&candidate_path);
         if direct.is_file() {
-            return vec![direct];
+            return HelperPathResolution {
+                paths: vec![direct],
+                plugin_resolved: false,
+            };
         }
     }
 
-    source_path_resolver
+    if let Some(plugin_paths) = context.plugin_resolver.map(|resolver| {
+        resolver
+            .resolve_source_path(source_path, candidate)
+            .into_iter()
+            .filter(|path| path.is_file())
+            .collect::<Vec<_>>()
+    }) && !plugin_paths.is_empty()
+    {
+        return HelperPathResolution {
+            paths: plugin_paths,
+            plugin_resolved: true,
+        };
+    }
+
+    let paths = context
+        .source_path_resolver
         .into_iter()
         .flat_map(|resolver| resolver.resolve_candidate_paths(source_path, candidate))
         .filter(|path| path.is_file())
-        .collect()
+        .collect();
+    HelperPathResolution {
+        paths,
+        plugin_resolved: false,
+    }
 }
 
 fn resolve_helper_paths_cached(
     source_path: &Path,
     candidate: &str,
     context: &SourceClosureLookupContext<'_>,
-) -> Vec<PathBuf> {
+) -> HelperPathResolution {
     let key = HelperPathResolutionKey {
         source_path: source_path.to_path_buf(),
         candidate: candidate.into(),
@@ -1869,7 +1907,7 @@ fn resolve_helper_paths_cached(
         return paths.clone();
     }
 
-    let paths = resolve_helper_paths(source_path, candidate, context.source_path_resolver);
+    let paths = resolve_helper_paths(source_path, candidate, context);
     context
         .resolved_helper_paths
         .borrow_mut()

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -949,6 +949,7 @@ fn anchor_configured_plugin_requests(
     bootstraps: &[DetectedPluginBootstrap],
     file_span: Span,
 ) -> Vec<PluginRequest> {
+    let file_scope_tail = Span::at(position_after(file_span.end));
     let mut anchored = Vec::new();
     for request in requests {
         if request.kind == PluginRequestKind::Entrypoint {
@@ -956,7 +957,7 @@ fn anchor_configured_plugin_requests(
                 // Configured entrypoints are not tied to a source command. Treat
                 // them as late file-scope loads so their contract can consume
                 // setup assignments made earlier in the file.
-                span: Span::at(file_span.end),
+                span: file_scope_tail,
                 ..request
             });
             continue;
@@ -986,6 +987,12 @@ fn anchor_configured_plugin_requests(
         }
     }
     anchored
+}
+
+fn position_after(mut position: shuck_ast::Position) -> shuck_ast::Position {
+    position.offset += 1;
+    position.column += 1;
+    position
 }
 
 fn dedup_plugin_requests(requests: Vec<PluginRequest>) -> Vec<PluginRequest> {

--- a/crates/shuck-semantic/src/source_closure.rs
+++ b/crates/shuck-semantic/src/source_closure.rs
@@ -1868,13 +1868,15 @@ fn resolve_helper_paths(
         }
     }
 
-    if let Some(plugin_paths) = context.plugin_resolver.map(|resolver| {
-        resolver
-            .resolve_source_path(source_path, candidate)
-            .into_iter()
-            .filter(|path| path.is_file())
-            .collect::<Vec<_>>()
-    }) && !plugin_paths.is_empty()
+    if context.shell_profile.dialect == ParseShellDialect::Zsh
+        && let Some(plugin_paths) = context.plugin_resolver.map(|resolver| {
+            resolver
+                .resolve_source_path(source_path, candidate)
+                .into_iter()
+                .filter(|path| path.is_file())
+                .collect::<Vec<_>>()
+        })
+        && !plugin_paths.is_empty()
     {
         return HelperPathResolution {
             paths: plugin_paths,
@@ -2489,11 +2491,19 @@ noglob source \"$3\"
             canonical_loader.parent().unwrap().to_string_lossy()
         );
 
-        let resolved = resolve_helper_paths(&canonical_loader, &candidate, None);
+        let context = SourceClosureLookupContext {
+            source_path_resolver: None,
+            plugin_resolver: None,
+            analyzed_paths: None,
+            shell_profile: ShellProfile::native(ParseShellDialect::Bash),
+            resolved_helper_paths: RefCell::new(FxHashMap::default()),
+            dependency_paths: RefCell::new(FxHashSet::default()),
+        };
+        let resolved = resolve_helper_paths(&canonical_loader, &candidate, &context);
 
-        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved.paths.len(), 1);
         assert_eq!(
-            fs::canonicalize(&resolved[0]).unwrap(),
+            fs::canonicalize(&resolved.paths[0]).unwrap(),
             fs::canonicalize(&helper).unwrap()
         );
     }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -3,7 +3,7 @@ use shuck_ast::{Command, CompoundCommand, Position, Span};
 use shuck_indexer::Indexer;
 use shuck_parser::parser::{Parser, ShellDialect};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::tempdir;
 
 fn model(source: &str) -> SemanticModel {
@@ -102,6 +102,28 @@ fn model_at_path_with_resolver(
         &mut observer,
         Some(path),
         source_path_resolver,
+    )
+}
+
+fn model_at_path_with_plugin_resolver(
+    path: &Path,
+    plugin_resolver: &(dyn PluginResolver + Send + Sync),
+) -> SemanticModel {
+    let source = fs::read_to_string(path).unwrap();
+    let output = Parser::with_dialect(&source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(&source, &output);
+    SemanticModel::build_with_options(
+        &output.file,
+        &source,
+        &indexer,
+        SemanticBuildOptions {
+            source_path: Some(path),
+            plugin_resolver: Some(plugin_resolver),
+            shell_profile: Some(ShellProfile::native(shuck_parser::ShellDialect::Zsh)),
+            ..SemanticBuildOptions::default()
+        },
     )
 }
 
@@ -9023,6 +9045,117 @@ source \"$(dirname \"${BASH_SOURCE[0]}\")/missing-helper.bash\"
     );
     let unused = reportable_unused_names(&model);
     assert!(unused.is_empty(), "unused: {:?}", unused);
+}
+
+#[test]
+fn configured_zsh_plugin_entrypoint_reads_apply_after_file_assignments() {
+    struct EntryResolver {
+        entrypoint: PathBuf,
+    }
+
+    impl PluginResolver for EntryResolver {
+        fn additional_plugin_requests(&self, _source_path: &Path) -> Vec<PluginRequest> {
+            vec![PluginRequest {
+                framework: PluginFramework::ExplicitFilesystem,
+                kind: PluginRequestKind::Entrypoint,
+                name: self.entrypoint.to_string_lossy().into_owned(),
+                span: Span::new(),
+                explicit: true,
+                root_hint: None,
+            }]
+        }
+
+        fn resolve_plugin_request(
+            &self,
+            _source_path: &Path,
+            request: &PluginRequest,
+        ) -> PluginResolution {
+            if request.kind == PluginRequestKind::Entrypoint {
+                PluginResolution {
+                    entrypoints: vec![self.entrypoint.clone()],
+                    file_entry_contracts: Vec::new(),
+                }
+            } else {
+                PluginResolution::default()
+            }
+        }
+    }
+
+    let temp = tempdir().unwrap();
+    let main = temp.path().join("main.zsh");
+    let plugin = temp.path().join("plugin.zsh");
+    fs::write(&main, "#!/bin/zsh\nflag=1\n").unwrap();
+    fs::write(&plugin, "echo \"$flag\"\n").unwrap();
+
+    let resolver = EntryResolver { entrypoint: plugin };
+    let model = model_at_path_with_plugin_resolver(&main, &resolver);
+
+    assert!(
+        model.synthetic_reads.iter().any(|read| read.name == "flag"),
+        "synthetic reads: {:?}",
+        model.synthetic_reads
+    );
+    let unused = reportable_unused_names(&model);
+    assert!(
+        !unused.contains(&Name::from("flag")),
+        "unused: {:?}",
+        unused
+    );
+}
+
+#[test]
+fn plugin_aware_zsh_source_resolution_imports_framework_entrypoint() {
+    struct SourceResolver {
+        entrypoint: PathBuf,
+    }
+
+    impl PluginResolver for SourceResolver {
+        fn resolve_source_path(&self, _source_path: &Path, candidate: &str) -> Vec<PathBuf> {
+            if candidate.ends_with("/oh-my-zsh.sh") {
+                vec![self.entrypoint.clone()]
+            } else {
+                Vec::new()
+            }
+        }
+
+        fn resolve_plugin_request(
+            &self,
+            _source_path: &Path,
+            _request: &PluginRequest,
+        ) -> PluginResolution {
+            PluginResolution::default()
+        }
+    }
+
+    let temp = tempdir().unwrap();
+    let main = temp.path().join("main.zsh");
+    let entrypoint = temp.path().join("oh-my-zsh.sh");
+    fs::write(
+        &main,
+        "#!/bin/zsh\nZSH=/not-installed/.oh-my-zsh\nflag=1\nsource \"$ZSH/oh-my-zsh.sh\"\n",
+    )
+    .unwrap();
+    fs::write(&entrypoint, "echo \"$flag\"\n").unwrap();
+
+    let resolver = SourceResolver { entrypoint };
+    let model = model_at_path_with_plugin_resolver(&main, &resolver);
+
+    assert!(
+        model.synthetic_reads.iter().any(|read| read.name == "flag"),
+        "synthetic reads: {:?}",
+        model.synthetic_reads
+    );
+    assert_eq!(
+        model.source_refs()[0].resolution,
+        SourceRefResolution::Resolved
+    );
+    assert!(model.source_refs()[0].explicitly_provided);
+    let unused = reportable_unused_names(&model);
+    assert!(
+        !unused.contains(&Name::from("flag")),
+        "unused: {:?}",
+        unused
+    );
 }
 
 #[test]

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9086,7 +9086,7 @@ fn configured_zsh_plugin_entrypoint_reads_apply_after_file_assignments() {
     let plugin = temp.path().join("plugin.zsh");
     fs::write(
         &main,
-        "#!/bin/zsh\nflag=1\nlate_scope() {\n  local flag=2\n}\n",
+        "#!/bin/zsh\nif true; then\n  flag=1\nelse\n  flag=2\nfi\nlate_scope() {\n  local flag=3\n}\n",
     )
     .unwrap();
     fs::write(&plugin, "echo \"$flag\"\n").unwrap();

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9159,6 +9159,61 @@ fn plugin_aware_zsh_source_resolution_imports_framework_entrypoint() {
 }
 
 #[test]
+fn plugin_source_resolution_does_not_apply_to_non_zsh_sources() {
+    struct SourceResolver {
+        entrypoint: PathBuf,
+    }
+
+    impl PluginResolver for SourceResolver {
+        fn resolve_source_path(&self, _source_path: &Path, _candidate: &str) -> Vec<PathBuf> {
+            vec![self.entrypoint.clone()]
+        }
+
+        fn resolve_plugin_request(
+            &self,
+            _source_path: &Path,
+            _request: &PluginRequest,
+        ) -> PluginResolution {
+            PluginResolution::default()
+        }
+    }
+
+    let temp = tempdir().unwrap();
+    let main = temp.path().join("main.sh");
+    let entrypoint = temp.path().join("plugin.sh");
+    fs::write(
+        &main,
+        "#!/bin/sh\nflag=1\nsource /opt/app/plugins/plugin.sh\n",
+    )
+    .unwrap();
+    fs::write(&entrypoint, "echo \"$flag\"\n").unwrap();
+
+    let resolver = SourceResolver { entrypoint };
+    let source = fs::read_to_string(&main).unwrap();
+    let output = Parser::with_dialect(&source, ShellDialect::Bash)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(&source, &output);
+    let model = SemanticModel::build_with_options(
+        &output.file,
+        &source,
+        &indexer,
+        SemanticBuildOptions {
+            source_path: Some(&main),
+            plugin_resolver: Some(&resolver),
+            shell_profile: Some(ShellProfile::native(shuck_parser::ShellDialect::Bash)),
+            ..SemanticBuildOptions::default()
+        },
+    );
+
+    assert_eq!(
+        model.source_refs()[0].resolution,
+        SourceRefResolution::Unresolved
+    );
+    assert!(!model.source_refs()[0].explicitly_provided);
+}
+
+#[test]
 fn precise_unused_assignments_match_dataflow_for_source_closure_cases() {
     let temp = tempdir().unwrap();
 

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9084,7 +9084,11 @@ fn configured_zsh_plugin_entrypoint_reads_apply_after_file_assignments() {
     let temp = tempdir().unwrap();
     let main = temp.path().join("main.zsh");
     let plugin = temp.path().join("plugin.zsh");
-    fs::write(&main, "#!/bin/zsh\nflag=1\n").unwrap();
+    fs::write(
+        &main,
+        "#!/bin/zsh\nflag=1\nlate_scope() {\n  local flag=2\n}\n",
+    )
+    .unwrap();
     fs::write(&plugin, "echo \"$flag\"\n").unwrap();
 
     let resolver = EntryResolver { entrypoint: plugin };


### PR DESCRIPTION
## Summary

- expose all zsh diagnostic corpus repositories under one visible root so framework and plugin files can resolve during corpus checks
- make zsh source closure ask the plugin resolver for framework-backed source candidates, starting with Oh My Zsh roots
- anchor configured plugin entrypoints late enough for plugin contracts to consume earlier setup assignments
- update the zsh diagnostic corpus baseline for the newly resolved Oh My Zsh source in `tools/theme_chooser.sh`

## Why

The zsh corpus plugin experiment showed that simply having plugin files on disk is not enough unless source closure can route framework paths like `$ZSH/oh-my-zsh.sh` through the configured plugin roots. This PR adds that first source-aware plugin resolution path and keeps the corpus harness able to exercise it.

## Validation

- `cargo test -p shuck-semantic plugin_aware_zsh_source_resolution_imports_framework_entrypoint`
- `cargo test -p shuck-semantic configured_zsh_plugin_entrypoint_reads_apply_after_file_assignments`
- `cargo test -p shuck-cli --test large_corpus`
- `SHUCK_ZSH_DIAGNOSTIC_CORPUS_ROOT=/Users/ewhauser/working/shuck/.cache/zsh-diagnostic-corpus cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --nocapture`
