### PR TITLE
ci: extract python-packaging steps into scripts/ci/

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,112 +153,14 @@ jobs:
       - name: "Install Rust toolchain"
         run: rustup show
       - name: "Build packaging test inputs"
-        run: |
-          set -euo pipefail
-          cargo build -p shuck-cli --locked
-
-          python3 -m venv "$RUNNER_TEMP/python-packaging"
-          source "$RUNNER_TEMP/python-packaging/bin/activate"
-          python -m pip install --upgrade pip
-          python -m pip install build pre-commit setuptools wheel
-
-          python scripts/build-python-release.py build-wheel \
-            --target x86_64-unknown-linux-gnu \
-            --binary target/debug/shuck \
-            --out-dir "$RUNNER_TEMP/python-dist"
-
-          pre-commit validate-manifest .pre-commit-hooks.yaml
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: ./scripts/ci/build-python-packaging-inputs.sh
       - name: "Smoke test wheel, placeholder install, and pre-commit hook"
-        run: |
-          set -euo pipefail
-
-          expected_version="$(
-            python3 - <<'PY'
-from pathlib import Path
-import tomllib
-
-data = tomllib.loads(Path("python/pyproject.toml").read_text())
-print(data["project"]["version"])
-PY
-          )"
-
-          python3 -m venv "$RUNNER_TEMP/wheel-smoke"
-          source "$RUNNER_TEMP/wheel-smoke/bin/activate"
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install "$RUNNER_TEMP"/python-dist/shuck_cli-*manylinux_2_28_x86_64.whl
-          test "$(shuck --version)" = "shuck ${expected_version}"
-          deactivate
-
-          python3 -m venv "$RUNNER_TEMP/placeholder-smoke"
-          source "$RUNNER_TEMP/placeholder-smoke/bin/activate"
-          python -m pip install --upgrade pip setuptools wheel pre-commit
-          python -m pip install \
-            --find-links "$RUNNER_TEMP/python-dist" \
-            --no-build-isolation \
-            --no-index \
-            .
-          test "$(shuck --version)" = "shuck ${expected_version}"
-
-          smoke_repo="$RUNNER_TEMP/pre-commit-smoke"
-          rm -rf "$smoke_repo"
-          mkdir -p "$smoke_repo"
-          cd "$smoke_repo"
-          git init -q
-          git config user.email shuck@example.com
-          git config user.name shuck
-          cat > bad.sh <<'EOF'
-tmp=$(mktemp)
-echo ok
-EOF
-          git add bad.sh
-          hook_rev="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
-          hook_repo="$RUNNER_TEMP/hook-repo"
-          rm -rf "$hook_repo"
-          git clone --no-local "$GITHUB_WORKSPACE" "$hook_repo" >/dev/null 2>&1
-          cat > .pre-commit-config.yaml <<EOF
-repos:
-  - repo: $GITHUB_WORKSPACE
-    rev: $hook_rev
-    hooks:
-      - id: shuck
-EOF
-
-          set +e
-          PIP_FIND_LINKS="$RUNNER_TEMP/python-dist" \
-            pre-commit run shuck --files bad.sh \
-            > "$RUNNER_TEMP/pre-commit-smoke.log" 2>&1
-          hook_status=$?
-          set -e
-
-          cat "$RUNNER_TEMP/pre-commit-smoke.log"
-          if [ "$hook_status" -eq 0 ]; then
-            echo "expected shuck pre-commit hook to report a lint failure" >&2
-            exit 1
-          fi
-
-          grep -F "warning[C001]" "$RUNNER_TEMP/pre-commit-smoke.log" >/dev/null
-
-          cat > .pre-commit-config.yaml <<EOF
-repos:
-  - repo: $hook_repo
-    rev: $hook_rev
-    hooks:
-      - id: shuck-src
-EOF
-
-          set +e
-          pre-commit run shuck-src --files bad.sh \
-            > "$RUNNER_TEMP/pre-commit-src-smoke.log" 2>&1
-          src_hook_status=$?
-          set -e
-
-          cat "$RUNNER_TEMP/pre-commit-src-smoke.log"
-          if [ "$src_hook_status" -eq 0 ]; then
-            echo "expected shuck-src pre-commit hook to report a lint failure" >&2
-            exit 1
-          fi
-
-          grep -F "warning[C001]" "$RUNNER_TEMP/pre-commit-src-smoke.log" >/dev/null
+        env:
+          RUNNER_TEMP: ${{ runner.temp }}
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+        run: ./scripts/ci/smoke-python-packaging.sh
 
   cargo-test-other:
     strategy:

