### PR TITLE
refactor: route source lookups through line indexes

### DIFF
--- a/crates/shuck-indexer/src/line_index.rs
+++ b/crates/shuck-indexer/src/line_index.rs
@@ -86,6 +86,36 @@ impl LineIndex {
         Some(TextRange::new(start, end))
     }
 
+    /// Return the byte offset for a 1-based line and 1-based column.
+    ///
+    /// `column` may point just past the final character on the line, in which
+    /// case the returned offset is the end of [`Self::line_range`].
+    pub fn offset_for_line_column(
+        &self,
+        line: usize,
+        column: usize,
+        source: &str,
+    ) -> Option<TextSize> {
+        if line == 0 || column == 0 {
+            return None;
+        }
+
+        let range = self.line_range(line, source)?;
+        let line_start = usize::from(range.start());
+        let line_end = usize::from(range.end());
+        let line_text = source.get(line_start..line_end)?;
+
+        let mut current_column = 1usize;
+        for (relative_offset, _) in line_text.char_indices() {
+            if current_column == column {
+                return Some(TextSize::new((line_start + relative_offset) as u32));
+            }
+            current_column += 1;
+        }
+
+        (current_column == column).then_some(range.end())
+    }
+
     /// Return the number of physical lines recorded for the source.
     ///
     /// The count is always at least `1`, even for empty source.
@@ -144,6 +174,33 @@ mod tests {
         assert_eq!(
             index.line_range(1, source).unwrap().slice(source),
             "caf\u{00E9}"
+        );
+    }
+
+    #[test]
+    fn resolves_line_and_column_to_offsets() {
+        let source = "alpha\nb\u{e9}ta\n";
+        let index = LineIndex::new(source);
+
+        assert_eq!(
+            index.offset_for_line_column(1, 1, source),
+            Some(TextSize::new(0))
+        );
+        assert_eq!(
+            index.offset_for_line_column(2, 1, source),
+            Some(TextSize::new("alpha\n".len() as u32))
+        );
+        assert_eq!(
+            index.offset_for_line_column(2, 3, source),
+            Some(TextSize::new("alpha\nb\u{e9}".len() as u32))
+        );
+        assert_eq!(
+            index.offset_for_line_column(2, 5, source),
+            Some(TextSize::new("alpha\nb\u{e9}ta".len() as u32))
+        );
+        assert_eq!(
+            index.offset_for_line_column(3, 1, source),
+            Some(TextSize::new(source.len() as u32))
         );
     }
 }

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -1312,6 +1312,7 @@ mod tests {
         assert!(regions.is_arithmetic(arithmetic));
     }
 
