### PR TITLE
ci: build pypi wheels with uv + PEP 723 inline deps

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: false
 
       - name: Download release assets
         env:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -25,10 +25,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install Python packaging tools
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install build setuptools wheel
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Download release assets
         env:
@@ -41,7 +39,7 @@ jobs:
 
       - name: Build PyPI wheels
         run: |
-          python3 scripts/build-python-release.py build-release-wheels \
+          uv run scripts/build-python-release.py build-release-wheels \
             --assets-dir "$RUNNER_TEMP/release-assets" \
             --out-dir dist
 

--- a/scripts/build-python-release.py
+++ b/scripts/build-python-release.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "build",
+#     "setuptools>=70.1",
+#     "wheel",
+# ]
+# ///
 """Build platform-specific shuck-cli wheels from staged binaries or release assets."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
The v0.0.37 PyPI publish failed at `Build PyPI wheels`:

```
ModuleNotFoundError: No module named 'setuptools.command.bdist_wheel'
```

Root cause: the prior `Install Python packaging tools` step ran `python3 -m pip install --upgrade ... setuptools wheel` against the runner's system Python. Under Ubuntu 24.04 / PEP 668 that's a silent no-op, so when `scripts/build-python-release.py` invokes `python -m build --no-isolation`, the build picks up the distro's older setuptools (which lacks `bdist_wheel` in `setuptools.command`).

Fix:
- Declare `build-python-release.py`'s runtime deps (`build`, `setuptools>=70.1`, `wheel`) as PEP 723 inline script metadata so they live with the script.
- Replace the `Install Python packaging tools` step with `astral-sh/setup-uv@v8.1.0` (SHA-pinned), and run the script via `uv run`. uv resolves the inline deps into an isolated env, so `--no-isolation` inside the script is now backed by a known-good interpreter.

## Follow-up (not in this PR)
`scripts/ci/build-python-packaging-inputs.sh` still pip-installs `build`/`setuptools`/`wheel` into a venv. It works because the venv ships modern setuptools, but it now duplicates the dep list. Happy to migrate it to `uv run` + `uvx pre-commit` in a follow-up.

## Test plan
- [x] `actionlint` and PyYAML parse cleanly (verified locally).
- [x] `uv run scripts/build-python-release.py --help` resolves the inline deps and runs the script (verified locally).
- [ ] Next release tag triggers `Publish to PyPI` and `Build PyPI wheels` succeeds.
- [ ] `pypa/gh-action-pypi-publish` uploads the wheels (Trusted Publishing already configured).