### PR TITLE
fix(linter): tighten powerlevel10k runtime contracts

### DIFF
--- a/contracts/zsh/themes/powerlevel10k.yaml
+++ b/contracts/zsh/themes/powerlevel10k.yaml
@@ -126,6 +126,146 @@ contracts:
           - __p9k_root_dir
           - __p9k_intro
 
+  - id: zsh/powerlevel10k/bootstrap/configure-state
+    groups:
+      - zsh
+      - zsh/powerlevel10k
+      - zsh/powerlevel10k/bootstrap
+    label: Powerlevel10k configure state shared with internal helpers
+    when:
+      type: always
+    match:
+      shell: zsh_or_unknown
+      source:
+        mentions-any-names:
+          - __p9k_cfg_path
+          - __p9k_cfg_path_u
+          - __p9k_zshrc
+          - __p9k_wizard_columns
+          - __p9k_zd
+    files:
+      - "**/powerlevel10k/internal/p10k.zsh"
+      - "**/powerlevel10k/internal/wizard.zsh"
+    effects:
+      provides:
+        variables:
+          - __p9k_cfg_basename
+          - __p9k_cfg_path
+          - __p9k_cfg_path_o
+          - __p9k_cfg_path_u
+          - __p9k_root_dir_u
+          - __p9k_wizard_columns
+          - __p9k_wizard_lines
+          - __p9k_zd
+          - __p9k_zd_u
+          - __p9k_zshrc
+          - __p9k_zshrc_u
+
+  - id: zsh/powerlevel10k/bootstrap/instant-prompt-state
+    groups:
+      - zsh
+      - zsh/powerlevel10k
+      - zsh/powerlevel10k/bootstrap
+    label: Powerlevel10k instant prompt bootstrap state
+    when:
+      type: always
+    match:
+      shell: zsh_or_unknown
+      source:
+        mentions-any-names:
+          - __p9k_dump_file
+          - __p9k_instant_prompt_date
+          - __p9k_instant_prompt_output
+          - __p9k_instant_prompt_param_sig
+          - __p9k_instant_prompt_sourced
+          - __p9k_instant_prompt_time
+          - __p9k_intro_locale
+          - __p9k_intro_no_locale
+          - __p9k_intro_no_reply
+    files:
+      - "**/powerlevel10k/internal/p10k.zsh"
+    effects:
+      provides:
+        variables:
+          - __p9k_dump_file
+          - __p9k_instant_prompt_date
+          - __p9k_instant_prompt_date_format
+          - __p9k_instant_prompt_output
+          - __p9k_instant_prompt_param_sig
+          - __p9k_instant_prompt_sourced
+          - __p9k_instant_prompt_time
+          - __p9k_instant_prompt_time_format
+          - __p9k_intro_locale
+          - __p9k_intro_no_locale
+          - __p9k_intro_no_reply
+
+  - id: zsh/powerlevel10k/internal/config-prefixes
+    groups:
+      - zsh
+      - zsh/powerlevel10k
+      - zsh/powerlevel10k/config
+    label: Powerlevel10k internal config namespaces
+    when:
+      type: always
+    match:
+      shell: zsh_or_unknown
+      source:
+        contains-any:
+          - POWERLEVEL9K_
+          - _POWERLEVEL9K_
+    files:
+      - "**/powerlevel10k/internal/p10k.zsh"
+      - "**/powerlevel10k/internal/configure.zsh"
+      - "**/powerlevel10k/internal/wizard.zsh"
+    effects:
+      consumes:
+        prefixes:
+          - POWERLEVEL9K_
+          - _POWERLEVEL9K_
+      provides:
+        variables:
+          - GOENV_VERSION
+          - NAME
+          - POWERLEVEL9K_BATTERY_STAGES
+          - PYENV_VERSION
+          - _POWERLEVEL9K_GOENV_PROMPT_ALWAYS_SHOW
+          - _POWERLEVEL9K_GOENV_SHOW_SYSTEM
+          - _POWERLEVEL9K_GOENV_SOURCES
+          - _POWERLEVEL9K_JENV_PROMPT_ALWAYS_SHOW
+          - _POWERLEVEL9K_JENV_SHOW_SYSTEM
+          - _POWERLEVEL9K_JENV_SOURCES
+          - _POWERLEVEL9K_PHPENV_PROMPT_ALWAYS_SHOW
+          - _POWERLEVEL9K_PHPENV_SHOW_SYSTEM
+          - _POWERLEVEL9K_PHPENV_SOURCES
+          - _POWERLEVEL9K_PLENV_PROMPT_ALWAYS_SHOW
+          - _POWERLEVEL9K_PLENV_SHOW_SYSTEM
+          - _POWERLEVEL9K_PLENV_SOURCES
+          - _POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW
+          - _POWERLEVEL9K_RBENV_SHOW_SYSTEM
+          - _POWERLEVEL9K_RBENV_SOURCES
+          - _POWERLEVEL9K_VCS_MAX_SYNC_LATENCY_SECONDS
+
+  - id: zsh/powerlevel10k/runtime/vcs-info-output
+    groups:
+      - zsh
+      - zsh/powerlevel10k
+      - zsh/powerlevel10k/runtime
+    label: Powerlevel10k vcs_info output state
+    when:
+      type: always
+    match:
+      shell: zsh_or_unknown
+      source:
+        mentions-all-names:
+          - vcs_info
+          - vcs_info_msg_0_
+    files:
+      - "**/powerlevel10k/internal/p10k.zsh"
+    effects:
+      provides:
+        variables:
+          - vcs_info_msg_0_
+
   - id: zsh/powerlevel10k/gitstatus/prefix
     groups:
       - zsh

