### PR TITLE
feat(linter): implement ambient contracts

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -7,12 +7,14 @@ use anyhow::{Result, anyhow};
 use globset::{Glob, GlobMatcher};
 use shuck_cache::{CacheKey, CacheKeyHasher};
 use shuck_config::{
-    ConfigArguments, LintConfig, ZshPluginEntrypointConfig, ZshPluginLoadConfig,
+    ConfigArguments, LintConfig, LintContractActivationTypeConfig, LintContractWhenConfig,
+    LintContractsConfig, LintCustomContractConfig, ZshPluginEntrypointConfig, ZshPluginLoadConfig,
     ZshThemeLoadConfig, load_project_config,
 };
 use shuck_linter::{
-    CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore, Rule, RuleSelector, RuleSet,
-    ShellDialect,
+    AmbientContractActivation, AmbientContractConfig, AmbientContractEffects, AmbientContractSpec,
+    AmbientFunctionContractSpec, CompiledPerFileIgnoreList, LinterSettings, PerFileIgnore,
+    ResolvedAmbientContracts, Rule, RuleSelector, RuleSet, ShellDialect,
 };
 use shuck_semantic::{
     PluginFramework, PluginRequest, PluginRequestKind, PluginResolution, PluginResolver,
@@ -32,6 +34,7 @@ pub(super) struct EffectiveCheckSettings {
     per_file_ignores: Vec<EffectivePerFileIgnore>,
     per_file_shell: Vec<EffectivePerFileShell>,
     rule_options: EffectiveRuleOptions,
+    ambient_contracts: EffectiveAmbientContractSettings,
     zsh_plugins: EffectiveZshPluginSettings,
     embedded_enabled: bool,
 }
@@ -52,6 +55,12 @@ struct EffectivePerFileShell {
 struct EffectiveRuleOptions {
     c001_treat_indirect_expansion_targets_as_used: bool,
     c063_report_unreached_nested_definitions: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EffectiveAmbientContractSettings {
+    well_known_ids: Vec<String>,
+    custom_descriptors: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -82,6 +91,7 @@ impl EffectiveCheckSettings {
         per_file_ignores: &[PerFileIgnore],
         per_file_shell: &[PerFileShell],
         rule_options: &shuck_linter::LinterRuleOptions,
+        ambient_contracts: &ResolvedAmbientContracts,
         zsh_plugins: &ResolvedZshPluginSettings,
         embedded_enabled: bool,
     ) -> Self {
@@ -121,6 +131,7 @@ impl EffectiveCheckSettings {
             per_file_ignores,
             per_file_shell,
             rule_options: EffectiveRuleOptions::new(rule_options),
+            ambient_contracts: EffectiveAmbientContractSettings::new(ambient_contracts),
             zsh_plugins: zsh_plugins.effective(),
             embedded_enabled,
         }
@@ -134,6 +145,7 @@ impl CacheKey for EffectiveCheckSettings {
         self.per_file_ignores.cache_key(state);
         self.per_file_shell.cache_key(state);
         self.rule_options.cache_key(state);
+        self.ambient_contracts.cache_key(state);
         self.zsh_plugins.cache_key(state);
         self.embedded_enabled.cache_key(state);
     }
@@ -173,6 +185,24 @@ impl CacheKey for EffectiveRuleOptions {
             .cache_key(state);
         self.c063_report_unreached_nested_definitions
             .cache_key(state);
+    }
+}
+
+impl EffectiveAmbientContractSettings {
+    fn new(ambient_contracts: &ResolvedAmbientContracts) -> Self {
+        let effective = ambient_contracts.effective();
+        Self {
+            well_known_ids: effective.well_known_ids,
+            custom_descriptors: effective.custom_descriptors,
+        }
+    }
+}
+
+impl CacheKey for EffectiveAmbientContractSettings {
+    fn cache_key(&self, state: &mut CacheKeyHasher) {
+        state.write_tag(b"effective-ambient-contracts");
+        self.well_known_ids.cache_key(state);
+        self.custom_descriptors.cache_key(state);
     }
 }
 
@@ -310,6 +340,7 @@ struct CompiledPerFileShell {
 pub(super) struct ResolvedZshPluginSettings {
     enabled: bool,
     project_root: PathBuf,
+    ambient_contracts: Arc<ResolvedAmbientContracts>,
     roots: BTreeMap<String, PathBuf>,
     plugin_loads: Vec<CompiledZshPluginLoad>,
     theme_loads: Vec<CompiledZshThemeLoad>,
@@ -400,6 +431,7 @@ impl ResolvedZshPluginSettings {
     fn resolve(
         project_root: impl Into<PathBuf>,
         enabled: bool,
+        ambient_contracts: Arc<ResolvedAmbientContracts>,
         roots: BTreeMap<String, String>,
         plugin_loads: Vec<ZshPluginLoadSpec>,
         theme_loads: Vec<ZshThemeLoadSpec>,
@@ -410,6 +442,7 @@ impl ResolvedZshPluginSettings {
             return Ok(Self {
                 enabled,
                 project_root,
+                ambient_contracts,
                 roots: BTreeMap::new(),
                 plugin_loads: Vec::new(),
                 theme_loads: Vec::new(),
@@ -459,6 +492,7 @@ impl ResolvedZshPluginSettings {
         Ok(Self {
             enabled,
             project_root,
+            ambient_contracts,
             roots,
             plugin_loads,
             theme_loads,
@@ -608,6 +642,7 @@ impl PluginResolver for ResolvedZshPluginSettings {
                 PluginResolution {
                     entrypoints: vec![path],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: Default::default(),
                 }
             }
             PluginRequestKind::Plugin => {
@@ -621,9 +656,13 @@ impl PluginResolver for ResolvedZshPluginSettings {
                 let Some(path) = resolve_zsh_plugin_entrypoint(&root, request) else {
                     return PluginResolution::default();
                 };
+                let request_contracts = self
+                    .ambient_contracts
+                    .request_contracts_for_plugin(_source_path, request);
                 PluginResolution {
                     entrypoints: vec![path],
-                    file_entry_contracts: Vec::new(),
+                    file_entry_contracts: request_contracts.imported_contracts,
+                    requesting_file_contract: request_contracts.requesting_file_contract,
                 }
             }
             PluginRequestKind::Theme => {
@@ -637,9 +676,13 @@ impl PluginResolver for ResolvedZshPluginSettings {
                 let Some(path) = resolve_zsh_plugin_entrypoint(&root, request) else {
                     return PluginResolution::default();
                 };
+                let request_contracts = self
+                    .ambient_contracts
+                    .request_contracts_for_plugin(_source_path, request);
                 PluginResolution {
                     entrypoints: vec![path],
-                    file_entry_contracts: Vec::new(),
+                    file_entry_contracts: request_contracts.imported_contracts,
+                    requesting_file_contract: request_contracts.requesting_file_contract,
                 }
             }
         }
@@ -856,9 +899,14 @@ pub(super) fn resolve_project_check_settings(
         project_root.canonical_root.clone(),
         per_file_shell.clone(),
     )?;
+    let ambient_contracts = Arc::new(resolve_ambient_contracts(
+        project_root.canonical_root.as_path(),
+        config.lint.contracts.as_ref(),
+    )?);
     let resolved_zsh_plugins = ResolvedZshPluginSettings::resolve(
         project_root.canonical_root.clone(),
         zsh_plugin_resolution_enabled,
+        Arc::clone(&ambient_contracts),
         zsh_plugin_roots,
         zsh_plugin_loads,
         zsh_theme_loads,
@@ -870,6 +918,7 @@ pub(super) fn resolve_project_check_settings(
         &per_file_ignores,
         &per_file_shell,
         &rule_options,
+        ambient_contracts.as_ref(),
         &resolved_zsh_plugins,
         embedded_enabled,
     );
@@ -877,6 +926,7 @@ pub(super) fn resolve_project_check_settings(
     Ok(ResolvedCheckSettings {
         linter_settings: LinterSettings {
             rules: enabled_rules,
+            ambient_contracts: Arc::clone(&ambient_contracts),
             per_file_ignores: Arc::new(compiled_per_file_ignores),
             rule_options,
             ..LinterSettings::default()
@@ -909,6 +959,117 @@ fn linter_rule_options_for_lint_config(lint: &LintConfig) -> shuck_linter::Linte
     }
 
     rule_options
+}
+
+fn resolve_ambient_contracts(
+    project_root: &Path,
+    config: Option<&LintContractsConfig>,
+) -> Result<ResolvedAmbientContracts> {
+    let Some(config) = config else {
+        return Ok(ResolvedAmbientContracts::default());
+    };
+
+    let mut ambient = AmbientContractConfig {
+        well_known: config.well_known.unwrap_or(true),
+        disabled: config.disabled.clone().unwrap_or_default(),
+        custom: Vec::new(),
+    };
+
+    for contract in config.custom.as_deref().unwrap_or(&[]) {
+        ambient
+            .custom
+            .push(ambient_contract_spec_from_config(contract)?);
+    }
+
+    ResolvedAmbientContracts::resolve(project_root.to_path_buf(), ambient)
+}
+
+fn ambient_contract_spec_from_config(
+    contract: &LintCustomContractConfig,
+) -> Result<AmbientContractSpec> {
+    Ok(AmbientContractSpec {
+        id: contract.id.clone(),
+        replaces: contract.replaces.clone().unwrap_or_default(),
+        when: ambient_contract_activation_from_config(&contract.when)?,
+        files: contract.files.clone().unwrap_or_default(),
+        effects: AmbientContractEffects {
+            reads: contract.reads.clone().unwrap_or_default(),
+            consumes_names: contract
+                .consumes
+                .as_ref()
+                .and_then(|consumes| consumes.names.clone())
+                .unwrap_or_default(),
+            consumes_prefixes: contract
+                .consumes
+                .as_ref()
+                .and_then(|consumes| consumes.prefixes.clone())
+                .unwrap_or_default(),
+            consumes_all: contract
+                .consumes
+                .as_ref()
+                .and_then(|consumes| consumes.all)
+                .unwrap_or(false),
+            provides_variables: contract
+                .provides
+                .as_ref()
+                .and_then(|provides| provides.variables.clone())
+                .unwrap_or_default(),
+            provides_functions: contract
+                .provides
+                .as_ref()
+                .and_then(|provides| provides.functions.clone())
+                .unwrap_or_default(),
+            functions: contract
+                .functions
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|function| AmbientFunctionContractSpec {
+                    name: function.name,
+                    reads: function.reads.unwrap_or_default(),
+                    sets: function.sets.unwrap_or_default(),
+                })
+                .collect(),
+        },
+    })
+}
+
+fn ambient_contract_activation_from_config(
+    when: &LintContractWhenConfig,
+) -> Result<AmbientContractActivation> {
+    match when {
+        LintContractWhenConfig::Always(value) => {
+            if value == "always" {
+                Ok(AmbientContractActivation::Always)
+            } else {
+                Err(anyhow!(
+                    "unsupported ambient contract activation {value:?}; expected \"always\" or a typed activation"
+                ))
+            }
+        }
+        LintContractWhenConfig::Activation(activation) => match activation.activation_type {
+            LintContractActivationTypeConfig::ZshPlugin => {
+                Ok(AmbientContractActivation::ZshPlugin {
+                    framework: activation.framework.clone().ok_or_else(|| {
+                        anyhow!("ambient zsh_plugin contract is missing `framework`")
+                    })?,
+                    plugin: activation.plugin.clone().ok_or_else(|| {
+                        anyhow!("ambient zsh_plugin contract is missing `plugin`")
+                    })?,
+                })
+            }
+            LintContractActivationTypeConfig::ZshTheme => Ok(AmbientContractActivation::ZshTheme {
+                framework: activation
+                    .framework
+                    .clone()
+                    .ok_or_else(|| anyhow!("ambient zsh_theme contract is missing `framework`"))?,
+                theme: activation
+                    .theme
+                    .clone()
+                    .ok_or_else(|| anyhow!("ambient zsh_theme contract is missing `theme`"))?,
+            }),
+        },
+    }
 }
 
 fn parse_lint_config_layer(lint: &LintConfig) -> Result<RuleSelectionLayer> {
@@ -1336,6 +1497,7 @@ mod tests {
         ShellDialect,
     };
     use shuck_parser::parser::Parser;
+    use shuck_semantic::FileContract;
     use tempfile::tempdir;
 
     use super::*;
@@ -1366,7 +1528,15 @@ mod tests {
     };
     use crate::commands::project_runner::PendingProjectFile;
     use crate::discover::{FileKind, ProjectRoot, normalize_path};
-    use shuck_config::ConfigArguments;
+    use shuck_config::{
+        ConfigArguments, LintContractActivationConfig, LintContractActivationTypeConfig,
+        LintContractConsumesConfig, LintContractWhenConfig, LintContractsConfig,
+        LintCustomContractConfig,
+    };
+
+    fn default_ambient_contracts() -> Arc<ResolvedAmbientContracts> {
+        Arc::new(ResolvedAmbientContracts::default())
+    }
 
     #[test]
     fn select_replaces_default_rules() {
@@ -1738,6 +1908,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             false,
+            default_ambient_contracts(),
             BTreeMap::from([("oh-my-zsh".to_owned(), "~/.oh-my-zsh".to_owned())]),
             vec![ZshPluginLoadSpec {
                 pattern: "[".to_owned(),
@@ -1768,6 +1939,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("oh-my-zsh".to_owned(), "/workspace/.oh-my-zsh".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -1807,6 +1979,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("oh-my-zsh".to_owned(), "/workspace/.oh-my-zsh".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -1828,6 +2001,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("zinit".to_owned(), "/workspace/zinit".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -1863,6 +2037,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("zinit".to_owned(), "/workspace/zinit".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -1884,6 +2059,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("zi".to_owned(), "/workspace/zi".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -1905,6 +2081,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("zinit".to_owned(), "/workspace/zinit".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -1931,6 +2108,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("custom".to_owned(), "/workspace/custom".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -1961,6 +2139,7 @@ mod tests {
                     "/workspace/custom/plugins/prompt-tools/prompt-tools.plugin.zsh"
                 )],
                 file_entry_contracts: Vec::new(),
+                requesting_file_contract: FileContract::default(),
             }
         );
         assert_eq!(
@@ -1968,7 +2147,127 @@ mod tests {
             PluginResolution {
                 entrypoints: vec![PathBuf::from("/workspace/custom/themes/minimal.zsh-theme")],
                 file_entry_contracts: Vec::new(),
+                requesting_file_contract: FileContract::default(),
             }
+        );
+    }
+
+    #[test]
+    fn built_in_tmux_plugin_contract_marks_requesting_file_consumption() {
+        let settings = ResolvedZshPluginSettings::resolve(
+            PathBuf::from("/workspace"),
+            true,
+            default_ambient_contracts(),
+            BTreeMap::from([("oh-my-zsh".to_owned(), "/workspace/.oh-my-zsh".to_owned())]),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let request = PluginRequest {
+            framework: PluginFramework::OhMyZsh,
+            kind: PluginRequestKind::Plugin,
+            name: "tmux".to_owned(),
+            span: shuck_ast::Span::new(),
+            explicit: true,
+            root_hint: None,
+        };
+
+        let resolution = settings.resolve_plugin_request(Path::new("/workspace/.zshrc"), &request);
+
+        assert!(
+            resolution
+                .requesting_file_contract
+                .externally_consumed_binding_prefixes
+                .iter()
+                .any(|prefix| prefix.as_str() == "ZSH_TMUX_")
+        );
+    }
+
+    #[test]
+    fn resolve_ambient_contracts_builds_custom_plugin_contracts_from_config() {
+        let config = LintContractsConfig {
+            well_known: Some(false),
+            disabled: None,
+            custom: Some(vec![LintCustomContractConfig {
+                id: "custom-tmux".to_owned(),
+                replaces: None,
+                when: LintContractWhenConfig::Activation(LintContractActivationConfig {
+                    activation_type: LintContractActivationTypeConfig::ZshPlugin,
+                    framework: Some("oh-my-zsh".to_owned()),
+                    plugin: Some("tmux".to_owned()),
+                    theme: None,
+                }),
+                files: Some(vec!["**/.zshrc".to_owned()]),
+                reads: None,
+                consumes: Some(LintContractConsumesConfig {
+                    names: None,
+                    prefixes: Some(vec!["LOCAL_TMUX_".to_owned()]),
+                    all: None,
+                }),
+                provides: None,
+                functions: None,
+            }]),
+        };
+        let request = PluginRequest {
+            framework: PluginFramework::OhMyZsh,
+            kind: PluginRequestKind::Plugin,
+            name: "tmux".to_owned(),
+            span: shuck_ast::Span::new(),
+            explicit: true,
+            root_hint: None,
+        };
+
+        let resolved = resolve_ambient_contracts(Path::new("/workspace"), Some(&config)).unwrap();
+        let contracts =
+            resolved.request_contracts_for_plugin(Path::new("/workspace/config/.zshrc"), &request);
+
+        assert!(
+            contracts
+                .requesting_file_contract
+                .externally_consumed_binding_prefixes
+                .iter()
+                .any(|prefix| prefix.as_str() == "LOCAL_TMUX_")
+        );
+        assert!(contracts.imported_contracts.is_empty());
+    }
+
+    #[test]
+    fn effective_ambient_contract_settings_change_when_contract_effects_change() {
+        let request_contracts = |prefix: &str| LintContractsConfig {
+            well_known: Some(false),
+            disabled: None,
+            custom: Some(vec![LintCustomContractConfig {
+                id: "custom-tmux".to_owned(),
+                replaces: None,
+                when: LintContractWhenConfig::Activation(LintContractActivationConfig {
+                    activation_type: LintContractActivationTypeConfig::ZshPlugin,
+                    framework: Some("oh-my-zsh".to_owned()),
+                    plugin: Some("tmux".to_owned()),
+                    theme: None,
+                }),
+                files: Some(vec!["**/.zshrc".to_owned()]),
+                reads: None,
+                consumes: Some(LintContractConsumesConfig {
+                    names: None,
+                    prefixes: Some(vec![prefix.to_owned()]),
+                    all: None,
+                }),
+                provides: None,
+                functions: None,
+            }]),
+        };
+
+        let first =
+            resolve_ambient_contracts(Path::new("/workspace"), Some(&request_contracts("TMUX_A_")))
+                .unwrap();
+        let second =
+            resolve_ambient_contracts(Path::new("/workspace"), Some(&request_contracts("TMUX_B_")))
+                .unwrap();
+
+        assert_ne!(
+            EffectiveAmbientContractSettings::new(&first),
+            EffectiveAmbientContractSettings::new(&second)
         );
     }
 
@@ -1977,6 +2276,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("prezto".to_owned(), "/workspace/prezto".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -1997,6 +2297,7 @@ mod tests {
             PluginResolution {
                 entrypoints: vec![PathBuf::from("/workspace/prezto/modules/editor/init.zsh")],
                 file_entry_contracts: Vec::new(),
+                requesting_file_contract: FileContract::default(),
             }
         );
     }
@@ -2006,6 +2307,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("prezto".to_owned(), "/workspace/prezto".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -2032,6 +2334,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("zdot".to_owned(), "/workspace/zdot".to_owned())]),
             Vec::new(),
             Vec::new(),
@@ -2052,6 +2355,7 @@ mod tests {
             PluginResolution {
                 entrypoints: vec![PathBuf::from("/workspace/zdot/modules/fzf/fzf.zsh")],
                 file_entry_contracts: Vec::new(),
+                requesting_file_contract: FileContract::default(),
             }
         );
     }
@@ -2061,6 +2365,7 @@ mod tests {
         let settings = ResolvedZshPluginSettings::resolve(
             PathBuf::from("/workspace"),
             true,
+            default_ambient_contracts(),
             BTreeMap::from([("zdot".to_owned(), "/workspace/zdot".to_owned())]),
             Vec::new(),
             Vec::new(),

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -629,7 +629,7 @@ impl PluginResolver for ResolvedZshPluginSettings {
 
     fn resolve_plugin_request(
         &self,
-        _source_path: &Path,
+        source_path: &Path,
         request: &PluginRequest,
     ) -> PluginResolution {
         if !self.enabled {
@@ -645,42 +645,18 @@ impl PluginResolver for ResolvedZshPluginSettings {
                     requesting_file_contract: Default::default(),
                 }
             }
-            PluginRequestKind::Plugin => {
-                let Some(root) = request
+            PluginRequestKind::Plugin | PluginRequestKind::Theme => {
+                let request_contracts = self
+                    .ambient_contracts
+                    .request_contracts_for_plugin(source_path, request);
+                let entrypoint = request
                     .root_hint
                     .clone()
                     .or_else(|| plugin_root_for_request(self, request))
-                else {
-                    return PluginResolution::default();
-                };
-                let Some(path) = resolve_zsh_plugin_entrypoint(&root, request) else {
-                    return PluginResolution::default();
-                };
-                let request_contracts = self
-                    .ambient_contracts
-                    .request_contracts_for_plugin(_source_path, request);
+                    .and_then(|root| resolve_zsh_plugin_entrypoint(&root, request));
+
                 PluginResolution {
-                    entrypoints: vec![path],
-                    file_entry_contracts: request_contracts.imported_contracts,
-                    requesting_file_contract: request_contracts.requesting_file_contract,
-                }
-            }
-            PluginRequestKind::Theme => {
-                let Some(root) = request
-                    .root_hint
-                    .clone()
-                    .or_else(|| plugin_root_for_request(self, request))
-                else {
-                    return PluginResolution::default();
-                };
-                let Some(path) = resolve_zsh_plugin_entrypoint(&root, request) else {
-                    return PluginResolution::default();
-                };
-                let request_contracts = self
-                    .ambient_contracts
-                    .request_contracts_for_plugin(_source_path, request);
-                PluginResolution {
-                    entrypoints: vec![path],
+                    entrypoints: entrypoint.into_iter().collect(),
                     file_entry_contracts: request_contracts.imported_contracts,
                     requesting_file_contract: request_contracts.requesting_file_contract,
                 }
@@ -2185,6 +2161,39 @@ mod tests {
     }
 
     #[test]
+    fn built_in_tmux_plugin_contract_applies_without_resolved_plugin_root() {
+        let settings = ResolvedZshPluginSettings::resolve(
+            PathBuf::from("/workspace"),
+            true,
+            default_ambient_contracts(),
+            BTreeMap::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let request = PluginRequest {
+            framework: PluginFramework::OhMyZsh,
+            kind: PluginRequestKind::Plugin,
+            name: "tmux".to_owned(),
+            span: shuck_ast::Span::new(),
+            explicit: true,
+            root_hint: None,
+        };
+
+        let resolution = settings.resolve_plugin_request(Path::new("/workspace/.zshrc"), &request);
+
+        assert!(resolution.entrypoints.is_empty());
+        assert!(
+            resolution
+                .requesting_file_contract
+                .externally_consumed_binding_prefixes
+                .iter()
+                .any(|prefix| prefix.as_str() == "ZSH_TMUX_")
+        );
+    }
+
+    #[test]
     fn resolve_ambient_contracts_builds_custom_plugin_contracts_from_config() {
         let config = LintContractsConfig {
             well_known: Some(false),
@@ -2230,6 +2239,61 @@ mod tests {
                 .any(|prefix| prefix.as_str() == "LOCAL_TMUX_")
         );
         assert!(contracts.imported_contracts.is_empty());
+    }
+
+    #[test]
+    fn resolve_ambient_contracts_treats_negated_file_patterns_as_exclusions() {
+        let config = LintContractsConfig {
+            well_known: Some(false),
+            disabled: None,
+            custom: Some(vec![LintCustomContractConfig {
+                id: "custom-tmux".to_owned(),
+                replaces: None,
+                when: LintContractWhenConfig::Activation(LintContractActivationConfig {
+                    activation_type: LintContractActivationTypeConfig::ZshPlugin,
+                    framework: Some("oh-my-zsh".to_owned()),
+                    plugin: Some("tmux".to_owned()),
+                    theme: None,
+                }),
+                files: Some(vec!["**/.zshrc".to_owned(), "!vendor/**".to_owned()]),
+                reads: None,
+                consumes: Some(LintContractConsumesConfig {
+                    names: None,
+                    prefixes: Some(vec!["LOCAL_TMUX_".to_owned()]),
+                    all: None,
+                }),
+                provides: None,
+                functions: None,
+            }]),
+        };
+        let request = PluginRequest {
+            framework: PluginFramework::OhMyZsh,
+            kind: PluginRequestKind::Plugin,
+            name: "tmux".to_owned(),
+            span: shuck_ast::Span::new(),
+            explicit: true,
+            root_hint: None,
+        };
+
+        let resolved = resolve_ambient_contracts(Path::new("/workspace"), Some(&config)).unwrap();
+        let included =
+            resolved.request_contracts_for_plugin(Path::new("/workspace/config/.zshrc"), &request);
+        let excluded =
+            resolved.request_contracts_for_plugin(Path::new("/workspace/vendor/.zshrc"), &request);
+
+        assert!(
+            included
+                .requesting_file_contract
+                .externally_consumed_binding_prefixes
+                .iter()
+                .any(|prefix| prefix.as_str() == "LOCAL_TMUX_")
+        );
+        assert!(
+            excluded
+                .requesting_file_contract
+                .externally_consumed_binding_prefixes
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -946,6 +946,7 @@ fn lint_with_context(
         severity_overrides: Default::default(),
         shell,
         ambient_shell_options: Default::default(),
+        ambient_contracts: Default::default(),
         analyzed_paths: Some(Arc::new(explicit.into_iter().collect())),
         per_file_ignores: Default::default(),
         report_environment_style_names: options.report_environment_style_names,

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -41,8 +41,10 @@ const CONFIG_OVERRIDE_LINT_KEYS: &[&str] = &[
     "unfixable",
     "extend-fixable",
     "rule-options",
+    "contracts",
     "zsh",
 ];
+const CONFIG_OVERRIDE_LINT_CONTRACT_KEYS: &[&str] = &["well-known", "disabled", "custom"];
 const CONFIG_OVERRIDE_LINT_ZSH_KEYS: &[&str] = &["plugins"];
 const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "resolution",
@@ -102,7 +104,77 @@ pub struct LintConfig {
     pub unfixable: Option<Vec<String>>,
     pub extend_fixable: Option<Vec<String>>,
     pub rule_options: Option<LintRuleOptionsConfig>,
+    pub contracts: Option<LintContractsConfig>,
     pub zsh: Option<LintZshConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct LintContractsConfig {
+    pub well_known: Option<bool>,
+    pub disabled: Option<Vec<String>>,
+    pub custom: Option<Vec<LintCustomContractConfig>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct LintCustomContractConfig {
+    pub id: String,
+    pub replaces: Option<Vec<String>>,
+    pub when: LintContractWhenConfig,
+    pub files: Option<Vec<String>>,
+    pub reads: Option<Vec<String>>,
+    pub consumes: Option<LintContractConsumesConfig>,
+    pub provides: Option<LintContractProvidesConfig>,
+    pub functions: Option<Vec<LintContractFunctionConfig>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum LintContractWhenConfig {
+    Always(String),
+    Activation(LintContractActivationConfig),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct LintContractActivationConfig {
+    #[serde(rename = "type")]
+    pub activation_type: LintContractActivationTypeConfig,
+    pub framework: Option<String>,
+    pub plugin: Option<String>,
+    pub theme: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum LintContractActivationTypeConfig {
+    #[serde(rename = "zsh_plugin")]
+    ZshPlugin,
+    #[serde(rename = "zsh_theme")]
+    ZshTheme,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct LintContractConsumesConfig {
+    pub names: Option<Vec<String>>,
+    pub prefixes: Option<Vec<String>>,
+    pub all: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct LintContractProvidesConfig {
+    pub variables: Option<Vec<String>>,
+    pub functions: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct LintContractFunctionConfig {
+    pub name: String,
+    pub reads: Option<Vec<String>>,
+    pub sets: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
@@ -303,6 +375,125 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
             },
         ],
         sections: &[
+            ConfigSectionMetadata {
+                key: "contracts",
+                docs: "Ambient contract settings for runtime behavior that cannot be recovered from the source graph alone.",
+                fields: &[
+                    ConfigFieldMetadata {
+                        key: "well-known",
+                        docs: "Enable or disable Shuck's built-in ambient contract registry.",
+                        default: "true",
+                        value_type: "bool",
+                        example: "well-known = false",
+                    },
+                    ConfigFieldMetadata {
+                        key: "disabled",
+                        docs: "Disable built-in ambient contracts by exact ID, by group selector, or with `*` for every built-in contract.",
+                        default: "[]",
+                        value_type: "list[string]",
+                        example: r#"disabled = ["zsh/oh-my-zsh", "runtime/github-actions/env"]"#,
+                    },
+                ],
+                sections: &[ConfigSectionMetadata {
+                    key: "custom",
+                    docs: "User-authored ambient contracts layered on top of, or in place of, the built-in registry.",
+                    fields: &[
+                        ConfigFieldMetadata {
+                            key: "id",
+                            docs: "Stable identifier for the custom contract.",
+                            default: "required",
+                            value_type: "string",
+                            example: r#"id = "github-actions-env""#,
+                        },
+                        ConfigFieldMetadata {
+                            key: "replaces",
+                            docs: "Built-in contract selectors that this custom contract replaces.",
+                            default: "[]",
+                            value_type: "list[string]",
+                            example: r#"replaces = ["zsh/oh-my-zsh/plugin/tmux"]"#,
+                        },
+                        ConfigFieldMetadata {
+                            key: "when",
+                            docs: "Activation for the contract, either `\"always\"` or an object such as `{ type = \"zsh_plugin\", framework = \"oh-my-zsh\", plugin = \"tmux\" }`.",
+                            default: "required",
+                            value_type: "string | table",
+                            example: r#"when = { type = "zsh_plugin", framework = "oh-my-zsh", plugin = "tmux" }"#,
+                        },
+                        ConfigFieldMetadata {
+                            key: "files",
+                            docs: "Optional file globs that limit where the contract applies.",
+                            default: "[]",
+                            value_type: "list[glob]",
+                            example: r#"files = ["**/.zshrc"]"#,
+                        },
+                        ConfigFieldMetadata {
+                            key: "reads",
+                            docs: "Ambient names the activated runtime reads from the caller environment.",
+                            default: "[]",
+                            value_type: "list[name]",
+                            example: r#"reads = ["GITHUB_ENV", "GITHUB_OUTPUT"]"#,
+                        },
+                        ConfigFieldMetadata {
+                            key: "functions",
+                            docs: "Provided function contracts with caller reads and caller-visible sets.",
+                            default: "[]",
+                            value_type: "list[{ name, reads?, sets? }]",
+                            example: r#"functions = [{ name = "helper", reads = ["CALLER_VALUE"], sets = ["REPLY"] }]"#,
+                        },
+                    ],
+                    sections: &[
+                        ConfigSectionMetadata {
+                            key: "consumes",
+                            docs: "Assignments that stay live because external runtime behavior consumes them.",
+                            fields: &[
+                                ConfigFieldMetadata {
+                                    key: "names",
+                                    docs: "Exact names consumed by external runtime behavior.",
+                                    default: "[]",
+                                    value_type: "list[name]",
+                                    example: r#"names = ["HISTFILE", "SAVEHIST"]"#,
+                                },
+                                ConfigFieldMetadata {
+                                    key: "prefixes",
+                                    docs: "Name prefixes consumed by external runtime behavior.",
+                                    default: "[]",
+                                    value_type: "list[prefix]",
+                                    example: r#"prefixes = ["ZSH_TMUX_"]"#,
+                                },
+                                ConfigFieldMetadata {
+                                    key: "all",
+                                    docs: "Treat every assignment in the file as externally consumed.",
+                                    default: "false",
+                                    value_type: "bool",
+                                    example: "all = true",
+                                },
+                            ],
+                            sections: &[],
+                        },
+                        ConfigSectionMetadata {
+                            key: "provides",
+                            docs: "Bindings made available by the activated runtime at file entry or activation time.",
+                            fields: &[
+                                ConfigFieldMetadata {
+                                    key: "variables",
+                                    docs: "Variables provided by the contract.",
+                                    default: "[]",
+                                    value_type: "list[name]",
+                                    example: r#"variables = ["reply", "REPLY"]"#,
+                                },
+                                ConfigFieldMetadata {
+                                    key: "functions",
+                                    docs: "Callable function names provided by the contract.",
+                                    default: "[]",
+                                    value_type: "list[name]",
+                                    example: r#"functions = ["helper"]"#,
+                                },
+                            ],
+                            sections: &[],
+                        },
+                    ],
+                }],
+            },
             ConfigSectionMetadata {
                 key: "rule-options",
                 docs: "Rule-specific behavior overrides for diagnostics that intentionally support more than one analysis mode.",
@@ -737,8 +928,27 @@ impl LintConfig {
                 .get_or_insert_default()
                 .apply_overrides(rule_options);
         }
+        if let Some(contracts) = overrides.contracts {
+            self.contracts
+                .get_or_insert_default()
+                .apply_overrides(contracts);
+        }
         if let Some(zsh) = overrides.zsh {
             self.zsh.get_or_insert_default().apply_overrides(zsh);
+        }
+    }
+}
+
+impl LintContractsConfig {
+    fn apply_overrides(&mut self, overrides: LintContractsConfig) {
+        if overrides.well_known.is_some() {
+            self.well_known = overrides.well_known;
+        }
+        if overrides.disabled.is_some() {
+            self.disabled = overrides.disabled;
+        }
+        if let Some(custom) = overrides.custom {
+            self.custom.get_or_insert_default().extend(custom);
         }
     }
 }
@@ -840,6 +1050,9 @@ fn validate_override_table(table: &toml::Table) -> std::result::Result<(), Strin
         if let Some(rule_options_value) = lint.get("rule-options") {
             validate_lint_rule_options_override(rule_options_value)?;
         }
+        if let Some(contracts_value) = lint.get("contracts") {
+            validate_lint_contracts_override(contracts_value)?;
+        }
         if let Some(zsh_value) = lint.get("zsh") {
             validate_lint_zsh_override(zsh_value)?;
         }
@@ -847,6 +1060,22 @@ fn validate_override_table(table: &toml::Table) -> std::result::Result<(), Strin
 
     if let Some(run_value) = table.get("run") {
         validate_run_override(run_value)?;
+    }
+
+    Ok(())
+}
+
+fn validate_lint_contracts_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let contracts = value
+        .as_table()
+        .ok_or_else(|| "`[lint.contracts]` must be a TOML table".to_owned())?;
+    for key in contracts.keys() {
+        if !CONFIG_OVERRIDE_LINT_CONTRACT_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.contracts]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_LINT_CONTRACT_KEYS.join(", ")
+            ));
+        }
     }
 
     Ok(())

--- a/crates/shuck-linter/src/ambient_contracts/contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts/contracts.rs
@@ -340,7 +340,26 @@ impl CompiledCustomContract {
     }
 
     fn files_match(&self, path: &Path) -> bool {
-        self.files.is_empty() || self.files.iter().any(|matcher| matcher.matches(path))
+        if self.files.is_empty() {
+            return true;
+        }
+
+        let mut saw_positive = false;
+        let mut matched_positive = false;
+
+        for matcher in &self.files {
+            if matcher.negated {
+                if matcher.path_matches(path) {
+                    return false;
+                }
+                continue;
+            }
+
+            saw_positive = true;
+            matched_positive |= matcher.path_matches(path);
+        }
+
+        if saw_positive { matched_positive } else { true }
     }
 
     fn effective_descriptor(&self) -> String {
@@ -405,16 +424,15 @@ impl CompiledPathMatcher {
         self
     }
 
-    fn matches(&self, path: &Path) -> bool {
+    fn path_matches(&self, path: &Path) -> bool {
         let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
         let file_name = relative_path.file_name().or_else(|| path.file_name());
         let Some(file_name) = file_name else {
             return false;
         };
-        let matches = self.basename_matcher.is_match(file_name)
+        self.basename_matcher.is_match(file_name)
             || self.relative_matcher.is_match(relative_path)
-            || self.absolute_matcher.is_match(path);
-        if self.negated { !matches } else { matches }
+            || self.absolute_matcher.is_match(path)
     }
 }
 

--- a/crates/shuck-linter/src/ambient_contracts/contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts/contracts.rs
@@ -1,0 +1,738 @@
+//! Compiled ambient-contract configuration and well-known contract registry.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use globset::{Glob, GlobMatcher};
+use shuck_ast::Name;
+use shuck_semantic::{
+    ContractCertainty, FileContract, FunctionContract, PluginRequest, PluginRequestKind,
+    ProvidedBinding, ProvidedBindingKind,
+};
+
+use super::AmbientContractCollector;
+use crate::ShellDialect;
+
+/// User-configurable ambient contract settings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmbientContractConfig {
+    /// Whether well-known ambient contracts are enabled.
+    pub well_known: bool,
+    /// Built-in contract selectors to disable.
+    pub disabled: Vec<String>,
+    /// User-authored custom contracts.
+    pub custom: Vec<AmbientContractSpec>,
+}
+
+impl Default for AmbientContractConfig {
+    fn default() -> Self {
+        Self {
+            well_known: true,
+            disabled: Vec::new(),
+            custom: Vec::new(),
+        }
+    }
+}
+
+/// One user-authored ambient contract specification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmbientContractSpec {
+    /// Stable contract identifier.
+    pub id: String,
+    /// Built-in contract selectors this contract replaces.
+    pub replaces: Vec<String>,
+    /// Activation that decides when the contract applies.
+    pub when: AmbientContractActivation,
+    /// Optional file globs that limit the contract to matching files.
+    pub files: Vec<String>,
+    /// Contract effects compiled into semantic file contracts.
+    pub effects: AmbientContractEffects,
+}
+
+/// Contract activation type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AmbientContractActivation {
+    /// Apply to matching files without an additional runtime request.
+    Always,
+    /// Apply when a matching zsh plugin request is observed.
+    ZshPlugin {
+        /// Framework name such as `oh-my-zsh`.
+        framework: String,
+        /// Plugin name such as `tmux`.
+        plugin: String,
+    },
+    /// Apply when a matching zsh theme request is observed.
+    ZshTheme {
+        /// Framework name such as `oh-my-zsh`.
+        framework: String,
+        /// Theme name such as `agnoster`.
+        theme: String,
+    },
+}
+
+/// User-facing contract effects.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AmbientContractEffects {
+    /// Names read from the caller environment when the contract activates.
+    pub reads: Vec<String>,
+    /// Exact names externally consumed by runtime behavior.
+    pub consumes_names: Vec<String>,
+    /// Name prefixes externally consumed by runtime behavior.
+    pub consumes_prefixes: Vec<String>,
+    /// Whether every non-local assignment in the file is externally consumed.
+    pub consumes_all: bool,
+    /// Variables provided by the contract.
+    pub provides_variables: Vec<String>,
+    /// Callable function names provided by the contract.
+    pub provides_functions: Vec<String>,
+    /// Function-specific caller reads and sets.
+    pub functions: Vec<AmbientFunctionContractSpec>,
+}
+
+/// Function-specific contract effects.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmbientFunctionContractSpec {
+    /// Function name.
+    pub name: String,
+    /// Caller names read when the function runs.
+    pub reads: Vec<String>,
+    /// Caller-visible names the function may set.
+    pub sets: Vec<String>,
+}
+
+/// Plugin-request contract effects split by imported facts and requesting-file consumption.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedAmbientRequestContracts {
+    /// Imported ordered effects applied at the plugin request span.
+    pub imported_contracts: Vec<FileContract>,
+    /// File-scoped consumption effects applied to the requesting file.
+    pub requesting_file_contract: FileContract,
+}
+
+/// Stable snapshot of the enabled ambient contract set for cache keys.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveAmbientContracts {
+    /// Enabled built-in contract ids.
+    pub well_known_ids: Vec<String>,
+    /// Stable descriptors for enabled custom contracts.
+    pub custom_descriptors: Vec<String>,
+}
+
+/// Compiled ambient contracts shared by file-entry and plugin-request analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedAmbientContracts {
+    project_root: PathBuf,
+    enabled_file_contract_ids: Vec<&'static str>,
+    enabled_request_contract_ids: Vec<&'static str>,
+    custom_contracts: Vec<CompiledCustomContract>,
+}
+
+impl Default for ResolvedAmbientContracts {
+    fn default() -> Self {
+        Self {
+            project_root: PathBuf::from("."),
+            enabled_file_contract_ids: enabled_well_known_file_contract_ids(&[]),
+            enabled_request_contract_ids: enabled_well_known_request_contract_ids(&[]),
+            custom_contracts: Vec::new(),
+        }
+    }
+}
+
+impl ResolvedAmbientContracts {
+    /// Compiles ambient contract settings for one project root.
+    pub fn resolve(
+        project_root: impl Into<PathBuf>,
+        config: AmbientContractConfig,
+    ) -> Result<Self> {
+        let project_root = project_root.into();
+        let mut disabled = config.disabled;
+        disabled.extend(
+            config
+                .custom
+                .iter()
+                .flat_map(|contract| contract.replaces.iter().cloned()),
+        );
+        let custom_contracts = config
+            .custom
+            .into_iter()
+            .map(|contract| CompiledCustomContract::resolve(&project_root, contract))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            project_root,
+            enabled_file_contract_ids: if config.well_known {
+                enabled_well_known_file_contract_ids(&disabled)
+            } else {
+                Vec::new()
+            },
+            enabled_request_contract_ids: if config.well_known {
+                enabled_well_known_request_contract_ids(&disabled)
+            } else {
+                Vec::new()
+            },
+            custom_contracts,
+        })
+    }
+
+    /// Returns a stable cache-key snapshot of the compiled contract set.
+    pub fn effective(&self) -> EffectiveAmbientContracts {
+        let mut well_known_ids = self
+            .enabled_file_contract_ids
+            .iter()
+            .chain(self.enabled_request_contract_ids.iter())
+            .map(|id| (*id).to_owned())
+            .collect::<Vec<_>>();
+        well_known_ids.sort();
+        well_known_ids.dedup();
+
+        let mut custom_descriptors = self
+            .custom_contracts
+            .iter()
+            .map(CompiledCustomContract::effective_descriptor)
+            .collect::<Vec<_>>();
+        custom_descriptors.sort();
+
+        EffectiveAmbientContracts {
+            well_known_ids,
+            custom_descriptors,
+        }
+    }
+
+    pub(crate) fn collector<'a>(
+        self: &Arc<Self>,
+        source: &'a str,
+        path: Option<&'a Path>,
+        shell: ShellDialect,
+    ) -> super::AmbientContractCollector<'a> {
+        super::AmbientContractCollector::new(source, path, shell, Arc::clone(self))
+    }
+
+    pub(crate) fn collector_factory(self: &Arc<Self>) -> super::AmbientContractCollectorFactory {
+        super::AmbientContractCollectorFactory::new(Arc::clone(self))
+    }
+
+    pub(crate) fn file_entry_contract(
+        &self,
+        collector: &AmbientContractCollector<'_>,
+        shell: ShellDialect,
+    ) -> Option<FileContract> {
+        let path = collector.signals.path()?;
+        let mut merged = FileContract::default();
+        let mut matched = false;
+
+        for id in &self.enabled_file_contract_ids {
+            let contract = well_known_file_contract_by_id(id).expect("known ambient contract id");
+            if (contract.matches)(collector, shell) {
+                matched = true;
+                (contract.apply)(&mut merged, collector);
+            }
+        }
+
+        for contract in self
+            .custom_contracts
+            .iter()
+            .filter(|contract| contract.matches_file(path.path(), shell))
+        {
+            matched = true;
+            merge_contract(&mut merged, contract.file_contract.clone());
+        }
+
+        matched.then_some(merged)
+    }
+
+    /// Returns imported and requesting-file contract effects for one plugin request.
+    pub fn request_contracts_for_plugin(
+        &self,
+        source_path: &Path,
+        request: &PluginRequest,
+    ) -> ResolvedAmbientRequestContracts {
+        let mut resolved = ResolvedAmbientRequestContracts::default();
+        let lower_path = source_path.to_string_lossy().to_ascii_lowercase();
+
+        for id in &self.enabled_request_contract_ids {
+            let contract =
+                well_known_request_contract_by_id(id).expect("known ambient request contract id");
+            if request_activation_matches(contract.activation, request) {
+                if let Some(file_match) = contract.file_match
+                    && !file_match(&lower_path)
+                {
+                    continue;
+                }
+                let imported_contract = (contract.imported_contract)();
+                if !contract_is_empty(&imported_contract) {
+                    resolved.imported_contracts.push(imported_contract);
+                }
+                merge_contract(
+                    &mut resolved.requesting_file_contract,
+                    (contract.requesting_file_contract)(),
+                );
+            }
+        }
+
+        for contract in self
+            .custom_contracts
+            .iter()
+            .filter(|contract| contract.matches_request(source_path, &lower_path, request))
+        {
+            if !contract_is_empty(&contract.imported_contract) {
+                resolved
+                    .imported_contracts
+                    .push(contract.imported_contract.clone());
+            }
+            merge_contract(
+                &mut resolved.requesting_file_contract,
+                contract.requesting_file_contract.clone(),
+            );
+        }
+
+        resolved
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CompiledCustomContract {
+    id: String,
+    when: AmbientContractActivation,
+    files: Vec<CompiledPathMatcher>,
+    file_contract: FileContract,
+    imported_contract: FileContract,
+    requesting_file_contract: FileContract,
+}
+
+impl CompiledCustomContract {
+    fn resolve(project_root: &Path, contract: AmbientContractSpec) -> Result<Self> {
+        let files = contract
+            .files
+            .into_iter()
+            .map(CompiledPathMatcher::new)
+            .collect::<Result<Vec<_>>>()?;
+        let file_contract = file_entry_contract_from_effects(&contract.effects);
+        let imported_contract = imported_contract_from_effects(&contract.effects);
+        let requesting_file_contract = requesting_file_contract_from_effects(&contract.effects);
+
+        Ok(Self {
+            id: contract.id,
+            when: contract.when,
+            files: files
+                .into_iter()
+                .map(|matcher| matcher.with_project_root(project_root))
+                .collect(),
+            file_contract,
+            imported_contract,
+            requesting_file_contract,
+        })
+    }
+
+    fn matches_file(&self, path: &Path, shell: ShellDialect) -> bool {
+        matches!(self.when, AmbientContractActivation::Always)
+            && self.files_match(path)
+            && file_activation_shell_matches(&self.when, shell)
+    }
+
+    fn matches_request(
+        &self,
+        source_path: &Path,
+        _lower_path: &str,
+        request: &PluginRequest,
+    ) -> bool {
+        self.files_match(source_path) && request_activation_matches_custom(&self.when, request)
+    }
+
+    fn files_match(&self, path: &Path) -> bool {
+        self.files.is_empty() || self.files.iter().any(|matcher| matcher.matches(path))
+    }
+
+    fn effective_descriptor(&self) -> String {
+        format!(
+            "id={};when={};files={};file={};imported={};requesting={}",
+            self.id,
+            activation_descriptor(&self.when),
+            join_sorted(self.files.iter().map(|matcher| matcher.pattern.clone())),
+            file_contract_descriptor(&self.file_contract),
+            file_contract_descriptor(&self.imported_contract),
+            file_contract_descriptor(&self.requesting_file_contract),
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CompiledPathMatcher {
+    pattern: String,
+    basename_matcher: GlobMatcher,
+    relative_matcher: GlobMatcher,
+    absolute_matcher: GlobMatcher,
+    negated: bool,
+    project_root: PathBuf,
+}
+
+impl PartialEq for CompiledPathMatcher {
+    fn eq(&self, other: &Self) -> bool {
+        self.pattern == other.pattern
+            && self.negated == other.negated
+            && self.project_root == other.project_root
+    }
+}
+
+impl Eq for CompiledPathMatcher {}
+
+impl CompiledPathMatcher {
+    fn new(pattern: String) -> Result<Self> {
+        let mut matcher_pattern = pattern.clone();
+        let negated = matcher_pattern.starts_with('!');
+        if negated {
+            matcher_pattern.drain(..1);
+        }
+
+        Ok(Self {
+            pattern,
+            basename_matcher: Glob::new(&matcher_pattern)
+                .map_err(|err| anyhow!("invalid glob {matcher_pattern:?}: {err}"))?
+                .compile_matcher(),
+            relative_matcher: Glob::new(&matcher_pattern)
+                .map_err(|err| anyhow!("invalid glob {matcher_pattern:?}: {err}"))?
+                .compile_matcher(),
+            absolute_matcher: Glob::new(&matcher_pattern)
+                .map_err(|err| anyhow!("invalid glob {matcher_pattern:?}: {err}"))?
+                .compile_matcher(),
+            negated,
+            project_root: PathBuf::new(),
+        })
+    }
+
+    fn with_project_root(mut self, project_root: &Path) -> Self {
+        self.project_root = project_root.to_path_buf();
+        self
+    }
+
+    fn matches(&self, path: &Path) -> bool {
+        let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
+        let file_name = relative_path.file_name().or_else(|| path.file_name());
+        let Some(file_name) = file_name else {
+            return false;
+        };
+        let matches = self.basename_matcher.is_match(file_name)
+            || self.relative_matcher.is_match(relative_path)
+            || self.absolute_matcher.is_match(path);
+        if self.negated { !matches } else { matches }
+    }
+}
+
+struct WellKnownFileContract {
+    id: &'static str,
+    groups: &'static [&'static str],
+    matches: fn(&AmbientContractCollector<'_>, ShellDialect) -> bool,
+    apply: fn(&mut FileContract, &AmbientContractCollector<'_>),
+}
+
+#[derive(Clone, Copy)]
+enum RequestActivation {
+    ZshPlugin {
+        framework: &'static str,
+        plugin: &'static str,
+    },
+}
+
+struct WellKnownRequestContract {
+    id: &'static str,
+    groups: &'static [&'static str],
+    activation: RequestActivation,
+    file_match: Option<fn(&str) -> bool>,
+    imported_contract: fn() -> FileContract,
+    requesting_file_contract: fn() -> FileContract,
+}
+
+const WELL_KNOWN_FILE_CONTRACTS: &[WellKnownFileContract] = &[
+    WellKnownFileContract {
+        id: "zsh/runtime",
+        groups: &["zsh"],
+        matches: super::zsh_runtime::matches_zsh_ambient_runtime_contract,
+        apply: super::zsh_runtime::apply_zsh_ambient_runtime_contract,
+    },
+    WellKnownFileContract {
+        id: "zsh/config",
+        groups: &["zsh"],
+        matches: super::zsh_config::matches_zsh_config_contract,
+        apply: super::zsh_config::apply_zsh_config_contract,
+    },
+    WellKnownFileContract {
+        id: "zsh/module-metadata",
+        groups: &["zsh"],
+        matches: super::zsh_module_metadata::matches_zsh_module_metadata_contract,
+        apply: super::zsh_module_metadata::apply_zsh_module_metadata_contract,
+    },
+];
+
+const WELL_KNOWN_REQUEST_CONTRACTS: &[WellKnownRequestContract] = &[WellKnownRequestContract {
+    id: "zsh/oh-my-zsh/plugin/tmux",
+    groups: &["zsh", "zsh/oh-my-zsh", "zsh/oh-my-zsh/plugin"],
+    activation: RequestActivation::ZshPlugin {
+        framework: "oh-my-zsh",
+        plugin: "tmux",
+    },
+    file_match: None,
+    imported_contract: FileContract::default,
+    requesting_file_contract: oh_my_zsh_tmux_requesting_file_contract,
+}];
+
+fn enabled_well_known_file_contract_ids(disabled: &[String]) -> Vec<&'static str> {
+    WELL_KNOWN_FILE_CONTRACTS
+        .iter()
+        .filter(|contract| !selector_matches(disabled, contract.id, contract.groups))
+        .map(|contract| contract.id)
+        .collect()
+}
+
+fn enabled_well_known_request_contract_ids(disabled: &[String]) -> Vec<&'static str> {
+    WELL_KNOWN_REQUEST_CONTRACTS
+        .iter()
+        .filter(|contract| !selector_matches(disabled, contract.id, contract.groups))
+        .map(|contract| contract.id)
+        .collect()
+}
+
+fn selector_matches(selectors: &[String], id: &str, groups: &[&str]) -> bool {
+    selectors.iter().any(|selector| {
+        selector == "*" || selector == id || groups.iter().any(|group| selector == group)
+    })
+}
+
+fn well_known_file_contract_by_id(id: &str) -> Option<&'static WellKnownFileContract> {
+    WELL_KNOWN_FILE_CONTRACTS
+        .iter()
+        .find(|contract| contract.id == id)
+}
+
+fn well_known_request_contract_by_id(id: &str) -> Option<&'static WellKnownRequestContract> {
+    WELL_KNOWN_REQUEST_CONTRACTS
+        .iter()
+        .find(|contract| contract.id == id)
+}
+
+fn request_activation_matches(activation: RequestActivation, request: &PluginRequest) -> bool {
+    match activation {
+        RequestActivation::ZshPlugin { framework, plugin } => {
+            request.kind == PluginRequestKind::Plugin
+                && plugin_framework_name(&request.framework) == framework
+                && request.name == plugin
+        }
+    }
+}
+
+fn request_activation_matches_custom(
+    activation: &AmbientContractActivation,
+    request: &PluginRequest,
+) -> bool {
+    match activation {
+        AmbientContractActivation::Always => false,
+        AmbientContractActivation::ZshPlugin { framework, plugin } => {
+            request.kind == PluginRequestKind::Plugin
+                && plugin_framework_name(&request.framework) == framework
+                && &request.name == plugin
+        }
+        AmbientContractActivation::ZshTheme { framework, theme } => {
+            request.kind == PluginRequestKind::Theme
+                && plugin_framework_name(&request.framework) == framework
+                && &request.name == theme
+        }
+    }
+}
+
+fn plugin_framework_name(framework: &shuck_semantic::PluginFramework) -> &str {
+    match framework {
+        shuck_semantic::PluginFramework::OhMyZsh => "oh-my-zsh",
+        shuck_semantic::PluginFramework::Prezto => "prezto",
+        shuck_semantic::PluginFramework::Zdot => "zdot",
+        shuck_semantic::PluginFramework::Zinit => "zinit",
+        shuck_semantic::PluginFramework::ExplicitFilesystem => "filesystem",
+        shuck_semantic::PluginFramework::Other(other) => other.as_str(),
+    }
+}
+
+fn file_activation_shell_matches(
+    activation: &AmbientContractActivation,
+    shell: ShellDialect,
+) -> bool {
+    match activation {
+        AmbientContractActivation::Always => true,
+        AmbientContractActivation::ZshPlugin { .. }
+        | AmbientContractActivation::ZshTheme { .. } => shell == ShellDialect::Zsh,
+    }
+}
+
+fn activation_descriptor(activation: &AmbientContractActivation) -> String {
+    match activation {
+        AmbientContractActivation::Always => "always".to_owned(),
+        AmbientContractActivation::ZshPlugin { framework, plugin } => {
+            format!("zsh_plugin:{framework}:{plugin}")
+        }
+        AmbientContractActivation::ZshTheme { framework, theme } => {
+            format!("zsh_theme:{framework}:{theme}")
+        }
+    }
+}
+
+fn file_contract_descriptor(contract: &FileContract) -> String {
+    let required_reads = join_sorted(
+        contract
+            .required_reads
+            .iter()
+            .map(|name| name.as_str().to_owned()),
+    );
+    let provided_bindings = join_sorted(contract.provided_bindings.iter().map(|binding| {
+        format!(
+            "{}:{:?}:{:?}:{:?}",
+            binding.name.as_str(),
+            binding.kind,
+            binding.certainty,
+            binding.file_entry_initialization
+        )
+    }));
+    let provided_functions = join_sorted(
+        contract
+            .provided_functions
+            .iter()
+            .map(function_contract_descriptor),
+    );
+    let consumed_names = join_sorted(
+        contract
+            .externally_consumed_binding_names
+            .iter()
+            .map(|name| name.as_str().to_owned()),
+    );
+    let consumed_prefixes = join_sorted(
+        contract
+            .externally_consumed_binding_prefixes
+            .iter()
+            .map(|name| name.as_str().to_owned()),
+    );
+
+    format!(
+        "reads=[{required_reads}]|bindings=[{provided_bindings}]|functions=[{provided_functions}]|all={}|names=[{consumed_names}]|prefixes=[{consumed_prefixes}]",
+        contract.externally_consumed_bindings
+    )
+}
+
+fn function_contract_descriptor(contract: &FunctionContract) -> String {
+    let required_reads = join_sorted(
+        contract
+            .required_reads
+            .iter()
+            .map(|name| name.as_str().to_owned()),
+    );
+    let provided_bindings = join_sorted(contract.provided_bindings.iter().map(|binding| {
+        format!(
+            "{}:{:?}:{:?}:{:?}",
+            binding.name.as_str(),
+            binding.kind,
+            binding.certainty,
+            binding.file_entry_initialization
+        )
+    }));
+
+    format!(
+        "{}|reads=[{}]|bindings=[{}]",
+        contract.name.as_str(),
+        required_reads,
+        provided_bindings
+    )
+}
+
+fn join_sorted(values: impl IntoIterator<Item = String>) -> String {
+    let mut values = values.into_iter().collect::<Vec<_>>();
+    values.sort();
+    values.join(",")
+}
+
+fn file_entry_contract_from_effects(effects: &AmbientContractEffects) -> FileContract {
+    let mut contract = imported_contract_from_effects(effects);
+    merge_contract(
+        &mut contract,
+        requesting_file_contract_from_effects(effects),
+    );
+    contract
+}
+
+fn imported_contract_from_effects(effects: &AmbientContractEffects) -> FileContract {
+    let mut contract = FileContract::default();
+    for name in &effects.reads {
+        contract.add_required_read(Name::from(name.as_str()));
+    }
+    for name in &effects.provides_variables {
+        contract.add_provided_binding(ProvidedBinding::new_file_entry_initialized(
+            Name::from(name.as_str()),
+            ProvidedBindingKind::Variable,
+            ContractCertainty::Definite,
+        ));
+    }
+    for name in &effects.provides_functions {
+        contract.add_provided_binding(ProvidedBinding::new(
+            Name::from(name.as_str()),
+            ProvidedBindingKind::Function,
+            ContractCertainty::Definite,
+        ));
+    }
+    for function in &effects.functions {
+        let mut function_contract = FunctionContract::new(Name::from(function.name.as_str()));
+        for name in &function.reads {
+            function_contract.add_required_read(Name::from(name.as_str()));
+        }
+        for name in &function.sets {
+            function_contract.add_provided_binding(ProvidedBinding::new(
+                Name::from(name.as_str()),
+                ProvidedBindingKind::Variable,
+                ContractCertainty::Definite,
+            ));
+        }
+        contract.add_provided_function(function_contract);
+    }
+    contract
+}
+
+fn requesting_file_contract_from_effects(effects: &AmbientContractEffects) -> FileContract {
+    let mut contract = FileContract {
+        externally_consumed_bindings: effects.consumes_all,
+        ..FileContract::default()
+    };
+    for name in &effects.consumes_names {
+        contract.add_externally_consumed_binding_name(Name::from(name.as_str()));
+    }
+    for prefix in &effects.consumes_prefixes {
+        contract.add_externally_consumed_binding_prefix(Name::from(prefix.as_str()));
+    }
+    contract
+}
+
+fn oh_my_zsh_tmux_requesting_file_contract() -> FileContract {
+    let mut contract = FileContract::default();
+    contract.add_externally_consumed_binding_prefix(Name::from("ZSH_TMUX_"));
+    contract
+}
+
+pub(crate) fn merge_contract(merged: &mut FileContract, contract: FileContract) {
+    merged.externally_consumed_bindings |= contract.externally_consumed_bindings;
+    for name in contract.required_reads {
+        merged.add_required_read(name);
+    }
+    for name in contract.externally_consumed_binding_names {
+        merged.add_externally_consumed_binding_name(name);
+    }
+    for binding in contract.provided_bindings {
+        merged.add_provided_binding(binding);
+    }
+    for function in contract.provided_functions {
+        merged.add_provided_function(function);
+    }
+    for prefix in contract.externally_consumed_binding_prefixes {
+        merged.add_externally_consumed_binding_prefix(prefix);
+    }
+}
+
+fn contract_is_empty(contract: &FileContract) -> bool {
+    contract.required_reads.is_empty()
+        && contract.provided_bindings.is_empty()
+        && contract.provided_functions.is_empty()
+        && !contract.externally_consumed_bindings
+        && contract.externally_consumed_binding_names.is_empty()
+        && contract.externally_consumed_binding_prefixes.is_empty()
+}

--- a/crates/shuck-linter/src/ambient_contracts/mod.rs
+++ b/crates/shuck-linter/src/ambient_contracts/mod.rs
@@ -31,6 +31,7 @@
 
 use std::collections::BTreeSet;
 use std::path::Path;
+use std::sync::Arc;
 
 use shuck_ast::{Name, NormalizedCommand};
 use shuck_parser::ShellProfile;
@@ -38,6 +39,7 @@ use shuck_semantic::{FileContract, FileEntryContractCollector, FileEntryContract
 
 use crate::ShellDialect;
 
+mod contracts;
 mod path;
 mod signals;
 mod source_scan;
@@ -50,20 +52,25 @@ mod zsh_module_metadata;
 mod zsh_paths;
 mod zsh_runtime;
 
-struct AmbientContractProvider {
-    matches: fn(&AmbientContractCollector<'_>, ShellDialect) -> bool,
-    build: fn(&AmbientContractCollector<'_>, ShellDialect) -> FileContract,
-}
+pub(crate) use contracts::merge_contract;
+pub use contracts::{
+    AmbientContractActivation, AmbientContractConfig, AmbientContractEffects, AmbientContractSpec,
+    AmbientFunctionContractSpec, EffectiveAmbientContracts, ResolvedAmbientContracts,
+    ResolvedAmbientRequestContracts,
+};
 
 pub(crate) struct AmbientContractCollector<'a> {
     source: &'a str,
     shell: ShellDialect,
     signals: signals::AmbientSignals<'a>,
+    contracts: Arc<ResolvedAmbientContracts>,
     completion_initializer_invoked: bool,
     caller_scoped_array_length_names: BTreeSet<Name>,
 }
 
-pub(crate) struct AmbientContractCollectorFactory;
+pub(crate) struct AmbientContractCollectorFactory {
+    contracts: Arc<ResolvedAmbientContracts>,
+}
 
 impl FileEntryContractCollectorFactory for AmbientContractCollectorFactory {
     fn collector_for_file<'a>(
@@ -76,12 +83,18 @@ impl FileEntryContractCollectorFactory for AmbientContractCollectorFactory {
             source,
             path,
             shell_dialect_from_profile(shell_profile),
+            Arc::clone(&self.contracts),
         )))
     }
 }
 
 impl<'a> AmbientContractCollector<'a> {
-    pub(crate) fn new(source: &'a str, path: Option<&'a Path>, shell: ShellDialect) -> Self {
+    pub(crate) fn new(
+        source: &'a str,
+        path: Option<&'a Path>,
+        shell: ShellDialect,
+        contracts: Arc<ResolvedAmbientContracts>,
+    ) -> Self {
         let mut caller_scoped_array_length_names = BTreeSet::new();
         if shell == ShellDialect::Zsh {
             zsh_caller_arrays::collect_caller_scoped_array_length_names_from_source(
@@ -94,6 +107,7 @@ impl<'a> AmbientContractCollector<'a> {
             source,
             shell,
             signals: signals::AmbientSignals::new(source, path),
+            contracts,
             completion_initializer_invoked: false,
             caller_scoped_array_length_names,
         }
@@ -101,17 +115,26 @@ impl<'a> AmbientContractCollector<'a> {
 
     fn file_entry_contract(&self) -> Option<FileContract> {
         self.signals.path()?;
-        let mut merged = FileContract::default();
-        let mut matched = false;
+        let mut merged = self.contracts.file_entry_contract(self, self.shell);
+        let mut matched = merged.is_some();
+        let merged_contract = merged.get_or_insert_default();
 
-        for provider in providers() {
-            if (provider.matches)(self, self.shell) {
-                matched = true;
-                merge_contract(&mut merged, (provider.build)(self, self.shell));
-            }
+        if sourced_runtime::matches_sourced_runtime_contract(self, self.shell) {
+            matched = true;
+            merge_contract(
+                merged_contract,
+                sourced_runtime::build_sourced_runtime_contract(self, self.shell),
+            );
+        }
+        if zsh_caller_arrays::matches_zsh_caller_scoped_array_contract(self, self.shell) {
+            matched = true;
+            merge_contract(
+                merged_contract,
+                zsh_caller_arrays::build_zsh_caller_scoped_array_contract(self, self.shell),
+            );
         }
 
-        matched.then_some(merged)
+        matched.then_some(merged_contract.clone())
     }
 
     fn source_signals(&self) -> &signals::SourceSignals<'a> {
@@ -122,6 +145,12 @@ impl<'a> AmbientContractCollector<'a> {
         self.signals
             .path()
             .expect("ambient contracts are only built for path-backed files")
+    }
+}
+
+impl AmbientContractCollectorFactory {
+    pub(crate) fn new(contracts: Arc<ResolvedAmbientContracts>) -> Self {
+        Self { contracts }
     }
 }
 
@@ -144,50 +173,6 @@ impl FileEntryContractCollector for AmbientContractCollector<'_> {
 
     fn finish(&self) -> Option<FileContract> {
         self.file_entry_contract()
-    }
-}
-
-fn providers() -> &'static [AmbientContractProvider] {
-    &[
-        AmbientContractProvider {
-            matches: sourced_runtime::matches_sourced_runtime_contract,
-            build: sourced_runtime::build_sourced_runtime_contract,
-        },
-        AmbientContractProvider {
-            matches: zsh_runtime::matches_zsh_ambient_runtime_contract,
-            build: zsh_runtime::build_zsh_ambient_runtime_contract,
-        },
-        AmbientContractProvider {
-            matches: zsh_config::matches_zsh_config_contract,
-            build: zsh_config::build_zsh_config_contract,
-        },
-        AmbientContractProvider {
-            matches: zsh_module_metadata::matches_zsh_module_metadata_contract,
-            build: zsh_module_metadata::build_zsh_module_metadata_contract,
-        },
-        AmbientContractProvider {
-            matches: zsh_caller_arrays::matches_zsh_caller_scoped_array_contract,
-            build: zsh_caller_arrays::build_zsh_caller_scoped_array_contract,
-        },
-    ]
-}
-
-fn merge_contract(merged: &mut FileContract, contract: FileContract) {
-    merged.externally_consumed_bindings |= contract.externally_consumed_bindings;
-    for name in contract.required_reads {
-        merged.add_required_read(name);
-    }
-    for name in contract.externally_consumed_binding_names {
-        merged.add_externally_consumed_binding_name(name);
-    }
-    for binding in contract.provided_bindings {
-        merged.add_provided_binding(binding);
-    }
-    for function in contract.provided_functions {
-        merged.add_provided_function(function);
-    }
-    for prefix in contract.externally_consumed_binding_prefixes {
-        merged.add_externally_consumed_binding_prefix(prefix);
     }
 }
 

--- a/crates/shuck-linter/src/ambient_contracts/signals.rs
+++ b/crates/shuck-linter/src/ambient_contracts/signals.rs
@@ -9,6 +9,7 @@
 
 use std::collections::BTreeSet;
 use std::path::Path;
+use std::path::PathBuf;
 
 use super::source_scan::{code_before_shell_comment, parse_shell_name_at};
 
@@ -35,14 +36,20 @@ impl<'a> AmbientSignals<'a> {
 }
 
 pub(super) struct PathSignals {
+    path: PathBuf,
     lower_path: String,
 }
 
 impl PathSignals {
     fn new(path: &Path) -> Self {
         Self {
+            path: path.to_path_buf(),
             lower_path: path.to_string_lossy().to_ascii_lowercase(),
         }
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
     }
 
     pub(super) fn lower_path(&self) -> &str {

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -6,8 +6,9 @@ use shuck_semantic::{
     FileContract, FileEntryContractCollector, NoopTraversalObserver, SemanticBuildOptions,
     build_with_observer_with_options,
 };
+use std::sync::Arc;
 
-use super::AmbientContractCollector;
+use super::{AmbientContractCollector, ResolvedAmbientContracts};
 use crate::ShellDialect;
 
 fn contract_for(path: &Path, source: &str) -> Option<FileContract> {
@@ -26,7 +27,12 @@ fn contract_for_optional_path(
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
     let mut observer = NoopTraversalObserver;
-    let mut collector = AmbientContractCollector::new(source, path, shell);
+    let mut collector = AmbientContractCollector::new(
+        source,
+        path,
+        shell,
+        Arc::new(ResolvedAmbientContracts::default()),
+    );
     let _semantic = build_with_observer_with_options(
         &output.file,
         source,

--- a/crates/shuck-linter/src/ambient_contracts/zsh_config.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_config.rs
@@ -29,20 +29,18 @@ pub(super) fn matches_zsh_config_contract(
             || !zsh_config_consumed_names(source, path).is_empty())
 }
 
-pub(super) fn build_zsh_config_contract(
+pub(super) fn apply_zsh_config_contract(
+    contract: &mut FileContract,
     collector: &AmbientContractCollector<'_>,
-    _shell: ShellDialect,
-) -> FileContract {
+) {
     let path = collector.path_signals();
     let source = collector.source_signals();
-    let mut contract = FileContract::default();
     for prefix in zsh_config_consumed_prefixes(source, path) {
         contract.add_externally_consumed_binding_prefix(Name::from(prefix));
     }
     for name in zsh_config_consumed_names(source, path) {
         contract.add_externally_consumed_binding_name(Name::from(name));
     }
-    contract
 }
 
 fn shell_matches_zsh_config_context(shell: ShellDialect, path: &PathSignals) -> bool {

--- a/crates/shuck-linter/src/ambient_contracts/zsh_module_metadata.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_module_metadata.rs
@@ -28,15 +28,13 @@ pub(super) fn matches_zsh_module_metadata_contract(
     shell == ShellDialect::Zsh && zsh_module_metadata_source_shape(collector.source_signals())
 }
 
-pub(super) fn build_zsh_module_metadata_contract(
+pub(super) fn apply_zsh_module_metadata_contract(
+    contract: &mut FileContract,
     _collector: &AmbientContractCollector<'_>,
-    _shell: ShellDialect,
-) -> FileContract {
-    let mut contract = FileContract::default();
+) {
     for name in ZSH_MODULE_METADATA_NAMES {
         contract.add_externally_consumed_binding_name(Name::from(*name));
     }
-    contract
 }
 
 const ZSH_MODULE_METADATA_NAMES: &[&str] =

--- a/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_runtime.rs
@@ -33,14 +33,12 @@ pub(super) fn matches_zsh_ambient_runtime_contract(
         && zsh_ambient_runtime_has_signal(collector.source_signals(), path)
 }
 
-pub(super) fn build_zsh_ambient_runtime_contract(
+pub(super) fn apply_zsh_ambient_runtime_contract(
+    contract: &mut FileContract,
     collector: &AmbientContractCollector<'_>,
-    _shell: ShellDialect,
-) -> FileContract {
+) {
     let path = collector.path_signals();
     let source = collector.source_signals();
-    let mut contract = FileContract::default();
-
     for name in zsh_initialized_runtime_names(source, path) {
         contract.add_provided_binding(ProvidedBinding::new_file_entry_initialized(
             Name::from(name),
@@ -56,8 +54,6 @@ pub(super) fn build_zsh_ambient_runtime_contract(
     for prefix in zsh_test_fixture_consumed_prefixes(source, path) {
         contract.add_externally_consumed_binding_prefix(Name::from(prefix));
     }
-
-    contract
 }
 
 fn shell_matches_zsh_runtime_context(shell: ShellDialect, path: &PathSignals) -> bool {

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -48,6 +48,11 @@ mod violation;
 #[allow(missing_docs)]
 pub mod test;
 
+pub use ambient_contracts::{
+    AmbientContractActivation, AmbientContractConfig, AmbientContractEffects, AmbientContractSpec,
+    AmbientFunctionContractSpec, EffectiveAmbientContracts, ResolvedAmbientContracts,
+    ResolvedAmbientRequestContracts,
+};
 /// Primary checker API for walking facts and emitting diagnostics.
 pub use checker::Checker;
 /// Rule diagnostics and severity levels.
@@ -771,8 +776,10 @@ fn analyze_linter_file_at_path_with_resolver_and_shell<'a>(
     first_parse_error: Option<(usize, usize)>,
 ) -> LinterAnalysisResult<'a> {
     let mut file_entry_contract_collector =
-        ambient_contracts::AmbientContractCollector::new(source, source_path, shell);
-    let file_entry_contract_collector_factory = ambient_contracts::AmbientContractCollectorFactory;
+        settings
+            .ambient_contracts
+            .collector(source, source_path, shell);
+    let file_entry_contract_collector_factory = settings.ambient_contracts.collector_factory();
     let analyzed_paths_fallback =
         source_path.map(|path| FxHashSet::from_iter([path.to_path_buf()]));
     let analyzed_paths = settings
@@ -1076,8 +1083,10 @@ fn analyze_file_at_path_with_resolver_and_parse_result_and_directives(
     let shell = resolve_shell(settings, source, source_path);
     let locator = Locator::new(source, indexer.line_index());
     let mut file_entry_contract_collector =
-        ambient_contracts::AmbientContractCollector::new(source, source_path, shell);
-    let file_entry_contract_collector_factory = ambient_contracts::AmbientContractCollectorFactory;
+        settings
+            .ambient_contracts
+            .collector(source, source_path, shell);
+    let file_entry_contract_collector_factory = settings.ambient_contracts.collector_factory();
     let analyzed_paths_fallback =
         source_path.map(|path| FxHashSet::from_iter([path.to_path_buf()]));
     let analyzed_paths = settings
@@ -1369,7 +1378,9 @@ mod tests {
     use shuck_parser::parser::{
         ParseDiagnostic, ParseStatus, Parser, ShellDialect as ParseDialect, SyntaxFacts,
     };
-    use shuck_semantic::{PluginFramework, PluginRequest, PluginRequestKind, PluginResolution};
+    use shuck_semantic::{
+        FileContract, PluginFramework, PluginRequest, PluginRequestKind, PluginResolution,
+    };
     use std::fs;
     use std::path::{Path, PathBuf};
     use tempfile::tempdir;
@@ -1644,6 +1655,7 @@ mod tests {
                     PluginResolution {
                         entrypoints: vec![self.entrypoint.clone()],
                         file_entry_contracts: Vec::new(),
+                        requesting_file_contract: FileContract::default(),
                     }
                 } else {
                     PluginResolution::default()

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -8,6 +8,7 @@ use rustc_hash::FxHashMap;
 use rustc_hash::FxHashSet;
 use shuck_semantic::{UnreachedFunctionAnalysisOptions, UnusedAssignmentAnalysisOptions};
 
+use crate::ambient_contracts::ResolvedAmbientContracts;
 use crate::{Category, Rule, RuleSelector, RuleSet, Severity, ShellDialect};
 
 // ShellCheck's optional checks currently map only to compat-only behavior
@@ -62,6 +63,7 @@ pub struct LinterSettings {
     pub severity_overrides: FxHashMap<Rule, Severity>,
     pub shell: ShellDialect,
     pub ambient_shell_options: AmbientShellOptions,
+    pub ambient_contracts: Arc<ResolvedAmbientContracts>,
     pub analyzed_paths: Option<Arc<FxHashSet<PathBuf>>>,
     pub per_file_ignores: Arc<CompiledPerFileIgnoreList>,
     pub report_environment_style_names: bool,
@@ -82,6 +84,7 @@ impl Default for LinterSettings {
             severity_overrides: FxHashMap::default(),
             shell: ShellDialect::Unknown,
             ambient_shell_options: AmbientShellOptions::default(),
+            ambient_contracts: Arc::new(ResolvedAmbientContracts::default()),
             analyzed_paths: None,
             per_file_ignores: Arc::new(CompiledPerFileIgnoreList::default()),
             report_environment_style_names: false,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -290,7 +290,6 @@ use crate::dataflow::{DataflowContext, ExactVariableDataflow};
 use crate::function_resolution::FunctionBindingLookup;
 use crate::runtime::RuntimePrelude;
 use crate::scope::{ancestor_scopes, enclosing_function_scope};
-use crate::source_closure::ImportedBindingContractSite;
 use crate::zsh_options::ZshOptionAnalysis;
 
 const MAX_FUNCTIONS_FOR_TERMINATION_REACHABILITY: usize = 200;
@@ -548,6 +547,8 @@ pub struct PluginResolution {
     pub entrypoints: Vec<PathBuf>,
     /// Optional plugin contracts supplied without reading entrypoint files.
     pub file_entry_contracts: Vec<FileContract>,
+    /// Optional file-scoped caller contract applied to the file that requested the plugin.
+    pub requesting_file_contract: FileContract,
 }
 
 /// Resolver for zsh plugin loads discovered during semantic analysis.
@@ -1984,28 +1985,63 @@ impl SemanticModel {
 
     pub(crate) fn apply_source_contracts(
         &mut self,
-        synthetic_reads: Vec<SyntheticRead>,
-        imported_bindings: Vec<ImportedBindingContractSite>,
-        dependency_paths: Vec<PathBuf>,
-        source_ref_resolutions: Vec<SourceRefResolution>,
-        source_ref_explicitness: Vec<bool>,
-        source_ref_diagnostic_classes: Vec<SourceRefDiagnosticClass>,
+        contracts: source_closure::SourceClosureContracts,
     ) {
-        if synthetic_reads.is_empty()
-            && imported_bindings.is_empty()
-            && dependency_paths.is_empty()
-            && source_ref_resolutions.is_empty()
-            && source_ref_explicitness.is_empty()
-            && source_ref_diagnostic_classes.is_empty()
+        if contracts
+            .requesting_file_contract
+            .externally_consumed_bindings
+        {
+            self.mark_file_entry_consumed_bindings();
+        }
+        if !contracts
+            .requesting_file_contract
+            .externally_consumed_binding_names
+            .is_empty()
+        {
+            self.mark_file_entry_consumed_binding_names(
+                &contracts
+                    .requesting_file_contract
+                    .externally_consumed_binding_names,
+            );
+        }
+        if !contracts
+            .requesting_file_contract
+            .externally_consumed_binding_prefixes
+            .is_empty()
+        {
+            self.mark_file_entry_consumed_binding_prefixes(
+                &contracts
+                    .requesting_file_contract
+                    .externally_consumed_binding_prefixes,
+            );
+        }
+
+        if contracts.synthetic_reads.is_empty()
+            && contracts.imported_bindings.is_empty()
+            && !contracts
+                .requesting_file_contract
+                .externally_consumed_bindings
+            && contracts
+                .requesting_file_contract
+                .externally_consumed_binding_names
+                .is_empty()
+            && contracts
+                .requesting_file_contract
+                .externally_consumed_binding_prefixes
+                .is_empty()
+            && contracts.dependency_paths.is_empty()
+            && contracts.source_ref_resolutions.is_empty()
+            && contracts.source_ref_explicitness.is_empty()
+            && contracts.source_ref_diagnostic_classes.is_empty()
         {
             return;
         }
 
         let mut merged_reads = self.synthetic_reads.clone();
-        merged_reads.extend(synthetic_reads);
+        merged_reads.extend(contracts.synthetic_reads);
         self.set_synthetic_reads(dedup_synthetic_reads(merged_reads));
-        if !dependency_paths.is_empty() {
-            for path in dependency_paths {
+        if !contracts.dependency_paths.is_empty() {
+            for path in contracts.dependency_paths {
                 if !self.imported_dependency_paths.contains(&path) {
                     self.imported_dependency_paths.push(path);
                 }
@@ -2014,33 +2050,47 @@ impl SemanticModel {
             self.imported_dependency_paths.dedup();
         }
 
-        if !source_ref_resolutions.is_empty() {
-            debug_assert_eq!(source_ref_resolutions.len(), self.source_refs.len());
-            for (source_ref, resolution) in self.source_refs.iter_mut().zip(source_ref_resolutions)
+        if !contracts.source_ref_resolutions.is_empty() {
+            debug_assert_eq!(
+                contracts.source_ref_resolutions.len(),
+                self.source_refs.len()
+            );
+            for (source_ref, resolution) in self
+                .source_refs
+                .iter_mut()
+                .zip(contracts.source_ref_resolutions)
             {
                 source_ref.resolution = resolution;
             }
         }
-        if !source_ref_explicitness.is_empty() {
-            debug_assert_eq!(source_ref_explicitness.len(), self.source_refs.len());
-            for (source_ref, explicitly_provided) in
-                self.source_refs.iter_mut().zip(source_ref_explicitness)
+        if !contracts.source_ref_explicitness.is_empty() {
+            debug_assert_eq!(
+                contracts.source_ref_explicitness.len(),
+                self.source_refs.len()
+            );
+            for (source_ref, explicitly_provided) in self
+                .source_refs
+                .iter_mut()
+                .zip(contracts.source_ref_explicitness)
             {
                 source_ref.explicitly_provided = explicitly_provided;
             }
         }
-        if !source_ref_diagnostic_classes.is_empty() {
-            debug_assert_eq!(source_ref_diagnostic_classes.len(), self.source_refs.len());
+        if !contracts.source_ref_diagnostic_classes.is_empty() {
+            debug_assert_eq!(
+                contracts.source_ref_diagnostic_classes.len(),
+                self.source_refs.len()
+            );
             for (source_ref, diagnostic_class) in self
                 .source_refs
                 .iter_mut()
-                .zip(source_ref_diagnostic_classes)
+                .zip(contracts.source_ref_diagnostic_classes)
             {
                 source_ref.diagnostic_class = diagnostic_class;
             }
         }
 
-        for site in imported_bindings {
+        for site in contracts.imported_bindings {
             self.add_imported_binding(
                 &site.binding,
                 site.scope,
@@ -2386,14 +2436,7 @@ fn build_semantic_model<'a>(
         model.apply_file_entry_contract(contract, file);
     }
     if let Some(source_path) = source_path {
-        let (
-            synthetic_reads,
-            imported_bindings,
-            dependency_paths,
-            source_ref_resolutions,
-            source_ref_explicitness,
-            source_ref_diagnostic_classes,
-        ) = if resolve_source_closure {
+        let contracts = if resolve_source_closure {
             source_closure::collect_source_closure_contracts(
                 &model,
                 file,
@@ -2414,23 +2457,13 @@ fn build_semantic_model<'a>(
                     source_path_resolver,
                     analyzed_paths,
                 );
-            (
-                Vec::new(),
-                Vec::new(),
-                Vec::new(),
+            source_closure::SourceClosureContracts::from_source_ref_metadata(
                 source_ref_resolutions,
                 source_ref_explicitness,
                 source_ref_diagnostic_classes,
             )
         };
-        model.apply_source_contracts(
-            synthetic_reads,
-            imported_bindings,
-            dependency_paths,
-            source_ref_resolutions,
-            source_ref_explicitness,
-            source_ref_diagnostic_classes,
-        );
+        model.apply_source_contracts(contracts);
     }
     model
 }

--- a/crates/shuck-semantic/src/plugins/tests.rs
+++ b/crates/shuck-semantic/src/plugins/tests.rs
@@ -6,7 +6,7 @@ use shuck_indexer::Indexer;
 use shuck_parser::parser::{Parser, ShellDialect};
 
 use crate::{
-    BindingKind, PluginFramework, PluginRequest, PluginResolution, PluginResolver,
+    BindingKind, FileContract, PluginFramework, PluginRequest, PluginResolution, PluginResolver,
     SemanticBuildOptions, SemanticModel, ShellProfile, resolve_zsh_plugin_entrypoint,
 };
 
@@ -68,6 +68,7 @@ impl PluginResolver for FixtureZshPluginResolver {
         PluginResolution {
             entrypoints: vec![entrypoint],
             file_entry_contracts: Vec::new(),
+            requesting_file_contract: FileContract::default(),
         }
     }
 }

--- a/crates/shuck-semantic/src/source_closure/mod.rs
+++ b/crates/shuck-semantic/src/source_closure/mod.rs
@@ -43,25 +43,36 @@ use crate::{
     infer_explicit_parse_dialect_from_source,
 };
 
-#[derive(Debug, Clone)]
-struct SourceClosureContracts {
-    synthetic_reads: Vec<SyntheticRead>,
-    imported_bindings: Vec<ImportedBindingContractSite>,
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SourceClosureContracts {
+    pub(crate) synthetic_reads: Vec<SyntheticRead>,
+    pub(crate) imported_bindings: Vec<ImportedBindingContractSite>,
     imported_functions: Vec<ImportedFunctionContractSite>,
-    dependency_paths: Vec<PathBuf>,
-    source_ref_resolutions: Vec<SourceRefResolution>,
-    source_ref_explicitness: Vec<bool>,
-    source_ref_diagnostic_classes: Vec<SourceRefDiagnosticClass>,
+    pub(crate) requesting_file_contract: FileContract,
+    pub(crate) dependency_paths: Vec<PathBuf>,
+    pub(crate) source_ref_resolutions: Vec<SourceRefResolution>,
+    pub(crate) source_ref_explicitness: Vec<bool>,
+    pub(crate) source_ref_diagnostic_classes: Vec<SourceRefDiagnosticClass>,
 }
 
-type SourceClosureContractResult = (
-    Vec<SyntheticRead>,
-    Vec<ImportedBindingContractSite>,
-    Vec<PathBuf>,
-    Vec<SourceRefResolution>,
-    Vec<bool>,
-    Vec<SourceRefDiagnosticClass>,
-);
+impl SourceClosureContracts {
+    pub(crate) fn from_source_ref_metadata(
+        source_ref_resolutions: Vec<SourceRefResolution>,
+        source_ref_explicitness: Vec<bool>,
+        source_ref_diagnostic_classes: Vec<SourceRefDiagnosticClass>,
+    ) -> Self {
+        Self {
+            synthetic_reads: Vec::new(),
+            imported_bindings: Vec::new(),
+            imported_functions: Vec::new(),
+            requesting_file_contract: FileContract::default(),
+            dependency_paths: Vec::new(),
+            source_ref_resolutions,
+            source_ref_explicitness,
+            source_ref_diagnostic_classes,
+        }
+    }
+}
 
 type SourceRefMetadataResult = (
     Vec<SourceRefResolution>,
@@ -145,7 +156,7 @@ pub(crate) fn collect_source_closure_contracts(
     source: &str,
     source_path: &Path,
     config: SourceClosureResolverConfig<'_>,
-) -> SourceClosureContractResult {
+) -> SourceClosureContracts {
     let mut summaries = FxHashMap::default();
     let mut active = FxHashSet::default();
     let context = SourceClosureLookupContext {
@@ -157,7 +168,7 @@ pub(crate) fn collect_source_closure_contracts(
         resolved_helper_paths: RefCell::new(FxHashMap::default()),
         dependency_paths: RefCell::new(FxHashSet::default()),
     };
-    let contracts = collect_source_closure_contracts_with_cache(
+    collect_source_closure_contracts_with_cache(
         model,
         file,
         source,
@@ -165,14 +176,6 @@ pub(crate) fn collect_source_closure_contracts(
         &mut summaries,
         &mut active,
         &context,
-    );
-    (
-        contracts.synthetic_reads,
-        contracts.imported_bindings,
-        contracts.dependency_paths,
-        contracts.source_ref_resolutions,
-        contracts.source_ref_explicitness,
-        contracts.source_ref_diagnostic_classes,
     )
 }
 
@@ -259,6 +262,7 @@ fn collect_source_closure_contracts_with_cache(
     let mut synthetic_reads = Vec::new();
     let mut imported_bindings = Vec::new();
     let mut imported_functions = Vec::new();
+    let mut requesting_file_contract = FileContract::default();
     let mut source_ref_resolutions = Vec::new();
     let mut source_ref_explicitness = Vec::new();
     let mut source_ref_diagnostic_classes = Vec::new();
@@ -324,6 +328,10 @@ fn collect_source_closure_contracts_with_cache(
         for request in collect_plugin_requests(model, file, source, source_path, plugin_resolver) {
             let scope = model.scope_at(request.span.start.offset);
             let resolution = plugin_resolver.resolve_plugin_request(source_path, &request);
+            requesting_file_contract = FileContract::merge_candidate_contracts(&[
+                requesting_file_contract,
+                resolution.requesting_file_contract.clone(),
+            ]);
             let mut contracts = resolution.file_entry_contracts;
             for entrypoint in resolution.entrypoints {
                 contracts.push(summarize_helper(&entrypoint, summaries, active, context));
@@ -421,6 +429,7 @@ fn collect_source_closure_contracts_with_cache(
         synthetic_reads: dedup_synthetic_reads(synthetic_reads),
         imported_bindings: dedup_imported_bindings(imported_bindings),
         imported_functions,
+        requesting_file_contract,
         dependency_paths: sorted_dependency_paths(&context.dependency_paths.borrow()),
         source_ref_resolutions,
         source_ref_explicitness,
@@ -1756,14 +1765,7 @@ fn summarize_helper_uncached(
             dependency_paths: RefCell::new(FxHashSet::default()),
         },
     );
-    semantic.apply_source_contracts(
-        collected.synthetic_reads.clone(),
-        collected.imported_bindings.clone(),
-        collected.dependency_paths.clone(),
-        collected.source_ref_resolutions.clone(),
-        collected.source_ref_explicitness.clone(),
-        collected.source_ref_diagnostic_classes.clone(),
-    );
+    semantic.apply_source_contracts(collected.clone());
     let analysis = semantic.analysis();
 
     let mut contract =

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -9126,6 +9126,7 @@ fn configured_zsh_plugin_entrypoint_reads_apply_after_file_assignments() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9160,6 +9161,54 @@ fn configured_zsh_plugin_entrypoint_reads_apply_after_file_assignments() {
 }
 
 #[test]
+fn plugin_request_contracts_mark_requesting_file_assignments_consumed() {
+    struct ContractOnlyResolver;
+
+    impl PluginResolver for ContractOnlyResolver {
+        fn additional_plugin_requests(&self, _source_path: &Path) -> Vec<PluginRequest> {
+            vec![PluginRequest {
+                framework: PluginFramework::OhMyZsh,
+                kind: PluginRequestKind::Plugin,
+                name: "tmux".to_owned(),
+                span: Span::new(),
+                explicit: true,
+                root_hint: None,
+            }]
+        }
+
+        fn resolve_plugin_request(
+            &self,
+            _source_path: &Path,
+            _request: &PluginRequest,
+        ) -> PluginResolution {
+            PluginResolution {
+                entrypoints: Vec::new(),
+                file_entry_contracts: Vec::new(),
+                requesting_file_contract: FileContract {
+                    externally_consumed_binding_prefixes: vec![Name::from("ZSH_TMUX_")],
+                    ..FileContract::default()
+                },
+            }
+        }
+    }
+
+    let temp = tempdir().unwrap();
+    let main = temp.path().join(".zshrc");
+    fs::write(
+        &main,
+        "ZSH_TMUX_AUTOQUIT=true\nZSH_TMUX_DEFAULT_SESSION_NAME=dev\nordinary=1\n",
+    )
+    .unwrap();
+
+    let model = model_at_path_with_plugin_resolver(&main, &ContractOnlyResolver);
+
+    assert_eq!(
+        binding_names(&model, model.analysis().unused_assignments()),
+        vec!["ordinary".to_owned()]
+    );
+}
+
+#[test]
 fn zsh_plugin_hook_callbacks_make_function_reads_required() {
     struct EntryResolver {
         entrypoint: PathBuf,
@@ -9186,6 +9235,7 @@ fn zsh_plugin_hook_callbacks_make_function_reads_required() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9257,6 +9307,7 @@ fn prezto_zstyle_pmodule_loads_static_module_entrypoints() {
                             .join("init.zsh"),
                     ],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9322,6 +9373,7 @@ fn prezto_pmodload_loads_static_transitive_module_entrypoints() {
                             .join("init.zsh"),
                     ],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9459,6 +9511,7 @@ fn zdot_load_module_loads_static_module_entrypoints() {
                             .join(format!("{}.zsh", request.name)),
                     ],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9562,6 +9615,7 @@ fn zsh_plugin_eval_generated_callbacks_make_function_reads_required() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9648,6 +9702,7 @@ fn zsh_plugin_generated_callback_inference_ignores_non_eval_text() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9722,6 +9777,7 @@ fn zsh_plugin_generated_callback_inference_ignores_commented_eval_text() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9796,6 +9852,7 @@ fn zsh_plugin_eval_generated_callbacks_handle_quoted_positional_aliases() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9870,6 +9927,7 @@ fn zsh_plugin_deferred_file_scope_reads_ignore_declaration_names() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -9937,6 +9995,7 @@ fn zsh_plugin_hook_listing_does_not_make_callback_reads_required() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -10004,6 +10063,7 @@ fn zsh_plugin_hook_registration_collects_later_callbacks() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -10074,6 +10134,7 @@ fn zsh_plugin_deferred_callback_uses_latest_function_definition() {
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()
@@ -10140,6 +10201,7 @@ fn zsh_plugin_hook_registration_inside_called_setup_function_is_deferred_root() 
                 PluginResolution {
                     entrypoints: vec![self.entrypoint.clone()],
                     file_entry_contracts: Vec::new(),
+                    requesting_file_contract: FileContract::default(),
                 }
             } else {
                 PluginResolution::default()


### PR DESCRIPTION
## Summary
- add `lint.contracts` config parsing, docs metadata, and override handling
- compile well-known and custom ambient contracts into a shared contracts layer used by CLI, linter, and semantic analysis
- apply plugin request contracts to the requesting file, move existing zsh ambient providers into the contracts registry, and cover the new behavior with tests
- include resolved ambient contract content in the cache key so config-only contract changes invalidate cached results

## Validation
- cargo test -p shuck-config -p shuck-semantic -p shuck-linter -p shuck-cli
- cargo clippy --all-targets -- -D warnings
- make test-large-corpus