### PR TITLE
perf(linter): index parameter operand word facts

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -176,11 +176,13 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             FxHashMap::with_capacity_and_hasher(estimated_word_nodes, Default::default());
         let mut word_occurrences = Vec::with_capacity(estimated_word_occurrences);
         let mut pending_arithmetic_word_occurrences = Vec::new();
+        let mut pending_parameter_operand_word_occurrences = Vec::new();
         let mut compound_assignment_value_word_spans = FxHashSet::default();
         let mut array_assignment_split_word_ids =
             Vec::with_capacity(capacity.commands.saturating_div(8));
         let mut seen_word_occurrences = FxHashSet::default();
         let mut seen_pending_arithmetic_word_occurrences = FxHashSet::default();
+        let mut seen_pending_parameter_operand_word_occurrences = FxHashSet::default();
         let mut assoc_binding_visibility_memo = FxHashMap::default();
         let array_like_capable_names = compute_array_like_capable_names(self.semantic);
         let single_array_like_bindings = compute_single_array_like_bindings(self.semantic);
@@ -308,12 +310,16 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                         word_occurrences: &mut word_occurrences,
                         pending_arithmetic_word_occurrences:
                             &mut pending_arithmetic_word_occurrences,
+                        pending_parameter_operand_word_occurrences:
+                            &mut pending_parameter_operand_word_occurrences,
                         compound_assignment_value_word_spans:
                             &mut compound_assignment_value_word_spans,
                         array_assignment_split_word_ids: &mut array_assignment_split_word_ids,
                         seen_word_occurrences: &mut seen_word_occurrences,
                         seen_pending_arithmetic_word_occurrences:
                             &mut seen_pending_arithmetic_word_occurrences,
+                        seen_pending_parameter_operand_word_occurrences:
+                            &mut seen_pending_parameter_operand_word_occurrences,
                         assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
                         array_like_capable_names: &array_like_capable_names,
                         single_array_like_bindings: &single_array_like_bindings,
@@ -895,6 +901,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &word_nodes,
             &mut word_occurrences,
             pending_arithmetic_word_occurrences,
