### PR TITLE
feat: add PyPI-backed pre-commit support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -212,6 +212,9 @@ echo ok
 EOF
           git add bad.sh
           hook_rev="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+          hook_repo="$RUNNER_TEMP/hook-repo"
+          rm -rf "$hook_repo"
+          git clone --no-local "$GITHUB_WORKSPACE" "$hook_repo" >/dev/null 2>&1
           cat > .pre-commit-config.yaml <<EOF
 repos:
   - repo: $GITHUB_WORKSPACE
@@ -234,6 +237,28 @@ EOF
           fi
 
           grep -F "warning[C001]" "$RUNNER_TEMP/pre-commit-smoke.log" >/dev/null
+
+          cat > .pre-commit-config.yaml <<EOF
+repos:
+  - repo: $hook_repo
+    rev: $hook_rev
+    hooks:
+      - id: shuck-src
+EOF
+
+          set +e
+          pre-commit run shuck-src --files bad.sh \
+            > "$RUNNER_TEMP/pre-commit-src-smoke.log" 2>&1
+          src_hook_status=$?
+          set -e
+
+          cat "$RUNNER_TEMP/pre-commit-src-smoke.log"
+          if [ "$src_hook_status" -eq 0 ]; then
+            echo "expected shuck-src pre-commit hook to report a lint failure" >&2
+            exit 1
+          fi
+
+          grep -F "warning[C001]" "$RUNNER_TEMP/pre-commit-src-smoke.log" >/dev/null
 
   cargo-test-other:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,102 @@ jobs:
         env:
           RUSTDOCFLAGS: "-D warnings"
 
+  python-packaging:
+    name: "python packaging"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: "Install Rust toolchain"
+        run: rustup show
+      - name: "Build packaging test inputs"
+        run: |
+          set -euo pipefail
+          cargo build -p shuck-cli --locked
+
+          python3 -m venv "$RUNNER_TEMP/python-packaging"
+          source "$RUNNER_TEMP/python-packaging/bin/activate"
+          python -m pip install --upgrade pip
+          python -m pip install build pre-commit setuptools wheel
+
+          python scripts/build-python-release.py build-wheel \
+            --target x86_64-unknown-linux-gnu \
+            --binary target/debug/shuck \
+            --out-dir "$RUNNER_TEMP/python-dist"
+
+          pre-commit validate-manifest .pre-commit-hooks.yaml
+      - name: "Smoke test wheel, placeholder install, and pre-commit hook"
+        run: |
+          set -euo pipefail
+
+          expected_version="$(
+            python3 - <<'PY'
+from pathlib import Path
+import tomllib
+
+data = tomllib.loads(Path("python/pyproject.toml").read_text())
+print(data["project"]["version"])
+PY
+          )"
+
+          python3 -m venv "$RUNNER_TEMP/wheel-smoke"
+          source "$RUNNER_TEMP/wheel-smoke/bin/activate"
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install "$RUNNER_TEMP"/python-dist/shuck_cli-*manylinux_2_28_x86_64.whl
+          test "$(shuck --version)" = "shuck ${expected_version}"
+          deactivate
+
+          python3 -m venv "$RUNNER_TEMP/placeholder-smoke"
+          source "$RUNNER_TEMP/placeholder-smoke/bin/activate"
+          python -m pip install --upgrade pip setuptools wheel pre-commit
+          python -m pip install \
+            --find-links "$RUNNER_TEMP/python-dist" \
+            --no-build-isolation \
+            --no-index \
+            .
+          test "$(shuck --version)" = "shuck ${expected_version}"
+
+          smoke_repo="$RUNNER_TEMP/pre-commit-smoke"
+          rm -rf "$smoke_repo"
+          mkdir -p "$smoke_repo"
+          cd "$smoke_repo"
+          git init -q
+          git config user.email shuck@example.com
+          git config user.name shuck
+          cat > bad.sh <<'EOF'
+tmp=$(mktemp)
+echo ok
+EOF
+          git add bad.sh
+          hook_rev="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+          cat > .pre-commit-config.yaml <<EOF
+repos:
+  - repo: $GITHUB_WORKSPACE
+    rev: $hook_rev
+    hooks:
+      - id: shuck
+EOF
+
+          set +e
+          PIP_FIND_LINKS="$RUNNER_TEMP/python-dist" \
+            pre-commit run shuck --files bad.sh \
+            > "$RUNNER_TEMP/pre-commit-smoke.log" 2>&1
+          hook_status=$?
+          set -e
+
+          cat "$RUNNER_TEMP/pre-commit-smoke.log"
+          if [ "$hook_status" -eq 0 ]; then
+            echo "expected shuck pre-commit hook to report a lint failure" >&2
+            exit 1
+          fi
+
+          grep -F "warning[C001]" "$RUNNER_TEMP/pre-commit-smoke.log" >/dev/null
+
   cargo-test-other:
     strategy:
       matrix:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,71 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pypi-publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: python publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install Python packaging tools
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install build setuptools wheel
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/release-assets"
+          gh release download "$RELEASE_TAG" --repo "$REPOSITORY" --dir "$RUNNER_TEMP/release-assets"
+
+      - name: Build PyPI wheels
+        run: |
+          python3 scripts/build-python-release.py build-release-wheels \
+            --assets-dir "$RUNNER_TEMP/release-assets" \
+            --out-dir dist
+
+      - name: Smoke test host wheel
+        run: |
+          set -euo pipefail
+          expected_version="$(
+            python3 - <<'PY'
+from pathlib import Path
+import tomllib
+
+data = tomllib.loads(Path("python/pyproject.toml").read_text())
+print(data["project"]["version"])
+PY
+          )"
+
+          python3 -m venv "$RUNNER_TEMP/pypi-smoke"
+          source "$RUNNER_TEMP/pypi-smoke/bin/activate"
+          python -m pip install --upgrade pip
+          python -m pip install dist/shuck_cli-*manylinux_2_28_x86_64.whl
+          test "$(shuck --version)" = "shuck ${expected_version}"
+
+      - name: Publish wheels to PyPI
+        # PyPI Trusted Publishing must be configured for this repo/workflow/environment.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 
 - id: shuck-src
   name: shuck
