### PR TITLE
docs: bump pre-commit rev pins to v0.0.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ without requiring a local Rust toolchain:
 ```yaml
 repos:
   - repo: https://github.com/ewhauser/shuck
-    rev: v0.0.35
+    rev: v0.0.38
     hooks:
       - id: shuck
 ```
 
-Replace `v0.0.35` with the release you want to pin.
+Replace `v0.0.38` with the release you want to pin.
 
 If you would rather run from the checked-out Rust sources, or you are on a
 platform that does not have a published wheel yet, use the source hook instead:
@@ -96,7 +96,7 @@ platform that does not have a published wheel yet, use the source hook instead:
 ```yaml
 repos:
   - repo: https://github.com/ewhauser/shuck
-    rev: v0.0.35
+    rev: v0.0.38
     hooks:
       - id: shuck-src
 ```


### PR DESCRIPTION
## Summary
- Bump the `rev:` pins for the `shuck` and `shuck-src` pre-commit hooks in the README from v0.0.35 to v0.0.38.

## Test plan
- [x] README renders the updated version in both YAML blocks and the surrounding "Replace" sentence.