### PR TITLE
refactor(linter): share fact-layer word subtree traversal

### DIFF
--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1429,7 +1429,9 @@ fn collect_array_assignment_split_scalar_expansion_spans(
     }
 
     split_sensitive_spans.retain(|span| {
-        !use_replacement_spans.contains(span)
+        !use_replacement_spans
+            .iter()
+            .any(|replacement_span| contains_span(*replacement_span, *span))
             && !brace_expansion_spans
                 .iter()
                 .any(|brace_span| contains_span(*brace_span, *span))

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::facts::words::{
+    WordSubtreeVisitor, WordTraversalContext, WordTraversalState, walk_word_subtree,
+};
 use shuck_ast::{
     HeredocBody, HeredocBodyPart, HeredocBodyPartNode, PatternGroupKind, PatternPartNode, Position,
 };
@@ -760,7 +763,19 @@ impl<'a> SurfaceFragmentSink<'a> {
                 context.assignment_target,
             );
         }
-        self.collect_word_parts(&word.parts, context, false);
+        let mut visitor = SurfaceWordVisitor {
+            sink: self,
+            context,
+        };
+        walk_word_subtree(
+            word,
+            WordTraversalContext {
+                source: visitor.sink.source,
+                locator: None,
+                shell_dialect: context.shell_dialect,
+            },
+            &mut visitor,
+        );
         self.facts.open_double_quotes.len() > open_double_quote_count
     }
 
@@ -840,318 +855,322 @@ impl<'a> SurfaceFragmentSink<'a> {
         }
     }
 