-  description: Shell script linter, build from Rust source
-  language: rust
-  entry: shuck check
+  description: Shell script linter, run from the Rust source checkout
+  language: script
+  entry: scripts/pre-commit-shuck-src
   types_or: [shell, yaml]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,13 @@
+- id: shuck
+  name: shuck
+  description: Shell script linter, binary install via PyPI
+  language: python
+  entry: shuck check
+  types_or: [shell, yaml]
+
+- id: shuck-src
+  name: shuck
+  description: Shell script linter, build from Rust source
+  language: rust
+  entry: shuck check
+  types_or: [shell, yaml]

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -39,8 +39,7 @@
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-semantic'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-extract'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-server'].version" },
-        { "type": "toml", "path": "pyproject.toml", "jsonpath": "$.project.version" },
-        { "type": "toml", "path": "pyproject.toml", "jsonpath": "$.project.dependencies[0]" },
+        { "type": "generic", "path": "pyproject.toml" },
         { "type": "toml", "path": "python/pyproject.toml", "jsonpath": "$.project.version" }
       ]
     }

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -38,7 +38,10 @@
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-run'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-semantic'].version" },
         { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-extract'].version" },
-        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-server'].version" }
+        { "type": "toml", "path": "Cargo.toml", "jsonpath": "$.workspace.dependencies['shuck-server'].version" },
+        { "type": "toml", "path": "pyproject.toml", "jsonpath": "$.project.version" },
+        { "type": "toml", "path": "pyproject.toml", "jsonpath": "$.project.dependencies[0]" },
+        { "type": "toml", "path": "python/pyproject.toml", "jsonpath": "$.project.version" }
       ]
     }
   }

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ repos:
 
 Replace `v0.0.35` with the release you want to pin.
 
-If you would rather build from source, or you are on a platform that does not
-have a published wheel yet, use the Rust hook instead:
+If you would rather run from the checked-out Rust sources, or you are on a
+platform that does not have a published wheel yet, use the source hook instead:
 
 ```yaml
 repos:
@@ -100,6 +100,9 @@ repos:
     hooks:
       - id: shuck-src
 ```
