### PR TITLE
fix(linter): add zsh framework contracts for C006

### DIFF
--- a/contracts/zsh/oh-my-zsh/core.yaml
+++ b/contracts/zsh/oh-my-zsh/core.yaml
@@ -1,0 +1,43 @@
+version: 1
+contracts:
+  - id: zsh/oh-my-zsh/core/plugins
+    groups:
+      - zsh
+      - zsh/oh-my-zsh
+      - zsh/oh-my-zsh/core
+    label: Oh My Zsh core plugin list configuration
+    when:
+      type: always
+    match:
+      shell: zsh_or_unknown
+      source:
+        mentions-any-names:
+          - plugins
+    files:
+      - "**/oh-my-zsh/oh-my-zsh.sh"
+      - "**/ohmyzsh/oh-my-zsh.sh"
+    effects:
+      provides:
+        variables:
+          - plugins
+
+  - id: zsh/oh-my-zsh/core/vcs-hook-state
+    groups:
+      - zsh
+      - zsh/oh-my-zsh
+      - zsh/oh-my-zsh/core
+    label: Oh My Zsh vcs_info hook state
+    when:
+      type: always
+    match:
+      shell: zsh_or_unknown
+      source:
+        mentions-any-names:
+          - hook_com
+    files:
+      - "**/oh-my-zsh/lib/git.zsh"
+      - "**/ohmyzsh/lib/git.zsh"
+    effects:
+      provides:
+        ambient-variables:
+          - hook_com

--- a/contracts/zsh/oh-my-zsh/core.yaml
+++ b/contracts/zsh/oh-my-zsh/core.yaml
@@ -14,6 +14,7 @@ contracts:
         mentions-any-names:
           - plugins
     files:
+      - "**/.oh-my-zsh/oh-my-zsh.sh"
       - "**/oh-my-zsh/oh-my-zsh.sh"
       - "**/ohmyzsh/oh-my-zsh.sh"
     effects:

--- a/contracts/zsh/oh-my-zsh/core.yaml
+++ b/contracts/zsh/oh-my-zsh/core.yaml
@@ -20,24 +20,3 @@ contracts:
       provides:
         variables:
           - plugins
-
-  - id: zsh/oh-my-zsh/core/vcs-hook-state
-    groups:
-      - zsh
-      - zsh/oh-my-zsh
-      - zsh/oh-my-zsh/core
-    label: Oh My Zsh vcs_info hook state
-    when:
-      type: always
-    match:
-      shell: zsh_or_unknown
-      source:
-        mentions-any-names:
-          - hook_com
-    files:
-      - "**/oh-my-zsh/lib/git.zsh"
-      - "**/ohmyzsh/lib/git.zsh"
-    effects:
-      provides:
-        ambient-variables:
-          - hook_com

--- a/contracts/zsh/oh-my-zsh/plugins/emoji.yaml
+++ b/contracts/zsh/oh-my-zsh/plugins/emoji.yaml
@@ -19,6 +19,7 @@ contracts:
           - emoji_mod
           - emoji_skintone
     files:
+      - "**/.oh-my-zsh/plugins/emoji/emoji.plugin.zsh"
       - "**/oh-my-zsh/plugins/emoji/emoji.plugin.zsh"
       - "**/ohmyzsh/plugins/emoji/emoji.plugin.zsh"
     effects:

--- a/contracts/zsh/oh-my-zsh/plugins/emoji.yaml
+++ b/contracts/zsh/oh-my-zsh/plugins/emoji.yaml
@@ -1,0 +1,31 @@
+version: 1
+contracts:
+  - id: zsh/oh-my-zsh/plugin/emoji/definitions
+    groups:
+      - zsh
+      - zsh/oh-my-zsh
+      - zsh/oh-my-zsh/plugin
+      - zsh/oh-my-zsh/plugin/emoji
+    label: Oh My Zsh emoji plugin definition tables
+    when:
+      type: always
+    match:
+      shell: zsh_or_unknown
+      source:
+        mentions-any-names:
+          - emoji
+          - emoji_flags
+          - emoji_groups
+          - emoji_mod
+          - emoji_skintone
+    files:
+      - "**/oh-my-zsh/plugins/emoji/emoji.plugin.zsh"
+      - "**/ohmyzsh/plugins/emoji/emoji.plugin.zsh"
+    effects:
+      provides:
+        variables:
+          - emoji
+          - emoji_flags
+          - emoji_groups
+          - emoji_mod
+          - emoji_skintone

