### PR TITLE
perf(linter): reuse indexed backtick substitution spans

### DIFF
--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -1,8 +1,9 @@
 use shuck_ast::{
-    ArithmeticForCommand, Assignment, AssignmentValue, BuiltinCommand, Command, CompoundCommand,
-    ConditionalExpr, DeclClause, DeclOperand, File, FunctionDef, HeredocBody, HeredocBodyPart,
-    HeredocBodyPartNode, Pattern, PatternPart, PatternPartNode, Redirect, RedirectKind, Stmt,
-    StmtSeq, Subscript, TextRange, TextSize, VarRef, Word, WordPart, WordPartNode, ZshGlobSegment,
+    ArithmeticForCommand, Assignment, AssignmentValue, BuiltinCommand, Command,
+    CommandSubstitutionSyntax, CompoundCommand, ConditionalExpr, DeclClause, DeclOperand, File,
+    FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, Pattern, PatternPart,
+    PatternPartNode, Redirect, RedirectKind, Stmt, StmtSeq, Subscript, TextRange, TextSize, VarRef,
+    Word, WordPart, WordPartNode, ZshGlobSegment,
 };
 /// A syntactic region that affects source interpretation.
 ///
@@ -49,6 +50,7 @@ pub struct RegionIndex {
     double_quoted: Vec<TextRange>,
     heredocs: Vec<TextRange>,
     command_substitutions: Vec<TextRange>,
+    backtick_command_substitutions: Vec<TextRange>,
     arithmetic: Vec<TextRange>,
     conditionals: Vec<TextRange>,
     quoted_heredocs: Vec<TextRange>,
@@ -138,6 +140,14 @@ impl RegionIndex {
         contains_any(&self.command_substitutions, offset)
     }
 
+    /// Return all backtick command-substitution ranges in source order.
+    ///
+    /// The ranges are half-open byte ranges for legacy `` `...` `` command
+    /// substitutions only. `$(...)` ranges are excluded.
+    pub fn backtick_command_substitution_ranges(&self) -> &[TextRange] {
+        &self.backtick_command_substitutions
+    }
+
     /// Return whether `offset` falls inside an arithmetic context.
     ///
     /// Arithmetic contexts include arithmetic commands, arithmetic `for`
@@ -190,6 +200,7 @@ struct RegionCollector<'a> {
     double_quoted: Vec<TextRange>,
     heredocs: Vec<TextRange>,
     command_substitutions: Vec<TextRange>,
+    backtick_command_substitutions: Vec<TextRange>,
     arithmetic: Vec<TextRange>,
     conditionals: Vec<TextRange>,
     quoted_heredocs: Vec<TextRange>,
@@ -205,6 +216,7 @@ impl<'a> RegionCollector<'a> {
             double_quoted: Vec::new(),
             heredocs: Vec::new(),
             command_substitutions: Vec::new(),
+            backtick_command_substitutions: Vec::new(),
             arithmetic: Vec::new(),
             conditionals: Vec::new(),
             quoted_heredocs: Vec::new(),
@@ -218,6 +230,7 @@ impl<'a> RegionCollector<'a> {
         sort_ranges(&mut self.double_quoted);
         sort_ranges(&mut self.heredocs);
         sort_ranges(&mut self.command_substitutions);
+        sort_ranges(&mut self.backtick_command_substitutions);
         sort_ranges(&mut self.arithmetic);
         sort_ranges(&mut self.conditionals);
         sort_ranges(&mut self.quoted_heredocs);
@@ -289,6 +302,7 @@ impl<'a> RegionCollector<'a> {
             double_quoted: self.double_quoted,
             heredocs: self.heredocs,
             command_substitutions: self.command_substitutions,
+            backtick_command_substitutions: self.backtick_command_substitutions,
             arithmetic: self.arithmetic,
             conditionals: self.conditionals,
             quoted_heredocs: self.quoted_heredocs,
@@ -687,8 +701,11 @@ impl<'a> RegionCollector<'a> {
                     self.push_dollar_brace_pairs_in_source_range(range);
                     self.visit_word_parts(parts);
                 }
-                WordPart::CommandSubstitution { body, .. } => {
+                WordPart::CommandSubstitution { body, syntax } => {
                     push_range(&mut self.command_substitutions, range);
+                    if *syntax == CommandSubstitutionSyntax::Backtick {
+                        push_range(&mut self.backtick_command_substitutions, range);
+                    }
                     self.visit_stmt_seq(body);
                 }
                 WordPart::ArithmeticExpansion { expression_ast, .. } => {
@@ -724,8 +741,11 @@ impl<'a> RegionCollector<'a> {
         for part in parts {
             let range = part.span.to_range();
             match &part.kind {
-                HeredocBodyPart::CommandSubstitution { body, .. } => {
+                HeredocBodyPart::CommandSubstitution { body, syntax } => {
                     push_range(&mut self.command_substitutions, range);
+                    if *syntax == CommandSubstitutionSyntax::Backtick {
+                        push_range(&mut self.backtick_command_substitutions, range);
+                    }
                     self.visit_stmt_seq(body);
                 }
                 HeredocBodyPart::ArithmeticExpansion { expression_ast, .. } => {
@@ -1090,6 +1110,22 @@ mod tests {
     }
 
     #[test]
+    fn tracks_backtick_command_substitution_ranges() {
+        let source = "echo `printf '%s' \"$name\"` $(pwd)\n";
+        let regions = regions(source);
+        let start = source.find('`').unwrap();
+        let end = source[start + 1..].find('`').unwrap() + start + 2;
+
+        assert_eq!(
+            regions.backtick_command_substitution_ranges(),
+            &[TextRange::new(
+                TextSize::new(start as u32),
+                TextSize::new(end as u32),
+            )]
+        );
+    }
+
+    #[test]
     fn tracks_quoted_regions_inside_keyed_array_subscripts() {
         let source = "declare -A map=(['$HOME']=1)\n";
         let regions = regions(source);
@@ -1108,6 +1144,20 @@ mod tests {
         assert_eq!(regions.region_at(offset), Some(RegionKind::Heredoc));
         assert!(regions.is_heredoc(offset));
         assert!(regions.is_quoted(offset));
+    }
+
+    #[test]
+    fn excludes_quoted_heredoc_backticks_from_backtick_ranges() {
+        let source = "cat <<'EOF'\n`printf quoted`\nEOF\ncat <<EOF\n`printf live`\nEOF\n";
+        let regions = regions(source);
+        let [range] = regions.backtick_command_substitution_ranges() else {
+            panic!("expected one live backtick substitution");
+        };
+
+        assert_eq!(
+            &source[usize::from(range.start())..usize::from(range.end())],
+            "`printf live`"
+        );
     }
 
     #[test]

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -1,9 +1,10 @@
 use shuck_ast::{
-    ArithmeticForCommand, Assignment, AssignmentValue, BuiltinCommand, Command,
-    CommandSubstitutionSyntax, CompoundCommand, ConditionalExpr, DeclClause, DeclOperand, File,
-    FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, Pattern, PatternPart,
-    PatternPartNode, Redirect, RedirectKind, Stmt, StmtSeq, Subscript, TextRange, TextSize, VarRef,
-    Word, WordPart, WordPartNode, ZshGlobSegment,
+    ArithmeticForCommand, Assignment, AssignmentValue, BourneParameterExpansion, BuiltinCommand,
+    Command, CommandSubstitutionSyntax, CompoundCommand, ConditionalExpr, DeclClause, DeclOperand,
+    File, FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, ParameterExpansion,
+    ParameterExpansionSyntax, ParameterOp, Pattern, PatternPart, PatternPartNode, Redirect,
+    RedirectKind, Stmt, StmtSeq, Subscript, TextRange, TextSize, VarRef, Word, WordPart,
+    WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment, ZshParameterExpansion,
 };
 /// A syntactic region that affects source interpretation.
 ///
@@ -657,6 +658,152 @@ impl<'a> RegionCollector<'a> {
         self.visit_word_parts(&word.parts);
     }
 
+    fn visit_parameter_expansion(&mut self, parameter: &ParameterExpansion) {
+        match &parameter.syntax {
+            ParameterExpansionSyntax::Bourne(syntax) => {
+                self.visit_bourne_parameter_expansion(syntax);
+            }
+            ParameterExpansionSyntax::Zsh(syntax) => {
+                self.visit_zsh_parameter_expansion(syntax);
+            }
+        }
+    }
+
+    fn visit_bourne_parameter_expansion(&mut self, syntax: &BourneParameterExpansion) {
+        match syntax {
+            BourneParameterExpansion::Access { reference }
+            | BourneParameterExpansion::Length { reference }
+            | BourneParameterExpansion::Indices { reference }
+            | BourneParameterExpansion::Transformation { reference, .. } => {
+                self.visit_var_ref_subscript(reference);
+            }
+            BourneParameterExpansion::Indirect {
+                reference,
+                operator,
+                operand_word_ast,
+                ..
+            } => {
+                self.visit_var_ref_subscript(reference);
+                if let Some(operator) = operator.as_deref() {
+                    self.visit_parameter_operator(operator);
+                }
+                if let Some(operand_word) = operand_word_ast.as_deref() {
+                    self.visit_word(operand_word);
+                }
+            }
+            BourneParameterExpansion::Slice {
+                reference,
+                offset_ast,
+                offset_word_ast,
+                length_ast,
+                length_word_ast,
+                ..
+            } => {
+                self.visit_var_ref_subscript(reference);
+                self.visit_arithmetic_operand_word(offset_ast.as_deref(), offset_word_ast);
+                if let Some(length_ast) = length_ast.as_deref() {
+                    self.visit_arithmetic_shell_words(length_ast);
+                } else if let Some(length_word) = length_word_ast.as_deref() {
+                    self.visit_word(length_word);
+                }
+            }
+            BourneParameterExpansion::Operation {
+                reference,
+                operator,
+                operand_word_ast,
+                ..
+            } => {
+                self.visit_var_ref_subscript(reference);
+                self.visit_parameter_operator(operator);
+                if let Some(operand_word) = operand_word_ast.as_deref() {
+                    self.visit_word(operand_word);
+                }
+            }
+            BourneParameterExpansion::PrefixMatch { .. } => {}
+        }
+    }
+
+    fn visit_parameter_operator(&mut self, operator: &ParameterOp) {
+        match operator {
+            ParameterOp::RemovePrefixShort { pattern }
+            | ParameterOp::RemovePrefixLong { pattern }
+            | ParameterOp::RemoveSuffixShort { pattern }
+            | ParameterOp::RemoveSuffixLong { pattern } => {
+                self.visit_pattern(pattern);
+            }
+            ParameterOp::ReplaceFirst {
+                pattern,
+                replacement_word_ast,
+                ..
+            }
+            | ParameterOp::ReplaceAll {
+                pattern,
+                replacement_word_ast,
+                ..
+            } => {
+                self.visit_pattern(pattern);
+                self.visit_word(replacement_word_ast);
+            }
+            ParameterOp::UseDefault
+            | ParameterOp::AssignDefault
+            | ParameterOp::UseReplacement
+            | ParameterOp::Error
+            | ParameterOp::UpperFirst
+            | ParameterOp::UpperAll
+            | ParameterOp::LowerFirst
+            | ParameterOp::LowerAll => {}
+        }
+    }
+
+    fn visit_zsh_parameter_expansion(&mut self, syntax: &ZshParameterExpansion) {
+        match &syntax.target {
+            ZshExpansionTarget::Reference(reference) => self.visit_var_ref_subscript(reference),
+            ZshExpansionTarget::Nested(parameter) => self.visit_parameter_expansion(parameter),
+            ZshExpansionTarget::Word(word) => self.visit_word(word),
+            ZshExpansionTarget::Empty => {}
+        }
+
+        for modifier in &syntax.modifiers {
+            if let Some(word) = modifier.argument_word_ast() {
+                self.visit_word(word);
+            }
+        }
+
+        if let Some(operation) = syntax.operation.as_ref() {
+            self.visit_zsh_expansion_operation(operation);
+        }
+    }
+
+    fn visit_zsh_expansion_operation(&mut self, operation: &ZshExpansionOperation) {
+        if let Some(word) = operation.operand_word_ast() {
+            self.visit_word(word);
+        }
+        if let Some(word) = operation.pattern_word_ast() {
+            self.visit_word(word);
+        }
+        if let Some(word) = operation.replacement_word_ast() {
+            self.visit_word(word);
+        }
+        if let Some(word) = operation.offset_word_ast() {
+            self.visit_word(word);
+        }
+        if let Some(word) = operation.length_word_ast() {
+            self.visit_word(word);
+        }
+    }
+
+    fn visit_arithmetic_operand_word(
+        &mut self,
+        expression_ast: Option<&shuck_ast::ArithmeticExprNode>,
+        word: &Word,
+    ) {
+        if let Some(expression_ast) = expression_ast {
+            self.visit_arithmetic_shell_words(expression_ast);
+        } else {
+            self.visit_word(word);
+        }
+    }
+
     fn visit_heredoc_body(&mut self, body: &HeredocBody) {
         self.visit_heredoc_body_parts(&body.parts);
     }
@@ -716,17 +863,72 @@ impl<'a> RegionCollector<'a> {
                     }
                 }
                 WordPart::ProcessSubstitution { body, .. } => self.visit_stmt_seq(body),
-                WordPart::Parameter(_)
-                | WordPart::ParameterExpansion { .. }
-                | WordPart::Length(_)
-                | WordPart::ArrayAccess(_)
-                | WordPart::ArrayLength(_)
-                | WordPart::ArrayIndices(_)
-                | WordPart::Substring { .. }
-                | WordPart::ArraySlice { .. }
-                | WordPart::IndirectExpansion { .. }
-                | WordPart::PrefixMatch { .. }
-                | WordPart::Transformation { .. } => {
+                WordPart::Parameter(parameter) => {
+                    self.push_dollar_brace_pair(range);
+                    self.visit_parameter_expansion(parameter);
+                }
+                WordPart::ParameterExpansion {
+                    reference,
+                    operator,
+                    operand_word_ast,
+                    ..
+                } => {
+                    self.push_dollar_brace_pair(range);
+                    self.visit_var_ref_subscript(reference);
+                    self.visit_parameter_operator(operator);
+                    if let Some(operand_word) = operand_word_ast.as_deref() {
+                        self.visit_word(operand_word);
+                    }
+                }
+                WordPart::Length(reference)
+                | WordPart::ArrayAccess(reference)
+                | WordPart::ArrayLength(reference)
+                | WordPart::ArrayIndices(reference)
+                | WordPart::Transformation { reference, .. } => {
+                    self.push_dollar_brace_pair(range);
+                    self.visit_var_ref_subscript(reference);
+                }
+                WordPart::Substring {
+                    reference,
+                    offset_ast,
+                    offset_word_ast,
+                    length_ast,
+                    length_word_ast,
+                    ..
+                }
+                | WordPart::ArraySlice {
+                    reference,
+                    offset_ast,
+                    offset_word_ast,
+                    length_ast,
+                    length_word_ast,
+                    ..
+                } => {
+                    self.push_dollar_brace_pair(range);
+                    self.visit_var_ref_subscript(reference);
+                    self.visit_arithmetic_operand_word(offset_ast.as_deref(), offset_word_ast);
+                    if let Some(length_ast) = length_ast.as_deref() {
+                        self.visit_arithmetic_shell_words(length_ast);
+                    } else if let Some(length_word) = length_word_ast.as_deref() {
+                        self.visit_word(length_word);
+                    }
+                }
+                WordPart::IndirectExpansion {
+                    reference,
+                    operator,
+                    operand_word_ast,
+                    ..
+                } => {
+                    self.push_dollar_brace_pair(range);
+                    self.visit_var_ref_subscript(reference);
+                    if let Some(operator) = operator.as_deref() {
+                        self.visit_parameter_operator(operator);
+                    }
+                    if let Some(operand_word) = operand_word_ast.as_deref() {
+                        self.visit_word(operand_word);
+                    }
+                }
+                WordPart::PrefixMatch { .. } => {
                     self.push_dollar_brace_pair(range);
                 }
                 WordPart::Variable(_) => {
@@ -755,8 +957,9 @@ impl<'a> RegionCollector<'a> {
                         self.visit_arithmetic_shell_words(expression_ast);
                     }
                 }
-                HeredocBodyPart::Parameter(_) => {
+                HeredocBodyPart::Parameter(parameter) => {
                     self.push_dollar_brace_pair(range);
+                    self.visit_parameter_expansion(parameter);
                 }
                 HeredocBodyPart::Variable(_) => {
                     self.push_dollar_brace_pair(range);
@@ -1112,6 +1315,22 @@ mod tests {
     #[test]
     fn tracks_backtick_command_substitution_ranges() {
         let source = "echo `printf '%s' \"$name\"` $(pwd)\n";
+        let regions = regions(source);
+        let start = source.find('`').unwrap();
+        let end = source[start + 1..].find('`').unwrap() + start + 2;
+
+        assert_eq!(
+            regions.backtick_command_substitution_ranges(),
+            &[TextRange::new(
+                TextSize::new(start as u32),
+                TextSize::new(end as u32),
+            )]
+        );
+    }
+
+    #[test]
+    fn tracks_backtick_command_substitution_ranges_in_parameter_operands() {
+        let source = "echo ${x:-`printf '%s' \"$name\"`}\n";
         let regions = regions(source);
         let start = source.find('`').unwrap();
         let end = source[start + 1..].find('`').unwrap() + start + 2;

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -975,13 +975,12 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 &subscript_later_suppression_spans,
             );
 
-        let mut backtick_substitution_spans = word_spans::backtick_substitution_spans(locator);
-        backtick_substitution_spans.retain(|span| {
-            !self
-                ._indexer
+        let backtick_substitution_spans = text_ranges_to_spans(
+            self._indexer
                 .region_index()
-                .is_quoted_heredoc(TextSize::new(span.start.offset as u32))
-        });
+                .backtick_command_substitution_ranges(),
+            locator,
+        );
         let backtick_escaped_parameters =
             word_spans::backtick_escaped_parameters(locator, &backtick_substitution_spans);
         let mut backtick_escaped_parameter_reference_spans =
@@ -1385,6 +1384,20 @@ fn linebreak_in_test_insert_offset(span: Span, source: &str) -> Option<usize> {
     } else {
         None
     }
+}
+
+fn text_ranges_to_spans(ranges: &[TextRange], locator: Locator<'_>) -> Vec<Span> {
+    ranges
+        .iter()
+        .filter_map(|range| text_range_to_span(*range, locator))
+        .collect()
+}
+
+fn text_range_to_span(range: TextRange, locator: Locator<'_>) -> Option<Span> {
+    Some(Span::from_positions(
+        locator.position_at_offset(usize::from(range.start()))?,
+        locator.position_at_offset(usize::from(range.end()))?,
+    ))
 }
 
 fn build_unset_command_ids_by_target_name(

--- a/crates/shuck-linter/src/facts/word_spans/backticks.rs
+++ b/crates/shuck-linter/src/facts/word_spans/backticks.rs
@@ -85,163 +85,10 @@ pub(crate) fn containing_backtick_substitution_span(
         .find(|span| span_contains(*span, target))
 }
 
-#[derive(Clone, Copy, Default)]
-pub(crate) struct BacktickQuoteContext {
-    in_single_quote: bool,
-    in_double_quote: bool,
-    in_comment: bool,
-    previous_char: Option<char>,
-}
-
 pub(crate) fn backtick_shell_comment_can_start(previous_char: Option<char>) -> bool {
     previous_char.is_none_or(|ch| {
         ch.is_ascii_whitespace() || matches!(ch, ';' | '|' | '&' | '(' | ')' | '<' | '>')
     })
-}
-
-pub(crate) fn backtick_substitution_spans(locator: Locator<'_>) -> Vec<Span> {
-    let source = locator.source();
-    let mut spans = Vec::new();
-    let mut contexts = vec![BacktickQuoteContext::default()];
-    let mut backtick_start_offsets = Vec::<usize>::new();
-    let mut index = 0usize;
-
-    while index < source.len() {
-        let ch = source[index..]
-            .chars()
-            .next()
-            .expect("index should remain on UTF-8 boundaries");
-        let ch_len = ch.len_utf8();
-
-        if contexts
-            .last()
-            .expect("scanner should always retain a root context")
-            .in_comment
-        {
-            if ch == '\n' {
-                let context = contexts
-                    .last_mut()
-                    .expect("scanner should always retain a root context");
-                context.in_comment = false;
-                context.previous_char = Some(ch);
-            }
-            index += ch_len;
-            continue;
-        }
-
-        if contexts
-            .last()
-            .expect("scanner should always retain a root context")
-            .in_single_quote
-        {
-            if ch == '\'' {
-                contexts
-                    .last_mut()
-                    .expect("scanner should always retain a root context")
-                    .in_single_quote = false;
-            }
-            contexts
-                .last_mut()
-                .expect("scanner should always retain a root context")
-                .previous_char = Some(ch);
-            index += ch_len;
-            continue;
-        }
-
-        match ch {
-            '\\' => {
-                index += ch_len;
-                if index < source.len() {
-                    let escaped = source[index..]
-                        .chars()
-                        .next()
-                        .expect("index should remain on UTF-8 boundaries");
-                    index += escaped.len_utf8();
-                    contexts
-                        .last_mut()
-                        .expect("scanner should always retain a root context")
-                        .previous_char = Some(escaped);
-                } else {
-                    contexts
-                        .last_mut()
-                        .expect("scanner should always retain a root context")
-                        .previous_char = Some('\\');
-                }
-            }
-            '\'' if !contexts
-                .last()
-                .expect("scanner should always retain a root context")
-                .in_double_quote =>
-            {
-                let context = contexts
-                    .last_mut()
-                    .expect("scanner should always retain a root context");
-                context.in_single_quote = true;
-                context.previous_char = Some(ch);
-                index += ch_len;
-            }
-            '"' => {
-                let context = contexts
-                    .last_mut()
-                    .expect("scanner should always retain a root context");
-                context.in_double_quote = !context.in_double_quote;
-                context.previous_char = Some(ch);
-                index += ch_len;
-            }
-            '#' if !contexts
-                .last()
-                .expect("scanner should always retain a root context")
-                .in_double_quote
-                && backtick_shell_comment_can_start(
-                    contexts
-                        .last()
-                        .expect("scanner should always retain a root context")
-                        .previous_char,
-                ) =>
-            {
-                contexts
-                    .last_mut()
-                    .expect("scanner should always retain a root context")
-                    .in_comment = true;
-                index += ch_len;
-            }
-            '`' => {
-                if let Some(start_offset) = backtick_start_offsets.pop() {
-                    let _ = contexts.pop();
-                    let Some(start) = locator.position_at_offset(start_offset) else {
-                        index += ch_len;
-                        continue;
-                    };
-                    let Some(end) = locator.position_at_offset(index + ch_len) else {
-                        index += ch_len;
-                        continue;
-                    };
-                    spans.push(Span::from_positions(start, end));
-                    contexts
-                        .last_mut()
-                        .expect("scanner should always retain a root context")
-                        .previous_char = Some(ch);
-                } else {
-                    backtick_start_offsets.push(index);
-                    contexts
-                        .last_mut()
-                        .expect("scanner should always retain a root context")
-                        .previous_char = Some(ch);
-                    contexts.push(BacktickQuoteContext::default());
-                }
-                index += ch_len;
-            }
-            _ => {
-                contexts
-                    .last_mut()
-                    .expect("scanner should always retain a root context")
-                    .previous_char = Some(ch);
-                index += ch_len;
-            }
-        }
-    }
-
-    spans
 }
 
 pub(crate) fn backtick_escaped_parameters(
@@ -1020,18 +867,37 @@ pub(crate) fn shellcheck_collapsed_position(
 #[cfg(test)]
 mod tests {
     use shuck_ast::Span;
-    use shuck_indexer::LineIndex;
+    use shuck_indexer::{Indexer, LineIndex};
+    use shuck_parser::parser::Parser;
 
     use super::{
         backtick_double_escaped_parameter_spans, backtick_escaped_parameters,
-        backtick_substitution_spans, shellcheck_collapsed_backtick_part_span,
+        shellcheck_collapsed_backtick_part_span,
     };
     use crate::Locator;
+
+    fn backtick_spans(source: &str) -> Vec<Span> {
+        let output = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &output);
+        let locator = Locator::new(source, indexer.line_index());
+
+        indexer
+            .region_index()
+            .backtick_command_substitution_ranges()
+            .iter()
+            .filter_map(|range| {
+                Some(Span::from_positions(
+                    locator.position_at_offset(usize::from(range.start()))?,
+                    locator.position_at_offset(usize::from(range.end()))?,
+                ))
+            })
+            .collect()
+    }
 
     fn shellcheck_collapsed_backtick_part_span_in_source(span: Span, source: &str) -> Span {
         let line_index = LineIndex::new(source);
         let locator = Locator::new(source, &line_index);
-        let backtick_spans = backtick_substitution_spans(locator);
+        let backtick_spans = backtick_spans(source);
         shellcheck_collapsed_backtick_part_span(span, locator, &backtick_spans)
     }
 
@@ -1154,7 +1020,7 @@ mod tests {
         let source = "`VAR=\"a b\" OTHER=$(printf '%s\\n' value) \\$cmd arg`";
         let line_index = LineIndex::new(source);
         let locator = Locator::new(source, &line_index);
-        let backtick_spans = backtick_substitution_spans(locator);
+        let backtick_spans = backtick_spans(source);
         let escaped = backtick_escaped_parameters(locator, &backtick_spans);
 
         assert_eq!(escaped.len(), 1);
@@ -1166,7 +1032,7 @@ mod tests {
         let source = "`VAR+=x \\$cmd arg`";
         let line_index = LineIndex::new(source);
         let locator = Locator::new(source, &line_index);
-        let backtick_spans = backtick_substitution_spans(locator);
+        let backtick_spans = backtick_spans(source);
         let escaped = backtick_escaped_parameters(locator, &backtick_spans);
 
         assert_eq!(escaped.len(), 1);
@@ -1178,7 +1044,7 @@ mod tests {
         let source = "`>/tmp/out 2>\"/tmp err\" FOO=bar \\$cmd arg`";
         let line_index = LineIndex::new(source);
         let locator = Locator::new(source, &line_index);
-        let backtick_spans = backtick_substitution_spans(locator);
+        let backtick_spans = backtick_spans(source);
         let escaped = backtick_escaped_parameters(locator, &backtick_spans);
 
         assert_eq!(escaped.len(), 1);
@@ -1197,7 +1063,7 @@ mod tests {
             r#"`echo "foreach dir {puts \\$dir} literal \\\\$literal"` `echo "plain $missing"`"#;
         let line_index = LineIndex::new(source);
         let locator = Locator::new(source, &line_index);
-        let backtick_spans = backtick_substitution_spans(locator);
+        let backtick_spans = backtick_spans(source);
         let escaped = backtick_double_escaped_parameter_spans(locator, &backtick_spans);
 
         assert_eq!(

--- a/crates/shuck-linter/src/facts/word_spans/backticks.rs
+++ b/crates/shuck-linter/src/facts/word_spans/backticks.rs
@@ -1051,6 +1051,23 @@ mod tests {
         assert!(escaped[0].standalone_command_name);
     }
 
+    #[test]
+    fn backtick_escaped_parameters_include_parameter_expansion_operands() {
+        let source = "echo ${x:-`printf '%s\\n' \\$HOME`}\n";
+        let line_index = LineIndex::new(source);
+        let locator = Locator::new(source, &line_index);
+        let backtick_spans = backtick_spans(source);
+        let escaped = backtick_escaped_parameters(locator, &backtick_spans);
+
+        assert_eq!(
+            escaped
+                .iter()
+                .map(|entry| entry.reference_span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$HOME"]
+        );
+    }
+
     fn span_for_text(source: &str, text: &str) -> Span {
         let start_offset = source.find(text).expect("expected text");
         let end_offset = start_offset + text.len();

--- a/crates/shuck-linter/src/facts/word_spans/mod.rs
+++ b/crates/shuck-linter/src/facts/word_spans/mod.rs
@@ -21,8 +21,7 @@ mod zsh;
 pub use arrays::*;
 pub(crate) use backticks::{
     backtick_double_escaped_parameter_spans, backtick_escaped_parameter_reference_spans,
-    backtick_escaped_parameters, backtick_substitution_spans,
-    shellcheck_collapsed_backtick_part_span,
+    backtick_escaped_parameters, shellcheck_collapsed_backtick_part_span,
 };
 pub use command_substitution::*;
 pub use expansions::*;

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -2172,6 +2172,31 @@ EOF
     }
 
     #[test]
+    fn preserves_shellcheck_columns_for_backticks_in_parameter_expansion_operands() {
+        let source = "\
+#!/bin/sh
+depfile=${depfile-`echo \"$object\" |
+  sed 's|[^\\\\/]*$|'${DEPDIR-.deps}'/&|;s|\\.\\([^.]*\\)$|.P\\1|;s|Pobj$|Po|'`}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedExpansion));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| {
+                    (
+                        diagnostic.span.start.line,
+                        diagnostic.span.start.column,
+                        diagnostic.span.end.line,
+                        diagnostic.span.end.column,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![(3, 19, 3, 34)]
+        );
+    }
+
+    #[test]
     fn reports_unsafe_escaped_parameters_in_legacy_backticks() {
         let source = "\
 #!/bin/sh


### PR DESCRIPTION
## Summary
- add backtick-specific command substitution ranges to `RegionIndex` from parser-owned command substitution syntax
- build linter backtick substitution spans from the indexed ranges instead of a separate full-source scan in facts
- update backtick and quoted-heredoc coverage to exercise the indexed path directly

## Why
This refactor removes an extra O(source_len) rediscovery pass for legacy backtick substitutions from the facts builder and moves that work onto the shared indexer path that already visits command substitutions.

## Testing
- `cargo fmt --all --check`
- `cargo test -p shuck-indexer`
- `cargo test -p shuck-linter backtick`
- `cargo test -p shuck-linter quoted_heredoc`