### PR TITLE
perf(linter): cache enclosing function scope on CommandFact

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -404,12 +404,14 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                     .conditional_expression_visits(command_span(visit.command));
                 let conditional =
                     build_conditional_fact(conditional_expression_visits, self.source);
+                let enclosing_function_scope = self.semantic.enclosing_function_scope(scope);
                 let command_fact = CommandFact {
                     id,
                     key,
                     visit,
                     nested_word_command,
                     scope,
+                    enclosing_function_scope,
                     normalized,
                     shell_behavior: command_shell_behavior,
                     redirect_facts: redirect_fact_range,
@@ -697,7 +699,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         );
         let completion_registered_function_command_flags =
             build_completion_registered_function_command_flags(
-                semantic_analysis,
                 &commands,
                 &completion_registered_function_scopes,
             );

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -5,6 +5,7 @@ pub struct CommandFact<'a> {
     visit: CommandVisit<'a>,
     nested_word_command: bool,
     scope: ScopeId,
+    enclosing_function_scope: Option<ScopeId>,
     normalized: NormalizedCommand<'a>,
     shell_behavior: ShellBehaviorAt<'a>,
     redirect_facts: IdRange<RedirectFact<'a>>,
@@ -54,6 +55,10 @@ impl<'a> CommandFact<'a> {
 
     pub fn scope(&self) -> ScopeId {
         self.scope
+    }
+
+    pub fn enclosing_function_scope(&self) -> Option<ScopeId> {
+        self.enclosing_function_scope
     }
 
     pub fn stmt(&self) -> &'a Stmt {
@@ -223,6 +228,10 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
 
     pub fn scope(self) -> ScopeId {
         self.fact.scope()
+    }
+
+    pub fn enclosing_function_scope(self) -> Option<ScopeId> {
+        self.fact.enclosing_function_scope()
     }
 
     pub fn stmt(self) -> &'a Stmt {

--- a/crates/shuck-linter/src/facts/functions.rs
+++ b/crates/shuck-linter/src/facts/functions.rs
@@ -221,14 +221,13 @@ fn build_function_parameter_fallback_spans(
 }
 
 fn build_completion_registered_function_command_flags(
-    semantic_analysis: &SemanticAnalysis<'_>,
     commands: &[CommandFact<'_>],
     registered_scopes: &FxHashSet<ScopeId>,
 ) -> Vec<bool> {
     let mut flags = vec![false; function_command_slot_count(commands)];
     for command in commands {
-        flags[command.id().index()] = semantic_analysis
-            .enclosing_function_scope_at(command.span().start.offset)
+        flags[command.id().index()] = command
+            .enclosing_function_scope()
             .is_some_and(|scope| registered_scopes.contains(&scope));
     }
     flags
@@ -400,8 +399,8 @@ fn extend_completion_registered_function_scopes_through_helpers(
                     });
             let referenced_by_completion_arguments = commands.iter().any(|command| {
                 command.normalized().effective_or_literal_name() == Some("_arguments")
-                    && semantic_analysis
-                        .enclosing_function_scope_at(command.span().start.offset)
+                    && command
+                        .enclosing_function_scope()
                         .is_some_and(|caller_scope| scopes.contains(&caller_scope))
                     && command.body_args().iter().any(|word| {
                         static_word_text(word, source).is_some_and(|text| {


### PR DESCRIPTION
## Summary
- Two hot sites in `facts/functions.rs` (`build_completion_registered_function_command_flags`, `extend_completion_registered_function_scopes_through_helpers`) called `SemanticAnalysis::enclosing_function_scope_at(command.span().start.offset)` on every command, the latter inside the completion-registered-function fixed-point loop. That expands to `enclosing_function_scope(scope_at(offset))`, but `CommandFact` already caches the inner scope, so the `scope_at` lookup was redundant.
- Add `enclosing_function_scope: Option<ScopeId>` to `CommandFact`, populate it once at construction via `semantic.enclosing_function_scope(scope)`, and replace the two sites with the cached field. The `_arguments` site is the hottest because it sits inside a fixed-point loop over `commands × candidate_bindings`.
- Drop the now-unused `SemanticAnalysis` parameter from `build_completion_registered_function_command_flags`.

## Performance
Profiled `romkatv__powerlevel10k__internal__p10k.zsh`, 12 iterations:

- avg `99.8ms` → `97.8ms` (~2%)
- diagnostics: 403, unchanged

`SemanticAnalysis::enclosing_function_scope_at` is gone from the top fact sub-frames; residual `SemanticModel::scope_at` (0.9%) now sits in sites without a `CommandFact` (declarations, references, fragment offsets, later-use spans, function-body interior).

## Test plan
- [x] `cargo build -p shuck-linter`
- [x] `cargo test -p shuck-linter --lib` (3657 passed)
- [x] `cargo fmt --check`
- [x] Re-profile with `scripts/profiling/profile_large_corpus.sh romkatv__powerlevel10k__internal__p10k.zsh .cache/profiles 2000 1 12`