--- a/contracts/zsh/oh-my-zsh/plugins/emotty.yaml
+++ b/contracts/zsh/oh-my-zsh/plugins/emotty.yaml
@@ -16,8 +16,10 @@ contracts:
           - emoji
           - emoji2
     files:
+      - "**/.oh-my-zsh/plugins/emotty/emotty.plugin.zsh"
       - "**/oh-my-zsh/plugins/emotty/emotty.plugin.zsh"
       - "**/ohmyzsh/plugins/emotty/emotty.plugin.zsh"
+      - "**/.oh-my-zsh/themes/emotty.zsh-theme"
       - "**/oh-my-zsh/themes/emotty.zsh-theme"
       - "**/ohmyzsh/themes/emotty.zsh-theme"
     effects:

--- a/contracts/zsh/oh-my-zsh/plugins/emotty.yaml
+++ b/contracts/zsh/oh-my-zsh/plugins/emotty.yaml
@@ -1,0 +1,27 @@
+version: 1
+contracts:
+  - id: zsh/oh-my-zsh/plugin/emotty/emoji-runtime
+    groups:
+      - zsh
+      - zsh/oh-my-zsh
+      - zsh/oh-my-zsh/plugin
+      - zsh/oh-my-zsh/plugin/emotty
+    label: Oh My Zsh emotty emoji runtime state
+    when:
+      type: always
+    match:
+      shell: zsh_or_unknown
+      source:
+        mentions-any-names:
+          - emoji
+          - emoji2
+    files:
+      - "**/oh-my-zsh/plugins/emotty/emotty.plugin.zsh"
+      - "**/ohmyzsh/plugins/emotty/emotty.plugin.zsh"
+      - "**/oh-my-zsh/themes/emotty.zsh-theme"
+      - "**/ohmyzsh/themes/emotty.zsh-theme"
+    effects:
+      provides:
+        variables:
+          - emoji
+          - emoji2

--- a/contracts/zsh/runtime/special-parameters.yaml
+++ b/contracts/zsh/runtime/special-parameters.yaml
@@ -139,9 +139,11 @@ contracts:
       shell: zsh
       source:
         mentions-any-names:
+          - dis_patchars
           - galiases
           - history
           - keymaps
+          - patchars
           - reswords
           - saliases
           - userdirs
@@ -150,9 +152,11 @@ contracts:
     effects:
       provides:
         variables:
+          - dis_patchars
           - galiases
           - history
           - keymaps
+          - patchars
           - reswords
           - saliases
           - userdirs

--- a/contracts/zsh/themes/powerlevel10k.yaml
+++ b/contracts/zsh/themes/powerlevel10k.yaml
@@ -161,6 +161,28 @@ contracts:
           - __p9k_zshrc
           - __p9k_zshrc_u
 
+  - id: zsh/powerlevel10k/bootstrap/wizard-ui-state
+    groups:
+      - zsh
+      - zsh/powerlevel10k
+      - zsh/powerlevel10k/bootstrap
+    label: Powerlevel10k wizard shared UI state
+    when:
+      type: always
+    match:
+      shell: zsh_or_unknown
+      source:
+        mentions-any-names:
+          - _p9k_term_has_href
+          - icons
+    files:
+      - "**/powerlevel10k/internal/wizard.zsh"
+    effects:
+      provides:
+        variables:
+          - _p9k_term_has_href
+          - icons
+
   - id: zsh/powerlevel10k/bootstrap/instant-prompt-state
     groups:
       - zsh

--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -1598,17 +1598,6 @@ repos:
           column: 9
         classification: real
       - path: "oh-my-zsh.sh"