--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -9247,17 +9247,6 @@ repos:
           column: 55
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_RBENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
-        start:
-          line: 2794
-          column: 8
-        end:
-          line: 2794
-          column: 48
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -9268,28 +9257,6 @@ repos:
           line: 2802
           column: 33
         classification: real
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_RBENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
-        start:
-          line: 2823
-          column: 10
-        end:
-          line: 2823
-          column: 48
-        classification: false_positive
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_RBENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
-        start:
-          line: 2835
-          column: 10
-        end:
-          line: 2835
-          column: 41
-        classification: false_positive
       - path: "internal/p10k.zsh"
         code: "C063"
         severity: "warning"
@@ -9313,17 +9280,6 @@ repos:
           column: 33
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_PHPENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
-        start:
-          line: 2915
-          column: 8
-        end:
-          line: 2915
-          column: 49
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -9334,28 +9290,6 @@ repos:
           line: 2923
           column: 33
         classification: real
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_PHPENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
-        start:
-          line: 2944
-          column: 10
-        end:
-          line: 2944
-          column: 49
-        classification: false_positive
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_PHPENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
-        start:
-          line: 2956
-          column: 10
-        end:
-          line: 2956
-          column: 42
-        classification: false_positive
       - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
@@ -9368,17 +9302,6 @@ repos:
           column: 33
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_JENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
-        start:
-          line: 3037
-          column: 8
-        end:
-          line: 3037
-          column: 47
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -9390,39 +9313,6 @@ repos:
           column: 33
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_JENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
-        start:
-          line: 3066
-          column: 10
-        end:
-          line: 3066
-          column: 47
-        classification: false_positive
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_JENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
-        start:
-          line: 3078
-          column: 10
-        end:
-          line: 3078
-          column: 40
-        classification: false_positive
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_PLENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
-        start:
-          line: 3098
-          column: 8
-        end:
-          line: 3098
-          column: 48
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -9433,28 +9323,6 @@ repos:
           line: 3106
           column: 33
         classification: real
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_PLENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
-        start:
-          line: 3127
-          column: 10
-        end:
-          line: 3127
-          column: 48
-        classification: false_positive
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_PLENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
-        start:
-          line: 3139
-          column: 10
-        end:
-          line: 3139
-          column: 41
-        classification: false_positive
       - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
