### PR TITLE
perf(linter): index compound-assignment values by occurrence id

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -869,6 +869,13 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &mut fact_store,
             &array_assignment_split_word_ids,
         );
+        let compound_assignment_value_word_flags: Box<[bool]> = word_occurrences
+            .iter()
+            .map(|occurrence| {
+                compound_assignment_value_word_spans
+                    .contains(&word_nodes[occurrence.node_id.index()].key)
+            })
+            .collect();
         let echo_to_sed_substitution_spans = build_echo_to_sed_substitution_spans(
             CommandFacts::new(&commands, &fact_store, &command_fact_indices_by_id),
             &pipelines,
@@ -1000,7 +1007,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             redundant_echo_space_facts: OnceLock::new(),
             suppressed_subscript_reference_spans,
             subscript_later_suppression_reference_spans,
-            compound_assignment_value_word_spans,
+            compound_assignment_value_word_flags,
             word_nodes,
             word_occurrences,
             word_index,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -38,7 +38,7 @@ pub struct LinterFacts<'a> {
     redundant_echo_space_facts: OnceLock<Vec<RedundantEchoSpaceFact>>,
     suppressed_subscript_reference_spans: FxHashSet<FactSpan>,
     subscript_later_suppression_reference_spans: FxHashSet<FactSpan>,
-    compound_assignment_value_word_spans: FxHashSet<FactSpan>,
+    compound_assignment_value_word_flags: Box<[bool]>,
     word_nodes: Vec<WordNode<'a>>,
     word_occurrences: Vec<WordOccurrence>,
     word_index: FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
@@ -592,8 +592,10 @@ impl<'a> LinterFacts<'a> {
     }
 
     pub fn is_compound_assignment_value_word(&self, fact: WordOccurrenceRef<'_, '_>) -> bool {
-        self.compound_assignment_value_word_spans
-            .contains(&fact.key())
+        self.compound_assignment_value_word_flags
+            .get(fact.occurrence_id().index())
+            .copied()
+            .unwrap_or(false)
     }
 
     pub fn expansion_word_facts(&self, context: ExpansionContext) -> WordOccurrenceIter<'_, 'a> {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -153,6 +153,10 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         self.node().key
     }
 
+    pub(in crate::facts) fn occurrence_id(self) -> WordOccurrenceId {
+        self.id
+    }
+
     pub fn span(self) -> Span {
         self.word().span
     }


### PR DESCRIPTION
## Summary

- `LinterFacts::is_compound_assignment_value_word` was hashing a `FactSpan` and probing an `FxHashSet` on every call. The two rules that use it (`glob_assigned_to_variable`, `quoted_array_slice`) filter their entire word-fact iterators through the predicate, plus an internal call from `facts/arrays.rs`. On a profile of `romkatv/powerlevel10k` `internal/p10k.zsh`, this single helper sat at 1.2 % of total samples (100 % self time) — see the drilldown below.
- Project the build-time span set into a `Box<[bool]>` indexed by `WordOccurrenceId` once at the end of fact building, so each per-rule call collapses to a direct byte load. The build-time `FxHashSet<FactSpan>` is retained as the natural mid-build accumulator across the two insert sites in `words/occurrence.rs`; only the lookup shape changes.
- Add a `pub(in crate::facts) fn occurrence_id` accessor on `WordOccurrenceRef` so `model.rs` can index the flag vec.

## Profile (12 iterations, warm, p10k `internal/p10k.zsh`)

| Metric | Before | After |
|---|---:|---:|
| Avg / iter | 106.86 ms | **98.55 ms** (−7.8 %) |
| Diagnostics | 403 | 403 |
| `is_compound_assignment_value_word` rank | #10 (1.2 %) | not in top 15 |

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo test -p shuck-linter --lib` (3657 tests)
- [x] Targeted: `cargo test -p shuck-linter -- glob` / `quoted` / `compound_assignment` all green
- [ ] CI green