-        code: "C006"
-        severity: "error"
-        message: "variable `plugins` is referenced before assignment"
-        start:
-          line: 90
-          column: 13
-        end:
-          line: 90
-          column: 21
-        classification: false_positive
-      - path: "oh-my-zsh.sh"
         code: "C002"
         severity: "warning"
         message: "source path is built at runtime"
@@ -2532,50 +2521,6 @@ repos:
           line: 47
           column: 18
         classification: real
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji_groups` is referenced before assignment"
-        start:
-          line: 60
-          column: 9
-        end:
-          line: 60
-          column: 33
-        classification: false_positive
-      - path: "plugins/emoji/emoji.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji_flags` is referenced before assignment"
-        start:
-          line: 67
-          column: 10
-        end:
-          line: 67
-          column: 31
-        classification: false_positive
-      - path: "plugins/emotty/emotty.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji` is referenced before assignment"
-        start:
-          line: 42
-          column: 9
-        end:
-          line: 42
-          column: 36
-        classification: false_positive
-      - path: "plugins/emotty/emotty.plugin.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji2` is referenced before assignment"
-        start:
-          line: 42
-          column: 36
-        end:
-          line: 42
-          column: 58
-        classification: false_positive
       - path: "plugins/emotty/emotty_emoji_set.zsh"
         code: "C006"
         severity: "error"
