### PR TITLE
perf(indexer): index expansion brace edges to drop two whole-source scans

### DIFF
--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -913,6 +913,11 @@ fn find_command_substitution_end(text: &str, start_offset: usize) -> Option<usiz
             continue;
         }
 
+        if ch == '`' {
+            index = find_backtick_substitution_end(text, index)?;
+            continue;
+        }
+
         match ch {
             '(' => {
                 paren_depth += 1;
@@ -1266,6 +1271,14 @@ mod tests {
                 TextSize::new((outer_start + "${outer".len()) as u32),
             )),
             Some(outer_pair)
+        );
+    }
+
+    #[test]
+    fn skips_backticks_when_indexing_command_substitution_end() {
+        assert_eq!(
+            find_command_substitution_end("$(echo `echo )`)", 0),
+            Some("$(echo `echo )`)".len())
         );
     }
 

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -869,19 +869,19 @@ fn find_command_substitution_end(text: &str, start_offset: usize) -> Option<usiz
         let ch = text[index..].chars().next()?;
         let ch_len = ch.len_utf8();
 
-        if ch == '\\' {
-            index += ch_len;
-            if let Some(escaped) = text[index..].chars().next() {
-                index += escaped.len_utf8();
-            }
-            continue;
-        }
-
         if in_single {
             if ch == '\'' {
                 in_single = false;
             }
             index += ch_len;
+            continue;
+        }
+
+        if ch == '\\' {
+            index += ch_len;
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
             continue;
         }
 
@@ -977,19 +977,19 @@ fn find_parameter_expansion_end(text: &str, start_offset: usize) -> Option<usize
         let ch = text[index..].chars().next()?;
         let ch_len = ch.len_utf8();
 
-        if ch == '\\' {
-            index += ch_len;
-            if let Some(escaped) = text[index..].chars().next() {
-                index += escaped.len_utf8();
-            }
-            continue;
-        }
-
         if in_single {
             if ch == '\'' {
                 in_single = false;
             }
             index += ch_len;
+            continue;
+        }
+
+        if ch == '\\' {
+            index += ch_len;
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
             continue;
         }
 
@@ -1247,6 +1247,14 @@ mod tests {
         assert_eq!(
             find_parameter_expansion_end("\"${x:-`echo }`}\"", 1),
             Some("\"${x:-`echo }`}".len())
+        );
+    }
+
+    #[test]
+    fn keeps_backslashes_literal_inside_single_quotes_when_indexing_parameter_expansion_end() {
+        assert_eq!(
+            find_parameter_expansion_end("${x:-'\\'}", 0),
+            Some("${x:-'\\'}".len())
         );
     }
 

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -922,6 +922,34 @@ fn find_command_substitution_end(text: &str, start_offset: usize) -> Option<usiz
     None
 }
 
+fn find_backtick_substitution_end(text: &str, start_offset: usize) -> Option<usize> {
+    if start_offset >= text.len() || !text[start_offset..].starts_with('`') {
+        return None;
+    }
+
+    let mut index = start_offset + '`'.len_utf8();
+    while index < text.len() {
+        let ch = text[index..].chars().next()?;
+        let ch_len = ch.len_utf8();
+
+        if ch == '\\' {
+            index += ch_len;
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
+            continue;
+        }
+
+        if ch == '`' {
+            return Some(index + ch_len);
+        }
+
+        index += ch_len;
+    }
+
+    None
+}
+
 fn find_parameter_expansion_end(text: &str, start_offset: usize) -> Option<usize> {
     if start_offset >= text.len() || !text[start_offset..].starts_with("${") {
         return None;
@@ -978,6 +1006,11 @@ fn find_parameter_expansion_end(text: &str, start_offset: usize) -> Option<usize
         {
             depth += 1;
             index += "${".len();
+            continue;
+        }
+
+        if ch == '`' {
+            index = find_backtick_substitution_end(text, index)?;
             continue;
         }
 
@@ -1193,6 +1226,14 @@ mod tests {
                 TextSize::new((parameter_start + "${x".len()) as u32),
             )),
             Some(parameter_pair)
+        );
+    }
+
+    #[test]
+    fn skips_backticks_when_indexing_parameter_expansion_end() {
+        assert_eq!(
+            find_parameter_expansion_end("\"${x:-`echo }`}\"", 1),
+            Some("\"${x:-`echo }`}".len())
         );
     }
 

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -475,6 +475,16 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn push_dollar_brace_pair(&mut self, range: TextRange) {
+        let start = usize::from(range.start());
+        let end = usize::from(range.end());
+        if !self
+            ._source
+            .get(start..end)
+            .is_some_and(|text| text.starts_with("${") && text.ends_with('}'))
+        {
+            return;
+        }
+
         let dollar_len = TextSize::new('$'.len_utf8() as u32);
         let close_len = TextSize::new('}'.len_utf8() as u32);
         if range.len() < dollar_len + close_len {
@@ -487,6 +497,36 @@ impl<'a> RegionCollector<'a> {
         }
         self.expansion_brace_edges.push(open);
         self.expansion_brace_edges.push(close);
+    }
+
+    fn push_dollar_brace_pairs_in_source_range(&mut self, range: TextRange) {
+        let source_start = usize::from(range.start());
+        let source_end = usize::from(range.end());
+        let Some(text) = self._source.get(source_start..source_end) else {
+            return;
+        };
+
+        let mut index = 0usize;
+        while index + 1 < text.len() {
+            let Some(relative_dollar) = text[index..].find("${") else {
+                break;
+            };
+            let dollar_offset = index + relative_dollar;
+            if has_odd_backslash_run_before(text, dollar_offset) {
+                index = dollar_offset + '$'.len_utf8();
+                continue;
+            }
+
+            let Some(end_offset) = find_parameter_expansion_end(text, dollar_offset) else {
+                index = dollar_offset + "${".len();
+                continue;
+            };
+            let open = source_start + dollar_offset + '$'.len_utf8();
+            let close = source_start + end_offset - '}'.len_utf8();
+            self.expansion_brace_edges.push(TextSize::new(open as u32));
+            self.expansion_brace_edges.push(TextSize::new(close as u32));
+            index = end_offset;
+        }
     }
 
     fn push_expansion_brace_pair(&mut self, range: TextRange) {
@@ -610,6 +650,7 @@ impl<'a> RegionCollector<'a> {
                 }
                 WordPart::DoubleQuoted { parts, .. } => {
                     push_range(&mut self.double_quoted, range);
+                    self.push_dollar_brace_pairs_in_source_range(range);
                     self.visit_word_parts(parts);
                 }
                 WordPart::CommandSubstitution { body, .. } => {
@@ -633,7 +674,10 @@ impl<'a> RegionCollector<'a> {
                 | WordPart::Transformation { .. } => {
                     self.push_dollar_brace_pair(range);
                 }
-                WordPart::Literal(_) | WordPart::Variable(_) => {}
+                WordPart::Variable(_) => {
+                    self.push_dollar_brace_pair(range);
+                }
+                WordPart::Literal(_) => {}
             }
         }
     }
@@ -652,7 +696,10 @@ impl<'a> RegionCollector<'a> {
                 HeredocBodyPart::Parameter(_) => {
                     self.push_dollar_brace_pair(range);
                 }
-                HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
+                HeredocBodyPart::Variable(_) => {
+                    self.push_dollar_brace_pair(range);
+                }
+                HeredocBodyPart::Literal(_) => {}
             }
         }
     }