-    fn collect_word_parts(
+    fn collect_word_part_from_traversal(
         &mut self,
-        parts: &[WordPartNode],
+        part: &WordPartNode,
+        state: WordTraversalState<'_>,
         context: SurfaceScanContext<'_>,
-        in_double_quote: bool,
     ) {
-        for (index, part) in parts.iter().enumerate() {
-            if let WordPart::Literal(text) = &part.kind
-                && !in_double_quote
-            {
-                let literal = text.as_str(self.source, part.span);
-                if literal.as_bytes().contains(&UNICODE_SMART_QUOTE_LEAD_BYTE) {
-                    for (offset, char) in literal.char_indices() {
-                        if !is_unicode_smart_quote(char) {
-                            continue;
-                        }
-                        let start = part.span.start.advanced_by(&literal[..offset]);
-                        let end = start.advanced_by(char.encode_utf8(&mut [0; 4]));
-                        self.facts
-                            .unicode_smart_quote_spans
-                            .push(Span::from_positions(start, end));
-                    }
-                }
-            }
-
-            if let WordPart::Variable(name) = &part.kind
-                && matches!(
-                    name.as_str(),
-                    "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
-                )
-                && let Some(next_part) = parts.get(index + 1)
-                && let WordPart::Literal(text) = &next_part.kind
-                && text
-                    .as_str(self.source, next_part.span)
-                    .starts_with(|char: char| char.is_ascii_digit())
-                && self.looks_like_unbraced_positional_above_nine(part.span.merge(next_part.span))
-            {
-                self.facts
-                    .positional_parameters
-                    .push(PositionalParameterFragmentFact {
-                        span: part.span.merge(next_part.span),
-                        kind: PositionalParameterFragmentKind::AboveNine,
-                        guarded: context.guarded_parameter_operand,
-                    });
-            }
-
-            match &part.kind {
-                WordPart::SingleQuoted { dollar, .. } => {
-                    let literal_expansion_exempt = context.literal_expansion_exempt
-                        || single_quoted_fragment_is_zsh_delayed_eval_exempt(
-                            part.span,
-                            context,
-                            self.source,
-                        );
-                    self.facts.single_quoted.push(SingleQuotedFragmentFact {
-                        span: part.span,
-                        diagnostic_span: self.single_quoted_fragment_diagnostic_span(part.span),
-                        dollar_quoted: *dollar,
-                        command_name: context
-                            .command_name
-                            .map(str::to_owned)
-                            .map(String::into_boxed_str),
-                        assignment_target: context
-                            .assignment_target
-                            .map(str::to_owned)
-                            .map(String::into_boxed_str),
-                        shell_dialect: context.shell_dialect,
-                        variable_set_operand: context.variable_set_operand,
-                        literal_expansion_exempt,
-                        literal_backslash_in_single_quotes_span:
-                            single_quoted_backslash_continuation_span(parts, index, self.source),
-                    });
-                }
-                WordPart::DoubleQuoted { parts, dollar } => {
-                    if *dollar {
-                        self.facts
-                            .dollar_double_quoted
-                            .push(DollarDoubleQuotedFragmentFact { span: part.span });
-                    }
-                    self.collect_word_parts(parts, context, true);
-                }
-                WordPart::ZshQualifiedGlob(glob) => self.collect_zsh_qualified_glob(glob, context),
-                WordPart::ArithmeticExpansion {
-                    expression,
-                    syntax: ArithmeticExpansionSyntax::LegacyBracket,
-                    expression_word_ast,
-                    expression_ast,
-                    ..
-                } => {
-                    self.facts
-                        .legacy_arithmetic
-                        .push(LegacyArithmeticFragmentFact { span: part.span });
-                    collect_positional_parameter_operator_spans_in_arithmetic(
-                        part.span,
-                        expression_ast.as_deref(),
-                        expression,
-                        self.source,
-                        &mut self.facts.positional_parameter_operator_spans,
-                    );
-                    if let Some(expression_ast) = expression_ast.as_deref() {
-                        visit_arithmetic_words(expression_ast, &mut |word| {
-                            self.collect_word(word, context);
-                        });
-                    } else {
-                        self.collect_word(expression_word_ast, context);
-                    }
-                }
-                WordPart::ArithmeticExpansion {
-                    expression,
-                    expression_word_ast,
-                    expression_ast,
-                    ..
-                } => {
-                    collect_positional_parameter_operator_spans_in_arithmetic(
-                        part.span,
-                        expression_ast.as_deref(),
-                        expression,
-                        self.source,
-                        &mut self.facts.positional_parameter_operator_spans,
-                    );
-                    if let Some(expression_ast) = expression_ast.as_deref() {
-                        visit_arithmetic_words(expression_ast, &mut |word| {
-                            self.collect_word(word, context);
-                        });
-                    } else {
-                        self.collect_word(expression_word_ast, context);
-                    }
-                }
-                WordPart::CommandSubstitution {
-                    syntax: CommandSubstitutionSyntax::Backtick,
-                    body,
-                    ..
-                } => {
-                    if self.opening_backtick_is_escaped(part.span) {
+        let in_double_quote = state.in_double_quote;
+        let Some(parts) = state.siblings else {
+            return;
+        };
+        let Some(index) = state.part_index else {
+            return;
+        };
+        if let WordPart::Literal(text) = &part.kind
+            && !in_double_quote
+        {
+            let literal = text.as_str(self.source, part.span);
+            if literal.as_bytes().contains(&UNICODE_SMART_QUOTE_LEAD_BYTE) {
+                for (offset, char) in literal.char_indices() {
+                    if !is_unicode_smart_quote(char) {
                         continue;
                     }
-                    self.facts.backticks.push(BacktickFragmentFact {
-                        span: part.span,
-                        empty: body.is_empty(),
-                    });
-                }
-                WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
-                WordPart::Parameter(parameter) => {
-                    if parameter_is_plain_unindexed_reference(parameter) {
-                        self.record_plain_unindexed_reference(part.span);
-                    }
-                    self.collect_parameter_expansion(parameter, part.span, context);
-                }
-                WordPart::Variable(name) => {
-                    if name_is_plain_reference_candidate(name) {
-                        self.record_plain_unindexed_reference(part.span);
-                    }
-                    if name.as_str() == "$"
-                        && contains_nested_parameter_marker(part.span.slice(self.source))
-                    {
-                        self.facts
-                            .nested_parameter_expansions
-                            .push(NestedParameterExpansionFragmentFact { span: part.span });
-                    }
-                }
-                WordPart::ParameterExpansion {
-                    reference,
-                    operator,
-                    operand,
-                    operand_word_ast,
-                    ..
-                } => {
-                    if reference_has_array_subscript(reference) {
-                        self.record_array_reference(part.span, false);
-                    }
-                    if parameter_pattern_target_is_special(reference, operator) {
-                        self.parameter_special_target_word_scratch.clear();
-                        collect_parameter_operator_special_target_word_spans(
-                            operator,
-                            &mut self.parameter_special_target_word_scratch,
-                        );
-                        for index in 0..self.parameter_special_target_word_scratch.len() {
-                            let pattern_span = self.parameter_special_target_word_scratch[index];
-                            self.record_parameter_pattern_special_target(pattern_span);
-                        }
-                    }
-                    if matches!(
-                        operator.as_ref(),
-                        ParameterOp::UpperFirst
-                            | ParameterOp::UpperAll
-                            | ParameterOp::LowerFirst
-                            | ParameterOp::LowerAll
-                    ) {
-                        self.record_case_modification(part.span);
-                    }
-                    if matches!(
-                        operator.as_ref(),
-                        ParameterOp::ReplaceFirst { .. } | ParameterOp::ReplaceAll { .. }
-                    ) {
-                        self.record_replacement_expansion(part.span);
-                    }
-                    if reference_is_positional_parameter_trim(reference, operator) {
-                        self.record_positional_parameter_trim(part.span);
-                    }
-                    self.record_var_ref_subscript(
-                        reference,
-                        context.subscript_suppresses_later_references,
-                    );
-                    self.collect_parameter_operator_patterns(
-                        operator,
-                        operand.as_ref(),
-                        operand_word_ast.as_deref(),
-                        context,
-                    );
-                }
-                WordPart::Length(reference)
-                | WordPart::ArrayLength(reference)
-                | WordPart::Transformation { reference, .. } => {
-                    self.record_var_ref_subscript(
-                        reference,
-                        context.subscript_suppresses_later_references,
-                    );
-                }
-                WordPart::ArrayAccess(reference) => {
-                    if reference_has_array_subscript(reference) {
-                        self.record_array_reference(part.span, true);
-                        let case_modification_span = parts
-                            .get(index + 1)
-                            .filter(|next_part| {
-                                matches!(&next_part.kind, WordPart::Literal(text) if {
-                                    let text = text.as_str(self.source, next_part.span);
-                                    text.starts_with('^') || text.starts_with(',')
-                                })
-                            })
-                            .map_or(part.span, |next_part| part.span.merge(next_part.span));
-                        self.record_case_modification(case_modification_span);
-                    }
-                    self.record_var_ref_subscript(
-                        reference,
-                        context.subscript_suppresses_later_references,
-                    );
-                }
-                WordPart::ArrayIndices(reference) => {
-                    self.record_var_ref_subscript(
-                        reference,
-                        context.subscript_suppresses_later_references,
-                    );
+                    let start = part.span.start.advanced_by(&literal[..offset]);
+                    let end = start.advanced_by(char.encode_utf8(&mut [0; 4]));
                     self.facts
-                        .indirect_expansions
-                        .push(IndirectExpansionFragmentFact {
-                            span: part.span,
-                            array_keys: true,
-                        });
+                        .unicode_smart_quote_spans
+                        .push(Span::from_positions(start, end));
                 }
-                WordPart::Substring { reference, .. } => {
-                    self.record_substring_expansion(part.span);
-                    self.record_var_ref_subscript(
-                        reference,
-                        context.subscript_suppresses_later_references,
-                    );
-                }
-                WordPart::ArraySlice { reference, .. } => {
-                    self.record_var_ref_subscript(
-                        reference,
-                        context.subscript_suppresses_later_references,
-                    );
-                }
-                WordPart::IndirectExpansion {
-                    reference,
-                    operator: Some(operator),
-                    operand,
-                    operand_word_ast,
-                    ..
-                } => {
-                    self.record_var_ref_subscript(
-                        reference,
-                        context.subscript_suppresses_later_references,
-                    );
-                    self.facts
-                        .indirect_expansions
-                        .push(IndirectExpansionFragmentFact {
-                            span: part.span,
-                            array_keys: false,
-                        });
-                    self.collect_parameter_operator_patterns(
-                        operator,
-                        operand.as_ref(),
-                        operand_word_ast.as_deref(),
-                        context,
-                    );
-                }
-                WordPart::IndirectExpansion {
-                    reference,
-                    operator: None,
-                    ..
-                } => {
-                    self.record_var_ref_subscript(
-                        reference,
-                        context.subscript_suppresses_later_references,
-                    );
-                    self.facts
-                        .indirect_expansions
-                        .push(IndirectExpansionFragmentFact {
-                            span: part.span,
-                            array_keys: false,
-                        });
-                }
-                WordPart::PrefixMatch { .. } => {
-                    self.facts
-                        .indirect_expansions
-                        .push(IndirectExpansionFragmentFact {
-                            span: part.span,
-                            array_keys: false,
-                        });
-                }
-                WordPart::Literal(_) => {}
             }
+        }
+
+        if let WordPart::Variable(name) = &part.kind
+            && matches!(
+                name.as_str(),
+                "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+            )
+            && let Some(next_part) = parts.get(index + 1)
+            && let WordPart::Literal(text) = &next_part.kind
+            && text
+                .as_str(self.source, next_part.span)
+                .starts_with(|char: char| char.is_ascii_digit())
+            && self.looks_like_unbraced_positional_above_nine(part.span.merge(next_part.span))
+        {
+            self.facts
+                .positional_parameters
+                .push(PositionalParameterFragmentFact {
+                    span: part.span.merge(next_part.span),
+                    kind: PositionalParameterFragmentKind::AboveNine,
+                    guarded: context.guarded_parameter_operand,
+                });
+        }
+
+        match &part.kind {
+            WordPart::SingleQuoted { dollar, .. } => {
+                let literal_expansion_exempt = context.literal_expansion_exempt
+                    || single_quoted_fragment_is_zsh_delayed_eval_exempt(
+                        part.span,
+                        context,
+                        self.source,
+                    );
+                self.facts.single_quoted.push(SingleQuotedFragmentFact {
+                    span: part.span,
+                    diagnostic_span: self.single_quoted_fragment_diagnostic_span(part.span),
+                    dollar_quoted: *dollar,
+                    command_name: context
+                        .command_name
+                        .map(str::to_owned)
+                        .map(String::into_boxed_str),
+                    assignment_target: context
+                        .assignment_target
+                        .map(str::to_owned)
+                        .map(String::into_boxed_str),
+                    shell_dialect: context.shell_dialect,
+                    variable_set_operand: context.variable_set_operand,
+                    literal_expansion_exempt,
+                    literal_backslash_in_single_quotes_span:
+                        single_quoted_backslash_continuation_span(parts, index, self.source),
+                });
+            }
+            WordPart::DoubleQuoted { dollar, .. } => {
+                if *dollar {
+                    self.facts
+                        .dollar_double_quoted
+                        .push(DollarDoubleQuotedFragmentFact { span: part.span });
+                }
+            }
+            WordPart::ZshQualifiedGlob(glob) => self.collect_zsh_qualified_glob(glob, context),
+            WordPart::ArithmeticExpansion {
+                expression,
+                syntax: ArithmeticExpansionSyntax::LegacyBracket,
+                expression_word_ast,
+                expression_ast,
+                ..
+            } => {
+                self.facts
+                    .legacy_arithmetic
+                    .push(LegacyArithmeticFragmentFact { span: part.span });
+                collect_positional_parameter_operator_spans_in_arithmetic(
+                    part.span,
+                    expression_ast.as_deref(),
+                    expression,
+                    self.source,
+                    &mut self.facts.positional_parameter_operator_spans,
+                );
+                if let Some(expression_ast) = expression_ast.as_deref() {
+                    visit_arithmetic_words(expression_ast, &mut |word| {
+                        self.collect_word(word, context);
+                    });
+                } else {
+                    self.collect_word(expression_word_ast, context);
+                }
+            }
+            WordPart::ArithmeticExpansion {
+                expression,
+                expression_word_ast,
+                expression_ast,
+                ..
+            } => {
+                collect_positional_parameter_operator_spans_in_arithmetic(
+                    part.span,
+                    expression_ast.as_deref(),
+                    expression,
+                    self.source,
+                    &mut self.facts.positional_parameter_operator_spans,
+                );
+                if let Some(expression_ast) = expression_ast.as_deref() {
+                    visit_arithmetic_words(expression_ast, &mut |word| {
+                        self.collect_word(word, context);
+                    });
+                } else {
+                    self.collect_word(expression_word_ast, context);
+                }
+            }
+            WordPart::CommandSubstitution {
+                syntax: CommandSubstitutionSyntax::Backtick,
+                body,
+                ..
+            } => {
+                if self.opening_backtick_is_escaped(part.span) {
+                    return;
+                }
+                self.facts.backticks.push(BacktickFragmentFact {
+                    span: part.span,
+                    empty: body.is_empty(),
+                });
+            }
+            WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
+            WordPart::Parameter(parameter) => {
+                if parameter_is_plain_unindexed_reference(parameter) {
+                    self.record_plain_unindexed_reference(part.span);
+                }
+                self.collect_parameter_expansion(parameter, part.span, context);
+            }
+            WordPart::Variable(name) => {
+                if name_is_plain_reference_candidate(name) {
+                    self.record_plain_unindexed_reference(part.span);
+                }
+                if name.as_str() == "$"
+                    && contains_nested_parameter_marker(part.span.slice(self.source))
+                {
+                    self.facts
+                        .nested_parameter_expansions
+                        .push(NestedParameterExpansionFragmentFact { span: part.span });
+                }
+            }
+            WordPart::ParameterExpansion {
+                reference,
+                operator,
+                operand,
+                operand_word_ast,
+                ..
+            } => {
+                if reference_has_array_subscript(reference) {
+                    self.record_array_reference(part.span, false);
+                }
+                if parameter_pattern_target_is_special(reference, operator) {
+                    self.parameter_special_target_word_scratch.clear();
+                    collect_parameter_operator_special_target_word_spans(
+                        operator,
+                        &mut self.parameter_special_target_word_scratch,
+                    );
+                    for index in 0..self.parameter_special_target_word_scratch.len() {
+                        let pattern_span = self.parameter_special_target_word_scratch[index];
+                        self.record_parameter_pattern_special_target(pattern_span);
+                    }
+                }
+                if matches!(
+                    operator.as_ref(),
+                    ParameterOp::UpperFirst
+                        | ParameterOp::UpperAll
+                        | ParameterOp::LowerFirst
+                        | ParameterOp::LowerAll
+                ) {
+                    self.record_case_modification(part.span);
+                }
+                if matches!(
+                    operator.as_ref(),
+                    ParameterOp::ReplaceFirst { .. } | ParameterOp::ReplaceAll { .. }
+                ) {
+                    self.record_replacement_expansion(part.span);
+                }
+                if reference_is_positional_parameter_trim(reference, operator) {
+                    self.record_positional_parameter_trim(part.span);
+                }
+                self.record_var_ref_subscript(
+                    reference,
+                    context.subscript_suppresses_later_references,
+                );
+                self.collect_parameter_operator_patterns(
+                    operator,
+                    operand.as_ref(),
+                    operand_word_ast.as_deref(),
+                    context,
+                );
+            }
+            WordPart::Length(reference)
+            | WordPart::ArrayLength(reference)
+            | WordPart::Transformation { reference, .. } => {
+                self.record_var_ref_subscript(
+                    reference,
+                    context.subscript_suppresses_later_references,
+                );
+            }
+            WordPart::ArrayAccess(reference) => {
+                if reference_has_array_subscript(reference) {
+                    self.record_array_reference(part.span, true);
+                    let case_modification_span = parts
+                        .get(index + 1)
+                        .filter(|next_part| {
+                            matches!(&next_part.kind, WordPart::Literal(text) if {
+                                let text = text.as_str(self.source, next_part.span);
+                                text.starts_with('^') || text.starts_with(',')
+                            })
+                        })
+                        .map_or(part.span, |next_part| part.span.merge(next_part.span));
+                    self.record_case_modification(case_modification_span);
+                }
+                self.record_var_ref_subscript(
+                    reference,
+                    context.subscript_suppresses_later_references,
+                );
+            }
+            WordPart::ArrayIndices(reference) => {
+                self.record_var_ref_subscript(
+                    reference,
+                    context.subscript_suppresses_later_references,
+                );
+                self.facts
+                    .indirect_expansions
+                    .push(IndirectExpansionFragmentFact {
+                        span: part.span,
+                        array_keys: true,
+                    });
+            }
+            WordPart::Substring { reference, .. } => {
+                self.record_substring_expansion(part.span);
+                self.record_var_ref_subscript(
+                    reference,
+                    context.subscript_suppresses_later_references,
+                );
+            }
+            WordPart::ArraySlice { reference, .. } => {
+                self.record_var_ref_subscript(
+                    reference,
+                    context.subscript_suppresses_later_references,
+                );
+            }
+            WordPart::IndirectExpansion {
+                reference,
+                operator: Some(operator),
+                operand,
+                operand_word_ast,
+                ..
+            } => {
+                self.record_var_ref_subscript(
+                    reference,
+                    context.subscript_suppresses_later_references,
+                );
+                self.facts
+                    .indirect_expansions
+                    .push(IndirectExpansionFragmentFact {
+                        span: part.span,
+                        array_keys: false,
+                    });
+                self.collect_parameter_operator_patterns(
+                    operator,
+                    operand.as_ref(),
+                    operand_word_ast.as_deref(),
+                    context,
+                );
+            }
+            WordPart::IndirectExpansion {
+                reference,
+                operator: None,
+                ..
+            } => {
+                self.record_var_ref_subscript(
+                    reference,
+                    context.subscript_suppresses_later_references,
+                );
+                self.facts
+                    .indirect_expansions
+                    .push(IndirectExpansionFragmentFact {
+                        span: part.span,
+                        array_keys: false,
+                    });
+            }
+            WordPart::PrefixMatch { .. } => {
+                self.facts
+                    .indirect_expansions
+                    .push(IndirectExpansionFragmentFact {
+                        span: part.span,
+                        array_keys: false,
+                    });
+            }
+            WordPart::Literal(_) => {}
         }
     }
 
@@ -1586,6 +1605,20 @@ impl<'a> SurfaceFragmentSink<'a> {
         .end;
 
         Span::from_positions(start, end)
+    }
+}
+
+struct SurfaceWordVisitor<'sink, 'a, 'context> {
+    sink: &'sink mut SurfaceFragmentSink<'a>,
+    context: SurfaceScanContext<'context>,
+}
+
+impl<'word> WordSubtreeVisitor<'word> for SurfaceWordVisitor<'_, '_, '_> {
+    fn visit_part(&mut self, part: &'word WordPartNode, state: WordTraversalState<'word>) {
+        if state.processes_root_word() {
+            self.sink
+                .collect_word_part_from_traversal(part, state, self.context);
+        }
     }
 }
 

--- a/crates/shuck-linter/src/facts/word_spans/arrays.rs
+++ b/crates/shuck-linter/src/facts/word_spans/arrays.rs
@@ -1815,7 +1815,7 @@ pub(crate) fn all_elements_array_expansion_is_standalone(
 
 #[cfg(test)]
 mod tests {
-    use shuck_ast::{Span, Word};
+    use shuck_ast::{Span, Word, WordPart, WordPartNode};
     use shuck_indexer::LineIndex;
     use shuck_parser::parser::Parser;
     use shuck_semantic::ShellDialect;
@@ -1831,7 +1831,10 @@ mod tests {
         word_unquoted_star_parameter_spans, word_unquoted_star_splat_spans,
     };
     use crate::Locator;
-    use crate::facts::word_spans::collect_scalar_expansion_part_spans;
+    use crate::facts::word_spans::parameter_is_scalar_like;
+    use crate::facts::words::{
+        WordSubtreeVisitor, WordTraversalContext, WordTraversalState, walk_word_subtree,
+    };
 
     fn all_elements_array_expansion_part_spans(word: &Word, source: &str) -> Vec<Span> {
         all_elements_array_expansion_part_spans_with_dialect(word, source, ShellDialect::Bash)
@@ -1946,8 +1949,71 @@ mod tests {
 
     fn scalar_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
         let mut spans = Vec::new();
-        collect_scalar_expansion_part_spans(word, &mut spans);
+        let mut visitor = TestScalarExpansionSpanVisitor {
+            spans: &mut spans,
+            only_unquoted: false,
+        };
+        walk_word_subtree(
+            word,
+            WordTraversalContext {
+                source: "",
+                locator: None,
+                shell_dialect: ShellDialect::Bash,
+            },
+            &mut visitor,
+        );
         spans
+    }
+
+    struct TestScalarExpansionSpanVisitor<'spans> {
+        spans: &'spans mut Vec<Span>,
+        only_unquoted: bool,
+    }
+
+    impl<'a> WordSubtreeVisitor<'a> for TestScalarExpansionSpanVisitor<'_> {
+        fn visit_part(&mut self, part: &'a WordPartNode, state: WordTraversalState<'a>) {
+            if !state.processes_root_word() {
+                return;
+            }
+            let quoted = state.in_double_quote;
+
+            match &part.kind {
+                WordPart::Literal(_)
+                | WordPart::SingleQuoted { .. }
+                | WordPart::DoubleQuoted { .. } => {}
+                WordPart::ZshQualifiedGlob(_) => {}
+                WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
+                WordPart::Parameter(parameter) => {
+                    if parameter_is_scalar_like(parameter) && (!self.only_unquoted || !quoted) {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::Variable(name) if matches!(name.as_str(), "@" | "*") => {}
+                WordPart::Variable(_)
+                | WordPart::ArithmeticExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::Substring { .. }
+                | WordPart::PrefixMatch { .. } => {
+                    if !self.only_unquoted || !quoted {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::ParameterExpansion { reference, .. }
+                | WordPart::IndirectExpansion { reference, .. }
+                | WordPart::Transformation { reference, .. } => {
+                    if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::ArrayAccess(reference) => {
+                    if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::ArrayIndices(_) | WordPart::ArraySlice { .. } => {}
+            }
+        }
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
+++ b/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
@@ -1,134 +1,177 @@
 use super::*;
+use crate::facts::words::{
+    WordSubtreeVisitor, WordTraversalContext, WordTraversalState, walk_word_subtree,
+};
 
+#[allow(dead_code)]
 pub fn collect_command_substitution_part_spans_in_source(
     word: &Word,
     locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
-    collect_command_substitution_spans(&word.parts, spans);
+    collect_command_substitution_spans(word, traversal_context_with_locator(locator), spans);
     normalize_command_substitution_spans(spans, locator);
 }
 
 pub fn arithmetic_expansion_part_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_arithmetic_expansion_spans(&word.parts, &mut spans);
+    collect_arithmetic_expansion_spans(word, &mut spans);
     spans
 }
 
 pub fn parenthesized_arithmetic_expansion_part_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_parenthesized_arithmetic_expansion_spans(&word.parts, &mut spans);
+    collect_parenthesized_arithmetic_expansion_spans(word, &mut spans);
     spans
 }
 
 pub fn unquoted_command_substitution_part_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_unquoted_command_substitution_spans(&word.parts, false, &mut spans);
+    collect_unquoted_command_substitution_spans(word, &mut spans);
     spans
 }
 
+#[allow(dead_code)]
 pub fn collect_unquoted_command_substitution_part_spans_in_source(
     word: &Word,
     locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
-    collect_unquoted_command_substitution_spans(&word.parts, false, spans);
+    collect_unquoted_command_substitution_spans(word, spans);
     normalize_command_substitution_spans(spans, locator);
 }
 
+#[allow(dead_code)]
 pub fn collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
     word: &Word,
     locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
-    collect_unquoted_dollar_paren_command_substitution_spans(&word.parts, false, spans);
+    collect_unquoted_dollar_paren_command_substitution_spans(word, spans);
     normalize_command_substitution_spans(spans, locator);
 }
 
-pub(crate) fn collect_command_substitution_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {
-    for part in parts {
-        match &part.kind {
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_command_substitution_spans(parts, spans)
-            }
-            WordPart::CommandSubstitution { .. } => spans.push(part.span),
-            _ => {}
-        }
-    }
-}
-
-pub(crate) fn collect_arithmetic_expansion_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {
-    for part in parts {
-        match &part.kind {
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_arithmetic_expansion_spans(parts, spans)
-            }
-            WordPart::ArithmeticExpansion { .. } => spans.push(part.span),
-            _ => {}
-        }
-    }
-}
-
-pub(crate) fn collect_parenthesized_arithmetic_expansion_spans(
-    parts: &[WordPartNode],
+fn collect_command_substitution_spans<'a>(
+    word: &'a Word,
+    context: WordTraversalContext<'a>,
     spans: &mut Vec<Span>,
 ) {
-    for part in parts {
-        match &part.kind {
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_parenthesized_arithmetic_expansion_spans(parts, spans)
-            }
-            WordPart::ArithmeticExpansion {
-                expression_ast: Some(expression),
-                ..
-            } => {
-                if matches!(expression.kind, ArithmeticExpr::Parenthesized { .. }) {
-                    spans.push(expression.span);
+    let mut visitor = CommandSubstitutionSpanVisitor {
+        spans,
+        only_unquoted: false,
+        only_dollar_paren: false,
+    };
+    walk_word_subtree(word, context, &mut visitor);
+}
+
+pub(crate) fn collect_arithmetic_expansion_spans(word: &Word, spans: &mut Vec<Span>) {
+    let mut visitor = ArithmeticExpansionSpanVisitor {
+        spans,
+        parenthesized_only: false,
+    };
+    walk_word_subtree(word, traversal_context_without_source(), &mut visitor);
+}
+
+pub(crate) fn collect_parenthesized_arithmetic_expansion_spans(word: &Word, spans: &mut Vec<Span>) {
+    let mut visitor = ArithmeticExpansionSpanVisitor {
+        spans,
+        parenthesized_only: true,
+    };
+    walk_word_subtree(word, traversal_context_without_source(), &mut visitor);
+}
+
+pub(crate) fn collect_unquoted_command_substitution_spans(word: &Word, spans: &mut Vec<Span>) {
+    let mut visitor = CommandSubstitutionSpanVisitor {
+        spans,
+        only_unquoted: true,
+        only_dollar_paren: false,
+    };
+    walk_word_subtree(word, traversal_context_without_source(), &mut visitor);
+}
+
+#[allow(dead_code)]
+fn collect_unquoted_dollar_paren_command_substitution_spans(word: &Word, spans: &mut Vec<Span>) {
+    let mut visitor = CommandSubstitutionSpanVisitor {
+        spans,
+        only_unquoted: true,
+        only_dollar_paren: true,
+    };
+    walk_word_subtree(word, traversal_context_without_source(), &mut visitor);
+}
+
+struct CommandSubstitutionSpanVisitor<'spans> {
+    spans: &'spans mut Vec<Span>,
+    only_unquoted: bool,
+    only_dollar_paren: bool,
+}
+
+impl<'a> WordSubtreeVisitor<'a> for CommandSubstitutionSpanVisitor<'_> {
+    fn visit_command_substitution(
+        &mut self,
+        part: &'a WordPartNode,
+        state: WordTraversalState<'a>,
+    ) {
+        if !state.processes_root_word() || (self.only_unquoted && state.in_double_quote) {
+            return;
+        }
+        if self.only_dollar_paren
+            && !matches!(
+                &part.kind,
+                WordPart::CommandSubstitution {
+                    syntax: CommandSubstitutionSyntax::DollarParen,
+                    ..
                 }
+            )
+        {
+            return;
+        }
+        self.spans.push(part.span);
+    }
+}
+
+struct ArithmeticExpansionSpanVisitor<'spans> {
+    spans: &'spans mut Vec<Span>,
+    parenthesized_only: bool,
+}
+
+impl<'a> WordSubtreeVisitor<'a> for ArithmeticExpansionSpanVisitor<'_> {
+    fn visit_arithmetic_expansion(
+        &mut self,
+        part: &'a WordPartNode,
+        state: WordTraversalState<'a>,
+    ) {
+        if !state.processes_root_word() {
+            return;
+        }
+        let WordPart::ArithmeticExpansion { expression_ast, .. } = &part.kind else {
+            return;
+        };
+        if self.parenthesized_only {
+            if let Some(expression) = expression_ast
+                && matches!(expression.kind, ArithmeticExpr::Parenthesized { .. })
+            {
+                self.spans.push(expression.span);
             }
-            WordPart::ArithmeticExpansion {
-                expression_ast: None,
-                ..
-            } => {}
-            _ => {}
+        } else {
+            self.spans.push(part.span);
         }
     }
 }
 
-pub(crate) fn collect_unquoted_command_substitution_spans(
-    parts: &[WordPartNode],
-    quoted: bool,
-    spans: &mut Vec<Span>,
-) {
-    for part in parts {
-        match &part.kind {
-            WordPart::SingleQuoted { .. } => {}
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_unquoted_command_substitution_spans(parts, true, spans)
-            }
-            WordPart::CommandSubstitution { .. } if !quoted => spans.push(part.span),
-            _ => {}
-        }
+#[allow(dead_code)]
+fn traversal_context_with_locator(locator: Locator<'_>) -> WordTraversalContext<'_> {
+    WordTraversalContext {
+        source: locator.source(),
+        locator: Some(locator),
+        shell_dialect: shuck_semantic::ShellDialect::Bash,
     }
 }
 
-pub(crate) fn collect_unquoted_dollar_paren_command_substitution_spans(
-    parts: &[WordPartNode],
-    quoted: bool,
-    spans: &mut Vec<Span>,
-) {
-    for part in parts {
-        match &part.kind {
-            WordPart::SingleQuoted { .. } => {}
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_unquoted_dollar_paren_command_substitution_spans(parts, true, spans)
-            }
-            WordPart::CommandSubstitution {
-                syntax: CommandSubstitutionSyntax::DollarParen,
-                ..
-            } if !quoted => spans.push(part.span),
-            _ => {}
-        }
+fn traversal_context_without_source<'a>() -> WordTraversalContext<'a> {
+    WordTraversalContext {
+        source: "",
+        locator: None,
+        shell_dialect: shuck_semantic::ShellDialect::Bash,
     }
 }
 
@@ -287,14 +330,19 @@ mod tests {
     use shuck_parser::parser::Parser;
 
     use super::{
-        collect_command_substitution_spans,
+        collect_command_substitution_part_spans_in_source,
         collect_unquoted_dollar_paren_command_substitution_part_spans_in_source,
     };
     use crate::Locator;
 
-    fn command_substitution_part_spans(word: &Word) -> Vec<Span> {
+    fn command_substitution_part_spans(word: &Word, source: &str) -> Vec<Span> {
+        let line_index = LineIndex::new(source);
         let mut spans = Vec::new();
-        collect_command_substitution_spans(&word.parts, &mut spans);
+        collect_command_substitution_part_spans_in_source(
+            word,
+            Locator::new(source, &line_index),
+            &mut spans,
+        );
         spans
     }
 
@@ -320,7 +368,7 @@ mod tests {
             panic!("expected simple command");
         };
 
-        let spans = command_substitution_part_spans(&command.args[1]);
+        let spans = command_substitution_part_spans(&command.args[1], source);
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].slice(source), "$(date)");
     }

--- a/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
+++ b/crates/shuck-linter/src/facts/word_spans/command_substitution.rs
@@ -3,16 +3,6 @@ use crate::facts::words::{
     WordSubtreeVisitor, WordTraversalContext, WordTraversalState, walk_word_subtree,
 };
 
-#[allow(dead_code)]
-pub fn collect_command_substitution_part_spans_in_source(
-    word: &Word,
-    locator: Locator<'_>,
-    spans: &mut Vec<Span>,
-) {
-    collect_command_substitution_spans(word, traversal_context_with_locator(locator), spans);
-    normalize_command_substitution_spans(spans, locator);
-}
-
 pub fn arithmetic_expansion_part_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_arithmetic_expansion_spans(word, &mut spans);
@@ -29,39 +19,6 @@ pub fn unquoted_command_substitution_part_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_unquoted_command_substitution_spans(word, &mut spans);
     spans
-}
-
-#[allow(dead_code)]
-pub fn collect_unquoted_command_substitution_part_spans_in_source(
-    word: &Word,
-    locator: Locator<'_>,
-    spans: &mut Vec<Span>,
-) {
-    collect_unquoted_command_substitution_spans(word, spans);
-    normalize_command_substitution_spans(spans, locator);
-}
-
-#[allow(dead_code)]
-pub fn collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
-    word: &Word,
-    locator: Locator<'_>,
-    spans: &mut Vec<Span>,
-) {
-    collect_unquoted_dollar_paren_command_substitution_spans(word, spans);
-    normalize_command_substitution_spans(spans, locator);
-}
-
-fn collect_command_substitution_spans<'a>(
-    word: &'a Word,
-    context: WordTraversalContext<'a>,
-    spans: &mut Vec<Span>,
-) {
-    let mut visitor = CommandSubstitutionSpanVisitor {
-        spans,
-        only_unquoted: false,
-        only_dollar_paren: false,
-    };
-    walk_word_subtree(word, context, &mut visitor);
 }
 
 pub(crate) fn collect_arithmetic_expansion_spans(word: &Word, spans: &mut Vec<Span>) {
@@ -84,17 +41,6 @@ pub(crate) fn collect_unquoted_command_substitution_spans(word: &Word, spans: &m
     let mut visitor = CommandSubstitutionSpanVisitor {
         spans,
         only_unquoted: true,
-        only_dollar_paren: false,
-    };
-    walk_word_subtree(word, traversal_context_without_source(), &mut visitor);
-}
-
-#[allow(dead_code)]
-fn collect_unquoted_dollar_paren_command_substitution_spans(word: &Word, spans: &mut Vec<Span>) {
-    let mut visitor = CommandSubstitutionSpanVisitor {
-        spans,
-        only_unquoted: true,
-        only_dollar_paren: true,
     };
     walk_word_subtree(word, traversal_context_without_source(), &mut visitor);
 }
@@ -102,7 +48,6 @@ fn collect_unquoted_dollar_paren_command_substitution_spans(word: &Word, spans: 
 struct CommandSubstitutionSpanVisitor<'spans> {
     spans: &'spans mut Vec<Span>,
     only_unquoted: bool,
-    only_dollar_paren: bool,
 }
 
 impl<'a> WordSubtreeVisitor<'a> for CommandSubstitutionSpanVisitor<'_> {
@@ -112,17 +57,6 @@ impl<'a> WordSubtreeVisitor<'a> for CommandSubstitutionSpanVisitor<'_> {
         state: WordTraversalState<'a>,
     ) {
         if !state.processes_root_word() || (self.only_unquoted && state.in_double_quote) {
-            return;
-        }
-        if self.only_dollar_paren
-            && !matches!(
-                &part.kind,
-                WordPart::CommandSubstitution {
-                    syntax: CommandSubstitutionSyntax::DollarParen,
-                    ..
-                }
-            )
-        {
             return;
         }
         self.spans.push(part.span);
@@ -155,15 +89,6 @@ impl<'a> WordSubtreeVisitor<'a> for ArithmeticExpansionSpanVisitor<'_> {
         } else {
             self.spans.push(part.span);
         }
-    }
-}
-
-#[allow(dead_code)]
-fn traversal_context_with_locator(locator: Locator<'_>) -> WordTraversalContext<'_> {
-    WordTraversalContext {
-        source: locator.source(),
-        locator: Some(locator),
-        shell_dialect: shuck_semantic::ShellDialect::Bash,
     }
 }
 
@@ -330,19 +255,29 @@ mod tests {
     use shuck_parser::parser::Parser;
 
     use super::{
-        collect_command_substitution_part_spans_in_source,
-        collect_unquoted_dollar_paren_command_substitution_part_spans_in_source,
+        CommandSubstitutionSpanVisitor, WordTraversalContext, normalize_command_substitution_spans,
+        unquoted_command_substitution_part_spans, walk_word_subtree,
     };
     use crate::Locator;
 
     fn command_substitution_part_spans(word: &Word, source: &str) -> Vec<Span> {
         let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
         let mut spans = Vec::new();
-        collect_command_substitution_part_spans_in_source(
+        let mut visitor = CommandSubstitutionSpanVisitor {
+            spans: &mut spans,
+            only_unquoted: false,
+        };
+        walk_word_subtree(
             word,
-            Locator::new(source, &line_index),
-            &mut spans,
+            WordTraversalContext {
+                source,
+                locator: Some(locator),
+                shell_dialect: shuck_semantic::ShellDialect::Bash,
+            },
+            &mut visitor,
         );
+        normalize_command_substitution_spans(&mut spans, locator);
         spans
     }
 
@@ -352,11 +287,12 @@ mod tests {
     ) -> Vec<Span> {
         let line_index = LineIndex::new(source);
         let locator = Locator::new(source, &line_index);
-        let mut spans = Vec::new();
-        collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
-            word, locator, &mut spans,
-        );
+        let mut spans = unquoted_command_substitution_part_spans(word);
+        normalize_command_substitution_spans(&mut spans, locator);
         spans
+            .into_iter()
+            .filter(|span| span.slice(source).starts_with("$("))
+            .collect()
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/word_spans/expansions.rs
+++ b/crates/shuck-linter/src/facts/word_spans/expansions.rs
@@ -9,43 +9,6 @@ pub fn expansion_part_spans(word: &Word) -> Vec<Span> {
     spans
 }
 
-#[allow(dead_code)]
-pub fn collect_active_expansion_spans_in_source(
-    word: &Word,
-    locator: Locator<'_>,
-    spans: &mut Vec<Span>,
-) {
-    collect_expansion_spans(
-        word,
-        WordTraversalContext {
-            source: locator.source(),
-            locator: Some(locator),
-            shell_dialect: shuck_semantic::ShellDialect::Bash,
-        },
-        spans,
-    );
-    normalize_command_substitution_spans(spans, locator);
-    spans.extend(
-        word.brace_syntax()
-            .iter()
-            .copied()
-            .filter(|brace| brace.expands())
-            .map(|brace| brace.span),
-    );
-    spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
-    spans.dedup();
-}
-
-#[allow(dead_code)]
-pub fn collect_scalar_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
-    collect_scalar_expansion_spans(word, false, spans);
-}
-
-#[allow(dead_code)]
-pub fn collect_unquoted_scalar_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
-    collect_scalar_expansion_spans(word, true, spans);
-}
-
 pub fn word_double_quoted_scalar_only_expansion_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
     collect_double_quoted_scalar_only_expansion_spans(&word.parts, false, &mut spans)
@@ -129,15 +92,6 @@ fn collect_expansion_spans<'a>(
     walk_word_subtree(word, context, &mut visitor);
 }
 
-#[allow(dead_code)]
-fn collect_scalar_expansion_spans(word: &Word, only_unquoted: bool, spans: &mut Vec<Span>) {
-    let mut visitor = ScalarExpansionSpanVisitor {
-        spans,
-        only_unquoted,
-    };
-    walk_word_subtree(word, traversal_context_without_source(), &mut visitor);
-}
-
 struct ExpansionSpanVisitor<'spans> {
     spans: &'spans mut Vec<Span>,
 }
