### PR TITLE
feat(docs): add website contracts guide

### DIFF
--- a/website/app/docs/[[...slug]]/page.tsx
+++ b/website/app/docs/[[...slug]]/page.tsx
@@ -10,6 +10,7 @@ const pages: Record<string, () => Promise<{ default: React.ComponentType; metada
   "embedded-scripts": () => import("@/content/embedded-scripts/index.mdx"),
   "configuration": () => import("@/content/configuration/index.mdx"),
   "zsh-support": () => import("@/content/zsh-support/index.mdx"),
+  "contracts": () => import("@/content/contracts/index.mdx"),
   "suppression": () => import("@/content/suppression/index.mdx"),
   "settings": () => import("@/content/settings/index.mdx"),
   "shellcheck-compat": () => import("@/content/shellcheck-compat/index.mdx"),

--- a/website/app/lib/docs-navigation.ts
+++ b/website/app/lib/docs-navigation.ts
@@ -11,6 +11,7 @@ export const docsNavigation: NavItem[] = [
       { title: "Overview", href: "/docs/getting-started" },
       { title: "Configuration", href: "/docs/configuration" },
       { title: "Zsh Support", href: "/docs/zsh-support" },
+      { title: "Contracts", href: "/docs/contracts" },
       { title: "Managed Runtime", href: "/docs/run" },
       { title: "Editor Integration", href: "/docs/editors" },
       { title: "Suppression", href: "/docs/suppression" },

--- a/website/content/configuration/index.mdx
+++ b/website/content/configuration/index.mdx
@@ -188,6 +188,23 @@ Use that section when you want Shuck to resolve real zsh plugin entrypoints for 
 
 See the dedicated [Zsh Support guide](/docs/zsh-support) for the recommended setup patterns and the [Settings Reference](/docs/settings) for the generated key-by-key reference.
 
+## Contracts
+
+Shuck prefers to discover behavior from real sourced files and resolved plugin
+entrypoints first. Use `[lint.contracts]` when important runtime or framework
+behavior cannot be recovered from source alone.
+
+Typical examples include:
+
+- runtime-provided names that a script reads;
+- plugin settings assigned in `.zshrc` and consumed later by framework code;
+- metadata assigned in one file and consumed elsewhere by a dispatcher.
+
+See the dedicated [Contracts guide](/docs/contracts) for the discovery boundary,
+examples, and when to prefer Contracts over more source resolution. The
+[Settings Reference](/docs/settings) includes the exact `[lint.contracts]`
+syntax.
+
 ## Runtime settings
 
 The `[run]` section controls managed interpreter defaults for `shuck run`, `shuck install`, and `shuck shell`.

--- a/website/content/contracts/index.mdx
+++ b/website/content/contracts/index.mdx
@@ -1,0 +1,139 @@
+# Contracts
+
+Shuck tries to learn as much as it can from real shell source before you add
+any extra configuration.
+
+When a file `source`s another file, Shuck parses that helper and summarizes the
+functions, bindings, and reads it contributes. When zsh plugin resolution can
+find a real plugin or theme entrypoint, Shuck imports that file through the
+same source-closure pipeline. In other words, Shuck prefers concrete shell
+files over hand-authored metadata whenever it can recover the behavior directly
+from source.
+
+That automatic path covers a lot:
+
+- sourced helpers that define functions or initialize variables;
+- static zsh plugin and theme entrypoints that resolve to real files;
+- explicit plugin loads, theme loads, or raw entrypoints added through config
+  or CLI flags.
+
+Sometimes the source is still not enough.
+
+Common cases include:
+
+- runtimes or CI systems that provide names the script reads, but that are not
+  assigned anywhere in the repo;
+- plugin or framework code that consumes settings from the requesting file,
+  such as `ZSH_TMUX_*` options in `.zshrc`;
+- framework conventions where one file assigns metadata and another dispatcher
+  consumes it later;
+- dynamic loaders, `eval`, generated names, or plugin-manager DSLs that prevent
+  exact recovery from source alone.
+
+That is where Contracts come in.
+
+Contracts let you add the missing runtime or framework knowledge that Shuck
+cannot reliably recover from shell source. They enhance analysis; they do not
+replace normal source closure. Shuck still prefers real sourced files and real
+plugin entrypoints whenever those are available.
+
+## What Contracts can enhance
+
+Contracts can tell Shuck about four kinds of behavior:
+
+- `reads`: names that the activated runtime reads;
+- `consumes`: assignments that remain live because external runtime behavior
+  observes them later;
+- `provides`: variables or functions that become available when the contract
+  applies;
+- `functions`: call-scoped function effects, including reads and variables a
+  provided helper may set.
+
+In practice, that means Contracts can improve:
+
+- unused-assignment analysis for settings that are consumed outside the current
+  file;
+- uninitialized-variable analysis for names that are provided by a runtime or
+  framework;
+- function and binding visibility when a helper is known to exist even though
+  its implementation is not recoverable from source.
+
+## Built-in and custom Contracts
+
+Shuck ships with built-in Contracts for well-known behavior that is stable
+enough to model in the tool itself.
+
+You can:
+
+- leave the built-ins enabled;
+- disable specific built-ins or whole built-in groups;
+- replace a built-in contract with a repo-specific version;
+- add fully custom Contracts for project-specific behavior.
+
+All of that lives under `[lint.contracts]`:
+
+```toml
+[lint.contracts]
+well-known = true
+
+[[lint.contracts.custom]]
+id = "github-actions-env"
+when = "always"
+files = [".github/**/*.sh"]
+provides = { variables = ["GITHUB_OUTPUT", "GITHUB_ENV"] }
+
+[[lint.contracts.custom]]
+id = "oh-my-zsh-tmux"
+when = { type = "zsh_plugin", framework = "oh-my-zsh", plugin = "tmux" }
+files = ["**/.zshrc"]
+consumes = { prefixes = ["ZSH_TMUX_"] }
+```
+
+In this example:
+
+- the `github-actions-env` contract tells Shuck that matching scripts can read
+  CI-provided names without assigning them locally;
+- the `oh-my-zsh-tmux` contract tells Shuck that matching `.zshrc` files may
+  assign `ZSH_TMUX_*` settings that are consumed by the tmux plugin runtime.
+
+## Activation and scope
+
+Contracts apply either:
+
+- to matching files with `when = "always"`, or
+- at a zsh plugin or theme request with `when = { type = "zsh_plugin", ... }`
+  or `when = { type = "zsh_theme", ... }`.
+
+For request-based Contracts, `files` matches the file that requested the
+plugin or theme, not the resolved plugin entrypoint. That distinction matters
+for settings-style Contracts: a `zsh_plugin` contract that consumes
+`ZSH_TMUX_*` keeps assignments in the `.zshrc` live, not assignments inside the
+tmux plugin file.
+
+`files` uses the same glob rules as other per-file settings. In most cases you
+should keep Contracts narrowly scoped to the files where the behavior really
+applies.
+
+## How Contracts relate to plugin resolution
+
+Contracts are especially useful around plugins, but they are not limited to
+plugins.
+
+Shuck already uses plugin resolution to bring real entrypoint files into the
+analysis when it can find them. Contracts cover the behavior around those files
+that source closure cannot see directly, such as:
+
+- settings consumed by the plugin runtime from the requesting file;
+- framework-provided names that exist before the plugin entrypoint runs;
+- project-specific conventions layered on top of a built-in framework.
+
+If the behavior is recoverable from a real sourced file, prefer source closure
+or plugin resolution. If it depends on runtime conventions or "assigned here,
+consumed elsewhere" behavior, use a Contract.
+
+## Next steps
+
+Use the [Configuration](/docs/configuration) guide for config-file discovery and
+precedence, the [Zsh Support](/docs/zsh-support) guide for plugin-resolution
+setup, and the [Settings Reference](/docs/settings) for the exact
+`[lint.contracts]` keys and examples.

--- a/website/content/settings/index.mdx
+++ b/website/content/settings/index.mdx
@@ -167,6 +167,243 @@ unfixable = ["C001"]
 
 ---
 
+### `[lint.contracts]`
+
+Ambient contract settings for runtime behavior that cannot be recovered from the source graph alone.
+
+#### `well-known`
+
+Enable or disable Shuck's built-in ambient contract registry.
+
+**Default value**: `true`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.contracts]
+well-known = false
+```
+
+---
+
+#### `disabled`
+
+Disable built-in ambient contracts by exact ID, by group selector, or with `*` for every built-in contract.
+
+**Default value**: `[]`
+
+**Type**: `list[string]`
+
+**Example usage**:
+
+```toml
+[lint.contracts]
+disabled = ["zsh/oh-my-zsh", "runtime/github-actions/env"]
+```
+
+---
+
+### `[lint.contracts.custom]`
+
+User-authored ambient contracts layered on top of, or in place of, the built-in registry.
+
+#### `id`
+
+Stable identifier for the custom contract.
+
+**Default value**: `required`
+
+**Type**: `string`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom]
+id = "github-actions-env"
+```
+
+---
+
+#### `replaces`
+
+Built-in contract selectors that this custom contract replaces.
+
+**Default value**: `[]`
+
+**Type**: `list[string]`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom]
+replaces = ["zsh/oh-my-zsh/plugin/tmux"]
+```
+
+---
+
+#### `when`
+
+Activation for the contract, either `"always"` or an object such as `{ type = "zsh_plugin", framework = "oh-my-zsh", plugin = "tmux" }`.
+
+**Default value**: `required`
+
+**Type**: `string | table`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom]
+when = { type = "zsh_plugin", framework = "oh-my-zsh", plugin = "tmux" }
+```
+
+---
+
+#### `files`
+
+Optional file globs that limit where the contract applies.
+
+**Default value**: `[]`
+
+**Type**: `list[glob]`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom]
+files = ["**/.zshrc"]
+```
+
+---
+
+#### `reads`
+
+Ambient names the activated runtime reads from the caller environment.
+
+**Default value**: `[]`
+
+**Type**: `list[name]`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom]
+reads = ["GITHUB_ENV", "GITHUB_OUTPUT"]
+```
+
+---
+
+#### `functions`
+
+Provided function contracts with caller reads and caller-visible sets.
+
+**Default value**: `[]`
+
+**Type**: `list[{ name, reads?, sets? }]`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom]
+functions = [{ name = "helper", reads = ["CALLER_VALUE"], sets = ["REPLY"] }]
+```
+
+---
+
+### `[lint.contracts.custom.consumes]`
+
+Assignments that stay live because external runtime behavior consumes them.
+
+#### `names`
+
+Exact names consumed by external runtime behavior.
+
+**Default value**: `[]`
+
+**Type**: `list[name]`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom.consumes]
+names = ["HISTFILE", "SAVEHIST"]
+```
+
+---
+
+#### `prefixes`
+
+Name prefixes consumed by external runtime behavior.
+
+**Default value**: `[]`
+
+**Type**: `list[prefix]`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom.consumes]
+prefixes = ["ZSH_TMUX_"]
+```
+
+---
+
+#### `all`
+
+Treat every assignment in the file as externally consumed.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom.consumes]
+all = true
+```
+
+---
+
+### `[lint.contracts.custom.provides]`
+
+Bindings made available by the activated runtime at file entry or activation time.
+
+#### `variables`
+
+Variables provided by the contract.
+
+**Default value**: `[]`
+
+**Type**: `list[name]`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom.provides]
+variables = ["reply", "REPLY"]
+```
+
+---
+
+#### `functions`
+
+Callable function names provided by the contract.
+
+**Default value**: `[]`
+
+**Type**: `list[name]`
+
+**Example usage**:
+
+```toml
+[lint.contracts.custom.provides]
+functions = ["helper"]
+```
+
+---
+
 ### `[lint.rule-options]`
 
 Rule-specific behavior overrides for diagnostics that intentionally support more than one analysis mode.

--- a/website/content/settings/index.mdx
+++ b/website/content/settings/index.mdx
@@ -205,7 +205,7 @@ disabled = ["zsh/oh-my-zsh", "runtime/github-actions/env"]
 
 ---
 
-### `[lint.contracts.custom]`
+### `[[lint.contracts.custom]]`
 
 User-authored ambient contracts layered on top of, or in place of, the built-in registry.
 
@@ -220,7 +220,7 @@ Stable identifier for the custom contract.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 id = "github-actions-env"
 ```
 
