### PR TITLE
perf(linter): skip non-$ bytes in parameter expansion edge scan

### DIFF
--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -77,14 +77,19 @@ fn build_plain_parameter_expansion_edge_offsets(
     candidate_offsets: &FxHashSet<usize>,
 ) -> FxHashSet<usize> {
     let mut offsets = FxHashSet::default();
+    let bytes = source.as_bytes();
     let mut index = 0usize;
 
-    while index < source.len() {
-        if source[index..].starts_with("${")
-            && !has_odd_backslash_run_before(source, index)
-            && let Some(end_offset) = find_runtime_parameter_closing_brace(source, index)
+    while index + 1 < bytes.len() {
+        let Some(rel) = bytes[index..].iter().position(|&b| b == b'$') else {
+            break;
+        };
+        let pos = index + rel;
+        if bytes.get(pos + 1) == Some(&b'{')
+            && !has_odd_backslash_run_before(source, pos)
+            && let Some(end_offset) = find_runtime_parameter_closing_brace(source, pos)
         {
-            let open_brace_offset = index + '$'.len_utf8();
+            let open_brace_offset = pos + '$'.len_utf8();
             let close_brace_offset = end_offset.saturating_sub('}'.len_utf8());
             if candidate_offsets.contains(&open_brace_offset) {
                 offsets.insert(open_brace_offset);
@@ -96,19 +101,7 @@ fn build_plain_parameter_expansion_edge_offsets(
             continue;
         }
 
-        let Some(ch) = source[index..].chars().next() else {
-            break;
-        };
-        let ch_len = ch.len_utf8();
-        if ch == '\\' {
-            index += ch_len;
-            if let Some(escaped) = source[index..].chars().next() {
-                index += escaped.len_utf8();
-            }
-            continue;
-        }
-
-        index += ch_len;
+        index = pos + 1;
     }
 
     offsets


### PR DESCRIPTION
## Summary

- Replace the per-char advance in `build_plain_parameter_expansion_edge_offsets` with `iter().position(|&b| b == b'$')` so we jump directly to the next `$` byte instead of inspecting every character of the source.
- Drop the redundant backslash-skip branch — `has_odd_backslash_run_before` already rejects escaped `${...}` openers at each candidate, so the byte-walker doesn't need to skip past `\<ch>` pairs.
- Behavior is unchanged: only positions where source[pos..pos+2] == "${" and a matching `}` is found are recorded, exactly as before.

On `romkatv__powerlevel10k__internal__p10k.zsh` (12 iterations), the function drops out of the drilldown above the 0.1% threshold; previously it was attributed ~0.2% of total samples. The parent `build_literal_brace_spans` move is within run-to-run noise (~1.7% → ~1.6%), but the eliminated whole-source byte walk is a clean per-file win that scales with source length.

## Test plan

- [x] `cargo test -p shuck-linter --lib` (3657 passed)
- [x] `cargo clippy -p shuck-linter --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [ ] CI green