@@ -9544,17 +9412,6 @@ repos:
           column: 18
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_instant_prompt_time_format` is referenced before assignment"
-        start:
-          line: 3495
-          column: 51
-        end:
-          line: 3495
-          column: 84
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -9566,28 +9423,6 @@ repos:
           column: 114
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_instant_prompt_time` is referenced before assignment"
-        start:
-          line: 3496
-          column: 20
-        end:
-          line: 3496
-          column: 55
-        classification: false_positive
-      - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_instant_prompt_date_format` is referenced before assignment"
-        start:
-          line: 3543
-          column: 49
-        end:
-          line: 3543
-          column: 82
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -9598,17 +9433,6 @@ repos:
           line: 3543
           column: 112
         classification: real
-      - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_instant_prompt_date` is referenced before assignment"
-        start:
-          line: 3544
-          column: 18
-        end:
-          line: 3544
-          column: 53
-        classification: false_positive
       - path: "internal/p10k.zsh"
         code: "C006"
         severity: "error"
@@ -9687,17 +9511,6 @@ repos:
           column: 84
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_VCS_MAX_SYNC_LATENCY_SECONDS` looks like it may mean `POWERLEVEL9K_VCS_MAX_SYNC_LATENCY_SECONDS`"
-        start:
-          line: 4058
-          column: 21
-        end:
-          line: 4058
-          column: 63
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C100"
         severity: "warning"
         message: "array references should choose an explicit element or selector"
@@ -9720,17 +9533,6 @@ repos:
           column: 41
         classification: false_positive
       - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `PYENV_VERSION` looks like it may mean `PLENV_VERSION`"
-        start:
-          line: 4364
-          column: 11
-        end:
-          line: 4364
-          column: 56
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -9742,28 +9544,6 @@ repos:
           column: 33
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `GOENV_VERSION` looks like it may mean `NODENV_VERSION`"
-        start:
-          line: 4444
-          column: 11
-        end:
-          line: 4444
-          column: 52
-        classification: false_positive
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_GOENV_SOURCES` looks like it may mean `_POWERLEVEL9K_PYENV_SOURCES`"
-        start:
-          line: 4446
-          column: 8
-        end:
-          line: 4446
-          column: 48
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -9774,28 +9554,6 @@ repos:
           line: 4453
           column: 33
         classification: real
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_GOENV_PROMPT_ALWAYS_SHOW` looks like it may mean `_POWERLEVEL9K_PYENV_PROMPT_ALWAYS_SHOW`"
-        start:
-          line: 4474
-          column: 10
-        end:
-          line: 4474
-          column: 48
-        classification: false_positive
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `_POWERLEVEL9K_GOENV_SHOW_SYSTEM` looks like it may mean `_POWERLEVEL9K_PYENV_SHOW_SYSTEM`"
-        start:
-          line: 4486
-          column: 10
-        end:
-          line: 4486
-          column: 41
-        classification: false_positive
       - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
@@ -10413,17 +10171,6 @@ repos:
           column: 54
         classification: false_positive
       - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_dump_file` is referenced before assignment"
-        start:
-          line: 6174
-          column: 18
-        end:
-          line: 6174
-          column: 38
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C005"
         severity: "warning"
         message: "shell expansion inside single quotes stays literal"
@@ -10445,17 +10192,6 @@ repos:
           line: 6199
           column: 25
         classification: real
-      - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_intro_no_locale` is referenced before assignment"
-        start:
-          line: 6200
-          column: 3
-        end:
-          line: 6200
-          column: 25
-        classification: false_positive
       - path: "internal/p10k.zsh"
         code: "C005"
         severity: "warning"
@@ -10666,17 +10402,6 @@ repos:
           column: 98
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_instant_prompt_param_sig` is referenced before assignment"
-        start:
-          line: 6672
-          column: 13
-        end:
-          line: 6672
-          column: 44
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -10721,17 +10446,6 @@ repos:
           column: 37
         classification: false_positive
       - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_instant_prompt_output` is referenced before assignment"
-        start:
-          line: 6692
-          column: 12
-        end:
-          line: 6692
-          column: 40
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `fill` is assigned but never used"
@@ -10754,17 +10468,6 @@ repos:
           column: 41
         classification: false_positive
       - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_instant_prompt_sourced` is referenced before assignment"