@@ -171,58 +125,6 @@ impl<'a> WordSubtreeVisitor<'a> for ExpansionSpanVisitor<'_> {
             | WordPart::PrefixMatch { .. }
             | WordPart::ProcessSubstitution { .. }
             | WordPart::Transformation { .. } => self.spans.push(part.span),
-        }
-    }
-}
-
-#[allow(dead_code)]
-struct ScalarExpansionSpanVisitor<'spans> {
-    spans: &'spans mut Vec<Span>,
-    only_unquoted: bool,
-}
-
-impl<'a> WordSubtreeVisitor<'a> for ScalarExpansionSpanVisitor<'_> {
-    fn visit_part(&mut self, part: &'a WordPartNode, state: WordTraversalState<'a>) {
-        if !state.processes_root_word() {
-            return;
-        }
-        let quoted = state.in_double_quote;
-
-        match &part.kind {
-            WordPart::Literal(_)
-            | WordPart::SingleQuoted { .. }
-            | WordPart::DoubleQuoted { .. } => {}
-            WordPart::ZshQualifiedGlob(_) => {}
-            WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
-            WordPart::Parameter(parameter) => {
-                if parameter_is_scalar_like(parameter) && (!self.only_unquoted || !quoted) {
-                    self.spans.push(part.span);
-                }
-            }
-            WordPart::Variable(name) if matches!(name.as_str(), "@" | "*") => {}
-            WordPart::Variable(_)
-            | WordPart::ArithmeticExpansion { .. }
-            | WordPart::Length(_)
-            | WordPart::ArrayLength(_)
-            | WordPart::Substring { .. }
-            | WordPart::PrefixMatch { .. } => {
-                if !self.only_unquoted || !quoted {
-                    self.spans.push(part.span);
-                }
-            }
-            WordPart::ParameterExpansion { reference, .. }
-            | WordPart::IndirectExpansion { reference, .. }
-            | WordPart::Transformation { reference, .. } => {
-                if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
-                    self.spans.push(part.span);
-                }
-            }
-            WordPart::ArrayAccess(reference) => {
-                if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
-                    self.spans.push(part.span);
-                }
-            }
-            WordPart::ArrayIndices(_) | WordPart::ArraySlice { .. } => {}
         }
     }
 }
