### PR TITLE
perf(semantic): skip unnecessary helper summary work

### DIFF
--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -21,7 +21,7 @@ use crate::binding::{
     AssignmentValueOrigin, Binding, BindingAttributes, BindingKind, BindingOrigin,
     BuiltinBindingTargetKind, LoopValueOrigin,
 };
-use crate::call_graph::{CallGraph, CallSite, build_call_graph};
+use crate::call_graph::CallSite;
 use crate::cfg::{
     CommandId, CommandKind, FlowContext, IsolatedRegion, RecordedCaseArm, RecordedCommand,
     RecordedCommandInfo, RecordedCommandKind, RecordedCommandRange, RecordedElifBranch,
@@ -60,7 +60,6 @@ pub(crate) struct BuildOutput {
     pub(crate) unresolved: Vec<ReferenceId>,
     pub(crate) functions: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     pub(crate) call_sites: FxHashMap<Name, SmallVec<[CallSite; 2]>>,
-    pub(crate) call_graph: CallGraph,
     pub(crate) source_refs: Vec<SourceRef>,
     pub(crate) source_path_templates_by_binding: FxHashMap<BindingId, SourcePathTemplate>,
     pub(crate) runtime: RuntimePrelude,
@@ -277,12 +276,6 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         builder.mark_scope_completed(ScopeId(0));
         builder.drain_deferred_functions();
 
-        let call_graph = build_call_graph(
-            &builder.scopes,
-            &builder.bindings,
-            &builder.functions,
-            &builder.call_sites,
-        );
         let heuristic_unused_assignments = builder.compute_heuristic_unused_assignments();
 
         BuildOutput {
@@ -301,7 +294,6 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             unresolved: builder.unresolved,
             functions: builder.functions,
             call_sites: builder.call_sites,
-            call_graph,
             source_refs: builder.source_refs,
             source_path_templates_by_binding: builder.source_path_templates_by_binding,
             runtime: builder.runtime,

--- a/crates/shuck-semantic/src/dataflow/mod.rs
+++ b/crates/shuck-semantic/src/dataflow/mod.rs
@@ -151,12 +151,13 @@ pub(crate) use dense::materialize_reaching_definitions;
 use dense::*;
 pub(crate) use exact::ExactVariableDataflow;
 use scope_reads::{
-    ScopeReadPlan, binding_has_future_reads_before_local_shadow, binding_initializes_name,
-    build_scope_read_plans, compute_compatibility_read_sets, compute_transitive_read_sets,
-    is_function_escape_candidate, next_shadowing_local_declarations, reachable_blocks_dense,
+    ScopeReadPlan, binding_has_future_reads_before_local_shadow, build_scope_read_plans,
+    compute_compatibility_read_sets, compute_transitive_read_sets, is_function_escape_candidate,
+    next_shadowing_local_declarations, reachable_blocks_dense,
 };
 pub(crate) use scope_reads::{
-    summarize_scope_provided_bindings, summarize_scope_provided_functions,
+    binding_initializes_name, function_binding_certainty, summarize_scope_provided_bindings,
+    summarize_scope_provided_functions,
 };
 use uninitialized::analyze_uninitialized_references_exact;
 use unused::analyze_unused_assignments_exact;

--- a/crates/shuck-semantic/src/dataflow/scope_reads.rs
+++ b/crates/shuck-semantic/src/dataflow/scope_reads.rs
@@ -626,7 +626,7 @@ fn future_reads_contain_after_without_shadow(
     })
 }
 
-pub(super) fn binding_initializes_name(binding: &Binding) -> Option<ContractCertainty> {
+pub(crate) fn binding_initializes_name(binding: &Binding) -> Option<ContractCertainty> {
     match binding.kind {
         BindingKind::Declaration(_) | BindingKind::Nameref => binding
             .attributes
@@ -662,7 +662,7 @@ pub(super) fn binding_initializes_name(binding: &Binding) -> Option<ContractCert
     }
 }
 
-fn function_binding_certainty(binding: &Binding) -> Option<ContractCertainty> {
+pub(crate) fn function_binding_certainty(binding: &Binding) -> Option<ContractCertainty> {
     match binding.kind {
         BindingKind::FunctionDefinition => Some(ContractCertainty::Definite),
         BindingKind::Imported

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -757,7 +757,7 @@ pub struct SemanticModel {
     unresolved: Vec<ReferenceId>,
     functions: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     call_sites: FxHashMap<Name, SmallVec<[CallSite; 2]>>,
-    call_graph: CallGraph,
+    call_graph: OnceLock<CallGraph>,
     source_refs: Vec<SourceRef>,
     source_path_templates_by_binding: FxHashMap<BindingId, source_closure::SourcePathTemplate>,
     runtime: RuntimePrelude,
@@ -776,7 +776,7 @@ pub struct SemanticModel {
     import_origins_by_binding: FxHashMap<BindingId, Vec<PathBuf>>,
     imported_dependency_paths: Vec<PathBuf>,
     heuristic_unused_assignments: Vec<BindingId>,
-    zsh_option_analysis: Option<ZshOptionAnalysis>,
+    zsh_option_analysis: OnceLock<Option<ZshOptionAnalysis>>,
     zsh_runtime_ambiguous_entry_mask: OnceLock<zsh_options::ZshOptionMask>,
     zsh_runtime_by_function: OnceLock<FxHashMap<ScopeId, OnceLock<Option<ZshOptionAnalysis>>>>,
     zsh_runtime_function_summaries: OnceLock<zsh_options::SharedFunctionSummaryCache>,
@@ -852,20 +852,6 @@ impl SemanticModel {
             &built.indirect_expansion_refs,
             &built.indirect_target_hints,
         );
-        let zsh_dynamic_calls = zsh_options::DynamicCallAnalysisContext {
-            references: &built.references,
-            resolved: &built.resolved,
-            indirect_target_hints: &built.indirect_target_hints,
-            indirect_targets_by_binding: &indirect_targets_by_binding,
-            command_references: &built.command_references,
-        };
-        let zsh_option_analysis = zsh_options::analyze(
-            &built.shell_profile,
-            &built.scopes,
-            &built.bindings,
-            &built.recorded_program,
-            zsh_dynamic_calls,
-        );
         let scope_lookup = ScopeLookup::new(&built.scopes);
         Self {
             shell_profile: built.shell_profile,
@@ -884,7 +870,7 @@ impl SemanticModel {
             unresolved: built.unresolved,
             functions: built.functions,
             call_sites: built.call_sites,
-            call_graph: built.call_graph,
+            call_graph: OnceLock::new(),
             source_refs: built.source_refs,
             source_path_templates_by_binding: built.source_path_templates_by_binding,
             runtime: built.runtime,
@@ -903,7 +889,7 @@ impl SemanticModel {
             import_origins_by_binding: FxHashMap::default(),
             imported_dependency_paths: Vec::new(),
             heuristic_unused_assignments: built.heuristic_unused_assignments,
-            zsh_option_analysis,
+            zsh_option_analysis: OnceLock::new(),
             zsh_runtime_ambiguous_entry_mask: OnceLock::new(),
             zsh_runtime_by_function: OnceLock::new(),
             zsh_runtime_function_summaries: OnceLock::new(),
@@ -933,15 +919,13 @@ impl SemanticModel {
 
     /// Returns the zsh option state visible at `offset`, when the model tracks zsh options.
     pub fn zsh_options_at(&self, offset: usize) -> Option<&ZshOptionState> {
-        self.zsh_option_analysis
-            .as_ref()
+        self.zsh_option_analysis()
             .and_then(|analysis| analysis.options_at(&self.scopes, offset))
     }
 
     /// Returns whether `offset` is in a definite zsh `emulate sh` region.
     pub fn zsh_sh_emulation_at(&self, offset: usize) -> Option<bool> {
-        self.zsh_option_analysis
-            .as_ref()
+        self.zsh_option_analysis()
             .and_then(|analysis| analysis.sh_emulation_at(&self.scopes, offset))
     }
 
@@ -980,6 +964,29 @@ impl SemanticModel {
             .and_then(|analysis| analysis.options_at(&self.scopes, offset));
 
         Some(ambient.map_or(ordinary, |options| ordinary.merge(options)))
+    }
+
+    fn zsh_option_analysis(&self) -> Option<&ZshOptionAnalysis> {
+        self.zsh_option_analysis
+            .get_or_init(|| self.build_zsh_option_analysis())
+            .as_ref()
+    }
+
+    fn build_zsh_option_analysis(&self) -> Option<ZshOptionAnalysis> {
+        let zsh_dynamic_calls = zsh_options::DynamicCallAnalysisContext {
+            references: &self.references,
+            resolved: &self.resolved,
+            indirect_target_hints: &self.indirect_target_hints,
+            indirect_targets_by_binding: &self.indirect_targets_by_binding,
+            command_references: &self.command_references,
+        };
+        zsh_options::analyze(
+            &self.shell_profile,
+            &self.scopes,
+            &self.bindings,
+            &self.recorded_program,
+            zsh_dynamic_calls,
+        )
     }
 
     fn zsh_runtime_by_function(&self) -> &FxHashMap<ScopeId, OnceLock<Option<ZshOptionAnalysis>>> {
@@ -1937,7 +1944,7 @@ impl SemanticModel {
         self.set_entry_bindings(entry_bindings);
         self.invalidate_function_binding_lookup();
         self.resolve_unresolved_references();
-        self.rebuild_call_graph();
+        self.invalidate_semantic_caches();
     }
 
     fn mark_file_entry_consumed_bindings(&mut self) {
@@ -2102,7 +2109,7 @@ impl SemanticModel {
         }
         self.invalidate_function_binding_lookup();
         self.resolve_unresolved_references();
-        self.rebuild_call_graph();
+        self.invalidate_semantic_caches();
     }
 
     fn invalidate_function_binding_lookup(&mut self) {
@@ -2112,13 +2119,11 @@ impl SemanticModel {
         self.function_definition_binding_ids.take();
     }
 
-    fn rebuild_call_graph(&mut self) {
-        self.call_graph = build_call_graph(
-            &self.scopes,
-            &self.bindings,
-            &self.functions,
-            &self.call_sites,
-        );
+    fn invalidate_semantic_caches(&mut self) {
+        self.call_graph.take();
+        self.zsh_option_analysis.take();
+        self.zsh_runtime_by_function.take();
+        self.zsh_runtime_function_summaries.take();
     }
 
     fn resolve_unresolved_references(&mut self) {
@@ -2171,7 +2176,14 @@ impl SemanticModel {
 
     /// Returns the current call-graph summary for the model.
     pub fn call_graph(&self) -> &CallGraph {
-        &self.call_graph
+        self.call_graph.get_or_init(|| {
+            build_call_graph(
+                &self.scopes,
+                &self.bindings,
+                &self.functions,
+                &self.call_sites,
+            )
+        })
     }
 
     /// Returns declaration commands recorded in the file.

--- a/crates/shuck-semantic/src/source_closure/mod.rs
+++ b/crates/shuck-semantic/src/source_closure/mod.rs
@@ -35,12 +35,13 @@ use plugin_managers::{
 };
 
 use crate::{
-    Binding, BindingKind, ContractCertainty, FileContract, FileEntryContractCollector,
-    FileEntryContractCollectorFactory, FunctionContract, FunctionScopeKind, PluginFramework,
-    PluginRequest, PluginRequestKind, PluginResolver, ProvidedBinding, ProvidedBindingKind,
-    ScopeId, ScopeKind, SemanticModel, SourcePathResolver, SourceRefDiagnosticClass, SourceRefKind,
-    SourceRefResolution, SpanKey, SyntheticRead, build_semantic_model_base,
-    infer_explicit_parse_dialect_from_source,
+    Binding, BindingAttributes, BindingKind, ContractCertainty, FileContract,
+    FileEntryContractCollector, FileEntryContractCollectorFactory, FunctionContract,
+    FunctionScopeKind, PluginFramework, PluginRequest, PluginRequestKind, PluginResolver,
+    ProvidedBinding, ProvidedBindingKind, ScopeId, ScopeKind, SemanticModel, SourcePathResolver,
+    SourceRefDiagnosticClass, SourceRefKind, SourceRefResolution, SpanKey, SyntheticRead,
+    build_semantic_model_base, dataflow::binding_initializes_name,
+    dataflow::function_binding_certainty, infer_explicit_parse_dialect_from_source,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -1767,34 +1768,51 @@ fn summarize_helper_uncached(
     );
     semantic.apply_source_contracts(collected.clone());
     let analysis = semantic.analysis();
+    let include_root_provided_bindings =
+        scope_has_provided_binding_candidates(&semantic, ScopeId(0));
+    let include_root_provided_functions =
+        scope_has_provided_function_candidates(&semantic, ScopeId(0));
 
-    let mut contract =
-        summarize_scope_body_contract(&semantic, &analysis, ScopeId(0), &collected.synthetic_reads);
-    let provided_functions = analysis.summarize_scope_provided_functions(ScopeId(0));
+    let mut contract = summarize_scope_body_contract(
+        &semantic,
+        &analysis,
+        ScopeId(0),
+        &collected.synthetic_reads,
+        include_root_provided_bindings,
+    );
+    let provided_functions = if include_root_provided_functions {
+        analysis.summarize_scope_provided_functions(ScopeId(0))
+    } else {
+        Vec::new()
+    };
     for binding in &provided_functions {
         contract.add_provided_binding(binding.clone());
     }
-    for function in build_scope_function_contracts(
-        path,
-        &semantic,
-        &analysis,
-        ScopeId(0),
-        &collected.synthetic_reads,
-        &collected.imported_functions,
-        &provided_functions,
-    ) {
-        contract.add_provided_function(function);
+    if !provided_functions.is_empty() {
+        for function in build_scope_function_contracts(
+            path,
+            &semantic,
+            &analysis,
+            ScopeId(0),
+            &collected.synthetic_reads,
+            &collected.imported_functions,
+            &provided_functions,
+        ) {
+            contract.add_provided_function(function);
+        }
     }
-    let facts = collect_ast_facts(&semantic);
-    for name in deferred_zsh_entrypoint_required_reads(
-        &semantic,
-        &analysis,
-        &facts,
-        source,
-        ScopeId(0),
-        &collected.synthetic_reads,
-    ) {
-        contract.add_required_read(name);
+    if semantic.shell_profile().dialect == ParseShellDialect::Zsh {
+        let facts = collect_ast_facts(&semantic);
+        for name in deferred_zsh_entrypoint_required_reads(
+            &semantic,
+            &analysis,
+            &facts,
+            source,
+            ScopeId(0),
+            &collected.synthetic_reads,
+        ) {
+            contract.add_required_read(name);
+        }
     }
     contract
 }
@@ -1810,6 +1828,7 @@ fn summarize_scope_body_contract(
     analysis: &crate::SemanticAnalysis<'_>,
     scope: ScopeId,
     synthetic_reads: &[SyntheticRead],
+    include_provided_bindings: bool,
 ) -> FileContract {
     let scope_members = scope_members_excluding_functions(semantic.scopes(), scope);
     let mut contract = FileContract::default();
@@ -1824,10 +1843,27 @@ fn summarize_scope_body_contract(
             contract.add_required_read(read.name.clone());
         }
     }
-    for binding in analysis.summarize_scope_provided_bindings(scope) {
-        contract.add_provided_binding(binding);
+    if include_provided_bindings {
+        for binding in analysis.summarize_scope_provided_bindings(scope) {
+            contract.add_provided_binding(binding);
+        }
     }
     contract
+}
+
+fn scope_has_provided_binding_candidates(semantic: &SemanticModel, scope: ScopeId) -> bool {
+    semantic.bindings().iter().any(|binding| {
+        binding.scope == scope
+            && !binding.attributes.contains(BindingAttributes::LOCAL)
+            && binding_initializes_name(binding).is_some()
+    })
+}
+
+fn scope_has_provided_function_candidates(semantic: &SemanticModel, scope: ScopeId) -> bool {
+    semantic
+        .bindings()
+        .iter()
+        .any(|binding| binding.scope == scope && function_binding_certainty(binding).is_some())
 }
 
 fn build_scope_function_contracts(
@@ -1861,7 +1897,13 @@ fn build_scope_function_contracts(
         let body_contract = local_contracts_by_scope
             .entry(function_scope)
             .or_insert_with(|| {
-                summarize_scope_body_contract(semantic, analysis, function_scope, synthetic_reads)
+                summarize_scope_body_contract(
+                    semantic,
+                    analysis,
+                    function_scope,
+                    synthetic_reads,
+                    scope_has_provided_binding_candidates(semantic, function_scope),
+                )
             })
             .clone();
         for name in names {
@@ -2097,6 +2139,78 @@ noglob source \"$3\"
 
         let second = summarize_helper(&canonical_helper, &mut summaries, &mut active, &context);
         assert_eq!(second, first);
+    }
+
+    #[test]
+    fn summarize_helper_without_export_candidates_keeps_required_reads_only() {
+        let temp = tempdir().unwrap();
+        let helper = temp.path().join("helper.sh");
+        std::fs::write(&helper, "printf '%s\\n' \"$flag\"\n").unwrap();
+        let canonical_helper = std::fs::canonicalize(&helper).unwrap();
+
+        let context = SourceClosureLookupContext {
+            source_path_resolver: None,
+            plugin_resolver: None,
+            file_entry_contract_collector_factory: None,
+            analyzed_paths: None,
+            shell_profile: ShellProfile::native(ParseShellDialect::Bash),
+            resolved_helper_paths: RefCell::new(FxHashMap::default()),
+            dependency_paths: RefCell::new(FxHashSet::default()),
+        };
+        let mut summaries = FxHashMap::default();
+        let mut active = FxHashSet::default();
+
+        let summary = summarize_helper(&canonical_helper, &mut summaries, &mut active, &context);
+
+        assert_eq!(summary.required_reads, vec![Name::from("flag")]);
+        assert!(summary.provided_bindings.is_empty());
+        assert!(summary.provided_functions.is_empty());
+    }
+
+    #[test]
+    fn summarize_helper_keeps_reexported_sourced_functions() {
+        let temp = tempdir().unwrap();
+        let outer = temp.path().join("outer.sh");
+        let inner = temp.path().join("inner.sh");
+        std::fs::write(&outer, ". ./inner.sh\n").unwrap();
+        std::fs::write(
+            &inner,
+            "\
+set_flag() {
+  flag=1
+}
+",
+        )
+        .unwrap();
+        let canonical_outer = std::fs::canonicalize(&outer).unwrap();
+
+        let context = SourceClosureLookupContext {
+            source_path_resolver: None,
+            plugin_resolver: None,
+            file_entry_contract_collector_factory: None,
+            analyzed_paths: None,
+            shell_profile: ShellProfile::native(ParseShellDialect::Bash),
+            resolved_helper_paths: RefCell::new(FxHashMap::default()),
+            dependency_paths: RefCell::new(FxHashSet::default()),
+        };
+        let mut summaries = FxHashMap::default();
+        let mut active = FxHashSet::default();
+
+        let summary = summarize_helper(&canonical_outer, &mut summaries, &mut active, &context);
+
+        assert!(summary.provided_bindings.iter().any(|binding| {
+            binding.name.as_str() == "set_flag"
+                && binding.kind == ProvidedBindingKind::Function
+                && binding.certainty == ContractCertainty::Definite
+        }));
+        assert!(summary.provided_functions.iter().any(|function| {
+            function.name.as_str() == "set_flag"
+                && function.provided_bindings.iter().any(|binding| {
+                    binding.name.as_str() == "flag"
+                        && binding.kind == ProvidedBindingKind::Variable
+                        && binding.certainty == ContractCertainty::Definite
+                })
+        }));
     }
 
     #[cfg(unix)]

--- a/crates/shuck-semantic/src/source_closure/plugin_managers/generic_zsh_runtime.rs
+++ b/crates/shuck-semantic/src/source_closure/plugin_managers/generic_zsh_runtime.rs
@@ -268,6 +268,7 @@ impl DeferredFunctionReadVisitor<'_> {
             self.analysis,
             scope,
             self.synthetic_reads,
+            false,
         );
         self.reads.extend(contract.required_reads);
 

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -5615,6 +5615,21 @@ fn unused_assignment_options_preserve_heuristic_fast_path_without_indirect_targe
 }
 
 #[test]
+fn call_graph_and_zsh_option_analysis_are_lazy_until_queried() {
+    let model = model_with_profile("echo hi\n", ShellProfile::native(ShellDialect::Zsh));
+
+    assert!(model.call_graph.get().is_none());
+    assert!(model.zsh_option_analysis.get().is_none());
+
+    model.call_graph();
+    assert!(model.call_graph.get().is_some());
+    assert!(model.zsh_option_analysis.get().is_none());
+
+    model.zsh_options_at(0);
+    assert!(model.zsh_option_analysis.get().is_some());
+}
+
+#[test]
 fn unused_assignment_options_can_report_unreachable_assignments() {
     let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- make semantic call graph and zsh option analysis lazy instead of building them eagerly
- add a safe source-closure helper fast path that skips CFG/dataflow-backed export summaries when a helper has no export candidates
- avoid collecting provided bindings when deferred zsh callback modeling only needs required reads, and add regressions for no-export helpers and sourced re-exports

## Why
Helper/source-closure files were still paying for semantic products that were not always used. This keeps the current contract behavior while avoiding unnecessary summary work in common helper paths.

## Validation
- `cargo fmt`
- `cargo test -p shuck-semantic`
- compared `large_corpus_profile` on `v1s1t0r1sh3r3__airgeddon__airgeddon.sh` before vs after this patch
  - with source closure: `1.425 s ± 0.031 s` -> `1.361 s ± 0.018 s`
  - without source closure: `925.5 ms ± 15.0 ms` -> `887.0 ms ± 7.2 ms`