### PR TITLE
refactor(linter): move array use classification into semantic

### DIFF
--- a/crates/shuck-linter/src/facts/arrays.rs
+++ b/crates/shuck-linter/src/facts/arrays.rs
@@ -23,15 +23,10 @@ fn build_plain_unindexed_array_reference_facts(
 struct PlainUnindexedArrayReferenceContext<'a, 'src> {
     facts: &'a LinterFacts<'src>,
     semantic: &'a SemanticModel,
-    local_declarations: LocalDeclarationIndex,
     simple_command_ancestors_by_offset: FxHashMap<usize, Vec<SimpleCommandAncestor>>,
     same_command_writers_by_name: FxHashMap<Name, Vec<BindingId>>,
     presence_test_ends_by_name_binding: FxHashMap<Name, FxHashMap<Option<BindingId>, Vec<usize>>>,
     resolved_binding_ids: FxHashMap<ReferenceId, Option<BindingId>>,
-    binding_inherits_indexed_array_type_cache: FxHashMap<BindingId, bool>,
-    binding_has_prior_local_barrier_cache: FxHashMap<BindingId, bool>,
-    binding_is_append_declaration_cache: FxHashMap<BindingId, bool>,
-    binding_reset_by_name_only_before_cache: FxHashMap<(BindingId, usize), bool>,
 }
 
 impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
@@ -39,15 +34,10 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         Self {
             facts,
             semantic: facts.semantic,
-            local_declarations: LocalDeclarationIndex::build(facts.semantic),
             simple_command_ancestors_by_offset: FxHashMap::default(),
             same_command_writers_by_name: FxHashMap::default(),
             presence_test_ends_by_name_binding: FxHashMap::default(),
             resolved_binding_ids: FxHashMap::default(),
-            binding_inherits_indexed_array_type_cache: FxHashMap::default(),
-            binding_has_prior_local_barrier_cache: FxHashMap::default(),
-            binding_is_append_declaration_cache: FxHashMap::default(),
-            binding_reset_by_name_only_before_cache: FxHashMap::default(),
         }
     }
 
@@ -60,65 +50,16 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
             || self.reference_is_zsh_presence_test(reference)
             || self.reference_has_prior_presence_test(reference)
             || self.reference_reads_into_same_name_array_writer(reference)
-            || self.reference_has_prior_zsh_scalar_local_barrier(reference)
         {
             return None;
         }
 