+
+The `shuck-src` hook requires a working Rust toolchain because it runs
+`cargo run -p shuck-cli -- check ...` from the cloned hook repository.
 
 ### Clean caches
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Shuck parses and analyzes shell scripts to catch common bugs, style issues, and 
 brew install ewhauser/tap/shuck
 ```
 
+### PyPI
+
+```sh
+pip install shuck-cli
+```
+
+The PyPI package is named `shuck-cli`, but it still installs the `shuck`
+command.
+
 ### From source
 
 ```sh
@@ -64,6 +73,32 @@ shuck check --no-cache .
 
 # Override the cache location
 shuck --cache-dir .tmp/shuck-cache check .
+```
+
+### Pre-commit
+
+Use the binary-backed hook when you want pre-commit to install `shuck`
+without requiring a local Rust toolchain:
+
+```yaml
+repos:
+  - repo: https://github.com/ewhauser/shuck
+    rev: v0.0.35
+    hooks:
+      - id: shuck
+```
+
+Replace `v0.0.35` with the release you want to pin.
+
+If you would rather build from source, or you are on a platform that does not
+have a published wheel yet, use the Rust hook instead:
+
+```yaml
+repos:
+  - repo: https://github.com/ewhauser/shuck
+    rev: v0.0.35
+    hooks:
+      - id: shuck-src
 ```
 
 ### Clean caches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=70.1"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "shuck-pre-commit-placeholder"
+version = "0.0.35"
+description = "Placeholder package for installing shuck from the repository pre-commit hook"
+requires-python = ">=3.8"
+license = "MIT"
+dependencies = ["shuck-cli==0.0.35"]
+
+[tool.setuptools]
+py-modules = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "shuck-pre-commit-placeholder"
-version = "0.0.35"
+version = "0.0.35" # x-release-please-version
 description = "Placeholder package for installing shuck from the repository pre-commit hook"
 requires-python = ">=3.8"
 license = "MIT"
-dependencies = ["shuck-cli==0.0.35"]
+dependencies = [
+  "shuck-cli==0.0.35", # x-release-please-version
+]
 
 [tool.setuptools]
 py-modules = []

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,11 @@
+# shuck-cli
+
+`shuck-cli` is the PyPI distribution for the `shuck` command-line tool.
+
+Install it with:
+
+```bash
+pip install shuck-cli
+```
+
+The installed executable is still named `shuck`.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,40 @@
+[build-system]
+requires = ["setuptools>=70.1"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "shuck-cli"
+version = "0.0.35"
+description = "Python wheel wrapper for the shuck CLI binary"
+readme = "README.md"
+requires-python = ">=3.8"
+license = "MIT"
+authors = [{ name = "Eric Hauser" }]
+keywords = ["shell", "bash", "linter", "static-analysis", "cli"]
+classifiers = [
+  "Environment :: Console",
+  "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Topic :: Software Development :: Quality Assurance",
+]
+
+[project.urls]
+Homepage = "https://github.com/ewhauser/shuck"
+Issues = "https://github.com/ewhauser/shuck/issues"
+Repository = "https://github.com/ewhauser/shuck"
+
+[project.scripts]
+shuck = "shuck_cli._launcher:main"
+
+[tool.setuptools]
+package-dir = { "" = "src" }
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+shuck_cli = ["bin/*"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from setuptools import setup
+from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+from setuptools.command.build_py import build_py as _build_py
+from setuptools.dist import Distribution
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parent / "src" / "shuck_cli"
+BIN_DIR = PACKAGE_ROOT / "bin"
+
+
+class BinaryDistribution(Distribution):
+    def has_ext_modules(self) -> bool:
+        return True
+
+
+class build_py(_build_py):
+    def run(self) -> None:
+        staged = [BIN_DIR / "shuck", BIN_DIR / "shuck.exe"]
+        if not any(path.is_file() for path in staged):
+            raise RuntimeError(
+                "no staged shuck binary found under src/shuck_cli/bin; "
+                "use scripts/build-python-release.py to prepare the wheel"
+            )
+        super().run()
+
+
+class bdist_wheel(_bdist_wheel):
+    def finalize_options(self) -> None:
+        super().finalize_options()
+        self.root_is_pure = False
+
+        plat_name = os.environ.get("SHUCK_PYTHON_WHEEL_PLAT_NAME")
+        if plat_name:
+            self.plat_name_supplied = True
+            self.plat_name = plat_name
+
+    def get_tag(self) -> tuple[str, str, str]:
+        python_tag = os.environ.get("SHUCK_PYTHON_WHEEL_PYTHON_TAG")
+        abi_tag = os.environ.get("SHUCK_PYTHON_WHEEL_ABI_TAG")
+        plat_name = os.environ.get("SHUCK_PYTHON_WHEEL_PLAT_NAME")
+        if python_tag and abi_tag and plat_name:
+            normalized_plat = plat_name.replace("-", "_").replace(".", "_")
+            return python_tag, abi_tag, normalized_plat
+        return super().get_tag()
+
+
+setup(
+    distclass=BinaryDistribution,
+    cmdclass={
+        "bdist_wheel": bdist_wheel,
+        "build_py": build_py,
+    },
+)

--- a/python/src/shuck_cli/__init__.py
+++ b/python/src/shuck_cli/__init__.py
@@ -1,0 +1,1 @@
+"""Python wheel wrapper for the shuck CLI."""

--- a/python/src/shuck_cli/_launcher.py
+++ b/python/src/shuck_cli/_launcher.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def bundled_binary_path() -> Path:
+    binary_name = "shuck.exe" if os.name == "nt" else "shuck"
+    return Path(__file__).resolve().parent / "bin" / binary_name
+
+
+def main() -> int:
+    binary_path = bundled_binary_path()
+    if not binary_path.is_file():
+        print(
+            f"shuck-cli wheel is missing bundled executable: {binary_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    argv = [os.fspath(binary_path), *sys.argv[1:]]
+    if os.name != "nt":
+        os.execv(os.fspath(binary_path), argv)
+        return 0
+
+    completed = subprocess.run(argv, check=False)
+    return completed.returncode

--- a/scripts/build-python-release.py
+++ b/scripts/build-python-release.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Build platform-specific shuck-cli wheels from staged binaries or release assets."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+PYTHON_TAG = "py3"
+ABI_TAG = "none"
+
+
+@dataclass(frozen=True)
+class TargetSpec:
+    target: str
+    archive_name: str
+    packaged_binary_name: str
+    wheel_platform_tag: str
+
+
+TARGETS: dict[str, TargetSpec] = {
+    "aarch64-apple-darwin": TargetSpec(
+        target="aarch64-apple-darwin",
+        archive_name="shuck-cli-aarch64-apple-darwin.tar.xz",
+        packaged_binary_name="shuck",
+        wheel_platform_tag="macosx_11_0_arm64",
+    ),
+    "aarch64-unknown-linux-gnu": TargetSpec(
+        target="aarch64-unknown-linux-gnu",
+        archive_name="shuck-cli-aarch64-unknown-linux-gnu.tar.xz",
+        packaged_binary_name="shuck",
+        wheel_platform_tag="manylinux_2_28_aarch64",
+    ),
+    "aarch64-unknown-linux-musl": TargetSpec(
+        target="aarch64-unknown-linux-musl",
+        archive_name="shuck-cli-aarch64-unknown-linux-musl.tar.xz",
+        packaged_binary_name="shuck",
+        wheel_platform_tag="musllinux_1_2_aarch64",
+    ),
+    "x86_64-pc-windows-msvc": TargetSpec(
+        target="x86_64-pc-windows-msvc",
+        archive_name="shuck-cli-x86_64-pc-windows-msvc.zip",
+        packaged_binary_name="shuck.exe",
+        wheel_platform_tag="win_amd64",
+    ),
+    "x86_64-unknown-linux-gnu": TargetSpec(
+        target="x86_64-unknown-linux-gnu",
+        archive_name="shuck-cli-x86_64-unknown-linux-gnu.tar.xz",
+        packaged_binary_name="shuck",
+        wheel_platform_tag="manylinux_2_28_x86_64",
+    ),
+    "x86_64-unknown-linux-musl": TargetSpec(
+        target="x86_64-unknown-linux-musl",
+        archive_name="shuck-cli-x86_64-unknown-linux-musl.tar.xz",
+        packaged_binary_name="shuck",
+        wheel_platform_tag="musllinux_1_2_x86_64",
+    ),
+}
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_wheel = subparsers.add_parser(
+        "build-wheel",
+        help="Build one wheel from a local binary or a downloaded release archive",
+    )
+    build_wheel.add_argument("--target", required=True, choices=sorted(TARGETS))
+    build_wheel.add_argument("--out-dir", required=True)
+    source_group = build_wheel.add_mutually_exclusive_group(required=True)
+    source_group.add_argument("--archive", help="Path to a downloaded release archive")
+    source_group.add_argument("--binary", help="Path to a compiled shuck executable")
+
+    build_release = subparsers.add_parser(
+        "build-release-wheels",
+        help="Build wheels for every supported target from a directory of release assets",
+    )
+    build_release.add_argument("--assets-dir", required=True)
+    build_release.add_argument("--out-dir", required=True)
+
+    return parser.parse_args()
+
+
+def stage_binary(source_binary: Path, spec: TargetSpec, build_root: Path) -> None:
+    package_bin_dir = build_root / "src" / "shuck_cli" / "bin"
+    package_bin_dir.mkdir(parents=True, exist_ok=True)
+
+    destination = package_bin_dir / spec.packaged_binary_name
+    shutil.copy2(source_binary, destination)
+    if spec.packaged_binary_name == "shuck":
+        destination.chmod(0o755)
+
+
+def find_archive_binary(extracted_root: Path, spec: TargetSpec) -> Path:
+    matches = sorted(extracted_root.rglob(spec.packaged_binary_name))
+    if len(matches) != 1:
+        raise SystemExit(
+            f"expected exactly one {spec.packaged_binary_name} inside {extracted_root}, "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def extract_archive(archive_path: Path, spec: TargetSpec, tempdir: Path) -> Path:
+    extracted_root = tempdir / "extracted"
+    extracted_root.mkdir(parents=True, exist_ok=True)
+
+    if archive_path.suffix == ".zip":
+        with zipfile.ZipFile(archive_path) as archive:
+            archive.extractall(extracted_root)
+    else:
+        with tarfile.open(archive_path, mode="r:*") as archive:
+            archive.extractall(extracted_root)
+
+    return find_archive_binary(extracted_root, spec)
+
+
+def prepare_build_tree(spec: TargetSpec, source_binary: Path) -> Path:
+    source_root = repo_root() / "python"
+    tempdir = Path(tempfile.mkdtemp(prefix="shuck-python-wheel-"))
+    build_root = tempdir / "python"
+    shutil.copytree(source_root, build_root)
+    stage_binary(source_binary, spec, build_root)
+    return build_root
+
+
+def build_wheel(build_root: Path, spec: TargetSpec, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    env = os.environ.copy()
+    env.update(
+        {
+            "SHUCK_PYTHON_WHEEL_ABI_TAG": ABI_TAG,
+            "SHUCK_PYTHON_WHEEL_PLAT_NAME": spec.wheel_platform_tag,
+            "SHUCK_PYTHON_WHEEL_PYTHON_TAG": PYTHON_TAG,
+        }
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--no-isolation",
+            "--outdir",
+            os.fspath(out_dir),
+            os.fspath(build_root),
+        ],
+        check=True,
+        env=env,
+    )
+
+
+def build_one_wheel(
+    spec: TargetSpec,
+    out_dir: Path,
+    archive: str | None,
+    binary: str | None,
+) -> None:
+    if archive is None and binary is None:
+        raise SystemExit("expected either --archive or --binary")
+
+    if archive is not None:
+        archive_path = Path(archive).resolve()
+        if not archive_path.is_file():
+            raise SystemExit(f"release archive not found: {archive_path}")
+        with tempfile.TemporaryDirectory(prefix="shuck-python-archive-") as tempdir:
+            source_binary = extract_archive(archive_path, spec, Path(tempdir))
+            build_root = prepare_build_tree(spec, source_binary)
+            try:
+                build_wheel(build_root, spec, out_dir)
+            finally:
+                shutil.rmtree(build_root.parent)
+        return
+
+    binary_path = Path(binary).resolve()
+    if not binary_path.is_file():
+        raise SystemExit(f"binary not found: {binary_path}")
+    build_root = prepare_build_tree(spec, binary_path)
+    try:
+        build_wheel(build_root, spec, out_dir)
+    finally:
+        shutil.rmtree(build_root.parent)
+
+
+def build_release_wheels(assets_dir: Path, out_dir: Path) -> None:
+    missing = [
+        spec.archive_name
+        for spec in TARGETS.values()
+        if not (assets_dir / spec.archive_name).is_file()
+    ]
+    if missing:
+        joined = "\n".join(f"  - {name}" for name in missing)
+        raise SystemExit(f"missing expected release assets:\n{joined}")
+
+    for target in sorted(TARGETS):
+        spec = TARGETS[target]
+        build_one_wheel(
+            spec,
+            out_dir,
+            archive=os.fspath(assets_dir / spec.archive_name),
+            binary=None,
+        )
+
+
+def main() -> int:
+    args = parse_args()
+
+    if args.command == "build-wheel":
+        spec = TARGETS[args.target]
+        build_one_wheel(
+            spec,
+            Path(args.out_dir).resolve(),
+            archive=args.archive,
+            binary=args.binary,
+        )
+        return 0
+
+    if args.command == "build-release-wheels":
+        build_release_wheels(
+            Path(args.assets_dir).resolve(),
+            Path(args.out_dir).resolve(),
+        )
+        return 0
+
+    raise AssertionError(f"unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check-release-please-config.py
+++ b/scripts/check-release-please-config.py
@@ -29,6 +29,16 @@ def configured_jsonpaths(repo_root: Path) -> set[str]:
     }
 
 
+def configured_generic_paths(repo_root: Path) -> set[str]:
+    config = json.loads((repo_root / ".release-please-config.json").read_text())
+    package_config = config["packages"]["."]
+    return {
+        entry["path"]
+        for entry in package_config.get("extra-files", [])
+        if entry.get("type") == "generic" and "path" in entry
+    }
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parent.parent
     expected = {
@@ -37,17 +47,29 @@ def main() -> int:
     }
     expected.update(
         {
-            "pyproject.toml::$.project.dependencies[0]",
-            "pyproject.toml::$.project.version",
             "python/pyproject.toml::$.project.version",
         }
     )
     actual = configured_jsonpaths(repo_root)
     missing = sorted(expected - actual)
+    generic_paths = configured_generic_paths(repo_root)
+
+    if "pyproject.toml" not in generic_paths:
+        missing.append("pyproject.toml::generic")
 
     if missing:
         for entry in missing:
             print(f"missing release-please extra-files entry: {entry}", file=sys.stderr)
+        return 1
+
+    pyproject_text = (repo_root / "pyproject.toml").read_text()
+    marker = "x-release-please-version"
+    marker_count = pyproject_text.count(marker)
+    if marker_count != 2:
+        print(
+            f"expected pyproject.toml to contain 2 {marker!r} annotations, found {marker_count}",
+            file=sys.stderr,
+        )
         return 1
 
     print("release-please config covers Rust crates and Python packaging metadata")

--- a/scripts/check-release-please-config.py
+++ b/scripts/check-release-please-config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate release-please version bumps for publishable workspace crates."""
+"""Validate release-please version bumps for Rust crates and Python packaging files."""
 
 from __future__ import annotations
 
@@ -23,27 +23,34 @@ def configured_jsonpaths(repo_root: Path) -> set[str]:
     config = json.loads((repo_root / ".release-please-config.json").read_text())
     package_config = config["packages"]["."]
     return {
-        entry["jsonpath"]
+        f"{entry['path']}::{entry['jsonpath']}"
         for entry in package_config.get("extra-files", [])
-        if entry.get("path") == "Cargo.toml" and "jsonpath" in entry
+        if "jsonpath" in entry and "path" in entry
     }
 
 
 def main() -> int:
     repo_root = Path(__file__).resolve().parent.parent
     expected = {
-        f"$.workspace.dependencies['{crate_name}'].version"
+        f"Cargo.toml::$.workspace.dependencies['{crate_name}'].version"
         for crate_name in publishable_workspace_crates(repo_root)
     }
+    expected.update(
+        {
+            "pyproject.toml::$.project.dependencies[0]",
+            "pyproject.toml::$.project.version",
+            "python/pyproject.toml::$.project.version",
+        }
+    )
     actual = configured_jsonpaths(repo_root)
     missing = sorted(expected - actual)
 
     if missing:
-        for jsonpath in missing:
-            print(f"missing release-please extra-files entry: {jsonpath}", file=sys.stderr)
+        for entry in missing:
+            print(f"missing release-please extra-files entry: {entry}", file=sys.stderr)
         return 1
 
-    print("release-please config covers all publishable workspace crates")
+    print("release-please config covers Rust crates and Python packaging metadata")
     return 0
 
 

--- a/scripts/pre-commit-shuck-src
+++ b/scripts/pre-commit-shuck-src
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+
+exec cargo run --quiet \
+  --manifest-path "$repo_root/crates/shuck-cli/Cargo.toml" \
+  -- check "$@"

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -69,8 +69,8 @@ repos:
 
 Replace `v0.0.35` with the release you want to pin.
 
-Use the source-build fallback instead when you prefer a Rust build or need an
-unsupported platform:
+Use the source fallback instead when you prefer to run from the Rust checkout or
+need an unsupported platform:
 
 ```yaml
 repos:
@@ -79,6 +79,9 @@ repos:
     hooks:
       - id: shuck-src
 ```
+
+The `shuck-src` hook requires a working Rust toolchain because it runs
+`cargo run -p shuck-cli -- check ...` from the cloned hook repository.
 
 ## Editor integration
 

--- a/website/content/getting-started/index.mdx
+++ b/website/content/getting-started/index.mdx
@@ -16,6 +16,15 @@ Shuck aims to be orders of magnitude faster than ShellCheck while expanding cove
 
 ## Installation
 
+### PyPI
+
+```bash
+pip install shuck-cli
+```
+
+The PyPI package name is `shuck-cli`, but it still installs the `shuck`
+command.
+
 ### From source
 
 ```bash
@@ -43,6 +52,32 @@ echo 'echo $foo' | shuck check -
 
 # Apply safe fixes automatically
 shuck check --fix .
+```
+
+## Pre-commit
+
+Use the published wheel-backed hook when you want pre-commit support without a
+local Rust toolchain:
+
+```yaml
+repos:
+  - repo: https://github.com/ewhauser/shuck
+    rev: v0.0.35
+    hooks:
+      - id: shuck
+```
+
+Replace `v0.0.35` with the release you want to pin.
+
+Use the source-build fallback instead when you prefer a Rust build or need an
+unsupported platform:
+
+```yaml
+repos:
+  - repo: https://github.com/ewhauser/shuck
+    rev: v0.0.35
+    hooks:
+      - id: shuck-src
 ```
 
 ## Editor integration


### PR DESCRIPTION
## Summary
- add repo-root pre-commit hook metadata for both the binary-backed `shuck` hook and the Rust source-build fallback
- add the `shuck-cli` Python packaging layout plus a release workflow that repackages GitHub release assets into PyPI wheels
- extend CI, release-please coverage, and install docs to validate and document the new packaging path

## Testing
- `python3 scripts/check-release-please-config.py`
- `python3 -m py_compile scripts/build-python-release.py python/setup.py python/src/shuck_cli/_launcher.py`
- `cargo build -p shuck-cli --locked`
- local wheel + placeholder install + `pre-commit` smoke run against a temporary repo
- `python scripts/build-python-release.py build-release-wheels --assets-dir <downloaded v0.0.35 assets> --out-dir <temp dir>`

Closes #816