@@ -413,18 +315,88 @@ pub(crate) fn collect_literal_scan_exclusions(parts: &[WordPartNode], excluded: 
 
 #[cfg(test)]
 mod tests {
-    use shuck_ast::{Span, Word};
+    use shuck_ast::{Span, Word, WordPart, WordPartNode};
     use shuck_parser::parser::Parser;
 
     use super::{
-        collect_scalar_expansion_part_spans, word_double_quoted_scalar_only_expansion_spans,
-        word_unquoted_assign_default_spans,
+        word_double_quoted_scalar_only_expansion_spans, word_unquoted_assign_default_spans,
+    };
+    use crate::facts::word_spans::parameter_is_scalar_like;
+    use crate::facts::words::{
+        WordSubtreeVisitor, WordTraversalContext, WordTraversalState, walk_word_subtree,
     };
 
     fn scalar_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
+        scalar_expansion_part_spans_with_mode(word, false)
+    }
+
+    fn scalar_expansion_part_spans_with_mode(word: &Word, only_unquoted: bool) -> Vec<Span> {
         let mut spans = Vec::new();
-        collect_scalar_expansion_part_spans(word, &mut spans);
+        let mut visitor = TestScalarExpansionSpanVisitor {
+            spans: &mut spans,
+            only_unquoted,
+        };
+        walk_word_subtree(
+            word,
+            WordTraversalContext {
+                source: "",
+                locator: None,
+                shell_dialect: shuck_semantic::ShellDialect::Bash,
+            },
+            &mut visitor,
+        );
         spans
+    }
+
+    struct TestScalarExpansionSpanVisitor<'spans> {
+        spans: &'spans mut Vec<Span>,
+        only_unquoted: bool,
+    }
+
+    impl<'a> WordSubtreeVisitor<'a> for TestScalarExpansionSpanVisitor<'_> {
+        fn visit_part(&mut self, part: &'a WordPartNode, state: WordTraversalState<'a>) {
+            if !state.processes_root_word() {
+                return;
+            }
+            let quoted = state.in_double_quote;
+
+            match &part.kind {
+                WordPart::Literal(_)
+                | WordPart::SingleQuoted { .. }
+                | WordPart::DoubleQuoted { .. } => {}
+                WordPart::ZshQualifiedGlob(_) => {}
+                WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
+                WordPart::Parameter(parameter) => {
+                    if parameter_is_scalar_like(parameter) && (!self.only_unquoted || !quoted) {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::Variable(name) if matches!(name.as_str(), "@" | "*") => {}
+                WordPart::Variable(_)
+                | WordPart::ArithmeticExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::Substring { .. }
+                | WordPart::PrefixMatch { .. } => {
+                    if !self.only_unquoted || !quoted {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::ParameterExpansion { reference, .. }
+                | WordPart::IndirectExpansion { reference, .. }
+                | WordPart::Transformation { reference, .. } => {
+                    if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::ArrayAccess(reference) => {
+                    if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::ArrayIndices(_) | WordPart::ArraySlice { .. } => {}
+            }
+        }
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/word_spans/expansions.rs
+++ b/crates/shuck-linter/src/facts/word_spans/expansions.rs
@@ -1,17 +1,29 @@
 use super::*;
+use crate::facts::words::{
+    WordSubtreeVisitor, WordTraversalContext, WordTraversalState, walk_word_subtree,
+};
 
 pub fn expansion_part_spans(word: &Word) -> Vec<Span> {
     let mut spans = Vec::new();
-    collect_expansion_spans(&word.parts, &mut spans);
+    collect_expansion_spans(word, traversal_context_without_source(), &mut spans);
     spans
 }
 
+#[allow(dead_code)]
 pub fn collect_active_expansion_spans_in_source(
     word: &Word,
     locator: Locator<'_>,
     spans: &mut Vec<Span>,
 ) {
-    collect_expansion_spans(&word.parts, spans);
+    collect_expansion_spans(
+        word,
+        WordTraversalContext {
+            source: locator.source(),
+            locator: Some(locator),
+            shell_dialect: shuck_semantic::ShellDialect::Bash,
+        },
+        spans,
+    );
     normalize_command_substitution_spans(spans, locator);
     spans.extend(
         word.brace_syntax()
@@ -24,12 +36,14 @@ pub fn collect_active_expansion_spans_in_source(
     spans.dedup();
 }
 
+#[allow(dead_code)]
 pub fn collect_scalar_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
-    collect_scalar_expansion_spans(&word.parts, false, false, spans);
+    collect_scalar_expansion_spans(word, false, spans);
 }
 
+#[allow(dead_code)]
 pub fn collect_unquoted_scalar_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
-    collect_scalar_expansion_spans(&word.parts, false, true, spans);
+    collect_scalar_expansion_spans(word, true, spans);
 }
 
 pub fn word_double_quoted_scalar_only_expansion_spans(word: &Word) -> Vec<Span> {
@@ -106,12 +120,41 @@ pub(crate) fn collect_unquoted_assign_default_spans(
     }
 }
 
-pub(crate) fn collect_expansion_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {
-    for part in parts {
+fn collect_expansion_spans<'a>(
+    word: &'a Word,
+    context: WordTraversalContext<'a>,
+    spans: &mut Vec<Span>,
+) {
+    let mut visitor = ExpansionSpanVisitor { spans };
+    walk_word_subtree(word, context, &mut visitor);
+}
+
+#[allow(dead_code)]
+fn collect_scalar_expansion_spans(word: &Word, only_unquoted: bool, spans: &mut Vec<Span>) {
+    let mut visitor = ScalarExpansionSpanVisitor {
+        spans,
+        only_unquoted,
+    };
+    walk_word_subtree(word, traversal_context_without_source(), &mut visitor);
+}
+
+struct ExpansionSpanVisitor<'spans> {
+    spans: &'spans mut Vec<Span>,
+}
+
+impl<'a> WordSubtreeVisitor<'a> for ExpansionSpanVisitor<'_> {
+    fn visit_part(&mut self, part: &'a WordPartNode, state: WordTraversalState<'a>) {
+        if !state.processes_root_word() {
+            return;
+        }
+
         match &part.kind {
-            WordPart::Literal(_) | WordPart::SingleQuoted { .. } => {}
-            WordPart::DoubleQuoted { parts, .. } => collect_expansion_spans(parts, spans),
-            WordPart::Variable(name) if matches!(name.as_str(), "@" | "*") => spans.push(part.span),
+            WordPart::Literal(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::DoubleQuoted { .. } => {}
+            WordPart::Variable(name) if matches!(name.as_str(), "@" | "*") => {
+                self.spans.push(part.span);
+            }
             WordPart::Variable(_)
             | WordPart::ZshQualifiedGlob(_)
             | WordPart::CommandSubstitution { .. }
@@ -127,28 +170,33 @@ pub(crate) fn collect_expansion_spans(parts: &[WordPartNode], spans: &mut Vec<Sp
             | WordPart::IndirectExpansion { .. }
             | WordPart::PrefixMatch { .. }
             | WordPart::ProcessSubstitution { .. }
-            | WordPart::Transformation { .. } => spans.push(part.span),
+            | WordPart::Transformation { .. } => self.spans.push(part.span),
         }
     }
 }
 
-pub(crate) fn collect_scalar_expansion_spans(
-    parts: &[WordPartNode],
-    quoted: bool,
+#[allow(dead_code)]
+struct ScalarExpansionSpanVisitor<'spans> {
+    spans: &'spans mut Vec<Span>,
     only_unquoted: bool,
-    spans: &mut Vec<Span>,
-) {
-    for part in parts {
+}
+
+impl<'a> WordSubtreeVisitor<'a> for ScalarExpansionSpanVisitor<'_> {
+    fn visit_part(&mut self, part: &'a WordPartNode, state: WordTraversalState<'a>) {
+        if !state.processes_root_word() {
+            return;
+        }
+        let quoted = state.in_double_quote;
+
         match &part.kind {
-            WordPart::Literal(_) | WordPart::SingleQuoted { .. } => {}
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_scalar_expansion_spans(parts, true, only_unquoted, spans)
-            }
+            WordPart::Literal(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::DoubleQuoted { .. } => {}
             WordPart::ZshQualifiedGlob(_) => {}
             WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
             WordPart::Parameter(parameter) => {
-                if parameter_is_scalar_like(parameter) && (!only_unquoted || !quoted) {
-                    spans.push(part.span);
+                if parameter_is_scalar_like(parameter) && (!self.only_unquoted || !quoted) {
+                    self.spans.push(part.span);
                 }
             }
             WordPart::Variable(name) if matches!(name.as_str(), "@" | "*") => {}
@@ -158,24 +206,32 @@ pub(crate) fn collect_scalar_expansion_spans(
             | WordPart::ArrayLength(_)
             | WordPart::Substring { .. }
             | WordPart::PrefixMatch { .. } => {
-                if !only_unquoted || !quoted {
-                    spans.push(part.span);
+                if !self.only_unquoted || !quoted {
+                    self.spans.push(part.span);
                 }
             }
             WordPart::ParameterExpansion { reference, .. }
             | WordPart::IndirectExpansion { reference, .. }
             | WordPart::Transformation { reference, .. } => {
-                if !reference.has_array_selector() && (!only_unquoted || !quoted) {
-                    spans.push(part.span);
+                if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
+                    self.spans.push(part.span);
                 }
             }
             WordPart::ArrayAccess(reference) => {
-                if !reference.has_array_selector() && (!only_unquoted || !quoted) {
-                    spans.push(part.span);
+                if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
+                    self.spans.push(part.span);
                 }
             }
             WordPart::ArrayIndices(_) | WordPart::ArraySlice { .. } => {}
         }
+    }
+}
+
+fn traversal_context_without_source<'a>() -> WordTraversalContext<'a> {
+    WordTraversalContext {
+        source: "",
+        locator: None,
+        shell_dialect: shuck_semantic::ShellDialect::Bash,
     }
 }
 

--- a/crates/shuck-linter/src/facts/word_spans/mod.rs
+++ b/crates/shuck-linter/src/facts/word_spans/mod.rs
@@ -1,8 +1,8 @@
 use shuck_ast::{
-    ArithmeticExpr, BourneParameterExpansion, CaseItem, CommandSubstitutionSyntax, ConditionalExpr,
-    ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position,
-    PrefixMatchKind, Span, SubscriptSelector, VarRef, Word, WordPart, WordPartNode,
-    ZshExpansionTarget, ZshGlobSegment, ZshQualifiedGlob,
+    ArithmeticExpr, BourneParameterExpansion, CaseItem, ConditionalExpr, ParameterExpansion,
+    ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, Position, PrefixMatchKind, Span,
+    SubscriptSelector, VarRef, Word, WordPart, WordPartNode, ZshExpansionTarget, ZshGlobSegment,
+    ZshQualifiedGlob,
 };
 
 use super::BacktickEscapedParameter;

--- a/crates/shuck-linter/src/facts/word_spans/shell_quoting.rs
+++ b/crates/shuck-linter/src/facts/word_spans/shell_quoting.rs
@@ -405,7 +405,7 @@ pub(crate) fn neighbor_is_literal(part: Option<&WordPartNode>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use shuck_ast::{Span, Word};
+    use shuck_ast::{Span, Word, WordPart, WordPartNode};
     use shuck_parser::parser::Parser;
 
     use super::{
@@ -414,22 +414,88 @@ mod tests {
         word_unquoted_word_after_single_quoted_segment_spans,
     };
     use crate::facts::word_spans::{
-        collect_unquoted_command_substitution_part_spans_in_source,
-        collect_unquoted_scalar_expansion_part_spans,
+        normalize_command_substitution_spans, parameter_is_scalar_like,
+        unquoted_command_substitution_part_spans,
+    };
+    use crate::facts::words::{
+        WordSubtreeVisitor, WordTraversalContext, WordTraversalState, walk_word_subtree,
     };
 
     fn unquoted_scalar_expansion_part_spans(word: &Word, _source: &str) -> Vec<Span> {
         let mut spans = Vec::new();
-        collect_unquoted_scalar_expansion_part_spans(word, &mut spans);
+        let mut visitor = TestScalarExpansionSpanVisitor {
+            spans: &mut spans,
+            only_unquoted: true,
+        };
+        walk_word_subtree(
+            word,
+            WordTraversalContext {
+                source: "",
+                locator: None,
+                shell_dialect: shuck_semantic::ShellDialect::Bash,
+            },
+            &mut visitor,
+        );
         spans
     }
 
     fn unquoted_command_substitution_part_spans_in_source(word: &Word, source: &str) -> Vec<Span> {
         let line_index = shuck_indexer::LineIndex::new(source);
         let locator = crate::Locator::new(source, &line_index);
-        let mut spans = Vec::new();
-        collect_unquoted_command_substitution_part_spans_in_source(word, locator, &mut spans);
+        let mut spans = unquoted_command_substitution_part_spans(word);
+        normalize_command_substitution_spans(&mut spans, locator);
         spans
+    }
+
+    struct TestScalarExpansionSpanVisitor<'spans> {
+        spans: &'spans mut Vec<Span>,
+        only_unquoted: bool,
+    }
+
+    impl<'a> WordSubtreeVisitor<'a> for TestScalarExpansionSpanVisitor<'_> {
+        fn visit_part(&mut self, part: &'a WordPartNode, state: WordTraversalState<'a>) {
+            if !state.processes_root_word() {
+                return;
+            }
+            let quoted = state.in_double_quote;
+
+            match &part.kind {
+                WordPart::Literal(_)
+                | WordPart::SingleQuoted { .. }
+                | WordPart::DoubleQuoted { .. } => {}
+                WordPart::ZshQualifiedGlob(_) => {}
+                WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
+                WordPart::Parameter(parameter) => {
+                    if parameter_is_scalar_like(parameter) && (!self.only_unquoted || !quoted) {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::Variable(name) if matches!(name.as_str(), "@" | "*") => {}
+                WordPart::Variable(_)
+                | WordPart::ArithmeticExpansion { .. }
+                | WordPart::Length(_)
+                | WordPart::ArrayLength(_)
+                | WordPart::Substring { .. }
+                | WordPart::PrefixMatch { .. } => {
+                    if !self.only_unquoted || !quoted {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::ParameterExpansion { reference, .. }
+                | WordPart::IndirectExpansion { reference, .. }
+                | WordPart::Transformation { reference, .. } => {
+                    if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::ArrayAccess(reference) => {
+                    if !reference.has_array_selector() && (!self.only_unquoted || !quoted) {
+                        self.spans.push(part.span);
+                    }
+                }
+                WordPart::ArrayIndices(_) | WordPart::ArraySlice { .. } => {}
+            }
+        }
     }
 
     #[test]

--- a/crates/shuck-linter/src/facts/words/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/words/arithmetic.rs
@@ -782,6 +782,186 @@ pub(super) fn collect_arithmetic_spans_in_parameter_operator(
     }
 }
 
+pub(super) fn collect_arithmetic_summary_spans_in_word(
+    word: &Word,
+    source: &str,
+    collect_dollar_spans: bool,
+    dollar_spans: &mut Vec<Span>,
+    command_substitution_spans: &mut Vec<Span>,
+) {
+    let mut visitor = ArithmeticSummarySpanVisitor {
+        source,
+        collect_dollar_spans,
+        dollar_spans,
+        command_substitution_spans,
+    };
+    walk_word_subtree(
+        word,
+        WordTraversalContext {
+            source,
+            locator: None,
+            shell_dialect: shuck_semantic::ShellDialect::Bash,
+        },
+        &mut visitor,
+    );
+}
+
+struct ArithmeticSummarySpanVisitor<'out, 'source> {
+    source: &'source str,
+    collect_dollar_spans: bool,
+    dollar_spans: &'out mut Vec<Span>,
+    command_substitution_spans: &'out mut Vec<Span>,
+}
+
+impl<'word> WordSubtreeVisitor<'word> for ArithmeticSummarySpanVisitor<'_, '_> {
+    fn visit_part(&mut self, part: &'word WordPartNode, state: WordTraversalState<'word>) {
+        if !state.processes_root_word() {
+            return;
+        }
+
+        match &part.kind {
+            WordPart::DoubleQuoted { .. } => {}
+            WordPart::ArithmeticExpansion {
+                expression_ast,
+                expression_word_ast,
+                ..
+            } => {
+                if let Some(expression) = expression_ast {
+                    visit_arithmetic_words(expression, &mut |word| {
+                        collect_arithmetic_context_spans_in_word(
+                            word,
+                            self.source,
+                            self.collect_dollar_spans,
+                            self.dollar_spans,
+                            self.command_substitution_spans,
+                        );
+                    });
+                } else {
+                    collect_arithmetic_summary_spans_in_word(
+                        expression_word_ast,
+                        self.source,
+                        self.collect_dollar_spans,
+                        self.dollar_spans,
+                        self.command_substitution_spans,
+                    );
+                }
+            }
+            WordPart::Parameter(parameter) => collect_arithmetic_spans_in_parameter_expansion(
+                parameter,
+                self.source,
+                self.collect_dollar_spans,
+                self.dollar_spans,
+                self.command_substitution_spans,
+            ),
+            WordPart::ParameterExpansion {
+                reference,
+                operator,
+                ..
+            } => {
+                collect_arithmetic_spans_in_var_ref(
+                    reference,
+                    self.source,
+                    self.collect_dollar_spans,
+                    self.dollar_spans,
+                    self.command_substitution_spans,
+                );
+                collect_arithmetic_spans_in_parameter_operator(
+                    operator,
+                    self.source,
+                    self.collect_dollar_spans,
+                    self.dollar_spans,
+                    self.command_substitution_spans,
+                );
+            }
+            WordPart::Length(reference)
+            | WordPart::ArrayAccess(reference)
+            | WordPart::ArrayLength(reference)
+            | WordPart::ArrayIndices(reference)
+            | WordPart::IndirectExpansion { reference, .. }
+            | WordPart::Transformation { reference, .. } => collect_arithmetic_spans_in_var_ref(
+                reference,
+                self.source,
+                self.collect_dollar_spans,
+                self.dollar_spans,
+                self.command_substitution_spans,
+            ),
+            WordPart::Substring {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            }
+            | WordPart::ArraySlice {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                collect_arithmetic_spans_in_var_ref(
+                    reference,
+                    self.source,
+                    self.collect_dollar_spans,
+                    self.dollar_spans,
+                    self.command_substitution_spans,
+                );
+                if let Some(expression) = offset_ast {
+                    collect_slice_arithmetic_expression_spans(
+                        expression,
+                        self.source,
+                        self.dollar_spans,
+                        self.command_substitution_spans,
+                    );
+                } else {
+                    collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
+                        &offset_word_ast.parts,
+                        self.source,
+                        self.dollar_spans,
+                    );
+                    collect_arithmetic_expansion_spans_from_parts(
+                        &offset_word_ast.parts,
+                        self.source,
+                        false,
+                        self.dollar_spans,
+                        self.command_substitution_spans,
+                    );
+                }
+                if let Some(expression) = length_ast {
+                    collect_slice_arithmetic_expression_spans(
+                        expression,
+                        self.source,
+                        self.dollar_spans,
+                        self.command_substitution_spans,
+                    );
+                } else if let Some(length_word_ast) = length_word_ast {
+                    collect_dollar_spans_in_nested_arithmetic_expansions_from_parts(
+                        &length_word_ast.parts,
+                        self.source,
+                        self.dollar_spans,
+                    );
+                    collect_arithmetic_expansion_spans_from_parts(
+                        &length_word_ast.parts,
+                        self.source,
+                        false,
+                        self.dollar_spans,
+                        self.command_substitution_spans,
+                    );
+                }
+            }
+            WordPart::Literal(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::Variable(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::ZshQualifiedGlob(_) => {}
+        }
+    }
+}
+
 pub(super) fn collect_arithmetic_expansion_spans_from_parts(
     parts: &[WordPartNode],
     source: &str,

--- a/crates/shuck-linter/src/facts/words/mod.rs
+++ b/crates/shuck-linter/src/facts/words/mod.rs
@@ -1,6 +1,11 @@
 use super::*;
 use crate::Locator;
 
+mod traversal;
+
+#[allow(unused_imports)]
+pub(in crate::facts) use traversal::*;
+
 include!("expansion.rs");
 include!("occurrence.rs");
 include!("arithmetic.rs");

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1324,6 +1324,13 @@ pub(super) fn derive_word_fact_data<'a>(
     let may_have_command_substitution_spans = word_may_have_command_substitution_spans(word);
     let may_have_mixed_quote_spans =
         word_may_have_unquoted_literal_between_double_quoted_segments_spans(word, source);
+    let mut traversal_spans = collect_derived_word_traversal_spans(
+        word,
+        locator,
+        shell_dialect,
+        may_have_runtime_expansion_spans,
+        may_have_command_substitution_spans,
+    );
 
     WordNodeDerived {
         static_text: borrowed_static_word_text(word, source),
@@ -1331,30 +1338,12 @@ pub(super) fn derive_word_fact_data<'a>(
         starts_with_extglob: word_spans::word_starts_with_extglob(word, source),
         has_literal_affixes: word_has_literal_affixes(word),
         contains_shell_quoting_literals: word_contains_shell_quoting_literals(word, source),
-        active_expansion_spans: push_needed_word_span_list(
-            span_store,
-            scratch,
-            may_have_runtime_expansion_spans || word.has_active_brace_expansion(),
-            |spans| {
-                word_spans::collect_active_expansion_spans_in_source(word, locator, spans);
-            },
-        ),
-        scalar_expansion_spans: push_needed_word_span_list(
-            span_store,
-            scratch,
-            may_have_runtime_expansion_spans,
-            |spans| {
-                word_spans::collect_scalar_expansion_part_spans(word, spans);
-            },
-        ),
-        unquoted_scalar_expansion_spans: push_needed_word_span_list(
-            span_store,
-            scratch,
-            may_have_runtime_expansion_spans,
-            |spans| {
-                word_spans::collect_unquoted_scalar_expansion_part_spans(word, spans);
-            },
-        ),
+        active_expansion_spans: span_store
+            .push_many(traversal_spans.active_expansion_spans.drain(..)),
+        scalar_expansion_spans: span_store
+            .push_many(traversal_spans.scalar_expansion_spans.drain(..)),
+        unquoted_scalar_expansion_spans: span_store
+            .push_many(traversal_spans.unquoted_scalar_expansion_spans.drain(..)),
         array_expansion_spans: push_needed_word_span_list(
             span_store,
             scratch,
@@ -1410,42 +1399,17 @@ pub(super) fn derive_word_fact_data<'a>(
                 word_spans::collect_unquoted_array_expansion_part_spans(word, spans);
             },
         ),
-        command_substitution_spans: push_needed_word_span_list(
-            span_store,
-            scratch,
-            may_have_command_substitution_spans,
-            |spans| {
-                word_spans::collect_command_substitution_part_spans_in_source(word, locator, spans);
-            },
+        command_substitution_spans: span_store
+            .push_many(traversal_spans.command_substitution_spans.drain(..)),
+        unquoted_command_substitution_spans: span_store
+            .push_many(traversal_spans.unquoted_command_substitution_spans.drain(..)),
+        unquoted_dollar_paren_command_substitution_spans: span_store.push_many(
+            traversal_spans
+                .unquoted_dollar_paren_command_substitution_spans
+                .drain(..),
         ),
-        unquoted_command_substitution_spans: push_needed_word_span_list(
-            span_store,
-            scratch,
-            may_have_command_substitution_spans,
-            |spans| {
-                word_spans::collect_unquoted_command_substitution_part_spans_in_source(
-                    word, locator, spans,
-                );
-            },
-        ),
-        unquoted_dollar_paren_command_substitution_spans: push_needed_word_span_list(
-            span_store,
-            scratch,
-            may_have_command_substitution_spans,
-            |spans| {
-                word_spans::collect_unquoted_dollar_paren_command_substitution_part_spans_in_source(
-                    word, locator, spans,
-                );
-            },
-        ),
-        double_quoted_expansion_spans: push_needed_word_span_list(
-            span_store,
-            scratch,
-            may_have_runtime_expansion_spans,
-            |spans| {
-                collect_double_quoted_expansion_part_spans(word, spans);
-            },
-        ),
+        double_quoted_expansion_spans: span_store
+            .push_many(traversal_spans.double_quoted_expansion_spans.drain(..)),
         unquoted_literal_between_double_quoted_segments_spans: push_needed_word_span_list(
             span_store,
             scratch,
@@ -1454,6 +1418,227 @@ pub(super) fn derive_word_fact_data<'a>(
                 collect_unquoted_literal_between_double_quoted_segments_spans(word, source, spans);
             },
         ),
+    }
+}
+
+#[derive(Default)]
+struct DerivedWordTraversalSpans {
+    active_expansion_spans: Vec<Span>,
+    scalar_expansion_spans: Vec<Span>,
+    unquoted_scalar_expansion_spans: Vec<Span>,
+    command_substitution_spans: Vec<Span>,
+    unquoted_command_substitution_spans: Vec<Span>,
+    unquoted_dollar_paren_command_substitution_spans: Vec<Span>,
+    double_quoted_expansion_spans: Vec<Span>,
+}
+
+fn collect_derived_word_traversal_spans<'a>(
+    word: &'a Word,
+    locator: Locator<'a>,
+    shell_dialect: shuck_semantic::ShellDialect,
+    may_have_runtime_expansion_spans: bool,
+    may_have_command_substitution_spans: bool,
+) -> DerivedWordTraversalSpans {
+    let mut spans = DerivedWordTraversalSpans::default();
+    if may_have_runtime_expansion_spans || may_have_command_substitution_spans {
+        let mut visitor = DerivedWordTraversalVisitor {
+            spans: &mut spans,
+            collect_runtime_expansion_spans: may_have_runtime_expansion_spans,
+            collect_command_substitution_spans: may_have_command_substitution_spans,
+        };
+        walk_word_subtree(
+            word,
+            WordTraversalContext {
+                source: locator.source(),
+                locator: Some(locator),
+                shell_dialect,
+            },
+            &mut visitor,
+        );
+    }
+
+    if may_have_command_substitution_spans {
+        word_spans::normalize_command_substitution_spans(
+            &mut spans.command_substitution_spans,
+            locator,
+        );
+        word_spans::normalize_command_substitution_spans(
+            &mut spans.unquoted_command_substitution_spans,
+            locator,
+        );
+        word_spans::normalize_command_substitution_spans(
+            &mut spans.unquoted_dollar_paren_command_substitution_spans,
+            locator,
+        );
+    }
+
+    if may_have_runtime_expansion_spans || word.has_active_brace_expansion() {
+        spans.active_expansion_spans.extend(
+            word.brace_syntax()
+                .iter()
+                .copied()
+                .filter(|brace| brace.expands())
+                .map(|brace| brace.span),
+        );
+        spans
+            .active_expansion_spans
+            .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+        spans.active_expansion_spans.dedup();
+    }
+
+    spans
+}
+
+struct DerivedWordTraversalVisitor<'spans> {
+    spans: &'spans mut DerivedWordTraversalSpans,
+    collect_runtime_expansion_spans: bool,
+    collect_command_substitution_spans: bool,
+}
+
+impl<'a> WordSubtreeVisitor<'a> for DerivedWordTraversalVisitor<'_> {
+    fn visit_part(&mut self, part: &'a WordPartNode, state: WordTraversalState<'a>) {
+        if !state.processes_root_word() {
+            return;
+        }
+
+        if self.collect_runtime_expansion_spans {
+            self.collect_runtime_expansion_part(part, state);
+            self.collect_scalar_expansion_part(part, state);
+            self.collect_double_quoted_expansion_part(part, state);
+        }
+    }
+
+    fn visit_command_substitution(
+        &mut self,
+        part: &'a WordPartNode,
+        state: WordTraversalState<'a>,
+    ) {
+        if !self.collect_command_substitution_spans || !state.processes_root_word() {
+            return;
+        }
+
+        self.spans.command_substitution_spans.push(part.span);
+        if !state.in_double_quote {
+            self.spans
+                .unquoted_command_substitution_spans
+                .push(part.span);
+            if matches!(
+                &part.kind,
+                WordPart::CommandSubstitution {
+                    syntax: CommandSubstitutionSyntax::DollarParen,
+                    ..
+                }
+            ) {
+                self.spans
+                    .unquoted_dollar_paren_command_substitution_spans
+                    .push(part.span);
+            }
+        }
+    }
+}
+
+impl DerivedWordTraversalVisitor<'_> {
+    fn collect_runtime_expansion_part(&mut self, part: &WordPartNode, _state: WordTraversalState<'_>) {
+        match &part.kind {
+            WordPart::Literal(_) | WordPart::SingleQuoted { .. } | WordPart::DoubleQuoted { .. } => {
+            }
+            WordPart::Variable(name) if matches!(name.as_str(), "@" | "*") => {
+                self.spans.active_expansion_spans.push(part.span);
+            }
+            WordPart::Variable(_)
+            | WordPart::ZshQualifiedGlob(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Parameter(_)
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. } => {
+                self.spans.active_expansion_spans.push(part.span);
+            }
+        }
+    }
+
+    fn collect_scalar_expansion_part(&mut self, part: &WordPartNode, state: WordTraversalState<'_>) {
+        let quoted = state.in_double_quote;
+        let push_scalar = |spans: &mut DerivedWordTraversalSpans| {
+            spans.scalar_expansion_spans.push(part.span);
+            if !quoted {
+                spans.unquoted_scalar_expansion_spans.push(part.span);
+            }
+        };
+
+        match &part.kind {
+            WordPart::Literal(_) | WordPart::SingleQuoted { .. } | WordPart::DoubleQuoted { .. } => {
+            }
+            WordPart::ZshQualifiedGlob(_) => {}
+            WordPart::CommandSubstitution { .. } | WordPart::ProcessSubstitution { .. } => {}
+            WordPart::Parameter(parameter) => {
+                if word_spans::parameter_is_scalar_like(parameter) {
+                    push_scalar(self.spans);
+                }
+            }
+            WordPart::Variable(name) if matches!(name.as_str(), "@" | "*") => {}
+            WordPart::Variable(_)
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::Substring { .. }
+            | WordPart::PrefixMatch { .. } => push_scalar(self.spans),
+            WordPart::ParameterExpansion { reference, .. }
+            | WordPart::IndirectExpansion { reference, .. }
+            | WordPart::Transformation { reference, .. } => {
+                if !reference.has_array_selector() {
+                    push_scalar(self.spans);
+                }
+            }
+            WordPart::ArrayAccess(reference) => {
+                if !reference.has_array_selector() {
+                    push_scalar(self.spans);
+                }
+            }
+            WordPart::ArrayIndices(_) | WordPart::ArraySlice { .. } => {}
+        }
+    }
+
+    fn collect_double_quoted_expansion_part(
+        &mut self,
+        part: &WordPartNode,
+        state: WordTraversalState<'_>,
+    ) {
+        if !state.in_double_quote {
+            return;
+        }
+
+        match &part.kind {
+            WordPart::Variable(_)
+            | WordPart::Parameter(_)
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. }
+            | WordPart::ParameterExpansion { .. }
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::Substring { .. }
+            | WordPart::ArraySlice { .. }
+            | WordPart::IndirectExpansion { .. }
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. }
+            | WordPart::ZshQualifiedGlob(_) => {
+                self.spans.double_quoted_expansion_spans.push(part.span);
+            }
+            WordPart::Literal(_) | WordPart::SingleQuoted { .. } | WordPart::DoubleQuoted { .. } => {
+            }
+        }
     }
 }
 
@@ -1651,28 +1836,122 @@ pub(super) fn simple_command_word_at(command: &SimpleCommand, index: usize) -> &
 }
 
 fn collect_split_sensitive_unquoted_command_substitution_spans(
-    parts: &[WordPartNode],
+    word: &Word,
     source: &str,
-    quoted: bool,
     behavior: &ShellBehaviorAt<'_>,
     spans: &mut Vec<Span>,
 ) {
-    for part in parts {
-        match &part.kind {
-            WordPart::SingleQuoted { .. } => {}
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_split_sensitive_unquoted_command_substitution_spans(
-                    parts, source, true, behavior, spans,
+    let mut visitor = SplitSensitiveCommandSubstitutionVisitor {
+        source,
+        behavior,
+        spans,
+    };
+    walk_word_subtree(
+        word,
+        WordTraversalContext {
+            source,
+            locator: None,
+            shell_dialect: behavior.shell_dialect(),
+        },
+        &mut visitor,
+    );
+}
+
+struct SplitSensitiveCommandSubstitutionVisitor<'spans, 'behavior, 'source> {
+    source: &'source str,
+    behavior: &'behavior ShellBehaviorAt<'source>,
+    spans: &'spans mut Vec<Span>,
+}
+
+impl<'a> WordSubtreeVisitor<'a>
+    for SplitSensitiveCommandSubstitutionVisitor<'_, '_, '_>
+{
+    fn visit_command_substitution(
+        &mut self,
+        part: &'a WordPartNode,
+        state: WordTraversalState<'a>,
+    ) {
+        if state.processes_root_word()
+            && !state.in_double_quote
+            && analyze_part(&part.kind, self.source, false, self.behavior)
+                .can_expand_to_multiple_fields
+        {
+            self.spans.push(part.span);
+        }
+    }
+}
+
+struct WordParameterPatternVisitor<'collector, 'out, 'a, 'norm> {
+    collector: &'collector mut WordFactCollector<'out, 'a, 'norm>,
+    host_kind: WordFactHostKind,
+}
+
+impl<'out, 'a, 'norm> WordSubtreeVisitor<'a>
+    for WordParameterPatternVisitor<'_, 'out, 'a, 'norm>
+{
+    fn visit_pattern_word(&mut self, word: &'a Word, state: WordTraversalState<'a>) {
+        if matches!(
+            (state.origin, state.pattern_context),
+            (
+                WordTraversalOrigin::ParameterPattern,
+                Some(WordTraversalPatternContext::ParameterOperator)
+            ) | (
+                WordTraversalOrigin::ZshQualifiedGlobPattern,
+                Some(WordTraversalPatternContext::ZshQualifiedGlob)
+            )
+        ) {
+            self.collector.push_word(
+                word,
+                WordFactContext::Expansion(ExpansionContext::ParameterPattern),
+                self.host_kind,
+            );
+        }
+    }
+}
+
+struct PendingArithmeticWordVisitor<'collector, 'out, 'a, 'norm> {
+    collector: &'collector mut WordFactCollector<'out, 'a, 'norm>,
+    enclosing_expansion_context: ExpansionContext,
+    host_kind: WordFactHostKind,
+}
+
+impl<'out, 'a, 'norm> WordSubtreeVisitor<'a>
+    for PendingArithmeticWordVisitor<'_, 'out, 'a, 'norm>
+{
+    fn visit_arithmetic_expansion(
+        &mut self,
+        part: &'a WordPartNode,
+        state: WordTraversalState<'a>,
+    ) {
+        if matches!(
+            state.origin,
+            WordTraversalOrigin::ParameterPattern | WordTraversalOrigin::ZshQualifiedGlobPattern
+        ) {
+            return;
+        }
+        let WordPart::ArithmeticExpansion {
+            expression_ast,
+            expression_word_ast,
+            ..
+        } = &part.kind
+        else {
+            return;
+        };
+
+        if let Some(expression) = expression_ast.as_ref() {
+            visit_arithmetic_words(expression, &mut |word| {
+                self.collector.push_pending_arithmetic_word_occurrence(
+                    word,
+                    self.enclosing_expansion_context,
+                    self.host_kind,
                 );
-            }
-            WordPart::CommandSubstitution { .. }
-                if !quoted
-                    && analyze_part(&part.kind, source, quoted, behavior)
-                        .can_expand_to_multiple_fields =>
-            {
-                spans.push(part.span);
-            }
-            _ => {}
+            });
+        } else {
+            self.collector.push_pending_arithmetic_word_occurrence(
+                expression_word_ast,
+                self.enclosing_expansion_context,
+                self.host_kind,
+            );
         }
     }
 }
@@ -2538,19 +2817,6 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }
     }
 
-    fn collect_zsh_qualified_glob_context_words(
-        &mut self,
-        glob: &'a ZshQualifiedGlob,
-        context: WordFactContext,
-        host_kind: WordFactHostKind,
-    ) {
-        for segment in &glob.segments {
-            if let ZshGlobSegment::Pattern(pattern) = segment {
-                self.collect_pattern_context_words(pattern, context, host_kind, None);
-            }
-        }
-    }
-
     fn collect_conditional_expansion_words(
         &mut self,
         expression: &'a ConditionalExpr,
@@ -2614,82 +2880,13 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         }
     }
 
-    fn collect_word_parameter_patterns(
-        &mut self,
-        parts: &'a [WordPartNode],
-        host_kind: WordFactHostKind,
-    ) {
-        for part in parts {
-            match &part.kind {
-                WordPart::ZshQualifiedGlob(glob) => self.collect_zsh_qualified_glob_context_words(
-                    glob,
-                    WordFactContext::Expansion(ExpansionContext::ParameterPattern),
-                    host_kind,
-                ),
-                WordPart::DoubleQuoted { parts, .. } => {
-                    self.collect_word_parameter_patterns(parts, host_kind)
-                }
-                WordPart::Parameter(parameter) => {
-                    if let ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
-                        operator,
-                        ..
-                    }) = &parameter.syntax
-                    {
-                        self.collect_parameter_operator_patterns(operator, host_kind);
-                    }
-                }
-                WordPart::ParameterExpansion { operator, .. } => {
-                    self.collect_parameter_operator_patterns(operator, host_kind)
-                }
-                WordPart::IndirectExpansion {
-                    operator: Some(operator),
-                    ..
-                } => self.collect_parameter_operator_patterns(operator, host_kind),
-                WordPart::Literal(_)
-                | WordPart::SingleQuoted { .. }
-                | WordPart::Variable(_)
-                | WordPart::CommandSubstitution { .. }
-                | WordPart::ArithmeticExpansion { .. }
-                | WordPart::Length(_)
-                | WordPart::ArrayAccess(_)
-                | WordPart::ArrayLength(_)
-                | WordPart::ArrayIndices(_)
-                | WordPart::Substring { .. }
-                | WordPart::ArraySlice { .. }
-                | WordPart::IndirectExpansion { operator: None, .. }
-                | WordPart::PrefixMatch { .. }
-                | WordPart::ProcessSubstitution { .. }
-                | WordPart::Transformation { .. } => {}
-            }
-        }
-    }
-
-    fn collect_parameter_operator_patterns(
-        &mut self,
-        operator: &'a ParameterOp,
-        host_kind: WordFactHostKind,
-    ) {
-        match operator {
-            ParameterOp::RemovePrefixShort { pattern }
-            | ParameterOp::RemovePrefixLong { pattern }
-            | ParameterOp::RemoveSuffixShort { pattern }
-            | ParameterOp::RemoveSuffixLong { pattern }
-            | ParameterOp::ReplaceFirst { pattern, .. }
-            | ParameterOp::ReplaceAll { pattern, .. } => self.collect_pattern_context_words(
-                pattern,
-                WordFactContext::Expansion(ExpansionContext::ParameterPattern),
-                host_kind,
-                None,
-            ),
-            ParameterOp::UseDefault
-            | ParameterOp::AssignDefault
-            | ParameterOp::UseReplacement
-            | ParameterOp::Error
-            | ParameterOp::UpperFirst
-            | ParameterOp::UpperAll
-            | ParameterOp::LowerFirst
-            | ParameterOp::LowerAll => {}
-        }
+    fn collect_word_parameter_patterns(&mut self, word: &'a Word, host_kind: WordFactHostKind) {
+        let context = self.word_traversal_context();
+        let mut visitor = WordParameterPatternVisitor {
+            collector: self,
+            host_kind,
+        };
+        walk_word_subtree(word, context, &mut visitor);
     }
 
     fn push_word(
@@ -2768,7 +2965,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             return (None, opened_double_quote);
         }
 
-        self.collect_word_parameter_patterns(&word.parts, host_kind);
+        self.collect_word_parameter_patterns(word, host_kind);
         self.collect_arithmetic_summary(word, context, host_kind);
 
         let node_id = self.intern_word_node(word);
@@ -2802,9 +2999,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         };
         self.word_span_scratch.clear();
         collect_split_sensitive_unquoted_command_substitution_spans(
-            &word.parts,
+            word,
             self.source,
-            false,
             &self.command_shell_behavior,
             self.word_span_scratch,
         );
@@ -2840,190 +3036,13 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         enclosing_expansion_context: ExpansionContext,
         host_kind: WordFactHostKind,
     ) {
-        self.collect_pending_arithmetic_word_occurrences_in_parts(
-            &word.parts,
+        let context = self.word_traversal_context();
+        let mut visitor = PendingArithmeticWordVisitor {
+            collector: self,
             enclosing_expansion_context,
             host_kind,
-        );
-    }
-
-    fn collect_pending_arithmetic_word_occurrences_in_parts(
-        &mut self,
-        parts: &'a [WordPartNode],
-        enclosing_expansion_context: ExpansionContext,
-        host_kind: WordFactHostKind,
-    ) {
-        for part in parts {
-            match &part.kind {
-                WordPart::DoubleQuoted { parts, .. } => self
-                    .collect_pending_arithmetic_word_occurrences_in_parts(
-                        parts,
-                        enclosing_expansion_context,
-                        host_kind,
-                    ),
-                WordPart::ArithmeticExpansion {
-                    expression_ast,
-                    expression_word_ast,
-                    ..
-                } => {
-                    if let Some(expression) = expression_ast.as_ref() {
-                        visit_arithmetic_words(expression, &mut |word| {
-                            self.push_pending_arithmetic_word_occurrence(
-                                word,
-                                enclosing_expansion_context,
-                                host_kind,
-                            );
-                        });
-                    } else {
-                        self.push_pending_arithmetic_word_occurrence(
-                            expression_word_ast,
-                            enclosing_expansion_context,
-                            host_kind,
-                        );
-                    }
-                }
-                WordPart::Parameter(parameter) => self
-                    .collect_pending_arithmetic_word_occurrences_in_parameter_expansion(
-                        parameter,
-                        enclosing_expansion_context,
-                        host_kind,
-                    ),
-                WordPart::ParameterExpansion {
-                    operator,
-                    operand_word_ast,
-                    ..
-                }
-                | WordPart::IndirectExpansion {
-                    operator: Some(operator),
-                    operand_word_ast,
-                    ..
-                } => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
-                    operator,
-                    operand_word_ast.as_deref(),
-                    enclosing_expansion_context,
-                    host_kind,
-                ),
-                WordPart::Literal(_)
-                | WordPart::SingleQuoted { .. }
-                | WordPart::Variable(_)
-                | WordPart::CommandSubstitution { .. }
-                | WordPart::Length(_)
-                | WordPart::ArrayAccess(_)
-                | WordPart::ArrayLength(_)
-                | WordPart::ArrayIndices(_)
-                | WordPart::Substring { .. }
-                | WordPart::ArraySlice { .. }
-                | WordPart::IndirectExpansion { operator: None, .. }
-                | WordPart::PrefixMatch { .. }
-                | WordPart::ProcessSubstitution { .. }
-                | WordPart::Transformation { .. }
-                | WordPart::ZshQualifiedGlob(_) => {}
-            }
-        }
-    }
-
-    fn collect_pending_arithmetic_word_occurrences_in_parameter_expansion(
-        &mut self,
-        parameter: &'a ParameterExpansion,
-        enclosing_expansion_context: ExpansionContext,
-        host_kind: WordFactHostKind,
-    ) {
-        match &parameter.syntax {
-            ParameterExpansionSyntax::Bourne(
-                BourneParameterExpansion::Operation {
-                    operator,
-                    operand_word_ast,
-                    ..
-                }
-                | BourneParameterExpansion::Indirect {
-                    operator: Some(operator),
-                    operand_word_ast,
-                    ..
-                },
-            ) => self.collect_pending_arithmetic_word_occurrences_in_parameter_operator(
-                operator,
-                operand_word_ast.as_deref(),
-                enclosing_expansion_context,
-                host_kind,
-            ),
-            ParameterExpansionSyntax::Bourne(
-                BourneParameterExpansion::Access { .. }
-                | BourneParameterExpansion::Length { .. }
-                | BourneParameterExpansion::Indices { .. }
-                | BourneParameterExpansion::Indirect { operator: None, .. }
-                | BourneParameterExpansion::PrefixMatch { .. }
-                | BourneParameterExpansion::Slice { .. }
-                | BourneParameterExpansion::Transformation { .. },
-            ) => {}
-            ParameterExpansionSyntax::Zsh(syntax) => {
-                match &syntax.target {
-                    ZshExpansionTarget::Nested(parameter) => self
-                        .collect_pending_arithmetic_word_occurrences_in_parameter_expansion(
-                            parameter,
-                            enclosing_expansion_context,
-                            host_kind,
-                        ),
-                    ZshExpansionTarget::Word(word) => self
-                        .collect_pending_arithmetic_word_occurrences(
-                            word,
-                            enclosing_expansion_context,
-                            host_kind,
-                        ),
-                    ZshExpansionTarget::Reference(_) | ZshExpansionTarget::Empty => {}
-                }
-
-                if let Some(operation) = syntax.operation.as_ref()
-                    && let Some(operand_word) = operation.operand_word_ast()
-                {
-                    self.collect_pending_arithmetic_word_occurrences(
-                        operand_word,
-                        enclosing_expansion_context,
-                        host_kind,
-                    );
-                }
-
-                if let Some(operation) = syntax.operation.as_ref()
-                    && let Some(replacement_word) = operation.replacement_word_ast()
-                {
-                    self.collect_pending_arithmetic_word_occurrences(
-                        replacement_word,
-                        enclosing_expansion_context,
-                        host_kind,
-                    );
-                }
-            }
-        }
-    }
-
-    fn collect_pending_arithmetic_word_occurrences_in_parameter_operator(
-        &mut self,
-        operator: &'a ParameterOp,
-        operand_word_ast: Option<&'a Word>,
-        enclosing_expansion_context: ExpansionContext,
-        host_kind: WordFactHostKind,
-    ) {
-        if matches!(
-            operator,
-            ParameterOp::UseDefault
-                | ParameterOp::AssignDefault
-                | ParameterOp::UseReplacement
-                | ParameterOp::Error
-        ) && let Some(operand_word) = operand_word_ast
-        {
-            self.collect_pending_arithmetic_word_occurrences(
-                operand_word,
-                enclosing_expansion_context,
-                host_kind,
-            );
-        }
-
-        if let Some(replacement_word) = operator.replacement_word_ast() {
-            self.collect_pending_arithmetic_word_occurrences(
-                replacement_word,
-                enclosing_expansion_context,
-                host_kind,
-            );
-        }
+        };
+        walk_word_subtree(word, context, &mut visitor);
     }
 
     fn push_pending_arithmetic_word_occurrence(
@@ -3049,11 +3068,14 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 host_kind,
                 enclosing_expansion_context,
             });