-        start:
-          line: 6701
-          column: 50
-        end:
-          line: 6701
-          column: 78
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C010"
         severity: "warning"
         message: "chaining `&&` and `||` makes the fallback depend on the middle command status"
@@ -10775,17 +10478,6 @@ repos:
           line: 6838
           column: 61
         classification: real
-      - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_intro_locale` is referenced before assignment"
-        start:
-          line: 6873
-          column: 9
-        end:
-          line: 6873
-          column: 28
-        classification: false_positive
       - path: "internal/p10k.zsh"
         code: "C088"
         severity: "warning"
@@ -10809,17 +10501,6 @@ repos:
           column: 38
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_cfg_path` is referenced before assignment"
-        start:
-          line: 7036
-          column: 31
-        end:
-          line: 7036
-          column: 46
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C008"
         severity: "warning"
         message: "double-quoted trap handlers expand variables when the trap is set"
@@ -10830,17 +10511,6 @@ repos:
           line: 7157
           column: 23
         classification: real
-      - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `POWERLEVEL9K_BATTERY_STAGES` looks like it may mean `_POWERLEVEL9K_BATTERY_STAGES`"
-        start:
-          line: 7518
-          column: 57
-        end:
-          line: 7518
-          column: 101
-        classification: false_positive
       - path: "internal/p10k.zsh"
         code: "C005"
         severity: "warning"
@@ -11645,17 +11315,6 @@ repos:
           column: 42
         classification: real
       - path: "internal/p10k.zsh"
-        code: "C156"
-        severity: "warning"
-        message: "reference to `NAME` looks like it may mean `name`"
-        start:
-          line: 8522
-          column: 32
-        end:
-          line: 8522
-          column: 37
-        classification: false_positive
-      - path: "internal/p10k.zsh"
         code: "C081"
         severity: "warning"
         message: "quote the right-hand side so string comparisons do not turn into glob matches"
@@ -11787,17 +11446,6 @@ repos:
           line: 9306
           column: 1
         classification: real
-      - path: "internal/p10k.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_intro_no_reply` is referenced before assignment"
-        start:
-          line: 9316
-          column: 9
-        end:
-          line: 9316
-          column: 30
-        classification: false_positive
       - path: "internal/p10k.zsh"
         code: "C005"
         severity: "warning"
@@ -12602,39 +12250,6 @@ repos:
           column: 20
         classification: real
       - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_zshrc_u` is referenced before assignment"
-        start:
-          line: 268
-          column: 85
-        end:
-          line: 268
-          column: 99
-        classification: false_positive
-      - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_wizard_columns` is referenced before assignment"
-        start:
-          line: 317
-          column: 32
-        end:
-          line: 317
-          column: 52
-        classification: false_positive
-      - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_wizard_lines` is referenced before assignment"
-        start:
-          line: 322
-          column: 32
-        end:
-          line: 322
-          column: 50
-        classification: false_positive
-      - path: "internal/wizard.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `columns` is assigned but never used"
@@ -13207,28 +12822,6 @@ repos:
           column: 2
         classification: real
       - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_cfg_path` is referenced before assignment"
-        start:
-          line: 1597
-          column: 14
-        end:
-          line: 1597
-          column: 29
-        classification: false_positive
-      - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_cfg_path_u` is referenced before assignment"
-        start:
-          line: 1601
-          column: 47
-        end:
-          line: 1601
-          column: 75
-        classification: false_positive
-      - path: "internal/wizard.zsh"
         code: "C005"
         severity: "warning"
         message: "shell expansion inside single quotes stays literal"
@@ -13238,17 +12831,6 @@ repos:
         end:
           line: 1612
           column: 33
-        classification: false_positive
-      - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_cfg_basename` is referenced before assignment"
-        start:
-          line: 1618
-          column: 43
-        end:
-          line: 1618
-          column: 62
         classification: false_positive
       - path: "internal/wizard.zsh"
         code: "C124"
@@ -13261,39 +12843,6 @@ repos:
           line: 1707
           column: 2
         classification: real
