### PR TITLE
fix(linter): keep unicode quote spans source-backed

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -871,7 +871,7 @@ impl<'a> SurfaceFragmentSink<'a> {
         if let WordPart::Literal(text) = &part.kind
             && !in_double_quote
         {
-            let literal = text.as_str(self.source, part.span);
+            let literal = text.syntax_str(self.source, part.span);
             if literal.as_bytes().contains(&UNICODE_SMART_QUOTE_LEAD_BYTE) {
                 for (offset, char) in literal.char_indices() {
                     if !is_unicode_smart_quote(char) {

--- a/crates/shuck-linter/src/facts/tests/surface.rs
+++ b/crates/shuck-linter/src/facts/tests/surface.rs
@@ -837,6 +837,22 @@ echo 'hello ‘world’'
 }
 
 #[test]
+fn builds_unicode_smart_quote_spans_from_source_offsets_for_escaped_literals() {
+    let source = "#!/bin/sh\necho “hello\\${”\n";
+
+    with_facts(source, None, |_, facts| {
+        assert_eq!(
+            facts
+                .unicode_smart_quote_spans()
+                .iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["“", "”"]
+        );
+    });
+}
+
+#[test]
 fn ignores_unicode_smart_quotes_in_heredoc_payloads() {
     let source = "\
 #!/bin/sh


### PR DESCRIPTION
## Summary
- Build C072 unicode smart quote facts from source syntax text instead of cooked literal text
- Add a regression for escaped literal text where cooked offsets drift from raw source offsets

## Root Cause
The linter fact builder scanned cooked literal text, then used those cooked offsets to construct spans in the original source. Escaped text such as `echo “hello\\${”` could make the second smart quote span point at the wrong bytes, and the diagnostic fix path then hit an internal unreachable assertion.

Fixes #997.

## Validation
- `cargo test -p shuck-linter builds_unicode_smart_quote_spans_from_source_offsets_for_escaped_literals`
- `rustup run nightly cargo fuzz run --sanitizer=none linter_no_panic_fuzz /tmp/shuck-fuzz-997/crash-2bc3d3d87e3b91df9f8968a04cac4db7440e7058`
- `cargo fmt --check`