### PR TITLE
feat(semantic): resolve zsh plugin dependencies

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -16,7 +16,8 @@ use shuck_linter::{
 };
 use shuck_semantic::{
     PluginFramework, PluginRequest, PluginRequestKind, PluginResolution, PluginResolver,
-    layout_for_plugin_framework, zsh_plugin_framework_from_name, zsh_plugin_frameworks,
+    resolve_zsh_plugin_entrypoint, resolve_zsh_plugin_source_paths, zsh_plugin_framework_from_name,
+    zsh_plugin_root_keys,
 };
 
 use crate::args::{
@@ -583,15 +584,13 @@ impl PluginResolver for ResolvedZshPluginSettings {
             return Vec::new();
         }
 
-        let mut paths = Vec::new();
-        for layout in zsh_plugin_frameworks() {
-            for root in configured_plugin_roots(self, layout.root_keys()) {
-                if let Some(suffix) = layout.resolve_source_suffix(root, source_path, candidate) {
-                    paths.push(root.join(suffix));
-                }
-            }
-        }
-        paths
+        resolve_zsh_plugin_source_paths(
+            self.roots
+                .iter()
+                .map(|(framework, root)| (framework.as_str(), root.as_path())),
+            source_path,
+            candidate,
+        )
     }
 
     fn resolve_plugin_request(
@@ -619,12 +618,7 @@ impl PluginResolver for ResolvedZshPluginSettings {
                 else {
                     return PluginResolution::default();
                 };
-                let Some(layout) = layout_for_plugin_framework(&request.framework) else {
-                    return custom_plugin_resolution(&root, request);
-                };
-                let Some(path) =
-                    layout.resolve_entrypoint(&root, PluginRequestKind::Plugin, &request.name)
-                else {
+                let Some(path) = resolve_zsh_plugin_entrypoint(&root, request) else {
                     return PluginResolution::default();
                 };
                 PluginResolution {
@@ -640,12 +634,7 @@ impl PluginResolver for ResolvedZshPluginSettings {
                 else {
                     return PluginResolution::default();
                 };
-                let Some(layout) = layout_for_plugin_framework(&request.framework) else {
-                    return custom_plugin_resolution(&root, request);
-                };
-                let Some(path) =
-                    layout.resolve_entrypoint(&root, PluginRequestKind::Theme, &request.name)
-                else {
+                let Some(path) = resolve_zsh_plugin_entrypoint(&root, request) else {
                     return PluginResolution::default();
                 };
                 PluginResolution {
@@ -654,23 +643,6 @@ impl PluginResolver for ResolvedZshPluginSettings {
                 }
             }
         }
-    }
-}
-
-fn custom_plugin_resolution(root: &Path, request: &PluginRequest) -> PluginResolution {
-    let path = match (&request.framework, request.kind) {
-        (PluginFramework::Other(_), PluginRequestKind::Plugin) => root
-            .join("plugins")
-            .join(&request.name)
-            .join(format!("{}.plugin.zsh", request.name)),
-        (PluginFramework::Other(_), PluginRequestKind::Theme) => root
-            .join("themes")
-            .join(format!("{}.zsh-theme", request.name)),
-        _ => return PluginResolution::default(),
-    };
-    PluginResolution {
-        entrypoints: vec![path],
-        file_entry_contracts: Vec::new(),
     }
 }
 
@@ -733,10 +705,8 @@ fn plugin_root_for_request(
     settings: &ResolvedZshPluginSettings,
     request: &PluginRequest,
 ) -> Option<PathBuf> {
-    if let Some(layout) = layout_for_plugin_framework(&request.framework) {
-        return configured_plugin_roots(settings, layout.root_keys())
-            .next()
-            .cloned();
+    if let Some(root_keys) = zsh_plugin_root_keys(&request.framework) {
+        return configured_plugin_roots(settings, root_keys).next().cloned();
     }
     match &request.framework {
         PluginFramework::Other(other) => settings.roots.get(other.as_str()).cloned(),

--- a/crates/shuck-linter/src/ambient_contracts/mod.rs
+++ b/crates/shuck-linter/src/ambient_contracts/mod.rs
@@ -33,7 +33,8 @@ use std::collections::BTreeSet;
 use std::path::Path;
 
 use shuck_ast::{Name, NormalizedCommand};
-use shuck_semantic::{FileContract, FileEntryContractCollector};
+use shuck_parser::ShellProfile;
+use shuck_semantic::{FileContract, FileEntryContractCollector, FileEntryContractCollectorFactory};
 
 use crate::ShellDialect;
 
@@ -60,6 +61,23 @@ pub(crate) struct AmbientContractCollector<'a> {
     signals: signals::AmbientSignals<'a>,
     completion_initializer_invoked: bool,
     caller_scoped_array_length_names: BTreeSet<Name>,
+}
+
+pub(crate) struct AmbientContractCollectorFactory;
+
+impl FileEntryContractCollectorFactory for AmbientContractCollectorFactory {
+    fn collector_for_file<'a>(
+        &self,
+        source: &'a str,
+        path: Option<&'a Path>,
+        shell_profile: &ShellProfile,
+    ) -> Option<Box<dyn FileEntryContractCollector + 'a>> {
+        Some(Box::new(AmbientContractCollector::new(
+            source,
+            path,
+            shell_dialect_from_profile(shell_profile),
+        )))
+    }
 }
 
 impl<'a> AmbientContractCollector<'a> {
@@ -170,5 +188,14 @@ fn merge_contract(merged: &mut FileContract, contract: FileContract) {
     }
     for prefix in contract.externally_consumed_binding_prefixes {
         merged.add_externally_consumed_binding_prefix(prefix);
+    }
+}
+
+fn shell_dialect_from_profile(profile: &ShellProfile) -> ShellDialect {
+    match profile.dialect {
+        shuck_parser::ShellDialect::Zsh => ShellDialect::Zsh,
+        shuck_parser::ShellDialect::Mksh => ShellDialect::Mksh,
+        shuck_parser::ShellDialect::Posix => ShellDialect::Sh,
+        shuck_parser::ShellDialect::Bash => ShellDialect::Bash,
     }
 }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -772,6 +772,7 @@ fn analyze_linter_file_at_path_with_resolver_and_shell<'a>(
 ) -> LinterAnalysisResult<'a> {
     let mut file_entry_contract_collector =
         ambient_contracts::AmbientContractCollector::new(source, source_path, shell);
+    let file_entry_contract_collector_factory = ambient_contracts::AmbientContractCollectorFactory;
     let analyzed_paths_fallback =
         source_path.map(|path| FxHashSet::from_iter([path.to_path_buf()]));
     let analyzed_paths = settings
@@ -790,6 +791,7 @@ fn analyze_linter_file_at_path_with_resolver_and_shell<'a>(
             plugin_resolver,
             file_entry_contract: None,
             file_entry_contract_collector: Some(&mut file_entry_contract_collector),
+            file_entry_contract_collector_factory: Some(&file_entry_contract_collector_factory),
             analyzed_paths,
             shell_profile: Some(shell_profile),
             resolve_source_closure: settings.resolve_source_closure,
@@ -1075,6 +1077,7 @@ fn analyze_file_at_path_with_resolver_and_parse_result_and_directives(
     let locator = Locator::new(source, indexer.line_index());
     let mut file_entry_contract_collector =
         ambient_contracts::AmbientContractCollector::new(source, source_path, shell);
+    let file_entry_contract_collector_factory = ambient_contracts::AmbientContractCollectorFactory;
     let analyzed_paths_fallback =
         source_path.map(|path| FxHashSet::from_iter([path.to_path_buf()]));
     let analyzed_paths = settings
@@ -1091,6 +1094,7 @@ fn analyze_file_at_path_with_resolver_and_parse_result_and_directives(
             plugin_resolver,
             file_entry_contract: None,
             file_entry_contract_collector: Some(&mut file_entry_contract_collector),
+            file_entry_contract_collector_factory: Some(&file_entry_contract_collector_factory),
             analyzed_paths,
             shell_profile: Some(shell.shell_profile()),
             resolve_source_closure: settings.resolve_source_closure,
@@ -1365,8 +1369,9 @@ mod tests {
     use shuck_parser::parser::{
         ParseDiagnostic, ParseStatus, Parser, ShellDialect as ParseDialect, SyntaxFacts,
     };
+    use shuck_semantic::{PluginFramework, PluginRequest, PluginRequestKind, PluginResolution};
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use tempfile::tempdir;
 
     fn lint(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
@@ -1429,6 +1434,33 @@ mod tests {
             Some(path),
             source_path_resolver,
             None,
+        )
+    }
+
+    fn lint_path_for_rule_with_plugin_resolver(
+        path: &Path,
+        rule: Rule,
+        plugin_resolver: &(dyn PluginResolver + Send + Sync),
+    ) -> Vec<Diagnostic> {
+        let source = fs::read_to_string(path).unwrap();
+        let output = Parser::with_dialect(&source, ParseDialect::Zsh)
+            .parse()
+            .unwrap();
+        let indexer = Indexer::new(&source, &output);
+        let directives = parse_directives(
+            &source,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        lint_file_at_path_with_resolver_and_parse_result_and_directives(
+            &output,
+            &source,
+            &indexer,
+            &LinterSettings::for_rule(rule),
+            &directives,
+            Some(path),
+            None,
+            Some(plugin_resolver),
         )
     }
 
@@ -1583,6 +1615,62 @@ mod tests {
         assert!(result.diagnostics.is_empty());
         assert!(!result.semantic.scopes().is_empty());
         assert!(!result.semantic.bindings().is_empty());
+    }
+
+    #[test]
+    fn plugin_entrypoints_receive_ambient_contracts_while_summarizing() {
+        struct EntrypointResolver {
+            entrypoint: PathBuf,
+        }
+
+        impl PluginResolver for EntrypointResolver {
+            fn additional_plugin_requests(&self, _source_path: &Path) -> Vec<PluginRequest> {
+                vec![PluginRequest {
+                    framework: PluginFramework::ExplicitFilesystem,
+                    kind: PluginRequestKind::Entrypoint,
+                    name: self.entrypoint.to_string_lossy().into_owned(),
+                    span: Span::new(),
+                    explicit: true,
+                    root_hint: None,
+                }]
+            }
+
+            fn resolve_plugin_request(
+                &self,
+                _source_path: &Path,
+                request: &PluginRequest,
+            ) -> PluginResolution {
+                if request.kind == PluginRequestKind::Entrypoint {
+                    PluginResolution {
+                        entrypoints: vec![self.entrypoint.clone()],
+                        file_entry_contracts: Vec::new(),
+                    }
+                } else {
+                    PluginResolution::default()
+                }
+            }
+        }
+
+        let temp = tempdir().unwrap();
+        let main = temp.path().join(".zshrc");
+        let plugin = temp
+            .path()
+            .join("zsh-autosuggestions")
+            .join("zsh-autosuggestions.plugin.zsh");
+        fs::create_dir_all(plugin.parent().unwrap()).unwrap();
+        fs::write(&main, "#!/bin/zsh\n").unwrap();
+        fs::write(&plugin, "print -r -- \"$widgets\"\n").unwrap();
+
+        let diagnostics = lint_path_for_rule_with_plugin_resolver(
+            &main,
+            Rule::UndefinedVariable,
+            &EntrypointResolver { entrypoint: plugin },
+        );
+
+        assert!(
+            diagnostics.is_empty(),
+            "plugin ambient runtime reads leaked into caller diagnostics: {diagnostics:?}"
+        );
     }
 
     #[test]

--- a/crates/shuck-semantic/src/contract.rs
+++ b/crates/shuck-semantic/src/contract.rs
@@ -218,6 +218,22 @@ pub trait FileEntryContractCollector {
     fn finish(&self) -> Option<FileContract>;
 }
 
+/// Factory for file-entry collectors used when semantic analysis opens helpers.
+///
+/// Source-closure summaries analyze sourced files and plugin entrypoints as
+/// separate file entries. Callers that derive file-entry contracts from source
+/// and path context can provide this factory so each resolved helper gets the
+/// same entry-contract treatment as the primary analyzed file.
+pub trait FileEntryContractCollectorFactory {
+    /// Creates a collector for one helper/plugin file summary.
+    fn collector_for_file<'a>(
+        &self,
+        source: &'a str,
+        path: Option<&'a Path>,
+        shell_profile: &ShellProfile,
+    ) -> Option<Box<dyn FileEntryContractCollector + 'a>>;
+}
+
 impl FileContract {
     /// Adds a required read if it has not already been recorded.
     pub fn add_required_read(&mut self, name: Name) {
@@ -364,6 +380,9 @@ pub struct SemanticBuildOptions<'a> {
     pub file_entry_contract: Option<FileContract>,
     /// Optional observer that can derive a file-entry contract during traversal.
     pub file_entry_contract_collector: Option<&'a mut dyn FileEntryContractCollector>,
+    /// Optional factory for deriving file-entry contracts while summarizing helpers.
+    pub file_entry_contract_collector_factory:
+        Option<&'a (dyn FileEntryContractCollectorFactory + Send + Sync)>,
     /// Paths already analyzed in the current source-closure walk.
     pub analyzed_paths: Option<&'a rustc_hash::FxHashSet<PathBuf>>,
     /// Explicit shell profile to use instead of inferring one from the source.
@@ -380,6 +399,7 @@ impl Default for SemanticBuildOptions<'_> {
             plugin_resolver: None,
             file_entry_contract: None,
             file_entry_contract_collector: None,
+            file_entry_contract_collector_factory: None,
             analyzed_paths: None,
             shell_profile: None,
             resolve_source_closure: true,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -55,7 +55,8 @@ pub use command_topology::{
 /// Contract and build-option types used when constructing semantic models.
 pub use contract::{
     ContractCertainty, FileContract, FileEntryBindingInitialization, FileEntryContractCollector,
-    FunctionContract, ProvidedBinding, ProvidedBindingKind, SemanticBuildOptions,
+    FileEntryContractCollectorFactory, FunctionContract, ProvidedBinding, ProvidedBindingKind,
+    SemanticBuildOptions,
 };
 /// Dataflow results surfaced by the semantic analysis layer.
 pub use dataflow::{
@@ -94,7 +95,10 @@ pub use source_ref::{SourceRef, SourceRefDiagnosticClass, SourceRefKind, SourceR
 /// Value-flow query object built over semantic bindings, call sites, CFG, and dataflow.
 pub use value_flow::SemanticValueFlow;
 /// Zsh plugin framework traits and name aliases.
-pub use zsh_plugin_framework::{ZshPluginFramework, zsh_plugin_framework_from_name};
+pub use zsh_plugin_framework::{
+    ZshPluginFramework, resolve_zsh_plugin_entrypoint, resolve_zsh_plugin_source_paths,
+    zsh_plugin_framework_from_name, zsh_plugin_root_keys,
+};
 
 /// How an unindexed array reference behaves at a source offset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2335,6 +2339,7 @@ pub fn build_with_observer_at_path_with_resolver<'a>(
             plugin_resolver: None,
             file_entry_contract: None,
             file_entry_contract_collector: None,
+            file_entry_contract_collector_factory: None,
             analyzed_paths: None,
             shell_profile: None,
             resolve_source_closure: true,
@@ -2355,6 +2360,7 @@ fn build_semantic_model<'a>(
         plugin_resolver,
         file_entry_contract,
         mut file_entry_contract_collector,
+        file_entry_contract_collector_factory,
         analyzed_paths,
         shell_profile,
         resolve_source_closure,
@@ -2393,9 +2399,12 @@ fn build_semantic_model<'a>(
                 file,
                 source,
                 source_path,
-                source_path_resolver,
-                plugin_resolver,
-                analyzed_paths,
+                source_closure::SourceClosureResolverConfig {
+                    source_path_resolver,
+                    plugin_resolver,
+                    file_entry_contract_collector_factory,
+                    analyzed_paths,
+                },
             )
         } else {
             let (source_ref_resolutions, source_ref_explicitness, source_ref_diagnostic_classes) =
@@ -2793,5 +2802,7 @@ fn indirect_target_matches(hint: &IndirectTargetHint, binding: &Binding) -> bool
     }
 }
 
+#[cfg(test)]
+mod plugins;
 #[cfg(test)]
 mod tests;

--- a/crates/shuck-semantic/src/plugins/mod.rs
+++ b/crates/shuck-semantic/src/plugins/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod tests;

--- a/crates/shuck-semantic/src/plugins/tests.rs
+++ b/crates/shuck-semantic/src/plugins/tests.rs
@@ -1,0 +1,140 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use shuck_ast::Name;
+use shuck_indexer::Indexer;
+use shuck_parser::parser::{Parser, ShellDialect};
+
+use crate::{
+    BindingKind, PluginFramework, PluginRequest, PluginResolution, PluginResolver,
+    SemanticBuildOptions, SemanticModel, ShellProfile, resolve_zsh_plugin_entrypoint,
+};
+
+fn zsh_plugin_fixture_path(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("testdata")
+        .join("zsh-plugins")
+        .join(name)
+}
+
+fn model_at_path_with_plugin_resolver(
+    path: &Path,
+    plugin_resolver: &(dyn PluginResolver + Send + Sync),
+) -> SemanticModel {
+    let source = fs::read_to_string(path).unwrap();
+    let output = Parser::with_dialect(&source, ShellDialect::Zsh)
+        .parse()
+        .unwrap();
+    let indexer = Indexer::new(&source, &output);
+    SemanticModel::build_with_options(
+        &output.file,
+        &source,
+        &indexer,
+        SemanticBuildOptions {
+            source_path: Some(path),
+            plugin_resolver: Some(plugin_resolver),
+            shell_profile: Some(ShellProfile::native(shuck_parser::ShellDialect::Zsh)),
+            ..SemanticBuildOptions::default()
+        },
+    )
+}
+
+struct FixtureZshPluginResolver {
+    roots: Vec<(PluginFramework, PathBuf)>,
+}
+
+impl FixtureZshPluginResolver {
+    fn new(roots: Vec<(PluginFramework, PathBuf)>) -> Self {
+        Self { roots }
+    }
+}
+
+impl PluginResolver for FixtureZshPluginResolver {
+    fn resolve_plugin_request(
+        &self,
+        _source_path: &Path,
+        request: &PluginRequest,
+    ) -> PluginResolution {
+        let Some((_, root)) = self
+            .roots
+            .iter()
+            .find(|(framework, _)| framework == &request.framework)
+        else {
+            return PluginResolution::default();
+        };
+        let Some(entrypoint) = resolve_zsh_plugin_entrypoint(root, request) else {
+            return PluginResolution::default();
+        };
+        PluginResolution {
+            entrypoints: vec![entrypoint],
+            file_entry_contracts: Vec::new(),
+        }
+    }
+}
+
+fn reportable_unused_names(model: &SemanticModel) -> Vec<Name> {
+    let analysis = model.analysis();
+    analysis
+        .unused_assignments()
+        .iter()
+        .filter_map(|binding| {
+            let binding = model.binding(*binding);
+            matches!(
+                binding.kind,
+                BindingKind::Assignment
+                    | BindingKind::ArrayAssignment
+                    | BindingKind::LoopVariable
+                    | BindingKind::ReadTarget
+                    | BindingKind::MapfileTarget
+                    | BindingKind::PrintfTarget
+                    | BindingKind::GetoptsTarget
+                    | BindingKind::ArithmeticAssignment
+            )
+            .then_some(binding.name.clone())
+        })
+        .collect()
+}
+
+fn assert_autosuggest_strategy_was_consumed(model: &SemanticModel) {
+    assert!(
+        model
+            .synthetic_reads
+            .iter()
+            .any(|read| read.name == "ZSH_AUTOSUGGEST_STRATEGY"),
+        "synthetic reads: {:?}",
+        model.synthetic_reads
+    );
+    let unused = reportable_unused_names(model);
+    assert!(
+        !unused.contains(&Name::from("ZSH_AUTOSUGGEST_STRATEGY")),
+        "unused: {:?}",
+        unused
+    );
+}
+
+#[test]
+fn prezto_autosuggestions_module_loads_standalone_plugin_dependency() {
+    let fixture = zsh_plugin_fixture_path("prezto-autosuggestions");
+    let resolver = FixtureZshPluginResolver::new(vec![
+        (PluginFramework::Prezto, fixture.join("prezto")),
+        (
+            PluginFramework::Other("zsh-autosuggestions".to_owned()),
+            fixture.join("zsh-autosuggestions"),
+        ),
+    ]);
+    let model = model_at_path_with_plugin_resolver(&fixture.join("home/.zpreztorc"), &resolver);
+
+    assert_autosuggest_strategy_was_consumed(&model);
+}
+
+#[test]
+fn zdot_use_plugin_loads_standalone_plugin_entrypoints() {
+    let fixture = zsh_plugin_fixture_path("zdot-use-plugin");
+    let resolver = FixtureZshPluginResolver::new(vec![(
+        PluginFramework::Other("zsh-autosuggestions".to_owned()),
+        fixture.join("zsh-autosuggestions"),
+    )]);
+    let model = model_at_path_with_plugin_resolver(&fixture.join("home/.zshrc"), &resolver);
+
+    assert_autosuggest_strategy_was_consumed(&model);
+}

--- a/crates/shuck-semantic/src/source_closure/mod.rs
+++ b/crates/shuck-semantic/src/source_closure/mod.rs
@@ -35,11 +35,12 @@ use plugin_managers::{
 };
 
 use crate::{
-    Binding, BindingKind, ContractCertainty, FileContract, FunctionContract, FunctionScopeKind,
-    PluginFramework, PluginRequest, PluginRequestKind, PluginResolver, ProvidedBinding,
-    ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel, SourcePathResolver,
-    SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution, SpanKey, SyntheticRead,
-    build_semantic_model_base, infer_explicit_parse_dialect_from_source,
+    Binding, BindingKind, ContractCertainty, FileContract, FileEntryContractCollector,
+    FileEntryContractCollectorFactory, FunctionContract, FunctionScopeKind, PluginFramework,
+    PluginRequest, PluginRequestKind, PluginResolver, ProvidedBinding, ProvidedBindingKind,
+    ScopeId, ScopeKind, SemanticModel, SourcePathResolver, SourceRefDiagnosticClass, SourceRefKind,
+    SourceRefResolution, SpanKey, SyntheticRead, build_semantic_model_base,
+    infer_explicit_parse_dialect_from_source,
 };
 
 #[derive(Debug, Clone)]
@@ -72,10 +73,20 @@ type SourceRefMetadataResult = (
 struct SourceClosureLookupContext<'a> {
     source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
     plugin_resolver: Option<&'a (dyn PluginResolver + Send + Sync)>,
+    file_entry_contract_collector_factory:
+        Option<&'a (dyn FileEntryContractCollectorFactory + Send + Sync)>,
     analyzed_paths: Option<&'a FxHashSet<PathBuf>>,
     shell_profile: ShellProfile,
     resolved_helper_paths: RefCell<FxHashMap<HelperPathResolutionKey, HelperPathResolution>>,
     dependency_paths: RefCell<FxHashSet<PathBuf>>,
+}
+
+pub(crate) struct SourceClosureResolverConfig<'a> {
+    pub(crate) source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
+    pub(crate) plugin_resolver: Option<&'a (dyn PluginResolver + Send + Sync)>,
+    pub(crate) file_entry_contract_collector_factory:
+        Option<&'a (dyn FileEntryContractCollectorFactory + Send + Sync)>,
+    pub(crate) analyzed_paths: Option<&'a FxHashSet<PathBuf>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -133,16 +144,15 @@ pub(crate) fn collect_source_closure_contracts(
     file: &File,
     source: &str,
     source_path: &Path,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
-    analyzed_paths: Option<&FxHashSet<PathBuf>>,
+    config: SourceClosureResolverConfig<'_>,
 ) -> SourceClosureContractResult {
     let mut summaries = FxHashMap::default();
     let mut active = FxHashSet::default();
     let context = SourceClosureLookupContext {
-        source_path_resolver,
-        plugin_resolver,
-        analyzed_paths,
+        source_path_resolver: config.source_path_resolver,
+        plugin_resolver: config.plugin_resolver,
+        file_entry_contract_collector_factory: config.file_entry_contract_collector_factory,
+        analyzed_paths: config.analyzed_paths,
         shell_profile: model.shell_profile().clone(),
         resolved_helper_paths: RefCell::new(FxHashMap::default()),
         dependency_paths: RefCell::new(FxHashSet::default()),
@@ -181,6 +191,7 @@ pub(crate) fn collect_source_ref_metadata(
     let context = SourceClosureLookupContext {
         source_path_resolver,
         plugin_resolver: None,
+        file_entry_contract_collector_factory: None,
         analyzed_paths,
         shell_profile: model.shell_profile().clone(),
         resolved_helper_paths: RefCell::new(FxHashMap::default()),
@@ -1594,8 +1605,7 @@ fn summarize_helper(
         shell_profile,
         summaries,
         active,
-        context.source_path_resolver,
-        context.plugin_resolver,
+        context,
     );
     active.remove(&key);
     summaries.insert(key, summary.clone());
@@ -1610,8 +1620,7 @@ fn summarize_helper_uncached(
     shell_profile: ShellProfile,
     summaries: &mut FxHashMap<HelperSummaryKey, FileContract>,
     active: &mut FxHashSet<HelperSummaryKey>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
+    context: &SourceClosureLookupContext<'_>,
 ) -> FileContract {
     let output = Parser::with_profile(source, shell_profile.clone()).parse();
     if output.is_err() {
@@ -1619,6 +1628,9 @@ fn summarize_helper_uncached(
     }
     let indexer = Indexer::new(source, &output);
     let mut observer = crate::NoopTraversalObserver;
+    let mut file_entry_contract_collector = context
+        .file_entry_contract_collector_factory
+        .and_then(|factory| factory.collector_for_file(source, Some(path), &shell_profile));
     let mut semantic = build_semantic_model_base(
         &output.file,
         source,
@@ -1626,8 +1638,16 @@ fn summarize_helper_uncached(
         &mut observer,
         Some(path),
         Some(shell_profile.clone()),
-        None,
+        file_entry_contract_collector
+            .as_mut()
+            .map(|collector| &mut **collector as &mut dyn FileEntryContractCollector),
     );
+    if let Some(contract) = file_entry_contract_collector
+        .as_ref()
+        .and_then(|collector| collector.finish())
+    {
+        semantic.apply_file_entry_contract(contract, &output.file);
+    }
     let collected = collect_source_closure_contracts_with_cache(
         &semantic,
         &output.file,
@@ -1636,8 +1656,9 @@ fn summarize_helper_uncached(
         summaries,
         active,
         &SourceClosureLookupContext {
-            source_path_resolver,
-            plugin_resolver,
+            source_path_resolver: context.source_path_resolver,
+            plugin_resolver: context.plugin_resolver,
+            file_entry_contract_collector_factory: context.file_entry_contract_collector_factory,
             analyzed_paths: None,
             shell_profile,
             resolved_helper_paths: RefCell::new(FxHashMap::default()),
@@ -1963,6 +1984,7 @@ noglob source \"$3\"
         let context = SourceClosureLookupContext {
             source_path_resolver: None,
             plugin_resolver: None,
+            file_entry_contract_collector_factory: None,
             analyzed_paths: None,
             shell_profile: ShellProfile::native(ParseShellDialect::Bash),
             resolved_helper_paths: RefCell::new(FxHashMap::default()),
@@ -1998,6 +2020,7 @@ noglob source \"$3\"
         let context = SourceClosureLookupContext {
             source_path_resolver: None,
             plugin_resolver: None,
+            file_entry_contract_collector_factory: None,
             analyzed_paths: None,
             shell_profile: ShellProfile::native(ParseShellDialect::Bash),
             resolved_helper_paths: RefCell::new(FxHashMap::default()),
@@ -2083,6 +2106,7 @@ noglob source \"$3\"
         let context = SourceClosureLookupContext {
             source_path_resolver: None,
             plugin_resolver: None,
+            file_entry_contract_collector_factory: None,
             analyzed_paths: None,
             shell_profile: ShellProfile::native(ParseShellDialect::Bash),
             resolved_helper_paths: RefCell::new(FxHashMap::default()),

--- a/crates/shuck-semantic/src/source_closure/plugin_managers/mod.rs
+++ b/crates/shuck-semantic/src/source_closure/plugin_managers/mod.rs
@@ -134,11 +134,18 @@ pub(super) fn collect_plugin_requests(
 
 fn plugin_request_dependency_key(
     request: &PluginRequest,
-) -> (PluginFramework, PluginRequestKind, String, Option<PathBuf>) {
+) -> (
+    PluginFramework,
+    PluginRequestKind,
+    String,
+    usize,
+    Option<PathBuf>,
+) {
     (
         request.framework.clone(),
         request.kind,
         request.name.clone(),
+        request.span.start.offset,
         request.root_hint.clone(),
     )
 }
@@ -222,4 +229,29 @@ fn path_text_starts_with_path(path: &str, root: &Path) -> bool {
         || path
             .strip_prefix(&root_text)
             .is_some_and(|tail| tail.starts_with('/'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dependency_dedup_key_preserves_request_anchor() {
+        let mut first = PluginRequest {
+            framework: PluginFramework::Other("zsh-autosuggestions".to_owned()),
+            kind: PluginRequestKind::Plugin,
+            name: "zsh-autosuggestions".to_owned(),
+            span: Span::new(),
+            explicit: false,
+            root_hint: None,
+        };
+        let mut second = first.clone();
+        first.span.start.offset = 10;
+        second.span.start.offset = 20;
+
+        assert_ne!(
+            plugin_request_dependency_key(&first),
+            plugin_request_dependency_key(&second)
+        );
+    }
 }

--- a/crates/shuck-semantic/src/source_closure/plugin_managers/mod.rs
+++ b/crates/shuck-semantic/src/source_closure/plugin_managers/mod.rs
@@ -113,7 +113,43 @@ pub(super) fn collect_plugin_requests(
             requests.extend(manager.collect_plugin_requests(&context));
         }
     }
+    let mut seen = requests
+        .iter()
+        .map(plugin_request_dependency_key)
+        .collect::<FxHashSet<_>>();
+    let mut index = 0;
+    while index < requests.len() {
+        let request = requests[index].clone();
+        if let Some(manager) = manager_for_plugin_framework(&request.framework) {
+            for dependency in manager.dependent_plugin_requests(&request) {
+                if seen.insert(plugin_request_dependency_key(&dependency)) {
+                    requests.push(dependency);
+                }
+            }
+        }
+        index += 1;
+    }
     dedup_plugin_requests(requests)
+}
+
+fn plugin_request_dependency_key(
+    request: &PluginRequest,
+) -> (PluginFramework, PluginRequestKind, String, Option<PathBuf>) {
+    (
+        request.framework.clone(),
+        request.kind,
+        request.name.clone(),
+        request.root_hint.clone(),
+    )
+}
+
+fn manager_for_plugin_framework(
+    framework: &PluginFramework,
+) -> Option<&'static dyn ZshPluginManager> {
+    ZSH_PLUGIN_MANAGERS
+        .iter()
+        .copied()
+        .find(|manager| &manager.framework() == framework)
 }
 
 pub(super) fn deferred_zsh_entrypoint_required_reads(

--- a/crates/shuck-semantic/src/source_closure/plugin_managers/prezto.rs
+++ b/crates/shuck-semantic/src/source_closure/plugin_managers/prezto.rs
@@ -41,6 +41,31 @@ impl ZshPluginFramework for PreztoPluginManager {
     ) -> Option<PathBuf> {
         None
     }
+
+    fn dependent_plugin_requests(&self, request: &PluginRequest) -> Vec<PluginRequest> {
+        if request.kind != PluginRequestKind::Plugin {
+            return Vec::new();
+        }
+        let Some(framework_name) = prezto_external_module_framework(&request.name) else {
+            return Vec::new();
+        };
+        vec![PluginRequest {
+            framework: PluginFramework::Other(framework_name.to_owned()),
+            kind: PluginRequestKind::Plugin,
+            name: framework_name.to_owned(),
+            span: request.span,
+            explicit: false,
+            root_hint: None,
+        }]
+    }
+}
+
+fn prezto_external_module_framework(module: &str) -> Option<&'static str> {
+    match module {
+        "autosuggestions" => Some("zsh-autosuggestions"),
+        "syntax-highlighting" => Some("zsh-syntax-highlighting"),
+        _ => None,
+    }
 }
 
 fn collect_prezto_plugin_requests(context: &PluginManagerContext<'_>) -> Vec<PluginRequest> {
@@ -145,6 +170,30 @@ mod tests {
                 "/not-installed/prezto/modules/editor/init.zsh",
             ),
             None
+        );
+    }
+
+    #[test]
+    fn declares_external_module_dependencies() {
+        let request = PluginRequest {
+            framework: PluginFramework::Prezto,
+            kind: PluginRequestKind::Plugin,
+            name: "autosuggestions".to_owned(),
+            span: Span::new(),
+            explicit: false,
+            root_hint: None,
+        };
+
+        assert_eq!(
+            PreztoPluginManager.dependent_plugin_requests(&request),
+            vec![PluginRequest {
+                framework: PluginFramework::Other("zsh-autosuggestions".to_owned()),
+                kind: PluginRequestKind::Plugin,
+                name: "zsh-autosuggestions".to_owned(),
+                span: request.span,
+                explicit: false,
+                root_hint: None,
+            }]
         );
     }
 }

--- a/crates/shuck-semantic/src/source_closure/plugin_managers/zdot.rs
+++ b/crates/shuck-semantic/src/source_closure/plugin_managers/zdot.rs
@@ -65,28 +65,67 @@ fn collect_zdot_plugin_requests(context: &PluginManagerContext<'_>) -> Vec<Plugi
         let Command::Simple(command) = &stmt.command else {
             continue;
         };
-        if static_word_text(&command.name, context.source).as_deref() != Some("zdot_load_module") {
+        let Some(command_name) = static_word_text(&command.name, context.source) else {
             continue;
-        }
+        };
         let args = static_command_args(command, context.source);
         let Some(args) = args.as_deref() else {
             continue;
         };
-        let modules = static_plugin_names(
-            args.iter()
-                .filter(|arg| !arg.starts_with('-'))
-                .map(String::as_str),
-        );
-        requests.extend(modules.into_iter().map(|module| PluginRequest {
-            framework: PluginFramework::Zdot,
-            kind: PluginRequestKind::Plugin,
-            name: module,
-            span: stmt.span,
-            explicit: false,
-            root_hint: None,
-        }));
+        match command_name.as_ref() {
+            "zdot_load_module" => {
+                let modules = static_plugin_names(
+                    args.iter()
+                        .filter(|arg| !arg.starts_with('-'))
+                        .map(String::as_str),
+                );
+                requests.extend(modules.into_iter().map(|module| PluginRequest {
+                    framework: PluginFramework::Zdot,
+                    kind: PluginRequestKind::Plugin,
+                    name: module,
+                    span: stmt.span,
+                    explicit: false,
+                    root_hint: None,
+                }));
+            }
+            "zdot_use_plugin" => {
+                if let Some(request) = zdot_plugin_request_from_spec(args, stmt.span) {
+                    requests.push(request);
+                }
+            }
+            _ => {}
+        }
     }
     requests
+}
+
+fn zdot_plugin_request_from_spec(args: &[String], span: Span) -> Option<PluginRequest> {
+    let spec = args.iter().find(|arg| !arg.starts_with('-'))?;
+    if let Some(name) = spec
+        .strip_prefix("omz:plugins/")
+        .filter(|name| !name.contains('/'))
+    {
+        return Some(PluginRequest {
+            framework: PluginFramework::OhMyZsh,
+            kind: PluginRequestKind::Plugin,
+            name: name.to_owned(),
+            span,
+            explicit: false,
+            root_hint: None,
+        });
+    }
+    let plugin = spec.rsplit('/').next()?.trim();
+    if plugin.is_empty() {
+        return None;
+    }
+    Some(PluginRequest {
+        framework: PluginFramework::Other(plugin.to_owned()),
+        kind: PluginRequestKind::Plugin,
+        name: plugin.to_owned(),
+        span,
+        explicit: false,
+        root_hint: None,
+    })
 }
 
 #[cfg(test)]
@@ -165,6 +204,43 @@ mod tests {
                 "/opt/app/core/hooks.zsh",
             ),
             None
+        );
+    }
+
+    #[test]
+    fn use_plugin_omz_specs_resolve_to_oh_my_zsh_plugins() {
+        let args = vec!["omz:plugins/zoxide".to_owned(), "defer".to_owned()];
+
+        assert_eq!(
+            zdot_plugin_request_from_spec(&args, Span::new()),
+            Some(PluginRequest {
+                framework: PluginFramework::OhMyZsh,
+                kind: PluginRequestKind::Plugin,
+                name: "zoxide".to_owned(),
+                span: Span::new(),
+                explicit: false,
+                root_hint: None,
+            })
+        );
+    }
+
+    #[test]
+    fn use_plugin_repo_specs_resolve_to_standalone_plugin_roots() {
+        let args = vec![
+            "zsh-users/zsh-autosuggestions".to_owned(),
+            "defer".to_owned(),
+        ];
+
+        assert_eq!(
+            zdot_plugin_request_from_spec(&args, Span::new()),
+            Some(PluginRequest {
+                framework: PluginFramework::Other("zsh-autosuggestions".to_owned()),
+                kind: PluginRequestKind::Plugin,
+                name: "zsh-autosuggestions".to_owned(),
+                span: Span::new(),
+                explicit: false,
+                root_hint: None,
+            })
         );
     }
 }

--- a/crates/shuck-semantic/src/zsh_plugin_framework.rs
+++ b/crates/shuck-semantic/src/zsh_plugin_framework.rs
@@ -7,7 +7,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::{PluginFramework, PluginRequestKind};
+use crate::{PluginFramework, PluginRequest, PluginRequestKind};
 
 /// Source and filesystem contract for a zsh plugin framework.
 pub trait ZshPluginFramework: Sync {
@@ -30,6 +30,11 @@ pub trait ZshPluginFramework: Sync {
         source_path: &Path,
         candidate: &str,
     ) -> Option<PathBuf>;
+
+    /// Returns plugin requests that should be loaded alongside `request`.
+    fn dependent_plugin_requests(&self, _request: &PluginRequest) -> Vec<PluginRequest> {
+        Vec::new()
+    }
 
     /// Resolve an entrypoint for a request kind beneath a configured root.
     fn resolve_entrypoint(
@@ -54,5 +59,145 @@ pub fn zsh_plugin_framework_from_name(name: &str) -> PluginFramework {
         "zdot" => PluginFramework::Zdot,
         "zinit" | "zi" => PluginFramework::Zinit,
         other => PluginFramework::Other(other.to_owned()),
+    }
+}
+
+/// Resolves a plugin request beneath a configured root.
+pub fn resolve_zsh_plugin_entrypoint(root: &Path, request: &PluginRequest) -> Option<PathBuf> {
+    if let Some(layout) = crate::layout_for_plugin_framework(&request.framework) {
+        return layout.resolve_entrypoint(root, request.kind, &request.name);
+    }
+
+    match (&request.framework, request.kind) {
+        (PluginFramework::Other(_), PluginRequestKind::Plugin) => {
+            let standalone = root.join(format!("{}.plugin.zsh", request.name));
+            if standalone.is_file() {
+                Some(standalone)
+            } else {
+                Some(
+                    root.join("plugins")
+                        .join(&request.name)
+                        .join(format!("{}.plugin.zsh", request.name)),
+                )
+            }
+        }
+        (PluginFramework::Other(_), PluginRequestKind::Theme) => Some(
+            root.join("themes")
+                .join(format!("{}.zsh-theme", request.name)),
+        ),
+        _ => None,
+    }
+}
+
+/// Returns the configuration root aliases for a built-in framework.
+pub fn zsh_plugin_root_keys(framework: &PluginFramework) -> Option<&'static [&'static str]> {
+    crate::layout_for_plugin_framework(framework).map(ZshPluginFramework::root_keys)
+}
+
+/// Resolves a zsh `source` candidate through configured plugin roots.
+pub fn resolve_zsh_plugin_source_paths<'a, I>(
+    roots: I,
+    source_path: &Path,
+    candidate: &str,
+) -> Vec<PathBuf>
+where
+    I: IntoIterator<Item = (&'a str, &'a Path)>,
+{
+    let roots = roots.into_iter().collect::<Vec<_>>();
+    let mut paths = Vec::new();
+    for layout in crate::zsh_plugin_frameworks() {
+        for root_key in layout.root_keys() {
+            for (configured_key, root) in &roots {
+                if configured_key != root_key {
+                    continue;
+                }
+                if let Some(suffix) = layout.resolve_source_suffix(root, source_path, candidate) {
+                    paths.push(root.join(suffix));
+                }
+            }
+        }
+    }
+    paths
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PluginRequest;
+    use tempfile::tempdir;
+
+    #[test]
+    fn custom_plugin_requests_use_default_nested_layout() {
+        let root = Path::new("/workspace/custom");
+        let request = PluginRequest {
+            framework: PluginFramework::Other("custom".to_owned()),
+            kind: PluginRequestKind::Plugin,
+            name: "prompt-tools".to_owned(),
+            span: shuck_ast::Span::new(),
+            explicit: true,
+            root_hint: None,
+        };
+
+        assert_eq!(
+            resolve_zsh_plugin_entrypoint(root, &request),
+            Some(PathBuf::from(
+                "/workspace/custom/plugins/prompt-tools/prompt-tools.plugin.zsh"
+            ))
+        );
+    }
+
+    #[test]
+    fn custom_plugin_requests_prefer_standalone_entrypoint_when_present() {
+        let temp = tempdir().unwrap();
+        std::fs::write(
+            temp.path().join("zsh-autosuggestions.plugin.zsh"),
+            "source zsh-autosuggestions.zsh\n",
+        )
+        .unwrap();
+        let request = PluginRequest {
+            framework: PluginFramework::Other("zsh-autosuggestions".to_owned()),
+            kind: PluginRequestKind::Plugin,
+            name: "zsh-autosuggestions".to_owned(),
+            span: shuck_ast::Span::new(),
+            explicit: false,
+            root_hint: None,
+        };
+
+        assert_eq!(
+            resolve_zsh_plugin_entrypoint(temp.path(), &request),
+            Some(temp.path().join("zsh-autosuggestions.plugin.zsh"))
+        );
+    }
+
+    #[test]
+    fn custom_theme_requests_use_default_theme_layout() {
+        let root = Path::new("/workspace/custom");
+        let request = PluginRequest {
+            framework: PluginFramework::Other("custom".to_owned()),
+            kind: PluginRequestKind::Theme,
+            name: "minimal".to_owned(),
+            span: shuck_ast::Span::new(),
+            explicit: true,
+            root_hint: None,
+        };
+
+        assert_eq!(
+            resolve_zsh_plugin_entrypoint(root, &request),
+            Some(PathBuf::from("/workspace/custom/themes/minimal.zsh-theme"))
+        );
+    }
+
+    #[test]
+    fn source_paths_resolve_through_framework_roots() {
+        let root = Path::new("/workspace/oh-my-zsh");
+
+        assert_eq!(
+            resolve_zsh_plugin_source_paths(
+                [("oh-my-zsh", root)].into_iter(),
+                Path::new("/workspace/app/.zshrc"),
+                "$ZSH/oh-my-zsh.sh",
+            ),
+            vec![PathBuf::from("/workspace/oh-my-zsh/oh-my-zsh.sh")]
+        );
     }
 }

--- a/crates/shuck-semantic/testdata/zsh-plugins/README.md
+++ b/crates/shuck-semantic/testdata/zsh-plugins/README.md
@@ -1,0 +1,10 @@
+# Zsh Plugin Fixtures
+
+These fixtures model small, real-world zsh plugin layouts for source-closure
+and plugin-manager tests. Keep each case focused: include the user startup file,
+the relevant framework/plugin-manager root, and any standalone plugin repositories
+that should be resolved automatically.
+
+The files are intentionally tiny. They should preserve the loading shape that
+Shuck needs to understand without copying full third-party plugins into tests.
+

--- a/crates/shuck-semantic/testdata/zsh-plugins/prezto-autosuggestions/home/.zpreztorc
+++ b/crates/shuck-semantic/testdata/zsh-plugins/prezto-autosuggestions/home/.zpreztorc
@@ -1,0 +1,7 @@
+#!/bin/zsh
+
+# Prezto reads this list and loads each named module from the configured Prezto
+# root. The autosuggestions module also depends on a standalone plugin repo.
+ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd completion)
+zstyle ':prezto:load' pmodule 'autosuggestions'
+

--- a/crates/shuck-semantic/testdata/zsh-plugins/prezto-autosuggestions/prezto/init.zsh
+++ b/crates/shuck-semantic/testdata/zsh-plugins/prezto-autosuggestions/prezto/init.zsh
@@ -1,0 +1,4 @@
+#!/bin/zsh
+
+pmodload 'autosuggestions'
+

--- a/crates/shuck-semantic/testdata/zsh-plugins/prezto-autosuggestions/prezto/modules/autosuggestions/init.zsh
+++ b/crates/shuck-semantic/testdata/zsh-plugins/prezto-autosuggestions/prezto/modules/autosuggestions/init.zsh
@@ -1,0 +1,7 @@
+#!/bin/zsh
+
+# The real Prezto module sources its bundled autosuggestions dependency and then
+# configures plugin variables. This fixture keeps the module lightweight; the
+# dependency relationship is modeled by the Prezto plugin manager.
+print -r -- loading-prezto-autosuggestions
+

--- a/crates/shuck-semantic/testdata/zsh-plugins/prezto-autosuggestions/zsh-autosuggestions/zsh-autosuggestions.plugin.zsh
+++ b/crates/shuck-semantic/testdata/zsh-plugins/prezto-autosuggestions/zsh-autosuggestions/zsh-autosuggestions.plugin.zsh
@@ -1,0 +1,12 @@
+#!/bin/zsh
+
+add-zsh-hook precmd _zsh_autosuggest_start
+
+_zsh_autosuggest_start() {
+  _zsh_autosuggest_fetch
+}
+
+_zsh_autosuggest_fetch() {
+  strategies=(${=ZSH_AUTOSUGGEST_STRATEGY})
+}
+

--- a/crates/shuck-semantic/testdata/zsh-plugins/zdot-use-plugin/home/.zshrc
+++ b/crates/shuck-semantic/testdata/zsh-plugins/zdot-use-plugin/home/.zshrc
@@ -1,0 +1,7 @@
+#!/bin/zsh
+
+# zdot_use_plugin accepts repository specs and resolves this one as the
+# standalone zsh-autosuggestions plugin root.
+ZSH_AUTOSUGGEST_STRATEGY=(match_prev_cmd completion)
+zdot_use_plugin zsh-users/zsh-autosuggestions defer
+

--- a/crates/shuck-semantic/testdata/zsh-plugins/zdot-use-plugin/zdot/zdot.zsh
+++ b/crates/shuck-semantic/testdata/zsh-plugins/zdot-use-plugin/zdot/zdot.zsh
@@ -1,0 +1,4 @@
+#!/bin/zsh
+
+zdot_use_plugin "$@"
+

--- a/crates/shuck-semantic/testdata/zsh-plugins/zdot-use-plugin/zsh-autosuggestions/zsh-autosuggestions.plugin.zsh
+++ b/crates/shuck-semantic/testdata/zsh-plugins/zdot-use-plugin/zsh-autosuggestions/zsh-autosuggestions.plugin.zsh
@@ -1,0 +1,12 @@
+#!/bin/zsh
+
+add-zsh-hook precmd _zsh_autosuggest_start
+
+_zsh_autosuggest_start() {
+  _zsh_autosuggest_fetch
+}
+
+_zsh_autosuggest_fetch() {
+  strategies=(${=ZSH_AUTOSUGGEST_STRATEGY})
+}
+


### PR DESCRIPTION
## Summary

- Move zsh plugin entrypoint/source resolution decisions into `shuck-semantic` helpers so CLI settings only provide configured roots.
- Add plugin dependency expansion for Prezto autosuggestions/syntax-highlighting and zdot `zdot_use_plugin` repository specs.
- Thread linter ambient contracts into source-closure helper/plugin summaries via a semantic collector factory.
- Add fixture-backed zsh plugin tests under `crates/shuck-semantic/testdata/zsh-plugins`.

## Validation

- `cargo fmt --all --check`
- `cargo test -p shuck-linter plugin_entrypoints_receive_ambient_contracts_while_summarizing -- --nocapture`
- `cargo test -p shuck-semantic plugins::tests -- --nocapture`
- `cargo clippy -p shuck-semantic -p shuck-linter -p shuck-cli --all-targets -- -D warnings`
- `SHUCK_TEST_LARGE_CORPUS=1 cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`