@@ -237,7 +237,7 @@ Built-in contract selectors that this custom contract replaces.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 replaces = ["zsh/oh-my-zsh/plugin/tmux"]
 ```
 
@@ -254,7 +254,7 @@ Activation for the contract, either `"always"` or an object such as `{ type = "z
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 when = { type = "zsh_plugin", framework = "oh-my-zsh", plugin = "tmux" }
 ```
 
@@ -271,7 +271,7 @@ Optional file globs that limit where the contract applies.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 files = ["**/.zshrc"]
 ```
 
@@ -288,7 +288,7 @@ Ambient names the activated runtime reads from the caller environment.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 reads = ["GITHUB_ENV", "GITHUB_OUTPUT"]
 ```
 
@@ -305,7 +305,7 @@ Provided function contracts with caller reads and caller-visible sets.
 **Example usage**:
 
 ```toml
-[lint.contracts.custom]
+[[lint.contracts.custom]]
 functions = [{ name = "helper", reads = ["CALLER_VALUE"], sets = ["REPLY"] }]
 ```
 

--- a/website/content/zsh-support/index.mdx
+++ b/website/content/zsh-support/index.mdx
@@ -48,6 +48,11 @@ In that shape, Shuck resolves:
 
 Those resolved files are summarized through the normal semantic source-closure pipeline, so their functions, bindings, and reads become available to the analyzed zsh file.
 
+That still only covers what Shuck can recover from real source files. If your
+zsh setup also relies on framework conventions or settings that are consumed
+outside the current file, use [Contracts](/docs/contracts) to describe that
+extra behavior.
+
 ## When to add config
 
 The source file is still the preferred source of truth. Add config when your real zsh setup is harder to recover statically.
@@ -92,6 +97,25 @@ entrypoints = [
   { pattern = "**/.zshrc", paths = ["./vendor/prompt/prompt.plugin.zsh"] },
 ]
 ```
+
+### Contracts for framework behavior
+
+Plugin resolution tells Shuck which files to import. Contracts tell Shuck about
+the surrounding runtime behavior that those files do not fully expose.
+
+For example, an `oh-my-zsh` plugin can consume settings from `.zshrc` even when
+those settings are not read lexically in the startup file itself:
+
+```toml
+[[lint.contracts.custom]]
+id = "oh-my-zsh-tmux"
+when = { type = "zsh_plugin", framework = "oh-my-zsh", plugin = "tmux" }
+files = ["**/.zshrc"]
+consumes = { prefixes = ["ZSH_TMUX_"] }
+```
+
+See the [Contracts guide](/docs/contracts) for the broader model and the
+[Settings Reference](/docs/settings) for the exact key shape.
 
 ## CLI equivalents
 


### PR DESCRIPTION
## Summary
- add a dedicated website docs page for Contracts
- explain the discovery boundary first: sourced files and resolved plugin entrypoints are preferred, and Contracts fill in behavior that source closure cannot recover directly
- link the new guide from Configuration and Zsh Support, and wire it into the docs navigation
- regenerate the Settings Reference so `[lint.contracts]` appears on the site

## Validation
- `pnpm --dir website generate:config`
- `pnpm --dir website build`

## Notes
- This is a docs-only follow-up after PR #964 merged.
- The docs use `Contracts` as the user-facing term rather than `ambient contracts`.