### PR TITLE
fix(semantic): model unresolved zsh reply helper outputs

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -15815,17 +15815,6 @@ repos:
           column: 42
         classification: real
       - path: "core/update.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `reply` is referenced before assignment"
-        start:
-          line: 52
-          column: 34
-        end:
-          line: 52
-          column: 45
-        classification: false_positive
-      - path: "core/update.zsh"
         code: "C002"
         severity: "warning"
         message: "source path is built at runtime"
@@ -15858,17 +15847,6 @@ repos:
           line: 67
           column: 26
         classification: real
-      - path: "modules/apt/apt.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `reply` is referenced before assignment"
-        start:
-          line: 15
-          column: 6
-        end:
-          line: 15
-          column: 17
-        classification: false_positive
       - path: "modules/autocompletion/autocompletion.zsh"
         code: "C001"
         severity: "warning"
@@ -15934,17 +15912,6 @@ repos:
         end:
           line: 17
           column: 33
-        classification: false_positive
-      - path: "modules/brew/brew.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `reply` is referenced before assignment"
-        start:
-          line: 29
-          column: 46
-        end:
-          line: 29
-          column: 57
         classification: false_positive
       - path: "modules/dotfiler/dotfiler.zsh"
         code: "C003"

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -881,6 +881,60 @@ _zdot_update_hook_unpack() {
     }
 
     #[test]