-        if let Some(binding) = self.semantic.resolved_binding(reference.id)
-            && self.semantic.binding_visible_at(binding.id, reference.span)
-            && !binding_is_array_like(binding)
-            && !self.binding_inherits_indexed_array_type(binding)
-            && (binding_resets_indexed_array_type(binding)
-                || self.binding_has_prior_local_barrier(binding)
-                || (self.facts.shell == ShellDialect::Zsh
-                    && binding_is_initialized_scalar_declaration(binding)))
-        {
+        let policy = self.semantic.reference_array_use_kind(reference.id)?;
+        if self.reference_is_zsh_array_assignment_list_value(reference, policy) {
             return None;
         }
 
-        let array_like = if is_bash_runtime_array_name(reference.name.as_str()) {
-            true
-        } else {
-            let mut binding_ids = Vec::new();
-            let mut seen = FxHashSet::default();
-            if let Some(binding) = self.semantic.resolved_binding(reference.id)
-                && !binding_is_array_like(binding)
-                && seen.insert(binding.id)
-            {
-                binding_ids.push(binding.id);
-            }
-            for binding_id in self
-                .semantic
-                .visible_candidate_bindings_for_reference(reference)
-            {
-                if seen.insert(binding_id) {
-                    binding_ids.push(binding_id);
-                }
-            }
-
-            binding_ids.into_iter().any(|binding_id| {
-                let binding = self.semantic.binding(binding_id);
-                !self.binding_reset_by_name_only_declaration_before(binding, reference.span)
-                    && (binding_is_array_like(binding)
-                        || self.binding_inherits_indexed_array_type(binding))
-            })
-        };
-        if !array_like {
-            return None;
-        }
-
-        if is_bash_runtime_array_name(reference.name.as_str()) {
-            return Some(PlainUnindexedArrayReferenceFact::SelectorRequired(
-                SelectorRequiredArrayReference::new(reference.id, reference.span),
-            ));
-        }
-
-        if self.reference_is_zsh_array_assignment_list_value(reference) {
-            return None;
-        }
-
-        Some(match self.array_reference_policy(reference) {
+        Some(match policy {
             shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector => {
                 PlainUnindexedArrayReferenceFact::SelectorRequired(
                     SelectorRequiredArrayReference::new(reference.id, reference.span),
@@ -138,12 +79,13 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         })
     }
 
-    fn reference_is_zsh_array_assignment_list_value(&mut self, reference: &Reference) -> bool {
+    fn reference_is_zsh_array_assignment_list_value(
+        &mut self,
+        reference: &Reference,
+        policy: shuck_semantic::ArrayReferencePolicy,
+    ) -> bool {
         if self.facts.shell != ShellDialect::Zsh
-            || matches!(
-                self.array_reference_policy(reference),
-                shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector
-            )
+            || matches!(policy, shuck_semantic::ArrayReferencePolicy::RequiresExplicitSelector)
         {
             return false;
         }
@@ -171,105 +113,6 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
         self.semantic
             .shell_behavior_at(reference.span.start.offset)
             .array_reference_policy()
-    }
-
-    fn binding_inherits_indexed_array_type(&mut self, binding: &Binding) -> bool {
-        if let Some(cached) = self
-            .binding_inherits_indexed_array_type_cache
-            .get(&binding.id)
-            .copied()
-        {
-            return cached;
-        }
-
-        let inherited = if binding_resets_indexed_array_type(binding) {
-            false
-        } else {
-            let initialized_scalar_declaration =
-                matches!(binding.kind, BindingKind::Declaration(_))
-                    && binding
-                        .attributes
-                        .contains(BindingAttributes::DECLARATION_INITIALIZED)
-                    && !binding
-                        .attributes
-                        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC);
-            let append_declaration = self.binding_is_append_declaration(binding);
-            let prior_local_barrier = self.binding_has_prior_local_barrier(binding);
-            let prior_bindings = self
-                .semantic
-                .bindings_for(&binding.name)
-                .iter()
-                .copied()
-                .filter(|candidate_id| {
-                    let candidate = self.semantic.binding(*candidate_id);
-                    let same_scope_candidate_allowed = !initialized_scalar_declaration
-                        || append_declaration
-                        || self.facts.shell != ShellDialect::Zsh;
-                    candidate.span.start.offset < binding.span.start.offset
-                        && ((candidate.scope != binding.scope && !prior_local_barrier)
-                            || same_scope_candidate_allowed)
-                        && !self
-                            .binding_reset_by_name_only_declaration_before(candidate, binding.span)
-                })
-                .collect::<Vec<_>>();
-
-            let mut inherited = false;
-            for candidate_id in prior_bindings.into_iter().rev() {
-                let candidate = self.semantic.binding(candidate_id);
-                if binding_resets_indexed_array_type(candidate) {
-                    inherited = false;
-                    break;
-                }
-                if binding_is_sticky_indexed_array(candidate) {
-                    inherited = true;
-                    break;
-                }
-            }
-            inherited
-        };
-
-        self.binding_inherits_indexed_array_type_cache
-            .insert(binding.id, inherited);
-        inherited
-    }
-
-    fn reference_has_prior_zsh_scalar_local_barrier(&self, reference: &Reference) -> bool {
-        if self.facts.shell != ShellDialect::Zsh {
-            return false;
-        }
-
-        let latest_barrier = self
-            .semantic
-            .ancestor_scopes(self.semantic.scope_at(reference.span.start.offset))
-            .flat_map(|scope| {
-                self.local_declarations
-                    .initialized_scalar_local_declarations_for(scope, &reference.name)
-                    .iter()
-                    .copied()
-            })
-            .filter(|span| span.end.offset < reference.span.start.offset)
-            .max_by_key(|span| span.start.offset);
-
-        latest_barrier
-            .is_some_and(|barrier| !self.zsh_array_binding_after_scalar_local_barrier(reference, barrier))
-    }
-
-    fn zsh_array_binding_after_scalar_local_barrier(
-        &self,
-        reference: &Reference,
-        barrier: Span,
-    ) -> bool {
-        self.semantic
-            .bindings_for(&reference.name)
-            .iter()
-            .copied()
-            .map(|binding_id| self.semantic.binding(binding_id))
-            .any(|binding| {
-                binding.span.start.offset > barrier.start.offset
-                    && binding.span.start.offset < reference.span.start.offset
-                    && self.semantic.binding_visible_at(binding.id, reference.span)
-                    && binding_is_array_like(binding)
-            })
     }
 
     fn reference_reads_into_same_name_array_writer(&mut self, reference: &Reference) -> bool {
@@ -436,50 +279,6 @@ impl<'a, 'src> PlainUnindexedArrayReferenceContext<'a, 'src> {
 
         None
     }
-
-    fn binding_reset_by_name_only_declaration_before(
-        &mut self,
-        binding: &Binding,
-        at: Span,
-    ) -> bool {
-        *self
-            .binding_reset_by_name_only_before_cache
-            .entry((binding.id, at.start.offset))
-            .or_insert_with(|| {
-                self.local_declarations
-                    .name_only_local_declarations_for(binding.scope, &binding.name)
-                    .iter()
-                    .any(|span| {
-                        span.start.offset > binding.span.start.offset
-                            && span.end.offset < at.start.offset
-                    })
-            })
-    }
-
-    fn binding_has_prior_local_barrier(&mut self, binding: &Binding) -> bool {
-        *self
-            .binding_has_prior_local_barrier_cache
-            .entry(binding.id)
-            .or_insert_with(|| {
-                self.local_declarations
-                    .local_declarations_for(binding.scope, &binding.name)
-                    .iter()
-                    .any(|span| span.end.offset < binding.span.start.offset)
-            })
-    }
-
-    fn binding_is_append_declaration(&mut self, binding: &Binding) -> bool {
-        *self
-            .binding_is_append_declaration_cache
-            .entry(binding.id)
-            .or_insert_with(|| {
-                self.local_declarations.is_local_append_declaration(
-                    binding.scope,
-                    &binding.name,
-                    binding.span,
-                )
-            })
-    }
 }
 
 #[derive(Clone, Copy)]
@@ -488,178 +287,8 @@ struct SimpleCommandAncestor {
     assignment_only: bool,
 }
 
-struct LocalDeclarationIndex {
-    local_declarations_by_scope_name: FxHashMap<(ScopeId, Name), Vec<Span>>,
-    name_only_local_declarations_by_scope_name: FxHashMap<(ScopeId, Name), Vec<Span>>,
-    initialized_scalar_local_declarations_by_scope_name: FxHashMap<(ScopeId, Name), Vec<Span>>,
-    append_local_declaration_spans: FxHashSet<(ScopeId, Name, usize, usize)>,
-}
-
-impl LocalDeclarationIndex {
-    fn build(semantic: &SemanticModel) -> Self {
-        let mut local_declarations_by_scope_name =
-            FxHashMap::<(ScopeId, Name), Vec<Span>>::default();
-        let mut name_only_local_declarations_by_scope_name =
-            FxHashMap::<(ScopeId, Name), Vec<Span>>::default();
-        let mut initialized_scalar_local_declarations_by_scope_name =
-            FxHashMap::<(ScopeId, Name), Vec<Span>>::default();
-        let mut append_local_declaration_spans = FxHashSet::default();
-
-        for declaration in semantic.declarations() {
-            if !matches!(declaration.builtin, DeclarationBuiltin::Local) {
-                continue;
-            }
-
-            let scope = semantic.scope_at(declaration.span.start.offset);
-            let declaration_has_array_flag = declaration.operands.iter().any(|operand| {
-                matches!(
-                    operand,
-                    SemanticDeclarationOperand::Flag {
-                        flag: 'a' | 'A',
-                        ..
-                    }
-                )
-            });
-            for operand in &declaration.operands {
-                match operand {
-                    SemanticDeclarationOperand::Name { name, .. } => {
-                        local_declarations_by_scope_name
-                            .entry((scope, name.clone()))
-                            .or_default()
-                            .push(declaration.span);
-                        name_only_local_declarations_by_scope_name
-                            .entry((scope, name.clone()))
-                            .or_default()
-                            .push(declaration.span);
-                    }
-                    SemanticDeclarationOperand::Assignment {
-                        name,
-                        name_span,
-                        append,
-                        ..
-                    } => {
-                        local_declarations_by_scope_name
-                            .entry((scope, name.clone()))
-                            .or_default()
-                            .push(declaration.span);
-                        if !*append && !declaration_has_array_flag {
-                            initialized_scalar_local_declarations_by_scope_name
-                                .entry((scope, name.clone()))
-                                .or_default()
-                                .push(declaration.span);
-                        }
-                        if *append {
-                            append_local_declaration_spans.insert((
-                                scope,
-                                name.clone(),
-                                name_span.start.offset,
-                                name_span.end.offset,
-                            ));
-                        }
-                    }
-                    SemanticDeclarationOperand::Flag { .. }
-                    | SemanticDeclarationOperand::DynamicWord { .. } => {}
-                }
-            }
-        }
-
-        Self {
-            local_declarations_by_scope_name,
-            name_only_local_declarations_by_scope_name,
-            initialized_scalar_local_declarations_by_scope_name,
-            append_local_declaration_spans,
-        }
-    }
-
-    fn local_declarations_for(&self, scope: ScopeId, name: &Name) -> &[Span] {
-        self.local_declarations_by_scope_name
-            .get(&(scope, name.clone()))
-            .map_or(&[], Vec::as_slice)
-    }
-
-    fn name_only_local_declarations_for(&self, scope: ScopeId, name: &Name) -> &[Span] {
-        self.name_only_local_declarations_by_scope_name
-            .get(&(scope, name.clone()))
-            .map_or(&[], Vec::as_slice)
-    }
-
-    fn initialized_scalar_local_declarations_for(&self, scope: ScopeId, name: &Name) -> &[Span] {
-        self.initialized_scalar_local_declarations_by_scope_name
-            .get(&(scope, name.clone()))
-            .map_or(&[], Vec::as_slice)
-    }
-
-    fn is_local_append_declaration(&self, scope: ScopeId, name: &Name, span: Span) -> bool {
-        self.append_local_declaration_spans.contains(&(
-            scope,
-            name.clone(),
-            span.start.offset,
-            span.end.offset,
-        ))
-    }
-}
-
 fn span_is_within(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
-}
-
-fn binding_is_array_like(binding: &Binding) -> bool {
-    let declared_array = binding
-        .attributes
-        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC);
-    (declared_array && !is_uninitialized_local_array_declaration(binding))
-        || matches!(
-            binding.kind,
-            BindingKind::ArrayAssignment | BindingKind::MapfileTarget
-        )
-}
-
-fn binding_resets_indexed_array_type(binding: &Binding) -> bool {
-    matches!(
-        binding.kind,
-        BindingKind::ArithmeticAssignment
-            | BindingKind::GetoptsTarget
-            | BindingKind::Imported
-            | BindingKind::LoopVariable
-            | BindingKind::PrintfTarget
-    ) || (matches!(binding.kind, BindingKind::ReadTarget)
-        && !binding.attributes.contains(BindingAttributes::ARRAY))
-        || (matches!(binding.kind, BindingKind::Declaration(_))
-            && !binding
-                .attributes
-                .contains(BindingAttributes::DECLARATION_INITIALIZED)
-            && !binding
-                .attributes
-                .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC))
-}
-
-fn binding_is_initialized_scalar_declaration(binding: &Binding) -> bool {
-    matches!(binding.kind, BindingKind::Declaration(_))
-        && binding
-            .attributes
-            .contains(BindingAttributes::DECLARATION_INITIALIZED)
-        && !binding
-            .attributes
-            .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
-}
-
-fn binding_is_sticky_indexed_array(binding: &Binding) -> bool {
-    !is_uninitialized_local_array_declaration(binding)
-        && (binding.attributes.contains(BindingAttributes::ARRAY)
-            || matches!(
-                binding.kind,
-                BindingKind::ArrayAssignment | BindingKind::MapfileTarget
-            ))
-}
-
-fn is_uninitialized_local_array_declaration(binding: &Binding) -> bool {
-    matches!(binding.kind, BindingKind::Declaration(DeclarationBuiltin::Local))
-        && binding
-            .attributes
-            .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
-        && !binding
-            .attributes
-            .contains(BindingAttributes::DECLARATION_INITIALIZED)
 }
 
 fn loop_header_word_quote(facts: &LinterFacts<'_>, span: Span) -> Option<WordQuote> {
@@ -682,28 +311,6 @@ fn binding_suppresses_same_command_array_read(binding: &Binding, assignment_only
         || (matches!(binding.kind, BindingKind::ReadTarget)
             && binding.attributes.contains(BindingAttributes::ARRAY))
         || (matches!(binding.kind, BindingKind::ArrayAssignment) && assignment_only)
-}
-
-fn is_bash_runtime_array_name(name: &str) -> bool {
-    matches!(
-        name,
-        "BASH_ALIASES"
-            | "BASH_ARGC"
-            | "BASH_ARGV"
-            | "BASH_CMDS"
-            | "BASH_LINENO"
-            | "BASH_REMATCH"
-            | "BASH_SOURCE"
-            | "BASH_VERSINFO"
-            | "COMP_WORDS"
-            | "COMPREPLY"
-            | "COPROC"
-            | "DIRSTACK"
-            | "FUNCNAME"
-            | "GROUPS"
-            | "MAPFILE"
-            | "PIPESTATUS"
-    )
 }
 
 fn collect_use_replacement_expansion_spans(parts: &[WordPartNode], spans: &mut Vec<Span>) {

--- a/crates/shuck-linter/src/facts/braces.rs
+++ b/crates/shuck-linter/src/facts/braces.rs
@@ -87,6 +87,9 @@ fn collect_literal_brace_spans_for_word(
     scratch: &mut LiteralBraceScratch,
 ) {
     let word = occurrence_word(nodes, fact);
+    let derived = word_node_derived(&nodes[fact.node_id.index()]);
+    let nested_escaped_templates =
+        fact_store.word_spans(derived.nested_escaped_parameter_template_body_spans);
     scratch.dynamic_exclusions.clear();
     collect_dynamic_brace_exclusions(
         &word.parts,
@@ -117,7 +120,13 @@ fn collect_literal_brace_spans_for_word(
         })
     {
         collect_brace_character_spans(brace.span, source, spans, |span| {
-            literal_brace_word_span_is_reportable(nodes, fact, fact_store, word, span, source)
+            literal_brace_word_span_is_reportable(
+                nodes,
+                fact,
+                fact_store,
+                span,
+                nested_escaped_templates,
+            )
         });
     }
 
@@ -131,7 +140,15 @@ fn collect_literal_brace_spans_for_word(
             escaped_parameter_stack: &mut scratch.escaped_parameter_stack,
         },
         spans,
-        |span| literal_brace_word_span_is_reportable(nodes, fact, fact_store, word, span, source),
+        |span| {
+            literal_brace_word_span_is_reportable(
+                nodes,
+                fact,
+                fact_store,
+                span,
+                nested_escaped_templates,
+            )
+        },
     );
     collect_unclassified_literal_brace_spans(
         word,
@@ -139,7 +156,15 @@ fn collect_literal_brace_spans_for_word(
         &mut scratch.dynamic_exclusions,
         &mut scratch.unmatched_offsets,
         spans,
-        |span| literal_brace_word_span_is_reportable(nodes, fact, fact_store, word, span, source),
+        |span| {
+            literal_brace_word_span_is_reportable(
+                nodes,
+                fact,
+                fact_store,
+                span,
+                nested_escaped_templates,
+            )
+        },
     );
 }
 
@@ -147,11 +172,13 @@ fn literal_brace_word_span_is_reportable(
     nodes: &[WordNode<'_>],
     fact: &WordOccurrence,
     fact_store: &FactStore<'_>,
-    word: &Word,
     span: Span,
-    source: &str,
+    nested_escaped_templates: &[Span],
 ) -> bool {
-    !span_inside_nested_escaped_parameter_template(word, span, source)
+    !nested_escaped_templates
+        .iter()
+        .copied()
+        .any(|body| body.start.offset <= span.start.offset && span.start.offset < body.end.offset)
         && !word_span_is_inside_command_substitution(nodes, fact, fact_store, span)
 }
 
@@ -1531,54 +1558,6 @@ fn brace_pair_matches_nonliteral_syntax(
             && brace.span.start.offset == absolute_open_offset
             && brace.span.end.offset == absolute_close_offset
     })
-}
-
-fn span_inside_nested_escaped_parameter_template(word: &Word, span: Span, source: &str) -> bool {
-    if span.start.offset < word.span.start.offset || span.start.offset >= word.span.end.offset {
-        return false;
-    }
-
-    let text = word.span.slice(source);
-    let relative_offset = span.start.offset - word.span.start.offset;
-    let mut index = 0usize;
-
-    while index < text.len() {
-        if text[index..].starts_with("\\${")
-            && let Some(end_offset) =
-                find_runtime_parameter_closing_brace(text, index + '\\'.len_utf8())
-        {
-            let body_start = index + "\\${".len();
-            let body_end = end_offset.saturating_sub('}'.len_utf8());
-            let has_nested_parameter =
-                body_start < body_end && text[body_start..body_end].contains("${");
-            let open_brace_offset = index + "\\$".len();
-            if has_nested_parameter
-                && relative_offset > open_brace_offset
-                && relative_offset < end_offset.saturating_sub('}'.len_utf8())
-            {
-                return true;
-            }
-            index = end_offset;
-            continue;
-        }
-
-        let Some(ch) = text[index..].chars().next() else {
-            break;
-        };
-        let ch_len = ch.len_utf8();
-
-        if ch == '\\' {
-            index += ch_len;
-            if let Some(escaped) = text[index..].chars().next() {
-                index += escaped.len_utf8();
-            }
-            continue;
-        }
-
-        index += ch_len;
-    }
-
-    false
 }
 
 fn collect_raw_escaped_parameter_exclusions(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -45,116 +45,6 @@ fn estimate_fact_build_capacity(semantic: &SemanticModel) -> FactBuildCapacity {
     }
 }
 
-fn binding_has_array_like_shape(binding: &Binding) -> bool {
-    binding
-        .attributes
-        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
-        || matches!(
-            binding.kind,
-            BindingKind::ArrayAssignment | BindingKind::MapfileTarget
-        )
-}
-
-fn binding_is_name_only_declaration(binding: &Binding) -> bool {
-    matches!(binding.origin, BindingOrigin::Declaration { .. })
-        && binding.attributes.contains(BindingAttributes::LOCAL)
-        && !binding
-            .attributes
-            .contains(BindingAttributes::DECLARATION_INITIALIZED)
-}
-
-fn binding_can_supply_parameter_value(binding: &Binding) -> bool {
-    match binding.origin {
-        BindingOrigin::FunctionDefinition { .. } => false,
-        BindingOrigin::Declaration { .. } => {
-            binding_is_name_only_declaration(binding)
-                || binding.attributes.intersects(
-                    BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
-                )
-        }
-        _ => true,
-    }
-}
-
-#[cfg_attr(shuck_profiling, inline(never))]
-fn compute_array_like_capable_names(semantic: &SemanticModel) -> FxHashSet<Name> {
-    let mut names = FxHashSet::default();
-    for binding in semantic.bindings() {
-        if binding_can_supply_parameter_value(binding) && binding_has_array_like_shape(binding) {
-            names.insert(binding.name.clone());
-        }
-    }
-    names
-}
-
-#[cfg_attr(shuck_profiling, inline(never))]
-fn compute_single_array_like_bindings(semantic: &SemanticModel) -> FxHashMap<Name, BindingId> {
-    let mut bindings_by_name = FxHashMap::default();
-    for binding in semantic.bindings() {
-        if !binding_can_supply_parameter_value(binding) {
-            continue;
-        }
-        let array_like = binding_has_array_like_shape(binding);
-        match bindings_by_name.entry(binding.name.clone()) {
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(array_like.then_some(binding.id));
-            }
-            std::collections::hash_map::Entry::Occupied(mut entry) => {
-                entry.insert(None);
-            }
-        }
-    }
-
-    bindings_by_name
-        .into_iter()
-        .filter_map(|(name, binding_id)| binding_id.map(|binding_id| (name, binding_id)))
-        .collect()
-}
-
-#[cfg_attr(shuck_profiling, inline(never))]
-fn compute_array_like_bindings_by_name(
-    semantic: &SemanticModel,
-) -> FxHashMap<Name, SmallVec<[BindingId; 2]>> {
-    let mut bindings_by_name = FxHashMap::<Name, SmallVec<[BindingId; 2]>>::default();
-    for binding in semantic.bindings() {
-        if binding_can_supply_parameter_value(binding) && binding_has_array_like_shape(binding) {
-            bindings_by_name
-                .entry(binding.name.clone())
-                .or_default()
-                .push(binding.id);
-        }
-    }
-    bindings_by_name
-}
-
-/// Names where *every* binding is array-like. For these names, the slow dataflow walk in
-/// `visible_name_is_array_like` is unnecessary: any lexically visible binding will satisfy the
-/// predicate.
-#[cfg_attr(shuck_profiling, inline(never))]
-fn compute_uniformly_array_like_names(semantic: &SemanticModel) -> FxHashSet<Name> {
-    let mut name_state: FxHashMap<Name, bool> = FxHashMap::default();
-    for binding in semantic.bindings() {
-        if !binding_can_supply_parameter_value(binding) {
-            continue;
-        }
-        let array_like = binding_has_array_like_shape(binding);
-        match name_state.entry(binding.name.clone()) {
-            std::collections::hash_map::Entry::Vacant(entry) => {
-                entry.insert(array_like);
-            }
-            std::collections::hash_map::Entry::Occupied(mut entry) => {
-                if !array_like {
-                    *entry.get_mut() = false;
-                }
-            }
-        }
-    }
-    name_state
-        .into_iter()
-        .filter_map(|(name, uniform)| uniform.then_some(name))
-        .collect()
-}
-
 impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
     fn new(
         file: &'a File,
@@ -227,10 +117,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let mut seen_pending_arithmetic_word_occurrences = FxHashSet::default();
         let mut seen_pending_parameter_operand_word_occurrences = FxHashSet::default();
         let mut assoc_binding_visibility_memo = FxHashMap::default();
-        let array_like_capable_names = compute_array_like_capable_names(self.semantic);
-        let single_array_like_bindings = compute_single_array_like_bindings(self.semantic);
-        let array_like_bindings_by_name = compute_array_like_bindings_by_name(self.semantic);
-        let uniformly_array_like_names = compute_uniformly_array_like_names(self.semantic);
         let mut pattern_exactly_one_extglob_spans = Vec::new();
         let mut case_pattern_expansions = Vec::new();
         let mut pattern_literal_spans = Vec::new();
@@ -365,10 +251,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                         seen_pending_parameter_operand_word_occurrences:
                             &mut seen_pending_parameter_operand_word_occurrences,
                         assoc_binding_visibility_memo: &mut assoc_binding_visibility_memo,
-                        array_like_capable_names: &array_like_capable_names,
-                        single_array_like_bindings: &single_array_like_bindings,
-                        array_like_bindings_by_name: &array_like_bindings_by_name,
-                        uniformly_array_like_names: &uniformly_array_like_names,
                         semantic_analysis: self.semantic_analysis,
                         case_pattern_expansions: &mut case_pattern_expansions,
                         pattern_literal_spans: &mut pattern_literal_spans,

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -65,8 +65,8 @@ use shuck_indexer::{Indexer, LineIndex, RegionIndex};
 #[cfg(test)]
 use shuck_parser::parser::Parser;
 use shuck_semantic::{
-    ArithmeticLiteralBehavior, Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin,
-    CaseCliDispatch, CommandKind, CompoundCommandKind, Declaration, DeclarationBuiltin,
+    ArithmeticLiteralBehavior, Binding, BindingAttributes, BindingId, BindingKind, CaseCliDispatch,
+    CommandKind, CompoundCommandKind, Declaration, DeclarationBuiltin,
     DeclarationOperand as SemanticDeclarationOperand, FieldSplittingBehavior,
     FileExpansionOrderBehavior, FunctionScopeKind, GlobDotBehavior, GlobFailureBehavior,
     GlobPatternBehavior, NonpersistentAssignmentAnalysisContext,

--- a/crates/shuck-linter/src/facts/word_spans/arrays.rs
+++ b/crates/shuck-linter/src/facts/word_spans/arrays.rs
@@ -1,4 +1,5 @@
 use super::*;
+use smallvec::SmallVec;
 
 pub fn collect_array_expansion_part_spans(word: &Word, spans: &mut Vec<Span>) {
     collect_array_expansion_spans(&word.parts, false, false, spans);
@@ -52,11 +53,12 @@ pub fn collect_direct_all_elements_array_expansion_part_spans(
     shell_dialect: shuck_semantic::ShellDialect,
     spans: &mut Vec<Span>,
 ) {
-    collect_direct_all_elements_array_expansion_spans(
-        &word.parts,
-        word.span,
+    let escaped_templates = escaped_parameter_template_bodies(word.span, locator.source());
+    collect_direct_all_elements_array_expansion_part_spans_with_escaped_templates(
+        word,
         locator,
         shell_dialect,
+        escaped_templates.as_slice(),
         spans,
     );
 }
@@ -482,26 +484,105 @@ pub(crate) fn collect_all_elements_array_slice_spans(
     }
 }
 
-pub(crate) fn collect_direct_all_elements_array_expansion_spans(
-    parts: &[WordPartNode],
-    word_span: Span,
+pub(crate) fn collect_direct_all_elements_array_expansion_part_spans_with_escaped_templates(
+    word: &Word,
     locator: Locator<'_>,
     shell_dialect: shuck_semantic::ShellDialect,
+    escaped_templates: &[EscapedParameterTemplateBody],
+    spans: &mut Vec<Span>,
+) {
+    collect_direct_all_elements_array_expansion_spans_with_escaped_templates(
+        &word.parts,
+        locator,
+        shell_dialect,
+        escaped_templates,
+        spans,
+    );
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct EscapedParameterTemplateBody {
+    pub span: Span,
+    pub contains_nested_parameter: bool,
+}
+
+pub(crate) fn escaped_parameter_template_bodies(
+    word_span: Span,
+    source: &str,
+) -> SmallVec<[EscapedParameterTemplateBody; 2]> {
+    let mut bodies = SmallVec::new();
+    if word_span.start.offset >= word_span.end.offset || word_span.end.offset > source.len() {
+        return bodies;
+    }
+
+    let text = word_span.slice(source);
+    if !text.contains("\\${") {
+        return bodies;
+    }
+
+    let mut index = 0usize;
+    while index < text.len() {
+        if text[index..].starts_with("\\${") {
+            let dollar_offset = index + '\\'.len_utf8();
+            if offset_is_backslash_escaped(word_span.start.offset + dollar_offset, source)
+                && let Some(end_offset) = escaped_parameter_template_end(text, dollar_offset)
+            {
+                let body_start = dollar_offset + "${".len();
+                let body_end = end_offset.saturating_sub('}'.len_utf8());
+                if body_start < body_end {
+                    let span = Span::from_positions(
+                        word_span.start.advanced_by(&text[..body_start]),
+                        word_span.start.advanced_by(&text[..body_end]),
+                    );
+                    bodies.push(EscapedParameterTemplateBody {
+                        span,
+                        contains_nested_parameter: text[body_start..body_end].contains("${"),
+                    });
+                }
+                index = end_offset;
+                continue;
+            }
+        }
+
+        let Some(ch) = text[index..].chars().next() else {
+            break;
+        };
+        index += ch.len_utf8();
+    }
+
+    bodies
+}
+
+pub(crate) fn span_start_inside_escaped_parameter_template(
+    span: Span,
+    bodies: &[EscapedParameterTemplateBody],
+) -> bool {
+    bodies
+        .iter()
+        .copied()
+        .any(|body| body.contains(span.start.offset))
+}
+
+fn collect_direct_all_elements_array_expansion_spans_with_escaped_templates(
+    parts: &[WordPartNode],
+    locator: Locator<'_>,
+    shell_dialect: shuck_semantic::ShellDialect,
+    escaped_templates: &[EscapedParameterTemplateBody],
     spans: &mut Vec<Span>,
 ) {
     let source = locator.source();
     for part in parts {
-        if span_inside_escaped_parameter_template(word_span, part.span, source) {
+        if span_start_inside_escaped_parameter_template(part.span, escaped_templates) {
             continue;
         }
         match &part.kind {
             WordPart::SingleQuoted { .. } => {}
             WordPart::DoubleQuoted { parts, .. } => {
-                collect_direct_all_elements_array_expansion_spans(
+                collect_direct_all_elements_array_expansion_spans_with_escaped_templates(
                     parts,
-                    word_span,
                     locator,
                     shell_dialect,
+                    escaped_templates,
                     spans,
                 )
             }
@@ -535,42 +616,10 @@ pub(crate) fn collect_direct_all_elements_array_expansion_spans(
     }
 }
 
-pub(crate) fn span_inside_escaped_parameter_template(
-    word_span: Span,
-    span: Span,
-    source: &str,
-) -> bool {
-    if span.start.offset < word_span.start.offset || span.start.offset >= word_span.end.offset {
-        return false;
+impl EscapedParameterTemplateBody {
+    fn contains(self, offset: usize) -> bool {
+        self.span.start.offset <= offset && offset < self.span.end.offset
     }
-
-    let text = word_span.slice(source);
-    let relative_offset = span.start.offset - word_span.start.offset;
-    let mut index = 0usize;
-
-    while index < text.len() {
-        if text[index..].starts_with("\\${") {
-            let dollar_offset = index + '\\'.len_utf8();
-            if offset_is_backslash_escaped(word_span.start.offset + dollar_offset, source)
-                && let Some(end_offset) = escaped_parameter_template_end(text, dollar_offset)
-            {
-                let body_start = dollar_offset + "${".len();
-                let body_end = end_offset.saturating_sub('}'.len_utf8());
-                if relative_offset >= body_start && relative_offset < body_end {
-                    return true;
-                }
-                index = end_offset;
-                continue;
-            }
-        }
-
-        let Some(ch) = text[index..].chars().next() else {
-            break;
-        };
-        index += ch.len_utf8();
-    }
-
-    false
 }
 
 pub(crate) fn escaped_parameter_template_end(text: &str, dollar_offset: usize) -> Option<usize> {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -1406,7 +1406,6 @@ pub(super) fn derive_word_fact_data<'a>(
         word,
         locator,
         shell_dialect,
-        escaped_template_bodies.as_slice(),
         may_have_runtime_expansion_spans,
         may_have_command_substitution_spans,
     );
@@ -1534,7 +1533,6 @@ fn collect_derived_word_traversal_spans<'a>(
     word: &'a Word,
     locator: Locator<'a>,
     shell_dialect: shuck_semantic::ShellDialect,
-    escaped_template_bodies: &[word_spans::EscapedParameterTemplateBody],
     may_have_runtime_expansion_spans: bool,
     may_have_command_substitution_spans: bool,
 ) -> DerivedWordTraversalSpans {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -16,6 +16,7 @@ pub(super) struct WordNodeDerived<'a> {
     pub(super) safe_value_plain_scalar_reference_name: Option<Name>,
     pub(super) safe_value_special_parameter_access: bool,
     pub(super) safe_value_contains_special_parameter_slice: bool,
+    pub(super) nested_escaped_parameter_template_body_spans: IdRange<Span>,
     pub(super) active_expansion_spans: IdRange<Span>,
     pub(super) scalar_expansion_spans: IdRange<Span>,
     pub(super) unquoted_scalar_expansion_spans: IdRange<Span>,
@@ -1178,15 +1179,6 @@ struct ZshArrayFanoutContext<'a, 'flow> {
     value_flow: &'flow SemanticValueFlow<'flow, 'a>,
     scope: ScopeId,
     options: Option<&'a ZshOptionState>,
-    lookups: ZshArrayFanoutLookups<'a>,
-}
-
-#[derive(Clone, Copy)]
-struct ZshArrayFanoutLookups<'a> {
-    array_like_capable_names: &'a FxHashSet<Name>,
-    single_array_like_bindings: &'a FxHashMap<Name, BindingId>,
-    array_like_bindings_by_name: &'a FxHashMap<Name, SmallVec<[BindingId; 2]>>,
-    uniformly_array_like_names: &'a FxHashSet<Name>,
 }
 
 fn apply_zsh_array_fanout(
@@ -1198,11 +1190,9 @@ fn apply_zsh_array_fanout(
         || zsh_unindexed_array_fanout_is_disabled(context.options)
         || !word_has_unquoted_visible_array_reference(
             word,
-            context.semantic,
             context.semantic_analysis,
             context.value_flow,
             context.scope,
-            context.lookups,
         )
     {
         return;
@@ -1221,43 +1211,35 @@ fn zsh_unindexed_array_fanout_is_disabled(options: Option<&ZshOptionState>) -> b
 
 fn word_has_unquoted_visible_array_reference(
     word: &Word,
-    semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
-    lookups: ZshArrayFanoutLookups<'_>,
 ) -> bool {
     parts_have_unquoted_visible_array_reference(
         &word.parts,
-        semantic,
         semantic_analysis,
         value_flow,
         scope,
         false,
-        lookups,
     )
 }
 
 fn parts_have_unquoted_visible_array_reference(
     parts: &[WordPartNode],
-    semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
     in_double_quotes: bool,
-    lookups: ZshArrayFanoutLookups<'_>,
 ) -> bool {
     for part in parts {
         match &part.kind {
             WordPart::DoubleQuoted { parts, .. } => {
                 if parts_have_unquoted_visible_array_reference(
                     parts,
-                    semantic,
                     semantic_analysis,
                     value_flow,
                     scope,
                     true,
-                    lookups,
                 ) {
                     return true;
                 }
@@ -1266,11 +1248,9 @@ fn parts_have_unquoted_visible_array_reference(
                 if visible_name_is_array_like(
                     name,
                     part.span,
-                    semantic,
                     semantic_analysis,
                     value_flow,
                     scope,
-                    lookups,
                 ) {
                     return true;
                 }
@@ -1278,11 +1258,9 @@ fn parts_have_unquoted_visible_array_reference(
             WordPart::Parameter(parameter) if !in_double_quotes => {
                 if zsh_parameter_targets_visible_array(
                     parameter,
-                    semantic,
                     semantic_analysis,
                     value_flow,
                     scope,
-                    lookups,
                 ) {
                     return true;
                 }
@@ -1296,11 +1274,9 @@ fn parts_have_unquoted_visible_array_reference(
 
 fn zsh_parameter_targets_visible_array(
     parameter: &ParameterExpansion,
-    semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
-    lookups: ZshArrayFanoutLookups<'_>,
 ) -> bool {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference })
@@ -1311,11 +1287,9 @@ fn zsh_parameter_targets_visible_array(
         }) if reference.subscript.is_none() => visible_name_is_array_like(
             &reference.name,
             reference.name_span,
-            semantic,
             semantic_analysis,
             value_flow,
             scope,
-            lookups,
         ),
         _ => false,
     }
@@ -1324,60 +1298,14 @@ fn zsh_parameter_targets_visible_array(
 fn visible_name_is_array_like(
     name: &Name,
     span: Span,
-    semantic: &SemanticModel,
     semantic_analysis: &SemanticAnalysis<'_>,
     value_flow: &SemanticValueFlow<'_, '_>,
     scope: ScopeId,
-    lookups: ZshArrayFanoutLookups<'_>,
 ) -> bool {
-    if !lookups.array_like_capable_names.contains(name) {
-        return false;
-    }
-    if let Some(binding_id) = lookups.single_array_like_bindings.get(name)
-        && semantic.binding_visible_at(*binding_id, span)
-    {
-        return true;
-    }
-    if lookups.uniformly_array_like_names.contains(name)
-        && semantic.visible_binding(name, span).is_some()
-    {
-        return true;
-    }
     if let Some(reference_id) = semantic_analysis.reference_id_for_name_at(name, span) {
-        if semantic
-            .resolved_binding(reference_id)
-            .is_some_and(binding_is_array_like)
-        {
-            return true;
-        }
-        if let Some(array_like_bindings) = lookups.array_like_bindings_by_name.get(name) {
-            return value_flow.reference_reaches_any_value_binding(reference_id, array_like_bindings);
-        }
-        return false;
+        return value_flow.reference_can_fan_out_when_unquoted(reference_id);
     }
-    let bindings =
-    {
-        let synthetic_use_block =
-            semantic_analysis.flow_entry_block_for_binding_scopes(&[scope], span.start.offset);
-        value_flow.reaching_value_bindings_for_name_without_reference(
-            name,
-            span,
-            synthetic_use_block,
-        )
-    };
-    bindings
-        .into_iter()
-        .any(|binding_id| binding_is_array_like(semantic.binding(binding_id)))
-}
-
-fn binding_is_array_like(binding: &Binding) -> bool {
-    binding
-        .attributes
-        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
-        || matches!(
-            binding.kind,
-            BindingKind::ArrayAssignment | BindingKind::MapfileTarget
-        )
+    value_flow.name_can_fan_out_when_unquoted_without_reference(name, span, scope)
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
@@ -1433,10 +1361,6 @@ pub(super) struct WordFactOutputs<'out, 'a> {
         &'out mut FxHashSet<PendingParameterOperandSeenKey>,
     pub(super) assoc_binding_visibility_memo:
         &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
-    pub(super) array_like_capable_names: &'out FxHashSet<Name>,
-    pub(super) single_array_like_bindings: &'out FxHashMap<Name, BindingId>,
-    pub(super) array_like_bindings_by_name: &'out FxHashMap<Name, SmallVec<[BindingId; 2]>>,
-    pub(super) uniformly_array_like_names: &'out FxHashSet<Name>,
     pub(super) semantic_analysis: &'out SemanticAnalysis<'a>,
     pub(super) case_pattern_expansions: &'out mut Vec<CasePatternExpansionFact>,
     pub(super) pattern_literal_spans: &'out mut Vec<Span>,
@@ -1473,6 +1397,7 @@ pub(super) fn derive_word_fact_data<'a>(
     scratch: &mut Vec<Span>,
 ) -> WordNodeDerived<'a> {
     let source = locator.source();
+    let escaped_template_bodies = word_spans::escaped_parameter_template_bodies(word.span, source);
     let may_have_runtime_expansion_spans = word_may_have_runtime_expansion_spans(word);
     let may_have_command_substitution_spans = word_may_have_command_substitution_spans(word);
     let may_have_mixed_quote_spans =
@@ -1481,6 +1406,7 @@ pub(super) fn derive_word_fact_data<'a>(
         word,
         locator,
         shell_dialect,
+        escaped_template_bodies.as_slice(),
         may_have_runtime_expansion_spans,
         may_have_command_substitution_spans,
     );
@@ -1494,6 +1420,21 @@ pub(super) fn derive_word_fact_data<'a>(
         safe_value_plain_scalar_reference_name: safe_value_plain_scalar_reference_name(word),
         safe_value_special_parameter_access: safe_value_special_parameter_access(word),
         safe_value_contains_special_parameter_slice: safe_value_contains_special_parameter_slice(word),
+        nested_escaped_parameter_template_body_spans: push_needed_word_span_list(
+            span_store,
+            scratch,
+            escaped_template_bodies
+                .iter()
+                .any(|body| body.contains_nested_parameter),
+            |spans| {
+                spans.extend(
+                    escaped_template_bodies
+                        .iter()
+                        .filter(|body| body.contains_nested_parameter)
+                        .map(|body| body.span),
+                );
+            },
+        ),
         active_expansion_spans: span_store
             .push_many(traversal_spans.active_expansion_spans.drain(..)),
         scalar_expansion_spans: span_store
@@ -1526,10 +1467,11 @@ pub(super) fn derive_word_fact_data<'a>(
             scratch,
             may_have_runtime_expansion_spans,
             |spans| {
-                word_spans::collect_direct_all_elements_array_expansion_part_spans(
+                word_spans::collect_direct_all_elements_array_expansion_part_spans_with_escaped_templates(
                     word,
                     locator,
                     shell_dialect,
+                    escaped_template_bodies.as_slice(),
                     spans,
                 );
             },
@@ -1592,6 +1534,7 @@ fn collect_derived_word_traversal_spans<'a>(
     word: &'a Word,
     locator: Locator<'a>,
     shell_dialect: shuck_semantic::ShellDialect,
+    escaped_template_bodies: &[word_spans::EscapedParameterTemplateBody],
     may_have_runtime_expansion_spans: bool,
     may_have_command_substitution_spans: bool,
 ) -> DerivedWordTraversalSpans {
@@ -1960,10 +1903,6 @@ pub(super) struct WordFactCollector<'out, 'a, 'norm> {
         &'out mut Vec<PendingParameterOperandWordOccurrence>,
     array_assignment_split_word_ids: &'out mut Vec<WordOccurrenceId>,
     assoc_binding_visibility_memo: &'out mut FxHashMap<(Name, ScopeId, Option<FactSpan>), bool>,
-    array_like_capable_names: &'out FxHashSet<Name>,
-    single_array_like_bindings: &'out FxHashMap<Name, BindingId>,
-    array_like_bindings_by_name: &'out FxHashMap<Name, SmallVec<[BindingId; 2]>>,
-    uniformly_array_like_names: &'out FxHashSet<Name>,
     semantic_analysis: &'out SemanticAnalysis<'a>,
     value_flow: SemanticValueFlow<'out, 'a>,
     seen: &'out mut FxHashSet<WordOccurrenceSeenKey>,
@@ -2164,10 +2103,6 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 .pending_parameter_operand_word_occurrences,
             array_assignment_split_word_ids: outputs.array_assignment_split_word_ids,
             assoc_binding_visibility_memo: outputs.assoc_binding_visibility_memo,
-            array_like_capable_names: outputs.array_like_capable_names,
-            single_array_like_bindings: outputs.single_array_like_bindings,
-            array_like_bindings_by_name: outputs.array_like_bindings_by_name,
-            uniformly_array_like_names: outputs.uniformly_array_like_names,
             semantic_analysis: outputs.semantic_analysis,
             value_flow,
             seen: {
@@ -3103,12 +3038,6 @@ impl<'out, 'a, 'norm> WordFactCollector<'out, 'a, 'norm> {
                 value_flow: &self.value_flow,
                 scope: self.command_scope,
                 options: self.command_shell_behavior.zsh_options(),
-                lookups: ZshArrayFanoutLookups {
-                    array_like_capable_names: self.array_like_capable_names,
-                    single_array_like_bindings: self.single_array_like_bindings,
-                    array_like_bindings_by_name: self.array_like_bindings_by_name,
-                    uniformly_array_like_names: self.uniformly_array_like_names,
-                },
             },
             &mut analysis,
         );

--- a/crates/shuck-linter/src/facts/words/traversal.rs
+++ b/crates/shuck-linter/src/facts/words/traversal.rs
@@ -641,7 +641,7 @@ fn walk_pattern<'a>(
             PatternPart::Word(word) => {
                 let word_state = state.with_origin(word_origin, word.span);
                 visitor.visit_pattern_word(word, word_state);
-                walk_word(word, context, word_state, visitor);
+                walk_word(word, context, word_state, None, visitor);
             }
             PatternPart::CharClass(_) => visitor.visit_pattern_char_class(part, state),
             PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => {}

--- a/crates/shuck-linter/src/facts/words/traversal.rs
+++ b/crates/shuck-linter/src/facts/words/traversal.rs
@@ -641,7 +641,7 @@ fn walk_pattern<'a>(
             PatternPart::Word(word) => {
                 let word_state = state.with_origin(word_origin, word.span);
                 visitor.visit_pattern_word(word, word_state);
-                walk_word(word, context, word_state, None, visitor);
+                walk_word(word, context, word_state, visitor);
             }
             PatternPart::CharClass(_) => visitor.visit_pattern_char_class(part, state),
             PatternPart::Literal(_) | PatternPart::AnyString | PatternPart::AnyChar => {}

--- a/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
@@ -1,4 +1,4 @@
-use shuck_semantic::{Binding, BindingAttributes, BindingKind};
+use shuck_semantic::{BindingAttributes, BindingKind};
 
 use crate::facts::words::leading_literal_word_prefix;
 use crate::{Checker, Rule, Violation};
@@ -38,7 +38,7 @@ pub fn append_to_array_as_string(checker: &mut Checker) {
                 binding.span,
                 Some(binding.span),
             )?;
-            if !binding_is_array_like(prior_binding) {
+            if !semantic.binding_has_array_value_shape(prior_binding.id) {
                 return None;
             }
 
@@ -50,13 +50,6 @@ pub fn append_to_array_as_string(checker: &mut Checker) {
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || AppendToArrayAsString);
-}
-
-fn binding_is_array_like(binding: &Binding) -> bool {
-    binding
-        .attributes
-        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
-        || binding.kind == BindingKind::ArrayAssignment
 }
 
 #[cfg(test)]

--- a/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_to_string_conversion.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use shuck_ast::Name;
 use shuck_semantic::{
     ArrayReferencePolicy, Binding, BindingAttributes, BindingKind, Declaration, DeclarationBuiltin,
-    DeclarationOperand, ScopeId,
+    DeclarationOperand, ScopeId, SemanticModel,
 };
 
 use crate::{Checker, ComparableNameUseKind, Rule, ShellDialect, Violation, WrapperKind};
@@ -50,7 +50,7 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
                 .map(|state| state.array_like)
                 .unwrap_or_else(|| binding_uses_builtin_array_history(checker, binding));
 
-            if declaration_resets_array_history(binding) {
+            if declaration_resets_array_history(semantic, binding) {
                 push_array_history(
                     &mut array_history,
                     name,
@@ -62,7 +62,7 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
                 binding,
                 &append_declaration_assignments,
             ) {
-                if binding_establishes_array_history(binding, &builtin_history) {
+                if binding_establishes_array_history(semantic, binding, &builtin_history) {
                     let prior = latest_array_history(&array_history, &name);
                     push_array_history(
                         &mut array_history,
@@ -78,8 +78,8 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
                 }
                 return None;
             }
-            if binding_is_array_like(binding) {
-                if binding_establishes_array_history(binding, &builtin_history) {
+            if semantic.binding_has_array_value_shape(binding.id) {
+                if binding_establishes_array_history(semantic, binding, &builtin_history) {
                     let prior = latest_array_history(&array_history, &name);
                     push_array_history(
                         &mut array_history,
@@ -106,7 +106,7 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
                 return None;
             }
 
-            if binding_establishes_array_history(binding, &builtin_history) {
+            if binding_establishes_array_history(semantic, binding, &builtin_history) {
                 let prior = latest_array_history(&array_history, &name);
                 push_array_history(
                     &mut array_history,
@@ -114,7 +114,7 @@ pub fn array_to_string_conversion(checker: &mut Checker) {
                     ArrayHistoryState::from_binding(checker, binding, true, prior),
                 );
             } else if checker.shell() == ShellDialect::Zsh
-                && binding_establishes_local_scalar_history(binding)
+                && binding_establishes_local_scalar_history(semantic, binding)
             {
                 push_array_history(
                     &mut array_history,
@@ -235,7 +235,7 @@ fn zsh_selectorless_subscript_value_resets_scalar_history(
             .is_some_and(|value| {
                 value.zsh_selectorless_subscript_value()
                     && (!saw_array_history
-                        || (binding_establishes_local_scalar_history(binding)
+                        || (binding_establishes_local_scalar_history(checker.semantic(), binding)
                             && !visible_array_state.is_some_and(|state| state.local))
                         || value
                             .zsh_selectorless_subscript_value_references_base_name(&binding.name))
@@ -523,6 +523,7 @@ fn binding_can_trigger_array_to_string_conversion(
 }
 
 fn binding_establishes_array_history(
+    semantic: &SemanticModel,
     binding: &Binding,
     builtin_history: &BuiltinArrayHistory,
 ) -> bool {
@@ -549,18 +550,18 @@ fn binding_establishes_array_history(
         | BindingKind::GetoptsTarget
         | BindingKind::ZparseoptsTarget
         | BindingKind::ArithmeticAssignment
-        | BindingKind::Nameref => binding_is_array_like(binding),
+        | BindingKind::Nameref => semantic.binding_has_array_value_shape(binding.id),
     }
 }
 
-fn binding_establishes_local_scalar_history(binding: &Binding) -> bool {
+fn binding_establishes_local_scalar_history(semantic: &SemanticModel, binding: &Binding) -> bool {
     matches!(
         binding.kind,
         BindingKind::Declaration(DeclarationBuiltin::Local)
     ) && binding
         .attributes
         .contains(BindingAttributes::DECLARATION_INITIALIZED)
-        && !binding_is_array_like(binding)
+        && !semantic.binding_has_array_value_shape(binding.id)
 }
 
 fn binding_resets_array_history(binding: &Binding, builtin_history: &BuiltinArrayHistory) -> bool {
@@ -584,7 +585,7 @@ fn binding_resets_array_history(binding: &Binding, builtin_history: &BuiltinArra
     }
 }
 
-fn declaration_resets_array_history(binding: &Binding) -> bool {
+fn declaration_resets_array_history(semantic: &SemanticModel, binding: &Binding) -> bool {
     match binding.kind {
         BindingKind::Declaration(DeclarationBuiltin::Local) => !binding
             .attributes
@@ -593,7 +594,7 @@ fn declaration_resets_array_history(binding: &Binding) -> bool {
             !binding
                 .attributes
                 .contains(BindingAttributes::DECLARATION_INITIALIZED)
-                && !binding_is_array_like(binding)
+                && !semantic.binding_has_array_value_shape(binding.id)
         }
         BindingKind::Assignment
         | BindingKind::ParameterDefaultAssignment
@@ -717,13 +718,6 @@ fn command_wrapper_is_shadowed_function(
 
 fn contains_span(outer: shuck_ast::Span, inner: shuck_ast::Span) -> bool {
     outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
-}
-
-fn binding_is_array_like(binding: &Binding) -> bool {
-    binding
-        .attributes
-        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
-        || binding.kind == BindingKind::ArrayAssignment
 }
 
 #[cfg(test)]

--- a/crates/shuck-semantic/src/array_use.rs
+++ b/crates/shuck-semantic/src/array_use.rs
@@ -1,0 +1,558 @@
+//! Semantic-owned array-use classification and supporting indexes.
+//!
+//! This module centralizes the meaning-level question "what kind of value does this
+//! reference behave like at this use site?" so the linter facts layer can stay focused on
+//! syntactic candidate discovery and rule-specific suppressions.
+//!
+//! There are two main consumers:
+//! - plain unindexed reference classification via `SemanticModel::reference_array_use_kind`
+//! - zsh unquoted fanout checks via `SemanticValueFlow`, which reuse the same indexes and
+//!   binding-shape predicates defined here
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
+
+use super::*;
+
+/// Lazy semantic indexes shared by array-use classification and zsh fanout checks.
+///
+/// The cached data here falls into two buckets:
+/// - declaration-history indexes used to answer "did a later local scalar barrier or
+///   name-only declaration break inherited array shape?"
+/// - name-based fast paths used by zsh fanout checks to avoid paying for full value-flow
+///   on obviously scalar or obviously array-valued names
+#[derive(Debug)]
+pub(crate) struct ArrayUseIndex {
+    name_only_local_declarations_by_scope_name: FxHashMap<(ScopeId, Name), Vec<Span>>,
+    initialized_scalar_local_declarations_by_scope_name: FxHashMap<(ScopeId, Name), Vec<Span>>,
+    binding_inherits_indexed_array_type: Vec<bool>,
+    binding_has_prior_local_barrier: Vec<bool>,
+    array_like_capable_names: FxHashSet<Name>,
+    single_array_like_bindings: FxHashMap<Name, BindingId>,
+    array_like_bindings_by_name: FxHashMap<Name, SmallVec<[BindingId; 2]>>,
+    uniformly_array_like_names: FxHashSet<Name>,
+}
+
+impl ArrayUseIndex {
+    /// Builds all semantic-owned array-use indexes once from the completed model.
+    fn build(model: &SemanticModel) -> Self {
+        let mut local_declarations_by_scope_name =
+            FxHashMap::<(ScopeId, Name), Vec<Span>>::default();
+        let mut name_only_local_declarations_by_scope_name =
+            FxHashMap::<(ScopeId, Name), Vec<Span>>::default();
+        let mut initialized_scalar_local_declarations_by_scope_name =
+            FxHashMap::<(ScopeId, Name), Vec<Span>>::default();
+        let mut append_local_declaration_spans = FxHashSet::default();
+
+        for declaration in model.declarations() {
+            if !matches!(declaration.builtin, DeclarationBuiltin::Local) {
+                continue;
+            }
+
+            let scope = model.scope_at(declaration.span.start.offset);
+            let declaration_has_array_flag = declaration.operands.iter().any(|operand| {
+                matches!(
+                    operand,
+                    DeclarationOperand::Flag {
+                        flag: 'a' | 'A',
+                        ..
+                    }
+                )
+            });
+            for operand in &declaration.operands {
+                match operand {
+                    DeclarationOperand::Name { name, .. } => {
+                        local_declarations_by_scope_name
+                            .entry((scope, name.clone()))
+                            .or_default()
+                            .push(declaration.span);
+                        name_only_local_declarations_by_scope_name
+                            .entry((scope, name.clone()))
+                            .or_default()
+                            .push(declaration.span);
+                    }
+                    DeclarationOperand::Assignment {
+                        name,
+                        name_span,
+                        append,
+                        ..
+                    } => {
+                        local_declarations_by_scope_name
+                            .entry((scope, name.clone()))
+                            .or_default()
+                            .push(declaration.span);
+                        if !*append && !declaration_has_array_flag {
+                            initialized_scalar_local_declarations_by_scope_name
+                                .entry((scope, name.clone()))
+                                .or_default()
+                                .push(declaration.span);
+                        }
+                        if *append {
+                            append_local_declaration_spans.insert((
+                                scope,
+                                name.clone(),
+                                name_span.start.offset,
+                                name_span.end.offset,
+                            ));
+                        }
+                    }
+                    DeclarationOperand::Flag { .. } | DeclarationOperand::DynamicWord { .. } => {}
+                }
+            }
+        }
+
+        let binding_has_prior_local_barrier = model
+            .bindings()
+            .iter()
+            .map(|binding| {
+                local_declarations_by_scope_name
+                    .get(&(binding.scope, binding.name.clone()))
+                    .is_some_and(|spans| {
+                        spans
+                            .iter()
+                            .any(|span| span.end.offset < binding.span.start.offset)
+                    })
+            })
+            .collect::<Vec<_>>();
+        let binding_is_append_declaration = model
+            .bindings()
+            .iter()
+            .map(|binding| {
+                append_local_declaration_spans.contains(&(
+                    binding.scope,
+                    binding.name.clone(),
+                    binding.span.start.offset,
+                    binding.span.end.offset,
+                ))
+            })
+            .collect::<Vec<_>>();
+
+        let mut binding_inherits_indexed_array_type = vec![false; model.bindings().len()];
+        for binding in model.bindings() {
+            let inherited = if binding_resets_indexed_array_type(binding) {
+                false
+            } else {
+                let initialized_scalar_declaration =
+                    binding_is_initialized_scalar_declaration(binding);
+                let append_declaration = binding_is_append_declaration[binding.id.index()];
+                let prior_local_barrier = binding_has_prior_local_barrier[binding.id.index()];
+                let same_scope_candidate_allowed = !initialized_scalar_declaration
+                    || append_declaration
+                    || model.shell_profile().dialect != ShellDialect::Zsh;
+
+                let mut inherited = false;
+                for candidate_id in model.bindings_for(&binding.name).iter().copied().rev() {
+                    let candidate = model.binding(candidate_id);
+                    if candidate.span.start.offset >= binding.span.start.offset {
+                        continue;
+                    }
+                    if !same_scope_candidate_allowed
+                        && (candidate.scope == binding.scope || prior_local_barrier)
+                    {
+                        continue;
+                    }
+                    if binding_reset_by_name_only_declaration_before(
+                        &name_only_local_declarations_by_scope_name,
+                        candidate,
+                        binding.span,
+                    ) {
+                        continue;
+                    }
+                    if binding_resets_indexed_array_type(candidate) {
+                        inherited = false;
+                        break;
+                    }
+                    if binding_has_sticky_indexed_array_type(candidate) {
+                        inherited = true;
+                        break;
+                    }
+                }
+                inherited
+            };
+            binding_inherits_indexed_array_type[binding.id.index()] = inherited;
+        }
+
+        let mut array_like_capable_names = FxHashSet::default();
+        let mut single_array_like_bindings = FxHashMap::<Name, Option<BindingId>>::default();
+        let mut array_like_bindings_by_name =
+            FxHashMap::<Name, SmallVec<[BindingId; 2]>>::default();
+        let mut uniformly_array_like_names = FxHashMap::<Name, bool>::default();
+
+        for binding in model.bindings() {
+            if !binding_can_supply_parameter_value(binding) {
+                continue;
+            }
+
+            let array_like = binding_has_array_value_shape(binding);
+            if array_like {
+                array_like_capable_names.insert(binding.name.clone());
+                array_like_bindings_by_name
+                    .entry(binding.name.clone())
+                    .or_default()
+                    .push(binding.id);
+            }
+
+            match single_array_like_bindings.entry(binding.name.clone()) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(array_like.then_some(binding.id));
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    entry.insert(None);
+                }
+            }
+
+            match uniformly_array_like_names.entry(binding.name.clone()) {
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(array_like);
+                }
+                std::collections::hash_map::Entry::Occupied(mut entry) => {
+                    if !array_like {
+                        *entry.get_mut() = false;
+                    }
+                }
+            }
+        }
+
+        Self {
+            name_only_local_declarations_by_scope_name,
+            initialized_scalar_local_declarations_by_scope_name,
+            binding_inherits_indexed_array_type,
+            binding_has_prior_local_barrier,
+            array_like_capable_names,
+            single_array_like_bindings: single_array_like_bindings
+                .into_iter()
+                .filter_map(|(name, binding_id)| binding_id.map(|binding_id| (name, binding_id)))
+                .collect(),
+            array_like_bindings_by_name,
+            uniformly_array_like_names: uniformly_array_like_names
+                .into_iter()
+                .filter_map(|(name, uniform)| uniform.then_some(name))
+                .collect(),
+        }
+    }
+}
+
+impl SemanticModel {
+    /// Returns the lazy array-use index shared across semantic array queries.
+    pub(crate) fn array_use_index(&self) -> &ArrayUseIndex {
+        self.array_use_index
+            .get_or_init(|| ArrayUseIndex::build(self))
+    }
+
+    /// Returns whether the binding itself has array value shape at its definition site.
+    ///
+    /// This is the shared predicate used by facts and rules that need the direct shape of a
+    /// binding, independent of inherited array history.
+    #[doc(hidden)]
+    pub fn binding_has_array_value_shape(&self, binding_id: BindingId) -> bool {
+        binding_has_array_value_shape(self.binding(binding_id))
+    }
+
+    /// Returns whether this binding contributes sticky indexed-array type for later plain reads.
+    ///
+    /// Unlike `binding_has_array_value_shape`, this excludes uninitialized `local -a/-A`
+    /// declarations because those reserve array intent without yet making a later plain read
+    /// definitively array-valued.
+    pub(crate) fn binding_has_sticky_indexed_array_type(&self, binding_id: BindingId) -> bool {
+        binding_has_sticky_indexed_array_type(self.binding(binding_id))
+    }
+
+    /// Returns whether the binding can supply a runtime parameter value at all.
+    ///
+    /// This stays semantic-owned so value-flow, fanout checks, and linter consumers all agree on
+    /// which bindings participate in value propagation.
+    #[doc(hidden)]
+    pub fn binding_can_supply_parameter_value(&self, binding_id: BindingId) -> bool {
+        binding_can_supply_parameter_value(self.binding(binding_id))
+    }
+
+    /// Returns whether the binding inherits indexed-array type from earlier visible history.
+    pub(crate) fn binding_inherits_indexed_array_type(&self, binding_id: BindingId) -> bool {
+        self.array_use_index().binding_inherits_indexed_array_type[binding_id.index()]
+    }
+
+    /// Returns whether a prior local declaration in the same scope forms a scalar barrier.
+    pub(crate) fn binding_has_prior_local_barrier(&self, binding_id: BindingId) -> bool {
+        self.array_use_index().binding_has_prior_local_barrier[binding_id.index()]
+    }
+
+    /// Returns whether a later name-only local declaration hides this binding before `at`.
+    pub(crate) fn binding_reset_by_name_only_declaration_before(
+        &self,
+        binding_id: BindingId,
+        at: Span,
+    ) -> bool {
+        binding_reset_by_name_only_declaration_before(
+            &self
+                .array_use_index()
+                .name_only_local_declarations_by_scope_name,
+            self.binding(binding_id),
+            at,
+        )
+    }
+
+    pub(crate) fn name_has_array_value_candidates(&self, name: &Name) -> bool {
+        self.array_use_index()
+            .array_like_capable_names
+            .contains(name)
+    }
+
+    pub(crate) fn single_array_value_binding_for_name(&self, name: &Name) -> Option<BindingId> {
+        self.array_use_index()
+            .single_array_like_bindings
+            .get(name)
+            .copied()
+    }
+
+    pub(crate) fn name_is_uniformly_array_valued(&self, name: &Name) -> bool {
+        self.array_use_index()
+            .uniformly_array_like_names
+            .contains(name)
+    }
+
+    pub(crate) fn array_value_bindings_for_name(&self, name: &Name) -> &[BindingId] {
+        self.array_use_index()
+            .array_like_bindings_by_name
+            .get(name)
+            .map(SmallVec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Returns whether zsh has a prior initialized local scalar declaration that prevents a
+    /// plain unindexed reference from inheriting outer array shape.
+    ///
+    /// This is the semantic part of the old linter-local "scalar local barrier" rule; the facts
+    /// layer still decides whether a classified reference should be suppressed for policy reasons.
+    pub(crate) fn reference_has_prior_zsh_scalar_local_barrier(
+        &self,
+        reference: &Reference,
+    ) -> bool {
+        if self.shell_profile().dialect != ShellDialect::Zsh {
+            return false;
+        }
+
+        let latest_barrier = self
+            .ancestor_scopes(self.scope_at(reference.span.start.offset))
+            .flat_map(|scope| {
+                self.array_use_index()
+                    .initialized_scalar_local_declarations_by_scope_name
+                    .get(&(scope, reference.name.clone()))
+                    .into_iter()
+                    .flatten()
+                    .copied()
+            })
+            .filter(|span| span.end.offset < reference.span.start.offset)
+            .max_by_key(|span| span.start.offset);
+
+        latest_barrier.is_some_and(|barrier| {
+            !self.zsh_array_binding_after_scalar_local_barrier(reference, barrier)
+        })
+    }
+
+    fn zsh_array_binding_after_scalar_local_barrier(
+        &self,
+        reference: &Reference,
+        barrier: Span,
+    ) -> bool {
+        self.bindings_for(&reference.name)
+            .iter()
+            .copied()
+            .any(|binding_id| {
+                let binding = self.binding(binding_id);
+                binding.span.start.offset > barrier.start.offset
+                    && binding.span.start.offset < reference.span.start.offset
+                    && self.binding_visible_at(binding_id, reference.span)
+                    && self.binding_has_sticky_indexed_array_type(binding_id)
+            })
+    }
+
+    /// Classifies a plain unindexed reference by the array semantics visible at that use site.
+    ///
+    /// The returned policy is only produced when the use site is meaningfully array-like after
+    /// considering runtime arrays, inherited array history, name-only declaration resets, and zsh
+    /// scalar-local barriers. Fact-local suppressions such as presence tests or same-command
+    /// reader/writer filtering intentionally remain outside this semantic query.
+    #[doc(hidden)]
+    pub fn reference_array_use_kind(
+        &self,
+        reference_id: ReferenceId,
+    ) -> Option<ArrayReferencePolicy> {
+        let reference = self.reference(reference_id);
+        if is_bash_runtime_array_name(reference.name.as_str()) {
+            return Some(ArrayReferencePolicy::RequiresExplicitSelector);
+        }
+
+        if self.reference_has_prior_zsh_scalar_local_barrier(reference) {
+            return None;
+        }
+
+        if let Some(binding) = self.resolved_binding(reference.id)
+            && self.binding_visible_at(binding.id, reference.span)
+            && !self.binding_has_sticky_indexed_array_type(binding.id)
+            && !self.binding_inherits_indexed_array_type(binding.id)
+            && (binding_resets_indexed_array_type(binding)
+                || self.binding_has_prior_local_barrier(binding.id)
+                || (self.shell_profile().dialect == ShellDialect::Zsh
+                    && binding_is_initialized_scalar_declaration(binding)))
+        {
+            return None;
+        }
+
+        let mut binding_ids = Vec::new();
+        let mut seen = FxHashSet::default();
+        if let Some(binding) = self.resolved_binding(reference.id)
+            && !self.binding_has_sticky_indexed_array_type(binding.id)
+            && seen.insert(binding.id)
+        {
+            binding_ids.push(binding.id);
+        }
+        for binding_id in self.visible_candidate_bindings_for_reference(reference) {
+            if seen.insert(binding_id) {
+                binding_ids.push(binding_id);
+            }
+        }
+
+        let array_like = binding_ids.into_iter().any(|binding_id| {
+            !self.binding_reset_by_name_only_declaration_before(binding_id, reference.span)
+                && (self.binding_has_sticky_indexed_array_type(binding_id)
+                    || self.binding_inherits_indexed_array_type(binding_id))
+        });
+        if !array_like {
+            return None;
+        }
+
+        Some(
+            self.shell_behavior_at(reference.span.start.offset)
+                .array_reference_policy(),
+        )
+    }
+}
+
+fn binding_reset_by_name_only_declaration_before(
+    name_only_local_declarations_by_scope_name: &FxHashMap<(ScopeId, Name), Vec<Span>>,
+    binding: &Binding,
+    at: Span,
+) -> bool {
+    name_only_local_declarations_by_scope_name
+        .get(&(binding.scope, binding.name.clone()))
+        .is_some_and(|spans| {
+            spans.iter().any(|span| {
+                span.start.offset > binding.span.start.offset && span.end.offset < at.start.offset
+            })
+        })
+}
+
+/// Returns whether the binding directly carries array value shape at its own definition.
+fn binding_has_array_value_shape(binding: &Binding) -> bool {
+    binding
+        .attributes
+        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+        || matches!(
+            binding.kind,
+            BindingKind::ArrayAssignment | BindingKind::MapfileTarget
+        )
+}
+
+/// Returns whether this binding should keep indexed-array type sticky for later plain reads.
+fn binding_has_sticky_indexed_array_type(binding: &Binding) -> bool {
+    !binding_is_uninitialized_local_array_declaration(binding)
+        && (binding.attributes.contains(BindingAttributes::ARRAY)
+            || matches!(
+                binding.kind,
+                BindingKind::ArrayAssignment | BindingKind::MapfileTarget
+            ))
+}
+
+/// Returns whether this binding participates in value flow for parameter reads.
+fn binding_can_supply_parameter_value(binding: &Binding) -> bool {
+    match binding.origin {
+        BindingOrigin::FunctionDefinition { .. } => false,
+        BindingOrigin::Declaration { .. } => {
+            binding_is_name_only_declaration(binding)
+                || binding.attributes.intersects(
+                    BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
+                )
+        }
+        _ => true,
+    }
+}
+
+/// Returns whether the binding is a name-only local declaration like `local foo`.
+fn binding_is_name_only_declaration(binding: &Binding) -> bool {
+    matches!(binding.origin, BindingOrigin::Declaration { .. })
+        && binding.attributes.contains(BindingAttributes::LOCAL)
+        && !binding
+            .attributes
+            .contains(BindingAttributes::DECLARATION_INITIALIZED)
+}
+
+/// Returns whether this binding breaks inherited indexed-array type for later plain reads.
+fn binding_resets_indexed_array_type(binding: &Binding) -> bool {
+    matches!(
+        binding.kind,
+        BindingKind::ArithmeticAssignment
+            | BindingKind::GetoptsTarget
+            | BindingKind::Imported
+            | BindingKind::LoopVariable
+            | BindingKind::PrintfTarget
+    ) || (matches!(binding.kind, BindingKind::ReadTarget)
+        && !binding.attributes.contains(BindingAttributes::ARRAY))
+        || (matches!(binding.kind, BindingKind::Declaration(_))
+            && !binding
+                .attributes
+                .contains(BindingAttributes::DECLARATION_INITIALIZED)
+            && !binding
+                .attributes
+                .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC))
+}
+
+/// Returns whether this binding is an initialized scalar declaration such as `local foo=value`.
+fn binding_is_initialized_scalar_declaration(binding: &Binding) -> bool {
+    matches!(binding.kind, BindingKind::Declaration(_))
+        && binding
+            .attributes
+            .contains(BindingAttributes::DECLARATION_INITIALIZED)
+        && !binding
+            .attributes
+            .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+}
+
+/// Returns whether this binding is only reserving an array-shaped local without initializing it.
+fn binding_is_uninitialized_local_array_declaration(binding: &Binding) -> bool {
+    matches!(
+        binding.kind,
+        BindingKind::Declaration(DeclarationBuiltin::Local)
+    ) && binding
+        .attributes
+        .intersects(BindingAttributes::ARRAY | BindingAttributes::ASSOC)
+        && !binding
+            .attributes
+            .contains(BindingAttributes::DECLARATION_INITIALIZED)
+}
+
+/// Returns whether the name is one of bash's predefined runtime arrays.
+///
+/// This stays as a name-based check rather than `reference_is_predefined_runtime_array` because
+/// we intentionally preserve the linter's historical behavior for these names even outside bash
+/// profile setup and even after local scalar rebinding.
+fn is_bash_runtime_array_name(name: &str) -> bool {
+    matches!(
+        name,
+        "BASH_ALIASES"
+            | "BASH_ARGC"
+            | "BASH_ARGV"
+            | "BASH_CMDS"
+            | "BASH_LINENO"
+            | "BASH_REMATCH"
+            | "BASH_SOURCE"
+            | "BASH_VERSINFO"
+            | "COMP_WORDS"
+            | "COMPREPLY"
+            | "COPROC"
+            | "DIRSTACK"
+            | "FUNCNAME"
+            | "GROUPS"
+            | "MAPFILE"
+            | "PIPESTATUS"
+    )
+}

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -6,6 +6,7 @@
 //! The semantic model tracks scopes, bindings, references, control flow, and selected dataflow
 //! facts so higher-level crates can reason about shell behavior without re-traversing the AST.
 mod analysis;
+mod array_use;
 mod binding;
 mod builder;
 mod call_graph;
@@ -791,6 +792,7 @@ pub struct SemanticModel {
     function_bindings_by_scope: OnceLock<FxHashMap<ScopeId, SmallVec<[BindingId; 2]>>>,
     visible_function_call_bindings: OnceLock<FxHashMap<SpanKey, BindingId>>,
     function_definition_binding_ids: OnceLock<Vec<BindingId>>,
+    array_use_index: OnceLock<array_use::ArrayUseIndex>,
 }
 
 /// Lazy analysis view over a `SemanticModel`.
@@ -904,6 +906,7 @@ impl SemanticModel {
             function_bindings_by_scope: OnceLock::new(),
             visible_function_call_bindings: OnceLock::new(),
             function_definition_binding_ids: OnceLock::new(),
+            array_use_index: OnceLock::new(),
         }
     }
 

--- a/crates/shuck-semantic/src/tests.rs
+++ b/crates/shuck-semantic/src/tests.rs
@@ -5018,6 +5018,83 @@ printf done
 }
 
 #[test]
+fn value_flow_direct_reference_tracks_zsh_unquoted_array_fanout() {
+    let source = "\
+#!/bin/zsh
+foo=(a b)
+print $foo
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+
+    assert!(value_flow.reference_can_fan_out_when_unquoted(reference.id));
+
+    let disabled_source = "\
+#!/bin/zsh
+setopt ksh_arrays
+foo=(a b)
+print $foo
+";
+    let disabled_model =
+        model_with_profile(disabled_source, ShellProfile::native(ShellDialect::Zsh));
+    let disabled_reference = disabled_model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "foo")
+        .expect("expected foo reference");
+    let disabled_analysis = disabled_model.analysis();
+    let disabled_value_flow = disabled_analysis.value_flow();
+
+    assert!(!disabled_value_flow.reference_can_fan_out_when_unquoted(disabled_reference.id));
+}
+
+#[test]
+fn value_flow_synthetic_use_site_tracks_zsh_unquoted_array_fanout() {
+    let source = "\
+#!/bin/zsh
+foo=(a b)
+printf done
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+    let printf = command_id_starting_with(&model, source, "printf").expect("expected printf");
+    let use_span = model.command_span(printf);
+    let analysis = model.analysis();
+    let value_flow = analysis.value_flow();
+
+    assert!(value_flow.name_can_fan_out_when_unquoted_without_reference(
+        &Name::from("foo"),
+        use_span,
+        model.scope_at(use_span.start.offset),
+    ));
+
+    let scalar_source = "\
+#!/bin/zsh
+foo=scalar
+printf done
+";
+    let scalar_model = model_with_profile(scalar_source, ShellProfile::native(ShellDialect::Zsh));
+    let scalar_printf =
+        command_id_starting_with(&scalar_model, scalar_source, "printf").expect("expected printf");
+    let scalar_use_span = scalar_model.command_span(scalar_printf);
+    let scalar_analysis = scalar_model.analysis();
+    let scalar_value_flow = scalar_analysis.value_flow();
+
+    assert!(
+        !scalar_value_flow.name_can_fan_out_when_unquoted_without_reference(
+            &Name::from("foo"),
+            scalar_use_span,
+            scalar_model.scope_at(scalar_use_span.start.offset),
+        )
+    );
+}
+
+#[test]
 fn value_flow_can_bypass_one_reaching_binding() {
     let source = "\
 #!/bin/bash
@@ -11487,6 +11564,122 @@ fn semantic_shell_behavior_uses_selector_policy_for_non_zsh_profiles() {
         array_reference_policy_at(&model, offset),
         ArrayReferencePolicy::RequiresExplicitSelector,
         "{source}"
+    );
+}
+
+#[test]
+fn reference_array_use_kind_tracks_zsh_runtime_policy_states() {
+    for (source, expected) in [
+        (
+            "\
+#!/bin/zsh
+arr=(one two)
+print $arr
+",
+            Some(ArrayReferencePolicy::NativeZshScalar),
+        ),
+        (
+            "\
+#!/bin/zsh
+setopt ksh_arrays
+arr=(one two)
+print $arr
+",
+            Some(ArrayReferencePolicy::RequiresExplicitSelector),
+        ),
+        (
+            "\
+#!/bin/zsh
+opt=ksh_arrays
+setopt \"$opt\"
+arr=(one two)
+print $arr
+",
+            Some(ArrayReferencePolicy::Ambiguous),
+        ),
+    ] {
+        let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+        let reference = model
+            .references()
+            .iter()
+            .find(|reference| reference.name == "arr")
+            .expect("expected arr reference");
+
+        assert_eq!(
+            model.reference_array_use_kind(reference.id),
+            expected,
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn reference_array_use_kind_preserves_inherited_array_shape() {
+    let source = "\
+#!/bin/bash
+declare -a items
+items=scalar
+printf '%s\\n' \"$items\"
+";
+    let model = model(source);
+    let reference = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "items")
+        .expect("expected items reference");
+
+    assert_eq!(
+        model.reference_array_use_kind(reference.id),
+        Some(ArrayReferencePolicy::RequiresExplicitSelector)
+    );
+}
+
+#[test]
+fn reference_array_use_kind_suppresses_after_zsh_scalar_local_barrier() {
+    let source = "\
+#!/bin/zsh
+items=(one two)
+fn() {
+  local items=value
+  print $items
+}
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Zsh));
+    let reference = model
+        .references()
+        .iter()
+        .rfind(|reference| reference.name == "items")
+        .expect("expected items reference");
+
+    assert_eq!(model.reference_array_use_kind(reference.id), None);
+}
+
+#[test]
+fn reference_array_use_kind_reports_bash_runtime_arrays_without_bash_profile() {
+    let source = "\
+#!/bin/sh
+MAPFILE=scalar
+printf '%s\\n' \"$MAPFILE\" \"$BASH_SOURCE\"
+";
+    let model = model_with_profile(source, ShellProfile::native(ShellDialect::Posix));
+    let mapfile = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "MAPFILE")
+        .expect("expected MAPFILE reference");
+    let bash_source = model
+        .references()
+        .iter()
+        .find(|reference| reference.name == "BASH_SOURCE")
+        .expect("expected BASH_SOURCE reference");
+
+    assert_eq!(
+        model.reference_array_use_kind(mapfile.id),
+        Some(ArrayReferencePolicy::RequiresExplicitSelector)
+    );
+    assert_eq!(
+        model.reference_array_use_kind(bash_source.id),
+        Some(ArrayReferencePolicy::RequiresExplicitSelector)
     );
 }
 

--- a/crates/shuck-semantic/src/value_flow.rs
+++ b/crates/shuck-semantic/src/value_flow.rs
@@ -73,6 +73,93 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         bindings
     }
 
+    /// Returns whether a direct semantic reference may fan out to multiple fields when used
+    /// unquoted under zsh's native array semantics.
+    #[doc(hidden)]
+    pub fn reference_can_fan_out_when_unquoted(&self, reference_id: ReferenceId) -> bool {
+        let reference = self.model().reference(reference_id);
+        if matches!(
+            self.model()
+                .shell_behavior_at(reference.span.start.offset)
+                .array_reference_policy(),
+            ArrayReferencePolicy::RequiresExplicitSelector
+        ) || !self
+            .model()
+            .name_has_array_value_candidates(&reference.name)
+        {
+            return false;
+        }
+
+        if let Some(binding_id) = self
+            .model()
+            .single_array_value_binding_for_name(&reference.name)
+            && self.model().binding_visible_at(binding_id, reference.span)
+        {
+            return true;
+        }
+
+        if self.model().name_is_uniformly_array_valued(&reference.name)
+            && self
+                .model()
+                .visible_binding(&reference.name, reference.span)
+                .is_some()
+        {
+            return true;
+        }
+
+        if self
+            .model()
+            .resolved_binding(reference_id)
+            .is_some_and(|binding| self.model().binding_has_array_value_shape(binding.id))
+        {
+            return true;
+        }
+
+        self.reference_reaches_any_value_binding(
+            reference_id,
+            self.model().array_value_bindings_for_name(&reference.name),
+        )
+    }
+
+    /// Returns whether a named use site that lacks a direct semantic reference may fan out to
+    /// multiple fields when used unquoted under zsh's native array semantics.
+    #[doc(hidden)]
+    pub fn name_can_fan_out_when_unquoted_without_reference(
+        &self,
+        name: &Name,
+        at: Span,
+        scope: ScopeId,
+    ) -> bool {
+        if matches!(
+            self.model()
+                .shell_behavior_at(at.start.offset)
+                .array_reference_policy(),
+            ArrayReferencePolicy::RequiresExplicitSelector
+        ) || !self.model().name_has_array_value_candidates(name)
+        {
+            return false;
+        }
+
+        if let Some(binding_id) = self.model().single_array_value_binding_for_name(name)
+            && self.model().binding_visible_at(binding_id, at)
+        {
+            return true;
+        }
+
+        if self.model().name_is_uniformly_array_valued(name)
+            && self.model().visible_binding(name, at).is_some()
+        {
+            return true;
+        }
+
+        let synthetic_use_block = self
+            .analysis
+            .flow_entry_block_for_binding_scopes(&[scope], at.start.offset);
+        self.reaching_value_bindings_for_name_without_reference(name, at, synthetic_use_block)
+            .into_iter()
+            .any(|binding_id| self.model().binding_has_array_value_shape(binding_id))
+    }
+
     /// Returns true when `reference_id` may observe any candidate binding from the provided set.
     /// Callers are expected to prefilter the candidate list to bindings that can supply a
     /// parameter value. This is a narrow fast path for callers that already know the small subset
@@ -403,17 +490,7 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
 
     /// Returns whether `binding_id` can contribute a runtime parameter value.
     pub fn binding_can_supply_parameter_value(&self, binding_id: BindingId) -> bool {
-        let binding = self.model().binding(binding_id);
-        match binding.origin {
-            BindingOrigin::FunctionDefinition { .. } => false,
-            BindingOrigin::Declaration { .. } => {
-                binding_is_name_only_declaration(binding)
-                    || binding.attributes.intersects(
-                        BindingAttributes::DECLARATION_INITIALIZED | BindingAttributes::INTEGER,
-                    )
-            }
-            _ => true,
-        }
+        self.model().binding_can_supply_parameter_value(binding_id)
     }
 
     fn synthetic_reaching_value_bindings_for_name(
@@ -1009,15 +1086,6 @@ impl<'analysis, 'model> SemanticValueFlow<'analysis, 'model> {
         self.analysis.model
     }
 }
-
-fn binding_is_name_only_declaration(binding: &Binding) -> bool {
-    matches!(binding.origin, BindingOrigin::Declaration { .. })
-        && binding.attributes.contains(BindingAttributes::LOCAL)
-        && !binding
-            .attributes
-            .contains(BindingAttributes::DECLARATION_INITIALIZED)
-}
-
 fn span_contains(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && inner.end.offset <= outer.end.offset
 }


### PR DESCRIPTION
## Summary
- move plain unindexed array-use classification and zsh unquoted fanout checks into `shuck-semantic`
- simplify linter facts and array rules to consume semantic-owned queries and shared binding predicates
- cache escaped `\\${...}` template body spans per word so array and brace fact builders stop rediscovering the same source regions

## Validation
- `cargo test -p shuck-semantic -p shuck-linter`
- `make test-large-corpus`

## Notes
- large corpus stayed clean with `blocking=0`, `implementation_diffs=0`, and `mapping_issues=0`
- this also keeps the post-rebase traversal wiring aligned with current `main`
