### PR TITLE
fix(zsh): preserve zinit associative array semantics

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -582,12 +582,18 @@ impl PluginResolver for ResolvedZshPluginSettings {
             return Vec::new();
         }
 
-        let Some(root) = self.roots.get("oh-my-zsh") else {
-            return Vec::new();
-        };
-        oh_my_zsh_source_suffix(root, source_path, candidate)
-            .map(|suffix| vec![root.join(suffix)])
-            .unwrap_or_default()
+        let mut paths = Vec::new();
+        if let Some(root) = self.roots.get("oh-my-zsh")
+            && let Some(suffix) = oh_my_zsh_source_suffix(root, source_path, candidate)
+        {
+            paths.push(root.join(suffix));
+        }
+        if let Some(root) = self.roots.get("zinit")
+            && let Some(suffix) = zinit_source_suffix(root, source_path, candidate)
+        {
+            paths.push(root.join(suffix));
+        }
+        paths
     }
 
     fn resolve_plugin_request(
@@ -608,6 +614,9 @@ impl PluginResolver for ResolvedZshPluginSettings {
                 }
             }
             PluginRequestKind::Plugin => {
+                if matches!(request.framework, PluginFramework::Zinit) {
+                    return PluginResolution::default();
+                }
                 let Some(root) = request
                     .root_hint
                     .clone()
@@ -625,6 +634,9 @@ impl PluginResolver for ResolvedZshPluginSettings {
                 }
             }
             PluginRequestKind::Theme => {
+                if matches!(request.framework, PluginFramework::Zinit) {
+                    return PluginResolution::default();
+                }
                 let Some(root) = request
                     .root_hint
                     .clone()
@@ -699,6 +711,7 @@ fn plugin_framework_from_name(name: &str) -> PluginFramework {
     match name {
         "oh-my-zsh" => PluginFramework::OhMyZsh,
         "prezto" => PluginFramework::Prezto,
+        "zinit" | "zi" => PluginFramework::Zinit,
         other => PluginFramework::Other(other.to_owned()),
     }
 }
@@ -710,6 +723,7 @@ fn plugin_root_for_request(
     let key = match &request.framework {
         PluginFramework::OhMyZsh => "oh-my-zsh",
         PluginFramework::Prezto => "prezto",
+        PluginFramework::Zinit => "zinit",
         PluginFramework::ExplicitFilesystem => return None,
         PluginFramework::Other(other) => other.as_str(),
     };
@@ -743,6 +757,46 @@ fn oh_my_zsh_source_suffix(root: &Path, source_path: &Path, candidate: &str) -> 
 
 fn path_text_has_oh_my_zsh_anchor(path: &str) -> bool {
     path.contains("/.oh-my-zsh/") || path.contains("/oh-my-zsh/")
+}
+
+fn zinit_source_suffix(root: &Path, source_path: &Path, candidate: &str) -> Option<PathBuf> {
+    let normalized = candidate.replace('\\', "/");
+    let source_in_framework = source_path.starts_with(root);
+    let candidate_has_framework_anchor =
+        path_text_has_zinit_anchor(&normalized) || path_text_starts_with_path(&normalized, root);
+    if !source_in_framework && !candidate_has_framework_anchor && normalized != "zinit.zsh" {
+        return None;
+    }
+
+    for marker in ["/share/", "/doc/"] {
+        if let Some(index) = normalized.rfind(marker) {
+            let suffix = &normalized[index + 1..];
+            if !suffix.is_empty() {
+                return Some(PathBuf::from(suffix));
+            }
+        }
+    }
+
+    zinit_builtin_source_suffix(&normalized).map(PathBuf::from)
+}
+
+fn zinit_builtin_source_suffix(path: &str) -> Option<&'static str> {
+    let file_name = path.rsplit('/').next().unwrap_or(path);
+    match file_name {
+        "zinit.zsh" => Some("zinit.zsh"),
+        "zinit-additional.zsh" => Some("zinit-additional.zsh"),
+        "zinit-autoload.zsh" => Some("zinit-autoload.zsh"),
+        "zinit-install.zsh" => Some("zinit-install.zsh"),
+        "zinit-side.zsh" => Some("zinit-side.zsh"),
+        _ => None,
+    }
+}
+
+fn path_text_has_zinit_anchor(path: &str) -> bool {
+    path.contains("/.zinit/")
+        || path.contains("/zinit/")
+        || path.contains("/.zi/")
+        || path.contains("/zi/")
 }
 
 fn path_text_starts_with_path(path: &str, root: &Path) -> bool {
@@ -1833,6 +1887,83 @@ mod tests {
                 "/not-installed/.oh-my-zsh/oh-my-zsh.sh",
             ),
             Some(PathBuf::from("oh-my-zsh.sh"))
+        );
+    }
+
+    #[test]
+    fn zinit_source_suffix_rewrites_framework_bootstrap_paths_only() {
+        let root = Path::new("/workspace/zinit");
+
+        assert_eq!(
+            zinit_source_suffix(
+                root,
+                Path::new("/workspace/script.zsh"),
+                "/not-installed/.zinit/bin/zinit.zsh",
+            ),
+            Some(PathBuf::from("zinit.zsh"))
+        );
+        assert_eq!(
+            zinit_source_suffix(
+                root,
+                Path::new("/workspace/zinit/zinit.zsh"),
+                "/opt/app/share/zinit-autoload.zsh",
+            ),
+            Some(PathBuf::from("share/zinit-autoload.zsh"))
+        );
+        assert_eq!(
+            zinit_source_suffix(
+                root,
+                Path::new("/workspace/script.zsh"),
+                "/opt/app/share/zinit-autoload.zsh",
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn zinit_plugin_root_resolves_bootstrap_source_paths() {
+        let settings = ResolvedZshPluginSettings::resolve(
+            PathBuf::from("/workspace"),
+            true,
+            BTreeMap::from([("zinit".to_owned(), "/workspace/zinit".to_owned())]),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings.resolve_source_path(
+                Path::new("/workspace/app/.zshrc"),
+                "/not-installed/.zinit/bin/zinit.zsh",
+            ),
+            vec![PathBuf::from("/workspace/zinit/zinit.zsh")]
+        );
+    }
+
+    #[test]
+    fn zinit_plugin_root_does_not_use_oh_my_zsh_plugin_layout() {
+        let settings = ResolvedZshPluginSettings::resolve(
+            PathBuf::from("/workspace"),
+            true,
+            BTreeMap::from([("zinit".to_owned(), "/workspace/zinit".to_owned())]),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let request = PluginRequest {
+            framework: PluginFramework::Zinit,
+            kind: PluginRequestKind::Plugin,
+            name: "owner/repo".to_owned(),
+            span: shuck_ast::Span::new(),
+            explicit: true,
+            root_hint: None,
+        };
+
+        assert_eq!(
+            settings.resolve_plugin_request(Path::new("/workspace/app/.zshrc"), &request),
+            PluginResolution::default()
         );
     }
 

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -588,10 +588,10 @@ impl PluginResolver for ResolvedZshPluginSettings {
         {
             paths.push(root.join(suffix));
         }
-        if let Some(root) = self.roots.get("zinit")
-            && let Some(suffix) = zinit_source_suffix(root, source_path, candidate)
-        {
-            paths.push(root.join(suffix));
+        for root in zinit_roots(self) {
+            if let Some(suffix) = zinit_source_suffix(root, source_path, candidate) {
+                paths.push(root.join(suffix));
+            }
         }
         paths
     }
@@ -723,11 +723,17 @@ fn plugin_root_for_request(
     let key = match &request.framework {
         PluginFramework::OhMyZsh => "oh-my-zsh",
         PluginFramework::Prezto => "prezto",
-        PluginFramework::Zinit => "zinit",
+        PluginFramework::Zinit => return zinit_roots(settings).next().cloned(),
         PluginFramework::ExplicitFilesystem => return None,
         PluginFramework::Other(other) => other.as_str(),
     };
     settings.roots.get(key).cloned()
+}
+
+fn zinit_roots(settings: &ResolvedZshPluginSettings) -> impl Iterator<Item = &PathBuf> {
+    ["zinit", "zi"]
+        .into_iter()
+        .filter_map(|key| settings.roots.get(key))
 }
 
 fn oh_my_zsh_source_suffix(root: &Path, source_path: &Path, candidate: &str) -> Option<PathBuf> {
@@ -1938,6 +1944,27 @@ mod tests {
                 "/not-installed/.zinit/bin/zinit.zsh",
             ),
             vec![PathBuf::from("/workspace/zinit/zinit.zsh")]
+        );
+    }
+
+    #[test]
+    fn zinit_plugin_root_resolves_zi_alias_bootstrap_source_paths() {
+        let settings = ResolvedZshPluginSettings::resolve(
+            PathBuf::from("/workspace"),
+            true,
+            BTreeMap::from([("zi".to_owned(), "/workspace/zi".to_owned())]),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            settings.resolve_source_path(
+                Path::new("/workspace/app/.zshrc"),
+                "/not-installed/.zi/bin/zinit.zsh",
+            ),
+            vec![PathBuf::from("/workspace/zi/zinit.zsh")]
         );
     }
 

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -84,6 +84,7 @@ const SHELLCHECK_CACHE_SCHEMA: u32 = 3;
 const SHELLCHECK_CACHE_MIGRATION_VERSION: u32 = 1;
 const ZSH_DIAGNOSTIC_CORPUS_BASELINE: &str = include_str!("testdata/zsh-diagnostic-corpus.yaml");
 const ZSH_DIAGNOSTIC_OH_MY_ZSH_REPO: &str = "ohmyzsh";
+const ZSH_DIAGNOSTIC_ZINIT_REPO: &str = "zinit";
 const ZSH_DIAGNOSTIC_PLUGIN_ENTRYPOINTS: &[(&str, &str)] = &[
     (
         "zdot/modules/autocompletion/autocompletion.zsh",
@@ -1993,6 +1994,11 @@ fn zsh_diagnostic_plugin_args(visible_root: &Path) -> Vec<String> {
     if oh_my_zsh_root.join("oh-my-zsh.sh").is_file() {
         args.push("--zsh-plugin-root".into());
         args.push(format!("oh-my-zsh={}", path_arg(&oh_my_zsh_root)));
+    }
+    let zinit_root = visible_root.join(ZSH_DIAGNOSTIC_ZINIT_REPO);
+    if zinit_root.join("zinit.zsh").is_file() {
+        args.push("--zsh-plugin-root".into());
+        args.push(format!("zinit={}", path_arg(&zinit_root)));
     }
 
     for (source_pattern, entrypoint) in ZSH_DIAGNOSTIC_PLUGIN_ENTRYPOINTS {
@@ -5621,6 +5627,7 @@ repos:
                 .join("zsh-autosuggestions/zsh-autosuggestions.plugin.zsh"),
             "autosuggestions plugin\n",
         );
+        write_file(visible_root.path().join("zinit/zinit.zsh"), "zinit\n");
 
         let args = zsh_diagnostic_plugin_args(visible_root.path());
 
@@ -5631,6 +5638,10 @@ repos:
                         "oh-my-zsh={}",
                         visible_root.path().join("ohmyzsh").display()
                     )
+        }));
+        assert!(args.windows(2).any(|window| {
+            window[0] == "--zsh-plugin-root"
+                && window[1] == format!("zinit={}", visible_root.path().join("zinit").display())
         }));
         assert!(args.windows(2).any(|window| {
             window[0] == "--extend-zsh-plugin-entrypoint"

--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -18426,28 +18426,6 @@ repos:
           column: 26
         classification: false_positive
       - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `ice` is referenced before assignment"
-        start:
-          line: 77
-          column: 7
-        end:
-          line: 77
-          column: 10
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `nval` is referenced before assignment"
-        start:
-          line: 98
-          column: 7
-        end:
-          line: 98
-          column: 11
-        classification: false_positive
-      - path: "zinit.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `ZINIT_2MAP` is assigned but never used"
@@ -18481,6 +18459,17 @@ repos:
           column: 65
         classification: real
       - path: "zinit.zsh"
+        code: "C156"
+        severity: "warning"
+        message: "reference to `PLUGINS_DIR` looks like it may mean `PLUGIN_DIR`"
+        start:
+          line: 353
+          column: 24
+        end:
+          line: 353
+          column: 36
+        classification: real
+      - path: "zinit.zsh"
         code: "C010"
         severity: "warning"
         message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
@@ -18491,28 +18480,6 @@ repos:
           line: 449
           column: 23
         classification: real
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `BINDKEYS___dtrace` is referenced before assignment"
-        start:
-          line: 551
-          column: 45
-        end:
-          line: 551
-          column: 62
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `_dtrace` is referenced before assignment"
-        start:
-          line: 551
-          column: 63
-        end:
-          line: 551
-          column: 70
-        classification: false_positive
       - path: "zinit.zsh"
         code: "C001"
         severity: "warning"
@@ -18525,17 +18492,6 @@ repos:
           column: 23
         classification: real
       - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `ZSTYLES___dtrace` is referenced before assignment"
-        start:
-          line: 620
-          column: 45
-        end:
-          line: 620
-          column: 61
-        classification: false_positive
-      - path: "zinit.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `avalue` is assigned but never used"
@@ -18546,127 +18502,6 @@ repos:
           line: 652
           column: 21
         classification: real
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `ALIASES___dtrace` is referenced before assignment"
-        start:
-          line: 677
-          column: 45
-        end:
-          line: 677
-          column: 61
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `WIDGETS_DELETE___dtrace` is referenced before assignment"
-        start:
-          line: 708
-          column: 53
-        end:
-          line: 708
-          column: 76
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `WIDGETS_SAVED___dtrace` is referenced before assignment"
-        start:
-          line: 726
-          column: 53
-        end:
-          line: 726
-          column: 75
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bkp` is referenced before assignment"
-        start:
-          line: 782
-          column: 48
-        end:
-          line: 782
-          column: 51
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `autoload` is referenced before assignment"
-        start:
-          line: 782
-          column: 52
-        end:
-          line: 782
-          column: 60
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `compdef` is referenced before assignment"
-        start:
-          line: 787
-          column: 47
-        end:
-          line: 787
-          column: 54
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `source` is referenced before assignment"
-        start:
-          line: 792
-          column: 50
-        end:
-          line: 792
-          column: 56
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `bindkey` is referenced before assignment"
-        start:
-          line: 806
-          column: 47
-        end:
-          line: 806
-          column: 54
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `zstyle` is referenced before assignment"
-        start:
-          line: 813
-          column: 46
-        end:
-          line: 813
-          column: 52
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `alias` is referenced before assignment"
-        start:
-          line: 817
-          column: 45
-        end:
-          line: 817
-          column: 50
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `zle` is referenced before assignment"
-        start:
-          line: 821
-          column: 43
-        end:
-          line: 821
-          column: 46
-        classification: false_positive
       - path: "zinit.zsh"
         code: "C081"
         severity: "warning"
@@ -19350,17 +19185,6 @@ repos:
           column: 27
         classification: real
       - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `fts` is referenced before assignment"
-        start:
-          line: 2375
-          column: 24
-        end:
-          line: 2375
-          column: 27
-        classification: false_positive
-      - path: "zinit.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -19404,50 +19228,6 @@ repos:
           line: 2673
           column: 47
         classification: real
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `annex` is referenced before assignment"
-        start:
-          line: 2689
-          column: 15
-        end:
-          line: 2689
-          column: 20
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `exposed` is referenced before assignment"
-        start:
-          line: 2689
-          column: 21
-        end:
-          line: 2689
-          column: 28
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `processed` is referenced before assignment"
-        start:
-          line: 2689
-          column: 29
-        end:
-          line: 2689
-          column: 38
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `IDs` is referenced before assignment"
-        start:
-          line: 2689
-          column: 39
-        end:
-          line: 2689
-          column: 42
-        classification: false_positive
       - path: "zinit.zsh"
         code: "C099"
         severity: "warning"
@@ -19569,28 +19349,6 @@ repos:
           line: 3133
           column: 67
         classification: real
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `STATES___local` is referenced before assignment"
-        start:
-          line: 3255
-          column: 7
-        end:
-          line: 3255
-          column: 21
-        classification: false_positive
-      - path: "zinit.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `zinit` is referenced before assignment"
-        start:
-          line: 3255
-          column: 22
-        end:
-          line: 3255
-          column: 27
-        classification: false_positive
       - path: "zinit.zsh"
         code: "C005"
         severity: "warning"

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -900,12 +900,18 @@ write_target
             .unwrap_or_else(|| panic!("expected {name} reference"))
             .span
     };
+    let has_reference = |name: &str| {
+        semantic
+            .references()
+            .iter()
+            .any(|reference| reference.name.as_str() == name)
+    };
 
     assert!(facts.is_suppressed_subscript_reference(reference_span("read_idx")));
     assert!(facts.is_suppressed_subscript_reference(reference_span("assoc_read_idx")));
     assert!(facts.is_suppressed_subscript_reference(reference_span("bare_check")));
-    assert!(facts.is_suppressed_subscript_reference(reference_span("assoc_target_bare")));
     assert!(facts.is_suppressed_subscript_reference(reference_span("assoc_bare_key")));
+    assert!(!has_reference("assoc_target_bare"));
     assert!(!facts.is_suppressed_subscript_reference(reference_span("dynamic_check")));
     assert!(!facts.is_suppressed_subscript_reference(reference_span("bare_target")));
     assert!(!facts.is_suppressed_subscript_reference(reference_span("dynamic_target")));

--- a/crates/shuck-semantic/src/builder/bindings.rs
+++ b/crates/shuck-semantic/src/builder/bindings.rs
@@ -45,6 +45,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         });
         attributes |= assignment_binding_attributes(assignment);
         if matches!(assignment.value, AssignmentValue::Compound(_))
+            && !explicit_array_declaration
             && self.previous_visible_binding_is_assoc(
                 &assignment.target.name,
                 assignment.target.name_span.start.offset,

--- a/crates/shuck-semantic/src/builder/bindings.rs
+++ b/crates/shuck-semantic/src/builder/bindings.rs
@@ -44,6 +44,21 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             (kind, self.current_scope())
         });
         attributes |= assignment_binding_attributes(assignment);
+        if matches!(assignment.value, AssignmentValue::Compound(_))
+            && self
+                .resolve_reference(
+                    &assignment.target.name,
+                    self.current_scope(),
+                    assignment.target.name_span.start.offset,
+                )
+                .is_some_and(|binding_id| {
+                    self.bindings[binding_id.index()]
+                        .attributes
+                        .contains(BindingAttributes::ASSOC)
+                })
+        {
+            attributes |= BindingAttributes::ARRAY | BindingAttributes::ASSOC;
+        }
         if zsh_scalar_subscript_assignment && !explicit_array_declaration {
             attributes.remove(BindingAttributes::ARRAY | BindingAttributes::ASSOC);
         }

--- a/crates/shuck-semantic/src/builder/bindings.rs
+++ b/crates/shuck-semantic/src/builder/bindings.rs
@@ -45,17 +45,10 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         });
         attributes |= assignment_binding_attributes(assignment);
         if matches!(assignment.value, AssignmentValue::Compound(_))
-            && self
-                .resolve_reference(
-                    &assignment.target.name,
-                    self.current_scope(),
-                    assignment.target.name_span.start.offset,
-                )
-                .is_some_and(|binding_id| {
-                    self.bindings[binding_id.index()]
-                        .attributes
-                        .contains(BindingAttributes::ASSOC)
-                })
+            && self.previous_visible_binding_is_assoc(
+                &assignment.target.name,
+                assignment.target.name_span.start.offset,
+            )
         {
             attributes |= BindingAttributes::ARRAY | BindingAttributes::ASSOC;
         }
@@ -173,6 +166,15 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
                 self.visit_array_expr_into(array, WordVisitKind::Expansion, flow, nested_regions);
             }
         }
+    }
+
+    fn previous_visible_binding_is_assoc(&self, name: &Name, offset: usize) -> bool {
+        let Some(binding_id) = self.resolve_reference(name, self.current_scope(), offset) else {
+            return false;
+        };
+        let binding = &self.bindings[binding_id.index()];
+        binding.attributes.contains(BindingAttributes::ASSOC)
+            && !self.binding_was_cleared_before_lookup(binding, self.current_scope(), offset)
     }
 
     pub(super) fn binding_was_cleared_in_scope_between(

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -494,6 +494,8 @@ pub enum PluginFramework {
     OhMyZsh,
     /// Prezto module layouts.
     Prezto,
+    /// Zinit/Zi plugin manager layouts.
+    Zinit,
     /// An explicit filesystem path rather than a logical framework/plugin pair.
     ExplicitFilesystem,
     /// A custom framework name reserved for future extension points.

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -10098,6 +10098,31 @@ print -r -- ${ZINIT[bkp-autoload]}
 }
 
 #[test]
+fn explicit_indexed_redeclaration_does_not_preserve_associative_attributes() {
+    let source = "\
+#!/bin/zsh
+typeset -A opts
+typeset -a opts=(alpha beta)
+print -r -- ${opts[$idx]}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let unresolved = unresolved_names(&model);
+
+    assert_names_present(&["idx"], &unresolved);
+    assert!(
+        model
+            .bindings()
+            .iter()
+            .rev()
+            .find(|binding| binding.name == "opts")
+            .is_some_and(|binding| {
+                binding.attributes.contains(BindingAttributes::ARRAY)
+                    && !binding.attributes.contains(BindingAttributes::ASSOC)
+            })
+    );
+}
+
+#[test]
 fn zsh_subscript_declarations_preserve_explicit_array_flags() {
     let source = "\
 #!/bin/zsh

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -10075,6 +10075,29 @@ print -r -- ${functions[iterm2_precmd]}
 }
 
 #[test]
+fn whole_array_reassignment_preserves_visible_associative_attributes() {
+    let source = "\
+#!/bin/zsh
+typeset -A ZINIT
+ZINIT=( ${(kv)OTHER[@]} ${(kv)ZINIT[@]} )
+ZINIT[bkp-autoload]=${functions[autoload]}
+print -r -- ${ZINIT[bkp-autoload]}
+";
+    let model = model_with_dialect(source, ShellDialect::Zsh);
+    let unresolved = unresolved_names(&model);
+
+    assert_names_absent(&["bkp", "autoload"], &unresolved);
+    assert!(
+        model
+            .bindings()
+            .iter()
+            .rev()
+            .find(|binding| binding.name == "ZINIT")
+            .is_some_and(|binding| binding.attributes.contains(BindingAttributes::ASSOC))
+    );
+}
+
+#[test]
 fn zsh_subscript_declarations_preserve_explicit_array_flags() {
     let source = "\
 #!/bin/zsh


### PR DESCRIPTION
## Summary

- Add zinit/zi as a zsh plugin framework root for bootstrap source resolution.
- Keep zinit plugin request resolution narrow so Shuck does not assume Oh My Zsh plugin layout for zinit plugins.
- Preserve visible zsh associative-array attributes across whole-array reassignment, which fixes zinit unresolved-name false positives.
- Update the zsh diagnostic corpus baseline for the improved zinit results and the newly visible likely-real C156 diagnostic.

## Validation

- `cargo fmt --all --check`
- `cargo test -p shuck-semantic whole_array_reassignment_preserves_visible_associative_attributes -- --nocapture`
- `cargo test -p shuck-cli zinit_ -- --nocapture`
- `SHUCK_TEST_LARGE_CORPUS=1 cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
- `cargo clippy -p shuck-semantic --all-targets -- -D warnings`
- `cargo clippy -p shuck-cli --all-targets -- -D warnings`