### PR TITLE
perf(linter): narrow zsh array fanout value-flow checks

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -55,11 +55,32 @@ fn binding_has_array_like_shape(binding: &Binding) -> bool {
         )
 }
 
+fn binding_is_name_only_declaration(binding: &Binding) -> bool {
+    matches!(binding.origin, BindingOrigin::Declaration { .. })
+        && binding.attributes.contains(BindingAttributes::LOCAL)
+        && !binding
+            .attributes
+            .contains(BindingAttributes::DECLARATION_INITIALIZED)
+}
+
+fn binding_can_supply_parameter_value(binding: &Binding) -> bool {
+    match binding.origin {
+        BindingOrigin::FunctionDefinition { .. } => false,
+        BindingOrigin::Declaration { .. } => {
+            binding_is_name_only_declaration(binding)
+                || binding.attributes.intersects(
+                    BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
+                )
+        }
+        _ => true,
+    }
+}
+
 #[cfg_attr(shuck_profiling, inline(never))]
 fn compute_array_like_capable_names(semantic: &SemanticModel) -> FxHashSet<Name> {
     let mut names = FxHashSet::default();
     for binding in semantic.bindings() {
-        if binding_has_array_like_shape(binding) {
+        if binding_can_supply_parameter_value(binding) && binding_has_array_like_shape(binding) {
             names.insert(binding.name.clone());
         }
     }
@@ -70,6 +91,9 @@ fn compute_array_like_capable_names(semantic: &SemanticModel) -> FxHashSet<Name>
 fn compute_single_array_like_bindings(semantic: &SemanticModel) -> FxHashMap<Name, BindingId> {
     let mut bindings_by_name = FxHashMap::default();
     for binding in semantic.bindings() {
+        if !binding_can_supply_parameter_value(binding) {
+            continue;
+        }
         let array_like = binding_has_array_like_shape(binding);
         match bindings_by_name.entry(binding.name.clone()) {
             std::collections::hash_map::Entry::Vacant(entry) => {
@@ -87,6 +111,22 @@ fn compute_single_array_like_bindings(semantic: &SemanticModel) -> FxHashMap<Nam
         .collect()
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
+fn compute_array_like_bindings_by_name(
+    semantic: &SemanticModel,
+) -> FxHashMap<Name, SmallVec<[BindingId; 2]>> {
+    let mut bindings_by_name = FxHashMap::<Name, SmallVec<[BindingId; 2]>>::default();
+    for binding in semantic.bindings() {
+        if binding_can_supply_parameter_value(binding) && binding_has_array_like_shape(binding) {
+            bindings_by_name
+                .entry(binding.name.clone())
+                .or_default()
+                .push(binding.id);
+        }
+    }
+    bindings_by_name
+}
+
 /// Names where *every* binding is array-like. For these names, the slow dataflow walk in
 /// `visible_name_is_array_like` is unnecessary: any lexically visible binding will satisfy the
 /// predicate.
@@ -94,6 +134,9 @@ fn compute_single_array_like_bindings(semantic: &SemanticModel) -> FxHashMap<Nam
 fn compute_uniformly_array_like_names(semantic: &SemanticModel) -> FxHashSet<Name> {
     let mut name_state: FxHashMap<Name, bool> = FxHashMap::default();
     for binding in semantic.bindings() {
+        if !binding_can_supply_parameter_value(binding) {
+            continue;
+        }
         let array_like = binding_has_array_like_shape(binding);
         match name_state.entry(binding.name.clone()) {
             std::collections::hash_map::Entry::Vacant(entry) => {
@@ -186,6 +229,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let mut assoc_binding_visibility_memo = FxHashMap::default();
         let array_like_capable_names = compute_array_like_capable_names(self.semantic);
         let single_array_like_bindings = compute_single_array_like_bindings(self.semantic);
+        let array_like_bindings_by_name = compute_array_like_bindings_by_name(self.semantic);
         let uniformly_array_like_names = compute_uniformly_array_like_names(self.semantic);
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut case_pattern_expansions = Vec::new();
@@ -323,6 +367,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                         assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
                         array_like_capable_names: &array_like_capable_names,
                         single_array_like_bindings: &single_array_like_bindings,
+                        array_like_bindings_by_name: &array_like_bindings_by_name,
                         uniformly_array_like_names: &uniformly_array_like_names,
                         semantic_analysis: self.semantic_analysis,
                         case_pattern_expansions: &mut case_pattern_expansions,

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -65,8 +65,8 @@ use shuck_indexer::{Indexer, LineIndex, RegionIndex};
 #[cfg(test)]
 use shuck_parser::parser::Parser;
 use shuck_semantic::{
-    ArithmeticLiteralBehavior, Binding, BindingAttributes, BindingId, BindingKind, CaseCliDispatch,
-    CommandKind, CompoundCommandKind, Declaration, DeclarationBuiltin,
+    ArithmeticLiteralBehavior, Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin,
+    CaseCliDispatch, CommandKind, CompoundCommandKind, Declaration, DeclarationBuiltin,
     DeclarationOperand as SemanticDeclarationOperand, FieldSplittingBehavior,
     FileExpansionOrderBehavior, FunctionScopeKind, GlobDotBehavior, GlobFailureBehavior,
     GlobPatternBehavior, NonpersistentAssignmentAnalysisContext,

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1185,6 +1185,7 @@ struct ZshArrayFanoutContext<'a, 'flow> {
 struct ZshArrayFanoutLookups<'a> {
     array_like_capable_names: &'a FxHashSet<Name>,
     single_array_like_bindings: &'a FxHashMap<Name, BindingId>,
+    array_like_bindings_by_name: &'a FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     uniformly_array_like_names: &'a FxHashSet<Name>,
 }
 
@@ -1342,17 +1343,29 @@ fn visible_name_is_array_like(
     {
         return true;
     }
-    let synthetic_use_block = if semantic_analysis.reference_id_for_name_at(name, span).is_none() {
-        Some(semantic_analysis.flow_entry_block_for_binding_scopes(&[scope], span.start.offset))
-    } else {
-        None
-    };
-    value_flow
-        .reaching_value_bindings_for_name_with_synthetic_use_block(
+    if let Some(reference_id) = semantic_analysis.reference_id_for_name_at(name, span) {
+        if semantic
+            .resolved_binding(reference_id)
+            .is_some_and(binding_is_array_like)
+        {
+            return true;
+        }
+        if let Some(array_like_bindings) = lookups.array_like_bindings_by_name.get(name) {
+            return value_flow.reference_reaches_any_value_binding(reference_id, array_like_bindings);
+        }
+        return false;
+    }
+    let bindings =
+    {
+        let synthetic_use_block =
+            semantic_analysis.flow_entry_block_for_binding_scopes(&[scope], span.start.offset);
+        value_flow.reaching_value_bindings_for_name_without_reference(
             name,
             span,
             synthetic_use_block,
         )
+    };
+    bindings
         .into_iter()
         .any(|binding_id| binding_is_array_like(semantic.binding(binding_id)))
 }
@@ -1422,6 +1435,7 @@ pub(super) struct WordFactOutputs<'out, 'a> {
         &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     pub(super) array_like_capable_names: &'out FxHashSet<Name>,
     pub(super) single_array_like_bindings: &'out FxHashMap<Name, BindingId>,
+    pub(super) array_like_bindings_by_name: &'out FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     pub(super) uniformly_array_like_names: &'out FxHashSet<Name>,
     pub(super) semantic_analysis: &'out SemanticAnalysis<'a>,
     pub(super) case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
@@ -1948,6 +1962,7 @@ pub(super) struct WordFactCollector<'out, 'a, 'norm> {
     assoc_binding_visibility_memo: &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
     array_like_capable_names: &'out FxHashSet<Name>,
     single_array_like_bindings: &'out FxHashMap<Name, BindingId>,
+    array_like_bindings_by_name: &'out FxHashMap<Name, SmallVec<[BindingId; 2]>>,
     uniformly_array_like_names: &'out FxHashSet<Name>,
     semantic_analysis: &'out SemanticAnalysis<'a>,
     value_flow: SemanticValueFlow<'out, 'a>,
@@ -2151,6 +2166,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
             assoc_binding_visibility_memo: outputs.assoc_binding_visibility_memo,
             array_like_capable_names: outputs.array_like_capable_names,
             single_array_like_bindings: outputs.single_array_like_bindings,
+            array_like_bindings_by_name: outputs.array_like_bindings_by_name,
             uniformly_array_like_names: outputs.uniformly_array_like_names,
             semantic_analysis: outputs.semantic_analysis,
             value_flow,
@@ -3090,6 +3106,7 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 lookups: ZshArrayFanoutLookups {
                     array_like_capable_names: self.array_like_capable_names,
                     single_array_like_bindings: self.single_array_like_bindings,
+                    array_like_bindings_by_name: self.array_like_bindings_by_name,
                     uniformly_array_like_names: self.uniformly_array_like_names,
                 },
             },

--- a/crates/shuck-semantic/src/dataflow/exact.rs
+++ b/crates/shuck-semantic/src/dataflow/exact.rs
@@ -137,6 +137,25 @@ impl ExactVariableDataflow {
             .collect()
     }
 
+    pub(crate) fn reference_reaches_any_binding(
+        &self,
+        context: &DataflowContext<'_>,
+        reference: &Reference,
+        candidate_bindings: impl IntoIterator<Item = BindingId>,
+    ) -> bool {
+        let Some(block_id) = self.reference_blocks[reference.id.index()] else {
+            return false;
+        };
+        if self.unreachable_blocks.contains(block_id.index()) {
+            return false;
+        }
+
+        let incoming = &self.reaching_definitions(context).reaching_in[block_id.index()];
+        candidate_bindings
+            .into_iter()
+            .any(|binding_id| incoming.contains(binding_id.index()))
+    }
+
     pub(crate) fn binding_block(&self, binding_id: BindingId) -> Option<BlockId> {
         self.binding_blocks[binding_id.index()]
     }

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -4893,6 +4893,70 @@ printf '%s\\n' \"$foo\"
 }
 
 #[test]
+fn value_flow_can_check_direct_references_against_candidate_bindings() {
+    for (source, expected) in [
+        (
+            "\
+#!/bin/bash
+foo=1
+if cond; then
+  foo=(a b)
+fi
+printf '%s\\n' \"$foo\"
+",
+            true,
+        ),
+        (
+            "\
+#!/bin/bash
+foo=(a b)
+foo=1
+printf '%s\\n' \"$foo\"
+",
+            false,
+        ),
+    ] {
+        let model = model(source);
+        let reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.name == "foo")
+            .expect("expected foo reference");
+        let candidate_bindings = model
+            .bindings()
+            .iter()
+            .filter(|binding| binding.name == "foo")
+            .filter(|binding| {
+                binding
+                    .attributes
+                    .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+                    || matches!(
+                        binding.kind,
+                        BindingKind::ArrayAssignment | BindingKind::MapfileTarget
+                    )
+            })
+            .map(|binding| binding.id)
+            .collect::<Vec<_>>();
+        let analysis = model.analysis();
+        let value_flow = analysis.value_flow();
+
+        assert_eq!(
+            value_flow.reference_reaches_any_value_binding(reference.id, &candidate_bindings),
+            expected,
+            "{source}"
+        );
+        assert_eq!(
+            value_flow
+                .reaching_value_bindings_for_name(&reference.name, reference.span)
+                .into_iter()
+                .any(|binding_id| candidate_bindings.contains(&binding_id)),
+            expected,
+            "{source}"
+        );
+    }
+}
+
+#[test]
 fn value_flow_returns_synthetic_use_site_value_bindings() {
     let source = "\
 #!/bin/bash
@@ -4916,6 +4980,40 @@ printf done
     assert_eq!(
         value_flow.reaching_value_bindings_for_name(&Name::from("foo"), model.command_span(printf)),
         bindings
+    );
+}
+
+#[test]
+fn value_flow_can_skip_reference_lookup_for_known_synthetic_use_sites() {
+    let source = "\
+#!/bin/bash
+foo=1
+if cond; then
+  foo=2
+fi
+printf done
+";
+    let model = model(source);
+    let printf = command_id_starting_with(&model, source, "printf").expect("expected printf");
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+    let use_span = model.command_span(printf);
+    let synthetic_use_block = analysis.flow_entry_block_for_binding_scopes(
+        &[model.scope_at(use_span.start.offset)],
+        use_span.start.offset,
+    );
+
+    assert_eq!(
+        value_flow.reaching_value_bindings_for_name_without_reference(
+            &Name::from("foo"),
+            use_span,
+            synthetic_use_block,
+        ),
+        value_flow.reaching_value_bindings_for_name_with_synthetic_use_block(
+            &Name::from("foo"),
+            use_span,
+            Some(synthetic_use_block),
+        )
     );
 }
 

--- a/crates/shuck-semantic/src/value_flow.rs
+++ b/crates/shuck-semantic/src/value_flow.rs
@@ -51,6 +51,52 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         self.reaching_value_bindings_for_name_inner(name, at, synthetic_use_block)
     }
 
+    /// Returns value-supplying bindings for a named use site that is known not to have a direct
+    /// semantic reference. This is currently used by zsh-specific linter fanout checks so they
+    /// can jump straight to synthetic-use dataflow without first paying for the ordinary
+    /// reference-based query path.
+    #[doc(hidden)]
+    pub fn reaching_value_bindings_for_name_without_reference(
+        &self,
+        name: &Name,
+        at: Span,
+        synthetic_use_block: BlockId,
+    ) -> Vec<BindingId> {
+        let mut bindings =
+            self.synthetic_reaching_value_bindings_for_name(name, at, Some(synthetic_use_block));
+        if bindings.is_empty()
+            && let Some(binding_id) = self.latest_visible_value_binding_for_name(name, at)
+        {
+            bindings.push(binding_id);
+        }
+        self.sort_and_dedup_bindings(&mut bindings);
+        bindings
+    }
+
+    /// Returns true when `reference_id` may observe any candidate binding from the provided set.
+    /// Callers are expected to prefilter the candidate list to bindings that can supply a
+    /// parameter value. This is a narrow fast path for callers that already know the small subset
+    /// of bindings they care about, such as zsh array-fanout checks.
+    #[doc(hidden)]
+    pub fn reference_reaches_any_value_binding(
+        &self,
+        reference_id: ReferenceId,
+        candidate_bindings: &[BindingId],
+    ) -> bool {
+        if candidate_bindings.is_empty() {
+            return false;
+        }
+
+        let cfg = self.analysis.cfg();
+        let context = self.model().dataflow_context(cfg);
+        let exact = self.analysis.exact_variable_dataflow();
+        exact.reference_reaches_any_binding(
+            &context,
+            self.model().reference(reference_id),
+            candidate_bindings.iter().copied(),
+        )
+    }
+
     fn reaching_value_bindings_for_name_inner(
         &self,
         name: &Name,


### PR DESCRIPTION
## Summary
- narrow the zsh array-fanout fast path to value-supplying array-like bindings only
- add direct-reference semantic helpers so mixed-name lookups can avoid full reaching-binding materialization
- short-circuit direct references that already resolve to an array-like binding and cover the new paths with semantic tests

## Testing
- cargo test -p shuck-linter
- cargo test -p shuck-semantic
- scripts/profiling/profile_large_corpus.sh romkatv__powerlevel10k__internal__p10k.zsh .cache/profiles 2000 1 12

## Profiling
- on the powerlevel10k fixture, `visible_name_is_array_like` moved from about 2.3% of total samples to about 2.0%
- the run-to-run wall clock stayed noisy, so the sample-share reduction is the main signal here