### PR TITLE
feat(linter): add declarative built-in contracts

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,88 @@
+# Declarative Built-In Contracts
+
+This directory contains Shuck's repository-authored built-in ambient contracts.
+They are source files for the build, not runtime configuration files.
+
+## Source First
+
+Before adding a contract, ask:
+
+> Could Shuck load real source and derive this fact instead?
+
+If yes, prefer improving source resolution, source closure, helper
+summarization, or deferred runtime modeling.
+
+Use a declarative contract only for residual behavior such as:
+
+- runtime-provided names available before file entry;
+- names or prefixes consumed by a framework after the file runs;
+- stable plugin or theme conventions that are not recoverable from reachable
+  source.
+
+## Layout
+
+Contracts live under a top-level `contracts/` tree, grouped by ecosystem:
+
+```text
+contracts/
+  runtime/
+  zsh/
+```
+
+Each YAML file uses this shape:
+
+```yaml
+version: 1
+contracts:
+  - id: zsh/oh-my-zsh/plugin/tmux
+    groups:
+      - zsh
+      - zsh/oh-my-zsh
+      - zsh/oh-my-zsh/plugin
+    label: Oh My Zsh tmux plugin
+    when:
+      type: zsh_plugin
+      framework: oh-my-zsh
+      plugin: tmux
+    effects:
+      consumes:
+        prefixes:
+          - ZSH_TMUX_
+```
+
+## Fields
+
+- `id`: Stable built-in selector id.
+- `groups`: Stable built-in selector groups.
+- `label`: Optional human-facing label.
+- `when`: One of `always`, `zsh_plugin`, or `zsh_theme`.
+- `files`: Optional path filters matched against the requesting or primary file.
+- `effects.reads`: Names read at activation time.
+- `effects.consumes.names`: Exact names consumed outside the lexical source.
+- `effects.consumes.prefixes`: Name prefixes consumed outside the lexical
+  source.
+- `effects.consumes.all`: Escape hatch for consuming all non-local
+  assignments.
+- `effects.provides.variables`: Definite initialized file-entry variables.
+- `effects.provides.functions`: Definite function bindings.
+- `effects.functions`: Function-specific caller reads and sets.
+
+## Validation
+
+The `shuck-linter` build script validates:
+
+- schema version;
+- duplicate ids;
+- invalid groups or selector tokens;
+- invalid shell names and prefixes;
+- invalid file globs;
+- empty effect bodies;
+- invalid activation field combinations.
+
+## Commands
+
+```bash
+cargo test -p shuck-linter build_script
+cargo test -p shuck-linter ambient_contracts
+cargo test -p shuck-cli contract
+```

--- a/contracts/zsh/oh-my-zsh/plugins/tmux.yaml
+++ b/contracts/zsh/oh-my-zsh/plugins/tmux.yaml
@@ -1,0 +1,16 @@
+version: 1
+contracts:
+  - id: zsh/oh-my-zsh/plugin/tmux
+    groups:
+      - zsh
+      - zsh/oh-my-zsh
+      - zsh/oh-my-zsh/plugin
+    label: Oh My Zsh tmux plugin
+    when:
+      type: zsh_plugin
+      framework: oh-my-zsh
+      plugin: tmux
+    effects:
+      consumes:
+        prefixes:
+          - ZSH_TMUX_

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -1469,8 +1469,9 @@ mod tests {
         EmbeddedFormat, EmbeddedScript, ExtractedDialect, HostLineStart, ImplicitShellFlags,
     };
     use shuck_linter::{
-        Category, LinterSettings, NamedGroup, Rule, RuleSelector, RuleSet, ShellCheckCodeMap,
-        ShellDialect,
+        AmbientContractActivation, AmbientContractConfig, AmbientContractEffects,
+        AmbientContractSpec, Category, LinterSettings, NamedGroup, Rule, RuleSelector, RuleSet,
+        ShellCheckCodeMap, ShellDialect,
     };
     use shuck_parser::parser::Parser;
     use shuck_semantic::FileContract;
@@ -2191,6 +2192,86 @@ mod tests {
                 .iter()
                 .any(|prefix| prefix.as_str() == "ZSH_TMUX_")
         );