@@ -6647,28 +6592,6 @@ repos:
           column: 8
         classification: real
       - path: "themes/emotty.zsh-theme"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji` is referenced before assignment"
-        start:
-          line: 60
-          column: 14
-        end:
-          line: 60
-          column: 20
-        classification: false_positive
-      - path: "themes/emotty.zsh-theme"
-        code: "C006"
-        severity: "error"
-        message: "variable `emoji2` is referenced before assignment"
-        start:
-          line: 63
-          column: 61
-        end:
-          line: 63
-          column: 68
-        classification: false_positive
-      - path: "themes/emotty.zsh-theme"
         code: "C001"
         severity: "warning"
         message: "variable `cyan` is assigned but never used"
@@ -7882,28 +7805,6 @@ repos:
           line: 223
           column: 34
         classification: real
-      - path: "gitstatus/mbuild"
-        code: "C006"
-        severity: "error"
-        message: "variable `patchars` is referenced before assignment"
-        start:
-          line: 351
-          column: 17
-        end:
-          line: 351
-          column: 31
-        classification: false_positive
-      - path: "gitstatus/mbuild"
-        code: "C006"
-        severity: "error"
-        message: "variable `dis_patchars` is referenced before assignment"
-        start:
-          line: 352
-          column: 21
-        end:
-          line: 352
-          column: 39
-        classification: false_positive
       - path: "gitstatus/mbuild"
         code: "C001"
         severity: "warning"
@@ -12206,17 +12107,6 @@ repos:
           column: 73
         classification: real
       - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `_p9k_term_has_href` is referenced before assignment"
-        start:
-          line: 169
-          column: 9
-        end:
-          line: 169
-          column: 27
-        classification: false_positive
-      - path: "internal/wizard.zsh"
         code: "C001"
         severity: "warning"
         message: "variable `indentation` is assigned but never used"
@@ -12480,17 +12370,6 @@ repos:
           line: 875
           column: 2
         classification: real
-      - path: "internal/wizard.zsh"
-        code: "C006"
-        severity: "error"
-        message: "variable `icons` is referenced before assignment"
-        start:
-          line: 838
-          column: 13
-        end:
-          line: 838
-          column: 38
-        classification: false_positive
       - path: "internal/wizard.zsh"
         code: "C124"
         severity: "warning"

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -355,16 +355,11 @@ fn oh_my_zsh_refined_theme_provides_vcs_info() {
 }
 
 #[test]
-fn oh_my_zsh_core_paths_get_plugin_configuration_and_vcs_hook_state() {
+fn oh_my_zsh_core_paths_get_plugin_configuration() {
     let core_path = Path::new("/tmp/zsh/ohmyzsh/oh-my-zsh.sh");
     let core_source = "print -r -- \"$plugins\"\n";
     let core_contract = contract_for_shell(core_path, core_source, ShellDialect::Zsh).unwrap();
     assert!(has_initialized_binding(&core_contract, "plugins"));
-
-    let git_path = Path::new("/tmp/zsh/ohmyzsh/lib/git.zsh");
-    let git_source = "print -r -- \"${hook_com[branch]}\"\n";
-    let git_contract = contract_for_shell(git_path, git_source, ShellDialect::Zsh).unwrap();
-    assert!(has_ambient_binding(&git_contract, "hook_com"));
 }
 
 #[test]

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -398,6 +398,36 @@ fn oh_my_zsh_emoji_and_emotty_paths_get_emoji_runtime_bindings() {
 }
 
 #[test]
+fn hidden_oh_my_zsh_paths_get_framework_contracts() {
+    let core_path = Path::new("/tmp/home/.oh-my-zsh/oh-my-zsh.sh");
+    let core_source = "print -r -- \"$plugins\"\n";
+    let core_contract = contract_for_shell(core_path, core_source, ShellDialect::Zsh).unwrap();
+    assert!(has_initialized_binding(&core_contract, "plugins"));
+
+    let emoji_path = Path::new("/tmp/home/.oh-my-zsh/plugins/emoji/emoji.plugin.zsh");
+    let emoji_source =
+        "print -r -- \"$emoji_groups[people]\" \"$emoji_flags[us]\" \"$emoji[rocket]\"\n";
+    let emoji_contract = contract_for_shell(emoji_path, emoji_source, ShellDialect::Zsh).unwrap();
+    for name in ["emoji", "emoji_flags", "emoji_groups"] {
+        assert!(
+            has_initialized_binding(&emoji_contract, name),
+            "{emoji_contract:?}"
+        );
+    }
+
+    let emotty_path = Path::new("/tmp/home/.oh-my-zsh/themes/emotty.zsh-theme");
+    let emotty_source = "print -r -- \"$emoji[skull]\" \"$emoji2[emoji_style]\"\n";
+    let emotty_contract =
+        contract_for_shell(emotty_path, emotty_source, ShellDialect::Zsh).unwrap();
+    for name in ["emoji", "emoji2"] {
+        assert!(
+            has_initialized_binding(&emotty_contract, name),
+            "{emotty_contract:?}"
+        );
+    }
+}
+
+#[test]
 fn oh_my_zsh_tools_get_prompt_color_bindings() {
     let path = Path::new("/tmp/zsh/ohmyzsh/tools/check_for_upgrade.sh");
     let source = "print -r -- \"$fg\" \"$reset_color\"\n";

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -370,10 +370,14 @@ fn oh_my_zsh_core_paths_get_plugin_configuration_and_vcs_hook_state() {
 #[test]
 fn oh_my_zsh_emoji_and_emotty_paths_get_emoji_runtime_bindings() {
     let emoji_path = Path::new("/tmp/zsh/ohmyzsh/plugins/emoji/emoji.plugin.zsh");
-    let emoji_source = "print -r -- \"$emoji_groups[people]\" \"$emoji_flags[us]\" \"$emoji[rocket]\"\n";
+    let emoji_source =
+        "print -r -- \"$emoji_groups[people]\" \"$emoji_flags[us]\" \"$emoji[rocket]\"\n";
     let emoji_contract = contract_for_shell(emoji_path, emoji_source, ShellDialect::Zsh).unwrap();
     for name in ["emoji", "emoji_flags", "emoji_groups"] {
-        assert!(has_initialized_binding(&emoji_contract, name), "{emoji_contract:?}");
+        assert!(
+            has_initialized_binding(&emoji_contract, name),
+            "{emoji_contract:?}"
+        );
     }
 
     let emotty_path = Path::new("/tmp/zsh/ohmyzsh/plugins/emotty/emotty.plugin.zsh");
@@ -715,7 +719,10 @@ fn powerlevel10k_wizard_paths_get_shared_ui_state_bindings() {
     let wizard_contract =
         contract_for_shell(wizard_path, wizard_source, ShellDialect::Zsh).unwrap();
     for name in ["icons", "_p9k_term_has_href"] {
-        assert!(has_initialized_binding(&wizard_contract, name), "{wizard_contract:?}");
+        assert!(
+            has_initialized_binding(&wizard_contract, name),
+            "{wizard_contract:?}"
+        );
     }
 }
 

--- a/crates/shuck-linter/src/ambient_contracts/tests.rs
+++ b/crates/shuck-linter/src/ambient_contracts/tests.rs
@@ -251,6 +251,21 @@ fn powerlevel10k_internal_paths_get_runtime_special_parameters() {
 }
 
 #[test]
+fn zmodload_parameter_contract_includes_patch_character_arrays() {
+    let path = Path::new("/tmp/zsh/powerlevel10k/gitstatus/mbuild");
+    let source = "\
+zmodload zsh/parameter zsh/param/private || return
+print -r -- \"$patchars\" \"$dis_patchars\"
+";
+
+    let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
+
+    for name in ["patchars", "dis_patchars"] {
+        assert!(has_initialized_binding(&contract, name), "{contract:?}");
+    }
+}
+
+#[test]
 fn powerlevel10k_internal_paths_get_hook_arrays() {
     let path = Path::new("/tmp/zsh/powerlevel10k/internal/p10k.zsh");
     let source = "print -r -- $zsh_directory_name_functions\n";
@@ -337,6 +352,50 @@ fn oh_my_zsh_refined_theme_provides_vcs_info() {
     let contract = contract_for_shell(path, source, ShellDialect::Zsh).unwrap();
 
     assert!(has_ambient_binding(&contract, "vcs_info_msg_0_"));
+}
+
+#[test]
+fn oh_my_zsh_core_paths_get_plugin_configuration_and_vcs_hook_state() {
+    let core_path = Path::new("/tmp/zsh/ohmyzsh/oh-my-zsh.sh");
+    let core_source = "print -r -- \"$plugins\"\n";
+    let core_contract = contract_for_shell(core_path, core_source, ShellDialect::Zsh).unwrap();
+    assert!(has_initialized_binding(&core_contract, "plugins"));
+
+    let git_path = Path::new("/tmp/zsh/ohmyzsh/lib/git.zsh");
+    let git_source = "print -r -- \"${hook_com[branch]}\"\n";
+    let git_contract = contract_for_shell(git_path, git_source, ShellDialect::Zsh).unwrap();
+    assert!(has_ambient_binding(&git_contract, "hook_com"));
+}
+
+#[test]
+fn oh_my_zsh_emoji_and_emotty_paths_get_emoji_runtime_bindings() {
+    let emoji_path = Path::new("/tmp/zsh/ohmyzsh/plugins/emoji/emoji.plugin.zsh");
+    let emoji_source = "print -r -- \"$emoji_groups[people]\" \"$emoji_flags[us]\" \"$emoji[rocket]\"\n";
+    let emoji_contract = contract_for_shell(emoji_path, emoji_source, ShellDialect::Zsh).unwrap();
+    for name in ["emoji", "emoji_flags", "emoji_groups"] {
+        assert!(has_initialized_binding(&emoji_contract, name), "{emoji_contract:?}");
+    }
+
+    let emotty_path = Path::new("/tmp/zsh/ohmyzsh/plugins/emotty/emotty.plugin.zsh");
+    let emotty_source = "print -r -- \"$emoji[rocket]\" \"$emoji2[emoji_style]\"\n";
+    let emotty_contract =
+        contract_for_shell(emotty_path, emotty_source, ShellDialect::Zsh).unwrap();
+    for name in ["emoji", "emoji2"] {
+        assert!(
+            has_initialized_binding(&emotty_contract, name),
+            "{emotty_contract:?}"
+        );
+    }
+
+    let theme_path = Path::new("/tmp/zsh/ohmyzsh/themes/emotty.zsh-theme");
+    let theme_source = "print -r -- \"$emoji[skull]\" \"$emoji2[emoji_style]\"\n";
+    let theme_contract = contract_for_shell(theme_path, theme_source, ShellDialect::Zsh).unwrap();
+    for name in ["emoji", "emoji2"] {
+        assert!(
+            has_initialized_binding(&theme_contract, name),
+            "{theme_contract:?}"
+        );
+    }
 }
 
 #[test]
@@ -646,6 +705,17 @@ print -r -- \"$__p9k_cfg_path\" \"$__p9k_cfg_path_u\" \"$__p9k_zshrc\" \"$__p9k_
         "__p9k_wizard_columns",
     ] {
         assert!(has_initialized_binding(&contract, name), "{contract:?}");
+    }
+}
+
+#[test]
+fn powerlevel10k_wizard_paths_get_shared_ui_state_bindings() {
+    let wizard_path = Path::new("/tmp/zsh/powerlevel10k/internal/wizard.zsh");
+    let wizard_source = "print -r -- \"$icons[VCS_GIT_ICON]\"; (( _p9k_term_has_href ))\n";
+    let wizard_contract =
+        contract_for_shell(wizard_path, wizard_source, ShellDialect::Zsh).unwrap();
+    for name in ["icons", "_p9k_term_has_href"] {
+        assert!(has_initialized_binding(&wizard_contract, name), "{wizard_contract:?}");
     }
 }
 

--- a/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/undefined_variable.rs
@@ -253,6 +253,70 @@ print -r -- \"$ordinary_missing\"
     }
 
     #[test]
+    fn oh_my_zsh_plugin_list_contract_suppresses_c006() {
+        let source = "\
+#!/bin/zsh
+for plugin ($plugins); do
+  print -r -- \"$plugin\"
+done
+print -r -- \"$ordinary_missing\"
+";
+        let diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/oh-my-zsh.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$ordinary_missing"]
+        );
+    }
+
+    #[test]
+    fn oh_my_zsh_emotty_dependency_contracts_suppress_c006() {
+        let plugin_source = "\
+#!/bin/zsh
+print -r -- \"${emoji[rocket]}${emoji2[emoji_style]}\"
+print -r -- \"$ordinary_missing\"
+";
+        let plugin_diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/plugins/emotty/emotty.plugin.zsh"),
+            plugin_source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+        assert_eq!(
+            plugin_diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(plugin_source))
+                .collect::<Vec<_>>(),
+            vec!["$ordinary_missing"]
+        );
+
+        let theme_source = "\
+#!/bin/zsh
+root_prompt=\"$emoji[skull]\"
+vcs_unstaged_glyph=\"%{$emoji[circled_latin_capital_letter_m]$emoji2[emoji_style] %2G%}\"
+print -r -- \"$ordinary_missing\"
+";
+        let theme_diagnostics = test_snippet_at_path(
+            Path::new("/tmp/zsh/ohmyzsh/themes/emotty.zsh-theme"),
+            theme_source,
+            &LinterSettings::for_rule(Rule::UndefinedVariable).with_shell(ShellDialect::Zsh),
+        );
+        assert_eq!(
+            theme_diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(theme_source))
+                .collect::<Vec<_>>(),
+            vec!["$ordinary_missing"]
+        );
+    }
+
+    #[test]
     fn zsh_special_associative_parameter_keys_do_not_report_undefined() {
         let source = "\
 #!/bin/zsh


### PR DESCRIPTION
## Summary
- add declarative zsh framework contracts for oh-my-zsh core, emoji, and emotty runtime state
- extend the zsh special-parameter contracts and powerlevel10k wizard contract for the remaining framework-supplied C006 cases
- refresh the zsh diagnostic corpus baseline to remove the cleared false positives

## Why
These remaining C006 zsh false positives were coming from framework-supplied state that exists at file entry but was not yet modeled in `contracts/`. This tightens the contract boundary around real framework state without treating generic environment inputs as framework-owned.

## Validation
- `cargo test -p shuck-linter ambient_contracts`
- `cargo test -p shuck-linter oh_my_zsh_ -- --nocapture`
- `SHUCK_ZSH_DIAGNOSTIC_CORPUS_ROOT=/Users/ewhauser/working/shuck/.cache/zsh-diagnostic-corpus cargo test -p shuck-cli zsh_diagnostic_corpus_matches_baseline -- --ignored`