-      - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_zd` is referenced before assignment"
-        start:
-          line: 1650
-          column: 14
-        end:
-          line: 1650
-          column: 23
-        classification: false_positive
-      - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_zd_u` is referenced before assignment"
-        start:
-          line: 1652
-          column: 46
-        end:
-          line: 1652
-          column: 68
-        classification: false_positive
-      - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_zshrc` is referenced before assignment"
-        start:
-          line: 1654
-          column: 14
-        end:
-          line: 1654
-          column: 26
-        classification: false_positive
       - path: "internal/wizard.zsh"
         code: "C005"
         severity: "warning"
@@ -13349,17 +12898,6 @@ repos:
           line: 2045
           column: 2
         classification: real
-      - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `__p9k_cfg_path_o` is referenced before assignment"
-        start:
-          line: 2019
-          column: 12
-        end:
-          line: 2019
-          column: 29
-        classification: false_positive
       - path: "internal/wizard.zsh"
         code: "C005"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -615,6 +615,61 @@ fn powerlevel10k_internal_bootstrap_files_initialize_injected_bindings() {
 }
 
 #[test]
+fn powerlevel10k_internal_paths_consume_public_and_private_config_prefixes() {
+    let path = Path::new("/tmp/zsh/powerlevel10k/internal/p10k.zsh");
+    let source = "\
+print -r -- \"$POWERLEVEL9K_LEFT_PROMPT_ELEMENTS\"
+print -r -- \"$_POWERLEVEL9K_RBENV_SOURCES\"
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    for prefix in ["POWERLEVEL9K_", "_POWERLEVEL9K_"] {
+        assert!(has_consumed_prefix(&contract, prefix), "{contract:?}");
+    }
+}
+
+#[test]
+fn powerlevel10k_internal_paths_get_configure_state_bindings() {
+    let path = Path::new("/tmp/zsh/powerlevel10k/internal/wizard.zsh");
+    let source = "\
+print -r -- \"$__p9k_cfg_path\" \"$__p9k_cfg_path_u\" \"$__p9k_zshrc\" \"$__p9k_zd\" \"$__p9k_wizard_columns\"
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    for name in [
+        "__p9k_cfg_path",
+        "__p9k_cfg_path_u",
+        "__p9k_zshrc",
+        "__p9k_zd",
+        "__p9k_wizard_columns",
+    ] {
+        assert!(has_initialized_binding(&contract, name), "{contract:?}");
+    }
+}
+
+#[test]
+fn powerlevel10k_p10k_paths_get_instant_prompt_and_vcs_info_bindings() {
+    let path = Path::new("/tmp/zsh/powerlevel10k/internal/p10k.zsh");
+    let source = "\
+vcs_info
+print -r -- \"$vcs_info_msg_0_\" \"$__p9k_intro_no_locale\" \"$__p9k_dump_file\" \"$__p9k_instant_prompt_time\"
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    for name in [
+        "vcs_info_msg_0_",
+        "__p9k_intro_no_locale",
+        "__p9k_dump_file",
+        "__p9k_instant_prompt_time",
+    ] {
+        assert!(has_initialized_binding(&contract, name), "{contract:?}");
+    }
+}
+
+#[test]
 fn powerlevel10k_gitstatus_zsh_contract_initializes_intro_base_and_consumes_status_prefix() {
     let path = Path::new("/tmp/zsh/powerlevel10k/gitstatus/gitstatus.plugin.zsh");
     let source = "\


### PR DESCRIPTION
## Summary
- add `powerlevel10k` ambient contract coverage for internal runtime/config state and private config namespaces
- add focused ambient-contract tests for the new `powerlevel10k` bindings and prefixes
- refresh the `powerlevel10k` zsh diagnostic corpus baseline after the false positives disappear

## Why
The remaining `powerlevel10k` false positives were not all rule bugs. A chunk of them still came from missing framework-specific file-entry state, so `powerlevel10k` internals were being treated as undefined or typo-like names. Once those contracts were modeled correctly, the zsh corpus baseline needed to drop the now-stale diagnostics.

## Validation
- `cargo test -p shuck-linter ambient_contracts`
- `cargo test -p shuck-cli zsh_diagnostic_corpus_matches_baseline -- --ignored`