### PR TITLE
fix(linter): handle missing xargs option arguments

### DIFF
--- a/crates/shuck-linter/src/facts/command_options/xargs.rs
+++ b/crates/shuck-linter/src/facts/command_options/xargs.rs
@@ -89,14 +89,16 @@ pub(super) fn parse_xargs_command<'a>(args: &[&'a Word], source: &str) -> XargsC
         }
     }
 
+    let command_operand_words = args.get(index..).unwrap_or(&[]);
+
     XargsCommandFacts {
         uses_null_input,
         max_procs,
         zero_digit_option_word,
         inline_replace_options: inline_replace_options.into_boxed_slice(),
-        command_operand_words: args[index..].to_vec().into_boxed_slice(),
+        command_operand_words: command_operand_words.to_vec().into_boxed_slice(),
         sc2267_default_replace_silent_shape: xargs_sc2267_default_replace_silent_shape(
-            &args[index..],
+            command_operand_words,
             source,
         ),
     }

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -3278,6 +3278,33 @@ find . | xargs -P11 echo
 }
 
 #[test]
+fn handles_xargs_options_with_missing_required_arguments() {
+    let source = "\
+#!/bin/bash
+ls *.txt | xargs -n
+find . | xargs --max-procs
+";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+
+    let xargs_facts = facts
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("xargs"))
+        .filter_map(|fact| fact.options().xargs())
+        .collect::<Vec<_>>();
+
+    assert_eq!(xargs_facts.len(), 2);
+    assert!(
+        xargs_facts
+            .iter()
+            .all(|xargs| xargs.command_operand_words().is_empty())
+    );
+}
+
+#[test]
 fn rm_command_facts_track_shellcheck_style_variable_path_hazards() {
     let source = "\
 #!/bin/bash


### PR DESCRIPTION
## Summary
- Avoid slicing past the end of xargs arguments when an option that requires a value appears without one.
- Add a regression test for trailing `xargs -n` and `xargs --max-procs` inputs.

## Root Cause
The xargs option facts parser advanced past the end of the argument list for malformed required-argument options, then sliced `args[index..]` while building command operand facts.

Fixes #994.

## Validation
- Replayed the downloaded `linter_no_panic_fuzz` crash artifact with `rustup run nightly cargo fuzz run --sanitizer=none linter_no_panic_fuzz ...`
- `cargo fmt --check`
- `cargo test -p shuck-linter handles_xargs_options_with_missing_required_arguments`
- `cargo test -p shuck-linter`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`