@@ -761,6 +808,83 @@ fn containing_range(ranges: &[TextRange], offset: TextSize) -> Option<TextRange>
 fn is_innermost(candidate: TextRange, current: TextRange) -> bool {
     candidate.len() < current.len()
         || (candidate.len() == current.len() && candidate.start() >= current.start())
+}
+
+fn has_odd_backslash_run_before(text: &str, offset: usize) -> bool {
+    let offset = offset.min(text.len());
+    text[..offset]
+        .chars()
+        .rev()
+        .take_while(|&ch| ch == '\\')
+        .count()
+        % 2
+        == 1
+}
+
+fn find_parameter_expansion_end(text: &str, start_offset: usize) -> Option<usize> {
+    if start_offset >= text.len() || !text[start_offset..].starts_with("${") {
+        return None;
+    }
+
+    let mut index = start_offset + "${".len();
+    let mut depth = 1usize;
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while index < text.len() {
+        let ch = text[index..].chars().next()?;
+        let ch_len = ch.len_utf8();
+
+        if ch == '\\' {
+            index += ch_len;
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
+            continue;
+        }
+
+        if in_single {
+            if ch == '\'' {
+                in_single = false;
+            }
+            index += ch_len;
+            continue;
+        }
+
+        if ch == '\'' && !in_double {
+            in_single = true;
+            index += ch_len;
+            continue;
+        }
+
+        if ch == '"' {
+            in_double = !in_double;
+            index += ch_len;
+            continue;
+        }
+
+        if ch == '$'
+            && text[index..].starts_with("${")
+            && !has_odd_backslash_run_before(text, index)
+        {
+            depth += 1;
+            index += "${".len();
+            continue;
+        }
+
+        if ch == '}' {
+            depth -= 1;
+            index += ch_len;
+            if depth == 0 {
+                return Some(index);
+            }
+            continue;
+        }
+
+        index += ch_len;
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -890,6 +1014,23 @@ mod tests {
 
         assert!(regions.is_expansion_brace_edge(open));
         assert!(regions.is_expansion_brace_edge(close));
+    }
+
+    #[test]
+    fn flags_braced_variable_edges_in_multiline_double_quoted_assignment() {
+        let source = "payload=\"{\n  \\\"description\\\": \\\"${MESSAGE}\\\"\n}\"\n";
+        let regions = regions(source);
+        let parameter_start = source.find("${MESSAGE}").unwrap();
+        let parameter_open = TextSize::new((parameter_start + 1) as u32);
+        let parameter_close = TextSize::new((parameter_start + "${MESSAGE}".len() - 1) as u32);
+
+        assert!(regions.is_expansion_brace_edge(parameter_open));
+        assert!(regions.is_expansion_brace_edge(parameter_close));
+
+        let object_open = TextSize::new(source.find("{\n").unwrap() as u32);
+        let object_close = TextSize::new((source.rfind("\n}").unwrap() + 1) as u32);
+        assert!(!regions.is_expansion_brace_edge(object_open));
+        assert!(!regions.is_expansion_brace_edge(object_close));
     }
 
     #[test]

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -905,6 +905,14 @@ fn find_command_substitution_end(text: &str, start_offset: usize) -> Option<usiz
             continue;
         }
 
+        if ch == '$'
+            && text[index..].starts_with("${")
+            && !has_odd_backslash_run_before(text, index)
+        {
+            index = find_parameter_expansion_end(text, index)?;
+            continue;
+        }
+
         match ch {
             '(' => {
                 paren_depth += 1;
@@ -1234,6 +1242,30 @@ mod tests {
         assert_eq!(
             find_parameter_expansion_end("\"${x:-`echo }`}\"", 1),
             Some("\"${x:-`echo }`}".len())
+        );
+    }
+
+    #[test]
+    fn skips_parameter_expansions_when_indexing_command_substitution_end() {
+        let source = "echo \"${outer:-$(echo ${x//)/y})}\"\n";
+        let regions = regions(source);
+        let outer_start = source.find("${outer").unwrap();
+        let outer_end = source.rfind('}').unwrap() + '}'.len_utf8();
+        let inner_close_paren = TextSize::new(source.find(')').unwrap() as u32);
+        let outer_parameter_close = TextSize::new((outer_end - 1) as u32);
+        let outer_pair = TextRange::new(
+            TextSize::new(outer_start as u32),
+            TextSize::new(outer_end as u32),
+        );
+
+        assert!(!regions.is_expansion_brace_edge(inner_close_paren));
+        assert!(regions.is_expansion_brace_edge(outer_parameter_close));
+        assert_eq!(
+            regions.first_dollar_brace_pair_in(TextRange::new(
+                TextSize::new(outer_start as u32),
+                TextSize::new((outer_start + "${outer".len()) as u32),
+            )),
+            Some(outer_pair)
         );
     }
 

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -54,6 +54,7 @@ pub struct RegionIndex {
     quoted_heredocs: Vec<TextRange>,
     regions: Vec<IndexedRegion>,
     expansion_brace_edges: Vec<TextSize>,
+    dollar_brace_pairs: Vec<TextRange>,
 }
 
 impl RegionIndex {
@@ -164,6 +165,23 @@ impl RegionIndex {
     pub fn is_expansion_brace_edge(&self, offset: TextSize) -> bool {
         self.expansion_brace_edges.binary_search(&offset).is_ok()
     }
+
+    /// Return the first indexed `${...}` parameter expansion whose `$` byte
+    /// position falls within `range`, in source order.
+    ///
+    /// The returned range is the full `${...}` syntactic span, so its end is
+    /// the byte position one past the matching `}`. Active brace expansions
+    /// such as `{a,b}` are not included; only `${...}`-shaped expansions are.
+    pub fn first_dollar_brace_pair_in(&self, range: TextRange) -> Option<TextRange> {
+        let start = range.start();
+        let idx = self
+            .dollar_brace_pairs
+            .partition_point(|pair| pair.start() < start);
+        self.dollar_brace_pairs
+            .get(idx)
+            .copied()
+            .filter(|pair| pair.start() < range.end())
+    }
 }
 
 struct RegionCollector<'a> {
@@ -176,6 +194,7 @@ struct RegionCollector<'a> {
     conditionals: Vec<TextRange>,
     quoted_heredocs: Vec<TextRange>,
     expansion_brace_edges: Vec<TextSize>,
+    dollar_brace_pairs: Vec<TextRange>,
 }
 
 impl<'a> RegionCollector<'a> {
@@ -190,6 +209,7 @@ impl<'a> RegionCollector<'a> {
             conditionals: Vec::new(),
             quoted_heredocs: Vec::new(),
             expansion_brace_edges: Vec::new(),
+            dollar_brace_pairs: Vec::new(),
         }
     }
 
@@ -203,6 +223,10 @@ impl<'a> RegionCollector<'a> {
         sort_ranges(&mut self.quoted_heredocs);
         self.expansion_brace_edges.sort_unstable();
         self.expansion_brace_edges.dedup();
+        self.dollar_brace_pairs
+            .sort_unstable_by_key(|range| (range.start(), range.end()));
+        self.dollar_brace_pairs
+            .dedup_by_key(|range| (range.start(), range.end()));
 
         let mut regions = Vec::with_capacity(
             self.single_quoted.len()
@@ -270,6 +294,7 @@ impl<'a> RegionCollector<'a> {
             quoted_heredocs: self.quoted_heredocs,
             regions,
             expansion_brace_edges: self.expansion_brace_edges,
+            dollar_brace_pairs: self.dollar_brace_pairs,
         }
     }
 
@@ -484,6 +509,9 @@ impl<'a> RegionCollector<'a> {
         {
             return;
         }
+        if find_parameter_expansion_end(self._source, start) != Some(end) {
+            return;
+        }
 
         let dollar_len = TextSize::new('$'.len_utf8() as u32);
         let close_len = TextSize::new('}'.len_utf8() as u32);
@@ -497,6 +525,7 @@ impl<'a> RegionCollector<'a> {
         }
         self.expansion_brace_edges.push(open);
         self.expansion_brace_edges.push(close);
+        self.dollar_brace_pairs.push(range);
     }
 
     fn push_dollar_brace_pairs_in_source_range(&mut self, range: TextRange) {
@@ -523,8 +552,13 @@ impl<'a> RegionCollector<'a> {
             };
             let open = source_start + dollar_offset + '$'.len_utf8();
             let close = source_start + end_offset - '}'.len_utf8();
+            let pair = TextRange::new(
+                TextSize::new((source_start + dollar_offset) as u32),
+                TextSize::new((source_start + end_offset) as u32),
+            );
             self.expansion_brace_edges.push(TextSize::new(open as u32));
             self.expansion_brace_edges.push(TextSize::new(close as u32));
+            self.dollar_brace_pairs.push(pair);
             index = end_offset;
         }
     }
@@ -821,6 +855,73 @@ fn has_odd_backslash_run_before(text: &str, offset: usize) -> bool {
         == 1
 }
 
+fn find_command_substitution_end(text: &str, start_offset: usize) -> Option<usize> {
+    if start_offset >= text.len() || !text[start_offset..].starts_with("$(") {
+        return None;
+    }
+
+    let mut index = start_offset + "$(".len();
+    let mut paren_depth = 0usize;
+    let mut in_single = false;
+    let mut in_double = false;
+
+    while index < text.len() {
+        let ch = text[index..].chars().next()?;
+        let ch_len = ch.len_utf8();
+
+        if ch == '\\' {
+            index += ch_len;
+            if let Some(escaped) = text[index..].chars().next() {
+                index += escaped.len_utf8();
+            }
+            continue;
+        }
+
+        if in_single {
+            if ch == '\'' {
+                in_single = false;
+            }
+            index += ch_len;
+            continue;
+        }
+
+        if ch == '\'' && !in_double {
+            in_single = true;
+            index += ch_len;
+            continue;
+        }
+
+        if ch == '"' {
+            in_double = !in_double;
+            index += ch_len;
+            continue;
+        }
+
+        if ch == '$'
+            && text[index..].starts_with("$(")
+            && !has_odd_backslash_run_before(text, index)
+        {
+            index = find_command_substitution_end(text, index)?;
+            continue;
+        }
+
+        match ch {
+            '(' => {
+                paren_depth += 1;
+                index += ch_len;
+            }
+            ')' if paren_depth == 0 => return Some(index + ch_len),
+            ')' => {
+                paren_depth -= 1;
+                index += ch_len;
+            }
+            _ => index += ch_len,
+        }
+    }
+
+    None
+}
+
 fn find_parameter_expansion_end(text: &str, start_offset: usize) -> Option<usize> {
     if start_offset >= text.len() || !text[start_offset..].starts_with("${") {
         return None;
@@ -860,6 +961,14 @@ fn find_parameter_expansion_end(text: &str, start_offset: usize) -> Option<usize
         if ch == '"' {
             in_double = !in_double;
             index += ch_len;
+            continue;
+        }
+
+        if ch == '$'
+            && text[index..].starts_with("$(")
+            && !has_odd_backslash_run_before(text, index)
+        {
+            index = find_command_substitution_end(text, index)?;
             continue;
         }
 
@@ -1023,14 +1132,68 @@ mod tests {
         let parameter_start = source.find("${MESSAGE}").unwrap();
         let parameter_open = TextSize::new((parameter_start + 1) as u32);
         let parameter_close = TextSize::new((parameter_start + "${MESSAGE}".len() - 1) as u32);
+        let parameter_pair = TextRange::new(
+            TextSize::new(parameter_start as u32),
+            TextSize::new((parameter_start + "${MESSAGE}".len()) as u32),
+        );
 
         assert!(regions.is_expansion_brace_edge(parameter_open));
         assert!(regions.is_expansion_brace_edge(parameter_close));
+        assert_eq!(
+            regions.first_dollar_brace_pair_in(TextRange::new(
+                TextSize::new((parameter_start - 3) as u32),
+                TextSize::new((parameter_start + "MESSAGE".len()) as u32),
+            )),
+            Some(parameter_pair)
+        );
 
         let object_open = TextSize::new(source.find("{\n").unwrap() as u32);
         let object_close = TextSize::new((source.rfind("\n}").unwrap() + 1) as u32);
         assert!(!regions.is_expansion_brace_edge(object_open));
         assert!(!regions.is_expansion_brace_edge(object_close));
+    }
+
+    #[test]
+    fn ignores_incomplete_parameter_expansion_recovery_edges() {
+        let source = "echo ${var:1\n";
+        let regions = regions(source);
+        let parameter_start = source.find("${").unwrap();
+        let range = TextRange::new(
+            TextSize::new(parameter_start as u32),
+            TextSize::new(source.len() as u32),
+        );
+
+        assert_eq!(regions.first_dollar_brace_pair_in(range), None);
+        for offset in parameter_start..source.len() {
+            assert!(
+                !regions.is_expansion_brace_edge(TextSize::new(offset as u32)),
+                "unexpected expansion brace edge at byte {offset}"
+            );
+        }
+    }
+
+    #[test]
+    fn skips_command_substitutions_when_indexing_parameter_expansion_end() {
+        let source = "echo \"${x:-$(echo })}\"\n";
+        let regions = regions(source);
+        let parameter_start = source.find("${").unwrap();
+        let parameter_end = source.rfind('}').unwrap() + '}'.len_utf8();
+        let inner_literal_close = TextSize::new(source.find('}').unwrap() as u32);
+        let outer_parameter_close = TextSize::new((parameter_end - 1) as u32);
+        let parameter_pair = TextRange::new(
+            TextSize::new(parameter_start as u32),
+            TextSize::new(parameter_end as u32),
+        );
+
+        assert!(!regions.is_expansion_brace_edge(inner_literal_close));
+        assert!(regions.is_expansion_brace_edge(outer_parameter_close));
+        assert_eq!(
+            regions.first_dollar_brace_pair_in(TextRange::new(
+                TextSize::new(parameter_start as u32),
+                TextSize::new((parameter_start + "${x".len()) as u32),
+            )),
+            Some(parameter_pair)
+        );
     }
 
     #[test]

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -53,6 +53,7 @@ pub struct RegionIndex {
     conditionals: Vec<TextRange>,
     quoted_heredocs: Vec<TextRange>,
     regions: Vec<IndexedRegion>,
+    expansion_brace_edges: Vec<TextSize>,
 }
 
 impl RegionIndex {
@@ -152,6 +153,17 @@ impl RegionIndex {
     pub fn heredoc_ranges(&self) -> &[TextRange] {
         &self.heredocs
     }
+
+    /// Return whether `offset` is the byte position of an `{` or `}` that the
+    /// parser classified as part of an expansion construct.
+    ///
+    /// Expansion brace edges include both delimiters of `${...}`-shaped
+    /// parameter expansions and the delimiters of unquoted active brace
+    /// expansions such as `{a,b}` or `{1..5}`. This lets downstream tools skip
+    /// those braces when reporting on stray literal `{` or `}` characters.
+    pub fn is_expansion_brace_edge(&self, offset: TextSize) -> bool {
+        self.expansion_brace_edges.binary_search(&offset).is_ok()
+    }
 }
 
 struct RegionCollector<'a> {
@@ -163,6 +175,7 @@ struct RegionCollector<'a> {
     arithmetic: Vec<TextRange>,
     conditionals: Vec<TextRange>,
     quoted_heredocs: Vec<TextRange>,
+    expansion_brace_edges: Vec<TextSize>,
 }
 
 impl<'a> RegionCollector<'a> {
@@ -176,6 +189,7 @@ impl<'a> RegionCollector<'a> {
             arithmetic: Vec::new(),
             conditionals: Vec::new(),
             quoted_heredocs: Vec::new(),
+            expansion_brace_edges: Vec::new(),
         }
     }
 
@@ -187,6 +201,8 @@ impl<'a> RegionCollector<'a> {
         sort_ranges(&mut self.arithmetic);
         sort_ranges(&mut self.conditionals);
         sort_ranges(&mut self.quoted_heredocs);
+        self.expansion_brace_edges.sort_unstable();
+        self.expansion_brace_edges.dedup();
 
         let mut regions = Vec::with_capacity(
             self.single_quoted.len()
@@ -253,6 +269,7 @@ impl<'a> RegionCollector<'a> {
             conditionals: self.conditionals,
             quoted_heredocs: self.quoted_heredocs,
             regions,
+            expansion_brace_edges: self.expansion_brace_edges,
         }
     }
 
@@ -457,6 +474,35 @@ impl<'a> RegionCollector<'a> {
         push_range(&mut self.arithmetic, range);
     }
 
+    fn push_dollar_brace_pair(&mut self, range: TextRange) {
+        let dollar_len = TextSize::new('$'.len_utf8() as u32);
+        let close_len = TextSize::new('}'.len_utf8() as u32);
+        if range.len() < dollar_len + close_len {
+            return;
+        }
+        let open = range.start() + dollar_len;
+        let close = range.end() - close_len;
+        if open >= close {
+            return;
+        }
+        self.expansion_brace_edges.push(open);
+        self.expansion_brace_edges.push(close);
+    }
+
+    fn push_expansion_brace_pair(&mut self, range: TextRange) {
+        let close_len = TextSize::new('}'.len_utf8() as u32);
+        if range.len() < close_len {
+            return;
+        }
+        let open = range.start();
+        let close = range.end() - close_len;
+        if open >= close {
+            return;
+        }
+        self.expansion_brace_edges.push(open);
+        self.expansion_brace_edges.push(close);
+    }
+
     fn visit_conditional_expr(&mut self, expression: &ConditionalExpr) {
         match expression {
             ConditionalExpr::Binary(expression) => {
@@ -515,6 +561,11 @@ impl<'a> RegionCollector<'a> {
     }
 
     fn visit_word(&mut self, word: &Word) {
+        for brace in word.brace_syntax.iter().copied() {
+            if brace.expands() {
+                self.push_expansion_brace_pair(brace.span.to_range());
+            }
+        }
         self.visit_word_parts(&word.parts);
     }
 
@@ -569,9 +620,7 @@ impl<'a> RegionCollector<'a> {
                     push_range(&mut self.arithmetic, range);
                 }
                 WordPart::ProcessSubstitution { body, .. } => self.visit_stmt_seq(body),
-                WordPart::Literal(_)
-                | WordPart::Variable(_)
-                | WordPart::Parameter(_)
+                WordPart::Parameter(_)
                 | WordPart::ParameterExpansion { .. }
                 | WordPart::Length(_)
                 | WordPart::ArrayAccess(_)
@@ -581,7 +630,10 @@ impl<'a> RegionCollector<'a> {
                 | WordPart::ArraySlice { .. }
                 | WordPart::IndirectExpansion { .. }
                 | WordPart::PrefixMatch { .. }
-                | WordPart::Transformation { .. } => {}
+                | WordPart::Transformation { .. } => {
+                    self.push_dollar_brace_pair(range);
+                }
+                WordPart::Literal(_) | WordPart::Variable(_) => {}
             }
         }
     }
@@ -597,9 +649,10 @@ impl<'a> RegionCollector<'a> {
                 HeredocBodyPart::ArithmeticExpansion { .. } => {
                     push_range(&mut self.arithmetic, range);
                 }
-                HeredocBodyPart::Literal(_)
-                | HeredocBodyPart::Variable(_)
-                | HeredocBodyPart::Parameter(_) => {}
+                HeredocBodyPart::Parameter(_) => {
+                    self.push_dollar_brace_pair(range);
+                }
+                HeredocBodyPart::Literal(_) | HeredocBodyPart::Variable(_) => {}
             }
         }
     }
@@ -802,5 +855,51 @@ mod tests {
         let offset = TextSize::new(source.find("foo").unwrap() as u32);
 
         assert_eq!(regions.region_at(offset), Some(RegionKind::Conditional));
+    }
+
+    #[test]
+    fn flags_parameter_expansion_brace_edges() {
+        let source = "echo ${name}\n";
+        let regions = regions(source);
+        let open = TextSize::new(source.find('{').unwrap() as u32);
+        let close = TextSize::new(source.find('}').unwrap() as u32);
+
+        assert!(regions.is_expansion_brace_edge(open));
+        assert!(regions.is_expansion_brace_edge(close));
+        let interior = TextSize::new(source.find("name").unwrap() as u32);
+        assert!(!regions.is_expansion_brace_edge(interior));
+    }
+
+    #[test]
+    fn flags_active_brace_expansion_edges() {
+        let source = "echo {a,b,c}\n";
+        let regions = regions(source);
+        let open = TextSize::new(source.find('{').unwrap() as u32);
+        let close = TextSize::new(source.find('}').unwrap() as u32);
+
+        assert!(regions.is_expansion_brace_edge(open));
+        assert!(regions.is_expansion_brace_edge(close));
+    }
+
+    #[test]
+    fn flags_parameter_expansion_brace_edges_in_heredocs() {
+        let source = "cat <<EOF\nhello ${name}\nEOF\n";
+        let regions = regions(source);
+        let open = TextSize::new(source.find('{').unwrap() as u32);
+        let close = TextSize::new(source.find('}').unwrap() as u32);
+
+        assert!(regions.is_expansion_brace_edge(open));
+        assert!(regions.is_expansion_brace_edge(close));
+    }
+
+    #[test]
+    fn does_not_flag_literal_braces() {
+        let source = "echo {literal}\n";
+        let regions = regions(source);
+        let open = TextSize::new(source.find('{').unwrap() as u32);
+        let close = TextSize::new(source.find('}').unwrap() as u32);
+
+        assert!(!regions.is_expansion_brace_edge(open));
+        assert!(!regions.is_expansion_brace_edge(close));
     }
 }

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -691,8 +691,12 @@ impl<'a> RegionCollector<'a> {
                     push_range(&mut self.command_substitutions, range);
                     self.visit_stmt_seq(body);
                 }
-                WordPart::ArithmeticExpansion { .. } => {
+                WordPart::ArithmeticExpansion { expression_ast, .. } => {
                     push_range(&mut self.arithmetic, range);
+                    self.push_dollar_brace_pairs_in_source_range(range);
+                    if let Some(expression_ast) = expression_ast.as_deref() {
+                        self.visit_arithmetic_shell_words(expression_ast);
+                    }
                 }
                 WordPart::ProcessSubstitution { body, .. } => self.visit_stmt_seq(body),
                 WordPart::Parameter(_)
@@ -724,8 +728,12 @@ impl<'a> RegionCollector<'a> {
                     push_range(&mut self.command_substitutions, range);
                     self.visit_stmt_seq(body);
                 }
-                HeredocBodyPart::ArithmeticExpansion { .. } => {
+                HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
                     push_range(&mut self.arithmetic, range);
+                    self.push_dollar_brace_pairs_in_source_range(range);
+                    if let Some(expression_ast) = expression_ast.as_ref() {
+                        self.visit_arithmetic_shell_words(expression_ast);
+                    }
                 }
                 HeredocBodyPart::Parameter(_) => {
                     self.push_dollar_brace_pair(range);
@@ -1279,6 +1287,29 @@ mod tests {
                 TextSize::new((outer_start + "${outer".len()) as u32),
             )),
             Some(outer_pair)
+        );
+    }
+
+    #[test]
+    fn indexes_parameter_expansion_edges_inside_arithmetic_expansions() {
+        let source = "echo $(( ${x:-1} + 1 ))\n";
+        let regions = regions(source);
+        let parameter_start = source.find("${x:-1}").unwrap();
+        let parameter_open = TextSize::new((parameter_start + 1) as u32);
+        let parameter_close = TextSize::new((parameter_start + "${x:-1}".len() - 1) as u32);
+        let parameter_pair = TextRange::new(
+            TextSize::new(parameter_start as u32),
+            TextSize::new((parameter_start + "${x:-1}".len()) as u32),
+        );
+
+        assert!(regions.is_expansion_brace_edge(parameter_open));
+        assert!(regions.is_expansion_brace_edge(parameter_close));
+        assert_eq!(
+            regions.first_dollar_brace_pair_in(TextRange::new(
+                TextSize::new(parameter_start as u32),
+                TextSize::new((parameter_start + "${x".len()) as u32),
+            )),
+            Some(parameter_pair)
         );
     }
 

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -36,6 +36,7 @@ fn build_literal_brace_spans(
             fact,
             fact_store,
             source,
+            region_index,
             &mut spans,
             &mut scratch,
         );
@@ -81,6 +82,7 @@ fn collect_literal_brace_spans_for_word(
     fact: &WordOccurrence,
     fact_store: &FactStore<'_>,
     source: &str,
+    region_index: &RegionIndex,
     spans: &mut Vec<Span>,
     scratch: &mut LiteralBraceScratch,
 ) {
@@ -89,8 +91,8 @@ fn collect_literal_brace_spans_for_word(
     collect_dynamic_brace_exclusions(
         &word.parts,
         word.span.start.offset,
-        word.span.end.offset,
         source,
+        region_index,
         &mut scratch.dynamic_exclusions,
     );
     scratch
@@ -1292,8 +1294,8 @@ fn has_escaped_dollar_before(text: &str, offset: usize) -> bool {
 fn collect_dynamic_brace_exclusions(
     parts: &[WordPartNode],
     word_base_offset: usize,
-    word_end_offset: usize,
     source: &str,
+    region_index: &RegionIndex,
     out: &mut Vec<DynamicBraceExcludedSpan>,
 ) {
     for part in parts {
@@ -1310,8 +1312,8 @@ fn collect_dynamic_brace_exclusions(
                 collect_dynamic_brace_exclusions(
                     parts,
                     word_base_offset,
-                    word_end_offset,
                     source,
+                    region_index,
                     out,
                 );
             }
@@ -1340,8 +1342,7 @@ fn collect_dynamic_brace_exclusions(
             | WordPart::ZshQualifiedGlob(_) => out.push(runtime_shell_dynamic_brace_exclusion(
                 part,
                 word_base_offset,
-                word_end_offset,
-                source,
+                region_index,
             )),
         }
     }
@@ -1350,20 +1351,18 @@ fn collect_dynamic_brace_exclusions(
 fn runtime_shell_dynamic_brace_exclusion(
     part: &WordPartNode,
     word_base_offset: usize,
-    word_end_offset: usize,
-    source: &str,
+    region_index: &RegionIndex,
 ) -> DynamicBraceExcludedSpan {
     let start_offset = part.span.start.offset - word_base_offset;
     let mut end_offset = part.span.end.offset - word_base_offset;
-    let part_text = part.span.slice(source);
-    let word_text = &source[word_base_offset..word_end_offset.min(source.len())];
 
-    if let Some(relative_parameter_start) = part_text.find("${") {
-        end_offset = find_runtime_parameter_closing_brace(
-            word_text,
-            start_offset + relative_parameter_start,
-        )
-        .map_or(end_offset, |closing_offset| end_offset.max(closing_offset));
+    let part_range = TextRange::new(
+        TextSize::new(part.span.start.offset as u32),
+        TextSize::new(part.span.end.offset as u32),
+    );
+    if let Some(pair) = region_index.first_dollar_brace_pair_in(part_range) {
+        let pair_end_relative = pair.end().to_u32() as usize - word_base_offset;
+        end_offset = end_offset.max(pair_end_relative);
     }
 
     DynamicBraceExcludedSpan {

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -5,9 +5,10 @@ fn build_literal_brace_spans(
     commands: CommandFacts<'_, '_>,
     fact_store: &FactStore<'_>,
     locator: Locator<'_>,
-    heredoc_ranges: &[TextRange],
+    region_index: &RegionIndex,
 ) -> Vec<Span> {
     let source = locator.source();
+    let heredoc_ranges = region_index.heredoc_ranges();
     let mut spans = Vec::new();
     let mut scratch = LiteralBraceScratch::default();
     scratch.processed_word_nodes.resize(nodes.len(), false);
@@ -54,144 +55,12 @@ fn build_literal_brace_spans(
         &mut spans,
         &mut scratch,
     );
-    let candidate_offsets = build_literal_brace_candidate_offsets(&spans);
-    let plain_parameter_expansion_edges =
-        build_plain_parameter_expansion_edge_offsets(source, &candidate_offsets);
-    let active_brace_expansion_edges =
-        build_active_brace_expansion_edge_offsets(source, &candidate_offsets);
     spans.retain(|span| {
-        !plain_parameter_expansion_edges.contains(&span.start.offset)
-            && !active_brace_expansion_edges.contains(&span.start.offset)
+        !region_index.is_expansion_brace_edge(TextSize::new(span.start.offset as u32))
     });
     spans.sort_by_key(|span| (span.start.offset, span.end.offset));
     spans.dedup_by_key(|span| (span.start.offset, span.end.offset));
     spans
-}
-
-fn build_literal_brace_candidate_offsets(spans: &[Span]) -> FxHashSet<usize> {
-    spans.iter().map(|span| span.start.offset).collect()
-}
-
-fn build_plain_parameter_expansion_edge_offsets(
-    source: &str,
-    candidate_offsets: &FxHashSet<usize>,
-) -> FxHashSet<usize> {
-    let mut offsets = FxHashSet::default();
-    let bytes = source.as_bytes();
-    let mut index = 0usize;
-
-    while index + 1 < bytes.len() {
-        let Some(rel) = bytes[index..].iter().position(|&b| b == b'$') else {
-            break;
-        };
-        let pos = index + rel;
-        if bytes.get(pos + 1) == Some(&b'{')
-            && !has_odd_backslash_run_before(source, pos)
-            && let Some(end_offset) = find_runtime_parameter_closing_brace(source, pos)
-        {
-            let open_brace_offset = pos + '$'.len_utf8();
-            let close_brace_offset = end_offset.saturating_sub('}'.len_utf8());
-            if candidate_offsets.contains(&open_brace_offset) {
-                offsets.insert(open_brace_offset);
-            }
-            if candidate_offsets.contains(&close_brace_offset) {
-                offsets.insert(close_brace_offset);
-            }
-            index = end_offset;
-            continue;
-        }
-
-        index = pos + 1;
-    }
-
-    offsets
-}
-
-fn build_active_brace_expansion_edge_offsets(
-    source: &str,
-    candidate_offsets: &FxHashSet<usize>,
-) -> FxHashSet<usize> {
-    let bytes = source.as_bytes();
-    let mut opens = Vec::new();
-    let mut closes = Vec::new();
-    for (offset, byte) in bytes.iter().enumerate() {
-        match byte {
-            b'{' => opens.push(offset),
-            b'}' => closes.push(offset),
-            _ => {}
-        }
-    }
-
-    let mut offsets = FxHashSet::default();
-    for &offset in candidate_offsets {
-        match bytes.get(offset) {
-            Some(b'{') => {
-                let close_index = closes.partition_point(|&close| close <= offset);
-                let Some(&close_offset) = closes.get(close_index) else {
-                    continue;
-                };
-                if active_brace_pair_qualifies(source, offset, close_offset) {
-                    offsets.insert(offset);
-                    continue;
-                }
-
-                let next_open = opens
-                    .get(opens.partition_point(|&open| open <= offset))
-                    .copied()
-                    .unwrap_or(source.len());
-                for &close_offset in &closes[close_index..] {
-                    if close_offset >= next_open {
-                        break;
-                    }
-                    if active_brace_pair_qualifies(source, offset, close_offset) {
-                        offsets.insert(offset);
-                        break;
-                    }
-                }
-            }
-            Some(b'}') => {
-                let open_index = opens.partition_point(|&open| open < offset);
-                if open_index == 0 {
-                    continue;
-                }
-                let open_offset = opens[open_index - 1];
-                if active_brace_pair_qualifies(source, open_offset, offset) {
-                    offsets.insert(offset);
-                    continue;
-                }
-
-                let previous_close_index = closes.partition_point(|&close| close < offset);
-                let previous_close = if previous_close_index == 0 {
-                    None
-                } else {
-                    closes.get(previous_close_index - 1).copied()
-                };
-                for &open_offset in opens[..open_index].iter().rev() {
-                    if previous_close.is_some_and(|close| open_offset <= close) {
-                        break;
-                    }
-                    if active_brace_pair_qualifies(source, open_offset, offset) {
-                        offsets.insert(offset);
-                        break;
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    offsets
-}
-
-fn active_brace_pair_qualifies(source: &str, open_offset: usize, close_offset: usize) -> bool {
-    if close_offset <= open_offset {
-        return false;
-    }
-    let text = &source[open_offset..=close_offset];
-    brace_text_has_unescaped_comma_or_sequence(text)
-        && text[1..text.len() - 1]
-            .chars()
-            .all(|candidate| !candidate.is_whitespace())
 }
 
 #[derive(Default)]

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -818,7 +818,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             CommandFacts::new(&commands, &fact_store, &command_fact_indices_by_id),
             &fact_store,
             locator,
-            self._indexer.region_index().heredoc_ranges(),
+            self._indexer.region_index(),
         );
         let function_positional_parameter_facts = build_function_positional_parameter_facts(
             self.semantic,

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -61,7 +61,7 @@ use shuck_ast::{
     is_shell_variable_name, static_command_name_text, static_command_wrapper_target_index,
     static_word_text, word_is_standalone_status_capture,
 };
-use shuck_indexer::{Indexer, LineIndex};
+use shuck_indexer::{Indexer, LineIndex, RegionIndex};
 #[cfg(test)]
 use shuck_parser::parser::Parser;
 use shuck_semantic::{


### PR DESCRIPTION
## Summary
- Move `${...}` parameter-expansion and active brace-expansion edge detection out of `facts::braces::build_literal_brace_spans`'s two whole-source byte scans and into the `RegionIndex` AST walk via a sorted `expansion_brace_edges: Vec<TextSize>`.
- Literal-brace candidate filtering now binary-searches that vector instead of re-scanning source for `${`/`}` and brace-expansion edges per file.
- Removes the per-rule edge helpers (`build_plain_parameter_expansion_edge_offsets`, `build_active_brace_expansion_edge_offsets`, `active_brace_pair_qualifies`, `build_literal_brace_candidate_offsets`). Net -32 lines.

## Test plan
- [ ] `cargo build -p shuck-cli -p shuck-cache`
- [ ] `cargo fmt --check`
- [ ] `cargo test -p shuck-indexer` (new region_index brace-edge tests)
- [ ] `cargo test -p shuck-linter`
- [ ] `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S029` clean