### PR TITLE
ci: fix pypi-publish workflow yaml syntax

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -48,15 +48,7 @@ jobs:
       - name: Smoke test host wheel
         run: |
           set -euo pipefail
-          expected_version="$(
-            python3 - <<'PY'
-from pathlib import Path
-import tomllib
-
-data = tomllib.loads(Path("python/pyproject.toml").read_text())
-print(data["project"]["version"])
-PY
-          )"
+          expected_version="$(python3 -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("python/pyproject.toml").read_text())["project"]["version"])')"
 
           python3 -m venv "$RUNNER_TEMP/pypi-smoke"
           source "$RUNNER_TEMP/pypi-smoke/bin/activate"


### PR DESCRIPTION
## Summary
- Fixes the same heredoc-at-column-0 YAML bug in `.github/workflows/pypi-publish.yml` that #952 fixed in `ci.yaml`. GitHub was rejecting the file outright (`0s` failures on every run), so the `release: published` event for v0.0.36 never triggered a PyPI publish.
- Replaces the inline Python heredoc in the host-wheel smoke step with a `python3 -c` one-liner.

Once this lands the next release tag (v0.0.37) will trigger PyPI publishing normally.

## Test plan
- [ ] Workflow file parses (verified locally with PyYAML).
- [ ] Next release run successfully publishes the wheels to PyPI.