+    fn zsh_zdot_module_helpers_can_populate_reply_arrays_without_local_definitions() {
+        let source = "\
+#!/bin/zsh
+zdot_provides_tool_args ':zdot:apt' op eza
+zdot_simple_hook apt --requires env-configured \"${reply[@]}\"
+print -r -- $missing
+";
+        let path = Path::new("/tmp/project/zdot/modules/apt/apt.zsh");
+        let diagnostics = test_snippet_at_path(
+            path,
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
+    fn zsh_zdot_core_helpers_can_populate_reply_indexes_without_local_definitions() {
+        let source = "\
+#!/bin/zsh
+main() {
+  local init_parent
+  _zdot_update_get_parent_root \"$ZDOT_REPO\"
+  init_parent=${reply[1]}
+  print -r -- \"$init_parent\"
+  print -r -- $missing
+}
+
+main
+";
+        let path = Path::new("/tmp/project/zdot/core/update.zsh");
+        let diagnostics = test_snippet_at_path(
+            path,
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$missing"]
+        );
+    }
+
+    #[test]
     fn zsh_arguments_initializes_completion_state_in_caller_scope() {
         let source = "\
 #!/bin/zsh

--- a/crates/shuck-semantic/src/source_closure/mod.rs
+++ b/crates/shuck-semantic/src/source_closure/mod.rs
@@ -250,6 +250,7 @@ fn collect_source_closure_contracts_with_cache(
     context: &SourceClosureLookupContext<'_>,
 ) -> SourceClosureContracts {
     let facts = collect_ast_facts(model);
+    let function_binding_lookup = model.function_binding_lookup();
     let call_args_by_scope = if facts.source_templates_use_positional_args {
         resolve_literal_call_args_by_scope(model, &facts.calls)
     } else {
@@ -353,13 +354,14 @@ fn collect_source_closure_contracts_with_cache(
     }
 
     for call in &facts.calls {
-        if let Some(function_site) = visible_imported_function_contract(
+        let imported_function_site = visible_imported_function_contract(
             model,
             &imported_functions,
             &call.name,
             call.scope,
             call.span.start.offset,
-        ) {
+        );
+        if let Some(function_site) = imported_function_site {
             for name in &function_site.contract.required_reads {
                 synthetic_reads.push(SyntheticRead {
                     scope: call.scope,
@@ -379,6 +381,25 @@ fn collect_source_closure_contracts_with_cache(
                         origin_paths: Vec::new(),
                     });
                 }
+            }
+        }
+        if imported_function_site.is_none()
+            && function_binding_lookup
+                .visible_function_binding(&call.name, call.scope, call.span.start.offset)
+                .is_none()
+            && let Some(bindings) = unresolved_zsh_reply_bindings_for_call(
+                source_path,
+                &context.shell_profile,
+                &call.name,
+            )
+        {
+            for binding in bindings {
+                imported_bindings.push(ImportedBindingContractSite {
+                    scope: call.scope,
+                    span: call.span,
+                    binding,
+                    origin_paths: Vec::new(),
+                });
             }
         }
 
@@ -1350,6 +1371,76 @@ fn local_helper_command_candidate(name: &Name) -> Option<String> {
 
 fn looks_like_local_helper_command(name: &str) -> bool {
     name.contains('/') || name.ends_with(".sh")
+}
+
+fn unresolved_zsh_reply_bindings_for_call(
+    source_path: &Path,
+    shell_profile: &ShellProfile,
+    name: &Name,
+) -> Option<[ProvidedBinding; 2]> {
+    if shell_profile.dialect != ParseShellDialect::Zsh
+        || !looks_like_zsh_runtime_path(source_path)
+        || !looks_like_zsh_reply_helper_command(name.as_str())
+    {
+        return None;
+    }
+
+    Some([
+        ProvidedBinding::new(
+            Name::from("REPLY"),
+            ProvidedBindingKind::Variable,
+            ContractCertainty::Definite,
+        ),
+        ProvidedBinding::new(
+            Name::from("reply"),
+            ProvidedBindingKind::Variable,
+            ContractCertainty::Definite,
+        ),
+    ])
+}
+
+fn looks_like_zsh_reply_helper_command(name: &str) -> bool {
+    !matches!(name, "." | ".." | "source")
+        && (name.starts_with('.') || name.contains('_') || name.contains(':'))
+}
+
+fn looks_like_zsh_runtime_path(path: &Path) -> bool {
+    let lower = path_to_template_string(path).to_ascii_lowercase();
+    let dotfile_shape = lower.split('/').any(|component| {
+        matches!(
+            component,
+            ".zshrc"
+                | "zshrc"
+                | ".zshenv"
+                | "zshenv"
+                | ".zprofile"
+                | "zprofile"
+                | ".zlogin"
+                | "zlogin"
+                | ".zlogout"
+                | "zlogout"
+                | "zdot"
+        )
+    }) || lower.contains("/zsh/config/")
+        || lower.contains("/zsh/configs/");
+    dotfile_shape
+        || [
+            "/completion/",
+            "/completions/",
+            "/functions/",
+            "/highlighters/",
+            "/lib/",
+            "/modules/",
+            "/plugins/",
+            "/plugin/",
+            "/themes/",
+            ".plugin.zsh",
+            ".theme.zsh",
+            "/zsh-autosuggestions/",
+            "/zsh-syntax-highlighting/",
+        ]
+        .iter()
+        .any(|pattern| lower.contains(pattern))
 }
 
 fn uses_positional_args(parts: &[TemplatePart]) -> bool {

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -8468,6 +8468,47 @@ set_flag() {
 }
 
 #[test]
+fn unresolved_zsh_runtime_helpers_can_export_reply_bindings_when_called() {
+    let temp = tempdir().unwrap();
+    let module_dir = temp.path().join("zdot/modules/apt");
+    fs::create_dir_all(&module_dir).unwrap();
+    let main = module_dir.join("apt.zsh");
+    fs::write(
+        &main,
+        "\
+#!/bin/zsh
+zdot_provides_tool_args ':zdot:apt' op eza
+printf '%s\\n' \"${reply[@]}\"
+",
+    )
+    .unwrap();
+
+    let model = model_at_path(&main);
+    assert!(model.analysis().uninitialized_references().is_empty());
+}
+
+#[test]
+fn unresolved_zsh_reply_helpers_do_not_seed_non_runtime_paths() {
+    let temp = tempdir().unwrap();
+    let main = temp.path().join("script.zsh");
+    fs::write(
+        &main,
+        "\
+#!/bin/zsh
+zdot_provides_tool_args ':zdot:apt' op eza
+printf '%s\\n' \"${reply[@]}\"
+",
+    )
+    .unwrap();
+
+    let model = model_at_path(&main);
+    assert_eq!(
+        uninitialized_details(&model),
+        vec![("reply".to_owned(), UninitializedCertainty::Definite)]
+    );
+}
+
+#[test]
 fn layered_source_closure_imports_function_contracts_transitively() {
     let temp = tempdir().unwrap();
     let main = temp.path().join("main.sh");


### PR DESCRIPTION
## Summary
Model unresolved zsh helper calls in runtime-style files as exporting `reply` and `REPLY` at the call site, so `C006` stops flagging the common zsh return-by-reference convention.

## What changed
- treat unresolved helper-like zsh calls in runtime/config paths as call-site providers of `reply` and `REPLY`
- keep the heuristic scoped away from non-runtime paths
- keep the `zdot` linter repros and add semantic regression coverage
- refresh the `zdot` zsh diagnostic corpus baseline now that the three stale `reply` false positives are gone

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-semantic --lib`
- `cargo test -p shuck-linter --lib`
- `cargo clippy -p shuck-semantic -p shuck-linter --all-targets -- -D warnings`
- `SHUCK_TEST_LARGE_CORPUS=1 cargo test -p shuck-cli --test large_corpus zsh_diagnostic_corpus_matches_baseline -- --ignored --exact --nocapture`