+    }
+
+    #[test]
+    fn disabled_built_in_tmux_selector_skips_generated_contract() {
+        let contracts = ResolvedAmbientContracts::resolve(
+            PathBuf::from("/workspace"),
+            AmbientContractConfig {
+                well_known: true,
+                disabled: vec!["zsh/oh-my-zsh/plugin/tmux".to_owned()],
+                custom: Vec::new(),
+            },
+        )
+        .unwrap();
+        let request = PluginRequest {
+            framework: PluginFramework::OhMyZsh,
+            kind: PluginRequestKind::Plugin,
+            name: "tmux".to_owned(),
+            span: shuck_ast::Span::new(),
+            explicit: true,
+            root_hint: None,
+        };
+
+        let resolved =
+            contracts.request_contracts_for_plugin(Path::new("/workspace/.zshrc"), &request);
+
+        assert!(
+            resolved
+                .requesting_file_contract
+                .externally_consumed_binding_prefixes
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn invalid_built_in_contract_selector_is_rejected() {
+        let error = ResolvedAmbientContracts::resolve(
+            PathBuf::from("/workspace"),
+            AmbientContractConfig {
+                well_known: true,
+                disabled: vec!["unknown/selector".to_owned()],
+                custom: Vec::new(),
+            },
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("unknown ambient contract selector")
+        );
+    }
+
+    #[test]
+    fn duplicate_custom_contract_ids_are_rejected() {
+        let error = ResolvedAmbientContracts::resolve(
+            PathBuf::from("/workspace"),
+            AmbientContractConfig {
+                well_known: false,
+                disabled: Vec::new(),
+                custom: vec![
+                    AmbientContractSpec {
+                        id: "duplicate".to_owned(),
+                        replaces: Vec::new(),
+                        when: AmbientContractActivation::Always,
+                        files: Vec::new(),
+                        effects: AmbientContractEffects::default(),
+                    },
+                    AmbientContractSpec {
+                        id: "duplicate".to_owned(),
+                        replaces: Vec::new(),
+                        when: AmbientContractActivation::Always,
+                        files: Vec::new(),
+                        effects: AmbientContractEffects::default(),
+                    },
+                ],
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("duplicate ambient contract id"));
     }
 
     #[test]

--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -2245,6 +2245,25 @@ mod tests {
     }
 
     #[test]
+    fn custom_only_contracts_ignore_built_in_selector_validation() {
+        ResolvedAmbientContracts::resolve(
+            PathBuf::from("/workspace"),
+            AmbientContractConfig {
+                well_known: false,
+                disabled: vec!["unknown/selector".to_owned()],
+                custom: vec![AmbientContractSpec {
+                    id: "custom".to_owned(),
+                    replaces: vec!["legacy/built-in".to_owned()],
+                    when: AmbientContractActivation::Always,
+                    files: Vec::new(),
+                    effects: AmbientContractEffects::default(),
+                }],
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn duplicate_custom_contract_ids_are_rejected() {
         let error = ResolvedAmbientContracts::resolve(
             PathBuf::from("/workspace"),

--- a/crates/shuck-linter/Cargo.toml
+++ b/crates/shuck-linter/Cargo.toml
@@ -35,5 +35,6 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 
 [build-dependencies]
+globset = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/shuck-linter/build.rs
+++ b/crates/shuck-linter/build.rs
@@ -576,15 +576,21 @@ fn collect_yaml_files(dir: &Path) -> Result<Vec<PathBuf>, String> {
     Ok(paths)
 }
 
-fn collect_yaml_files_recursive(dir: &Path, paths: &mut Vec<PathBuf>) -> Result<(), String> {
+fn read_dir_paths(dir: &Path) -> Result<Vec<PathBuf>, String> {
     let mut entries = fs::read_dir(dir)
         .map_err(|err| format!("read {}: {err}", dir.display()))?
-        .flatten()
-        .map(|entry| entry.path())
-        .collect::<Vec<_>>();
+        .map(|entry| {
+            entry
+                .map(|entry| entry.path())
+                .map_err(|err| format!("read {}: {err}", dir.display()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     entries.sort();
+    Ok(entries)
+}
 
-    for path in entries {
+fn collect_yaml_files_recursive(dir: &Path, paths: &mut Vec<PathBuf>) -> Result<(), String> {
+    for path in read_dir_paths(dir)? {
         if path.is_dir() {
             collect_yaml_files_recursive(&path, paths)?;
             continue;
@@ -597,13 +603,10 @@ fn collect_yaml_files_recursive(dir: &Path, paths: &mut Vec<PathBuf>) -> Result<
 }
 
 fn load_rule_metadata(docs_dir: &Path) -> Result<LoadedRuleMetadata, String> {
-    let mut entries = fs::read_dir(docs_dir)
-        .map_err(|err| format!("read {}: {err}", docs_dir.display()))?
-        .flatten()
-        .map(|entry| entry.path())
+    let entries = read_dir_paths(docs_dir)?
+        .into_iter()
         .filter(|path| path.extension().is_some_and(|ext| ext == "yaml"))
         .collect::<Vec<_>>();
-    entries.sort();
 
     let mut mappings = Vec::new();
     let mut metadata_rows = Vec::new();

--- a/crates/shuck-linter/build.rs
+++ b/crates/shuck-linter/build.rs
@@ -144,6 +144,9 @@ struct RuleMetadataRow {
     shellcheck_level: Option<ShellCheckLevel>,
 }
 
+type RuleShellCheckMapping = (String, u32);
+type LoadedRuleMetadata = (Vec<RuleShellCheckMapping>, Vec<RuleMetadataRow>);
+
 fn parse_shellcheck_code_value(raw: &str) -> Result<Option<u32>, String> {
     let raw = raw.trim().trim_matches(|ch| matches!(ch, '"' | '\''));
     if raw.is_empty() || raw.eq_ignore_ascii_case("null") || raw == "~" {
@@ -593,9 +596,7 @@ fn collect_yaml_files_recursive(dir: &Path, paths: &mut Vec<PathBuf>) -> Result<
     Ok(())
 }
 
-fn load_rule_metadata(
-    docs_dir: &Path,
-) -> Result<(Vec<(String, u32)>, Vec<RuleMetadataRow>), String> {
+fn load_rule_metadata(docs_dir: &Path) -> Result<LoadedRuleMetadata, String> {
     let mut entries = fs::read_dir(docs_dir)
         .map_err(|err| format!("read {}: {err}", docs_dir.display()))?
         .flatten()

--- a/crates/shuck-linter/build.rs
+++ b/crates/shuck-linter/build.rs
@@ -1,5 +1,10 @@
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::fs;
+use std::path::{Path, PathBuf};
+
 #[cfg(not(test))]
-use std::{env, fs, path::PathBuf};
+use std::env;
 
 use serde::Deserialize;
 
@@ -19,6 +24,124 @@ enum ShellCheckLevel {
     Info,
     Warning,
     Error,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct ContractDocument {
+    version: u32,
+    contracts: Vec<DeclarativeContract>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeContract {
+    id: String,
+    #[serde(default)]
+    groups: Vec<String>,
+    label: Option<String>,
+    when: DeclarativeContractWhen,
+    #[serde(default)]
+    files: Vec<String>,
+    effects: DeclarativeContractEffects,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeContractWhen {
+    #[serde(rename = "type")]
+    activation_type: DeclarativeContractActivationType,
+    framework: Option<String>,
+    plugin: Option<String>,
+    theme: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+enum DeclarativeContractActivationType {
+    #[serde(rename = "always")]
+    Always,
+    #[serde(rename = "zsh_plugin")]
+    ZshPlugin,
+    #[serde(rename = "zsh_theme")]
+    ZshTheme,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeContractEffects {
+    reads: Vec<String>,
+    consumes: DeclarativeContractConsumes,
+    provides: DeclarativeContractProvides,
+    functions: Vec<DeclarativeFunctionEffects>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeContractConsumes {
+    names: Vec<String>,
+    prefixes: Vec<String>,
+    all: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeContractProvides {
+    variables: Vec<String>,
+    functions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeFunctionEffects {
+    name: String,
+    #[serde(default)]
+    reads: Vec<String>,
+    #[serde(default)]
+    sets: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedDeclarativeContract {
+    id: String,
+    groups: Vec<String>,
+    label: Option<String>,
+    activation: NormalizedDeclarativeActivation,
+    files: Vec<String>,
+    effects: NormalizedDeclarativeEffects,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum NormalizedDeclarativeActivation {
+    Always,
+    ZshPlugin { framework: String, plugin: String },
+    ZshTheme { framework: String, theme: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedDeclarativeEffects {
+    reads: Vec<String>,
+    consumes_names: Vec<String>,
+    consumes_prefixes: Vec<String>,
+    consumes_all: bool,
+    provides_variables: Vec<String>,
+    provides_functions: Vec<String>,
+    functions: Vec<NormalizedDeclarativeFunctionEffects>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedDeclarativeFunctionEffects {
+    name: String,
+    reads: Vec<String>,
+    sets: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RuleMetadataRow {
+    code: String,
+    description: String,
+    rationale: String,
+    fix_description: Option<String>,
+    shellcheck_level: Option<ShellCheckLevel>,
 }
 
 fn parse_shellcheck_code_value(raw: &str) -> Result<Option<u32>, String> {
@@ -84,6 +207,598 @@ fn parse_rule_metadata(
     Ok((metadata, shellcheck_code, shellcheck_level))
 }
 
+fn parse_declarative_contract_document(data: &str) -> Result<ContractDocument, String> {
+    serde_yaml::from_str(data).map_err(|err| format!("invalid declarative contracts: {err}"))
+}
+
+fn validate_declarative_contract_document(
+    data: &str,
+    source_path: &Path,
+) -> Result<Vec<NormalizedDeclarativeContract>, String> {
+    let document = parse_declarative_contract_document(data)?;
+    if document.version != 1 {
+        return Err(format!(
+            "unsupported declarative contract version {} in {}",
+            document.version,
+            source_path.display()
+        ));
+    }
+
+    let mut normalized = Vec::new();
+    for contract in document.contracts {
+        normalized.push(normalize_declarative_contract(contract, source_path)?);
+    }
+
+    Ok(normalized)
+}
+
+fn normalize_declarative_contract(
+    contract: DeclarativeContract,
+    source_path: &Path,
+) -> Result<NormalizedDeclarativeContract, String> {
+    let id = normalize_selector_token("contract id", &contract.id, source_path)?;
+    let groups = normalize_selector_tokens("contract group", &contract.groups, source_path)?;
+    if groups.is_empty() {
+        return Err(format!(
+            "missing groups for declarative contract {id:?} in {}",
+            source_path.display()
+        ));
+    }
+    if groups.iter().any(|group| group == &id) {
+        return Err(format!(
+            "contract group must not repeat id {id:?} in {}",
+            source_path.display()
+        ));
+    }
+
+    let activation = normalize_declarative_activation(&contract.when, source_path)?;
+    let files = normalize_globs(&contract.files, source_path)?;
+    let effects = normalize_declarative_effects(&contract.effects, source_path)?;
+    if effects_is_empty(&effects) {
+        return Err(format!(
+            "declarative contract {id:?} in {} must define at least one effect",
+            source_path.display()
+        ));
+    }
+
+    Ok(NormalizedDeclarativeContract {
+        id,
+        groups,
+        label: contract.label.map(|label| label.trim().to_owned()),
+        activation,
+        files,
+        effects,
+    })
+}
+
+fn normalize_declarative_activation(
+    when: &DeclarativeContractWhen,
+    source_path: &Path,
+) -> Result<NormalizedDeclarativeActivation, String> {
+    match when.activation_type {
+        DeclarativeContractActivationType::Always => {
+            if when.framework.is_some() || when.plugin.is_some() || when.theme.is_some() {
+                return Err(format!(
+                    "`always` activation cannot include framework, plugin, or theme in {}",
+                    source_path.display()
+                ));
+            }
+            Ok(NormalizedDeclarativeActivation::Always)
+        }
+        DeclarativeContractActivationType::ZshPlugin => {
+            let framework = normalize_nonempty_text(
+                "activation framework",
+                when.framework.as_deref(),
+                source_path,
+            )?;
+            let plugin =
+                normalize_nonempty_text("activation plugin", when.plugin.as_deref(), source_path)?;
+            if when.theme.is_some() {
+                return Err(format!(
+                    "`zsh_plugin` activation cannot include `theme` in {}",
+                    source_path.display()
+                ));
+            }
+            Ok(NormalizedDeclarativeActivation::ZshPlugin { framework, plugin })
+        }
+        DeclarativeContractActivationType::ZshTheme => {
+            let framework = normalize_nonempty_text(
+                "activation framework",
+                when.framework.as_deref(),
+                source_path,
+            )?;
+            let theme =
+                normalize_nonempty_text("activation theme", when.theme.as_deref(), source_path)?;
+            if when.plugin.is_some() {
+                return Err(format!(
+                    "`zsh_theme` activation cannot include `plugin` in {}",
+                    source_path.display()
+                ));
+            }
+            Ok(NormalizedDeclarativeActivation::ZshTheme { framework, theme })
+        }
+    }
+}
+
+fn normalize_declarative_effects(
+    effects: &DeclarativeContractEffects,
+    source_path: &Path,
+) -> Result<NormalizedDeclarativeEffects, String> {
+    Ok(NormalizedDeclarativeEffects {
+        reads: normalize_shell_names("reads", &effects.reads, source_path)?,
+        consumes_names: normalize_shell_names(
+            "consumes.names",
+            &effects.consumes.names,
+            source_path,
+        )?,
+        consumes_prefixes: normalize_shell_prefixes(
+            "consumes.prefixes",
+            &effects.consumes.prefixes,
+            source_path,
+        )?,
+        consumes_all: effects.consumes.all,
+        provides_variables: normalize_shell_names(
+            "provides.variables",
+            &effects.provides.variables,
+            source_path,
+        )?,
+        provides_functions: normalize_shell_names(
+            "provides.functions",
+            &effects.provides.functions,
+            source_path,
+        )?,
+        functions: effects
+            .functions
+            .iter()
+            .map(|function| normalize_declarative_function_effects(function, source_path))
+            .collect::<Result<Vec<_>, _>>()?,
+    })
+}
+
+fn normalize_declarative_function_effects(
+    function: &DeclarativeFunctionEffects,
+    source_path: &Path,
+) -> Result<NormalizedDeclarativeFunctionEffects, String> {
+    Ok(NormalizedDeclarativeFunctionEffects {
+        name: normalize_shell_name("function name", &function.name, source_path)?,
+        reads: normalize_shell_names("functions[].reads", &function.reads, source_path)?,
+        sets: normalize_shell_names("functions[].sets", &function.sets, source_path)?,
+    })
+}
+
+fn normalize_selector_tokens(
+    field: &str,
+    values: &[String],
+    source_path: &Path,
+) -> Result<Vec<String>, String> {
+    let mut normalized = Vec::new();
+    for value in values {
+        normalized.push(normalize_selector_token(field, value, source_path)?);
+    }
+    Ok(unique_stable(normalized))
+}
+
+fn normalize_selector_token(
+    field: &str,
+    value: &str,
+    source_path: &Path,
+) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!(
+            "{field} must not be empty in {}",
+            source_path.display()
+        ));
+    }
+    if trimmed != value {
+        return Err(format!(
+            "{field} must not have leading or trailing whitespace in {}",
+            source_path.display()
+        ));
+    }
+    if value.chars().any(char::is_whitespace) {
+        return Err(format!(
+            "{field} must not contain whitespace in {}",
+            source_path.display()
+        ));
+    }
+    Ok(value.to_owned())
+}
+
+fn normalize_nonempty_text(
+    field: &str,
+    value: Option<&str>,
+    source_path: &Path,
+) -> Result<String, String> {
+    let Some(value) = value else {
+        return Err(format!("missing {field} in {}", source_path.display()));
+    };
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!(
+            "{field} must not be empty in {}",
+            source_path.display()
+        ));
+    }
+    if trimmed != value {
+        return Err(format!(
+            "{field} must not have leading or trailing whitespace in {}",
+            source_path.display()
+        ));
+    }
+    Ok(value.to_owned())
+}
+
+fn normalize_globs(values: &[String], source_path: &Path) -> Result<Vec<String>, String> {
+    let mut normalized = Vec::new();
+    for value in values {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "file glob must not be empty in {}",
+                source_path.display()
+            ));
+        }
+        if trimmed != value {
+            return Err(format!(
+                "file glob must not have leading or trailing whitespace in {}",
+                source_path.display()
+            ));
+        }
+        let matcher = value.strip_prefix('!').unwrap_or(value.as_str());
+        globset::Glob::new(matcher).map_err(|err| {
+            format!(
+                "invalid declarative contract glob {value:?} in {}: {err}",
+                source_path.display()
+            )
+        })?;
+        normalized.push(value.to_owned());
+    }
+    Ok(unique_stable(normalized))
+}
+
+fn normalize_shell_names(
+    field: &str,
+    values: &[String],
+    source_path: &Path,
+) -> Result<Vec<String>, String> {
+    let mut normalized = Vec::new();
+    for value in values {
+        normalized.push(normalize_shell_name(field, value, source_path)?);
+    }
+    Ok(unique_stable(normalized))
+}
+
+fn normalize_shell_name(field: &str, value: &str, source_path: &Path) -> Result<String, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!(
+            "{field} must not be empty in {}",
+            source_path.display()
+        ));
+    }
+    if trimmed != value {
+        return Err(format!(
+            "{field} must not have leading or trailing whitespace in {}",
+            source_path.display()
+        ));
+    }
+    if !is_portable_shell_identifier(value) {
+        return Err(format!(
+            "{field} must use a portable shell identifier in {}: {value:?}",
+            source_path.display()
+        ));
+    }
+    Ok(value.to_owned())
+}
+
+fn normalize_shell_prefixes(
+    field: &str,
+    values: &[String],
+    source_path: &Path,
+) -> Result<Vec<String>, String> {
+    let mut normalized = Vec::new();
+    for value in values {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(format!(
+                "{field} must not be empty in {}",
+                source_path.display()
+            ));
+        }
+        if trimmed != value {
+            return Err(format!(
+                "{field} must not have leading or trailing whitespace in {}",
+                source_path.display()
+            ));
+        }
+        if !is_portable_shell_identifier_prefix(value) {
+            return Err(format!(
+                "{field} must use a portable shell identifier prefix in {}: {value:?}",
+                source_path.display()
+            ));
+        }
+        normalized.push(value.to_owned());
+    }
+    Ok(unique_stable(normalized))
+}
+
+fn is_portable_shell_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn is_portable_shell_identifier_prefix(value: &str) -> bool {
+    let mut chars = value.chars();
+    match chars.next() {
+        Some(first) if first == '_' || first.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn unique_stable(values: Vec<String>) -> Vec<String> {
+    let mut unique = Vec::new();
+    for value in values {
+        if !unique.contains(&value) {
+            unique.push(value);
+        }
+    }
+    unique
+}
+
+fn effects_is_empty(effects: &NormalizedDeclarativeEffects) -> bool {
+    effects.reads.is_empty()
+        && effects.consumes_names.is_empty()
+        && effects.consumes_prefixes.is_empty()
+        && !effects.consumes_all
+        && effects.provides_variables.is_empty()
+        && effects.provides_functions.is_empty()
+        && effects.functions.is_empty()
+}
+
+fn collect_yaml_files(dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let metadata = fs::symlink_metadata(dir)
+        .map_err(|err| format!("read metadata for {}: {err}", dir.display()))?;
+    if !metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+        return Err(format!("{} is not a directory", dir.display()));
+    }
+    let mut paths = Vec::new();
+    collect_yaml_files_recursive(dir, &mut paths)?;
+    paths.sort();
+    Ok(paths)
+}
+
+fn collect_yaml_files_recursive(dir: &Path, paths: &mut Vec<PathBuf>) -> Result<(), String> {
+    let mut entries = fs::read_dir(dir)
+        .map_err(|err| format!("read {}: {err}", dir.display()))?
+        .flatten()
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
+    entries.sort();
+
+    for path in entries {
+        if path.is_dir() {
+            collect_yaml_files_recursive(&path, paths)?;
+            continue;
+        }
+        if path.extension().is_some_and(|ext| ext == "yaml") {
+            paths.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn load_rule_metadata(
+    docs_dir: &Path,
+) -> Result<(Vec<(String, u32)>, Vec<RuleMetadataRow>), String> {
+    let mut entries = fs::read_dir(docs_dir)
+        .map_err(|err| format!("read {}: {err}", docs_dir.display()))?
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "yaml"))
+        .collect::<Vec<_>>();
+    entries.sort();
+
+    let mut mappings = Vec::new();
+    let mut metadata_rows = Vec::new();
+    for path in entries {
+        let data =
+            fs::read_to_string(&path).map_err(|err| format!("read {}: {err}", path.display()))?;
+        let (metadata, shellcheck_code, shellcheck_level) =
+            parse_rule_metadata(&data).map_err(|err| format!("{err} in {}", path.display()))?;
+        let rule_code = metadata.new_code.trim().to_owned();
+        metadata_rows.push(RuleMetadataRow {
+            code: rule_code.clone(),
+            description: metadata.description,
+            rationale: metadata.rationale,
+            fix_description: metadata.fix_description,
+            shellcheck_level,
+        });
+        if let Some(shellcheck_code) = shellcheck_code {
+            mappings.push((rule_code, shellcheck_code));
+        }
+    }
+    Ok((mappings, metadata_rows))
+}
+
+fn load_declarative_contracts(
+    contracts_dir: &Path,
+) -> Result<Vec<NormalizedDeclarativeContract>, String> {
+    let yaml_files = collect_yaml_files(contracts_dir)?;
+    let mut contracts = Vec::new();
+    let mut seen_ids = HashSet::new();
+
+    for path in yaml_files {
+        let data =
+            fs::read_to_string(&path).map_err(|err| format!("read {}: {err}", path.display()))?;
+        for contract in validate_declarative_contract_document(&data, &path)? {
+            if !seen_ids.insert(contract.id.clone()) {
+                return Err(format!(
+                    "duplicate declarative contract id {:?} in {}",
+                    contract.id,
+                    path.display()
+                ));
+            }
+            contracts.push(contract);
+        }
+    }
+
+    contracts.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(contracts)
+}
+
+fn generate_shellcheck_map_data(mappings: &[(String, u32)]) -> String {
+    let mut generated = String::from("pub const RULE_SHELLCHECK_CODES: &[(&str, u32)] = &[\n");
+    for (rule_code, sc_number) in mappings {
+        generated.push_str(&format!("    ({rule_code:?}, {sc_number}),\n"));
+    }
+    generated.push_str("];\n");
+    generated
+}
+
+fn generate_rule_metadata_data(rows: &[RuleMetadataRow]) -> String {
+    let mut generated = String::from("pub const RULE_METADATA: &[RuleMetadata] = &[\n");
+    for row in rows {
+        generated.push_str("    RuleMetadata {\n");
+        generated.push_str(&format!("        code: {:?},\n", row.code));
+        generated.push_str(&format!(
+            "        shellcheck_level: {},\n",
+            match row.shellcheck_level {
+                Some(ShellCheckLevel::Style) => "Some(ShellCheckLevel::Style)",
+                Some(ShellCheckLevel::Info) => "Some(ShellCheckLevel::Info)",
+                Some(ShellCheckLevel::Warning) => "Some(ShellCheckLevel::Warning)",
+                Some(ShellCheckLevel::Error) => "Some(ShellCheckLevel::Error)",
+                None => "None",
+            }
+        ));
+        generated.push_str(&format!("        description: {:?},\n", row.description));
+        generated.push_str(&format!("        rationale: {:?},\n", row.rationale));
+        generated.push_str(&format!(
+            "        fix_description: {},\n",
+            match &row.fix_description {
+                Some(value) => format!("Some({value:?})"),
+                None => "None".to_owned(),
+            }
+        ));
+        generated.push_str("    },\n");
+    }
+    generated.push_str("];\n");
+    generated
+}
+
+fn generate_declarative_contract_data(contracts: &[NormalizedDeclarativeContract]) -> String {
+    let mut generated = format!(
+        "static DECLARATIVE_CONTRACT_DATA: [DeclarativeContractDescriptor; {}] = [\n",
+        contracts.len()
+    );
+    for contract in contracts {
+        generated.push_str("    DeclarativeContractDescriptor {\n");
+        generated.push_str(&format!("        id: {:?},\n", contract.id));
+        generated.push_str(&format!(
+            "        groups: {},\n",
+            format_string_slice(&contract.groups)
+        ));
+        generated.push_str(&format!(
+            "        label: {},\n",
+            match &contract.label {
+                Some(label) => format!("Some({label:?})"),
+                None => "None".to_owned(),
+            }
+        ));
+        generated.push_str("        activation: ");
+        generated.push_str(&format_activation(&contract.activation));
+        generated.push_str(",\n");
+        generated.push_str(&format!(
+            "        files: {},\n",
+            format_string_slice(&contract.files)
+        ));
+        generated.push_str("        effects: DeclarativeEffectsDescriptor {\n");
+        generated.push_str(&format!(
+            "            reads: {},\n",
+            format_string_slice(&contract.effects.reads)
+        ));
+        generated.push_str(&format!(
+            "            consumes_names: {},\n",
+            format_string_slice(&contract.effects.consumes_names)
+        ));
+        generated.push_str(&format!(
+            "            consumes_prefixes: {},\n",
+            format_string_slice(&contract.effects.consumes_prefixes)
+        ));
+        generated.push_str(&format!(
+            "            consumes_all: {},\n",
+            contract.effects.consumes_all
+        ));
+        generated.push_str(&format!(
+            "            provides_variables: {},\n",
+            format_string_slice(&contract.effects.provides_variables)
+        ));
+        generated.push_str(&format!(
+            "            provides_functions: {},\n",
+            format_string_slice(&contract.effects.provides_functions)
+        ));
+        generated.push_str("            functions: &[\n");
+        for function in &contract.effects.functions {
+            generated.push_str("                DeclarativeFunctionDescriptor {\n");
+            generated.push_str(&format!("                    name: {:?},\n", function.name));
+            generated.push_str(&format!(
+                "                    reads: {},\n",
+                format_string_slice(&function.reads)
+            ));
+            generated.push_str(&format!(
+                "                    sets: {},\n",
+                format_string_slice(&function.sets)
+            ));
+            generated.push_str("                },\n");
+        }
+        generated.push_str("            ],\n");
+        generated.push_str("        },\n");
+        generated.push_str("        compiled_files: std::sync::OnceLock::new(),\n");
+        generated.push_str("        file_entry_contract: std::sync::OnceLock::new(),\n");
+        generated.push_str("        imported_contract: std::sync::OnceLock::new(),\n");
+        generated.push_str("        requesting_file_contract: std::sync::OnceLock::new(),\n");
+        generated.push_str("    },\n");
+    }
+    generated.push_str("];\n");
+    generated.push_str("static DECLARATIVE_CONTRACTS: &[DeclarativeContractDescriptor] = &DECLARATIVE_CONTRACT_DATA;\n");
+    generated
+}
+
+fn format_activation(activation: &NormalizedDeclarativeActivation) -> String {
+    match activation {
+        NormalizedDeclarativeActivation::Always => {
+            "DeclarativeActivationDescriptor::Always".to_owned()
+        }
+        NormalizedDeclarativeActivation::ZshPlugin { framework, plugin } => format!(
+            "DeclarativeActivationDescriptor::ZshPlugin {{ framework: {framework:?}, plugin: {plugin:?} }}"
+        ),
+        NormalizedDeclarativeActivation::ZshTheme { framework, theme } => format!(
+            "DeclarativeActivationDescriptor::ZshTheme {{ framework: {framework:?}, theme: {theme:?} }}"
+        ),
+    }
+}
+
+fn format_string_slice(values: &[String]) -> String {
+    if values.is_empty() {
+        return "&[]".to_owned();
+    }
+
+    let mut rendered = String::from("&[");
+    for (index, value) in values.iter().enumerate() {
+        if index > 0 {
+            rendered.push_str(", ");
+        }
+        write!(&mut rendered, "{value:?}").expect("write to string");
+    }
+    rendered.push(']');
+    rendered
+}
+
 #[cfg(not(test))]
 fn main() {
     println!("cargo:rustc-check-cfg=cfg(shuck_profiling)");
@@ -109,90 +824,46 @@ fn main() {
         Ok(value) => value,
         Err(err) => panic!("CARGO_MANIFEST_DIR: {err}"),
     });
-    // `rules` is a symlink to `../../docs/rules` in the workspace; cargo
-    // follows the symlink when packaging so the YAML ships with the crate.
     let docs_dir = manifest_dir.join("rules");
     println!("cargo:rerun-if-changed={}", docs_dir.display());
 
-    let mut entries = fs::read_dir(&docs_dir)
-        .unwrap_or_else(|err| panic!("read {}: {err}", docs_dir.display()))
-        .flatten()
-        .map(|entry| entry.path())
-        .filter(|path| path.extension().is_some_and(|ext| ext == "yaml"))
-        .collect::<Vec<_>>();
-    entries.sort();
+    let contracts_dir = manifest_dir.join("contracts");
+    println!("cargo:rerun-if-changed={}", contracts_dir.display());
 
-    let mut mappings = Vec::new();
-    let mut metadata_rows = Vec::new();
-
-    for path in entries {
+    let (mappings, metadata_rows) =
+        load_rule_metadata(&docs_dir).unwrap_or_else(|err| panic!("{err}"));
+    for path in collect_yaml_files(&docs_dir).unwrap_or_else(|err| panic!("{err}")) {
         println!("cargo:rerun-if-changed={}", path.display());
-        let data = fs::read_to_string(&path)
-            .unwrap_or_else(|err| panic!("read {}: {err}", path.display()));
-
-        let (metadata, shellcheck_code, shellcheck_level) =
-            parse_rule_metadata(&data).unwrap_or_else(|err| panic!("{err} in {}", path.display()));
-        let rule_code = metadata.new_code.trim().to_owned();
-        metadata_rows.push((
-            rule_code.clone(),
-            metadata.description,
-            metadata.rationale,
-            metadata.fix_description,
-            shellcheck_level,
-        ));
-
-        let Some(shellcheck_code) = shellcheck_code else {
-            continue;
-        };
-        mappings.push((rule_code, shellcheck_code));
     }
-
-    let mut generated = String::from("pub const RULE_SHELLCHECK_CODES: &[(&str, u32)] = &[\n");
-    for (rule_code, sc_number) in mappings {
-        generated.push_str(&format!("    (\"{rule_code}\", {sc_number}),\n"));
+    for path in collect_yaml_files(&contracts_dir).unwrap_or_else(|err| panic!("{err}")) {
+        println!("cargo:rerun-if-changed={}", path.display());
     }
-    generated.push_str("];\n");
+    let contracts =
+        load_declarative_contracts(&contracts_dir).unwrap_or_else(|err| panic!("{err}"));
 
-    let out_path = PathBuf::from(match env::var("OUT_DIR") {
+    let out_dir = PathBuf::from(match env::var("OUT_DIR") {
         Ok(value) => value,
         Err(err) => panic!("OUT_DIR: {err}"),
-    })
-    .join("shellcheck_map_data.rs");
-    fs::write(&out_path, generated)
-        .unwrap_or_else(|err| panic!("write {}: {err}", out_path.display()));
+    });
 
-    let mut metadata_generated = String::from("pub const RULE_METADATA: &[RuleMetadata] = &[\n");
-    for (rule_code, description, rationale, fix_description, shellcheck_level) in metadata_rows {
-        metadata_generated.push_str("    RuleMetadata {\n");
-        metadata_generated.push_str(&format!("        code: {:?},\n", rule_code));
-        metadata_generated.push_str(&format!(
-            "        shellcheck_level: {},\n",
-            match shellcheck_level {
-                Some(ShellCheckLevel::Style) => "Some(ShellCheckLevel::Style)".to_owned(),
-                Some(ShellCheckLevel::Info) => "Some(ShellCheckLevel::Info)".to_owned(),
-                Some(ShellCheckLevel::Warning) => "Some(ShellCheckLevel::Warning)".to_owned(),
-                Some(ShellCheckLevel::Error) => "Some(ShellCheckLevel::Error)".to_owned(),
-                None => "None".to_owned(),
-            }
-        ));
-        metadata_generated.push_str(&format!("        description: {:?},\n", description));
-        metadata_generated.push_str(&format!("        rationale: {:?},\n", rationale));
-        metadata_generated.push_str(&format!(
-            "        fix_description: {},\n",
-            match fix_description {
-                Some(value) => format!("Some({value:?})"),
-                None => "None".to_owned(),
-            }
-        ));
-        metadata_generated.push_str("    },\n");
-    }
-    metadata_generated.push_str("];\n");
+    let shellcheck_out_path = out_dir.join("shellcheck_map_data.rs");
+    fs::write(
+        &shellcheck_out_path,
+        generate_shellcheck_map_data(&mappings),
+    )
+    .unwrap_or_else(|err| panic!("write {}: {err}", shellcheck_out_path.display()));
 
-    let metadata_out_path = PathBuf::from(match env::var("OUT_DIR") {
-        Ok(value) => value,
-        Err(err) => panic!("OUT_DIR: {err}"),
-    })
-    .join("rule_metadata_data.rs");
-    fs::write(&metadata_out_path, metadata_generated)
-        .unwrap_or_else(|err| panic!("write {}: {err}", metadata_out_path.display()));
+    let metadata_out_path = out_dir.join("rule_metadata_data.rs");
+    fs::write(
+        &metadata_out_path,
+        generate_rule_metadata_data(&metadata_rows),
+    )
+    .unwrap_or_else(|err| panic!("write {}: {err}", metadata_out_path.display()));
+
+    let contracts_out_path = out_dir.join("ambient_contracts_data.rs");
+    fs::write(
+        &contracts_out_path,
+        generate_declarative_contract_data(&contracts),
+    )
+    .unwrap_or_else(|err| panic!("write {}: {err}", contracts_out_path.display()));
 }

--- a/crates/shuck-linter/build.rs
+++ b/crates/shuck-linter/build.rs
@@ -147,6 +147,10 @@ struct RuleMetadataRow {
 type RuleShellCheckMapping = (String, u32);
 type LoadedRuleMetadata = (Vec<RuleShellCheckMapping>, Vec<RuleMetadataRow>);
 
+// Keep this list in sync with the Rust-defined built-ins in
+// `src/ambient_contracts/contracts.rs`.
+const RUST_BUILT_IN_CONTRACT_IDS: &[&str] = &["zsh/runtime", "zsh/config", "zsh/module-metadata"];
+
 fn parse_shellcheck_code_value(raw: &str) -> Result<Option<u32>, String> {
     let raw = raw.trim().trim_matches(|ch| matches!(ch, '"' | '\''));
     if raw.is_empty() || raw.eq_ignore_ascii_case("null") || raw == "~" {
@@ -641,6 +645,13 @@ fn load_declarative_contracts(
         let data =
             fs::read_to_string(&path).map_err(|err| format!("read {}: {err}", path.display()))?;
         for contract in validate_declarative_contract_document(&data, &path)? {
+            if RUST_BUILT_IN_CONTRACT_IDS.contains(&contract.id.as_str()) {
+                return Err(format!(
+                    "declarative contract id {:?} in {} conflicts with existing Rust built-in contract id",
+                    contract.id,
+                    path.display()
+                ));
+            }
             if !seen_ids.insert(contract.id.clone()) {
                 return Err(format!(
                     "duplicate declarative contract id {:?} in {}",

--- a/crates/shuck-linter/contracts
+++ b/crates/shuck-linter/contracts
@@ -1,0 +1,1 @@
+../../contracts

--- a/crates/shuck-linter/src/ambient_contracts/contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts/contracts.rs
@@ -154,13 +154,15 @@ impl ResolvedAmbientContracts {
             }
         }
         let mut disabled = config.disabled;
-        disabled.extend(
-            config
-                .custom
-                .iter()
-                .flat_map(|contract| contract.replaces.iter().cloned()),
-        );
-        validate_well_known_selectors(&disabled)?;
+        if config.well_known {
+            disabled.extend(
+                config
+                    .custom
+                    .iter()
+                    .flat_map(|contract| contract.replaces.iter().cloned()),
+            );
+            validate_well_known_selectors(&disabled)?;
+        }
         let custom_contracts = config
             .custom
             .into_iter()

--- a/crates/shuck-linter/src/ambient_contracts/contracts.rs
+++ b/crates/shuck-linter/src/ambient_contracts/contracts.rs
@@ -1,7 +1,8 @@
 //! Compiled ambient-contract configuration and well-known contract registry.
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use anyhow::{Result, anyhow};
 use globset::{Glob, GlobMatcher};
@@ -146,6 +147,12 @@ impl ResolvedAmbientContracts {
         config: AmbientContractConfig,
     ) -> Result<Self> {
         let project_root = project_root.into();
+        let mut custom_ids = HashSet::new();
+        for contract in &config.custom {
+            if !custom_ids.insert(contract.id.clone()) {
+                return Err(anyhow!("duplicate ambient contract id {:?}", contract.id));
+            }
+        }
         let mut disabled = config.disabled;
         disabled.extend(
             config
@@ -153,6 +160,7 @@ impl ResolvedAmbientContracts {
                 .iter()
                 .flat_map(|contract| contract.replaces.iter().cloned()),
         );
+        validate_well_known_selectors(&disabled)?;
         let custom_contracts = config
             .custom
             .into_iter()
@@ -222,10 +230,20 @@ impl ResolvedAmbientContracts {
         let mut matched = false;
 
         for id in &self.enabled_file_contract_ids {
-            let contract = well_known_file_contract_by_id(id).expect("known ambient contract id");
-            if (contract.matches)(collector, shell) {
+            if let Some(contract) = well_known_file_contract_by_id(id) {
+                if (contract.matches)(collector, shell) {
+                    matched = true;
+                    (contract.apply)(&mut merged, collector);
+                }
+                continue;
+            }
+
+            let contract = declarative_contract_by_id(id).expect("known ambient contract id");
+            if declarative_file_activation_matches(&contract.activation, shell)
+                && contract.file_matches(&self.project_root, path.path())
+            {
                 matched = true;
-                (contract.apply)(&mut merged, collector);
+                merge_contract(&mut merged, contract.file_entry_contract().clone());
             }
         }
 
@@ -251,21 +269,37 @@ impl ResolvedAmbientContracts {
         let lower_path = source_path.to_string_lossy().to_ascii_lowercase();
 
         for id in &self.enabled_request_contract_ids {
-            let contract =
-                well_known_request_contract_by_id(id).expect("known ambient request contract id");
-            if request_activation_matches(contract.activation, request) {
-                if let Some(file_match) = contract.file_match
-                    && !file_match(&lower_path)
-                {
-                    continue;
+            if let Some(contract) = well_known_request_contract_by_id(id) {
+                if request_activation_matches(contract.activation, request) {
+                    if let Some(file_match) = contract.file_match
+                        && !file_match(&lower_path)
+                    {
+                        continue;
+                    }
+                    let imported_contract = (contract.imported_contract)();
+                    if !contract_is_empty(&imported_contract) {
+                        resolved.imported_contracts.push(imported_contract);
+                    }
+                    merge_contract(
+                        &mut resolved.requesting_file_contract,
+                        (contract.requesting_file_contract)(),
+                    );
                 }
-                let imported_contract = (contract.imported_contract)();
+                continue;
+            }
+
+            let contract =
+                declarative_contract_by_id(id).expect("known ambient request contract id");
+            if request_activation_matches_declarative(&contract.activation, request)
+                && contract.file_matches(&self.project_root, source_path)
+            {
+                let imported_contract = contract.imported_contract().clone();
                 if !contract_is_empty(&imported_contract) {
                     resolved.imported_contracts.push(imported_contract);
                 }
                 merge_contract(
                     &mut resolved.requesting_file_contract,
-                    (contract.requesting_file_contract)(),
+                    contract.requesting_file_contract().clone(),
                 );
             }
         }
@@ -294,6 +328,7 @@ impl ResolvedAmbientContracts {
 struct CompiledCustomContract {
     id: String,
     when: AmbientContractActivation,
+    project_root: PathBuf,
     files: Vec<CompiledPathMatcher>,
     file_contract: FileContract,
     imported_contract: FileContract,
@@ -314,10 +349,8 @@ impl CompiledCustomContract {
         Ok(Self {
             id: contract.id,
             when: contract.when,
-            files: files
-                .into_iter()
-                .map(|matcher| matcher.with_project_root(project_root))
-                .collect(),
+            project_root: project_root.to_path_buf(),
+            files,
             file_contract,
             imported_contract,
             requesting_file_contract,
@@ -349,14 +382,14 @@ impl CompiledCustomContract {
 
         for matcher in &self.files {
             if matcher.negated {
-                if matcher.path_matches(path) {
+                if matcher.path_matches(&self.project_root, path) {
                     return false;
                 }
                 continue;
             }
 
             saw_positive = true;
-            matched_positive |= matcher.path_matches(path);
+            matched_positive |= matcher.path_matches(&self.project_root, path);
         }
 
         if saw_positive { matched_positive } else { true }
@@ -382,14 +415,11 @@ struct CompiledPathMatcher {
     relative_matcher: GlobMatcher,
     absolute_matcher: GlobMatcher,
     negated: bool,
-    project_root: PathBuf,
 }
 
 impl PartialEq for CompiledPathMatcher {
     fn eq(&self, other: &Self) -> bool {
-        self.pattern == other.pattern
-            && self.negated == other.negated
-            && self.project_root == other.project_root
+        self.pattern == other.pattern && self.negated == other.negated
     }
 }
 
@@ -415,17 +445,11 @@ impl CompiledPathMatcher {
                 .map_err(|err| anyhow!("invalid glob {matcher_pattern:?}: {err}"))?
                 .compile_matcher(),
             negated,
-            project_root: PathBuf::new(),
         })
     }
 
-    fn with_project_root(mut self, project_root: &Path) -> Self {
-        self.project_root = project_root.to_path_buf();
-        self
-    }
-
-    fn path_matches(&self, path: &Path) -> bool {
-        let relative_path = path.strip_prefix(&self.project_root).unwrap_or(path);
+    fn path_matches(&self, project_root: &Path, path: &Path) -> bool {
+        let relative_path = path.strip_prefix(project_root).unwrap_or(path);
         let file_name = relative_path.file_name().or_else(|| path.file_name());
         let Some(file_name) = file_name else {
             return false;
@@ -436,6 +460,49 @@ impl CompiledPathMatcher {
     }
 }
 
+struct DeclarativeContractDescriptor {
+    id: &'static str,
+    groups: &'static [&'static str],
+    #[allow(dead_code)]
+    label: Option<&'static str>,
+    activation: DeclarativeActivationDescriptor,
+    files: &'static [&'static str],
+    effects: DeclarativeEffectsDescriptor,
+    compiled_files: OnceLock<Vec<CompiledPathMatcher>>,
+    file_entry_contract: OnceLock<FileContract>,
+    imported_contract: OnceLock<FileContract>,
+    requesting_file_contract: OnceLock<FileContract>,
+}
+
+#[allow(dead_code)]
+enum DeclarativeActivationDescriptor {
+    Always,
+    ZshPlugin {
+        framework: &'static str,
+        plugin: &'static str,
+    },
+    ZshTheme {
+        framework: &'static str,
+        theme: &'static str,
+    },
+}
+
+struct DeclarativeEffectsDescriptor {
+    reads: &'static [&'static str],
+    consumes_names: &'static [&'static str],
+    consumes_prefixes: &'static [&'static str],
+    consumes_all: bool,
+    provides_variables: &'static [&'static str],
+    provides_functions: &'static [&'static str],
+    functions: &'static [DeclarativeFunctionDescriptor],
+}
+
+struct DeclarativeFunctionDescriptor {
+    name: &'static str,
+    reads: &'static [&'static str],
+    sets: &'static [&'static str],
+}
+
 struct WellKnownFileContract {
     id: &'static str,
     groups: &'static [&'static str],
@@ -443,6 +510,7 @@ struct WellKnownFileContract {
     apply: fn(&mut FileContract, &AmbientContractCollector<'_>),
 }
 
+#[allow(dead_code)]
 #[derive(Clone, Copy)]
 enum RequestActivation {
     ZshPlugin {
@@ -459,6 +527,62 @@ struct WellKnownRequestContract {
     imported_contract: fn() -> FileContract,
     requesting_file_contract: fn() -> FileContract,
 }
+
+impl DeclarativeContractDescriptor {
+    fn compiled_files(&self) -> &[CompiledPathMatcher] {
+        self.compiled_files
+            .get_or_init(|| {
+                self.files
+                    .iter()
+                    .map(|pattern| {
+                        CompiledPathMatcher::new((*pattern).to_owned())
+                            .expect("generated declarative contract glob is valid")
+                    })
+                    .collect()
+            })
+            .as_slice()
+    }
+
+    fn file_matches(&self, project_root: &Path, path: &Path) -> bool {
+        if self.files.is_empty() {
+            return true;
+        }
+
+        let mut saw_positive = false;
+        let mut matched_positive = false;
+
+        for matcher in self.compiled_files() {
+            if matcher.negated {
+                if matcher.path_matches(project_root, path) {
+                    return false;
+                }
+                continue;
+            }
+
+            saw_positive = true;
+            matched_positive |= matcher.path_matches(project_root, path);
+        }
+
+        if saw_positive { matched_positive } else { true }
+    }
+
+    fn file_entry_contract(&self) -> &FileContract {
+        self.file_entry_contract
+            .get_or_init(|| file_entry_contract_from_declarative_effects(&self.effects))
+    }
+
+    fn imported_contract(&self) -> &FileContract {
+        self.imported_contract
+            .get_or_init(|| imported_contract_from_declarative_effects(&self.effects))
+    }
+
+    fn requesting_file_contract(&self) -> &FileContract {
+        self.requesting_file_contract
+            .get_or_init(|| requesting_file_contract_from_declarative_effects(&self.effects))
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/ambient_contracts_data.rs"));
 
 const WELL_KNOWN_FILE_CONTRACTS: &[WellKnownFileContract] = &[
     WellKnownFileContract {
@@ -481,23 +605,22 @@ const WELL_KNOWN_FILE_CONTRACTS: &[WellKnownFileContract] = &[
     },
 ];
 
-const WELL_KNOWN_REQUEST_CONTRACTS: &[WellKnownRequestContract] = &[WellKnownRequestContract {
-    id: "zsh/oh-my-zsh/plugin/tmux",
-    groups: &["zsh", "zsh/oh-my-zsh", "zsh/oh-my-zsh/plugin"],
-    activation: RequestActivation::ZshPlugin {
-        framework: "oh-my-zsh",
-        plugin: "tmux",
-    },
-    file_match: None,
-    imported_contract: FileContract::default,
-    requesting_file_contract: oh_my_zsh_tmux_requesting_file_contract,
-}];
+const WELL_KNOWN_REQUEST_CONTRACTS: &[WellKnownRequestContract] = &[];
 
 fn enabled_well_known_file_contract_ids(disabled: &[String]) -> Vec<&'static str> {
     WELL_KNOWN_FILE_CONTRACTS
         .iter()
         .filter(|contract| !selector_matches(disabled, contract.id, contract.groups))
         .map(|contract| contract.id)
+        .chain(
+            DECLARATIVE_CONTRACTS
+                .iter()
+                .filter(|contract| {
+                    matches!(contract.activation, DeclarativeActivationDescriptor::Always)
+                        && !selector_matches(disabled, contract.id, contract.groups)
+                })
+                .map(|contract| contract.id),
+        )
         .collect()
 }
 
@@ -506,6 +629,15 @@ fn enabled_well_known_request_contract_ids(disabled: &[String]) -> Vec<&'static 
         .iter()
         .filter(|contract| !selector_matches(disabled, contract.id, contract.groups))
         .map(|contract| contract.id)
+        .chain(
+            DECLARATIVE_CONTRACTS
+                .iter()
+                .filter(|contract| {
+                    !matches!(contract.activation, DeclarativeActivationDescriptor::Always)
+                        && !selector_matches(disabled, contract.id, contract.groups)
+                })
+                .map(|contract| contract.id),
+        )
         .collect()
 }
 
@@ -527,12 +659,72 @@ fn well_known_request_contract_by_id(id: &str) -> Option<&'static WellKnownReque
         .find(|contract| contract.id == id)
 }
 
+fn declarative_contract_by_id(id: &str) -> Option<&'static DeclarativeContractDescriptor> {
+    DECLARATIVE_CONTRACTS
+        .iter()
+        .find(|contract| contract.id == id)
+}
+
+fn validate_well_known_selectors(selectors: &[String]) -> Result<()> {
+    for selector in selectors {
+        if selector == "*" || well_known_selector_exists(selector) {
+            continue;
+        }
+        return Err(anyhow!(
+            "unknown ambient contract selector {selector:?}; expected `*`, a built-in contract id, or a built-in contract group"
+        ));
+    }
+    Ok(())
+}
+
+fn well_known_selector_exists(selector: &str) -> bool {
+    WELL_KNOWN_FILE_CONTRACTS
+        .iter()
+        .any(|contract| selector == contract.id || contract.groups.contains(&selector))
+        || WELL_KNOWN_REQUEST_CONTRACTS
+            .iter()
+            .any(|contract| selector == contract.id || contract.groups.contains(&selector))
+        || DECLARATIVE_CONTRACTS
+            .iter()
+            .any(|contract| selector == contract.id || contract.groups.contains(&selector))
+}
+
 fn request_activation_matches(activation: RequestActivation, request: &PluginRequest) -> bool {
     match activation {
         RequestActivation::ZshPlugin { framework, plugin } => {
             request.kind == PluginRequestKind::Plugin
                 && plugin_framework_name(&request.framework) == framework
                 && request.name == plugin
+        }
+    }
+}
+
+fn declarative_file_activation_matches(
+    activation: &DeclarativeActivationDescriptor,
+    shell: ShellDialect,
+) -> bool {
+    match activation {
+        DeclarativeActivationDescriptor::Always => true,
+        DeclarativeActivationDescriptor::ZshPlugin { .. }
+        | DeclarativeActivationDescriptor::ZshTheme { .. } => shell == ShellDialect::Zsh,
+    }
+}
+
+fn request_activation_matches_declarative(
+    activation: &DeclarativeActivationDescriptor,
+    request: &PluginRequest,
+) -> bool {
+    match activation {
+        DeclarativeActivationDescriptor::Always => false,
+        DeclarativeActivationDescriptor::ZshPlugin { framework, plugin } => {
+            request.kind == PluginRequestKind::Plugin
+                && plugin_framework_name(&request.framework) == *framework
+                && request.name == *plugin
+        }
+        DeclarativeActivationDescriptor::ZshTheme { framework, theme } => {
+            request.kind == PluginRequestKind::Theme
+                && plugin_framework_name(&request.framework) == *framework
+                && request.name == *theme
         }
     }
 }
@@ -721,9 +913,68 @@ fn requesting_file_contract_from_effects(effects: &AmbientContractEffects) -> Fi
     contract
 }
 
-fn oh_my_zsh_tmux_requesting_file_contract() -> FileContract {
+fn file_entry_contract_from_declarative_effects(
+    effects: &DeclarativeEffectsDescriptor,
+) -> FileContract {
+    let mut contract = imported_contract_from_declarative_effects(effects);
+    merge_contract(
+        &mut contract,
+        requesting_file_contract_from_declarative_effects(effects),
+    );
+    contract
+}
+
+fn imported_contract_from_declarative_effects(
+    effects: &DeclarativeEffectsDescriptor,
+) -> FileContract {
     let mut contract = FileContract::default();
-    contract.add_externally_consumed_binding_prefix(Name::from("ZSH_TMUX_"));
+    for name in effects.reads {
+        contract.add_required_read(Name::from(*name));
+    }
+    for name in effects.provides_variables {
+        contract.add_provided_binding(ProvidedBinding::new_file_entry_initialized(
+            Name::from(*name),
+            ProvidedBindingKind::Variable,
+            ContractCertainty::Definite,
+        ));
+    }
+    for name in effects.provides_functions {
+        contract.add_provided_binding(ProvidedBinding::new(
+            Name::from(*name),
+            ProvidedBindingKind::Function,
+            ContractCertainty::Definite,
+        ));
+    }
+    for function in effects.functions {
+        let mut function_contract = FunctionContract::new(Name::from(function.name));
+        for name in function.reads {
+            function_contract.add_required_read(Name::from(*name));
+        }
+        for name in function.sets {
+            function_contract.add_provided_binding(ProvidedBinding::new(
+                Name::from(*name),
+                ProvidedBindingKind::Variable,
+                ContractCertainty::Definite,
+            ));
+        }
+        contract.add_provided_function(function_contract);
+    }
+    contract
+}
+
+fn requesting_file_contract_from_declarative_effects(
+    effects: &DeclarativeEffectsDescriptor,
+) -> FileContract {
+    let mut contract = FileContract {
+        externally_consumed_bindings: effects.consumes_all,
+        ..FileContract::default()
+    };
+    for name in effects.consumes_names {
+        contract.add_externally_consumed_binding_name(Name::from(*name));
+    }
+    for prefix in effects.consumes_prefixes {
+        contract.add_externally_consumed_binding_prefix(Name::from(*prefix));
+    }
     contract
 }
 

--- a/crates/shuck-linter/tests/build_script.rs
+++ b/crates/shuck-linter/tests/build_script.rs
@@ -194,6 +194,29 @@ contracts:
     }
 
     #[test]
+    fn load_declarative_contracts_rejects_rust_built_in_id_collisions() {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("collision.yaml");
+        let yaml = r#"
+version: 1
+contracts:
+  - id: zsh/runtime
+    groups:
+      - zsh
+    when:
+      type: always
+    effects:
+      provides:
+        variables:
+          - GITHUB_ENV
+"#;
+        std::fs::write(&path, yaml).unwrap();
+
+        let error = load_declarative_contracts(tempdir.path()).unwrap_err();
+        assert!(error.contains("conflicts with existing Rust built-in contract id"));
+    }
+
+    #[test]
     fn generate_declarative_contract_data_renders_runtime_descriptors() {
         let tempdir = tempdir().unwrap();
         let path = tempdir.path().join("tmux.yaml");

--- a/crates/shuck-linter/tests/build_script.rs
+++ b/crates/shuck-linter/tests/build_script.rs
@@ -1,5 +1,9 @@
 mod build_script {
+    #![allow(dead_code)]
+
     include!(concat!(env!("CARGO_MANIFEST_DIR"), "/build.rs"));
+
+    use tempfile::tempdir;
 
     #[test]
     fn parse_shellcheck_code_value_skips_nullable_forms() {
@@ -117,5 +121,112 @@ rationale: Example rationale
         let (_, shellcheck_code, shellcheck_level) = parse_rule_metadata(yaml).unwrap();
         assert_eq!(shellcheck_code, None);
         assert_eq!(shellcheck_level, Some(ShellCheckLevel::Info));
+    }
+
+    #[test]
+    fn parse_declarative_contract_document_accepts_tmux_contract() {
+        let yaml = r#"
+version: 1
+contracts:
+  - id: zsh/oh-my-zsh/plugin/tmux
+    groups:
+      - zsh
+      - zsh/oh-my-zsh
+      - zsh/oh-my-zsh/plugin
+    when:
+      type: zsh_plugin
+      framework: oh-my-zsh
+      plugin: tmux
+    effects:
+      consumes:
+        prefixes:
+          - ZSH_TMUX_
+"#;
+
+        let document = parse_declarative_contract_document(yaml).unwrap();
+        assert_eq!(document.version, 1);
+        assert_eq!(document.contracts.len(), 1);
+        assert_eq!(document.contracts[0].id, "zsh/oh-my-zsh/plugin/tmux");
+    }
+
+    #[test]
+    fn validate_declarative_contract_document_rejects_empty_effects() {
+        let yaml = r#"
+version: 1
+contracts:
+  - id: runtime/example
+    groups:
+      - runtime
+    when:
+      type: always
+    effects: {}
+"#;
+
+        let error =
+            validate_declarative_contract_document(yaml, std::path::Path::new("/tmp/example.yaml"))
+                .unwrap_err();
+        assert!(error.contains("must define at least one effect"));
+    }
+
+    #[test]
+    fn load_declarative_contracts_rejects_duplicate_ids_across_files() {
+        let tempdir = tempdir().unwrap();
+        let first = tempdir.path().join("first.yaml");
+        let second = tempdir.path().join("second.yaml");
+        let yaml = r#"
+version: 1
+contracts:
+  - id: runtime/example
+    groups:
+      - runtime
+    when:
+      type: always
+    effects:
+      provides:
+        variables:
+          - GITHUB_ENV
+"#;
+        std::fs::write(&first, yaml).unwrap();
+        std::fs::write(&second, yaml).unwrap();
+
+        let error = load_declarative_contracts(tempdir.path()).unwrap_err();
+        assert!(error.contains("duplicate declarative contract id"));
+    }
+
+    #[test]
+    fn generate_declarative_contract_data_renders_runtime_descriptors() {
+        let tempdir = tempdir().unwrap();
+        let path = tempdir.path().join("tmux.yaml");
+        std::fs::write(
+            &path,
+            r#"
+version: 1
+contracts:
+  - id: zsh/oh-my-zsh/plugin/tmux
+    groups:
+      - zsh
+      - zsh/oh-my-zsh
+      - zsh/oh-my-zsh/plugin
+    label: Oh My Zsh tmux plugin
+    when:
+      type: zsh_plugin
+      framework: oh-my-zsh
+      plugin: tmux
+    effects:
+      consumes:
+        prefixes:
+          - ZSH_TMUX_
+"#,
+        )
+        .unwrap();
+
+        let contracts = load_declarative_contracts(tempdir.path()).unwrap();
+        let generated = generate_declarative_contract_data(&contracts);
+
+        assert!(generated.contains("static DECLARATIVE_CONTRACT_DATA"));
+        assert!(generated.contains("static DECLARATIVE_CONTRACTS"));
+        assert!(generated.contains("\"zsh/oh-my-zsh/plugin/tmux\""));
+        assert!(generated.contains("std::sync::OnceLock::new()"));
+        assert!(generated.contains("\"ZSH_TMUX_\""));
     }
 }

--- a/specs/022-declarative-contracts.md
+++ b/specs/022-declarative-contracts.md
@@ -1,0 +1,721 @@
+# 022: Declarative Built-In Contracts
+
+## Status
+
+Proposed
+
+## Summary
+
+Add a repository-local declarative authoring layer for Shuck's built-in ambient
+contracts. Contributors write well-known contract data as YAML under a
+top-level `contracts/` tree, and `shuck-linter` generates Rust registry tables
+from that YAML at build time. Runtime behavior stays the same shape as spec
+021: activated contracts compile into the existing `FileContract` fields and
+join the current ambient-contract and plugin-resolution pipeline. Shuck does
+not parse built-in YAML while linting.
+
+This spec extends [020-zsh-plugin-resolution.md](020-zsh-plugin-resolution.md)
+and [021-ambient-contracts.md](021-ambient-contracts.md). Spec 020 resolves
+real plugin source files. Spec 021 defines the contract model and runtime
+activation semantics. This spec defines how the built-in well-known registry is
+authored, generated, validated, documented, and migrated away from ad hoc Rust
+tables.
+
+## Motivation
+
+Specs 020 and 021 intentionally made real source loading the first choice.
+When Shuck can resolve a sourced helper, zsh plugin entrypoint, theme, or
+framework file, it should parse that file and summarize real reads, provided
+bindings, provided functions, and source-closure behavior. That already handles
+important plugin cases without hard-coded per-plugin data.
+
+The remaining built-in contracts are residual ecosystem facts:
+
+- names provided by a runtime before the file starts;
+- options or prefixes consumed by a framework after a file is sourced;
+- generated or indirect behavior that cannot be recovered from concrete source;
+- plugin-manager conventions that expose a stable contract but not a stable
+  source edge;
+- common CI or shell runtimes that users should not have to model themselves.
+
+Those facts are easier for AI and contributors to add when they are small,
+declarative documents instead of hand-written Rust entries. The current
+centralized registry in `crates/shuck-linter/src/ambient_contracts/contracts.rs`
+is the right runtime join point, but it is not the right long-term authoring
+surface if Shuck needs broad plugin and runtime coverage.
+
+At the same time, built-in contracts are on the hot path for `shuck check`.
+Shuck should not deserialize bundled YAML on every invocation or allocate
+`Name`s for contracts that do not apply. Build-time generation gives
+contributors a data-file workflow while preserving cheap runtime activation.
+
+## Design
+
+### Goals
+
+- Keep source resolution and source-closure summarization as the primary plugin
+  model.
+- Make well-known contract authoring declarative and approachable for AI and
+  contributors.
+- Generate Rust tables from declarative YAML at build time.
+- Do not parse built-in YAML at runtime.
+- Materialize `FileContract` values only after disabled-selector checks,
+  activation matching, and optional path matching succeed.
+- Reuse the existing `AmbientContractConfig`, custom TOML contract shape, and
+  `FileContract` effect model from spec 021.
+- Preserve `shuck-linter` ownership of well-known lint-facing contracts.
+- Keep dynamic ambient providers in Rust when they inspect source text, paths,
+  normalized commands, or shell-specific runtime signals.
+- Provide deterministic validation, generated cache-key descriptors, and
+  contributor documentation.
+
+### Non-Goals
+
+- This spec does not make plugin-authored contract files a runtime discovery
+  mechanism. Built-in declarative YAML is repository source, not a user plugin
+  API.
+- This spec does not replace user-authored `[[lint.contracts.custom]]` entries
+  in `.shuck.toml`.
+- This spec does not move source-resolution layout logic out of
+  `crates/shuck-semantic/src/source_closure/plugin_managers`.
+- This spec does not require complete coverage for every zsh plugin manager in
+  the first implementation.
+- This spec does not generate parser or semantic logic for dynamic shell
+  behavior. Complex source inspection remains Rust code.
+- This spec does not add a runtime dependency on `serde_yaml` to
+  `shuck-linter`.
+
+### Source-First Boundary
+
+Declarative contracts must pass the same source-first test from spec 021:
+
+> Could Shuck load a real source file and derive this fact instead?
+
+If yes, improve plugin resolution, source closure, helper summarization,
+deferred runtime modeling, or semantic facts. Use declarative contracts only
+for facts outside the static source graph or facts whose source exists but does
+not expose the stable contract in a recoverable way.
+
+Examples:
+
+| Case | Preferred mechanism |
+|---|---|
+| A plugin hook reads an option variable from a resolved callback | Source closure and deferred callback summarization |
+| A sourced helper sets `reply` for its caller | Source closure and function contract summarization |
+| A framework consumes `ZSH_TMUX_*` after a user file has run | Declarative `zsh_plugin` contract |
+| A CI runtime initializes `GITHUB_OUTPUT` before a script starts | Declarative `always` contract |
+| A zsh special parameter is always available in interactive zsh | Rust ambient runtime provider if it depends on shell/path/source signals |
+| A plugin manager command DSL discovers plugin requests | Rust plugin manager adapter |
+
+The declarative layer is an authoring surface for the existing contract model,
+not a second semantic model.
+
+### Repository Layout
+
+Built-in contract sources live at the repository root:
+
+```text
+contracts/
+  README.md
+  zsh/
+    oh-my-zsh/
+      contracts.yaml
+      plugins/
+        tmux.yaml
+      themes/
+        agnoster.yaml
+    zdot/
+      contracts.yaml
+  runtime/
+    github-actions.yaml
+```
+
+`contracts/README.md` documents the schema, examples, validation rules, and
+source-first policy for contributors.
+
+`crates/shuck-linter` exposes the files to Cargo through a crate-local symlink:
+
+```text
+crates/shuck-linter/contracts -> ../../contracts
+```
+
+This mirrors the existing `crates/shuck-linter/rules -> ../../docs/rules`
+packaging pattern. The build script reads `crates/shuck-linter/contracts` so
+packaged builds see the same files Cargo included for the crate.
+
+The directory layout is organizational. Contract identity comes from the
+document `id`, not from the path, but validation should warn through build
+errors when a path and id clearly disagree, such as an
+`oh-my-zsh/plugins/tmux.yaml` file declaring a non-`tmux` zsh plugin activation.
+
+### YAML Document Shape
+
+Every YAML file contains one document with a schema version and one or more
+contracts:
+
+```yaml
+version: 1
+contracts:
+  - id: zsh/oh-my-zsh/plugin/tmux
+    groups:
+      - zsh
+      - zsh/oh-my-zsh
+      - zsh/oh-my-zsh/plugin
+    label: Oh My Zsh tmux plugin
+    when:
+      type: zsh_plugin
+      framework: oh-my-zsh
+      plugin: tmux
+    effects:
+      consumes:
+        prefixes:
+          - ZSH_TMUX_
+```
+
+The same file shape also covers global file-entry contracts:
+
+```yaml
+version: 1
+contracts:
+  - id: runtime/github-actions/env
+    groups:
+      - runtime
+      - runtime/github-actions
+    label: GitHub Actions environment files
+    when:
+      type: always
+    files:
+      - ".github/**/*.sh"
+    effects:
+      provides:
+        variables:
+          - GITHUB_OUTPUT
+          - GITHUB_ENV
+```
+
+The `label` is human-facing and optional. It is not a selector and does not
+participate in cache keys.
+
+### Schema
+
+The build script deserializes this Rust shape in build-only code:
+
+```rust
+#[derive(Debug, Deserialize)]
+struct ContractDocument {
+    version: u32,
+    contracts: Vec<DeclarativeContract>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeContract {
+    id: String,
+    groups: Vec<String>,
+    label: Option<String>,
+    when: DeclarativeActivation,
+    files: Option<Vec<String>>,
+    effects: DeclarativeEffects,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum DeclarativeActivation {
+    Always,
+    ZshPlugin { framework: String, plugin: String },
+    ZshTheme { framework: String, theme: String },
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeEffects {
+    reads: Vec<String>,
+    consumes: DeclarativeConsumes,
+    provides: DeclarativeProvides,
+    functions: Vec<DeclarativeFunctionEffects>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeConsumes {
+    names: Vec<String>,
+    prefixes: Vec<String>,
+    all: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeProvides {
+    variables: Vec<String>,
+    functions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct DeclarativeFunctionEffects {
+    name: String,
+    reads: Option<Vec<String>>,
+    sets: Option<Vec<String>>,
+}
+```
+
+Build-time deserialization can use `serde_yaml`, which is already a
+`shuck-linter` build dependency. Runtime `shuck-linter` must keep
+`serde_yaml` out of normal dependencies.
+
+### Effect Mapping
+
+Declarative effects compile to the same fields as spec 021 custom contracts:
+
+| YAML field | Internal effect |
+|---|---|
+| `effects.reads` | `FileContract.required_reads` |
+| `effects.consumes.names` | `FileContract.externally_consumed_binding_names` |
+| `effects.consumes.prefixes` | `FileContract.externally_consumed_binding_prefixes` |
+| `effects.consumes.all` | `FileContract.externally_consumed_bindings` |
+| `effects.provides.variables` | initialized definite variable `ProvidedBinding`s |
+| `effects.provides.functions` | definite function `ProvidedBinding`s |
+| `effects.functions[].reads` | `FunctionContract.required_reads` |
+| `effects.functions[].sets` | definite variable bindings provided by the function |
+
+The build script does not generate `FileContract` constants. `FileContract`
+contains `Vec` fields and `Name` values, so the generated registry should store
+static string slices and use small runtime materializer helpers only after a
+contract matches.
+
+### Generated Runtime Data
+
+`crates/shuck-linter/build.rs` generates
+`$OUT_DIR/ambient_contracts_data.rs`.
+
+The checked-in Rust side owns the runtime descriptor types:
+
+```rust
+struct DeclarativeContractDescriptor {
+    id: &'static str,
+    groups: &'static [&'static str],
+    label: Option<&'static str>,
+    activation: DeclarativeActivationDescriptor,
+    files: &'static [&'static str],
+    effects: DeclarativeEffectsDescriptor,
+}
+
+enum DeclarativeActivationDescriptor {
+    Always,
+    ZshPlugin {
+        framework: &'static str,
+        plugin: &'static str,
+    },
+    ZshTheme {
+        framework: &'static str,
+        theme: &'static str,
+    },
+}
+
+struct DeclarativeEffectsDescriptor {
+    reads: &'static [&'static str],
+    consumes_names: &'static [&'static str],
+    consumes_prefixes: &'static [&'static str],
+    consumes_all: bool,
+    provides_variables: &'static [&'static str],
+    provides_functions: &'static [&'static str],
+    functions: &'static [DeclarativeFunctionDescriptor],
+}
+
+struct DeclarativeFunctionDescriptor {
+    name: &'static str,
+    reads: &'static [&'static str],
+    sets: &'static [&'static str],
+}
+```
+
+The generated file contains only static data:
+
+```rust
+pub(super) const DECLARATIVE_CONTRACTS: &[DeclarativeContractDescriptor] = &[
+    DeclarativeContractDescriptor {
+        id: "zsh/oh-my-zsh/plugin/tmux",
+        groups: &["zsh", "zsh/oh-my-zsh", "zsh/oh-my-zsh/plugin"],
+        label: Some("Oh My Zsh tmux plugin"),
+        activation: DeclarativeActivationDescriptor::ZshPlugin {
+            framework: "oh-my-zsh",
+            plugin: "tmux",
+        },
+        files: &[],
+        effects: DeclarativeEffectsDescriptor {
+            reads: &[],
+            consumes_names: &[],
+            consumes_prefixes: &["ZSH_TMUX_"],
+            consumes_all: false,
+            provides_variables: &[],
+            provides_functions: &[],
+            functions: &[],
+        },
+    },
+];
+```
+
+`contracts.rs` includes that generated data and adapts it into the existing
+well-known registry flow. The build script should emit deterministic output:
+files sorted by path, contracts sorted by `id`, groups and effect lists
+deduplicated in stable order.
+
+### Runtime Activation Flow
+
+The runtime flow stays lazy:
+
+1. Config parsing builds `AmbientContractConfig`.
+2. `ResolvedAmbientContracts::resolve` collects disabled selectors and
+   `custom[].replaces`.
+3. Disabled selectors are validated against all built-in Rust and declarative
+   ids/groups.
+4. Enabled declarative file-entry and request contract ids are stored in
+   `ResolvedAmbientContracts`.
+5. During file-entry collection, only enabled declarative `always` contracts
+   are considered.
+6. During plugin request resolution, only enabled declarative request
+   contracts whose activation matches the observed request are considered.
+7. Optional `files` matchers are compiled lazily only after selector and
+   activation checks pass.
+8. The effect descriptor materializes a `FileContract` and merges it through
+   the same helpers used by custom contracts.
+
+This preserves the startup target:
+
+- no built-in YAML parsing during `shuck check`;
+- no `Name` allocation for inactive contracts;
+- disabled families are skipped before path matching and materialization;
+- request contracts for unrelated frameworks/plugins are skipped by string
+  comparison;
+- path glob cost is paid only for contracts that reached path matching.
+
+### File Pattern Matching
+
+Declarative `files` uses the same matching semantics as custom contracts and
+per-file settings:
+
+- basename match;
+- project-root relative match;
+- absolute path match;
+- `!` negation entries;
+- positive entries are ORed, negations exclude.
+
+Generated descriptors store pattern strings. The runtime side uses a small
+`OnceLock<Vec<CompiledPathMatcher>>` cache per descriptor when file matching is
+needed. Empty `files` means the activation alone decides applicability.
+
+Request-based activations match the file that requested the plugin or theme,
+not the resolved plugin entrypoint.
+
+### Dynamic Rust Providers
+
+Not every current well-known contract should move to YAML.
+
+Keep Rust providers for contracts that inspect source text, normalized command
+streams, path tags, or shell-specific runtime conditions:
+
+- `zsh_runtime`;
+- `zsh_config`;
+- `zsh_module_metadata`;
+- `sourced_runtime`;
+- `zsh_caller_arrays`;
+- future plugin-manager adapters that parse command DSLs or infer dynamic
+  plugin requests.
+
+Move contracts to declarative YAML when the behavior is a static activation
+plus static effects, such as:
+
+- exact plugin consumes a prefix;
+- exact plugin reads one or more caller names at load time;
+- exact theme provides or consumes stable names;
+- a runtime file pattern provides initialized environment variables;
+- a framework convention consumes exact metadata names or prefixes.
+
+### Crate Boundaries
+
+- `shuck-linter` owns declarative built-in contract descriptors, generation,
+  validation, and materialization.
+- `shuck-linter` build code may parse YAML; runtime `shuck-linter` may not.
+- `shuck-semantic` continues to own `FileContract`, `PluginRequest`,
+  `PluginResolution`, and semantic application.
+- `shuck-semantic` does not parse declarative YAML and does not own the
+  well-known registry.
+- `shuck-config` continues to own user TOML config shapes.
+- `shuck-cli` continues to compile user config into `ResolvedAmbientContracts`
+  and `ResolvedZshPluginSettings`.
+
+### Build Script Integration
+
+Extend `crates/shuck-linter/build.rs`:
+
+- keep the existing rule metadata generation;
+- add `contracts_dir = manifest_dir.join("contracts")`;
+- emit `cargo:rerun-if-changed` for the directory and every YAML file;
+- parse every `*.yaml` recursively;
+- validate schema and semantic rules;
+- generate `ambient_contracts_data.rs` into `OUT_DIR`;
+- keep build-script parser functions testable under `#[cfg(test)]`.
+
+`crates/shuck-linter/src/ambient_contracts/contracts.rs` should include:
+
+```rust
+include!(concat!(env!("OUT_DIR"), "/ambient_contracts_data.rs"));
+```
+
+or delegate to a new sibling module such as
+`ambient_contracts/declarative.rs` that owns descriptor types and includes the
+generated constants.
+
+If the contracts directory is missing in a packaged crate, build should fail
+with a clear error. A missing directory means the package is incomplete, not
+that Shuck should silently ship without built-in contracts.
+
+### Validation Rules
+
+Build-time validation rejects:
+
+- unsupported schema versions;
+- duplicate contract ids across all YAML files;
+- empty ids or groups;
+- ids, groups, framework names, plugin names, theme names, variables, function
+  names, and prefixes with leading/trailing whitespace;
+- ids or groups containing whitespace;
+- a group that is equal to the id;
+- an empty `effects` body;
+- a `zsh_plugin` activation without `framework` or `plugin`;
+- a `zsh_theme` activation without `framework` or `theme`;
+- `always` activations that include plugin or theme fields;
+- invalid globs in `files`;
+- duplicated names inside one effect list after normalization;
+- invalid shell identifier names for fields that require complete names;
+- invalid identifier prefixes for `consumes.prefixes`.
+
+Runtime config validation rejects:
+
+- disabled selectors that are not `*`, a known built-in id, or a known
+  built-in group;
+- `custom[].replaces` selectors that are not known built-in ids or groups;
+- duplicate custom contract ids;
+- malformed custom contract names, prefixes, and file globs.
+
+The first implementation may validate names using the existing portable shell
+identifier subset. If zsh-specific names need broader syntax, add a
+shell-profile-aware validator rather than weakening all validation.
+
+### Cache Keys
+
+Built-in declarative contracts are part of the compiled binary. Cache
+fingerprints do not need to include YAML file mtimes at runtime.
+
+The existing effective settings snapshot must include:
+
+- enabled declarative contract ids after disabled and replacement selectors are
+  applied;
+- custom contract descriptors;
+- plugin-resolution enabled state.
+
+It does not need to preserve the original disabled selector text when two
+different selector spellings produce the same enabled built-in set.
+
+When a built-in contract changes, the Shuck version or binary hash changes with
+the compiled artifact. During local development, Cargo rebuilds
+`shuck-linter` because the build script emits `rerun-if-changed` for the YAML
+inputs.
+
+### Documentation And Contributor Workflow
+
+Add `contracts/README.md` with:
+
+- the source-first rule;
+- a minimal plugin contract example;
+- a minimal runtime contract example;
+- field-by-field schema reference;
+- guidance for choosing `reads` vs `consumes`;
+- activation examples for `always`, `zsh_plugin`, and `zsh_theme`;
+- validation and test commands;
+- clean-room reminders for compatibility-oriented research.
+
+The README should tell contributors to add contract data from project-owned
+knowledge, source inspection, official shell/runtime documentation, or
+black-box behavior probes. It must not encourage copying ShellCheck diagnostic
+text, examples, or source-derived wording.
+
+Generated website or docs inventory can be added after the initial
+implementation, but the generated data should make it easy to list built-in ids
+and groups later.
+
+### Migration Strategy
+
+Phase 1:
+
+- add `contracts/` and the crate-local symlink;
+- add build-script parsing and generated descriptor output;
+- add runtime descriptor types and materializers;
+- move `zsh/oh-my-zsh/plugin/tmux` from the hard-coded request registry into
+  `contracts/zsh/oh-my-zsh/plugins/tmux.yaml`;
+- keep existing Rust providers for dynamic zsh runtime/config/module behavior;
+- add focused unit and end-to-end tests for the moved tmux contract.
+
+Phase 2:
+
+- move other static well-known plugin/theme/runtime facts into YAML as they are
+  added or touched;
+- add `contracts/README.md` examples for common contribution paths;
+- tighten runtime disabled/replaces validation against the generated selector
+  inventory;
+- add generated docs or website data if contributors need a browsable catalog.
+
+Phase 3:
+
+- audit `ambient_contracts` for static tables that should become declarative;
+- keep dynamic source/path/command-sensitive providers in Rust;
+- add broader large-corpus verification for rule families affected by new
+  contracts, especially unused-assignment and uninitialized-read behavior.
+
+## Concrete Code Changes
+
+### `contracts/`
+
+- create the root directory;
+- add `README.md`;
+- add initial YAML for `zsh/oh-my-zsh/plugin/tmux`;
+- use `version: 1` and `contracts: [...]` in every YAML file.
+
+### `crates/shuck-linter`
+
+- add `contracts -> ../../contracts` symlink;
+- extend `build.rs` to parse contract YAML and emit
+  `ambient_contracts_data.rs`;
+- add build-script tests for parsing, validation, sorting, and generated Rust
+  snippets;
+- add runtime descriptor/materializer code under `ambient_contracts`;
+- merge generated declarative contracts into
+  `ResolvedAmbientContracts::resolve`;
+- include generated ids in `EffectiveAmbientContracts`;
+- replace the hard-coded `oh_my_zsh_tmux_requesting_file_contract` registry
+  entry with generated data;
+- keep `merge_contract`, `imported_contract_from_effects`, and
+  `requesting_file_contract_from_effects` as shared materialization helpers
+  where practical.
+
+### `crates/shuck-config`
+
+- keep the existing user TOML schema;
+- add or tighten tests for disabled and replacement selectors once
+  `shuck-linter` exposes the built-in selector inventory needed for
+  validation;
+- do not add runtime YAML config parsing.
+
+### `crates/shuck-cli`
+
+- keep current config compilation flow;
+- ensure selector validation errors surface as configuration errors with the
+  offending selector and the accepted selector form;
+- keep effective contract state in check cache keys;
+- add integration tests that prove declarative built-ins behave the same as the
+  old Rust tmux contract.
+
+### `crates/shuck-semantic`
+
+- no declarative YAML changes;
+- keep `PluginResolution.file_entry_contracts` and
+  `PluginResolution.requesting_file_contract` as the request-site import hooks;
+- add semantic tests only if the migration reveals a gap in how generated
+  request contracts are applied.
+
+## Alternatives Considered
+
+### Runtime-Parse Built-In YAML
+
+Rejected. This gives contributors a declarative format but makes every Shuck
+run pay deserialization and validation costs for built-in data. It also creates
+more startup work for contracts that cannot possibly activate for the analyzed
+file. Build-time generation gives the same authoring ergonomics with static
+runtime data.
+
+### Keep All Built-Ins As Hand-Written Rust
+
+Rejected. Centralized Rust tables are acceptable for a few entries, but they do
+not scale to broad plugin and runtime coverage. Hand-written entries make small
+data additions look like code changes, which is harder for AI and casual
+contributors to produce consistently.
+
+### Store Generated Rust In The Repository
+
+Rejected for the first implementation. Checked-in generated Rust makes reviews
+larger and creates a stale-output failure mode. The existing rule metadata path
+already generates Rust in `OUT_DIR`, and contract generation should follow that
+local pattern.
+
+### Put The Registry In `shuck-semantic`
+
+Rejected. `shuck-semantic` owns contract application types and plugin resolver
+interfaces, but the list of lint-facing ecosystem assumptions belongs next to
+the linter ambient-contract machinery.
+
+### Make YAML The User Config Format For Contracts
+
+Rejected. Users already have TOML config under `[lint.contracts]`, and spec 021
+defines that surface. Built-in YAML is for repository authorship and build-time
+generation only.
+
+### Move Dynamic Providers To YAML
+
+Rejected. Providers that inspect source text, path context, command streams, or
+shell-specific runtime signals are logic, not static contract data. They should
+remain Rust code until a concrete declarative form can express them without
+losing precision.
+
+## Verification
+
+### Build-Script Tests
+
+- parse a single-contract YAML document;
+- parse a multi-contract YAML document;
+- reject unknown schema versions;
+- reject duplicate ids across files;
+- reject invalid activation fields;
+- reject invalid names and prefixes;
+- reject invalid globs;
+- produce deterministic sorted generated output;
+- include all contract files in `cargo:rerun-if-changed` output.
+
+### Linter Unit Tests
+
+- generated tmux contract appears in the built-in selector inventory;
+- disabling `zsh/oh-my-zsh/plugin/tmux` skips the generated contract;
+- disabling `zsh/oh-my-zsh` skips the generated contract by group;
+- generated request contracts are not materialized for unrelated plugin
+  requests;
+- generated request contracts materialize the expected `FileContract` only
+  after activation matches;
+- generated `always` contracts apply to matching file paths and skip
+  non-matching paths;
+- generated path matchers handle basename, relative, absolute, and negated
+  patterns.
+
+### CLI And End-To-End Tests
+
+- a `.zshrc` that loads the oh-my-zsh `tmux` plugin keeps `ZSH_TMUX_*`
+  assignments live through the generated contract;
+- the same `.zshrc` reports the assignment when the built-in contract is
+  disabled by exact id;
+- disabling the `zsh/oh-my-zsh` group has the same effect;
+- custom `[[lint.contracts.custom]]` entries still work and can replace a
+  generated built-in;
+- plugin resolution disabled prevents generated `zsh_plugin` contracts from
+  applying, while generated `always` contracts still apply.
+
+### Commands
+
+```bash
+cargo test -p shuck-linter build_script
+cargo test -p shuck-linter ambient_contracts
+cargo test -p shuck-cli contract
+make test
+make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C001,C006
+```
+
+The large-corpus command is required before landing the implementation because
+these contracts affect unused-assignment and uninitialized-read behavior. It is
+not required for this spec-only change.


### PR DESCRIPTION
## Summary
Add a declarative built-in contract pipeline for ambient contracts.

This change:
- adds a repository `contracts/` tree with contributor docs and an initial `oh-my-zsh` `tmux` contract
- extends `shuck-linter`'s build script to parse, validate, and generate static Rust descriptors from declarative contract YAML
- wires generated contracts into the existing ambient contract resolution path with lazy matcher and `FileContract` materialization
- validates built-in selectors and duplicate custom ids in ambient contract resolution
- adds focused tests for build-script parsing/generation and the generated tmux contract behavior

## Why
We want built-in plugin and runtime contracts to be easier for contributors and AI to add without paying YAML parsing cost at runtime.

## Validation
- `cargo test -p shuck-linter --test build_script`
- `cargo test -p shuck-cli built_in_tmux_plugin_contract`
- `cargo test -p shuck-cli invalid_built_in_contract_selector_is_rejected`
- `cargo test -p shuck-cli disabled_built_in_tmux_selector_skips_generated_contract`
- `cargo test -p shuck-cli duplicate_custom_contract_ids_are_rejected`