### PR TITLE
refactor(linter): register remaining ambient file contracts

### DIFF
--- a/crates/shuck-linter/src/ambient_contracts/contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts/contracts.rs
@@ -462,10 +462,22 @@ struct WellKnownRequestContract {
 
 const WELL_KNOWN_FILE_CONTRACTS: &[WellKnownFileContract] = &[
     WellKnownFileContract {
+        id: "sourced/runtime",
+        groups: &["sourced"],
+        matches: super::sourced_runtime::matches_sourced_runtime_contract,
+        apply: super::sourced_runtime::apply_sourced_runtime_contract,
+    },
+    WellKnownFileContract {
         id: "zsh/runtime",
         groups: &["zsh"],
         matches: super::zsh_runtime::matches_zsh_ambient_runtime_contract,
         apply: super::zsh_runtime::apply_zsh_ambient_runtime_contract,
+    },
+    WellKnownFileContract {
+        id: "zsh/caller-scoped-arrays",
+        groups: &["zsh"],
+        matches: super::zsh_caller_arrays::matches_zsh_caller_scoped_array_contract,
+        apply: super::zsh_caller_arrays::apply_zsh_caller_scoped_array_contract,
     },
     WellKnownFileContract {
         id: "zsh/config",

--- a/crates/shuck-linter/src/ambient_contracts/mod.rs
+++ b/crates/shuck-linter/src/ambient_contracts/mod.rs
@@ -52,7 +52,6 @@ mod zsh_module_metadata;
 mod zsh_paths;
 mod zsh_runtime;
 
-pub(crate) use contracts::merge_contract;
 pub use contracts::{
     AmbientContractActivation, AmbientContractConfig, AmbientContractEffects, AmbientContractSpec,
     AmbientFunctionContractSpec, EffectiveAmbientContracts, ResolvedAmbientContracts,
@@ -115,26 +114,7 @@ impl<'a> AmbientContractCollector<'a> {
 
     fn file_entry_contract(&self) -> Option<FileContract> {
         self.signals.path()?;
-        let mut merged = self.contracts.file_entry_contract(self, self.shell);
-        let mut matched = merged.is_some();
-        let merged_contract = merged.get_or_insert_default();
-
-        if sourced_runtime::matches_sourced_runtime_contract(self, self.shell) {
-            matched = true;
-            merge_contract(
-                merged_contract,
-                sourced_runtime::build_sourced_runtime_contract(self, self.shell),
-            );
-        }
-        if zsh_caller_arrays::matches_zsh_caller_scoped_array_contract(self, self.shell) {
-            matched = true;
-            merge_contract(
-                merged_contract,
-                zsh_caller_arrays::build_zsh_caller_scoped_array_contract(self, self.shell),
-            );
-        }
-
-        matched.then_some(merged_contract.clone())
+        self.contracts.file_entry_contract(self, self.shell)
     }
 
     fn source_signals(&self) -> &signals::SourceSignals<'a> {

--- a/crates/shuck-linter/src/ambient_contracts/sourced_runtime.rs
+++ b/crates/shuck-linter/src/ambient_contracts/sourced_runtime.rs
@@ -43,19 +43,16 @@ pub(super) fn matches_sourced_runtime_contract(
     sourced_runtime_path_shape(collector.path_signals()) && sourced_runtime_source_shape(collector)
 }
 
-pub(super) fn build_sourced_runtime_contract(
+pub(super) fn apply_sourced_runtime_contract(
+    contract: &mut FileContract,
     collector: &AmbientContractCollector<'_>,
-    _shell: ShellDialect,
-) -> FileContract {
+) {
     let mut names = BTreeSet::new();
 
     for name in runtime_names_for_source_path(collector) {
         names.insert((*name).to_owned());
     }
 
-    let mut contract = FileContract {
-        ..FileContract::default()
-    };
     for name in names {
         contract.add_provided_binding(ProvidedBinding::new(
             Name::from(name.as_str()),
@@ -63,7 +60,6 @@ pub(super) fn build_sourced_runtime_contract(
             ContractCertainty::Definite,
         ));
     }
-    contract
 }
 
 fn sourced_runtime_path_shape(path: &PathSignals) -> bool {

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -8,7 +8,7 @@ use shuck_semantic::{
 };
 use std::sync::Arc;
 
-use super::{AmbientContractCollector, ResolvedAmbientContracts};
+use super::{AmbientContractCollector, AmbientContractConfig, ResolvedAmbientContracts};
 use crate::ShellDialect;
 
 fn contract_for(path: &Path, source: &str) -> Option<FileContract> {
@@ -24,15 +24,24 @@ fn contract_for_optional_path(
     source: &str,
     shell: ShellDialect,
 ) -> Option<FileContract> {
+    contract_for_optional_path_with_contracts(
+        path,
+        source,
+        shell,
+        Arc::new(ResolvedAmbientContracts::default()),
+    )
+}
+
+fn contract_for_optional_path_with_contracts(
+    path: Option<&Path>,
+    source: &str,
+    shell: ShellDialect,
+    contracts: Arc<ResolvedAmbientContracts>,
+) -> Option<FileContract> {
     let output = Parser::new(source).parse().unwrap();
     let indexer = Indexer::new(source, &output);
     let mut observer = NoopTraversalObserver;
-    let mut collector = AmbientContractCollector::new(
-        source,
-        path,
-        shell,
-        Arc::new(ResolvedAmbientContracts::default()),
-    );
+    let mut collector = AmbientContractCollector::new(source, path, shell, contracts);
     let _semantic = build_with_observer_with_options(
         &output.file,
         source,
@@ -95,6 +104,22 @@ printf '%s\\n' \"$XBPS_SRCPKGDIR\" \"$configure_args\" \"$wrksrc\"
 }
 
 #[test]
+fn effective_well_known_ids_include_registry_backed_sourced_and_zsh_array_contracts() {
+    let effective = ResolvedAmbientContracts::default().effective();
+
+    assert!(
+        effective
+            .well_known_ids
+            .contains(&"sourced/runtime".to_owned())
+    );
+    assert!(
+        effective
+            .well_known_ids
+            .contains(&"zsh/caller-scoped-arrays".to_owned())
+    );
+}
+
+#[test]
 fn bash_it_theme_paths_get_palette_ambient_contracts() {
     let path = Path::new("/tmp/Bash-it/themes/example/example.theme.bash");
     let source = "\
@@ -111,6 +136,32 @@ PROMPT_COMMAND=prompt_command
     assert!(!has_initialized_binding(&contract, "green"));
     assert!(!has_initialized_binding(&contract, "reset_color"));
     assert!(!contract.externally_consumed_bindings);
+}
+
+#[test]
+fn disabling_sourced_runtime_contract_selector_removes_palette_bindings() {
+    let path = Path::new("/tmp/Bash-it/themes/example/example.theme.bash");
+    let source = "\
+prompt_command() {
+  PS1=\"${green?} ${green} ${reset_color?}\"
+}
+PROMPT_COMMAND=prompt_command
+";
+    let contracts = Arc::new(
+        ResolvedAmbientContracts::resolve(
+            "/tmp",
+            AmbientContractConfig {
+                disabled: vec!["sourced/runtime".to_owned()],
+                ..AmbientContractConfig::default()
+            },
+        )
+        .unwrap(),
+    );
+
+    let contract =
+        contract_for_optional_path_with_contracts(Some(path), source, ShellDialect::Sh, contracts);
+
+    assert!(contract.is_none(), "{contract:?}");
 }
 
 #[test]
@@ -517,6 +568,34 @@ safe_rm() {
 
     assert!(has_initialized_binding(&contract, "dry_run"));
     assert!(!contract.externally_consumed_bindings);
+}
+
+#[test]
+fn disabling_zsh_caller_scoped_array_contract_selector_keeps_helper_array_reads_reportable() {
+    let path = Path::new("/tmp/project/core/update_core.zsh");
+    let source = "\
+#!/bin/zsh
+safe_rm() {
+  if [[ ${#dry_run[@]} -gt 0 ]]; then
+    print -r -- dry
+  fi
+}
+";
+    let contracts = Arc::new(
+        ResolvedAmbientContracts::resolve(
+            "/tmp/project",
+            AmbientContractConfig {
+                disabled: vec!["zsh/caller-scoped-arrays".to_owned()],
+                ..AmbientContractConfig::default()
+            },
+        )
+        .unwrap(),
+    );
+
+    let contract =
+        contract_for_optional_path_with_contracts(Some(path), source, ShellDialect::Zsh, contracts);
+
+    assert!(contract.is_none(), "{contract:?}");
 }
 
 #[test]

--- a/crates/shuck-linter/src/ambient_contracts/zsh_caller_arrays.rs
+++ b/crates/shuck-linter/src/ambient_contracts/zsh_caller_arrays.rs
@@ -37,11 +37,10 @@ pub(super) fn matches_zsh_caller_scoped_array_contract(
         && !collector.caller_scoped_array_length_names.is_empty()
 }
 
-pub(super) fn build_zsh_caller_scoped_array_contract(
+pub(super) fn apply_zsh_caller_scoped_array_contract(
+    contract: &mut FileContract,
     collector: &AmbientContractCollector<'_>,
-    _shell: ShellDialect,
-) -> FileContract {
-    let mut contract = FileContract::default();
+) {
     for name in &collector.caller_scoped_array_length_names {
         contract.add_provided_binding(ProvidedBinding::new_file_entry_initialized(
             name.clone(),
@@ -49,7 +48,6 @@ pub(super) fn build_zsh_caller_scoped_array_contract(
             ContractCertainty::Definite,
         ));
     }
-    contract
 }
 
 pub(super) fn collect_caller_scoped_array_length_names(word: &Word, names: &mut BTreeSet<Name>) {


### PR DESCRIPTION
## Summary
- register sourced runtime and zsh caller-scoped array providers as well-known ambient file contracts
- route file-entry ambient contract collection entirely through the resolved contract registry
- add selector regression tests so these built-ins can be enabled and disabled like the rest of the well-known catalog

## Why
The remaining sourced-runtime and caller-scoped-array behaviors were still being merged directly in the collector instead of coming from the well-known contract registry. That made them inconsistent with spec 021's contract controls and bypassed the normal selector/disable path.

This keeps the source-first boundary intact: source-derived plugin and helper behavior still belongs in source closure and semantic summarization, while residual ambient file-entry behavior goes through well-known contracts.

## Impact
Ambient contract built-ins now share one registry path, so selector handling is uniform and future contract splits can happen without special collector logic.

## Validation
- `cargo test -p shuck-linter ambient_contracts::tests`
- `cargo test -p shuck-linter plugin_entrypoints_receive_ambient_contracts_while_summarizing`
- `cargo test -p shuck-linter zsh_sourced_runtime_helpers_accept_caller_scoped_option_arrays`