--- a/scripts/ci/build-python-packaging-inputs.sh
+++ b/scripts/ci/build-python-packaging-inputs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RUNNER_TEMP:?RUNNER_TEMP must be set}"
+
+cargo build -p shuck-cli --locked
+
+python3 -m venv "$RUNNER_TEMP/python-packaging"
+# shellcheck disable=SC1091
+source "$RUNNER_TEMP/python-packaging/bin/activate"
+python -m pip install --upgrade pip
+python -m pip install build pre-commit setuptools wheel
+
+python scripts/build-python-release.py build-wheel \
+  --target x86_64-unknown-linux-gnu \
+  --binary target/debug/shuck \
+  --out-dir "$RUNNER_TEMP/python-dist"
+
+pre-commit validate-manifest .pre-commit-hooks.yaml

--- a/scripts/ci/smoke-python-packaging.sh
+++ b/scripts/ci/smoke-python-packaging.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RUNNER_TEMP:?RUNNER_TEMP must be set}"
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set}"
+
+expected_version="$(python3 -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("python/pyproject.toml").read_text())["project"]["version"])')"
+
+python3 -m venv "$RUNNER_TEMP/wheel-smoke"
+# shellcheck disable=SC1091
+source "$RUNNER_TEMP/wheel-smoke/bin/activate"
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install "$RUNNER_TEMP"/python-dist/shuck_cli-*manylinux_2_28_x86_64.whl
+test "$(shuck --version)" = "shuck ${expected_version}"
+deactivate
+
+python3 -m venv "$RUNNER_TEMP/placeholder-smoke"
+# shellcheck disable=SC1091
+source "$RUNNER_TEMP/placeholder-smoke/bin/activate"
+python -m pip install --upgrade pip setuptools wheel pre-commit
+python -m pip install \
+  --find-links "$RUNNER_TEMP/python-dist" \
+  --no-build-isolation \
+  --no-index \
+  .
+test "$(shuck --version)" = "shuck ${expected_version}"
+
+smoke_repo="$RUNNER_TEMP/pre-commit-smoke"
+rm -rf "$smoke_repo"
+mkdir -p "$smoke_repo"
+cd "$smoke_repo"
+git init -q
+git config user.email shuck@example.com
+git config user.name shuck
+printf '%s\n' 'tmp=$(mktemp)' 'echo ok' > bad.sh
+git add bad.sh
+hook_rev="$(git -C "$GITHUB_WORKSPACE" rev-parse HEAD)"
+hook_repo="$RUNNER_TEMP/hook-repo"
+rm -rf "$hook_repo"
+git clone --no-local "$GITHUB_WORKSPACE" "$hook_repo" >/dev/null 2>&1
+{
+  echo 'repos:'
+  echo "  - repo: $GITHUB_WORKSPACE"
+  echo "    rev: $hook_rev"
+  echo '    hooks:'
+  echo '      - id: shuck'
+} > .pre-commit-config.yaml
+
+hook_status=0
+PIP_FIND_LINKS="$RUNNER_TEMP/python-dist" \
+  pre-commit run shuck --files bad.sh \
+  > "$RUNNER_TEMP/pre-commit-smoke.log" 2>&1 || hook_status=$?
+
+cat "$RUNNER_TEMP/pre-commit-smoke.log"
+if [ "$hook_status" -eq 0 ]; then
+  echo "expected shuck pre-commit hook to report a lint failure" >&2
+  exit 1
+fi
+
+grep -F "warning[C001]" "$RUNNER_TEMP/pre-commit-smoke.log" >/dev/null
+
+{
+  echo 'repos:'
+  echo "  - repo: $hook_repo"
+  echo "    rev: $hook_rev"
+  echo '    hooks:'
+  echo '      - id: shuck-src'
+} > .pre-commit-config.yaml
+
+src_hook_status=0
+pre-commit run shuck-src --files bad.sh \
+  > "$RUNNER_TEMP/pre-commit-src-smoke.log" 2>&1 || src_hook_status=$?
+
+cat "$RUNNER_TEMP/pre-commit-src-smoke.log"
+if [ "$src_hook_status" -eq 0 ]; then
+  echo "expected shuck-src pre-commit hook to report a lint failure" >&2
+  exit 1
+fi
+
+grep -F "warning[C001]" "$RUNNER_TEMP/pre-commit-src-smoke.log" >/dev/null


### PR DESCRIPTION
## Summary
- Fix invalid YAML in `.github/workflows/ci.yaml` (line 177): the `python-packaging` smoke step embedded a Python heredoc whose body sat at column 0 inside a `run: |` block scalar, terminating the scalar and breaking workflow parsing.
- Move both `python-packaging` steps into dedicated scripts under `scripts/ci/`, passing `RUNNER_TEMP` / `GITHUB_WORKSPACE` through explicit step-level `env:` so zizmor and bash can audit the shell cleanly.

## Test plan
- [ ] `python-packaging` job parses and runs (was previously failing with "Invalid workflow file ... line 177").
- [ ] Wheel smoke + placeholder install + pre-commit `shuck` and `shuck-src` hooks still detect the seeded C001 violation in `bad.sh`.
- [ ] zizmor reports no new findings on the workflow.