### PR TITLE
perf(linter): skip array-like dataflow walk for uniform names

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -45,18 +45,21 @@ fn estimate_fact_build_capacity(semantic: &SemanticModel) -> FactBuildCapacity {
     }
 }
 
+fn binding_has_array_like_shape(binding: &Binding) -> bool {
+    binding
+        .attributes
+        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+        || matches!(
+            binding.kind,
+            BindingKind::ArrayAssignment | BindingKind::MapfileTarget
+        )
+}
+
 #[cfg_attr(shuck_profiling, inline(never))]
 fn compute_array_like_capable_names(semantic: &SemanticModel) -> FxHashSet<Name> {
     let mut names = FxHashSet::default();
     for binding in semantic.bindings() {
-        if binding
-            .attributes
-            .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
-            || matches!(
-                binding.kind,
-                BindingKind::ArrayAssignment | BindingKind::MapfileTarget
-            )
-        {
+        if binding_has_array_like_shape(binding) {
             names.insert(binding.name.clone());
         }
     }
@@ -67,13 +70,7 @@ fn compute_array_like_capable_names(semantic: &SemanticModel) -> FxHashSet<Name>
 fn compute_single_array_like_bindings(semantic: &SemanticModel) -> FxHashMap<Name, BindingId> {
     let mut bindings_by_name = FxHashMap::default();
     for binding in semantic.bindings() {
-        let array_like = binding
-            .attributes
-            .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
-            || matches!(
-                binding.kind,
-                BindingKind::ArrayAssignment | BindingKind::MapfileTarget
-            );
+        let array_like = binding_has_array_like_shape(binding);
         match bindings_by_name.entry(binding.name.clone()) {
             std::collections::hash_map::Entry::Vacant(entry) => {
                 entry.insert(array_like.then_some(binding.id));
@@ -87,6 +84,31 @@ fn compute_single_array_like_bindings(semantic: &SemanticModel) -> FxHashMap<Nam
     bindings_by_name
         .into_iter()
         .filter_map(|(name, binding_id)| binding_id.map(|binding_id| (name, binding_id)))
+        .collect()
+}
+
+/// Names where *every* binding is array-like. For these names, the slow dataflow walk in
+/// `visible_name_is_array_like` is unnecessary: any lexically visible binding will satisfy the
+/// predicate.
+#[cfg_attr(shuck_profiling, inline(never))]
+fn compute_uniformly_array_like_names(semantic: &SemanticModel) -> FxHashSet<Name> {
+    let mut name_state: FxHashMap<Name, bool> = FxHashMap::default();
+    for binding in semantic.bindings() {
+        let array_like = binding_has_array_like_shape(binding);
+        match name_state.entry(binding.name.clone()) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(array_like);
+            }
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if !array_like {
+                    *entry.get_mut() = false;
+                }
+            }
+        }
+    }
+    name_state
+        .into_iter()
+        .filter_map(|(name, uniform)| uniform.then_some(name))
         .collect()
 }
 
@@ -158,6 +180,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let mut assoc_binding_visibility_memo = FxHashMap::default();
         let array_like_capable_names = compute_array_like_capable_names(self.semantic);
         let single_array_like_bindings = compute_single_array_like_bindings(self.semantic);
+        let uniformly_array_like_names = compute_uniformly_array_like_names(self.semantic);
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut case_pattern_expansions = Vec::new();
         let mut pattern_literal_spans = Vec::new();
@@ -290,6 +313,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                         assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
                         array_like_capable_names: &array_like_capable_names,
                         single_array_like_bindings: &single_array_like_bindings,
+                        uniformly_array_like_names: &uniformly_array_like_names,
                         semantic_analysis: self.semantic_analysis,
                         case_pattern_expansions: &mut case_pattern_expansions,
                         pattern_literal_spans: &mut pattern_literal_spans,

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1060,6 +1060,7 @@ struct ZshArrayFanoutContext<'a, 'flow> {
 struct ZshArrayFanoutLookups<'a> {
     array_like_capable_names: &'a FxHashSet<Name>,
     single_array_like_bindings: &'a FxHashMap<Name, BindingId>,
+    uniformly_array_like_names: &'a FxHashSet<Name>,
 }
 
 fn apply_zsh_array_fanout(
@@ -1211,6 +1212,11 @@ fn visible_name_is_array_like(
     {
         return true;
     }
+    if lookups.uniformly_array_like_names.contains(name)
+        && semantic.visible_binding(name, span).is_some()
+    {
+        return true;
+    }
     let synthetic_use_block = if semantic_analysis.reference_id_for_name_at(name, span).is_none() {
         Some(semantic_analysis.flow_entry_block_for_binding_scopes(&[scope], span.start.offset))
     } else {
@@ -1287,6 +1293,7 @@ pub(super) struct WordFactOutputs<'out, 'a> {
         &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     pub(super) array_like_capable_names: &'out FxHashSet<Name>,
     pub(super) single_array_like_bindings: &'out FxHashMap<Name, BindingId>,
+    pub(super) uniformly_array_like_names: &'out FxHashSet<Name>,
     pub(super) semantic_analysis: &'out SemanticAnalysis<'a>,
     pub(super) case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
     pub(super) pattern_literal_spans: &'out mut Vec<Span>,
@@ -1612,6 +1619,7 @@ pub(super) struct WordFactCollector<'out, 'a, 'norm> {
     assoc_binding_visibility_memo: &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     array_like_capable_names: &'out FxHashSet<Name>,
     single_array_like_bindings: &'out FxHashMap<Name, BindingId>,
+    uniformly_array_like_names: &'out FxHashSet<Name>,
     semantic_analysis: &'out SemanticAnalysis<'a>,
     value_flow: SemanticValueFlow<'out, 'a>,
     seen: &'out mut FxHashSet<WordOccurrenceSeenKey>,
@@ -1707,6 +1715,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             assoc_binding_visibility_memo: outputs.assoc_binding_visibility_memo,
             array_like_capable_names: outputs.array_like_capable_names,
             single_array_like_bindings: outputs.single_array_like_bindings,
+            uniformly_array_like_names: outputs.uniformly_array_like_names,
             semantic_analysis: outputs.semantic_analysis,
             value_flow,
             seen: {
@@ -2721,6 +2730,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 lookups: ZshArrayFanoutLookups {
                     array_like_capable_names: self.array_like_capable_names,
                     single_array_like_bindings: self.single_array_like_bindings,
+                    uniformly_array_like_names: self.uniformly_array_like_names,
                 },
             },
             &mut analysis,


### PR DESCRIPTION
## Summary

- Adds `compute_uniformly_array_like_names` — names where *every* binding has array-like shape — and consults it as a third fast path in `visible_name_is_array_like` before falling through to the CFG dataflow walk.
- For names whose every binding is array-like, any lexically visible binding already satisfies the predicate, so `value_flow.reaching_value_bindings_for_name_with_synthetic_use_block(...)` (and the `reaching_bindings_for_name` walk underneath it) is unnecessary.
- Refactors the existing predicate inlined in `compute_array_like_capable_names` and `compute_single_array_like_bindings` into a shared `binding_has_array_like_shape` helper to avoid drift between the three checks.

## Profile (p10k, `romkatv__powerlevel10k__internal__p10k.zsh`, 12 iters samply)

- `visible_name_is_array_like` drops from 2.3% (56 samples) to 2.1% (51 samples) of total.
- Drilldown into `shuck_semantic::analysis::reaching_bindings_for_name` returns 0 samples after the change — the slow path is no longer hit on this fixture. The remaining 51 samples are split between `Once::call_once_force` (one-time lazy init) and the function body itself.
- Diagnostics unchanged: 403 in both runs.

The wall-clock movement on p10k itself is small (most p10k references are caught by the existing `single_array_like_bindings` fast path), but the structural improvement broadens worst-case coverage to any name with multiple bindings where each is array-like.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo test -p shuck-linter --lib` (3657 passed)
- [x] Re-profiled p10k and confirmed `reaching_bindings_for_name` no longer appears under `visible_name_is_array_like`