+            pending_parameter_operand_word_occurrences,
             &mut fact_store,
         );
         populate_array_assignment_split_scalar_expansion_spans(
@@ -1159,6 +1166,7 @@ fn build_word_occurrence_index(
     word_nodes: &[WordNode<'_>],
     word_occurrences: &mut Vec<WordOccurrence>,
     pending_arithmetic_word_occurrences: Vec<PendingArithmeticWordOccurrence>,
+    pending_parameter_operand_word_occurrences: Vec<PendingParameterOperandWordOccurrence>,
     fact_store: &mut FactStore<'_>,
 ) -> FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>> {
     word_occurrences.extend(
@@ -1169,6 +1177,22 @@ fn build_word_occurrence_index(
                 command_id: pending.command_id,
                 nested_word_command: pending.nested_word_command,
                 context: WordFactContext::ArithmeticCommand,
+                host_kind: pending.host_kind,
+                runtime_literal: RuntimeLiteralAnalysis::default(),
+                operand_class: None,
+                enclosing_expansion_context: Some(pending.enclosing_expansion_context),
+                split_sensitive_unquoted_command_substitution_spans: IdRange::empty(),
+                array_assignment_split_scalar_expansion_spans: IdRange::empty(),
+            }),
+    );
+    word_occurrences.extend(
+        pending_parameter_operand_word_occurrences
+            .into_iter()
+            .map(|pending| WordOccurrence {
+                node_id: pending.node_id,
+                command_id: pending.command_id,
+                nested_word_command: pending.nested_word_command,
+                context: WordFactContext::ParameterOperand,
                 host_kind: pending.host_kind,
                 runtime_literal: RuntimeLiteralAnalysis::default(),
                 operand_class: None,

--- a/crates/shuck-linter/src/facts/conditional_portability.rs
+++ b/crates/shuck-linter/src/facts/conditional_portability.rs
@@ -161,7 +161,9 @@ pub(super) fn build_conditional_portability_facts<'a>(
     for fact in inputs.word_occurrences {
         let expansion_context = match fact.context {
             super::WordFactContext::Expansion(context) => Some(context),
-            super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
+            super::WordFactContext::CaseSubject
+            | super::WordFactContext::ArithmeticCommand
+            | super::WordFactContext::ParameterOperand => None,
         };
         let word = occurrence_word(inputs.word_nodes, fact);
         if supports_extglob_portability_context(expansion_context)

--- a/crates/shuck-linter/src/facts/escape_scan.rs
+++ b/crates/shuck-linter/src/facts/escape_scan.rs
@@ -119,7 +119,9 @@ pub(super) fn build_escape_scan_matches(
             is_tr_operand_argument(commands, command_fact_indices_by_id, nodes, fact);
         let expansion_context = match fact.context {
             super::WordFactContext::Expansion(context) => Some(context),
-            super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
+            super::WordFactContext::CaseSubject
+            | super::WordFactContext::ArithmeticCommand
+            | super::WordFactContext::ParameterOperand => None,
         };
         if is_regex_like_context(expansion_context) {
             continue;
@@ -150,7 +152,9 @@ pub(super) fn build_escape_scan_matches(
     for fact in occurrences.iter().filter(|fact| {
         is_assignment_value_context(match fact.context {
             super::WordFactContext::Expansion(context) => Some(context),
-            super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
+            super::WordFactContext::CaseSubject
+            | super::WordFactContext::ArithmeticCommand
+            | super::WordFactContext::ParameterOperand => None,
         })
     }) {
         if !word_spans::word_has_single_literal_part(occurrence_word(nodes, fact)) {
@@ -192,7 +196,9 @@ pub(super) fn build_escape_scan_matches(
             is_tr_operand_argument(commands, command_fact_indices_by_id, nodes, fact);
         if is_regex_like_context(match fact.context {
             super::WordFactContext::Expansion(context) => Some(context),
-            super::WordFactContext::CaseSubject | super::WordFactContext::ArithmeticCommand => None,
+            super::WordFactContext::CaseSubject
+            | super::WordFactContext::ArithmeticCommand
+            | super::WordFactContext::ParameterOperand => None,
         }) {
             continue;
         }
@@ -393,7 +399,9 @@ fn is_relevant_word_occurrence(fact: &WordOccurrence) -> bool {
             fact.host_kind == WordFactHostKind::CommandWrapperTarget
         }
         WordFactContext::Expansion(context) => is_relevant_word_context(Some(context)),
-        WordFactContext::CaseSubject | WordFactContext::ArithmeticCommand => false,
+        WordFactContext::CaseSubject
+        | WordFactContext::ArithmeticCommand
+        | WordFactContext::ParameterOperand => false,
     }
 }
 

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -591,6 +591,10 @@ impl<'a> LinterFacts<'a> {
         WordOccurrenceIter::all(self, WordOccurrenceFilter::ArithmeticCommand)
     }
 
+    pub fn parameter_operand_word_facts(&self) -> WordOccurrenceIter<'_, 'a> {
+        WordOccurrenceIter::all(self, WordOccurrenceFilter::ParameterOperand)
+    }
+
     pub fn is_compound_assignment_value_word(&self, fact: WordOccurrenceRef<'_, '_>) -> bool {
         self.compound_assignment_value_word_flags
             .get(fact.occurrence_id().index())

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -1268,6 +1268,74 @@ fn word_facts_track_only_literal_command_trailers() {
 }
 
 #[test]
+fn word_facts_expose_safe_value_structural_summaries() {
+    let source = "\
+#!/bin/bash
+printf '%s\n' \"$name\" \"${name:-fallback}\" \"${@:1}\" ${@:1} \"$@\" $@
+";
+
+    with_facts(source, None, |_, facts| {
+        let word_fact = |text: &str| {
+            facts
+                .word_facts()
+                .find(|fact| fact.span().slice(source) == text)
+                .expect("expected word fact")
+        };
+
+        let plain_name = word_fact("\"$name\"");
+        assert_eq!(
+            plain_name
+                .safe_value_plain_scalar_reference_name()
+                .map(|name| name.as_str()),
+            Some("name")
+        );
+        assert!(!plain_name.safe_value_special_parameter_access());
+        assert!(!plain_name.safe_value_contains_special_parameter_slice());
+
+        let defaulted = word_fact("\"${name:-fallback}\"");
+        assert_eq!(defaulted.safe_value_plain_scalar_reference_name(), None);
+
+        let quoted_slice = word_fact("\"${@:1}\"");
+        assert!(!quoted_slice.safe_value_contains_special_parameter_slice());
+
+        let unquoted_slice = word_fact("${@:1}");
+        assert!(unquoted_slice.safe_value_contains_special_parameter_slice());
+
+        let quoted_special = word_fact("\"$@\"");
+        assert!(quoted_special.safe_value_special_parameter_access());
+        assert_eq!(
+            quoted_special.safe_value_plain_scalar_reference_name(),
+            None
+        );
+
+        let unquoted_special = word_fact("$@");
+        assert!(unquoted_special.safe_value_special_parameter_access());
+    });
+}
+
+#[test]
+fn word_facts_report_arithmetic_expansion_hazards() {
+    let source = "\
+#!/bin/bash
+printf '%s\n' \"prefix $((x + 1)) suffix\" plain
+";
+
+    with_facts(source, None, |_, facts| {
+        let arithmetic = facts
+            .word_facts()
+            .find(|fact| fact.span().slice(source) == "\"prefix $((x + 1)) suffix\"")
+            .expect("expected arithmetic word fact");
+        let plain = facts
+            .word_facts()
+            .find(|fact| fact.span().slice(source) == "plain")
+            .expect("expected plain word fact");
+
+        assert!(arithmetic.has_arithmetic_expansion());
+        assert!(!plain.has_arithmetic_expansion());
+    });
+}
+
+#[test]
 fn builds_case_pattern_expansion_spans_for_simple_dynamic_patterns() {
     let source = "\
 #!/bin/sh
@@ -1931,6 +1999,38 @@ fn indexes_pending_arithmetic_word_facts_by_span() {
                 .any_word_fact(arithmetic.span())
                 .map(|fact| fact.span().slice(source)),
             Some("$name")
+        );
+    });
+}
+
+#[test]
+fn indexes_parameter_operand_word_facts_by_span_without_exposing_them_in_word_facts() {
+    let source = "#!/bin/bash\nprintf '%s\\n' \"${value:-$name}\"\n";
+
+    with_facts(source, None, |_, facts| {
+        let operand = facts
+            .parameter_operand_word_facts()
+            .find(|fact| fact.span().slice(source) == "$name")
+            .expect("expected parameter operand word fact");
+
+        assert!(operand.is_parameter_operand());
+        assert_eq!(
+            facts
+                .word_fact(operand.span(), operand.context())
+                .map(|fact| fact.span().slice(source)),
+            Some("$name")
+        );
+        assert_eq!(
+            facts
+                .any_word_fact(operand.span())
+                .map(|fact| fact.span().slice(source)),
+            Some("$name")
+        );
+        assert!(
+            facts
+                .word_facts()
+                .all(|fact| fact.span().slice(source) != "$name"),
+            "parameter operand fact should stay out of the normal word_facts stream"
         );
     });
 }

--- a/crates/shuck-linter/src/facts/words/expansion.rs
+++ b/crates/shuck-linter/src/facts/words/expansion.rs
@@ -165,6 +165,7 @@ pub enum WordFactContext {
     Expansion(ExpansionContext),
     CaseSubject,
     ArithmeticCommand,
+    ParameterOperand,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -13,6 +13,9 @@ pub(super) struct WordNodeDerived<'a> {
     pub(super) starts_with_extglob: bool,
     pub(super) has_literal_affixes: bool,
     pub(super) contains_shell_quoting_literals: bool,
+    pub(super) safe_value_plain_scalar_reference_name: Option<Name>,
+    pub(super) safe_value_special_parameter_access: bool,
+    pub(super) safe_value_contains_special_parameter_slice: bool,
     pub(super) active_expansion_spans: IdRange<Span>,
     pub(super) scalar_expansion_spans: IdRange<Span>,
     pub(super) unquoted_scalar_expansion_spans: IdRange<Span>,
@@ -64,6 +67,7 @@ pub(super) enum WordOccurrenceFilter {
     Any,
     NonArithmetic,
     ArithmeticCommand,
+    ParameterOperand,
     Expansion(ExpansionContext),
     CaseSubject,
 }
@@ -98,10 +102,16 @@ impl<'facts, 'a> WordOccurrenceIter<'facts, 'a> {
         match self.filter {
             WordOccurrenceFilter::Any => true,
             WordOccurrenceFilter::NonArithmetic => {
-                occurrence.context != WordFactContext::ArithmeticCommand
+                !matches!(
+                    occurrence.context,
+                    WordFactContext::ArithmeticCommand | WordFactContext::ParameterOperand
+                )
             }
             WordOccurrenceFilter::ArithmeticCommand => {
                 occurrence.context == WordFactContext::ArithmeticCommand
+            }
+            WordOccurrenceFilter::ParameterOperand => {
+                occurrence.context == WordFactContext::ParameterOperand
             }
             WordOccurrenceFilter::Expansion(context) => {
                 occurrence.context == WordFactContext::Expansion(context)
@@ -182,6 +192,7 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
             WordFactContext::Expansion(context) => Some(context),
             WordFactContext::CaseSubject => None,
             WordFactContext::ArithmeticCommand => None,
+            WordFactContext::ParameterOperand => None,
         }
     }
 
@@ -196,6 +207,10 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
 
     pub fn is_arithmetic_command(self) -> bool {
         self.context() == WordFactContext::ArithmeticCommand
+    }
+
+    pub fn is_parameter_operand(self) -> bool {
+        self.context() == WordFactContext::ParameterOperand
     }
 
     pub fn part_is_inside_backtick_escaped_double_quotes(
@@ -356,12 +371,28 @@ impl<'facts, 'a> WordOccurrenceRef<'facts, 'a> {
         word_is_plain_scalar_reference(self.word())
     }
 
+    pub fn safe_value_plain_scalar_reference_name(self) -> Option<&'facts Name> {
+        self.derived().safe_value_plain_scalar_reference_name.as_ref()
+    }
+
     pub fn is_plain_parameter_reference(self) -> bool {
         word_is_plain_parameter_reference(self.word())
     }
 
     pub fn is_direct_numeric_expansion(self) -> bool {
         word_is_direct_numeric_expansion(self.word())
+    }
+
+    pub fn has_arithmetic_expansion(self) -> bool {
+        self.analysis().hazards.arithmetic_expansion
+    }
+
+    pub fn safe_value_special_parameter_access(self) -> bool {
+        self.derived().safe_value_special_parameter_access
+    }
+
+    pub fn safe_value_contains_special_parameter_slice(self) -> bool {
+        self.derived().safe_value_contains_special_parameter_slice
     }
 
     pub fn starts_with_extglob(self) -> bool {
@@ -871,7 +902,12 @@ pub(super) fn build_brace_variable_before_bracket_spans<'a>(
     let mut spans = occurrences
         .iter()
         .filter(|fact| fact.host_kind == WordFactHostKind::Direct)
-        .filter(|fact| fact.context != WordFactContext::ArithmeticCommand)
+        .filter(|fact| {
+            !matches!(
+                fact.context,
+                WordFactContext::ArithmeticCommand | WordFactContext::ParameterOperand
+            )
+        })
         .flat_map(|fact| {
             word_unbraced_variable_before_bracket_spans(occurrence_word(nodes, fact), source)
         })
@@ -914,6 +950,51 @@ pub(super) fn word_node_derived<'node, 'word>(
 
 pub(super) fn word_is_plain_scalar_reference(word: &Word) -> bool {
     word_is_plain_reference(word, false)
+}
+
+fn safe_value_plain_scalar_reference_name(word: &Word) -> Option<Name> {
+    let [part] = word.parts.as_slice() else {
+        return None;
+    };
+    safe_value_plain_scalar_reference_name_from_part(&part.kind)
+}
+
+fn safe_value_plain_scalar_reference_name_from_part(part: &WordPart) -> Option<Name> {
+    match part {
+        WordPart::Variable(name) if !matches!(name.as_str(), "@" | "*") => Some(name.clone()),
+        WordPart::DoubleQuoted { parts, .. } => {
+            let [part] = parts.as_slice() else {
+                return None;
+            };
+            safe_value_plain_scalar_reference_name_from_part(&part.kind)
+        }
+        WordPart::Parameter(parameter) => match &parameter.syntax {
+            ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
+                if reference.subscript.is_none()
+                    && !matches!(reference.name.as_str(), "@" | "*") =>
+            {
+                Some(reference.name.clone())
+            }
+            ParameterExpansionSyntax::Bourne(_) | ParameterExpansionSyntax::Zsh(_) => None,
+        },
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => None,
+    }
 }
 
 pub(super) fn word_is_plain_parameter_reference(word: &Word) -> bool {
@@ -1002,6 +1083,98 @@ pub(super) fn parameter_is_direct_numeric_expansion(parameter: &ParameterExpansi
         ParameterExpansionSyntax::Zsh(syntax) => syntax.length_prefix.is_some(),
         _ => false,
     }
+}
+
+fn safe_value_special_parameter_access(word: &Word) -> bool {
+    let [part] = word.parts.as_slice() else {
+        return false;
+    };
+    safe_value_special_parameter_access_from_part(&part.kind)
+}
+
+fn safe_value_special_parameter_access_from_part(part: &WordPart) -> bool {
+    match part {
+        WordPart::Variable(name) => safe_value_special_parameter(name),
+        WordPart::DoubleQuoted { parts, .. } => {
+            matches!(
+                parts.as_slice(),
+                [part] if safe_value_special_parameter_access_from_part(&part.kind)
+            )
+        }
+        WordPart::Parameter(parameter) => matches!(
+            parameter.bourne(),
+            Some(BourneParameterExpansion::Access { reference })
+                if safe_value_special_parameter(&reference.name) && reference.subscript.is_none()
+        ),
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::Substring { .. }
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn safe_value_special_parameter(name: &Name) -> bool {
+    matches!(name.as_str(), "@" | "#" | "?" | "$" | "!" | "-")
+}
+
+fn safe_value_contains_special_parameter_slice(word: &Word) -> bool {
+    word.parts.iter().any(|part| {
+        safe_value_part_contains_special_parameter_slice(&part.kind)
+            && !matches!(part.kind, WordPart::DoubleQuoted { .. })
+    })
+}
+
+fn safe_value_part_contains_special_parameter_slice(part: &WordPart) -> bool {
+    match part {
+        WordPart::DoubleQuoted { parts, .. } => parts
+            .iter()
+            .any(|part| safe_value_part_contains_special_parameter_slice(&part.kind)),
+        WordPart::Substring { reference, .. } => safe_value_special_parameter_slice_reference(reference),
+        WordPart::Parameter(parameter) => {
+            safe_value_parameter_contains_special_parameter_slice(parameter)
+        }
+        WordPart::Literal(_)
+        | WordPart::ZshQualifiedGlob(_)
+        | WordPart::SingleQuoted { .. }
+        | WordPart::Variable(_)
+        | WordPart::CommandSubstitution { .. }
+        | WordPart::ArithmeticExpansion { .. }
+        | WordPart::ParameterExpansion { .. }
+        | WordPart::Length(_)
+        | WordPart::ArrayAccess(_)
+        | WordPart::ArrayLength(_)
+        | WordPart::ArrayIndices(_)
+        | WordPart::ArraySlice { .. }
+        | WordPart::IndirectExpansion { .. }
+        | WordPart::PrefixMatch { .. }
+        | WordPart::ProcessSubstitution { .. }
+        | WordPart::Transformation { .. } => false,
+    }
+}
+
+fn safe_value_parameter_contains_special_parameter_slice(parameter: &ParameterExpansion) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Slice { reference, .. }) => {
+            safe_value_special_parameter_slice_reference(reference)
+        }
+        ParameterExpansionSyntax::Bourne(_) | ParameterExpansionSyntax::Zsh(_) => false,
+    }
+}
+
+fn safe_value_special_parameter_slice_reference(reference: &VarRef) -> bool {
+    matches!(reference.name.as_str(), "@" | "*")
 }
 
 
@@ -1284,11 +1457,15 @@ pub(super) struct WordFactOutputs<'out, 'a> {
     pub(super) word_occurrences: &'out mut Vec<WordOccurrence>,
     pub(super) pending_arithmetic_word_occurrences:
         &'out mut Vec<PendingArithmeticWordOccurrence>,
+    pub(super) pending_parameter_operand_word_occurrences:
+        &'out mut Vec<PendingParameterOperandWordOccurrence>,
     pub(super) compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
     pub(super) array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     pub(super) seen_word_occurrences: &'out mut FxHashSet<WordOccurrenceSeenKey>,
     pub(super) seen_pending_arithmetic_word_occurrences:
         &'out mut FxHashSet<PendingArithmeticSeenKey>,
+    pub(super) seen_pending_parameter_operand_word_occurrences:
+        &'out mut FxHashSet<PendingParameterOperandSeenKey>,
     pub(super) assoc_binding_visibility_memo:
         &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     pub(super) array_like_capable_names: &'out FxHashSet<Name>,
@@ -1309,8 +1486,18 @@ pub(super) struct PendingArithmeticWordOccurrence {
     pub(super) enclosing_expansion_context: ExpansionContext,
 }
 
+pub(super) struct PendingParameterOperandWordOccurrence {
+    pub(super) node_id: WordNodeId,
+    pub(super) command_id: CommandId,
+    pub(super) nested_word_command: bool,
+    pub(super) host_kind: WordFactHostKind,
+    pub(super) enclosing_expansion_context: ExpansionContext,
+}
+
 pub(super) type WordOccurrenceSeenKey = (FactSpan, WordFactContext, WordFactHostKind);
 pub(super) type PendingArithmeticSeenKey = (FactSpan, ExpansionContext, WordFactHostKind);
+pub(super) type PendingParameterOperandSeenKey =
+    (FactSpan, ExpansionContext, WordFactHostKind);
 
 pub(super) fn derive_word_fact_data<'a>(
     word: &'a Word,
@@ -1338,6 +1525,9 @@ pub(super) fn derive_word_fact_data<'a>(
         starts_with_extglob: word_spans::word_starts_with_extglob(word, source),
         has_literal_affixes: word_has_literal_affixes(word),
         contains_shell_quoting_literals: word_contains_shell_quoting_literals(word, source),
+        safe_value_plain_scalar_reference_name: safe_value_plain_scalar_reference_name(word),
+        safe_value_special_parameter_access: safe_value_special_parameter_access(word),
+        safe_value_contains_special_parameter_slice: safe_value_contains_special_parameter_slice(word),
         active_expansion_spans: span_store
             .push_many(traversal_spans.active_expansion_spans.drain(..)),
         scalar_expansion_spans: span_store
@@ -1800,6 +1990,8 @@ pub(super) struct WordFactCollector<'out, 'a, 'norm> {
     word_node_ids_by_span: &'out mut FxHashMap<FactSpan, WordNodeId>,
     word_occurrences: &'out mut Vec<WordOccurrence>,
     pending_arithmetic_word_occurrences: &'out mut Vec<PendingArithmeticWordOccurrence>,
+    pending_parameter_operand_word_occurrences:
+        &'out mut Vec<PendingParameterOperandWordOccurrence>,
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     assoc_binding_visibility_memo: &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     array_like_capable_names: &'out FxHashSet<Name>,
@@ -1809,6 +2001,7 @@ pub(super) struct WordFactCollector<'out, 'a, 'norm> {
     value_flow: SemanticValueFlow<'out, 'a>,
     seen: &'out mut FxHashSet<WordOccurrenceSeenKey>,
     seen_pending_arithmetic: &'out mut FxHashSet<PendingArithmeticSeenKey>,
+    seen_pending_parameter_operand: &'out mut FxHashSet<PendingParameterOperandSeenKey>,
     compound_assignment_value_word_spans: &'out mut FxHashSet<FactSpan>,
     case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
     pattern_literal_spans: &'out mut Vec<Span>,
@@ -1918,6 +2111,16 @@ struct PendingArithmeticWordVisitor<'collector, 'out, 'a, 'norm> {
 impl<'out, 'a, 'norm> WordSubtreeVisitor<'a>
     for PendingArithmeticWordVisitor<'_, 'out, 'a, 'norm>
 {
+    fn enter_word(&mut self, word: &'a Word, state: WordTraversalState<'a>) {
+        if state.origin == WordTraversalOrigin::ParameterOperand {
+            self.collector.push_pending_parameter_operand_word_occurrence(
+                word,
+                self.enclosing_expansion_context,
+                self.host_kind,
+            );
+        }
+    }
+
     fn visit_arithmetic_expansion(
         &mut self,
         part: &'a WordPartNode,
@@ -1990,6 +2193,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             word_node_ids_by_span: outputs.word_node_ids_by_span,
             word_occurrences: outputs.word_occurrences,
             pending_arithmetic_word_occurrences: outputs.pending_arithmetic_word_occurrences,
+            pending_parameter_operand_word_occurrences: outputs
+                .pending_parameter_operand_word_occurrences,
             array_assignment_split_word_ids: outputs.array_assignment_split_word_ids,
             assoc_binding_visibility_memo: outputs.assoc_binding_visibility_memo,
             array_like_capable_names: outputs.array_like_capable_names,
@@ -2004,6 +2209,12 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             seen_pending_arithmetic: {
                 outputs.seen_pending_arithmetic_word_occurrences.clear();
                 outputs.seen_pending_arithmetic_word_occurrences
+            },
+            seen_pending_parameter_operand: {
+                outputs
+                    .seen_pending_parameter_operand_word_occurrences
+                    .clear();
+                outputs.seen_pending_parameter_operand_word_occurrences
             },
             compound_assignment_value_word_spans: outputs.compound_assignment_value_word_spans,
             case_pattern_expansions: outputs.case_pattern_expansions,
@@ -2977,7 +3188,9 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 context,
                 Some(&self.command_shell_behavior),
             ),
-            WordFactContext::CaseSubject | WordFactContext::ArithmeticCommand => {
+            WordFactContext::CaseSubject
+            | WordFactContext::ArithmeticCommand
+            | WordFactContext::ParameterOperand => {
                 RuntimeLiteralAnalysis::default()
             }
         };
@@ -2995,7 +3208,8 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             }
             WordFactContext::Expansion(_)
             | WordFactContext::CaseSubject
-            | WordFactContext::ArithmeticCommand => None,
+            | WordFactContext::ArithmeticCommand
+            | WordFactContext::ParameterOperand => None,
         };
         self.word_span_scratch.clear();
         collect_split_sensitive_unquoted_command_substitution_spans(
@@ -3062,6 +3276,31 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
         let node_id = self.intern_word_node(word);
         self.pending_arithmetic_word_occurrences
             .push(PendingArithmeticWordOccurrence {
+                node_id,
+                command_id: self.command_id,
+                nested_word_command: self.nested_word_command,
+                host_kind,
+                enclosing_expansion_context,
+            });
+    }
+
+    fn push_pending_parameter_operand_word_occurrence(
+        &mut self,
+        word: &'a Word,
+        enclosing_expansion_context: ExpansionContext,
+        host_kind: WordFactHostKind,
+    ) {
+        let key = FactSpan::new(word.span);
+        if !self
+            .seen_pending_parameter_operand
+            .insert((key, enclosing_expansion_context, host_kind))
+        {
+            return;
+        }
+
+        let node_id = self.intern_word_node(word);
+        self.pending_parameter_operand_word_occurrences
+            .push(PendingParameterOperandWordOccurrence {
                 node_id,
                 command_id: self.command_id,
                 nested_word_command: self.nested_word_command,

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion/safe_value.rs
@@ -202,20 +202,20 @@ impl<'a> SafeValueIndex<'a> {
         if self.span_is_after_unconditional_inline_terminator(word.span) {
             return false;
         }
-        let Some(analysis) = self
-            .facts
-            .any_word_fact(word.span)
-            .map(|fact| fact.analysis())
-        else {
+        let Some(fact) = self.facts.any_word_fact(word.span) else {
             return false;
         };
+        let analysis = fact.analysis();
         if query != SafeValueQuery::Quoted
             && (analysis.array_valued || analysis.hazards.command_or_process_substitution)
         {
             return false;
         }
+        if fact.safe_value_special_parameter_access() {
+            return true;
+        }
 
-        word.parts_with_spans()
+        fact.parts_with_spans()
             .all(|(part, span)| self.part_is_safe(part, span, query))
     }
 
@@ -257,9 +257,31 @@ impl<'a> SafeValueIndex<'a> {
         {
             return false;
         }
+        if fact.safe_value_special_parameter_access() {
+            return true;
+        }
 
         fact.parts_with_spans()
             .all(|(part, span)| self.part_is_safe(part, span, query))
+    }
+
+    fn word_fact(&self, word: &Word) -> Option<crate::WordOccurrenceRef<'_, 'a>> {
+        self.facts.any_word_fact(word.span)
+    }
+
+    fn word_plain_scalar_reference_name(&self, word: &Word) -> Option<Name> {
+        self.word_fact(word)
+            .and_then(|fact| fact.safe_value_plain_scalar_reference_name().cloned())
+    }
+
+    fn word_has_arithmetic_expansion(&self, word: &Word) -> bool {
+        self.word_fact(word)
+            .is_some_and(|fact| fact.has_arithmetic_expansion())
+    }
+
+    fn word_contains_special_parameter_slice(&self, word: &Word) -> bool {
+        self.word_fact(word)
+            .is_some_and(|fact| fact.safe_value_contains_special_parameter_slice())
     }
 
     pub fn name_reference_is_safe(&mut self, name: &Name, at: Span, query: SafeValueQuery) -> bool {
@@ -1793,7 +1815,7 @@ impl<'a> SafeValueIndex<'a> {
             .facts
             .binding_value(binding_id)
             .and_then(|value| value.scalar_word())?;
-        let target_name = plain_scalar_reference_name(word)?;
+        let target_name = self.word_plain_scalar_reference_name(word)?;
         let binding_span = self.semantic.binding(binding_id).span;
         self.binding_value_stack.push(binding_id);
         let prior_bindings = self.safe_bindings_for_name(&target_name, binding_span);
@@ -1901,7 +1923,7 @@ impl<'a> SafeValueIndex<'a> {
                                 at,
                             ))
                         && words.into_iter().all(|word| {
-                            !word_contains_special_parameter_slice(word)
+                            !self.word_contains_special_parameter_slice(word)
                                 && self.word_is_safe(word, query)
                         })
                 })
@@ -1968,7 +1990,7 @@ impl<'a> SafeValueIndex<'a> {
         if word_static_text_is_shell_integer(word, self.source) {
             return true;
         }
-        word_has_arithmetic_expansion(word)
+        self.word_has_arithmetic_expansion(word)
             && self.word_is_safe_for_binding_value(binding_id, word, query)
     }
 
@@ -3907,7 +3929,7 @@ impl<'a> SafeValueIndex<'a> {
             return true;
         }
 
-        plain_scalar_reference_name(word)
+        self.word_plain_scalar_reference_name(word)
             .is_some_and(|name| self.name_is_safe(&name, at, SafeValueQuery::NumericTestOperand))
     }
 
@@ -4134,12 +4156,12 @@ impl<'a> SafeValueIndex<'a> {
         };
 
         if word_static_text_is_shell_integer(word, self.source)
-            || word_has_arithmetic_expansion(word)
+            || self.word_has_arithmetic_expansion(word)
         {
             return true;
         }
 
-        plain_scalar_reference_name(word)
+        self.word_plain_scalar_reference_name(word)
             .is_some_and(|name| self.name_is_safe(&name, at, SafeValueQuery::NumericTestOperand))
     }
 }
@@ -4178,13 +4200,6 @@ fn literal_is_regex_safe(text: &str) -> bool {
     }
 
     !escaped
-}
-
-fn plain_scalar_reference_name(word: &Word) -> Option<Name> {
-    let [part] = word.parts.as_slice() else {
-        return None;
-    };
-    plain_scalar_reference_name_from_part(&part.kind)
 }
 
 fn plain_scalar_reference_name_from_part(part: &WordPart) -> Option<Name> {
@@ -4316,85 +4331,11 @@ fn shell_integer_text_is_safe(text: &str) -> bool {
     !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
 }
 
-fn word_has_arithmetic_expansion(word: &Word) -> bool {
-    parts_have_arithmetic_expansion(&word.parts)
-}
-
 fn word_is_arithmetic_expansion(word: &Word) -> bool {
     matches!(
         word.parts.as_slice(),
         [part] if matches!(part.kind, WordPart::ArithmeticExpansion { .. })
     )
-}
-
-fn parts_have_arithmetic_expansion(parts: &[WordPartNode]) -> bool {
-    parts.iter().any(|part| match &part.kind {
-        WordPart::ArithmeticExpansion { .. } => true,
-        WordPart::DoubleQuoted { parts, .. } => parts_have_arithmetic_expansion(parts),
-        WordPart::Literal(_)
-        | WordPart::ZshQualifiedGlob(_)
-        | WordPart::SingleQuoted { .. }
-        | WordPart::Variable(_)
-        | WordPart::CommandSubstitution { .. }
-        | WordPart::Parameter(_)
-        | WordPart::ParameterExpansion { .. }
-        | WordPart::Length(_)
-        | WordPart::ArrayAccess(_)
-        | WordPart::ArrayLength(_)
-        | WordPart::ArrayIndices(_)
-        | WordPart::Substring { .. }
-        | WordPart::ArraySlice { .. }
-        | WordPart::IndirectExpansion { .. }
-        | WordPart::PrefixMatch { .. }
-        | WordPart::ProcessSubstitution { .. }
-        | WordPart::Transformation { .. } => false,
-    })
-}
-
-fn word_contains_special_parameter_slice(word: &Word) -> bool {
-    word.parts.iter().any(|part| {
-        part_contains_special_parameter_slice(&part.kind)
-            && !matches!(part.kind, WordPart::DoubleQuoted { .. })
-    })
-}
-
-fn part_contains_special_parameter_slice(part: &WordPart) -> bool {
-    match part {
-        WordPart::DoubleQuoted { parts, .. } => parts
-            .iter()
-            .any(|part| part_contains_special_parameter_slice(&part.kind)),
-        WordPart::Substring { reference, .. } => special_parameter_slice_reference(reference),
-        WordPart::Parameter(parameter) => parameter_contains_special_parameter_slice(parameter),
-        WordPart::Literal(_)
-        | WordPart::ZshQualifiedGlob(_)
-        | WordPart::SingleQuoted { .. }
-        | WordPart::Variable(_)
-        | WordPart::CommandSubstitution { .. }
-        | WordPart::ArithmeticExpansion { .. }
-        | WordPart::ParameterExpansion { .. }
-        | WordPart::Length(_)
-        | WordPart::ArrayAccess(_)
-        | WordPart::ArrayLength(_)
-        | WordPart::ArrayIndices(_)
-        | WordPart::ArraySlice { .. }
-        | WordPart::IndirectExpansion { .. }
-        | WordPart::PrefixMatch { .. }
-        | WordPart::ProcessSubstitution { .. }
-        | WordPart::Transformation { .. } => false,
-    }
-}
-
-fn parameter_contains_special_parameter_slice(parameter: &ParameterExpansion) -> bool {
-    match &parameter.syntax {
-        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Slice { reference, .. }) => {
-            special_parameter_slice_reference(reference)
-        }
-        ParameterExpansionSyntax::Bourne(_) | ParameterExpansionSyntax::Zsh(_) => false,
-    }
-}
-
-fn special_parameter_slice_reference(reference: &VarRef) -> bool {
-    matches!(reference.name.as_str(), "@" | "*")
 }
 
 fn function_has_terminal_exit(function: &FunctionDef) -> bool {


### PR DESCRIPTION
## Summary
- index nested parameter operand words as their own word-fact context
- let `safe_value` consume those fact-backed summaries instead of falling back to direct word traversal
- add coverage that keeps parameter operand facts out of the default `word_facts()` stream while making them addressable by span

## Why
`safe_value` still needed a local fallback for words nested inside parameter operands like `${value:-$name}` because those words were not materialized in the fact layer. That kept a rule-local traversal path alive even after the broader subtree traversal refactor.

## Impact
This removes the whole-word fallback from `safe_value`, keeps the rule fact-scoped, and reuses the same derived summaries for nested parameter operand words that direct word facts already expose.

## Validation
- `cargo fmt`
- `cargo test -p shuck-linter --no-default-features`
- `cargo clippy --all-targets -- -D warnings`