-        self.collect_pending_arithmetic_word_occurrences(
-            word,
-            enclosing_expansion_context,
-            host_kind,
-        );
+    }
+
+    fn word_traversal_context(&self) -> WordTraversalContext<'a> {
+        WordTraversalContext {
+            source: self.source,
+            locator: Some(self.locator),
+            shell_dialect: self.command_shell_behavior.shell_dialect(),
+        }
     }
 
     fn collect_arithmetic_summary(
@@ -3074,8 +3096,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             );
         }
 
-        collect_arithmetic_expansion_spans_from_parts(
-            &word.parts,
+        collect_arithmetic_summary_spans_in_word(
+            word,
             self.source,
             host_kind == WordFactHostKind::Direct,
             &mut self.arithmetic.dollar_in_arithmetic_spans,

--- a/crates/shuck-linter/src/facts/words/quote_spans.rs
+++ b/crates/shuck-linter/src/facts/words/quote_spans.rs
@@ -918,7 +918,16 @@ pub(super) fn double_quoted_expansion_part_spans(word: &Word) -> Vec<Span> {
 }
 
 pub(super) fn collect_double_quoted_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
-    collect_double_quoted_expansion_spans(&word.parts, false, spans);
+    let mut visitor = DoubleQuotedExpansionSpanVisitor { spans };
+    walk_word_subtree(
+        word,
+        WordTraversalContext {
+            source: "",
+            locator: None,
+            shell_dialect: shuck_semantic::ShellDialect::Bash,
+        },
+        &mut visitor,
+    );
 }
 
 pub(super) fn single_quoted_equivalent_if_plain_double_quoted_word(
@@ -974,17 +983,17 @@ pub(super) fn shell_single_quoted_literal(text: &str) -> String {
     quoted
 }
 
-pub(super) fn collect_double_quoted_expansion_spans(
-    parts: &[WordPartNode],
-    inside_double_quotes: bool,
-    spans: &mut Vec<Span>,
-) {
-    for part in parts {
+struct DoubleQuotedExpansionSpanVisitor<'spans> {
+    spans: &'spans mut Vec<Span>,
+}
+
+impl<'a> WordSubtreeVisitor<'a> for DoubleQuotedExpansionSpanVisitor<'_> {
+    fn visit_part(&mut self, part: &'a WordPartNode, state: WordTraversalState<'a>) {
+        if !state.processes_root_word() || !state.in_double_quote {
+            return;
+        }
+
         match &part.kind {
-            WordPart::SingleQuoted { .. } => {}
-            WordPart::DoubleQuoted { parts, .. } => {
-                collect_double_quoted_expansion_spans(parts, true, spans);
-            }
             WordPart::Variable(_)
             | WordPart::Parameter(_)
             | WordPart::CommandSubstitution { .. }
@@ -1000,13 +1009,9 @@ pub(super) fn collect_double_quoted_expansion_spans(
             | WordPart::PrefixMatch { .. }
             | WordPart::ProcessSubstitution { .. }
             | WordPart::Transformation { .. }
-            | WordPart::ZshQualifiedGlob(_)
-                if inside_double_quotes =>
-            {
-                spans.push(part.span)
+            | WordPart::ZshQualifiedGlob(_) => self.spans.push(part.span),
+            WordPart::Literal(_) | WordPart::SingleQuoted { .. } | WordPart::DoubleQuoted { .. } => {
             }
-            WordPart::Literal(_) => {}
-            _ => {}
         }
     }
 }

--- a/crates/shuck-linter/src/facts/words/traversal.rs
+++ b/crates/shuck-linter/src/facts/words/traversal.rs
@@ -1,0 +1,914 @@
+use super::*;
+use crate::facts::word_spans;
+use shuck_ast::{LiteralText, PatternGroupKind, PatternPartNode};
+
+#[derive(Clone, Copy)]
+pub(in crate::facts) struct WordTraversalContext<'a> {
+    pub source: &'a str,
+    pub locator: Option<Locator<'a>>,
+    pub shell_dialect: shuck_semantic::ShellDialect,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::facts) enum WordTraversalOrigin {
+    Root,
+    ArithmeticExpansion,
+    ParameterOperand,
+    ParameterPattern,
+    ZshQualifiedGlobPattern,
+    ZshParameterTarget,
+    ZshModifierArgument,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::facts) enum WordTraversalPatternContext {
+    ParameterOperator,
+    ZshQualifiedGlob,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
+pub(in crate::facts) struct WordTraversalState<'a> {
+    pub parent_word_span: Span,
+    pub part_span: Option<Span>,
+    pub part_index: Option<usize>,
+    pub siblings: Option<&'a [WordPartNode]>,
+    pub in_double_quote: bool,
+    pub origin: WordTraversalOrigin,
+    pub pattern_context: Option<WordTraversalPatternContext>,
+    pub escaped_template_suppressed: bool,
+}
+
+impl<'a> WordTraversalState<'a> {
+    fn root(word: &'a Word) -> Self {
+        Self {
+            parent_word_span: word.span,
+            part_span: None,
+            part_index: None,
+            siblings: None,
+            in_double_quote: false,
+            origin: WordTraversalOrigin::Root,
+            pattern_context: None,
+            escaped_template_suppressed: false,
+        }
+    }
+
+    pub(in crate::facts) fn processes_root_word(self) -> bool {
+        self.origin == WordTraversalOrigin::Root
+    }
+
+    fn with_part(
+        self,
+        part: &'a WordPartNode,
+        siblings: &'a [WordPartNode],
+        part_index: usize,
+        escaped_template_suppressed: bool,
+    ) -> Self {
+        Self {
+            parent_word_span: self.parent_word_span,
+            part_span: Some(part.span),
+            part_index: Some(part_index),
+            siblings: Some(siblings),
+            in_double_quote: self.in_double_quote,
+            origin: self.origin,
+            pattern_context: self.pattern_context,
+            escaped_template_suppressed,
+        }
+    }
+
+    fn without_part(self) -> Self {
+        Self {
+            parent_word_span: self.parent_word_span,
+            part_span: None,
+            part_index: None,
+            siblings: None,
+            in_double_quote: self.in_double_quote,
+            origin: self.origin,
+            pattern_context: self.pattern_context,
+            escaped_template_suppressed: self.escaped_template_suppressed,
+        }
+    }
+
+    fn inside_double_quote(self) -> Self {
+        Self {
+            in_double_quote: true,
+            ..self.without_part()
+        }
+    }
+
+    fn with_origin(self, origin: WordTraversalOrigin, word_span: Span) -> Self {
+        Self {
+            parent_word_span: word_span,
+            part_span: None,
+            part_index: None,
+            siblings: None,
+            in_double_quote: false,
+            origin,
+            pattern_context: self.pattern_context,
+            escaped_template_suppressed: false,
+        }
+    }
+
+    fn with_pattern_context(self, pattern_context: WordTraversalPatternContext) -> Self {
+        Self {
+            pattern_context: Some(pattern_context),
+            ..self.without_part()
+        }
+    }
+}
+
+pub(in crate::facts) trait WordSubtreeVisitor<'a> {
+    fn enter_word(&mut self, _word: &'a Word, _state: WordTraversalState<'a>) {}
+    fn exit_word(&mut self, _word: &'a Word, _state: WordTraversalState<'a>) {}
+    fn visit_part(&mut self, _part: &'a WordPartNode, _state: WordTraversalState<'a>) {}
+    fn visit_literal(
+        &mut self,
+        _part: &'a WordPartNode,
+        _text: &'a str,
+        _state: WordTraversalState<'a>,
+    ) {
+    }
+    fn visit_single_quoted(&mut self, _part: &'a WordPartNode, _state: WordTraversalState<'a>) {}
+    fn enter_double_quoted(&mut self, _part: &'a WordPartNode, _state: WordTraversalState<'a>) {}
+    fn exit_double_quoted(&mut self, _part: &'a WordPartNode, _state: WordTraversalState<'a>) {}
+    fn visit_command_substitution(
+        &mut self,
+        _part: &'a WordPartNode,
+        _state: WordTraversalState<'a>,
+    ) {
+    }
+    fn visit_arithmetic_expansion(
+        &mut self,
+        _part: &'a WordPartNode,
+        _state: WordTraversalState<'a>,
+    ) {
+    }
+    fn visit_parameter_expansion(
+        &mut self,
+        _part: &'a WordPartNode,
+        _state: WordTraversalState<'a>,
+    ) {
+    }
+    fn visit_zsh_qualified_glob(
+        &mut self,
+        _part: &'a WordPartNode,
+        _glob: &'a ZshQualifiedGlob,
+        _state: WordTraversalState<'a>,
+    ) {
+    }
+    fn visit_pattern_group(
+        &mut self,
+        _part: &'a PatternPartNode,
+        _kind: PatternGroupKind,
+        _state: WordTraversalState<'a>,
+    ) {
+    }
+    fn visit_pattern_word(&mut self, _word: &'a Word, _state: WordTraversalState<'a>) {}
+    fn visit_pattern_char_class(
+        &mut self,
+        _part: &'a PatternPartNode,
+        _state: WordTraversalState<'a>,
+    ) {
+    }
+}
+
+pub(in crate::facts) fn walk_word_subtree<'a>(
+    word: &'a Word,
+    context: WordTraversalContext<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    let _ = (context.locator, context.shell_dialect);
+    walk_word(word, context, WordTraversalState::root(word), visitor);
+}
+
+fn walk_word<'a>(
+    word: &'a Word,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    visitor.enter_word(word, state);
+    walk_word_parts(&word.parts, context, state, visitor);
+    visitor.exit_word(word, state);
+}
+
+fn walk_word_parts<'a>(
+    parts: &'a [WordPartNode],
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    for (index, part) in parts.iter().enumerate() {
+        let escaped_template_suppressed = state.parent_word_span.end.offset <= context.source.len()
+            && word_spans::span_inside_escaped_parameter_template(
+                state.parent_word_span,
+                part.span,
+                context.source,
+            );
+        let part_state = state.with_part(part, parts, index, escaped_template_suppressed);
+        visitor.visit_part(part, part_state);
+        match &part.kind {
+            WordPart::Literal(text) => {
+                visitor.visit_literal(
+                    part,
+                    literal_text_for_context(text, context.source, part.span),
+                    part_state,
+                );
+            }
+            WordPart::SingleQuoted { .. } => visitor.visit_single_quoted(part, part_state),
+            WordPart::DoubleQuoted { parts, .. } => {
+                visitor.enter_double_quoted(part, part_state);
+                walk_word_parts(parts, context, part_state.inside_double_quote(), visitor);
+                visitor.exit_double_quoted(part, part_state);
+            }
+            WordPart::Variable(_)
+            | WordPart::Length(_)
+            | WordPart::ArrayAccess(_)
+            | WordPart::ArrayLength(_)
+            | WordPart::ArrayIndices(_)
+            | WordPart::PrefixMatch { .. }
+            | WordPart::ProcessSubstitution { .. }
+            | WordPart::Transformation { .. } => {}
+            WordPart::CommandSubstitution { .. } => {
+                visitor.visit_command_substitution(part, part_state);
+            }
+            WordPart::ArithmeticExpansion {
+                expression_ast,
+                expression_word_ast,
+                ..
+            } => {
+                visitor.visit_arithmetic_expansion(part, part_state);
+                if let Some(expression) = expression_ast.as_deref() {
+                    walk_arithmetic_expression_words(
+                        expression,
+                        context,
+                        part_state,
+                        WordTraversalOrigin::ArithmeticExpansion,
+                        visitor,
+                    );
+                } else {
+                    walk_embedded_word(
+                        expression_word_ast,
+                        context,
+                        part_state,
+                        WordTraversalOrigin::ArithmeticExpansion,
+                        visitor,
+                    );
+                }
+            }
+            WordPart::Parameter(parameter) => {
+                visitor.visit_parameter_expansion(part, part_state);
+                walk_parameter_expansion(parameter, context, part_state, visitor);
+            }
+            WordPart::ParameterExpansion {
+                operator,
+                operand_word_ast,
+                ..
+            }
+            | WordPart::IndirectExpansion {
+                operator: Some(operator),
+                operand_word_ast,
+                ..
+            } => {
+                visitor.visit_parameter_expansion(part, part_state);
+                walk_parameter_operator(operator, context, part_state, visitor);
+                if let Some(operand_word) = operand_word_ast.as_deref() {
+                    walk_embedded_word(
+                        operand_word,
+                        context,
+                        part_state,
+                        WordTraversalOrigin::ParameterOperand,
+                        visitor,
+                    );
+                }
+            }
+            WordPart::IndirectExpansion { operator: None, .. } => {
+                visitor.visit_parameter_expansion(part, part_state);
+            }
+            WordPart::Substring {
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            }
+            | WordPart::ArraySlice {
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                walk_arithmetic_operand_word(
+                    offset_ast.as_deref(),
+                    offset_word_ast,
+                    context,
+                    part_state,
+                    visitor,
+                );
+                if let Some(length_ast) = length_ast.as_deref() {
+                    walk_arithmetic_expression_words(
+                        length_ast,
+                        context,
+                        part_state,
+                        WordTraversalOrigin::ParameterOperand,
+                        visitor,
+                    );
+                } else if let Some(length_word) = length_word_ast.as_deref() {
+                    walk_embedded_word(
+                        length_word,
+                        context,
+                        part_state,
+                        WordTraversalOrigin::ParameterOperand,
+                        visitor,
+                    );
+                }
+            }
+            WordPart::ZshQualifiedGlob(glob) => {
+                visitor.visit_zsh_qualified_glob(part, glob, part_state);
+                walk_zsh_qualified_glob(glob, context, part_state, visitor);
+            }
+        }
+    }
+}
+
+fn literal_text_for_context<'a>(text: &'a LiteralText, source: &'a str, span: Span) -> &'a str {
+    match text {
+        LiteralText::Owned(_) => text.as_str(source, span),
+        LiteralText::Source | LiteralText::CookedSource(_) if span.end.offset <= source.len() => {
+            text.as_str(source, span)
+        }
+        LiteralText::Source | LiteralText::CookedSource(_) => "",
+    }
+}
+
+fn walk_embedded_word<'a>(
+    word: &'a Word,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    origin: WordTraversalOrigin,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    walk_word(word, context, state.with_origin(origin, word.span), visitor);
+}
+
+fn walk_arithmetic_operand_word<'a>(
+    expression: Option<&'a ArithmeticExprNode>,
+    word: &'a Word,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    if let Some(expression) = expression {
+        walk_arithmetic_expression_words(
+            expression,
+            context,
+            state,
+            WordTraversalOrigin::ParameterOperand,
+            visitor,
+        );
+    } else {
+        walk_embedded_word(
+            word,
+            context,
+            state,
+            WordTraversalOrigin::ParameterOperand,
+            visitor,
+        );
+    }
+}
+
+fn walk_arithmetic_expression_words<'a>(
+    expression: &'a ArithmeticExprNode,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    origin: WordTraversalOrigin,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    visit_arithmetic_words(expression, &mut |word| {
+        walk_embedded_word(word, context, state, origin, visitor);
+    });
+}
+
+fn walk_parameter_expansion<'a>(
+    parameter: &'a ParameterExpansion,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => {
+            walk_bourne_parameter_expansion(syntax, context, state, visitor);
+        }
+        ParameterExpansionSyntax::Zsh(syntax) => {
+            walk_zsh_parameter_expansion(syntax, context, state, visitor);
+        }
+    }
+}
+
+fn walk_bourne_parameter_expansion<'a>(
+    syntax: &'a BourneParameterExpansion,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    match syntax {
+        BourneParameterExpansion::Operation {
+            operator,
+            operand_word_ast,
+            ..
+        }
+        | BourneParameterExpansion::Indirect {
+            operator: Some(operator),
+            operand_word_ast,
+            ..
+        } => {
+            walk_parameter_operator(operator, context, state, visitor);
+            if let Some(operand_word) = operand_word_ast.as_deref() {
+                walk_embedded_word(
+                    operand_word,
+                    context,
+                    state,
+                    WordTraversalOrigin::ParameterOperand,
+                    visitor,
+                );
+            }
+        }
+        BourneParameterExpansion::Slice {
+            offset_ast,
+            offset_word_ast,
+            length_ast,
+            length_word_ast,
+            ..
+        } => {
+            walk_arithmetic_operand_word(
+                offset_ast.as_deref(),
+                offset_word_ast,
+                context,
+                state,
+                visitor,
+            );
+            if let Some(length_ast) = length_ast.as_deref() {
+                walk_arithmetic_expression_words(
+                    length_ast,
+                    context,
+                    state,
+                    WordTraversalOrigin::ParameterOperand,
+                    visitor,
+                );
+            } else if let Some(length_word) = length_word_ast.as_deref() {
+                walk_embedded_word(
+                    length_word,
+                    context,
+                    state,
+                    WordTraversalOrigin::ParameterOperand,
+                    visitor,
+                );
+            }
+        }
+        BourneParameterExpansion::Access { .. }
+        | BourneParameterExpansion::Length { .. }
+        | BourneParameterExpansion::Indices { .. }
+        | BourneParameterExpansion::Indirect { operator: None, .. }
+        | BourneParameterExpansion::PrefixMatch { .. }
+        | BourneParameterExpansion::Transformation { .. } => {}
+    }
+}
+
+fn walk_parameter_operator<'a>(
+    operator: &'a ParameterOp,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    match operator {
+        ParameterOp::RemovePrefixShort { pattern }
+        | ParameterOp::RemovePrefixLong { pattern }
+        | ParameterOp::RemoveSuffixShort { pattern }
+        | ParameterOp::RemoveSuffixLong { pattern } => {
+            walk_pattern(
+                pattern,
+                context,
+                state.with_pattern_context(WordTraversalPatternContext::ParameterOperator),
+                WordTraversalOrigin::ParameterPattern,
+                visitor,
+            );
+        }
+        ParameterOp::ReplaceFirst {
+            pattern,
+            replacement_word_ast,
+            ..
+        }
+        | ParameterOp::ReplaceAll {
+            pattern,
+            replacement_word_ast,
+            ..
+        } => {
+            walk_pattern(
+                pattern,
+                context,
+                state.with_pattern_context(WordTraversalPatternContext::ParameterOperator),
+                WordTraversalOrigin::ParameterPattern,
+                visitor,
+            );
+            walk_embedded_word(
+                replacement_word_ast,
+                context,
+                state,
+                WordTraversalOrigin::ParameterOperand,
+                visitor,
+            );
+        }
+        ParameterOp::UseDefault
+        | ParameterOp::AssignDefault
+        | ParameterOp::UseReplacement
+        | ParameterOp::Error
+        | ParameterOp::UpperFirst
+        | ParameterOp::UpperAll
+        | ParameterOp::LowerFirst
+        | ParameterOp::LowerAll => {}
+    }
+}
+
+fn walk_zsh_parameter_expansion<'a>(
+    syntax: &'a ZshParameterExpansion,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    match &syntax.target {
+        ZshExpansionTarget::Nested(parameter) => {
+            walk_parameter_expansion(parameter, context, state, visitor);
+        }
+        ZshExpansionTarget::Word(word) => {
+            walk_embedded_word(
+                word,
+                context,
+                state,
+                WordTraversalOrigin::ZshParameterTarget,
+                visitor,
+            );
+        }
+        ZshExpansionTarget::Reference(_) | ZshExpansionTarget::Empty => {}
+    }
+
+    for modifier in &syntax.modifiers {
+        if let Some(word) = modifier.argument_word_ast() {
+            walk_embedded_word(
+                word,
+                context,
+                state,
+                WordTraversalOrigin::ZshModifierArgument,
+                visitor,
+            );
+        }
+    }
+
+    if let Some(operation) = syntax.operation.as_ref() {
+        walk_zsh_expansion_operation(operation, context, state, visitor);
+    }
+}
+
+fn walk_zsh_expansion_operation<'a>(
+    operation: &'a ZshExpansionOperation,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    if let Some(word) = operation.operand_word_ast() {
+        walk_embedded_word(
+            word,
+            context,
+            state,
+            WordTraversalOrigin::ParameterOperand,
+            visitor,
+        );
+    }
+    if let Some(word) = operation.pattern_word_ast() {
+        walk_embedded_word(
+            word,
+            context,
+            state,
+            WordTraversalOrigin::ParameterPattern,
+            visitor,
+        );
+    }
+    if let Some(word) = operation.replacement_word_ast() {
+        walk_embedded_word(
+            word,
+            context,
+            state,
+            WordTraversalOrigin::ParameterOperand,
+            visitor,
+        );
+    }
+    if let Some(word) = operation.offset_word_ast() {
+        walk_embedded_word(
+            word,
+            context,
+            state,
+            WordTraversalOrigin::ParameterOperand,
+            visitor,
+        );
+    }
+    if let Some(word) = operation.length_word_ast() {
+        walk_embedded_word(
+            word,
+            context,
+            state,
+            WordTraversalOrigin::ParameterOperand,
+            visitor,
+        );
+    }
+}
+
+fn walk_zsh_qualified_glob<'a>(
+    glob: &'a ZshQualifiedGlob,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    let state = state.with_pattern_context(WordTraversalPatternContext::ZshQualifiedGlob);
+    for segment in &glob.segments {
+        if let ZshGlobSegment::Pattern(pattern) = segment {
+            walk_pattern(
+                pattern,
+                context,
+                state,
+                WordTraversalOrigin::ZshQualifiedGlobPattern,
+                visitor,
+            );
+        }
+    }
+}
+
+fn walk_pattern<'a>(
+    pattern: &'a Pattern,
+    context: WordTraversalContext<'a>,
+    state: WordTraversalState<'a>,
+    word_origin: WordTraversalOrigin,
+    visitor: &mut impl WordSubtreeVisitor<'a>,
+) {
+    for part in &pattern.parts {
+        match &part.kind {
+            PatternPart::Group { kind, patterns } => {
+                visitor.visit_pattern_group(part, *kind, state);
+                for pattern in patterns {
+                    walk_pattern(pattern, context, state, word_origin, visitor);
+                }
+            }
+            PatternPart::Word(word) => {
+                let word_state = state.with_origin(word_origin, word.span);
+                visitor.visit_pattern_word(word, word_state);
+                walk_word(word, context, word_state, visitor);
+            }
+            PatternPart::CharClass(_) => visitor.visit_pattern_char_class(part, state),
+            PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use shuck_ast::LiteralText;
+    use shuck_indexer::LineIndex;
+    use shuck_parser::parser::Parser;
+
+    #[derive(Default)]
+    struct RecordingVisitor {
+        events: Vec<String>,
+        escaped_suppressed: Vec<String>,
+    }
+
+    impl<'a> WordSubtreeVisitor<'a> for RecordingVisitor {
+        fn visit_literal(
+            &mut self,
+            part: &'a WordPartNode,
+            text: &'a str,
+            state: WordTraversalState<'a>,
+        ) {
+            if state.escaped_template_suppressed {
+                self.escaped_suppressed.push(text.to_owned());
+            }
+            self.events.push(format!(
+                "literal:{text}:{:?}:{:?}",
+                state.origin, state.in_double_quote
+            ));
+            assert_eq!(state.part_span, Some(part.span));
+        }
+
+        fn enter_double_quoted(&mut self, _part: &'a WordPartNode, _state: WordTraversalState<'a>) {
+            self.events.push("enter-double".to_owned());
+        }
+
+        fn visit_command_substitution(
+            &mut self,
+            _part: &'a WordPartNode,
+            state: WordTraversalState<'a>,
+        ) {
+            self.events.push(format!(
+                "command:{:?}:{:?}",
+                state.origin, state.in_double_quote
+            ));
+        }
+
+        fn visit_arithmetic_expansion(
+            &mut self,
+            _part: &'a WordPartNode,
+            state: WordTraversalState<'a>,
+        ) {
+            self.events.push(format!("arithmetic:{:?}", state.origin));
+        }
+
+        fn visit_parameter_expansion(
+            &mut self,
+            _part: &'a WordPartNode,
+            state: WordTraversalState<'a>,
+        ) {
+            self.events.push(format!("parameter:{:?}", state.origin));
+        }
+
+        fn visit_pattern_group(
+            &mut self,
+            _part: &'a PatternPartNode,
+            kind: PatternGroupKind,
+            state: WordTraversalState<'a>,
+        ) {
+            self.events.push(format!(
+                "pattern-group:{kind:?}:{:?}",
+                state.pattern_context
+            ));
+        }
+
+        fn visit_pattern_word(&mut self, _word: &'a Word, state: WordTraversalState<'a>) {
+            self.events.push(format!("pattern-word:{:?}", state.origin));
+        }
+
+        fn visit_zsh_qualified_glob(
+            &mut self,
+            _part: &'a WordPartNode,
+            _glob: &'a ZshQualifiedGlob,
+            state: WordTraversalState<'a>,
+        ) {
+            self.events.push(format!("zsh-glob:{:?}", state.origin));
+        }
+    }
+
+    fn first_arg(source: &str) -> Word {
+        let output = Parser::new(source).parse().unwrap();
+        let Command::Simple(command) = &output.file.body[0].command else {
+            panic!("expected simple command");
+        };
+        command.args[0].clone()
+    }
+
+    fn walk_recorded(source: &str, word: &Word) -> RecordingVisitor {
+        let line_index = LineIndex::new(source);
+        let context = WordTraversalContext {
+            source,
+            locator: Some(Locator::new(source, &line_index)),
+            shell_dialect: shuck_semantic::ShellDialect::Bash,
+        };
+        let mut visitor = RecordingVisitor::default();
+        walk_word_subtree(word, context, &mut visitor);
+        visitor
+    }
+
+    #[test]
+    fn walker_visits_literals_and_double_quoted_nested_parts() {
+        let source = "echo pre\"$value $(date)\"post\n";
+        let word = first_arg(source);
+        let visitor = walk_recorded(source, &word);
+
+        assert!(
+            visitor
+                .events
+                .iter()
+                .any(|event| event == "literal:pre:Root:false")
+        );
+        assert!(visitor.events.iter().any(|event| event == "enter-double"));
+        assert!(
+            visitor
+                .events
+                .iter()
+                .any(|event| event == "command:Root:true")
+        );
+    }
+
+    #[test]
+    fn walker_visits_parameter_operand_and_pattern_words() {
+        let source = "echo ${name:-$(fallback)} ${path#@(tmp|var)/$leaf}\n";
+        let first = first_arg(source);
+        let second = {
+            let output = Parser::new(source).parse().unwrap();
+            let Command::Simple(command) = &output.file.body[0].command else {
+                panic!("expected simple command");
+            };
+            command.args[1].clone()
+        };
+
+        let operand = walk_recorded(source, &first);
+        assert!(
+            operand
+                .events
+                .iter()
+                .any(|event| event == "command:ParameterOperand:false")
+        );
+
+        let pattern = walk_recorded(source, &second);
+        assert!(
+            pattern
+                .events
+                .iter()
+                .any(|event| event == "pattern-group:ExactlyOne:Some(ParameterOperator)")
+        );
+        assert!(
+            pattern
+                .events
+                .iter()
+                .any(|event| event == "pattern-word:ParameterPattern")
+        );
+    }
+
+    #[test]
+    fn walker_visits_arithmetic_word_asts() {
+        let source = "echo $(( $(value) + 1 ))\n";
+        let word = first_arg(source);
+        let visitor = walk_recorded(source, &word);
+
+        assert!(
+            visitor
+                .events
+                .iter()
+                .any(|event| event == "arithmetic:Root")
+        );
+        assert!(
+            visitor
+                .events
+                .iter()
+                .any(|event| event == "command:ArithmeticExpansion:false")
+        );
+    }
+
+    #[test]
+    fn walker_visits_zsh_qualified_glob_pattern_words() {
+        let source = "prefix";
+        let inner = Word::literal_with_span("prefix", span_for(source, 0, source.len()));
+        let pattern = Pattern {
+            parts: vec![PatternPartNode::new(
+                PatternPart::Word(inner),
+                span_for(source, 0, source.len()),
+            )],
+            span: span_for(source, 0, source.len()),
+        };
+        let word = Word {
+            parts: vec![WordPartNode::new(
+                WordPart::ZshQualifiedGlob(ZshQualifiedGlob {
+                    span: span_for(source, 0, source.len()),
+                    segments: vec![ZshGlobSegment::Pattern(pattern)],
+                    qualifiers: None,
+                }),
+                span_for(source, 0, source.len()),
+            )],
+            span: span_for(source, 0, source.len()),
+            brace_syntax: Vec::new(),
+        };
+        let visitor = walk_recorded(source, &word);
+
+        assert!(visitor.events.iter().any(|event| event == "zsh-glob:Root"));
+        assert!(
+            visitor
+                .events
+                .iter()
+                .any(|event| event == "pattern-word:ZshQualifiedGlobPattern")
+        );
+    }
+
+    #[test]
+    fn walker_marks_escaped_template_parts() {
+        let source = "\\${name}";
+        let word = Word {
+            parts: vec![WordPartNode::new(
+                WordPart::Literal(LiteralText::source()),
+                span_for(source, 3, 7),
+            )],
+            span: span_for(source, 0, source.len()),
+            brace_syntax: Vec::new(),
+        };
+        let visitor = walk_recorded(source, &word);
+
+        assert!(
+            visitor
+                .escaped_suppressed
+                .iter()
+                .any(|text| text.contains("name"))
+        );
+    }
+
+    fn span_for(source: &str, start: usize, end: usize) -> Span {
+        let start = Position::new().advanced_by(&source[..start]);
+        let end = Position::new().advanced_by(&source[..end]);
+        Span::from_positions(start, end)
+    }
+}

--- a/crates/shuck-linter/src/facts/words/traversal.rs
+++ b/crates/shuck-linter/src/facts/words/traversal.rs
@@ -27,10 +27,8 @@ pub(in crate::facts) enum WordTraversalPatternContext {
 }
 
 #[derive(Clone, Copy, Debug)]
-#[allow(dead_code)]
 pub(in crate::facts) struct WordTraversalState<'a> {
     pub parent_word_span: Span,
-    pub part_span: Option<Span>,
     pub part_index: Option<usize>,
     pub siblings: Option<&'a [WordPartNode]>,
     pub in_double_quote: bool,
@@ -43,7 +41,6 @@ impl<'a> WordTraversalState<'a> {
     fn root(word: &'a Word) -> Self {
         Self {
             parent_word_span: word.span,
-            part_span: None,
             part_index: None,
             siblings: None,
             in_double_quote: false,
@@ -59,14 +56,13 @@ impl<'a> WordTraversalState<'a> {
 
     fn with_part(
         self,
-        part: &'a WordPartNode,
+        _part: &'a WordPartNode,
         siblings: &'a [WordPartNode],
         part_index: usize,
         escaped_template_suppressed: bool,
     ) -> Self {
         Self {
             parent_word_span: self.parent_word_span,
-            part_span: Some(part.span),
             part_index: Some(part_index),
             siblings: Some(siblings),
             in_double_quote: self.in_double_quote,
@@ -79,7 +75,6 @@ impl<'a> WordTraversalState<'a> {
     fn without_part(self) -> Self {
         Self {
             parent_word_span: self.parent_word_span,
-            part_span: None,
             part_index: None,
             siblings: None,
             in_double_quote: self.in_double_quote,
@@ -99,7 +94,6 @@ impl<'a> WordTraversalState<'a> {
     fn with_origin(self, origin: WordTraversalOrigin, word_span: Span) -> Self {
         Self {
             parent_word_span: word_span,
-            part_span: None,
             part_index: None,
             siblings: None,
             in_double_quote: false,
@@ -695,7 +689,9 @@ mod tests {
                 "literal:{text}:{:?}:{:?}",
                 state.origin, state.in_double_quote
             ));
-            assert_eq!(state.part_span, Some(part.span));
+            let siblings = state.siblings.expect("literal should expose siblings");
+            let part_index = state.part_index.expect("literal should expose index");
+            assert_eq!(siblings[part_index].span, part.span);
         }
 
         fn enter_double_quoted(&mut self, _part: &'a WordPartNode, _state: WordTraversalState<'a>) {

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -115,6 +115,7 @@ pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     short_circuit_condition_depth: u32,
     arithmetic_reference_kind: ReferenceKind,
     word_reference_kind_override: Option<ReferenceKind>,
+    escaped_parameter_template_body_starts_cache: FxHashMap<SpanKey, SmallVec<[usize; 2]>>,
 }
 
 fn semantic_statement_span(stmt: &Stmt) -> Span {
@@ -267,6 +268,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             short_circuit_condition_depth: 0,
             arithmetic_reference_kind: ReferenceKind::ArithmeticRead,
             word_reference_kind_override: None,
+            escaped_parameter_template_body_starts_cache: FxHashMap::default(),
         };
         let file_commands = builder.visit_stmt_seq(
             &file.body,

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -194,8 +194,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         flow: FlowState,
         nested_regions: &mut Vec<IsolatedRegion>,
     ) {
-        let escaped_template_starts =
-            escaped_parameter_template_body_starts(word_span, self.source);
+        let escaped_template_starts = self.escaped_parameter_template_body_starts_cached(word_span);
         for part in parts {
             if !escaped_template_starts.is_empty()
                 && escaped_template_starts.contains(&part.span.start.offset)
@@ -204,6 +203,21 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             }
             self.visit_word_part(&part.kind, part.span, kind, flow, nested_regions);
         }
+    }
+
+    fn escaped_parameter_template_body_starts_cached(
+        &mut self,
+        word_span: Span,
+    ) -> SmallVec<[usize; 2]> {
+        let key = SpanKey::new(word_span);
+        if let Some(starts) = self.escaped_parameter_template_body_starts_cache.get(&key) {
+            return starts.clone();
+        }
+
+        let starts = escaped_parameter_template_body_starts(word_span, self.source);
+        self.escaped_parameter_template_body_starts_cache
+            .insert(key, starts.clone());
+        starts
     }
 
     pub(super) fn visit_pattern_part_nodes(


### PR DESCRIPTION
## Summary
- add a shared `facts/words/traversal.rs` walker for word and pattern subtrees, including quote, origin, pattern, and escaped-template traversal state
- migrate low-risk span collectors, derived-span fanout, surface collection, per-occurrence scans, and the arithmetic-summary entrypoint onto visitor-backed traversal
- cache `escaped_parameter_template_body_starts` in the semantic builder to avoid rescanning source-backed words

## Why
This reduces repeated recursive word-subtree walks in fact building and completes the acceptance work in `/tmp/TRAVERSAL.md` without intending behavior changes.

## Impact
This is an internal linter and semantic refactor. No CLI, config, or rule-surface behavior is intended to change.

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter --no-default-features`
- `cargo clippy --all-targets -- -D warnings`
- `make test`

## Not Run
- `make test-large-corpus`