+    #[test]
     fn tracks_backtick_command_substitution_ranges() {
         let source = "echo `printf '%s' \"$name\"` $(pwd)\n";
         let regions = regions(source);

--- a/crates/shuck-indexer/src/region_index.rs
+++ b/crates/shuck-indexer/src/region_index.rs
@@ -1312,7 +1312,6 @@ mod tests {
         assert!(regions.is_arithmetic(arithmetic));
     }
 
-    #[test]
     fn tracks_backtick_command_substitution_ranges() {
         let source = "echo `printf '%s' \"$name\"` $(pwd)\n";
         let regions = regions(source);

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -19,7 +19,7 @@ fn build_literal_brace_spans(
         }
 
         let is_find_exec_placeholder_word =
-            is_find_exec_placeholder_word(commands, nodes, fact, source);
+            is_find_exec_placeholder_word(commands, nodes, fact, source, locator);
         let is_xargs_replacement_word = is_xargs_replacement_word(commands, nodes, fact, source);
         if is_find_exec_placeholder_word || is_xargs_replacement_word {
             continue;
@@ -174,6 +174,7 @@ fn is_find_exec_placeholder_word(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     source: &str,
+    locator: Locator<'_>,
 ) -> bool {
     if !word_is_empty_brace_pair_variant(occurrence_word(nodes, fact), source) {
         return false;
@@ -191,7 +192,7 @@ fn is_find_exec_placeholder_word(
         command.stmt().span.start.offset <= occurrence_span(nodes, fact).start.offset
             && command.stmt().span.end.offset >= occurrence_span(nodes, fact).end.offset
             && is_find_exec_command(command, source)
-    }) || line_has_find_exec_placeholder_context(source, occurrence_span(nodes, fact))
+    }) || line_has_find_exec_placeholder_context(locator, occurrence_span(nodes, fact))
 }
 
 fn is_find_exec_command(command: CommandFactRef<'_, '_>, source: &str) -> bool {
@@ -222,15 +223,13 @@ fn is_find_exec_command(command: CommandFactRef<'_, '_>, source: &str) -> bool {
     has_exec_flag && has_exec_terminator
 }
 
-fn line_has_find_exec_placeholder_context(source: &str, brace_span: Span) -> bool {
-    let Some(line_text) = source.lines().nth(brace_span.start.line.saturating_sub(1)) else {
+fn line_has_find_exec_placeholder_context(locator: Locator<'_>, brace_span: Span) -> bool {
+    let source = locator.source();
+    let Some(line_range) = locator.line_range(brace_span.start.line) else {
         return false;
     };
-    let line_start_offset = source
-        .lines()
-        .take(brace_span.start.line.saturating_sub(1))
-        .map(|line| line.len() + '\n'.len_utf8())
-        .sum::<usize>();
+    let line_start_offset = usize::from(line_range.start());
+    let line_text = line_range.slice(source);
     let Some(relative_start) = brace_span.start.offset.checked_sub(line_start_offset) else {
         return false;
     };

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -727,7 +727,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &command_child_index,
             locator,
         );
-        let shebang_header_facts = build_shebang_header_facts(self.source);
+        let shebang_header_facts = build_shebang_header_facts(locator);
         let errexit_enabled_anywhere = self.ambient_shell_options.errexit
             || shebang_header_facts.enables_errexit
             || commands

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -14,9 +14,10 @@ struct ShebangHeaderFacts {
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
-fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
-    let mut source_lines = source_lines_with_offsets(source).enumerate();
-    let Some((_, first_line)) = source_lines.next() else {
+fn build_shebang_header_facts(locator: Locator<'_>) -> ShebangHeaderFacts {
+    let source = locator.source();
+    let line_index = locator.line_index();
+    let Some(first_line) = source_line(source, line_index, 1) else {
         return ShebangHeaderFacts::default();
     };
     let first_line_offset = first_line.offset;
@@ -31,7 +32,9 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
     let mut last_line_ending =
         (!first_line.line_ending.is_empty()).then_some(first_line.line_ending);
 
-    for (line_index, source_line) in std::iter::once((0, first_line)).chain(source_lines) {
+    for (line_index, source_line) in (1..=line_index.line_count()).filter_map(|line_number| {
+        source_line(source, line_index, line_number).map(|line| (line_number - 1, line))
+    }) {
         let offset = source_line.offset;
         let raw_line = source_line.text;
         let line = raw_line.trim_end_matches('\r');
@@ -115,12 +118,12 @@ fn build_shebang_header_facts(source: &str) -> ShebangHeaderFacts {
         if interpreter.starts_with('/') || *interpreter == "/usr/bin/env" {
             return None;
         }
-        if has_header_shellcheck_shell_directive(source) {
+        if has_header_shellcheck_shell_directive(source, line_index) {
             return None;
         }
         Some(line_span(1, first_line_offset, first_line_text))
     });
-    let enables_errexit = first_nonempty_source_line(source)
+    let enables_errexit = first_nonempty_source_line(source, line_index)
         .and_then(|(_, line)| line.trim_end_matches('\r').strip_prefix("#!"))
         .map(parse_shebang_words)
         .is_some_and(|words| shebang_enables_errexit(&words));
@@ -227,29 +230,34 @@ struct SourceLine<'a> {
     line_ending: &'static str,
 }
 
-fn source_lines_with_offsets(source: &str) -> impl Iterator<Item = SourceLine<'_>> + '_ {
-    source
-        .split_inclusive('\n')
-        .scan(0usize, |offset, raw_line| {
-            let (line, line_ending) = if let Some(line) = raw_line.strip_suffix("\r\n") {
-                (line, "\r\n")
-            } else if let Some(line) = raw_line.strip_suffix('\n') {
-                (line, "\n")
-            } else {
-                (raw_line, "")
-            };
-            let line_offset = *offset;
-            *offset += raw_line.len();
-            Some(SourceLine {
-                offset: line_offset,
-                text: line,
-                line_ending,
-            })
-        })
+fn source_line<'a>(source: &'a str, line_index: &LineIndex, line: usize) -> Option<SourceLine<'a>> {
+    let range = line_index.line_range(line, source)?;
+    let offset = usize::from(range.start());
+    let raw_text = range.slice(source);
+    let has_newline = source.as_bytes().get(usize::from(range.end())) == Some(&b'\n');
+    let (text, line_ending) = if has_newline {
+        if let Some(text) = raw_text.strip_suffix('\r') {
+            (text, "\r\n")
+        } else {
+            (raw_text, "\n")
+        }
+    } else {
+        (raw_text, "")
+    };
+
+    Some(SourceLine {
+        offset,
+        text,
+        line_ending,
+    })
 }
 
-fn first_nonempty_source_line(source: &str) -> Option<(usize, &str)> {
-    source_lines_with_offsets(source)
+fn first_nonempty_source_line<'a>(
+    source: &'a str,
+    line_index: &LineIndex,
+) -> Option<(usize, &'a str)> {
+    (1..=line_index.line_count())
+        .filter_map(|line_number| source_line(source, line_index, line_number))
         .find(|line| !line.text.trim().is_empty())
         .map(|line| (line.offset, line.text))
 }
@@ -342,9 +350,11 @@ fn build_commented_continuation_comment_spans(source: &str, indexer: &Indexer) -
 }
 
 fn build_comment_double_quote_nesting_spans(source: &str, indexer: &Indexer) -> Vec<Span> {
-    source_lines_with_offsets(source)
-        .enumerate()
-        .filter_map(|(line_index, source_line)| {
+    let line_index = indexer.line_index();
+
+    (1..=line_index.line_count())
+        .filter_map(|line_number| {
+            let source_line = source_line(source, line_index, line_number)?;
             let line = source_line.text.trim_end_matches('\r');
             let comment_start = line.find('#')?;
             let comment_offset = source_line.offset + comment_start;
@@ -365,7 +375,7 @@ fn build_comment_double_quote_nesting_spans(source: &str, indexer: &Indexer) -> 
                 .map(|offset| parameter_start + offset)?;
             let expansion_start = comment_start + quoted_positional + 1;
             Some(line_slice_span(
-                line_index + 1,
+                line_number,
                 source_line.offset,
                 line,
                 expansion_start,
@@ -447,9 +457,12 @@ fn case_item_label_comment(
     })
 }
 
-fn has_header_shellcheck_shell_directive(source: &str) -> bool {
-    for line in source.lines().skip(1) {
-        let trimmed = line.trim_start();
+fn has_header_shellcheck_shell_directive(source: &str, line_index: &LineIndex) -> bool {
+    for line_number in 2..=line_index.line_count() {
+        let Some(source_line) = source_line(source, line_index, line_number) else {
+            continue;
+        };
+        let trimmed = source_line.text.trim_end_matches('\r').trim_start();
         if trimmed.is_empty() || trimmed.starts_with("#!") {
             continue;
         }

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -1449,11 +1449,14 @@ fn shell_has_brace_expansion(shell: ShellDialect) -> bool {
 fn build_flag_for_loop_source_name_uses(locator: Locator<'_>) -> Vec<ComparableNameUse> {
     let source = locator.source();
     let mut uses = Vec::new();
-    let mut line_start = 0;
-    for line in source.split_inclusive('\n') {
-        let line_without_newline = line.trim_end_matches('\n');
-        let trimmed = line_without_newline.trim_start();
-        let leading_whitespace = line_without_newline.len() - trimmed.len();
+    for line_number in 1..=locator.line_index().line_count() {
+        let Some(line_range) = locator.line_range(line_number) else {
+            continue;
+        };
+        let line_start = usize::from(line_range.start());
+        let line = line_range.slice(source).trim_end_matches('\r');
+        let trimmed = line.trim_start();
+        let leading_whitespace = line.len() - trimmed.len();
         if let Some(after_for) = trimmed.strip_prefix("for ")
             && let Some(in_offset) = after_for.find(" in ")
         {
@@ -1490,7 +1493,6 @@ fn build_flag_for_loop_source_name_uses(locator: Locator<'_>) -> Vec<ComparableN
                 }
             }
         }
-        line_start += line.len();
     }
     uses
 }

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -509,14 +509,16 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
                         .map_or(part_span, |relative_start| {
                             let start_offset = search_start + relative_start;
                             let end_offset = start_offset + expected.len();
-                            let start = Position::new().advanced_by(&source[..start_offset]);
-                            let end = Position::new().advanced_by(&source[..end_offset]);
-                            Span::from_positions(start, end)
+                            locator
+                                .position_at_offset(start_offset)
+                                .zip(locator.position_at_offset(end_offset))
+                                .map(|(start, end)| Span::from_positions(start, end))
+                                .unwrap_or(part_span)
                         })
                 }
             }
             WordPart::Parameter(_) | WordPart::ParameterExpansion { .. } => {
-                shellcheck_parameter_span_inside_escaped_quotes(part_span, source)
+                shellcheck_parameter_span_inside_escaped_quotes(part_span, locator)
                     .unwrap_or(part_span)
             }
             _ => return part_span,
@@ -737,26 +739,28 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
     }
 }
 
-pub(super) fn shellcheck_parameter_span_inside_escaped_quotes(span: Span, source: &str) -> Option<Span> {
+pub(super) fn shellcheck_parameter_span_inside_escaped_quotes(
+    span: Span,
+    locator: Locator<'_>,
+) -> Option<Span> {
     if span.start.line != span.end.line {
         return None;
     }
 
-    let search_start = offset_for_line_column(
-        source,
+    let source = locator.source();
+    let search_start = locator.offset_for_line_column(
         span.start.line,
         span.start.column.saturating_sub(2).max(1),
     )?;
-    let search_end = offset_for_line_column(
-        source,
+    let search_end = locator.offset_for_line_column(
         span.end.line,
         span.end.column.saturating_add(3),
     )
-    .or_else(|| line_end_offset(source, span.end.line))?;
+    .or_else(|| locator.line_range(span.end.line).map(|range| usize::from(range.end())))?;
     let window = source.get(search_start..search_end)?;
     let relative_dollar = window.find('$')?;
     let start_offset = search_start + relative_dollar;
-    let start = Position::new().advanced_by(&source[..start_offset]);
+    let start = locator.position_at_offset(start_offset)?;
     if start.line != span.start.line
         || start.column < span.start.column
         || start.column > span.start.column.saturating_add(2)
@@ -764,14 +768,14 @@ pub(super) fn shellcheck_parameter_span_inside_escaped_quotes(span: Span, source
         return None;
     }
 
-    let span_start_offset = offset_for_line_column(source, span.start.line, span.start.column)?;
+    let span_start_offset = locator.offset_for_line_column(span.start.line, span.start.column)?;
     let prefix = source.get(span_start_offset..start_offset)?;
     if !prefix.contains('"') && !prefix.contains('\\') {
         return None;
     }
 
     let end_offset = parameter_expansion_end_offset(source, start_offset)?;
-    let end = Position::new().advanced_by(&source[..end_offset]);
+    let end = locator.position_at_offset(end_offset)?;
     if end.line != span.end.line
         || end.column < span.end.column
         || end.column > span.end.column.saturating_add(3)
@@ -784,58 +788,6 @@ pub(super) fn shellcheck_parameter_span_inside_escaped_quotes(span: Span, source
     }
 
     Some(Span::from_positions(start, end))
-}
-
-pub(super) fn offset_for_line_column(source: &str, line: usize, column: usize) -> Option<usize> {
-    if line == 0 || column == 0 {
-        return None;
-    }
-
-    let mut current_line = 1usize;
-    let mut line_start = 0usize;
-    for (offset, ch) in source.char_indices() {
-        if current_line == line {
-            return offset_for_column_in_line(source, line_start, column);
-        }
-        if ch == '\n' {
-            current_line += 1;
-            line_start = offset + ch.len_utf8();
-        }
-    }
-
-    (current_line == line).then(|| offset_for_column_in_line(source, line_start, column))?
-}
-
-pub(super) fn offset_for_column_in_line(source: &str, line_start: usize, column: usize) -> Option<usize> {
-    let mut current_column = 1usize;
-    for (relative_offset, ch) in source.get(line_start..)?.char_indices() {
-        if ch == '\n' {
-            break;
-        }
-        if current_column == column {
-            return Some(line_start + relative_offset);
-        }
-        current_column += 1;
-    }
-
-    (current_column == column).then_some(
-        line_start
-            + source
-                .get(line_start..)?
-                .find('\n')
-                .unwrap_or(source.len() - line_start),
-    )
-}
-
-pub(super) fn line_end_offset(source: &str, line: usize) -> Option<usize> {
-    let line_start = offset_for_line_column(source, line, 1)?;
-    Some(
-        line_start
-            + source
-                .get(line_start..)?
-                .find('\n')
-                .unwrap_or(source.len() - line_start),
-    )
 }
 
 pub(super) fn parameter_expansion_end_offset(source: &str, dollar_offset: usize) -> Option<usize> {

--- a/crates/shuck-linter/src/facts/words/quote_spans.rs
+++ b/crates/shuck-linter/src/facts/words/quote_spans.rs
@@ -490,6 +490,7 @@ pub(super) fn mixed_quote_chained_line_join_between_double_quotes_spans(
 
     let mut spans = Vec::new();
     let mut cursor = word.span.end.offset;
+    let mut cursor_position = word.span.end;
     while source[cursor..].starts_with('"') {
         let Some(closing_quote_relative) =
             mixed_quote_closing_double_quote_offset(&source[cursor..])
@@ -509,9 +510,10 @@ pub(super) fn mixed_quote_chained_line_join_between_double_quotes_spans(
             break;
         };
 
-        let start = Position::new().advanced_by(&source[..after_closing_quote]);
+        let start = cursor_position.advanced_by(&source[cursor..after_closing_quote]);
         spans.push(Span::from_positions(start, start.advanced_by(suffix)));
         cursor = after_closing_quote + suffix.len();
+        cursor_position = start.advanced_by(suffix);
     }
 
     spans

--- a/crates/shuck-linter/src/locator.rs
+++ b/crates/shuck-linter/src/locator.rs
@@ -6,7 +6,7 @@
 //! keeps signatures compact while still routing every offset lookup through
 //! the precomputed [`LineIndex`].
 
-use shuck_ast::{Position, TextSize};
+use shuck_ast::{Position, TextRange, TextSize};
 use shuck_indexer::LineIndex;
 
 #[derive(Clone, Copy, Debug)]
@@ -26,6 +26,18 @@ impl<'a> Locator<'a> {
 
     pub fn line_index(&self) -> &'a LineIndex {
         self.line_index
+    }
+
+    #[inline]
+    pub fn line_range(&self, line: usize) -> Option<TextRange> {
+        self.line_index.line_range(line, self.source)
+    }
+
+    #[inline]
+    pub fn offset_for_line_column(&self, line: usize, column: usize) -> Option<usize> {
+        self.line_index
+            .offset_for_line_column(line, column, self.source)
+            .map(usize::from)
     }
 
     /// Resolve a byte offset to a [`Position`] using the precomputed

--- a/crates/shuck-linter/tests/no_full_source_traversal.rs
+++ b/crates/shuck-linter/tests/no_full_source_traversal.rs
@@ -1,0 +1,167 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug)]
+struct ForbiddenPattern {
+    needle: &'static str,
+    guidance: &'static str,
+}
+
+#[derive(Debug)]
+struct Violation {
+    path: PathBuf,
+    line_number: usize,
+    line: String,
+    pattern: ForbiddenPattern,
+}
+
+const FORBIDDEN_PATTERNS: &[ForbiddenPattern] = &[
+    ForbiddenPattern {
+        needle: "source.char_indices()",
+        guidance: "use RegionCollector, Locator, or LineIndex instead of rescanning the full source",
+    },
+    ForbiddenPattern {
+        needle: "source.lines()",
+        guidance: "use LineIndex line ranges instead of iterating every source line",
+    },
+    ForbiddenPattern {
+        needle: "source.split_inclusive('\\n')",
+        guidance: "use LineIndex line ranges instead of splitting the entire source",
+    },
+    ForbiddenPattern {
+        needle: "source.split_inclusive(\"\\n\")",
+        guidance: "use LineIndex line ranges instead of splitting the entire source",
+    },
+    ForbiddenPattern {
+        needle: "while index < source.len()",
+        guidance: "use parser/indexer facts instead of scanning the full source buffer",
+    },
+    ForbiddenPattern {
+        needle: "Position::new().advanced_by(&source[..",
+        guidance: "use Locator or LineIndex-backed offset-to-position helpers instead of rescanning prefixes",
+    },
+];
+
+#[test]
+fn facts_do_not_reintroduce_full_source_traversals() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let scan_root = manifest_dir.join("src/facts");
+    let mut violations = Vec::new();
+
+    collect_violations(manifest_dir, &scan_root, &mut violations);
+
+    assert!(
+        violations.is_empty(),
+        "{}",
+        format_violations(manifest_dir, &violations)
+    );
+}
+
+fn collect_violations(manifest_dir: &Path, path: &Path, violations: &mut Vec<Violation>) {
+    let metadata = fs::metadata(path).expect("expected scan path metadata");
+    if metadata.is_dir() {
+        let mut entries = fs::read_dir(path)
+            .expect("expected scan directory")
+            .map(|entry| entry.expect("expected directory entry").path())
+            .collect::<Vec<_>>();
+        entries.sort();
+        for entry in entries {
+            collect_violations(manifest_dir, &entry, violations);
+        }
+        return;
+    }
+
+    if !should_scan(path) {
+        return;
+    }
+
+    let source = fs::read_to_string(path).expect("expected Rust source file");
+    violations.extend(file_violations(manifest_dir, path, &source));
+}
+
+fn should_scan(path: &Path) -> bool {
+    if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+        return false;
+    }
+
+    !path
+        .components()
+        .any(|component| component.as_os_str() == "tests")
+        && path.file_name().and_then(|name| name.to_str()) != Some("tests.rs")
+}
+
+fn file_violations(manifest_dir: &Path, path: &Path, source: &str) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    let mut brace_depth = 0i32;
+    let mut pending_cfg_test_block = false;
+    let mut ignored_test_depth = None::<i32>;
+
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim();
+        let opens = line.matches('{').count() as i32;
+        let closes = line.matches('}').count() as i32;
+
+        if ignored_test_depth.is_none() && trimmed.starts_with("#[cfg") && trimmed.contains("test")
+        {
+            pending_cfg_test_block = true;
+        }
+
+        let ignore_line = ignored_test_depth.is_some() || pending_cfg_test_block;
+        if !ignore_line {
+            for pattern in FORBIDDEN_PATTERNS {
+                if line.contains(pattern.needle) {
+                    violations.push(Violation {
+                        path: path
+                            .strip_prefix(manifest_dir)
+                            .unwrap_or(path)
+                            .to_path_buf(),
+                        line_number: line_index + 1,
+                        line: line.trim().to_owned(),
+                        pattern: *pattern,
+                    });
+                }
+            }
+        }
+
+        if pending_cfg_test_block {
+            if opens > closes {
+                ignored_test_depth = Some(brace_depth + (opens - closes));
+                pending_cfg_test_block = false;
+            } else if opens > 0 || trimmed.ends_with(';') {
+                pending_cfg_test_block = false;
+            }
+        }
+
+        brace_depth += opens - closes;
+        if let Some(depth) = ignored_test_depth
+            && brace_depth < depth
+        {
+            ignored_test_depth = None;
+        }
+    }
+
+    violations
+}
+
+fn format_violations(manifest_dir: &Path, violations: &[Violation]) -> String {
+    let mut message = String::from(
+        "found full-source traversal patterns in shuck-linter facts; route these through parser/indexer facts instead:\n",
+    );
+
+    for violation in violations {
+        let path = violation
+            .path
+            .strip_prefix(manifest_dir)
+            .unwrap_or(&violation.path);
+        message.push_str(&format!(
+            "{}:{}: `{}` -> {}\n  {}\n",
+            path.display(),
+            violation.line_number,
+            violation.pattern.needle,
+            violation.pattern.guidance,
+            violation.line
+        ));
+    }
+
+    message
+}

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -9,11 +9,11 @@ use shuck_ast::{
     FunctionDef, HeredocBody, HeredocBodyPart, HeredocBodyPartNode, LiteralText, Name,
     NormalizedCommand, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
     PatternGroupKind, PatternPart, PatternPartNode, Position, SourceText, Span, Stmt, StmtSeq,
-    Subscript, SubscriptInterpretation, VarRef, Word, WordPart, WordPartNode, WrapperKind,
-    ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment, ZshParameterExpansion,
+    Subscript, SubscriptInterpretation, TextSize, VarRef, Word, WordPart, WordPartNode,
+    WrapperKind, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment, ZshParameterExpansion,
     normalize_command_words, static_word_text, try_static_word_parts_text,
 };
-use shuck_indexer::Indexer;
+use shuck_indexer::{Indexer, LineIndex};
 use shuck_parser::{ShellDialect, ShellProfile, ZshEmulationMode, ZshOptionState, parser::Parser};
 use smallvec::SmallVec;
 
@@ -77,7 +77,7 @@ pub(crate) struct BuildOutput {
 pub(crate) struct SemanticModelBuilder<'a, 'observer> {
     source: &'a str,
     file_entry_contract_collector: Option<&'observer mut dyn FileEntryContractCollector>,
-    line_start_offsets: Vec<usize>,
+    line_index: &'a LineIndex,
     shell_profile: ShellProfile,
     observer: &'observer mut dyn TraversalObserver<'a>,
     scopes: Vec<Scope>,
@@ -230,7 +230,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         let mut builder = Self {
             source,
             file_entry_contract_collector,
-            line_start_offsets: source_line_start_offsets(source),
+            line_index: indexer.line_index(),
             shell_profile: shell_profile.clone(),
             observer,
             scopes: vec![file_scope],
@@ -2439,16 +2439,6 @@ fn recorded_list_operator(op: BinaryOp) -> RecordedListOperator {
     }
 }
 
-fn source_line_start_offsets(source: &str) -> Vec<usize> {
-    let mut starts = vec![0];
-    for (offset, ch) in source.char_indices() {
-        if ch == '\n' {
-            starts.push(offset + ch.len_utf8());
-        }
-    }
-    starts
-}
-
 fn reference_kind_uses_braced_parameter_syntax(kind: ReferenceKind) -> bool {
     matches!(
         kind,
@@ -2548,17 +2538,12 @@ fn braced_parameter_end_offset(
 
 fn source_line<'a>(
     source: &'a str,
-    line_start_offsets: &[usize],
+    line_index: &LineIndex,
     target_line: usize,
 ) -> Option<(usize, &'a str)> {
-    let line_index = target_line.checked_sub(1)?;
-    let line_start = *line_start_offsets.get(line_index)?;
-    let line_end = line_start_offsets
-        .get(line_index + 1)
-        .copied()
-        .unwrap_or(source.len());
-    let line = source.get(line_start..line_end)?;
-    let line = line.strip_suffix('\n').unwrap_or(line);
-    let line = line.strip_suffix('\r').unwrap_or(line);
-    Some((line_start, line))
+    let range = line_index.line_range(target_line, source)?;
+    Some((
+        usize::from(range.start()),
+        range.slice(source).trim_end_matches('\r'),
+    ))
 }

--- a/crates/shuck-semantic/src/builder/references.rs
+++ b/crates/shuck-semantic/src/builder/references.rs
@@ -143,8 +143,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
             return None;
         }
 
-        let (line_start_offset, line) =
-            source_line(self.source, &self.line_start_offsets, span.start.line)?;
+        let (line_start_offset, line) = source_line(self.source, self.line_index, span.start.line)?;
         let name = name.as_str();
         let mut best = None::<(usize, usize, usize)>;
         for (start, _) in line.match_indices('$') {
@@ -174,8 +173,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
         needle: &str,
         span: Span,
     ) -> Option<Span> {
-        let (line_start_offset, line) =
-            source_line(self.source, &self.line_start_offsets, span.start.line)?;
+        let (line_start_offset, line) = source_line(self.source, self.line_index, span.start.line)?;
         let mut best = None::<(usize, usize, usize)>;
         let name = needle.strip_prefix("${").unwrap_or(needle);
         for (start, _) in line.match_indices(needle) {
@@ -217,7 +215,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
     }
 
     pub(super) fn source_position_at_offset(&self, offset: usize) -> Option<Position> {
-        source_position_at_offset(self.source, &self.line_start_offsets, offset)
+        source_position_at_offset(self.source, self.line_index, offset)
     }
 
     pub(super) fn add_parameter_default_binding(&mut self, reference: &VarRef) {
@@ -325,20 +323,18 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 
 fn source_position_at_offset(
     source: &str,
-    line_start_offsets: &[usize],
+    line_index: &LineIndex,
     offset: usize,
 ) -> Option<Position> {
     if offset > source.len() || !source.is_char_boundary(offset) {
         return None;
     }
 
-    let line_index = line_start_offsets
-        .partition_point(|line_start| *line_start <= offset)
-        .checked_sub(1)?;
-    let line_start = *line_start_offsets.get(line_index)?;
+    let line = line_index.line_number(TextSize::new(offset as u32));
+    let line_start = usize::from(line_index.line_start(line)?);
     let column = source.get(line_start..offset)?.chars().count() + 1;
     Some(Position {
-        line: line_index + 1,
+        line,
         column,
         offset,
     })
@@ -351,10 +347,10 @@ mod tests {
     #[test]
     fn source_position_lookup_uses_precomputed_line_starts() {
         let source = "alpha\nb\u{e9}ta\n";
-        let line_starts = source_line_start_offsets(source);
+        let line_index = LineIndex::new(source);
 
         assert_eq!(
-            source_position_at_offset(source, &line_starts, 0),
+            source_position_at_offset(source, &line_index, 0),
             Some(Position {
                 line: 1,
                 column: 1,
@@ -363,7 +359,7 @@ mod tests {
         );
         let beta_offset = source.find('b').expect("expected second line");
         assert_eq!(
-            source_position_at_offset(source, &line_starts, beta_offset),
+            source_position_at_offset(source, &line_index, beta_offset),
             Some(Position {
                 line: 2,
                 column: 1,
@@ -372,7 +368,7 @@ mod tests {
         );
         let after_e_acute = beta_offset + "b\u{e9}".len();
         assert_eq!(
-            source_position_at_offset(source, &line_starts, after_e_acute),
+            source_position_at_offset(source, &line_index, after_e_acute),
             Some(Position {
                 line: 2,
                 column: 3,
@@ -380,7 +376,7 @@ mod tests {
             })
         );
         assert_eq!(
-            source_position_at_offset(source, &line_starts, source.len()),
+            source_position_at_offset(source, &line_index, source.len()),
             Some(Position {
                 line: 3,
                 column: 1,

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2532,7 +2532,9 @@ pub(crate) fn infer_explicit_parse_dialect_from_source(
 }
 
 fn shebang_interpreter(source: &str) -> Option<&str> {
-    shuck_parser::shebang::interpreter_name(source.lines().next()?)
+    let first_line_end = source.find('\n').unwrap_or(source.len());
+    let first_line = source.get(..first_line_end)?;
+    shuck_parser::shebang::interpreter_name(first_line.strip_suffix('\r').unwrap_or(first_line))
 }
 
 fn infer_parse_dialect_from_path(path: Option<&Path>) -> Option<shuck_parser::ShellDialect> {

--- a/crates/shuck-semantic/tests/no_full_source_traversal.rs
+++ b/crates/shuck-semantic/tests/no_full_source_traversal.rs
@@ -1,0 +1,167 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug)]
+struct ForbiddenPattern {
+    needle: &'static str,
+    guidance: &'static str,
+}
+
+#[derive(Debug)]
+struct Violation {
+    path: PathBuf,
+    line_number: usize,
+    line: String,
+    pattern: ForbiddenPattern,
+}
+
+const FORBIDDEN_PATTERNS: &[ForbiddenPattern] = &[
+    ForbiddenPattern {
+        needle: "source.char_indices()",
+        guidance: "use the shared LineIndex or parser/indexer facts instead of rescanning the full source",
+    },
+    ForbiddenPattern {
+        needle: "source.lines()",
+        guidance: "use indexed line lookups instead of iterating every source line",
+    },
+    ForbiddenPattern {
+        needle: "source.split_inclusive('\\n')",
+        guidance: "use indexed line lookups instead of splitting the entire source",
+    },
+    ForbiddenPattern {
+        needle: "source.split_inclusive(\"\\n\")",
+        guidance: "use indexed line lookups instead of splitting the entire source",
+    },
+    ForbiddenPattern {
+        needle: "while index < source.len()",
+        guidance: "use parser/indexer facts instead of scanning the full source buffer",
+    },
+    ForbiddenPattern {
+        needle: "Position::new().advanced_by(&source[..",
+        guidance: "use shared offset-to-position helpers instead of rescanning prefixes",
+    },
+];
+
+#[test]
+fn semantic_does_not_reintroduce_full_source_traversals() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let scan_root = manifest_dir.join("src");
+    let mut violations = Vec::new();
+
+    collect_violations(manifest_dir, &scan_root, &mut violations);
+
+    assert!(
+        violations.is_empty(),
+        "{}",
+        format_violations(manifest_dir, &violations)
+    );
+}
+
+fn collect_violations(manifest_dir: &Path, path: &Path, violations: &mut Vec<Violation>) {
+    let metadata = fs::metadata(path).expect("expected scan path metadata");
+    if metadata.is_dir() {
+        let mut entries = fs::read_dir(path)
+            .expect("expected scan directory")
+            .map(|entry| entry.expect("expected directory entry").path())
+            .collect::<Vec<_>>();
+        entries.sort();
+        for entry in entries {
+            collect_violations(manifest_dir, &entry, violations);
+        }
+        return;
+    }
+
+    if !should_scan(path) {
+        return;
+    }
+
+    let source = fs::read_to_string(path).expect("expected Rust source file");
+    violations.extend(file_violations(manifest_dir, path, &source));
+}
+
+fn should_scan(path: &Path) -> bool {
+    if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+        return false;
+    }
+
+    !path
+        .components()
+        .any(|component| component.as_os_str() == "tests")
+        && path.file_name().and_then(|name| name.to_str()) != Some("tests.rs")
+}
+
+fn file_violations(manifest_dir: &Path, path: &Path, source: &str) -> Vec<Violation> {
+    let mut violations = Vec::new();
+    let mut brace_depth = 0i32;
+    let mut pending_cfg_test_block = false;
+    let mut ignored_test_depth = None::<i32>;
+
+    for (line_index, line) in source.lines().enumerate() {
+        let trimmed = line.trim();
+        let opens = line.matches('{').count() as i32;
+        let closes = line.matches('}').count() as i32;
+
+        if ignored_test_depth.is_none() && trimmed.starts_with("#[cfg") && trimmed.contains("test")
+        {
+            pending_cfg_test_block = true;
+        }
+
+        let ignore_line = ignored_test_depth.is_some() || pending_cfg_test_block;
+        if !ignore_line {
+            for pattern in FORBIDDEN_PATTERNS {
+                if line.contains(pattern.needle) {
+                    violations.push(Violation {
+                        path: path
+                            .strip_prefix(manifest_dir)
+                            .unwrap_or(path)
+                            .to_path_buf(),
+                        line_number: line_index + 1,
+                        line: line.trim().to_owned(),
+                        pattern: *pattern,
+                    });
+                }
+            }
+        }
+
+        if pending_cfg_test_block {
+            if opens > closes {
+                ignored_test_depth = Some(brace_depth + (opens - closes));
+                pending_cfg_test_block = false;
+            } else if opens > 0 || trimmed.ends_with(';') {
+                pending_cfg_test_block = false;
+            }
+        }
+
+        brace_depth += opens - closes;
+        if let Some(depth) = ignored_test_depth
+            && brace_depth < depth
+        {
+            ignored_test_depth = None;
+        }
+    }
+
+    violations
+}
+
+fn format_violations(manifest_dir: &Path, violations: &[Violation]) -> String {
+    let mut message = String::from(
+        "found full-source traversal patterns in shuck-semantic production code; route these through shared indexes instead:\n",
+    );
+
+    for violation in violations {
+        let path = violation
+            .path
+            .strip_prefix(manifest_dir)
+            .unwrap_or(&violation.path);
+        message.push_str(&format!(
+            "{}:{}: `{}` -> {}\n  {}\n",
+            path.display(),
+            violation.line_number,
+            violation.pattern.needle,
+            violation.pattern.guidance,
+            violation.line
+        ));
+    }
+
+    message
+}


### PR DESCRIPTION
## Summary
- route remaining fact and semantic source lookups through shared line indexes and locators
- remove full-source line and prefix rescans from the remaining production helpers
- add guard tests that fail if facts or semantic reintroduce full-source traversals

## Testing
- cargo fmt --all
- cargo test -p shuck-linter --test no_full_source_traversal
- cargo test -p shuck-semantic --test no_full_source_traversal
- cargo test -p shuck-indexer
- cargo test -p shuck-linter backtick
- cargo test -p shuck-linter quoted_heredoc