### PR TITLE
fix(linter): add documented autofixes

### DIFF
--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -469,6 +469,28 @@ fn zsh_literal_assignment_value_for_command_name_check<'a>(
 struct EnvPrefixScopeSpans {
     assignment_scope_spans: Vec<Span>,
     expansion_scope_spans: Vec<Span>,
+    expansion_fix_facts: Vec<EnvPrefixExpansionFixFact>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EnvPrefixExpansionFixFact {
+    diagnostic_span: Span,
+    assignment_spans: Vec<Span>,
+    delete_span: Span,
+}
+
+impl EnvPrefixExpansionFixFact {
+    pub fn diagnostic_span(&self) -> Span {
+        self.diagnostic_span
+    }
+
+    pub fn assignment_spans(&self) -> &[Span] {
+        &self.assignment_spans
+    }
+
+    pub fn delete_span(&self) -> Span {
+        self.delete_span
+    }
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
@@ -488,6 +510,7 @@ fn build_env_prefix_scope_spans(
 
         let command_span = command.span();
         let assignments = command_assignments(command.command());
+        let fix_seed = env_prefix_expansion_fix_seed(source, assignments);
         let broken_legacy_bracket_tail = match command.command() {
             Command::Simple(simple) => broken_legacy_bracket_tail(simple, source),
             Command::Builtin(_)
@@ -571,10 +594,12 @@ fn build_env_prefix_scope_spans(
                     other,
                     &assignment.target.name,
                     &mut |span| {
-                        push_fact_span(
+                        push_env_prefix_expansion_fact(
                             span,
+                            fix_seed.as_ref(),
                             &mut scope_spans.expansion_scope_spans,
                             &mut seen_expansion_scope_spans,
+                            &mut scope_spans.expansion_fix_facts,
                         );
                         ControlFlow::Continue(())
                     },
@@ -591,10 +616,12 @@ fn build_env_prefix_scope_spans(
                             tail,
                             &assignment.target.name,
                             &mut |span| {
-                                push_fact_span(
+                                push_env_prefix_expansion_fact(
                                     span,
+                                    fix_seed.as_ref(),
                                     &mut scope_spans.expansion_scope_spans,
                                     &mut seen_expansion_scope_spans,
+                                    &mut scope_spans.expansion_fix_facts,
                                 );
                                 ControlFlow::Continue(())
                             },
@@ -622,10 +649,12 @@ fn build_env_prefix_scope_spans(
                     assignment,
                     &assignment.target.name,
                     &mut |span| {
-                        push_fact_span(
+                        push_env_prefix_expansion_fact(
                             span,
+                            fix_seed.as_ref(),
                             &mut scope_spans.expansion_scope_spans,
                             &mut seen_expansion_scope_spans,
+                            &mut scope_spans.expansion_fix_facts,
                         );
                         ControlFlow::Continue(())
                     },
@@ -638,10 +667,12 @@ fn build_env_prefix_scope_spans(
                 source,
                 &assignment.target.name,
                 &mut |span| {
-                    push_fact_span(
+                    push_env_prefix_expansion_fact(
                         span,
+                        fix_seed.as_ref(),
                         &mut scope_spans.expansion_scope_spans,
                         &mut seen_expansion_scope_spans,
+                        &mut scope_spans.expansion_fix_facts,
                     );
                     ControlFlow::Continue(())
                 },
@@ -656,6 +687,80 @@ fn build_env_prefix_scope_spans(
         .expansion_scope_spans
         .sort_by_key(|span| (span.start.offset, span.end.offset));
     scope_spans
+        .expansion_fix_facts
+        .sort_by_key(|fact| (fact.diagnostic_span.start.offset, fact.diagnostic_span.end.offset));
+    scope_spans
+}
+
+#[derive(Debug, Clone)]
+struct EnvPrefixExpansionFixSeed {
+    assignment_spans: Vec<Span>,
+    delete_span: Span,
+}
+
+impl EnvPrefixExpansionFixSeed {
+    fn for_diagnostic(&self, diagnostic_span: Span) -> EnvPrefixExpansionFixFact {
+        EnvPrefixExpansionFixFact {
+            diagnostic_span,
+            assignment_spans: self.assignment_spans.clone(),
+            delete_span: self.delete_span,
+        }
+    }
+}
+
+fn env_prefix_expansion_fix_seed(
+    source: &str,
+    assignments: &[Assignment],
+) -> Option<EnvPrefixExpansionFixSeed> {
+    let first_assignment = assignments.first()?;
+    let last_assignment = assignments.last()?;
+    let prefix = source.get(line_start_offset(source, first_assignment.span.start.offset)..first_assignment.span.start.offset)?;
+    if !prefix.bytes().all(|byte| matches!(byte, b' ' | b'\t')) {
+        return None;
+    }
+
+    let body_start = skip_env_prefix_separator(source, last_assignment.span.end)?;
+    if body_start.offset <= last_assignment.span.end.offset {
+        return None;
+    }
+
+    Some(EnvPrefixExpansionFixSeed {
+        assignment_spans: assignments
+            .iter()
+            .map(|assignment| assignment.span)
+            .collect(),
+        delete_span: Span::from_positions(first_assignment.span.start, body_start),
+    })
+}
+
+fn line_start_offset(source: &str, offset: usize) -> usize {
+    source[..offset]
+        .rfind('\n')
+        .map_or(0, |newline| newline + '\n'.len_utf8())
+}
+
+fn skip_env_prefix_separator(source: &str, start: Position) -> Option<Position> {
+    let mut position = start;
+    let mut tail = source.get(start.offset..)?;
+    while let Some(ch) = tail.chars().next() {
+        if matches!(ch, ' ' | '\t' | '\r' | '\n') {
+            position.advance(ch);
+            tail = &tail[ch.len_utf8()..];
+            continue;
+        }
+        if ch == '\\' {
+            let mut chars = tail.chars();
+            let _ = chars.next();
+            if matches!(chars.next(), Some('\n')) {
+                position.advance('\\');
+                position.advance('\n');
+                tail = &tail['\\'.len_utf8() + '\n'.len_utf8()..];
+                continue;
+            }
+        }
+        break;
+    }
+    Some(position)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1002,10 +1107,29 @@ fn parameter_is_plain_access_to_name(parameter: &ParameterExpansion, name: &Name
     }
 }
 
-fn push_fact_span(span: Span, spans: &mut Vec<Span>, seen: &mut FxHashSet<FactSpan>) {
+fn push_fact_span(span: Span, spans: &mut Vec<Span>, seen: &mut FxHashSet<FactSpan>) -> bool {
     let key = FactSpan::new(span);
     if seen.insert(key) {
         spans.push(span);
+        true
+    } else {
+        false
+    }
+}
+
+fn push_env_prefix_expansion_fact(
+    span: Span,
+    fix_seed: Option<&EnvPrefixExpansionFixSeed>,
+    spans: &mut Vec<Span>,
+    seen: &mut FxHashSet<FactSpan>,
+    fix_facts: &mut Vec<EnvPrefixExpansionFixFact>,
+) {
+    if !push_fact_span(span, spans, seen) {
+        return;
+    }
+
+    if let Some(seed) = fix_seed {
+        fix_facts.push(seed.for_diagnostic(span));
     }
 }
 

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -809,6 +809,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         let EnvPrefixScopeSpans {
             assignment_scope_spans: env_prefix_assignment_scope_spans,
             expansion_scope_spans: env_prefix_expansion_scope_spans,
+            expansion_fix_facts: env_prefix_expansion_fix_facts,
         } = build_env_prefix_scope_spans(self.source, self.semantic, &commands);
         let unset_command_ids_by_target_name = build_unset_command_ids_by_target_name(
             &commands,
@@ -959,6 +960,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             ifs_literal_backslash_assignment_value_spans,
             env_prefix_assignment_scope_spans,
             env_prefix_expansion_scope_spans,
+            env_prefix_expansion_fix_facts,
             unset_command_ids_by_target_name,
             function_unset_command_ids_by_target_name,
             presence_tested_names: presence_tested_names.global_names,

--- a/crates/shuck-linter/src/facts/command_options/find.rs
+++ b/crates/shuck-linter/src/facts/command_options/find.rs
@@ -266,6 +266,11 @@ pub(super) fn parse_find_command<'a>(
             continue;
         }
 
+        if is_find_not_token(text.as_ref()) {
+            state.note_branch_prefix(word.span);
+            continue;
+        }
+
         if is_find_branch_action_token(text.as_ref()) {
             if matches!(text.as_ref(), "-fprint0" | "-printf" | "-fprintf") {
                 has_formatted_output_action = true;
@@ -377,6 +382,10 @@ impl FindGroupState {
         self.current_branch_has_explicit_and = true;
     }
 
+    fn note_branch_prefix(&mut self, span: Span) {
+        self.current_branch_start.get_or_insert(span);
+    }
+
     fn note_predicate(&mut self, span: Span) {
         self.current_branch_start.get_or_insert(span);
         self.current_branch_has_predicate = true;
@@ -442,6 +451,10 @@ fn is_find_or_token(token: &str) -> bool {
 
 fn is_find_and_token(token: &str) -> bool {
     matches!(token, "-a" | "-and" | ",")
+}
+
+fn is_find_not_token(token: &str) -> bool {
+    matches!(token, "!" | "-not")
 }
 
 fn is_find_action_token(token: &str) -> bool {
@@ -525,5 +538,5 @@ fn is_find_predicate_token(token: &str) -> bool {
         && !is_find_and_token(token)
         && !is_find_group_open_token(token)
         && !is_find_group_close_token(token)
-        && !matches!(token, "-not")
+        && !is_find_not_token(token)
 }

--- a/crates/shuck-linter/src/facts/command_options/find.rs
+++ b/crates/shuck-linter/src/facts/command_options/find.rs
@@ -193,6 +193,7 @@ pub(super) fn parse_find_command<'a>(
     let mut has_print0 = false;
     let mut has_formatted_output_action = false;
     let mut or_without_grouping_spans = Vec::new();
+    let mut or_without_grouping_fix_spans = Vec::new();
     let mut glob_pattern_operand_spans = Vec::new();
     let mut group_stack = vec![FindGroupState::default()];
     let mut pending_argument: Option<FindPendingArgument> = None;
@@ -269,17 +270,20 @@ pub(super) fn parse_find_command<'a>(
             if matches!(text.as_ref(), "-fprint0" | "-printf" | "-fprintf") {
                 has_formatted_output_action = true;
             }
+            let pending = find_pending_argument(text.as_ref());
             state.note_action(
                 word.span,
                 is_find_reportable_action_token(text.as_ref()),
+                pending.is_none(),
                 &mut or_without_grouping_spans,
+                &mut or_without_grouping_fix_spans,
             );
-            pending_argument = find_pending_argument(text.as_ref());
+            pending_argument = pending;
             continue;
         }
 
         if is_find_predicate_token(text.as_ref()) {
-            state.note_predicate();
+            state.note_predicate(word.span);
             pending_argument = find_pending_argument(text.as_ref());
         }
     }
@@ -288,6 +292,7 @@ pub(super) fn parse_find_command<'a>(
         has_print0,
         has_formatted_output_action,
         or_without_grouping_spans: or_without_grouping_spans.into_boxed_slice(),
+        or_without_grouping_fix_spans: or_without_grouping_fix_spans.into_boxed_slice(),
         glob_pattern_operand_spans: glob_pattern_operand_spans.into_boxed_slice(),
     }
 }
@@ -351,6 +356,7 @@ struct FindGroupState {
     saw_action_before_current_branch: bool,
     current_branch_has_predicate: bool,
     current_branch_has_explicit_and: bool,
+    current_branch_start: Option<Span>,
     has_any_predicate: bool,
     has_any_action: bool,
 }
@@ -364,24 +370,42 @@ impl FindGroupState {
         self.saw_or = true;
         self.current_branch_has_predicate = false;
         self.current_branch_has_explicit_and = false;
+        self.current_branch_start = None;
     }
 
     fn note_and(&mut self) {
         self.current_branch_has_explicit_and = true;
     }
 
-    fn note_predicate(&mut self) {
+    fn note_predicate(&mut self, span: Span) {
+        self.current_branch_start.get_or_insert(span);
         self.current_branch_has_predicate = true;
         self.has_any_predicate = true;
     }
 
-    fn note_action(&mut self, span: Span, reportable: bool, spans: &mut Vec<Span>) {
+    fn note_action(
+        &mut self,
+        span: Span,
+        reportable: bool,
+        fixable_without_action_arguments: bool,
+        spans: &mut Vec<Span>,
+        fix_spans: &mut Vec<FindOrWithoutGroupingFixSpan>,
+    ) {
         if reportable
             && self.saw_or
             && !self.saw_action_before_current_branch
             && self.current_branch_can_bind_action()
         {
             spans.push(span);
+            if fixable_without_action_arguments
+                && let Some(branch_start) = self.current_branch_start
+            {
+                fix_spans.push(FindOrWithoutGroupingFixSpan {
+                    diagnostic_span: span,
+                    branch_start,
+                    action_span: span,
+                });
+            }
         }
 
         self.saw_action_before_current_branch = true;
@@ -390,7 +414,11 @@ impl FindGroupState {
 
     fn incorporate_group(&mut self, child: Self) {
         if child.has_any_predicate {
-            self.note_predicate();
+            if let Some(span) = child.current_branch_start {
+                self.current_branch_start.get_or_insert(span);
+            }
+            self.current_branch_has_predicate = true;
+            self.has_any_predicate = true;
         }
 
         if child.has_any_action {

--- a/crates/shuck-linter/src/facts/command_options/mod.rs
+++ b/crates/shuck-linter/src/facts/command_options/mod.rs
@@ -226,6 +226,7 @@ pub struct FindCommandFacts {
     pub has_print0: bool,
     has_formatted_output_action: bool,
     or_without_grouping_spans: Box<[Span]>,
+    or_without_grouping_fix_spans: Box<[FindOrWithoutGroupingFixSpan]>,
     glob_pattern_operand_spans: Box<[Span]>,
 }
 
@@ -238,9 +239,20 @@ impl FindCommandFacts {
         &self.or_without_grouping_spans
     }
 
+    pub fn or_without_grouping_fix_spans(&self) -> &[FindOrWithoutGroupingFixSpan] {
+        &self.or_without_grouping_fix_spans
+    }
+
     pub fn glob_pattern_operand_spans(&self) -> &[Span] {
         &self.glob_pattern_operand_spans
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct FindOrWithoutGroupingFixSpan {
+    pub diagnostic_span: Span,
+    pub branch_start: Span,
+    pub action_span: Span,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -22,6 +22,7 @@ pub struct LinterFacts<'a> {
     ifs_literal_backslash_assignment_value_spans: Vec<Span>,
     env_prefix_assignment_scope_spans: Vec<Span>,
     env_prefix_expansion_scope_spans: Vec<Span>,
+    env_prefix_expansion_fix_facts: Vec<EnvPrefixExpansionFixFact>,
     unset_command_ids_by_target_name: FxHashMap<Name, Vec<CommandId>>,
     function_unset_command_ids_by_target_name: FxHashMap<Name, Vec<CommandId>>,
     presence_tested_names: FxHashSet<Name>,
@@ -434,6 +435,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn env_prefix_expansion_scope_spans(&self) -> &[Span] {
         &self.env_prefix_expansion_scope_spans
+    }
+
+    pub fn env_prefix_expansion_fix_facts(&self) -> &[EnvPrefixExpansionFixFact] {
+        &self.env_prefix_expansion_fix_facts
     }
 
     pub fn is_if_condition_command(&self, id: CommandId) -> bool {

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -2697,7 +2697,7 @@ fn collect_suspect_double_quote_spans(
     }
 }
 
-pub(super) fn rewrite_word_as_single_double_quoted_string(
+pub(crate) fn rewrite_word_as_single_double_quoted_string(
     word: &Word,
     source: &str,
     _assignment_target: Option<&str>,

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -280,6 +280,24 @@ fn summarizes_command_options_and_invokers() {
         .map(|span| span.slice(source))
         .collect::<Vec<_>>();
     assert_eq!(find_or_without_grouping_spans, vec!["-print"]);
+    let find_or_without_grouping_fix_spans = facts
+        .commands()
+        .iter()
+        .filter(|fact| fact.effective_name_is("find"))
+        .filter_map(|fact| fact.options().find())
+        .flat_map(|find| find.or_without_grouping_fix_spans().iter().copied())
+        .map(|fix| {
+            (
+                fix.diagnostic_span.slice(source),
+                fix.branch_start.slice(source),
+                fix.action_span.slice(source),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        find_or_without_grouping_fix_spans,
+        vec![("-print", "-name", "-print")]
+    );
     let find_glob_pattern_operand_spans = facts
         .commands()
         .iter()

--- a/crates/shuck-linter/src/facts/word_spans/arrays.rs
+++ b/crates/shuck-linter/src/facts/word_spans/arrays.rs
@@ -136,10 +136,11 @@ pub fn word_is_pure_positional_at_splat(word: &Word) -> bool {
     parts_are_pure_positional_at_splat(&word.parts)
 }
 
-pub fn word_positional_at_splat_span_in_source(word: &Word, source: &str) -> Option<Span> {
+pub fn word_positional_at_splat_spans_in_source(word: &Word, source: &str) -> Vec<Span> {
     word_positional_at_splat_spans(word)
         .into_iter()
-        .find(|span| !span_is_escaped(*span, source))
+        .filter(|span| !span_is_escaped(*span, source))
+        .collect()
 }
 
 pub fn word_folded_positional_at_splat_span_in_source(word: &Word, source: &str) -> Option<Span> {
@@ -1874,7 +1875,7 @@ mod tests {
         collect_unquoted_all_elements_array_expansion_part_spans,
         collect_unquoted_array_expansion_part_spans, span_is_escaped,
         word_has_quoted_all_elements_array_slice, word_has_single_positional_at_splat_part,
-        word_is_pure_positional_at_splat, word_positional_at_splat_span_in_source,
+        word_is_pure_positional_at_splat, word_positional_at_splat_spans_in_source,
         word_positional_at_splat_spans, word_quoted_all_elements_array_slice_spans,
         word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
         word_unquoted_star_parameter_spans, word_unquoted_star_splat_spans,
@@ -2878,7 +2879,7 @@ printf '%s\\n' \"${arr[@]}\" \"x${arr[@]}\" \"x${!arr[@]}\" \"x${arr[@]:1}\" \"x
     }
 
     #[test]
-    fn word_positional_at_splat_span_in_source_tracks_operation_forms() {
+    fn word_positional_at_splat_spans_in_source_tracks_operation_forms() {
         let source = "printf '%s\\n' \"${@:-fallback}\" \"$@\" \"\\$@\"\n";
         let output = Parser::new(source).parse().unwrap();
         let command = &output.file.body[0].command;
@@ -2887,17 +2888,19 @@ printf '%s\\n' \"${arr[@]}\" \"x${arr[@]}\" \"x${!arr[@]}\" \"x${arr[@]:1}\" \"x
         };
 
         assert_eq!(
-            word_positional_at_splat_span_in_source(&command.args[1], source)
-                .expect("expected positional span")
-                .slice(source),
-            "${@:-fallback}"
+            word_positional_at_splat_spans_in_source(&command.args[1], source)
+                .into_iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["${@:-fallback}"]
         );
         assert_eq!(
-            word_positional_at_splat_span_in_source(&command.args[2], source)
-                .expect("expected positional span")
-                .slice(source),
-            "$@"
+            word_positional_at_splat_spans_in_source(&command.args[2], source)
+                .into_iter()
+                .map(|span| span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["$@"]
         );
-        assert!(word_positional_at_splat_span_in_source(&command.args[3], source).is_none());
+        assert!(word_positional_at_splat_spans_in_source(&command.args[3], source).is_empty());
     }
 }

--- a/crates/shuck-linter/src/facts/word_spans/arrays.rs
+++ b/crates/shuck-linter/src/facts/word_spans/arrays.rs
@@ -1875,8 +1875,8 @@ mod tests {
         collect_unquoted_all_elements_array_expansion_part_spans,
         collect_unquoted_array_expansion_part_spans, span_is_escaped,
         word_has_quoted_all_elements_array_slice, word_has_single_positional_at_splat_part,
-        word_is_pure_positional_at_splat, word_positional_at_splat_spans_in_source,
-        word_positional_at_splat_spans, word_quoted_all_elements_array_slice_spans,
+        word_is_pure_positional_at_splat, word_positional_at_splat_spans,
+        word_positional_at_splat_spans_in_source, word_quoted_all_elements_array_slice_spans,
         word_quoted_star_splat_spans, word_quoted_unindexed_bash_source_span_in_source,
         word_unquoted_star_parameter_spans, word_unquoted_star_splat_spans,
     };

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -89,7 +89,10 @@ pub(crate) fn collect_parse_rule_diagnostics(
     if enabled_rules.contains(crate::Rule::MissingDoneInForLoop)
         && missing_done_loop_kind == Some(MissingDoneLoopKind::For)
     {
-        diagnostics.push(Diagnostic::new(MissingDoneInForLoop, eof_point(file)));
+        diagnostics.push(
+            Diagnostic::new(MissingDoneInForLoop, eof_point(file))
+                .with_fix(missing_done_fix(source)),
+        );
     }
     if enabled_rules.contains(crate::Rule::DanglingElse)
         && let Some(span) = dangling_else_span(parse_diagnostics)
@@ -185,6 +188,16 @@ fn missing_fi_fix(source: &str) -> Fix {
         "fi\n"
     } else {
         "\nfi\n"
+    };
+
+    Fix::unsafe_edit(Edit::insertion(source.len(), content))
+}
+
+fn missing_done_fix(source: &str) -> Fix {
+    let content = if source.is_empty() || source.ends_with('\n') {
+        "done\n"
+    } else {
+        "\ndone\n"
     };
 
     Fix::unsafe_edit(Edit::insertion(source.len(), content))
@@ -1232,6 +1245,14 @@ fi
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::MissingDoneInForLoop);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("append a closing `done`")
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/a_flag_in_double_bracket.rs
+++ b/crates/shuck-linter/src/rules/correctness/a_flag_in_double_bracket.rs
@@ -1,16 +1,24 @@
 use shuck_ast::ConditionalUnaryOp;
 
-use crate::{Checker, ConditionalNodeFact, Rule, Violation};
+use crate::{
+    Checker, ConditionalNodeFact, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation,
+};
 
 pub struct AFlagInDoubleBracket;
 
 impl Violation for AFlagInDoubleBracket {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::AFlagInDoubleBracket
     }
 
     fn message(&self) -> String {
         "use `-e` or `&&` instead of `-a` inside `[[ ... ]]`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace `-a` with `-e`".to_owned())
     }
 }
 
@@ -41,13 +49,20 @@ pub fn a_flag_in_double_bracket(checker: &mut Checker) {
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || AFlagInDoubleBracket);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(AFlagInDoubleBracket, span)
+                .with_fix(Fix::safe_edit(Edit::replacement("-e", span))),
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_double_bracket_a_flags() {
@@ -85,5 +100,42 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_double_bracket_a_flags() {
+        let source = "\
+#!/bin/sh
+[[ -a \"$path\" ]]
+[[ ! -a \"$path\" ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AFlagInDoubleBracket),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+[[ -e \"$path\" ]]
+[[ ! -e \"$path\" ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C122.sh").as_path(),
+            &LinterSettings::for_rule(Rule::AFlagInDoubleBracket),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("C122_fix_C122.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
+++ b/crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
@@ -1,11 +1,13 @@
 use shuck_semantic::{BindingAttributes, BindingKind};
 
 use crate::facts::words::leading_literal_word_prefix;
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct AppendToArrayAsString;
 
 impl Violation for AppendToArrayAsString {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::AppendToArrayAsString
     }
@@ -13,13 +15,17 @@ impl Violation for AppendToArrayAsString {
     fn message(&self) -> String {
         "appending a string to an array with `+=` merges into an element; use `+=(...)`".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("append a new array element".to_owned())
+    }
 }
 
 pub fn append_to_array_as_string(checker: &mut Checker) {
     let source = checker.source();
     let semantic = checker.semantic();
 
-    let spans = semantic
+    let diagnostics = semantic
         .bindings()
         .iter()
         .filter_map(|binding| {
@@ -43,19 +49,31 @@ pub fn append_to_array_as_string(checker: &mut Checker) {
             }
 
             let value = checker.facts().binding_value(binding.id)?.scalar_word()?;
-            leading_literal_word_prefix(value, source)
-                .starts_with(' ')
-                .then_some(binding.span)
+            if !leading_literal_word_prefix(value, source).starts_with(' ') {
+                return None;
+            }
+
+            Some((
+                binding.span,
+                Fix::unsafe_edits([
+                    Edit::insertion(value.span.start.offset, "("),
+                    Edit::insertion(value.span.end.offset, ")"),
+                ]),
+            ))
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || AppendToArrayAsString);
+    for (span, fix) in diagnostics {
+        checker.report_diagnostic_dedup(Diagnostic::new(AppendToArrayAsString, span).with_fix(fix));
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_string_appends_on_array_bindings() {
@@ -114,5 +132,60 @@ f() {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_string_appends_on_array_bindings() {
+        let source = "\
+#!/bin/bash
+items=(one)
+items+=\" two\"
+declare -a flags=(--first)
+flags+=\" ${extra}\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AppendToArrayAsString),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+items=(one)
+items+=(\" two\")
+declare -a flags=(--first)
+flags+=(\" ${extra}\")
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_string_appends_unchanged() {
+        let source = "#!/bin/bash\nitems=(one)\nitems+=\" two\"\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AppendToArrayAsString),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C106.sh").as_path(),
+            &LinterSettings::for_rule(Rule::AppendToArrayAsString),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C106_fix_C106.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
@@ -1,12 +1,15 @@
 use shuck_ast::Span;
 
 use crate::{
-    Checker, ConditionalNodeFact, ConditionalOperatorFamily, ExpansionContext, Rule, Violation,
+    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Diagnostic, Edit, ExpansionContext,
+    Fix, FixAvailability, Rule, Violation,
 };
 
 pub struct ArraySliceInComparison;
 
 impl Violation for ArraySliceInComparison {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::ArraySliceInComparison
     }
@@ -14,11 +17,16 @@ impl Violation for ArraySliceInComparison {
     fn message(&self) -> String {
         "all-elements array expansions collapse inside `[[ ... ]]` tests".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the expansion as an intentional join".to_owned())
+    }
 }
 
 pub fn array_slice_in_comparison(checker: &mut Checker) {
     let locator = checker.locator();
-    let direct_operand_spans = [
+    let source = checker.source();
+    let direct_operand_diagnostics = [
         ExpansionContext::StringTestOperand,
         ExpansionContext::RegexOperand,
     ]
@@ -26,43 +34,65 @@ pub fn array_slice_in_comparison(checker: &mut Checker) {
     .flat_map(|context| checker.facts().expansion_word_facts(context))
     .filter(|fact| !fact.is_nested_word_command())
     .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(locator))
-    .map(|fact| fact.span())
+    .map(|fact| {
+        (
+            fact.span(),
+            intentional_join_fix(fact.direct_all_elements_array_expansion_spans(), source),
+        )
+    })
     .collect::<Vec<_>>();
 
-    let risky_pattern_word_spans = checker
+    let risky_pattern_words = checker
         .facts()
         .expansion_word_facts(ExpansionContext::ConditionalPattern)
         .filter(|fact| !fact.is_nested_word_command())
         .filter(|fact| fact.command_substitution_spans().is_empty())
         .filter(|fact| !fact.is_pure_positional_at_splat())
         .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(locator))
-        .map(|fact| fact.span())
+        .map(|fact| RiskyPatternWord {
+            span: fact.span(),
+            expansion_spans: fact.direct_all_elements_array_expansion_spans(),
+        })
         .collect::<Vec<_>>();
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|fact| fact.conditional())
         .flat_map(|conditional| conditional.nodes().iter())
-        .flat_map(|node| conditional_pattern_spans(node, &risky_pattern_word_spans))
-        .chain(direct_operand_spans)
+        .flat_map(|node| conditional_pattern_spans(node, &risky_pattern_words, source))
+        .chain(direct_operand_diagnostics)
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || ArraySliceInComparison);
+    for (span, fix) in diagnostics {
+        let diagnostic = Diagnostic::new(ArraySliceInComparison, span);
+        if let Some(fix) = fix {
+            checker.report_diagnostic_dedup(diagnostic.with_fix(fix));
+        } else {
+            checker.report_diagnostic_dedup(diagnostic);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RiskyPatternWord<'a> {
+    span: Span,
+    expansion_spans: &'a [Span],
 }
 
 fn conditional_pattern_spans(
     fact: &ConditionalNodeFact<'_>,
-    risky_word_spans: &[Span],
-) -> Vec<Span> {
+    risky_words: &[RiskyPatternWord<'_>],
+    source: &str,
+) -> Vec<(Span, Option<Fix>)> {
     match fact {
         ConditionalNodeFact::Binary(binary)
             if binary.operator_family() != ConditionalOperatorFamily::Logical =>
         {
             [
-                pattern_span_if_risky(binary.left().expression().span(), risky_word_spans),
-                pattern_span_if_risky(binary.right().expression().span(), risky_word_spans),
+                pattern_span_if_risky(binary.left().expression().span(), risky_words, source),
+                pattern_span_if_risky(binary.right().expression().span(), risky_words, source),
             ]
             .into_iter()
             .flatten()
@@ -75,22 +105,62 @@ fn conditional_pattern_spans(
     }
 }
 
-fn pattern_span_if_risky(span: Span, risky_word_spans: &[Span]) -> Option<Span> {
-    risky_word_spans
+fn pattern_span_if_risky(
+    span: Span,
+    risky_words: &[RiskyPatternWord<'_>],
+    source: &str,
+) -> Option<(Span, Option<Fix>)> {
+    let expansion_spans = risky_words
         .iter()
-        .copied()
-        .any(|word_span| span_contains(span, word_span))
-        .then_some(span)
+        .filter(|word| span_contains(span, word.span))
+        .flat_map(|word| word.expansion_spans.iter().copied())
+        .collect::<Vec<_>>();
+
+    (!expansion_spans.is_empty()).then(|| (span, intentional_join_fix(&expansion_spans, source)))
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
     outer.start.offset <= inner.start.offset && outer.end.offset >= inner.end.offset
 }
 
+fn intentional_join_fix(expansion_spans: &[Span], source: &str) -> Option<Fix> {
+    expansion_spans
+        .iter()
+        .map(|span| {
+            intentional_join_expansion(span.slice(source))
+                .map(|replacement| Edit::replacement(replacement, *span))
+        })
+        .collect::<Option<Vec<_>>>()
+        .filter(|edits| !edits.is_empty())
+        .map(Fix::unsafe_edits)
+}
+
+fn intentional_join_expansion(raw: &str) -> Option<String> {
+    if raw == "$@" {
+        return Some("$*".to_owned());
+    }
+
+    if let Some(rest) = raw.strip_prefix("$@[*]") {
+        return Some(format!("$*{rest}"));
+    }
+
+    if raw.starts_with("${@") {
+        return Some(raw.replacen("${@", "${*", 1));
+    }
+
+    if raw.contains("[@]") {
+        return Some(raw.replacen("[@]", "[*]", 1));
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn reports_all_elements_array_expansions_in_double_bracket_tests() {
@@ -185,5 +255,60 @@ if [[ \"$@[*]\" == \"alpha --scope tail\" ]]; then :; fi
                 .collect::<Vec<_>>(),
             vec!["\"${@[*]}\"", "\"$@[*]\""]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_all_elements_expansions_in_double_bracket_tests() {
+        let source = "\
+#!/bin/bash
+if [[ \"${sel[@]:0:4}\" == \"HELP\" ]]; then :; fi
+if [[ -n \"$@\" ]]; then :; fi
+if [[ x == *${arr[@]}* ]]; then :; fi
+if [[ \"_$@:${arr[@]}\" = x ]]; then :; fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ArraySliceInComparison),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+if [[ \"${sel[*]:0:4}\" == \"HELP\" ]]; then :; fi
+if [[ -n \"$*\" ]]; then :; fi
+if [[ x == *${arr[*]}* ]]; then :; fi
+if [[ \"_$*:${arr[*]}\" = x ]]; then :; fi
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_all_elements_expansions_unchanged() {
+        let source = "#!/bin/bash\nif [[ -n \"$@\" ]]; then :; fi\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ArraySliceInComparison),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C112.sh").as_path(),
+            &LinterSettings::for_rule(Rule::ArraySliceInComparison),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C112_fix_C112.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
@@ -2,17 +2,26 @@ use rustc_hash::FxHashSet;
 use shuck_ast::{Assignment, AssignmentValue, Command, Span, static_word_text};
 use shuck_semantic::{Binding, BindingKind};
 
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote};
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation,
+    WordFactContext, WordQuote,
+};
 
 pub struct AssignmentLooksLikeComparison;
 
 impl Violation for AssignmentLooksLikeComparison {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::AssignmentLooksLikeComparison
     }
 
     fn message(&self) -> String {
         "assignment value looks like arithmetic subtraction".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the assignment value".to_owned())
     }
 }
 
@@ -33,7 +42,13 @@ pub fn assignment_looks_like_comparison(checker: &mut Checker) {
         .flat_map(|fact| command_assignment_spans(checker, fact.command(), source, &known_names))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || AssignmentLooksLikeComparison);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(AssignmentLooksLikeComparison, span).with_fix(Fix::safe_edit(
+                Edit::replacement(format!("\"{}\"", span.slice(source)), span),
+            )),
+        );
+    }
 }
 
 fn command_assignment_spans(
@@ -122,8 +137,10 @@ fn binding_contributes_known_variable_name(binding: &Binding) -> bool {
 mod tests {
     use std::path::Path;
 
-    use crate::test::{test_snippet, test_snippet_at_path};
-    use crate::{LinterSettings, Rule};
+    use crate::test::{
+        test_path_with_fix, test_snippet, test_snippet_at_path, test_snippet_with_fix,
+    };
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn anchors_on_assignment_values() {
@@ -243,5 +260,60 @@ style=history-expansion
         );
 
         assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_safe_fix_to_literal_assignment_values() {
+        let source = "\
+#!/bin/bash
+foo=foo-bar
+foo+=foo-1
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentLooksLikeComparison),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+foo=\"foo-bar\"
+foo+=\"foo-1\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_non_matching_values_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+foo=bar-baz
+foo=\"$foo-bar\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentLooksLikeComparison),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C095.sh").as_path(),
+            &LinterSettings::for_rule(Rule::AssignmentLooksLikeComparison),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("C095_fix_C095.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/at_sign_in_string_compare.rs
+++ b/crates/shuck-linter/src/rules/correctness/at_sign_in_string_compare.rs
@@ -1,11 +1,13 @@
 use shuck_ast::Span;
 
 use crate::facts::word_spans;
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct AtSignInStringCompare;
 
 impl Violation for AtSignInStringCompare {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::AtSignInStringCompare
     }
@@ -13,11 +15,15 @@ impl Violation for AtSignInStringCompare {
     fn message(&self) -> String {
         "positional-parameter at-splats fold arguments when used as test operands".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("use positional `*` splats".to_owned())
+    }
 }
 
 pub fn at_sign_in_string_compare(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -25,22 +31,39 @@ pub fn at_sign_in_string_compare(checker: &mut Checker) {
         .flat_map(|simple_test| simple_test_spans(simple_test, source))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || AtSignInStringCompare);
+    for (span, fix) in diagnostics {
+        checker.report_diagnostic_dedup(Diagnostic::new(AtSignInStringCompare, span).with_fix(fix));
+    }
 }
 
-fn simple_test_spans(fact: &crate::SimpleTestFact<'_>, source: &str) -> Vec<Span> {
+fn simple_test_spans(fact: &crate::SimpleTestFact<'_>, source: &str) -> Vec<(Span, Fix)> {
     fact.operator_expression_operand_words(source)
         .into_iter()
         .filter_map(|word| {
-            word_spans::word_positional_at_splat_span_in_source(word, source).map(|_| word.span)
+            let edits = word_spans::word_positional_at_splat_spans_in_source(word, source)
+                .into_iter()
+                .filter_map(at_splat_edit)
+                .collect::<Vec<_>>();
+            (!edits.is_empty()).then(|| (word.span, Fix::unsafe_edits(edits)))
         })
         .collect()
 }
 
+fn at_splat_edit(span: Span) -> Option<Edit> {
+    let start = span.start.offset;
+    let offset = match span.end.offset.saturating_sub(start) {
+        2 => start + 1,
+        _ => start + 2,
+    };
+    (offset < span.end.offset).then(|| Edit::replacement_at(offset, offset + 1, "*"))
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_positional_at_splats_in_test_operands() {
@@ -99,5 +122,58 @@ if [ \"_$*\" = \"_--version\" ]; then :; fi
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_positional_at_splats_in_test_operands() {
+        let source = "\
+#!/bin/bash
+if [ -z \"$@\" ]; then :; fi
+if test -n \"${@:-fallback}\"; then :; fi
+if [ \"_$@:${@:-fallback}\" = x ]; then :; fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AtSignInStringCompare),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+if [ -z \"$*\" ]; then :; fi
+if test -n \"${*:-fallback}\"; then :; fi
+if [ \"_$*:${*:-fallback}\" = x ]; then :; fi
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_positional_at_splats_unchanged() {
+        let source = "#!/bin/bash\nif [ -z \"$@\" ]; then :; fi\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AtSignInStringCompare),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C111.sh").as_path(),
+            &LinterSettings::for_rule(Rule::AtSignInStringCompare),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C111_fix_C111.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/backtick_in_command_position.rs
+++ b/crates/shuck-linter/src/rules/correctness/backtick_in_command_position.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct BacktickInCommandPosition;
 
 impl Violation for BacktickInCommandPosition {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::BacktickInCommandPosition
     }
@@ -10,19 +12,39 @@ impl Violation for BacktickInCommandPosition {
     fn message(&self) -> String {
         "run the command directly instead of executing backtick output as a command name".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the command-name backticks".to_owned())
+    }
 }
 
 pub fn backtick_in_command_position(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.backtick_command_name_spans(),
-        || BacktickInCommandPosition,
-    );
+    let source = checker.source();
+    let spans = checker.facts().backtick_command_name_spans().to_vec();
+
+    for span in spans {
+        checker.report_diagnostic_dedup(Diagnostic::new(BacktickInCommandPosition, span).with_fix(
+            Fix::unsafe_edit(Edit::replacement(
+                backtick_inner_text(span.slice(source)),
+                span,
+            )),
+        ));
+    }
+}
+
+fn backtick_inner_text(raw: &str) -> String {
+    raw.strip_prefix('`')
+        .and_then(|inner| inner.strip_suffix('`'))
+        .unwrap_or(raw)
+        .to_owned()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_plain_backticks_used_as_command_names() {
@@ -72,5 +94,62 @@ true && `echo hello` arg
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_backtick_command_names() {
+        let source = "\
+#!/bin/sh
+`echo hello` | cat
+if `echo true`; then :; fi
+FOO=1 `echo run`
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::BacktickInCommandPosition),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo hello | cat
+if echo true; then :; fi
+FOO=1 echo run
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_argument_backticks_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+command `echo hello`
+echo `date`
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::BacktickInCommandPosition),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C093.sh").as_path(),
+            &LinterSettings::for_rule(Rule::BacktickInCommandPosition),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C093_fix_C093.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/case_arm_not_in_getopts.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_arm_not_in_getopts.rs
@@ -1,10 +1,15 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::{Pattern, Position, Span};
+
+use crate::facts::CaseItemFact;
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CaseArmNotInGetopts {
     option: Option<char>,
 }
 
 impl Violation for CaseArmNotInGetopts {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::CaseArmNotInGetopts
     }
@@ -18,9 +23,14 @@ impl Violation for CaseArmNotInGetopts {
             None => "this case arm does not match any option declared by getopts".to_owned(),
         }
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete the undeclared case pattern".to_owned())
+    }
 }
 
 pub fn case_arm_not_in_getopts(checker: &mut Checker) {
+    let source = checker.source();
     let unexpected = checker
         .facts()
         .getopts_cases()
@@ -28,25 +38,143 @@ pub fn case_arm_not_in_getopts(checker: &mut Checker) {
         .flat_map(|fact| {
             fact.unexpected_case_labels()
                 .iter()
-                .map(|label| (label.span(), Some(label.label())))
+                .map(|label| (label.span(), Some(label.label()), false))
                 .chain(
                     fact.invalid_case_pattern_spans()
                         .iter()
                         .copied()
-                        .map(|span| (span, None)),
+                        .map(|span| (span, None, true)),
                 )
         })
         .collect::<Vec<_>>();
 
-    for (span, option) in unexpected {
-        checker.report(CaseArmNotInGetopts { option }, span);
+    for (span, option, delete_item) in unexpected {
+        let diagnostic = Diagnostic::new(CaseArmNotInGetopts { option }, span);
+        if let Some(fix) = case_pattern_deletion_fix(checker, span, source, delete_item) {
+            checker.report_diagnostic_dedup(diagnostic.with_fix(fix));
+        } else {
+            checker.report_diagnostic_dedup(diagnostic);
+        }
     }
+}
+
+fn case_pattern_deletion_fix(
+    checker: &Checker<'_>,
+    pattern_span: Span,
+    source: &str,
+    delete_item: bool,
+) -> Option<Fix> {
+    let item = checker.facts().case_items().iter().find(|item| {
+        item.item().patterns.iter().any(|pattern| {
+            pattern.span.start.offset == pattern_span.start.offset
+                && pattern.span.end.offset == pattern_span.end.offset
+        })
+    })?;
+
+    if delete_item || item.item().patterns.len() == 1 || all_item_patterns_reported(checker, item) {
+        return item_deletion_span(item.item(), source)
+            .map(|span| Fix::unsafe_edit(Edit::deletion(span)));
+    }
+
+    pattern_alternative_deletion_span(&item.item().patterns, pattern_span, source)
+        .map(|span| Fix::unsafe_edit(Edit::deletion(span)))
+}
+
+fn all_item_patterns_reported(checker: &Checker<'_>, item: &CaseItemFact<'_>) -> bool {
+    let reported_spans = checker
+        .facts()
+        .getopts_cases()
+        .iter()
+        .flat_map(|fact| {
+            fact.unexpected_case_labels()
+                .iter()
+                .map(|label| label.span())
+                .chain(fact.invalid_case_pattern_spans().iter().copied())
+        })
+        .collect::<Vec<_>>();
+
+    item.item().patterns.iter().all(|pattern| {
+        reported_spans.iter().any(|span| {
+            span.start.offset == pattern.span.start.offset
+                && span.end.offset == pattern.span.end.offset
+        })
+    })
+}
+
+fn item_deletion_span(item: &shuck_ast::CaseItem, source: &str) -> Option<Span> {
+    let first = item.patterns.first()?.span;
+    let end = item.terminator_span.unwrap_or(item.body.span).end;
+    let mut start_offset = first.start.offset;
+    while start_offset > 0 {
+        let previous = source.as_bytes()[start_offset - 1];
+        if previous == b'\n' {
+            break;
+        }
+        if !previous.is_ascii_whitespace() {
+            break;
+        }
+        start_offset -= 1;
+    }
+    let mut end_offset = end.offset;
+    while end_offset < source.len() {
+        let byte = source.as_bytes()[end_offset];
+        end_offset += 1;
+        if byte == b'\n' {
+            break;
+        }
+    }
+
+    Some(Span::from_positions(
+        Position {
+            offset: start_offset,
+            line: first.start.line,
+            column: first
+                .start
+                .column
+                .saturating_sub(first.start.offset.saturating_sub(start_offset)),
+        },
+        end.advanced_by(&source[end.offset..end_offset]),
+    ))
+}
+
+fn pattern_alternative_deletion_span(
+    patterns: &[Pattern],
+    pattern_span: Span,
+    source: &str,
+) -> Option<Span> {
+    let index = patterns.iter().position(|pattern| {
+        pattern.span.start.offset == pattern_span.start.offset
+            && pattern.span.end.offset == pattern_span.end.offset
+    })?;
+
+    if index + 1 < patterns.len() {
+        let next_start = patterns[index + 1].span.start.offset;
+        let pipe = source[pattern_span.end.offset..next_start].find('|')?;
+        let end = pattern_span
+            .end
+            .advanced_by(&source[pattern_span.end.offset..pattern_span.end.offset + pipe + 1]);
+        return Some(Span::from_positions(pattern_span.start, end));
+    }
+
+    if index > 0 {
+        let previous_end = patterns[index - 1].span.end.offset;
+        let pipe = source[previous_end..pattern_span.start.offset].rfind('|')?;
+        let start = patterns[index - 1]
+            .span
+            .end
+            .advanced_by(&source[previous_end..previous_end + pipe]);
+        return Some(Span::from_positions(start, pattern_span.end));
+    }
+
+    None
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_case_labels_that_are_not_declared_by_getopts() {
@@ -277,5 +405,67 @@ done
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "b");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_undeclared_getopts_patterns() {
+        let source = "\
+while getopts 'a' opt; do
+  case \"$opt\" in
+    a|b) : ;;
+    c) : ;;
+    de) : ;;
+  esac
+done
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaseArmNotInGetopts),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+while getopts 'a' opt; do
+  case \"$opt\" in
+    a) : ;;
+  esac
+done
+"
+        );
+        assert_eq!(result.fixes_applied, 3);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_getopts_patterns_unchanged() {
+        let source = "\
+while getopts 'a' opt; do
+  case \"$opt\" in
+    b) : ;;
+  esac
+done
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaseArmNotInGetopts),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixes_applied, 0);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C135.sh").as_path(),
+            &LinterSettings::for_rule(Rule::CaseArmNotInGetopts),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C135_fix_C135.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/case_arm_not_in_getopts.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_arm_not_in_getopts.rs
@@ -1,5 +1,6 @@
-use shuck_ast::{Pattern, Position, Span};
+use shuck_ast::{Pattern, Span};
 
+use super::case_item_delete::case_item_deletion_span;
 use crate::facts::CaseItemFact;
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
@@ -72,7 +73,7 @@ fn case_pattern_deletion_fix(
     })?;
 
     if delete_item || item.item().patterns.len() == 1 || all_item_patterns_reported(checker, item) {
-        return item_deletion_span(item.item(), source)
+        return case_item_deletion_span(item.item(), source)
             .map(|span| Fix::unsafe_edit(Edit::deletion(span)));
     }
 
@@ -99,42 +100,6 @@ fn all_item_patterns_reported(checker: &Checker<'_>, item: &CaseItemFact<'_>) ->
                 && span.end.offset == pattern.span.end.offset
         })
     })
-}
-
-fn item_deletion_span(item: &shuck_ast::CaseItem, source: &str) -> Option<Span> {
-    let first = item.patterns.first()?.span;
-    let end = item.terminator_span.unwrap_or(item.body.span).end;
-    let mut start_offset = first.start.offset;
-    while start_offset > 0 {
-        let previous = source.as_bytes()[start_offset - 1];
-        if previous == b'\n' {
-            break;
-        }
-        if !previous.is_ascii_whitespace() {
-            break;
-        }
-        start_offset -= 1;
-    }
-    let mut end_offset = end.offset;
-    while end_offset < source.len() {
-        let byte = source.as_bytes()[end_offset];
-        end_offset += 1;
-        if byte == b'\n' {
-            break;
-        }
-    }
-
-    Some(Span::from_positions(
-        Position {
-            offset: start_offset,
-            line: first.start.line,
-            column: first
-                .start
-                .column
-                .saturating_sub(first.start.offset.saturating_sub(start_offset)),
-        },
-        end.advanced_by(&source[end.offset..end_offset]),
-    ))
 }
 
 fn pattern_alternative_deletion_span(
@@ -435,6 +400,23 @@ done
 "
         );
         assert_eq!(result.fixes_applied, 3);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unsafe_fix_for_inline_getopts_case_arm_stops_before_esac() {
+        let source = "while getopts 'a' opt; do case \"$opt\" in a) : ;; b) : ;; esac; done\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaseArmNotInGetopts),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "while getopts 'a' opt; do case \"$opt\" in a) : ;; esac; done\n"
+        );
         assert!(result.fixed_diagnostics.is_empty());
     }
 

--- a/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
@@ -1,5 +1,6 @@
-use shuck_ast::{Pattern, Position, Span};
+use shuck_ast::{Pattern, Span};
 
+use super::case_item_delete::case_item_deletion_span;
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CaseDefaultBeforeGlob;
@@ -69,48 +70,12 @@ fn case_pattern_deletion_fix(
     });
 
     if item.item().patterns.len() == 1 || all_item_patterns_shadowed {
-        return item_deletion_span(item.item(), source)
+        return case_item_deletion_span(item.item(), source)
             .map(|span| Fix::unsafe_edit(Edit::deletion(span)));
     }
 
     pattern_alternative_deletion_span(&item.item().patterns, pattern_span, source)
         .map(|span| Fix::unsafe_edit(Edit::deletion(span)))
-}
-
-fn item_deletion_span(item: &shuck_ast::CaseItem, source: &str) -> Option<Span> {
-    let first = item.patterns.first()?.span;
-    let end = item.terminator_span.unwrap_or(item.body.span).end;
-    let mut start_offset = first.start.offset;
-    while start_offset > 0 {
-        let previous = source.as_bytes()[start_offset - 1];
-        if previous == b'\n' {
-            break;
-        }
-        if !previous.is_ascii_whitespace() {
-            break;
-        }
-        start_offset -= 1;
-    }
-    let mut end_offset = end.offset;
-    while end_offset < source.len() {
-        let byte = source.as_bytes()[end_offset];
-        end_offset += 1;
-        if byte == b'\n' {
-            break;
-        }
-    }
-
-    Some(Span::from_positions(
-        Position {
-            offset: start_offset,
-            line: first.start.line,
-            column: first
-                .start
-                .column
-                .saturating_sub(first.start.offset.saturating_sub(start_offset)),
-        },
-        end.advanced_by(&source[end.offset..end_offset]),
-    ))
 }
 
 fn pattern_alternative_deletion_span(
@@ -344,6 +309,23 @@ case \"$x\" in
   default|foo*) : ;;
 esac
 "
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unsafe_fix_for_inline_shadowed_case_arm_stops_before_esac() {
+        let source = "#!/bin/sh\ncase \"$x\" in *) : ;; foo) : ;; esac\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaseDefaultBeforeGlob),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\ncase \"$x\" in *) : ;; esac\n"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::{Pattern, Position, Span};
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CaseDefaultBeforeGlob;
 
 impl Violation for CaseDefaultBeforeGlob {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::CaseDefaultBeforeGlob
     }
@@ -10,23 +14,143 @@ impl Violation for CaseDefaultBeforeGlob {
     fn message(&self) -> String {
         "this case pattern is unreachable because an earlier pattern already matches it".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete the unreachable case pattern".to_owned())
+    }
 }
 
 pub fn case_default_before_glob(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .case_pattern_shadows()
+        .iter()
+        .map(|shadow| {
+            let span = shadow.shadowed_pattern_span();
+            (span, case_pattern_deletion_fix(checker, span, source))
+        })
+        .collect::<Vec<_>>();
+
+    for (span, fix) in diagnostics {
+        let diagnostic = Diagnostic::new(CaseDefaultBeforeGlob, span);
+        if let Some(fix) = fix {
+            checker.report_diagnostic_dedup(diagnostic.with_fix(fix));
+        } else {
+            checker.report_diagnostic_dedup(diagnostic);
+        }
+    }
+}
+
+fn case_pattern_deletion_fix(
+    checker: &Checker<'_>,
+    pattern_span: Span,
+    source: &str,
+) -> Option<Fix> {
+    let item = checker.facts().case_items().iter().find(|item| {
+        item.item().patterns.iter().any(|pattern| {
+            pattern.span.start.offset == pattern_span.start.offset
+                && pattern.span.end.offset == pattern_span.end.offset
+        })
+    })?;
+
+    let shadowed_spans = checker
         .facts()
         .case_pattern_shadows()
         .iter()
         .map(|shadow| shadow.shadowed_pattern_span())
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || CaseDefaultBeforeGlob);
+    let all_item_patterns_shadowed = item.item().patterns.iter().all(|pattern| {
+        shadowed_spans.iter().any(|span| {
+            span.start.offset == pattern.span.start.offset
+                && span.end.offset == pattern.span.end.offset
+        })
+    });
+
+    if item.item().patterns.len() == 1 || all_item_patterns_shadowed {
+        return item_deletion_span(item.item(), source)
+            .map(|span| Fix::unsafe_edit(Edit::deletion(span)));
+    }
+
+    pattern_alternative_deletion_span(&item.item().patterns, pattern_span, source)
+        .map(|span| Fix::unsafe_edit(Edit::deletion(span)))
+}
+
+fn item_deletion_span(item: &shuck_ast::CaseItem, source: &str) -> Option<Span> {
+    let first = item.patterns.first()?.span;
+    let end = item.terminator_span.unwrap_or(item.body.span).end;
+    let mut start_offset = first.start.offset;
+    while start_offset > 0 {
+        let previous = source.as_bytes()[start_offset - 1];
+        if previous == b'\n' {
+            break;
+        }
+        if !previous.is_ascii_whitespace() {
+            break;
+        }
+        start_offset -= 1;
+    }
+    let mut end_offset = end.offset;
+    while end_offset < source.len() {
+        let byte = source.as_bytes()[end_offset];
+        end_offset += 1;
+        if byte == b'\n' {
+            break;
+        }
+    }
+
+    Some(Span::from_positions(
+        Position {
+            offset: start_offset,
+            line: first.start.line,
+            column: first
+                .start
+                .column
+                .saturating_sub(first.start.offset.saturating_sub(start_offset)),
+        },
+        end.advanced_by(&source[end.offset..end_offset]),
+    ))
+}
+
+fn pattern_alternative_deletion_span(
+    patterns: &[Pattern],
+    pattern_span: Span,
+    source: &str,
+) -> Option<Span> {
+    let index = patterns.iter().position(|pattern| {
+        pattern.span.start.offset == pattern_span.start.offset
+            && pattern.span.end.offset == pattern_span.end.offset
+    })?;
+
+    if index + 1 < patterns.len() {
+        let next_start = patterns[index + 1].span.start.offset;
+        let pipe = source[pattern_span.end.offset..next_start].find('|')?;
+        let end = pattern_span
+            .end
+            .advanced_by(&source[pattern_span.end.offset..pattern_span.end.offset + pipe + 1]);
+        return Some(Span::from_positions(pattern_span.start, end));
+    }
+
+    if index > 0 {
+        let previous_end = patterns[index - 1].span.end.offset;
+        let pipe = source[previous_end..pattern_span.start.offset].rfind('|')?;
+        let start = patterns[index - 1]
+            .span
+            .end
+            .advanced_by(&source[previous_end..previous_end + pipe]);
+        return Some(Span::from_positions(start, pattern_span.end));
+    }
+
+    None
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_shadowed_patterns_in_same_arm_and_later_arms() {
@@ -187,5 +311,66 @@ esac
                 .collect::<Vec<_>>(),
             vec!["foobar"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_shadowed_case_patterns() {
+        let source = "\
+#!/bin/sh
+case \"$x\" in
+  *|foo*) : ;;
+  foo) : ;;
+esac
+case \"$x\" in
+  default|foo*) : ;;
+  foo) : ;;
+esac
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaseDefaultBeforeGlob),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+case \"$x\" in
+  *) : ;;
+esac
+case \"$x\" in
+  default|foo*) : ;;
+esac
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_shadowed_case_patterns_unchanged() {
+        let source = "#!/bin/sh\ncase \"$x\" in\n  foo*) : ;;\n  foo) : ;;\nesac\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaseDefaultBeforeGlob),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C129.sh").as_path(),
+            &LinterSettings::for_rule(Rule::CaseDefaultBeforeGlob),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C129_fix_C129.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
@@ -1,5 +1,6 @@
-use shuck_ast::{Pattern, Position, Span};
+use shuck_ast::{Pattern, Span};
 
+use super::case_item_delete::case_item_deletion_span;
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CaseGlobReachability;
@@ -69,48 +70,12 @@ fn case_pattern_deletion_fix(
     });
 
     if item.item().patterns.len() == 1 || all_item_patterns_shadow {
-        return item_deletion_span(item.item(), source)
+        return case_item_deletion_span(item.item(), source)
             .map(|span| Fix::unsafe_edit(Edit::deletion(span)));
     }
 
     pattern_alternative_deletion_span(&item.item().patterns, pattern_span, source)
         .map(|span| Fix::unsafe_edit(Edit::deletion(span)))
-}
-
-fn item_deletion_span(item: &shuck_ast::CaseItem, source: &str) -> Option<Span> {
-    let first = item.patterns.first()?.span;
-    let end = item.terminator_span.unwrap_or(item.body.span).end;
-    let mut start_offset = first.start.offset;
-    while start_offset > 0 {
-        let previous = source.as_bytes()[start_offset - 1];
-        if previous == b'\n' {
-            break;
-        }
-        if !previous.is_ascii_whitespace() {
-            break;
-        }
-        start_offset -= 1;
-    }
-    let mut end_offset = end.offset;
-    while end_offset < source.len() {
-        let byte = source.as_bytes()[end_offset];
-        end_offset += 1;
-        if byte == b'\n' {
-            break;
-        }
-    }
-
-    Some(Span::from_positions(
-        Position {
-            offset: start_offset,
-            line: first.start.line,
-            column: first
-                .start
-                .column
-                .saturating_sub(first.start.offset.saturating_sub(start_offset)),
-        },
-        end.advanced_by(&source[end.offset..end_offset]),
-    ))
 }
 
 fn pattern_alternative_deletion_span(
@@ -338,6 +303,23 @@ case \"$x\" in
   foo) : ;;
 esac
 "
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn unsafe_fix_for_inline_shadowing_case_arm_stops_before_next_arm() {
+        let source = "#!/bin/sh\ncase \"$x\" in foo*) : ;; foo) : ;; esac\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaseGlobReachability),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\ncase \"$x\" in foo) : ;; esac\n"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::{Pattern, Position, Span};
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CaseGlobReachability;
 
 impl Violation for CaseGlobReachability {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::CaseGlobReachability
     }
@@ -10,23 +14,143 @@ impl Violation for CaseGlobReachability {
     fn message(&self) -> String {
         "this case pattern shadows a later pattern".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete the shadowing case pattern".to_owned())
+    }
 }
 
 pub fn case_glob_reachability(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .case_pattern_shadows()
+        .iter()
+        .map(|shadow| {
+            let span = shadow.shadowing_pattern_span();
+            (span, case_pattern_deletion_fix(checker, span, source))
+        })
+        .collect::<Vec<_>>();
+
+    for (span, fix) in diagnostics {
+        let diagnostic = Diagnostic::new(CaseGlobReachability, span);
+        if let Some(fix) = fix {
+            checker.report_diagnostic_dedup(diagnostic.with_fix(fix));
+        } else {
+            checker.report_diagnostic_dedup(diagnostic);
+        }
+    }
+}
+
+fn case_pattern_deletion_fix(
+    checker: &Checker<'_>,
+    pattern_span: Span,
+    source: &str,
+) -> Option<Fix> {
+    let item = checker.facts().case_items().iter().find(|item| {
+        item.item().patterns.iter().any(|pattern| {
+            pattern.span.start.offset == pattern_span.start.offset
+                && pattern.span.end.offset == pattern_span.end.offset
+        })
+    })?;
+
+    let shadowing_spans = checker
         .facts()
         .case_pattern_shadows()
         .iter()
         .map(|shadow| shadow.shadowing_pattern_span())
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || CaseGlobReachability);
+    let all_item_patterns_shadow = item.item().patterns.iter().all(|pattern| {
+        shadowing_spans.iter().any(|span| {
+            span.start.offset == pattern.span.start.offset
+                && span.end.offset == pattern.span.end.offset
+        })
+    });
+
+    if item.item().patterns.len() == 1 || all_item_patterns_shadow {
+        return item_deletion_span(item.item(), source)
+            .map(|span| Fix::unsafe_edit(Edit::deletion(span)));
+    }
+
+    pattern_alternative_deletion_span(&item.item().patterns, pattern_span, source)
+        .map(|span| Fix::unsafe_edit(Edit::deletion(span)))
+}
+
+fn item_deletion_span(item: &shuck_ast::CaseItem, source: &str) -> Option<Span> {
+    let first = item.patterns.first()?.span;
+    let end = item.terminator_span.unwrap_or(item.body.span).end;
+    let mut start_offset = first.start.offset;
+    while start_offset > 0 {
+        let previous = source.as_bytes()[start_offset - 1];
+        if previous == b'\n' {
+            break;
+        }
+        if !previous.is_ascii_whitespace() {
+            break;
+        }
+        start_offset -= 1;
+    }
+    let mut end_offset = end.offset;
+    while end_offset < source.len() {
+        let byte = source.as_bytes()[end_offset];
+        end_offset += 1;
+        if byte == b'\n' {
+            break;
+        }
+    }
+
+    Some(Span::from_positions(
+        Position {
+            offset: start_offset,
+            line: first.start.line,
+            column: first
+                .start
+                .column
+                .saturating_sub(first.start.offset.saturating_sub(start_offset)),
+        },
+        end.advanced_by(&source[end.offset..end_offset]),
+    ))
+}
+
+fn pattern_alternative_deletion_span(
+    patterns: &[Pattern],
+    pattern_span: Span,
+    source: &str,
+) -> Option<Span> {
+    let index = patterns.iter().position(|pattern| {
+        pattern.span.start.offset == pattern_span.start.offset
+            && pattern.span.end.offset == pattern_span.end.offset
+    })?;
+
+    if index + 1 < patterns.len() {
+        let next_start = patterns[index + 1].span.start.offset;
+        let pipe = source[pattern_span.end.offset..next_start].find('|')?;
+        let end = pattern_span
+            .end
+            .advanced_by(&source[pattern_span.end.offset..pattern_span.end.offset + pipe + 1]);
+        return Some(Span::from_positions(pattern_span.start, end));
+    }
+
+    if index > 0 {
+        let previous_end = patterns[index - 1].span.end.offset;
+        let pipe = source[previous_end..pattern_span.start.offset].rfind('|')?;
+        let start = patterns[index - 1]
+            .span
+            .end
+            .advanced_by(&source[previous_end..previous_end + pipe]);
+        return Some(Span::from_positions(start, pattern_span.end));
+    }
+
+    None
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_shadowing_patterns_in_same_arm_and_later_arms() {
@@ -181,5 +305,66 @@ esac
                 .collect::<Vec<_>>(),
             vec!["foo*"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_shadowing_case_patterns() {
+        let source = "\
+#!/bin/sh
+case \"$x\" in
+  foo) : ;;
+  foo) : ;;
+esac
+case \"$x\" in
+  *|foo*) : ;;
+  foo) : ;;
+esac
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaseGlobReachability),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+case \"$x\" in
+  foo) : ;;
+esac
+case \"$x\" in
+  foo) : ;;
+esac
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_shadowing_case_patterns_unchanged() {
+        let source = "#!/bin/sh\ncase \"$x\" in\n  foo) : ;;\n  foo) : ;;\nesac\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaseGlobReachability),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C128.sh").as_path(),
+            &LinterSettings::for_rule(Rule::CaseGlobReachability),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C128_fix_C128.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/case_item_delete.rs
+++ b/crates/shuck-linter/src/rules/correctness/case_item_delete.rs
@@ -1,0 +1,44 @@
+use shuck_ast::{Position, Span};
+
+pub(super) fn case_item_deletion_span(item: &shuck_ast::CaseItem, source: &str) -> Option<Span> {
+    let first = item.patterns.first()?.span;
+    let end = item.terminator_span.unwrap_or(item.body.span).end;
+    let mut start_offset = first.start.offset;
+    while start_offset > 0 {
+        let previous = source.as_bytes()[start_offset - 1];
+        if previous == b'\n' {
+            break;
+        }
+        if !previous.is_ascii_whitespace() {
+            break;
+        }
+        start_offset -= 1;
+    }
+
+    let mut trailing_offset = end.offset;
+    let end_offset = loop {
+        if trailing_offset >= source.len() {
+            break trailing_offset;
+        }
+        let byte = source.as_bytes()[trailing_offset];
+        if byte == b'\n' {
+            break trailing_offset + 1;
+        }
+        if !byte.is_ascii_whitespace() {
+            break end.offset;
+        }
+        trailing_offset += 1;
+    };
+
+    Some(Span::from_positions(
+        Position {
+            offset: start_offset,
+            line: first.start.line,
+            column: first
+                .start
+                .column
+                .saturating_sub(first.start.offset.saturating_sub(start_offset)),
+        },
+        end.advanced_by(&source[end.offset..end_offset]),
+    ))
+}

--- a/crates/shuck-linter/src/rules/correctness/continue_outside_loop_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/continue_outside_loop_in_function.rs
@@ -1,10 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 use super::loop_control_outside_loop::loop_control_violations;
 
 pub struct ContinueOutsideLoopInFunction;
 
 impl Violation for ContinueOutsideLoopInFunction {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::ContinueOutsideLoopInFunction
     }
@@ -12,18 +14,27 @@ impl Violation for ContinueOutsideLoopInFunction {
     fn message(&self) -> String {
         "`continue` inside a function must be inside a loop".into()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace `continue` with `return`".to_owned())
+    }
 }
 
 pub fn continue_outside_loop_in_function(checker: &mut Checker) {
     for (_, span, _) in loop_control_violations(checker, true, true) {
-        checker.report(ContinueOutsideLoopInFunction, span);
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(ContinueOutsideLoopInFunction, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement("return", span))),
+        );
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_continue_inside_a_function_outside_a_loop() {
@@ -129,5 +140,58 @@ f() {
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::ContinueOutsideLoopInFunction);
         assert_eq!(diagnostics[0].span.slice(source), "continue");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_continue_inside_function_outside_loop() {
+        let source = "\
+#!/bin/sh
+f() {
+\tcontinue 2
+}
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ContinueOutsideLoopInFunction),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+f() {
+\treturn 2
+}
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_continue_unchanged() {
+        let source = "#!/bin/sh\nf() {\n\tcontinue\n}\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ContinueOutsideLoopInFunction),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C126.sh").as_path(),
+            &LinterSettings::for_rule(Rule::ContinueOutsideLoopInFunction),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C126_fix_C126.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/env_prefix_expansion_only.rs
+++ b/crates/shuck-linter/src/rules/correctness/env_prefix_expansion_only.rs
@@ -1,8 +1,11 @@
-use crate::{Checker, Rule, Violation};
+use crate::facts::EnvPrefixExpansionFixFact;
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct EnvPrefixExpansionOnly;
 
 impl Violation for EnvPrefixExpansionOnly {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::EnvPrefixExpansionOnly
     }
@@ -10,19 +13,69 @@ impl Violation for EnvPrefixExpansionOnly {
     fn message(&self) -> String {
         "this same-command expansion still sees the earlier shell value".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("move the prefix assignment before the command".to_owned())
+    }
 }
 
 pub fn env_prefix_expansion_only(checker: &mut Checker) {
+    let source = checker.source();
+    let facts = checker
+        .facts()
+        .env_prefix_expansion_fix_facts()
+        .iter()
+        .filter_map(|fact| {
+            env_prefix_expansion_fix(fact, source).map(|fix| (fact.diagnostic_span(), fix))
+        })
+        .collect::<Vec<_>>();
+
+    for (span, fix) in facts {
+        checker
+            .report_diagnostic_dedup(Diagnostic::new(EnvPrefixExpansionOnly, span).with_fix(fix));
+    }
+
     checker.report_fact_slice_dedup(
         |facts| facts.env_prefix_expansion_scope_spans(),
         || EnvPrefixExpansionOnly,
     );
 }
 
+fn env_prefix_expansion_fix(fact: &EnvPrefixExpansionFixFact, source: &str) -> Option<Fix> {
+    let indent = line_indent_before_offset(source, fact.delete_span().start.offset)?;
+    let mut replacement = String::new();
+    for assignment_span in fact.assignment_spans() {
+        if !replacement.is_empty() {
+            replacement.push_str(indent);
+        }
+        replacement.push_str(assignment_span.slice(source));
+        replacement.push('\n');
+    }
+    replacement.push_str(indent);
+
+    Some(Fix::unsafe_edit(Edit::replacement(
+        replacement,
+        fact.delete_span(),
+    )))
+}
+
+fn line_indent_before_offset(source: &str, offset: usize) -> Option<&str> {
+    let line_start = source[..offset]
+        .rfind('\n')
+        .map_or(0, |newline| newline + '\n'.len_utf8());
+    let indent = source.get(line_start..offset)?;
+    indent
+        .bytes()
+        .all(|byte| matches!(byte, b' ' | b'\t'))
+        .then_some(indent)
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_later_expansions_that_cannot_see_prefix_assignments() {
@@ -76,5 +129,84 @@ COUNTDOWN=$[ $COUNTDOWN - 1 ]
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_lifting_prefix_assignments() {
+        let source = "\
+#!/bin/bash
+CFLAGS=\"${SLKCFLAGS}\" ./configure --with-optmizer=${CFLAGS}
+  A=1 B=\"$A\" C=\"$B\" cmd
+COUNTDOWN=$[ $COUNTDOWN - 1 ] echo \"$COUNTDOWN\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::EnvPrefixExpansionOnly),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+CFLAGS=\"${SLKCFLAGS}\"
+./configure --with-optmizer=${CFLAGS}
+  A=1
+  B=\"$A\"
+  C=\"$B\"
+  cmd
+COUNTDOWN=$[ $COUNTDOWN - 1 ]
+echo \"$COUNTDOWN\"
+"
+        );
+        assert_eq!(result.fixes_applied, 3);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_prefix_assignments_unchanged() {
+        let source = "\
+#!/bin/bash
+A=1 B=\"$A\" cmd
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::EnvPrefixExpansionOnly),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixes_applied, 0);
+    }
+
+    #[test]
+    fn skips_fix_for_inline_command_contexts() {
+        let source = "\
+#!/bin/bash
+if A=1 B=\"$A\" cmd; then
+  :
+fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::EnvPrefixExpansionOnly),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C132.sh").as_path(),
+            &LinterSettings::for_rule(Rule::EnvPrefixExpansionOnly),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C132_fix_C132.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/find_or_without_grouping.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_or_without_grouping.rs
@@ -224,6 +224,29 @@ find . -name a -o \\( -name b -delete \\)
     }
 
     #[test]
+    fn applies_safe_fix_to_negated_action_branches_from_operator_start() {
+        let source = "\
+find . -name a -o ! -name b -print
+find . -name a -o -not -name b -delete
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FindOrWithoutGrouping),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+find . -name a -o \\( ! -name b -print \\)
+find . -name a -o \\( -not -name b -delete \\)
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
     fn withholds_fix_for_exec_actions_that_have_arguments() {
         let source = "find . -name a -o -name b -exec rm -f {} \\;\n";
         let result = test_snippet_with_fix(

--- a/crates/shuck-linter/src/rules/correctness/find_or_without_grouping.rs
+++ b/crates/shuck-linter/src/rules/correctness/find_or_without_grouping.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct FindOrWithoutGrouping;
 
 impl Violation for FindOrWithoutGrouping {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::FindOrWithoutGrouping
     }
@@ -10,24 +12,53 @@ impl Violation for FindOrWithoutGrouping {
     fn message(&self) -> String {
         "`find` alternatives joined with `-o` should be grouped before applying actions".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("group the action-bearing find branch".to_owned())
+    }
 }
 
 pub fn find_or_without_grouping(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|fact| fact.options().find())
-        .flat_map(|find| find.or_without_grouping_spans().iter().copied())
+        .flat_map(|find| {
+            find.or_without_grouping_spans()
+                .iter()
+                .map(|span| {
+                    (
+                        *span,
+                        find.or_without_grouping_fix_spans()
+                            .iter()
+                            .find(|fix| fix.diagnostic_span == *span)
+                            .copied(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || FindOrWithoutGrouping);
+    for (span, fix_span) in diagnostics {
+        let diagnostic = Diagnostic::new(FindOrWithoutGrouping, span);
+        if let Some(fix_span) = fix_span {
+            checker.report_diagnostic_dedup(diagnostic.with_fix(Fix::safe_edits([
+                Edit::insertion(fix_span.branch_start.start.offset, "\\( "),
+                Edit::insertion(fix_span.action_span.end.offset, " \\)"),
+            ])));
+        } else {
+            checker.report_diagnostic_dedup(diagnostic);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_ungrouped_or_when_action_is_only_in_later_branch() {
@@ -167,5 +198,54 @@ find . -name a -o -name b -a -exec rm -f {} \\;
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_action_branches_without_action_arguments() {
+        let source = "\
+find . -name a -o -name b -print
+find . -name a -o -name b -delete
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FindOrWithoutGrouping),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+find . -name a -o \\( -name b -print \\)
+find . -name a -o \\( -name b -delete \\)
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn withholds_fix_for_exec_actions_that_have_arguments() {
+        let source = "find . -name a -o -name b -exec rm -f {} \\;\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FindOrWithoutGrouping),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C103.sh").as_path(),
+            &LinterSettings::for_rule(Rule::FindOrWithoutGrouping),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("C103_fix_C103.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
@@ -1,10 +1,15 @@
 use shuck_ast::static_word_text;
 
-use crate::{Checker, LinterFacts, Rule, SimpleTestShape, SimpleTestSyntax, Violation};
+use crate::{
+    Checker, Diagnostic, Edit, Fix, FixAvailability, LinterFacts, Rule, SimpleTestShape,
+    SimpleTestSyntax, Violation,
+};
 
 pub struct GlobInTestComparison;
 
 impl Violation for GlobInTestComparison {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::GlobInTestComparison
     }
@@ -12,25 +17,34 @@ impl Violation for GlobInTestComparison {
     fn message(&self) -> String {
         "glob matching on the right-hand side of `[ ... ]` won't work here".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the literal glob operand".to_owned())
+    }
 }
 
 pub fn glob_in_test_comparison(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|command| command.simple_test())
-        .filter_map(|simple_test| report_span(simple_test, checker.facts(), checker.source()))
+        .filter_map(|simple_test| diagnostic_fix(simple_test, checker.facts(), checker.source()))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || GlobInTestComparison);
+    for (span, replacement) in diagnostics {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(GlobInTestComparison, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement(replacement, span))),
+        );
+    }
 }
 
-fn report_span(
+fn diagnostic_fix(
     simple_test: &crate::SimpleTestFact<'_>,
     facts: &LinterFacts<'_>,
     source: &str,
-) -> Option<shuck_ast::Span> {
+) -> Option<(shuck_ast::Span, String)> {
     if simple_test.syntax() != SimpleTestSyntax::Bracket
         || simple_test.effective_shape() != SimpleTestShape::Binary
     {
@@ -45,17 +59,27 @@ fn report_span(
     let rhs = *simple_test.effective_operands().get(2)?;
     let rhs_class = simple_test.effective_operand_class(2)?;
 
-    (!rhs_class.is_fixed_literal()
-        && facts
+    if rhs_class.is_fixed_literal()
+        || facts
             .any_word_fact(rhs.span)
-            .is_some_and(|fact| !fact.active_literal_glob_spans(source).is_empty()))
-    .then_some(rhs.span)
+            .is_none_or(|fact| fact.active_literal_glob_spans(source).is_empty())
+    {
+        return None;
+    }
+
+    Some((rhs.span, double_quoted_replacement(rhs.span.slice(source))))
+}
+
+fn double_quoted_replacement(text: &str) -> String {
+    format!("\"{}\"", text.replace('"', "\\\""))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_unquoted_globs_in_bracket_string_comparisons() {
@@ -135,5 +159,63 @@ setopt glob
                 .collect::<Vec<_>>(),
             vec!["i?86"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_unquoted_globs_in_bracket_comparisons() {
+        let source = "\
+#!/bin/bash
+[ \"$ARCH\" == i?86 ]
+[ \"$ARCH\" = *.x86 ]
+[ \"$ARCH\" != [[:digit:]] ]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInTestComparison),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ \"$ARCH\" == \"i?86\" ]
+[ \"$ARCH\" = \"*.x86\" ]
+[ \"$ARCH\" != \"[[:digit:]]\" ]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_already_literal_operands_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+[ \"$ARCH\" == \"i?86\" ]
+[ \"$ARCH\" == i\\?86 ]
+[[ \"$ARCH\" == i?86 ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInTestComparison),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C090.sh").as_path(),
+            &LinterSettings::for_rule(Rule::GlobInTestComparison),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C090_fix_C090.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
@@ -1,19 +1,25 @@
 use shuck_ast::{ConditionalUnaryOp, Span, Word, static_word_text};
 
 use crate::{
-    Checker, ConditionalFact, ConditionalNodeFact, LinterFacts, Rule, SimpleTestFact,
-    SimpleTestShape, Violation,
+    Checker, ConditionalFact, ConditionalNodeFact, Diagnostic, Edit, Fix, FixAvailability,
+    LinterFacts, Rule, SimpleTestFact, SimpleTestShape, Violation,
 };
 
 pub struct GlobInTestDirectory;
 
 impl Violation for GlobInTestDirectory {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::GlobInTestDirectory
     }
 
     fn message(&self) -> String {
         "unquoted globs in file tests can match multiple paths".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the file-test operand".to_owned())
     }
 }
 
@@ -43,7 +49,14 @@ pub fn glob_in_test_directory(checker: &mut Checker) {
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || GlobInTestDirectory);
+    for span in spans {
+        checker.report_diagnostic_dedup(Diagnostic::new(GlobInTestDirectory, span).with_fix(
+            Fix::unsafe_edit(Edit::replacement(
+                format!("\"{}\"", span.slice(source)),
+                span,
+            )),
+        ));
+    }
 }
 
 fn simple_test_file_test_spans(
@@ -217,8 +230,10 @@ fn is_simple_test_file_test_unary_operator(token: Option<&str>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_unquoted_globs_in_simple_and_conditional_file_tests() {
@@ -264,5 +279,62 @@ test -n mtp2*
             test_snippet(source, &LinterSettings::for_rule(Rule::GlobInTestDirectory));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_unquoted_file_test_globs() {
+        let source = "\
+#!/bin/bash
+[ -d mtp2* ]
+[ -e bar* -a -L baz* ]
+[[ -r qux* && -w quux* ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInTestDirectory),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 5);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ -d \"mtp2*\" ]
+[ -e \"bar*\" -a -L \"baz*\" ]
+[[ -r \"qux*\" && -w \"quux*\" ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_quoted_globs_and_non_file_tests_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+[ -d \"mtp2*\" ]
+test -n mtp2*
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobInTestDirectory),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C102.sh").as_path(),
+            &LinterSettings::for_rule(Rule::GlobInTestDirectory),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C102_fix_C102.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
@@ -1,15 +1,24 @@
-use crate::{Checker, ExpansionContext, Rule, Violation, WordOccurrenceRef};
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation,
+    WordOccurrenceRef,
+};
 use shuck_ast::Span;
 
 pub struct GlobWithExpansionInLoop;
 
 impl Violation for GlobWithExpansionInLoop {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::GlobWithExpansionInLoop
     }
 
     fn message(&self) -> String {
         "quote expansion prefixes when combining them with loop globs".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the expansion prefix".to_owned())
     }
 }
 
@@ -26,7 +35,14 @@ pub fn glob_with_expansion_in_loop(checker: &mut Checker) {
         .flat_map(unquoted_expansion_prefix_spans)
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || GlobWithExpansionInLoop);
+    for span in spans {
+        checker.report_diagnostic_dedup(Diagnostic::new(GlobWithExpansionInLoop, span).with_fix(
+            Fix::unsafe_edits([
+                Edit::insertion(span.start.offset, "\""),
+                Edit::insertion(span.end.offset, "\""),
+            ]),
+        ));
+    }
 }
 
 fn unquoted_expansion_prefix_spans(fact: WordOccurrenceRef<'_, '_>) -> Vec<Span> {
@@ -43,8 +59,10 @@ fn unquoted_expansion_prefix_spans(fact: WordOccurrenceRef<'_, '_>) -> Vec<Span>
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn reports_unquoted_expansion_prefixes_in_for_glob_words() {
@@ -138,5 +156,58 @@ for repo in \"${ZINIT[PLUGINS_DIR]}\"/*; do :; done
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_unquoted_expansion_prefixes() {
+        let source = "\
+#!/bin/sh
+for i in $CWD/file.*pattern*; do :; done
+for i in ${CWD}/file.*pattern*; do :; done
+for i in $(pwd)/file.*pattern*; do :; done
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobWithExpansionInLoop),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+for i in \"$CWD\"/file.*pattern*; do :; done
+for i in \"${CWD}\"/file.*pattern*; do :; done
+for i in \"$(pwd)\"/file.*pattern*; do :; done
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_unquoted_expansion_prefixes_unchanged() {
+        let source = "#!/bin/sh\nfor i in $CWD/file.*pattern*; do :; done\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobWithExpansionInLoop),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C114.sh").as_path(),
+            &LinterSettings::for_rule(Rule::GlobWithExpansionInLoop),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C114_fix_C114.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/heredoc_closer_not_alone.rs
+++ b/crates/shuck-linter/src/rules/correctness/heredoc_closer_not_alone.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct HeredocCloserNotAlone;
 
 impl Violation for HeredocCloserNotAlone {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::HeredocCloserNotAlone
     }
@@ -10,19 +12,46 @@ impl Violation for HeredocCloserNotAlone {
     fn message(&self) -> String {
         "this here-document closer must be on its own line".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("append the here-document closer".to_owned())
+    }
 }
 
 pub fn heredoc_closer_not_alone(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.heredoc_closer_not_alone_spans(),
-        || HeredocCloserNotAlone,
-    );
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .heredoc_closer_not_alone_spans()
+        .iter()
+        .copied()
+        .map(|span| {
+            Diagnostic::new(HeredocCloserNotAlone, span)
+                .with_fix(append_heredoc_closer_fix(source, span.slice(source)))
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn append_heredoc_closer_fix(source: &str, delimiter: &str) -> Fix {
+    let content = if source.is_empty() || source.ends_with('\n') {
+        format!("{delimiter}\n")
+    } else {
+        format!("\n{delimiter}\n")
+    };
+
+    Fix::safe_edit(Edit::insertion(source.len(), content))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_content_prefixed_terminator_lines() {
@@ -72,5 +101,42 @@ EOF
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_by_appending_heredoc_closer() {
+        let source = "\
+#!/bin/sh
+cat <<EOF
+x EOF";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::HeredocCloserNotAlone),
+            Applicability::Safe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+cat <<EOF
+x EOF
+EOF
+"
+        );
+        assert_eq!(result.fixes_applied, 1);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C144.sh").as_path(),
+            &LinterSettings::for_rule(Rule::HeredocCloserNotAlone),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("C144_fix_C144.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
+++ b/crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
@@ -1,13 +1,15 @@
 use rustc_hash::FxHashMap;
-use shuck_ast::{ArrayElem, Assignment, AssignmentValue, Span};
+use shuck_ast::{ArrayElem, Assignment, AssignmentValue, DeclOperand, Span};
 use shuck_semantic::ReferenceKind;
 use smallvec::SmallVec;
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct LocalCrossReference;
 
 impl Violation for LocalCrossReference {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::LocalCrossReference
     }
@@ -15,17 +17,33 @@ impl Violation for LocalCrossReference {
     fn message(&self) -> String {
         "assignment is reused later in the same declaration".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("split the declaration assignments".to_owned())
+    }
 }
 
 pub fn local_cross_reference(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
-        .flat_map(|fact| declaration_cross_reference_spans(checker, fact))
+        .flat_map(|fact| {
+            let fix = split_declaration_fix(checker.source(), fact);
+            declaration_cross_reference_spans(checker, fact)
+                .into_iter()
+                .map(move |span| (span, fix.clone()))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || LocalCrossReference);
+    for (span, fix) in diagnostics {
+        let diagnostic = Diagnostic::new(LocalCrossReference, span);
+        if let Some(fix) = fix {
+            checker.report_diagnostic_dedup(diagnostic.with_fix(fix));
+        } else {
+            checker.report_diagnostic_dedup(diagnostic);
+        }
+    }
 }
 
 fn declaration_cross_reference_spans<'a>(
@@ -82,10 +100,69 @@ fn push_array_element_spans(element: &ArrayElem, spans: &mut SmallVec<[Span; 4]>
     }
 }
 
+fn split_declaration_fix<'a>(source: &str, fact: crate::CommandFactRef<'_, 'a>) -> Option<Fix> {
+    let declaration = fact.declaration()?;
+    if !declaration.redirects.is_empty() || declaration.assignment_operands.len() < 2 {
+        return None;
+    }
+
+    let first_assignment = declaration.assignment_operands.first()?;
+    let first_assignment_index = declaration.operands.iter().position(|operand| {
+        matches!(operand, DeclOperand::Assignment(assignment) if assignment.span == first_assignment.span)
+    })?;
+
+    if !declaration.operands[..first_assignment_index]
+        .iter()
+        .all(|operand| matches!(operand, DeclOperand::Flag(_)))
+        || !declaration.operands[first_assignment_index..]
+            .iter()
+            .all(|operand| matches!(operand, DeclOperand::Assignment(_)))
+    {
+        return None;
+    }
+
+    let indent = line_indent_before_offset(source, declaration.span.start.offset)?;
+    let head = source
+        .get(declaration.span.start.offset..first_assignment.span.start.offset)?
+        .trim_end();
+    if head.is_empty() {
+        return None;
+    }
+
+    let mut replacement = String::new();
+    for assignment in &declaration.assignment_operands {
+        if !replacement.is_empty() {
+            replacement.push_str(indent);
+        }
+        replacement.push_str(head);
+        replacement.push(' ');
+        replacement.push_str(assignment.span.slice(source));
+        replacement.push('\n');
+    }
+
+    Some(Fix::unsafe_edit(Edit::replacement(
+        replacement,
+        declaration.span,
+    )))
+}
+
+fn line_indent_before_offset(source: &str, offset: usize) -> Option<&str> {
+    let line_start = source[..offset]
+        .rfind('\n')
+        .map_or(0, |newline| newline + '\n'.len_utf8());
+    let indent = source.get(line_start..offset)?;
+    indent
+        .bytes()
+        .all(|byte| matches!(byte, b' ' | b'\t'))
+        .then_some(indent)
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn anchors_on_prior_assignment_names_in_declarations() {
@@ -152,5 +229,85 @@ f() {
             test_snippet(source, &LinterSettings::for_rule(Rule::LocalCrossReference));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_splitting_declaration_assignments() {
+        let source = "\
+#!/bin/sh
+f() {
+  local -r a=1 b=$a c=$b
+  declare x=1 y=$(printf '%s' \"$x\")
+}
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LocalCrossReference),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+f() {
+  local -r a=1
+  local -r b=$a
+  local -r c=$b
+  declare x=1
+  declare y=$(printf '%s' \"$x\")
+}
+"
+        );
+        assert_eq!(result.fixes_applied, 2);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_declarations_unchanged() {
+        let source = "\
+#!/bin/sh
+local a=1 b=$a
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LocalCrossReference),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixes_applied, 0);
+    }
+
+    #[test]
+    fn skips_fix_for_mixed_or_inline_declarations() {
+        let source = "\
+#!/bin/sh
+if local a=1 b=$a; then
+  :
+fi
+local keep a=1 b=$a
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LocalCrossReference),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C136.sh").as_path(),
+            &LinterSettings::for_rule(Rule::LocalCrossReference),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C136_fix_C136.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/missing_done_in_for_loop.rs
+++ b/crates/shuck-linter/src/rules/correctness/missing_done_in_for_loop.rs
@@ -1,13 +1,81 @@
-use crate::{Rule, Violation};
+use crate::{FixAvailability, Rule, Violation};
 
 pub struct MissingDoneInForLoop;
 
 impl Violation for MissingDoneInForLoop {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::MissingDoneInForLoop
     }
 
     fn message(&self) -> String {
         "this `for` loop is missing a closing `done`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("append a closing `done`".to_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
+
+    #[test]
+    fn applies_unsafe_fix_by_appending_done() {
+        let source = "\
+#!/bin/sh
+for x in a; do
+  echo \"$x\"";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MissingDoneInForLoop),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+for x in a; do
+  echo \"$x\"
+done
+"
+        );
+        assert_eq!(result.fixes_applied, 1);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_missing_done_unchanged() {
+        let source = "\
+#!/bin/sh
+for x in a; do
+  echo \"$x\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MissingDoneInForLoop),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixes_applied, 0);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C142.sh").as_path(),
+            &LinterSettings::for_rule(Rule::MissingDoneInForLoop),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C142_fix_C142.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -22,6 +22,7 @@ pub mod c_style_comment;
 pub mod case_arm_not_in_getopts;
 pub mod case_default_before_glob;
 pub mod case_glob_reachability;
+mod case_item_delete;
 pub mod case_pattern_var;
 pub mod chained_test_branches;
 pub mod comma_array_elements;

--- a/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
+++ b/crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
@@ -1,10 +1,12 @@
 use shuck_ast::{Command, StmtTerminator, static_word_text};
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct NonShellSyntaxInScript;
 
 impl Violation for NonShellSyntaxInScript {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::NonShellSyntaxInScript
     }
@@ -12,23 +14,32 @@ impl Violation for NonShellSyntaxInScript {
     fn message(&self) -> String {
         "line looks like non-shell declaration syntax".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete the non-shell declaration".to_owned())
+    }
 }
 
 pub fn non_shell_syntax_in_script(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
-        .filter_map(|command| non_shell_syntax_span(command, checker.source()))
+        .filter_map(|command| non_shell_syntax_spans(command, checker.source()))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || NonShellSyntaxInScript);
+    for (span, fix_span) in diagnostics {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(NonShellSyntaxInScript, span)
+                .with_fix(Fix::unsafe_edit(Edit::deletion(fix_span))),
+        );
+    }
 }
 
-fn non_shell_syntax_span(
+fn non_shell_syntax_spans(
     command: crate::CommandFactRef<'_, '_>,
     source: &str,
-) -> Option<shuck_ast::Span> {
+) -> Option<(shuck_ast::Span, shuck_ast::Span)> {
     if command.stmt().terminator != Some(StmtTerminator::Semicolon) {
         return None;
     }
@@ -45,7 +56,7 @@ fn non_shell_syntax_span(
         return None;
     }
 
-    Some(simple.name.span)
+    Some((simple.name.span, command.stmt().span))
 }
 
 fn looks_like_c_declaration_keyword(text: &str) -> bool {
@@ -70,8 +81,10 @@ fn looks_like_c_declaration_keyword(text: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_c_style_declaration_like_lines() {
@@ -94,5 +107,45 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_declaration_like_statements() {
+        let source = "#!/bin/sh\nint value;\necho ok\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::NonShellSyntaxInScript),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\n\necho ok\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_regular_shell_commands_unchanged_when_fixing() {
+        let source = "#!/bin/sh\necho value;\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::NonShellSyntaxInScript),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C104.sh").as_path(),
+            &LinterSettings::for_rule(Rule::NonShellSyntaxInScript),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C104_fix_C104.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
@@ -1,8 +1,13 @@
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFactHostKind};
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation,
+    WordFactHostKind,
+};
 
 pub struct QuotedArraySlice;
 
 impl Violation for QuotedArraySlice {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::QuotedArraySlice
     }
@@ -10,12 +15,17 @@ impl Violation for QuotedArraySlice {
     fn message(&self) -> String {
         "all-elements array expansions collapse in scalar assignment values".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the expansion as an intentional join".to_owned())
+    }
 }
 
 pub fn quoted_array_slice(checker: &mut Checker) {
     let facts = checker.facts();
     let locator = checker.locator();
-    let spans = [
+    let source = checker.source();
+    let diagnostics = [
         ExpansionContext::AssignmentValue,
         ExpansionContext::DeclarationAssignmentValue,
     ]
@@ -24,16 +34,62 @@ pub fn quoted_array_slice(checker: &mut Checker) {
     .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
     .filter(|fact| !facts.is_compound_assignment_value_word(*fact))
     .filter(|fact| fact.has_direct_all_elements_array_expansion_in_source(locator))
-    .map(|fact| fact.span())
+    .map(|fact| {
+        (
+            fact.span(),
+            intentional_join_fix(fact.direct_all_elements_array_expansion_spans(), source),
+        )
+    })
     .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || QuotedArraySlice);
+    for (span, fix) in diagnostics {
+        let diagnostic = Diagnostic::new(QuotedArraySlice, span);
+        if let Some(fix) = fix {
+            checker.report_diagnostic_dedup(diagnostic.with_fix(fix));
+        } else {
+            checker.report_diagnostic_dedup(diagnostic);
+        }
+    }
+}
+
+fn intentional_join_fix(expansion_spans: &[shuck_ast::Span], source: &str) -> Option<Fix> {
+    expansion_spans
+        .iter()
+        .map(|span| {
+            intentional_join_expansion(span.slice(source))
+                .map(|replacement| Edit::replacement(replacement, *span))
+        })
+        .collect::<Option<Vec<_>>>()
+        .filter(|edits| !edits.is_empty())
+        .map(Fix::unsafe_edits)
+}
+
+fn intentional_join_expansion(raw: &str) -> Option<String> {
+    if raw == "$@" {
+        return Some("$*".to_owned());
+    }
+
+    if let Some(rest) = raw.strip_prefix("$@[*]") {
+        return Some(format!("$*{rest}"));
+    }
+
+    if raw.starts_with("${@") {
+        return Some(raw.replacen("${@", "${*", 1));
+    }
+
+    if raw.contains("[@]") {
+        return Some(raw.replacen("[@]", "[*]", 1));
+    }
+
+    None
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn reports_all_elements_array_expansions_in_scalar_bindings() {
@@ -163,5 +219,93 @@ selected_short=\"$@[*]\"
                 .collect::<Vec<_>>(),
             vec!["\"${@[*]}\"", "\"$@[*]\""]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_intentional_join_selectors() {
+        let source = "\
+#!/bin/bash
+x=\"$@\"
+y=\"${@}\"
+z=${@:5}
+p=\"${arr[@]}\"
+q=\"${arr[@]:-fallback}\"
+flags+=\" ${add_flags[@]}\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedArraySlice),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 6);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+x=\"$*\"
+y=\"${*}\"
+z=${*:5}
+p=\"${arr[*]}\"
+q=\"${arr[*]:-fallback}\"
+flags+=\" ${add_flags[*]}\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_zsh_star_selector_forms() {
+        let source = "\
+#!/bin/zsh
+selected=\"${@[*]}\"
+selected_short=\"$@[*]\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedArraySlice).with_shell(ShellDialect::Zsh),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/zsh
+selected=\"${*[*]}\"
+selected_short=\"$*[*]\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_replacement_and_array_assignment_forms_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+x=\"${@:+fallback}\"
+arr=(\"${@:2}\")
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedArraySlice),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C099.sh").as_path(),
+            &LinterSettings::for_rule(Rule::QuotedArraySlice),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C099_fix_C099.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
@@ -1,13 +1,16 @@
 use shuck_ast::{ConditionalUnaryOp, Span, Word};
 
 use crate::{
-    Checker, ConditionalNodeFact, ConditionalOperatorFamily, ExpansionContext, Rule,
-    SimpleTestOperatorFamily, SimpleTestShape, Violation, WordFactContext, WordQuote,
+    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Diagnostic, Edit, ExpansionContext,
+    Fix, FixAvailability, Rule, SimpleTestOperatorFamily, SimpleTestShape, Violation,
+    WordFactContext, WordQuote,
 };
 
 pub struct QuotedCommandInTest;
 
 impl Violation for QuotedCommandInTest {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::QuotedCommandInTest
     }
@@ -15,37 +18,46 @@ impl Violation for QuotedCommandInTest {
     fn message(&self) -> String {
         "this test uses a quoted pipeline literal instead of command output".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("wrap the pipeline in command substitution".to_owned())
+    }
 }
 
 pub fn quoted_command_in_test(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .flat_map(|command| {
-            let mut spans = Vec::new();
+            let mut diagnostics = Vec::new();
             if let Some(simple_test) = command.simple_test() {
-                spans.extend(collect_simple_test_spans(checker, simple_test));
+                diagnostics.extend(collect_simple_test_diagnostics(checker, simple_test));
             }
             if let Some(conditional) = command.conditional() {
-                spans.extend(collect_conditional_spans(conditional, source));
+                diagnostics.extend(collect_conditional_diagnostics(conditional, source));
             }
-            spans
+            diagnostics
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || QuotedCommandInTest);
+    for (span, replacement) in diagnostics {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(QuotedCommandInTest, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement(replacement, span))),
+        );
+    }
 }
 
-fn collect_simple_test_spans(
+fn collect_simple_test_diagnostics(
     checker: &Checker<'_>,
     simple_test: &crate::SimpleTestFact<'_>,
-) -> Vec<Span> {
+) -> Vec<(Span, String)> {
     simple_test_condition_operand(simple_test)
         .and_then(|word| {
-            simple_test_word_looks_like_quoted_pipeline(checker, word.span, checker.source())
-                .then_some(word.span)
+            simple_test_quoted_pipeline_replacement(checker, word.span, checker.source())
+                .map(|replacement| (word.span, replacement))
         })
         .into_iter()
         .collect()
@@ -68,8 +80,11 @@ fn simple_test_condition_operand<'a>(
     }
 }
 
-fn collect_conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &str) -> Vec<Span> {
-    let mut spans = Vec::new();
+fn collect_conditional_diagnostics(
+    conditional: &crate::ConditionalFact<'_>,
+    source: &str,
+) -> Vec<(Span, String)> {
+    let mut diagnostics = Vec::new();
     let unary_operand_spans = conditional
         .nodes()
         .iter()
@@ -103,18 +118,24 @@ fn collect_conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &
 
     match conditional.root() {
         ConditionalNodeFact::BareWord(bare_word)
-            if conditional_operand_looks_like_quoted_pipeline(bare_word.operand(), source) =>
+            if conditional_quoted_pipeline_replacement(bare_word.operand(), source).is_some() =>
         {
-            if let Some(word) = bare_word.operand().word() {
-                spans.push(word.span);
+            if let Some(word) = bare_word.operand().word()
+                && let Some(replacement) =
+                    conditional_quoted_pipeline_replacement(bare_word.operand(), source)
+            {
+                diagnostics.push((word.span, replacement));
             }
         }
         ConditionalNodeFact::Unary(unary)
             if conditional_unary_checks_literal_string(unary)
-                && conditional_operand_looks_like_quoted_pipeline(unary.operand(), source) =>
+                && conditional_quoted_pipeline_replacement(unary.operand(), source).is_some() =>
         {
-            if let Some(word) = unary.operand().word() {
-                spans.push(word.span);
+            if let Some(word) = unary.operand().word()
+                && let Some(replacement) =
+                    conditional_quoted_pipeline_replacement(unary.operand(), source)
+            {
+                diagnostics.push((word.span, replacement));
             }
         }
         ConditionalNodeFact::BareWord(_)
@@ -129,22 +150,27 @@ fn collect_conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &
                 if bare_word.operand().word().is_some_and(|word| {
                     !unary_operand_spans.contains(&word.span)
                         && !comparison_operand_spans.contains(&word.span)
-                        && conditional_operand_looks_like_quoted_pipeline(
-                            bare_word.operand(),
-                            source,
-                        )
+                        && conditional_quoted_pipeline_replacement(bare_word.operand(), source)
+                            .is_some()
                 }) =>
             {
-                if let Some(word) = bare_word.operand().word() {
-                    spans.push(word.span);
+                if let Some(word) = bare_word.operand().word()
+                    && let Some(replacement) =
+                        conditional_quoted_pipeline_replacement(bare_word.operand(), source)
+                {
+                    diagnostics.push((word.span, replacement));
                 }
             }
             ConditionalNodeFact::Unary(unary)
                 if conditional_unary_checks_literal_string(unary)
-                    && conditional_operand_looks_like_quoted_pipeline(unary.operand(), source) =>
+                    && conditional_quoted_pipeline_replacement(unary.operand(), source)
+                        .is_some() =>
             {
-                if let Some(word) = unary.operand().word() {
-                    spans.push(word.span);
+                if let Some(word) = unary.operand().word()
+                    && let Some(replacement) =
+                        conditional_quoted_pipeline_replacement(unary.operand(), source)
+                {
+                    diagnostics.push((word.span, replacement));
                 }
             }
             ConditionalNodeFact::BareWord(_)
@@ -154,7 +180,7 @@ fn collect_conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &
         }
     }
 
-    spans
+    diagnostics
 }
 
 fn conditional_unary_checks_literal_string(unary: &crate::ConditionalUnaryFact<'_>) -> bool {
@@ -162,36 +188,38 @@ fn conditional_unary_checks_literal_string(unary: &crate::ConditionalUnaryFact<'
         || unary.op() == ConditionalUnaryOp::Not
 }
 
-fn simple_test_word_looks_like_quoted_pipeline(
+fn simple_test_quoted_pipeline_replacement(
     checker: &Checker<'_>,
     span: Span,
     source: &str,
-) -> bool {
+) -> Option<String> {
     checker
         .facts()
         .word_fact(
             span,
             WordFactContext::Expansion(ExpansionContext::CommandArgument),
         )
-        .is_some_and(|fact| word_fact_looks_like_quoted_pipeline(fact, source))
+        .and_then(|fact| quoted_pipeline_replacement_from_word_fact(fact, source))
 }
 
-fn word_fact_looks_like_quoted_pipeline(
+fn quoted_pipeline_replacement_from_word_fact(
     fact: crate::WordOccurrenceRef<'_, '_>,
     source: &str,
-) -> bool {
-    fact.classification().quote == WordQuote::FullyQuoted
-        && fact.classification().is_fixed_literal()
-        && fact
-            .static_text_cow(source)
-            .as_deref()
-            .is_some_and(looks_like_quoted_pipeline_literal)
+) -> Option<String> {
+    if fact.classification().quote != WordQuote::FullyQuoted
+        || !fact.classification().is_fixed_literal()
+    {
+        return None;
+    }
+
+    let text = fact.static_text_cow(source)?;
+    looks_like_quoted_pipeline_literal(&text).then(|| command_substitution_replacement(&text))
 }
 
-fn conditional_operand_looks_like_quoted_pipeline(
+fn conditional_quoted_pipeline_replacement(
     operand: crate::ConditionalOperandFact<'_>,
     source: &str,
-) -> bool {
+) -> Option<String> {
     operand
         .word()
         .zip(operand.word_classification())
@@ -200,8 +228,14 @@ fn conditional_operand_looks_like_quoted_pipeline(
                 .then(|| shuck_ast::static_word_text(word, source))
         })
         .flatten()
-        .as_deref()
-        .is_some_and(looks_like_quoted_pipeline_literal)
+        .and_then(|text| {
+            looks_like_quoted_pipeline_literal(&text)
+                .then(|| command_substitution_replacement(&text))
+        })
+}
+
+fn command_substitution_replacement(text: &str) -> String {
+    format!("\"$({})\"", text.replace('"', "\\\""))
 }
 
 fn looks_like_quoted_pipeline_literal(text: &str) -> bool {
@@ -229,8 +263,10 @@ fn looks_like_command_word(token: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_quoted_pipeline_literals_in_simple_tests() {
@@ -335,5 +371,63 @@ test ! -z \"modprobe | grep snd_hda\"
             test_snippet(source, &LinterSettings::for_rule(Rule::QuotedCommandInTest));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_quoted_pipeline_literals() {
+        let source = "\
+#!/bin/sh
+[ \"lsmod | grep v4l2loopback\" ]
+[ -n \"modprobe | grep snd\" ]
+[[ \"$ok\" && \"dmesg | grep usb\" ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedCommandInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+[ \"$(lsmod | grep v4l2loopback)\" ]
+[ -n \"$(modprobe | grep snd)\" ]
+[[ \"$ok\" && \"$(dmesg | grep usb)\" ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_non_pipeline_literals_unchanged_when_fixing() {
+        let source = "\
+#!/bin/sh
+[ \"echo hi\" ]
+[ \"foo | bar\" = x ]
+[[ -f \"foo | bar\" ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedCommandInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C089.sh").as_path(),
+            &LinterSettings::for_rule(Rule::QuotedCommandInTest),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C089_fix_C089.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
@@ -235,7 +235,7 @@ fn conditional_quoted_pipeline_replacement(
 }
 
 fn command_substitution_replacement(text: &str) -> String {
-    format!("\"$({})\"", text.replace('"', "\\\""))
+    format!("\"$({text})\"")
 }
 
 fn looks_like_quoted_pipeline_literal(text: &str) -> bool {
@@ -395,6 +395,29 @@ test ! -z \"modprobe | grep snd_hda\"
 [ \"$(lsmod | grep v4l2loopback)\" ]
 [ -n \"$(modprobe | grep snd)\" ]
 [[ \"$ok\" && \"$(dmesg | grep usb)\" ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn preserves_inner_quotes_when_fixing_quoted_pipeline_literals() {
+        let source = "\
+#!/bin/sh
+[ \"printf \\\"%s\\\" foo | grep foo\" ]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedCommandInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+[ \"$(printf \"%s\" foo | grep foo)\" ]
 "
         );
         assert!(result.fixed_diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
+++ b/crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
@@ -1,10 +1,12 @@
-use shuck_ast::{BinaryOp, RedirectKind, Span};
+use shuck_ast::{BinaryOp, Position, RedirectKind, Span};
 
-use crate::{Checker, PipelineFact, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, PipelineFact, Rule, Violation};
 
 pub struct RedirectBeforePipe;
 
 impl Violation for RedirectBeforePipe {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::RedirectBeforePipe
     }
@@ -12,20 +14,30 @@ impl Violation for RedirectBeforePipe {
     fn message(&self) -> String {
         "a stdout redirect before a pipe only affects the command on the left".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("move the redirect after the pipeline".to_owned())
+    }
 }
 
 pub fn redirect_before_pipe(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .pipelines()
         .iter()
-        .flat_map(|pipeline| redirect_spans_for_pipeline(checker, pipeline))
+        .flat_map(|pipeline| redirect_diagnostics_for_pipeline(checker, pipeline))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || RedirectBeforePipe);
+    for (span, fix) in diagnostics {
+        checker.report_diagnostic_dedup(Diagnostic::new(RedirectBeforePipe, span).with_fix(fix));
+    }
 }
 
-fn redirect_spans_for_pipeline(checker: &Checker<'_>, pipeline: &PipelineFact<'_>) -> Vec<Span> {
+fn redirect_diagnostics_for_pipeline(
+    checker: &Checker<'_>,
+    pipeline: &PipelineFact<'_>,
+) -> Vec<(Span, Fix)> {
+    let source = checker.source();
     pipeline
         .segments()
         .iter()
@@ -36,13 +48,69 @@ fn redirect_spans_for_pipeline(checker: &Checker<'_>, pipeline: &PipelineFact<'_
             fact.redirect_facts()
                 .iter()
                 .filter_map(|redirect| {
-                    stdout_redirect_span_before_pipe(redirect, checker.source()).filter(|_| {
-                        !has_independent_stderr_to_stdout_dup(fact.redirect_facts(), redirect)
-                    })
+                    let operator_span =
+                        stdout_redirect_span_before_pipe(redirect, source).filter(|_| {
+                            !has_independent_stderr_to_stdout_dup(fact.redirect_facts(), redirect)
+                        })?;
+                    let fix = move_redirect_after_pipeline_fix(redirect, pipeline, source)?;
+                    Some((operator_span, fix))
                 })
                 .collect::<Vec<_>>()
         })
         .collect()
+}
+
+fn move_redirect_after_pipeline_fix(
+    redirect: &crate::RedirectFact<'_>,
+    pipeline: &PipelineFact<'_>,
+    source: &str,
+) -> Option<Fix> {
+    let redirect_span = redirect.redirect().span;
+    let delete_span = redirect_deletion_span(redirect_span, source);
+    let insertion_offset = trim_trailing_whitespace_offset(
+        pipeline.last_segment()?.stmt().span.start.offset,
+        pipeline.last_segment()?.stmt().span.end.offset,
+        source,
+    );
+    let insertion = format!(" {}", redirect_span.slice(source).trim());
+    Some(Fix::unsafe_edits([
+        Edit::deletion(delete_span),
+        Edit::insertion(insertion_offset, insertion),
+    ]))
+}
+
+fn trim_trailing_whitespace_offset(start: usize, mut end: usize, source: &str) -> usize {
+    while end > start {
+        let previous = source.as_bytes()[end - 1];
+        if !previous.is_ascii_whitespace() {
+            break;
+        }
+        end -= 1;
+    }
+    end
+}
+
+fn redirect_deletion_span(span: Span, source: &str) -> Span {
+    let mut start = span.start.offset;
+    while start > 0 {
+        let previous = source.as_bytes()[start - 1];
+        if !matches!(previous, b' ' | b'\t') {
+            break;
+        }
+        start -= 1;
+    }
+
+    Span::from_positions(
+        Position {
+            offset: start,
+            line: span.start.line,
+            column: span
+                .start
+                .column
+                .saturating_sub(span.start.offset.saturating_sub(start)),
+        },
+        span.end,
+    )
 }
 
 fn has_independent_stderr_to_stdout_dup(
@@ -119,8 +187,10 @@ fn redirect_operator_span(redirect: &crate::RedirectFact<'_>, source: &str) -> O
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_stdout_redirects_before_plain_pipes() {
@@ -212,5 +282,58 @@ cmd >out 3>&1 | next
                 .collect::<Vec<_>>(),
             vec![">", ">"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_moving_redirect_after_pipeline() {
+        let source = "\
+#!/bin/sh
+cmd >/dev/null | next
+cmd 1>out | next
+left | mid >>log | right
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectBeforePipe),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+cmd | next >/dev/null
+cmd | next 1>out
+left | mid | right >>log
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_redirect_before_pipe_unchanged() {
+        let source = "#!/bin/sh\ncmd >/dev/null | next\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::RedirectBeforePipe),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C119.sh").as_path(),
+            &LinterSettings::for_rule(Rule::RedirectBeforePipe),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C119_fix_C119.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/set_flags_without_dashes.rs
+++ b/crates/shuck-linter/src/rules/correctness/set_flags_without_dashes.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct SetFlagsWithoutDashes;
 
 impl Violation for SetFlagsWithoutDashes {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SetFlagsWithoutDashes
     }
 
     fn message(&self) -> String {
         "flags passed to `set` should start with `-` or `+`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("insert `--` before positional arguments".to_owned())
     }
 }
 
@@ -33,13 +39,20 @@ pub fn set_flags_without_dashes(checker: &mut Checker) {
         .flat_map(|set| set.flags_without_prefix_spans().iter().copied())
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || SetFlagsWithoutDashes);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(SetFlagsWithoutDashes, span)
+                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset, "-- "))),
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn reports_set_flags_without_prefix() {
@@ -122,5 +135,58 @@ set OFFLINE_PATH \"$PWD\"
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_bare_set_operands() {
+        let source = "\
+set euox pipefail
+set foo bar
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes).with_shell(ShellDialect::Bash),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+set -- euox pipefail
+set -- foo bar
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_explicit_and_unambiguous_set_operands_unchanged_when_fixing() {
+        let source = "\
+set -euo pipefail
+set -- foo bar
+set foo
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes).with_shell(ShellDialect::Bash),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C098.sh").as_path(),
+            &LinterSettings::for_rule(Rule::SetFlagsWithoutDashes).with_shell(ShellDialect::Bash),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("C098_fix_C098.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__a_flag_in_double_bracket__tests__C122_fix_C122.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__a_flag_in_double_bracket__tests__C122_fix_C122.sh.snap
@@ -1,0 +1,41 @@
+---
+source: crates/shuck-linter/src/rules/correctness/a_flag_in_double_bracket.rs
+assertion_line: 138
+---
+Diagnostics:
+C122 use `-e` or `&&` instead of `-a` inside `[[ ... ]]`
+ --> <source>:2:4
+  |
+2 | [[ -a "$path" ]]
+  |
+
+C122 use `-e` or `&&` instead of `-a` inside `[[ ... ]]`
+ --> <source>:3:6
+  |
+3 | [[ ! -a "$path" ]]
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,5 +1,5 @@
+ #!/bin/sh
+-[[ -a "$path" ]]
+-[[ ! -a "$path" ]]
+ [[ -e "$path" ]]
++[[ ! -e "$path" ]]
++[[ -e "$path" ]]
+ [ -a "$path" ]
+
+Fixed source:
+#!/bin/sh
+[[ -e "$path" ]]
+[[ ! -e "$path" ]]
+[[ -e "$path" ]]
+[ -a "$path" ]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__append_to_array_as_string__tests__C106_fix_C106.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__append_to_array_as_string__tests__C106_fix_C106.sh.snap
@@ -1,0 +1,72 @@
+---
+source: crates/shuck-linter/src/rules/correctness/append_to_array_as_string.rs
+assertion_line: 188
+---
+Diagnostics:
+C106 appending a string to an array with `+=` merges into an element; use `+=(...)`
+ --> <source>:5:1
+  |
+5 | items+=" two"
+  |
+
+C106 appending a string to an array with `+=` merges into an element; use `+=(...)`
+ --> <source>:9:1
+  |
+9 | flags+=" ${extra}"
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -2,11 +2,11 @@
+ 
+ # Invalid: this appends text to an existing array element.
+ items=(one)
+-items+=" two"
++items+=(" two")
+ 
+ # Invalid: declaration-created arrays still need +=(...) for new elements.
+ declare -a flags=(--first)
+-flags+=" ${extra}"
++flags+=(" ${extra}")
+ 
+ # Valid: this appends a new element.
+ items+=("three")
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: this appends text to an existing array element.
+items=(one)
+items+=(" two")
+
+# Invalid: declaration-created arrays still need +=(...) for new elements.
+declare -a flags=(--first)
+flags+=(" ${extra}")
+
+# Valid: this appends a new element.
+items+=("three")
+
+# Valid: scalar append is intentional.
+name=base
+name+=" suffix"
+
+# Valid: appending to a specific element is outside this rule.
+items[0]+=" tail"
+
+# Valid: array defined later should not classify this as an array append.
+late+=" value"
+late=(value)
+
+# Valid: local scalar shadowing should not inherit outer array type.
+arr=(one)
+f() {
+  local arr=base
+  arr+=" two"
+}
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__array_slice_in_comparison__tests__C112_fix_C112.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__array_slice_in_comparison__tests__C112_fix_C112.sh.snap
@@ -1,0 +1,97 @@
+---
+source: crates/shuck-linter/src/rules/correctness/array_slice_in_comparison.rs
+assertion_line: 311
+---
+Diagnostics:
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+ --> <source>:8:7
+  |
+8 | if [[ "${sel[@]:0:4}" == "HELP" ]]; then :; fi
+  |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+ --> <source>:9:10
+  |
+9 | if [[ -n "$@" ]]; then :; fi
+  |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:10:12
+   |
+10 | if [[ x == *${arr[@]}* ]]; then :; fi
+   |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:11:7
+   |
+11 | if [[ "${@: -1}" == "mM" || "${@:-1}" == "Mm" ]]; then :; fi
+   |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:11:29
+   |
+11 | if [[ "${@: -1}" == "mM" || "${@:-1}" == "Mm" ]]; then :; fi
+   |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:12:7
+   |
+12 | if [[ " ${arr[@]} " =~ " x " ]]; then :; fi
+   |
+
+C112 all-elements array expansions collapse inside `[[ ... ]]` tests
+  --> <source>:13:7
+   |
+13 | if [[ "${arr[@]}" ]]; then :; fi
+   |
+
+
+Applied fixes: 7
+
+Diff:
+--- before
++++ after
+@@ -5,12 +5,12 @@
+ # Invalid: all-elements array expansions in [[ ... ]] tests.
+ set -- a b
+ arr=(x y)
+-if [[ "${sel[@]:0:4}" == "HELP" ]]; then :; fi
+-if [[ -n "$@" ]]; then :; fi
+-if [[ x == *${arr[@]}* ]]; then :; fi
+-if [[ "${@: -1}" == "mM" || "${@:-1}" == "Mm" ]]; then :; fi
+-if [[ " ${arr[@]} " =~ " x " ]]; then :; fi
+-if [[ "${arr[@]}" ]]; then :; fi
++if [[ "${sel[*]:0:4}" == "HELP" ]]; then :; fi
++if [[ -n "$*" ]]; then :; fi
++if [[ x == *${arr[*]}* ]]; then :; fi
++if [[ "${*: -1}" == "mM" || "${*:-1}" == "Mm" ]]; then :; fi
++if [[ " ${arr[*]} " =~ " x " ]]; then :; fi
++if [[ "${arr[*]}" ]]; then :; fi
+ 
+ # Valid: star-selector forms, escaped text, and single-bracket tests.
+ if [[ "${sel[*]:1}" == "HELP" ]]; then :; fi
+
+Fixed source:
+#!/bin/bash
+
+# shellcheck disable=2034,2154
+
+# Invalid: all-elements array expansions in [[ ... ]] tests.
+set -- a b
+arr=(x y)
+if [[ "${sel[*]:0:4}" == "HELP" ]]; then :; fi
+if [[ -n "$*" ]]; then :; fi
+if [[ x == *${arr[*]}* ]]; then :; fi
+if [[ "${*: -1}" == "mM" || "${*:-1}" == "Mm" ]]; then :; fi
+if [[ " ${arr[*]} " =~ " x " ]]; then :; fi
+if [[ "${arr[*]}" ]]; then :; fi
+
+# Valid: star-selector forms, escaped text, and single-bracket tests.
+if [[ "${sel[*]:1}" == "HELP" ]]; then :; fi
+if [[ "\${sel[@]:1}" == "HELP" ]]; then :; fi
+if [[ x == ${sel[*]}* ]]; then :; fi
+if [[ "\$@" ]]; then :; fi
+if [ "${sel[@]:1}" = "HELP" ]; then :; fi
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__assignment_looks_like_comparison__tests__C095_fix_C095.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__assignment_looks_like_comparison__tests__C095_fix_C095.sh.snap
@@ -1,0 +1,30 @@
+---
+source: crates/shuck-linter/src/rules/correctness/assignment_looks_like_comparison.rs
+assertion_line: 316
+---
+Diagnostics:
+C095 assignment value looks like arithmetic subtraction
+ --> <source>:3:4
+  |
+3 | qt=qt-unicode-3.2
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,3 +1,3 @@
+ #!/bin/bash
+ # shellcheck disable=2034
+-qt=qt-unicode-3.2
++qt="qt-unicode-3.2"
+
+Fixed source:
+#!/bin/bash
+# shellcheck disable=2034
+qt="qt-unicode-3.2"
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__at_sign_in_string_compare__tests__C111_fix_C111.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__at_sign_in_string_compare__tests__C111_fix_C111.sh.snap
@@ -1,0 +1,110 @@
+---
+source: crates/shuck-linter/src/rules/correctness/at_sign_in_string_compare.rs
+assertion_line: 176
+---
+Diagnostics:
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:5:9
+  |
+5 | if [ -z "$@" ]; then :; fi
+  |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:6:12
+  |
+6 | if test -n "${@:-fallback}"; then :; fi
+  |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:7:9
+  |
+7 | if [ -d "$@" ]; then :; fi
+  |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:8:6
+  |
+8 | if [ "_$@" = "_--version" ]; then :; fi
+  |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+ --> <source>:9:6
+  |
+9 | if [ "$@" = "--version" ]; then :; fi
+  |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+  --> <source>:10:16
+   |
+10 | if [ -n foo -a "${@:-lhs}" = "${@:-rhs}" ]; then :; fi
+   |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+  --> <source>:10:30
+   |
+10 | if [ -n foo -a "${@:-lhs}" = "${@:-rhs}" ]; then :; fi
+   |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+  --> <source>:11:9
+   |
+11 | if [ -d "$@" -o "${@:-fallback}" = "x" ]; then :; fi
+   |
+
+C111 positional-parameter at-splats fold arguments when used as test operands
+  --> <source>:11:17
+   |
+11 | if [ -d "$@" -o "${@:-fallback}" = "x" ]; then :; fi
+   |
+
+
+Applied fixes: 9
+
+Diff:
+--- before
++++ after
+@@ -2,13 +2,13 @@
+ set -- a b
+ 
+ # Invalid: positional @ expansion used as a [ ] or test operand.
+-if [ -z "$@" ]; then :; fi
+-if test -n "${@:-fallback}"; then :; fi
+-if [ -d "$@" ]; then :; fi
+-if [ "_$@" = "_--version" ]; then :; fi
+-if [ "$@" = "--version" ]; then :; fi
+-if [ -n foo -a "${@:-lhs}" = "${@:-rhs}" ]; then :; fi
+-if [ -d "$@" -o "${@:-fallback}" = "x" ]; then :; fi
++if [ -z "$*" ]; then :; fi
++if test -n "${*:-fallback}"; then :; fi
++if [ -d "$*" ]; then :; fi
++if [ "_$*" = "_--version" ]; then :; fi
++if [ "$*" = "--version" ]; then :; fi
++if [ -n foo -a "${*:-lhs}" = "${*:-rhs}" ]; then :; fi
++if [ -d "$*" -o "${*:-fallback}" = "x" ]; then :; fi
+ 
+ # Valid: truthy tests, non-positional uses, and double-bracket comparisons.
+ if [ "$@" ]; then :; fi
+
+Fixed source:
+#!/bin/bash
+set -- a b
+
+# Invalid: positional @ expansion used as a [ ] or test operand.
+if [ -z "$*" ]; then :; fi
+if test -n "${*:-fallback}"; then :; fi
+if [ -d "$*" ]; then :; fi
+if [ "_$*" = "_--version" ]; then :; fi
+if [ "$*" = "--version" ]; then :; fi
+if [ -n foo -a "${*:-lhs}" = "${*:-rhs}" ]; then :; fi
+if [ -d "$*" -o "${*:-fallback}" = "x" ]; then :; fi
+
+# Valid: truthy tests, non-positional uses, and double-bracket comparisons.
+if [ "$@" ]; then :; fi
+if [ "_$*" = "_--version" ]; then :; fi
+if [ -d "${arr[@]}" ]; then :; fi
+if [ "_${arr[@]}" = "_x" ]; then :; fi
+if [[ "_$@" == "_--version" ]]; then :; fi
+if [[ "\$@" == "x" ]]; then :; fi
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__backtick_in_command_position__tests__C093_fix_C093.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__backtick_in_command_position__tests__C093_fix_C093.sh.snap
@@ -1,0 +1,59 @@
+---
+source: crates/shuck-linter/src/rules/correctness/backtick_in_command_position.rs
+assertion_line: 157
+---
+Diagnostics:
+C093 run the command directly instead of executing backtick output as a command name
+ --> <source>:4:1
+  |
+4 | `echo hello` | cat
+  |
+
+C093 run the command directly instead of executing backtick output as a command name
+ --> <source>:5:4
+  |
+5 | if `echo true`; then :; fi
+  |
+
+C093 run the command directly instead of executing backtick output as a command name
+ --> <source>:6:7
+  |
+6 | FOO=1 `echo run`
+  |
+
+
+Applied fixes: 3
+
+Diff:
+--- before
++++ after
+@@ -1,9 +1,9 @@
+ #!/bin/sh
+ 
+ # Invalid: backtick output becomes the command name.
+-`echo hello` | cat
+-if `echo true`; then :; fi
+-FOO=1 `echo run`
++echo hello | cat
++if echo true; then :; fi
++FOO=1 echo run
+ 
+ # Valid: wrappers, quoting, and argument positions are outside this rule.
+ command `echo hello`
+
+Fixed source:
+#!/bin/sh
+
+# Invalid: backtick output becomes the command name.
+echo hello | cat
+if echo true; then :; fi
+FOO=1 echo run
+
+# Valid: wrappers, quoting, and argument positions are outside this rule.
+command `echo hello`
+"`echo hello`" | cat
+x`echo hello`
+echo `date`
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__case_arm_not_in_getopts__tests__C135_fix_C135.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__case_arm_not_in_getopts__tests__C135_fix_C135.sh.snap
@@ -1,0 +1,72 @@
+---
+source: crates/shuck-linter/src/rules/correctness/case_arm_not_in_getopts.rs
+assertion_line: 468
+---
+Diagnostics:
+C135 this case arm handles -k, but getopts does not declare it
+ --> <source>:8:5
+  |
+8 |     k) keyfile=$OPTARG ;;
+  |
+
+C135 this case arm handles -b, but getopts does not declare it
+  --> <source>:16:7
+   |
+16 |     a|b) : ;;
+   |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -5,7 +5,6 @@
+   case "$OPT" in
+     a) alg=$OPTARG ;;
+     d) domain=$OPTARG ;;
+-    k) keyfile=$OPTARG ;;
+     h) echo help; exit 0 ;;
+   esac
+ done
+@@ -13,7 +12,7 @@
+ # Should trigger only on the undeclared alternative.
+ while getopts 'a' opt; do
+   case "$opt" in
+-    a|b) : ;;
++    a) : ;;
+   esac
+ done
+ 
+
+Fixed source:
+#!/bin/sh
+
+# Should trigger: -k is handled in the case statement but missing from getopts.
+while getopts ':a:d:h' OPT; do
+  case "$OPT" in
+    a) alg=$OPTARG ;;
+    d) domain=$OPTARG ;;
+    h) echo help; exit 0 ;;
+  esac
+done
+
+# Should trigger only on the undeclared alternative.
+while getopts 'a' opt; do
+  case "$opt" in
+    a) : ;;
+  esac
+done
+
+# Should not trigger: getopts error handlers and fallback arms are intentional.
+while getopts ':a' opt; do
+  case "$opt" in
+    a) : ;;
+    \?) : ;;
+    :) : ;;
+    *) : ;;
+  esac
+done
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__case_default_before_glob__tests__C129_fix_C129.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__case_default_before_glob__tests__C129_fix_C129.sh.snap
@@ -1,0 +1,98 @@
+---
+source: crates/shuck-linter/src/rules/correctness/case_default_before_glob.rs
+assertion_line: 374
+---
+Diagnostics:
+C129 this case pattern is unreachable because an earlier pattern already matches it
+ --> <source>:8:3
+  |
+8 |   foo) : ;;
+  |
+
+C129 this case pattern is unreachable because an earlier pattern already matches it
+  --> <source>:14:3
+   |
+14 |   foo*) : ;;
+   |
+
+C129 this case pattern is unreachable because an earlier pattern already matches it
+  --> <source>:19:5
+   |
+19 |   *|foo*) : ;;
+   |
+
+C129 this case pattern is unreachable because an earlier pattern already matches it
+  --> <source>:20:3
+   |
+20 |   foo) : ;;
+   |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -5,19 +5,16 @@
+ # Should trigger: duplicate patterns make the later arm unreachable.
+ case "$value" in
+   foo) : ;;
+-  foo) : ;;
+ esac
+ 
+ # Should trigger: a catch-all arm makes a later glob unreachable.
+ case "$value" in
+   *) : ;;
+-  foo*) : ;;
+ esac
+ 
+ # Should trigger: earlier alternatives in the same arm can make later patterns unreachable.
+ case "$value" in
+-  *|foo*) : ;;
+-  foo) : ;;
++  *) : ;;
+ esac
+ 
+ # Should not trigger: character classes are intentionally left out of this reachability check.
+
+Fixed source:
+#!/bin/bash
+
+value=foobar
+
+# Should trigger: duplicate patterns make the later arm unreachable.
+case "$value" in
+  foo) : ;;
+esac
+
+# Should trigger: a catch-all arm makes a later glob unreachable.
+case "$value" in
+  *) : ;;
+esac
+
+# Should trigger: earlier alternatives in the same arm can make later patterns unreachable.
+case "$value" in
+  *) : ;;
+esac
+
+# Should not trigger: character classes are intentionally left out of this reachability check.
+case "$value" in
+  [ab]*) : ;;
+  afoo) : ;;
+esac
+
+# Should not trigger: continue-matching terminators keep later arms reachable.
+case "$value" in
+  foo) : ;;&
+  foo) : ;;
+esac
+
+# Should not trigger: escaped wildcards are literal characters, not catch-all patterns.
+case "$value" in
+  \?) : ;;
+  :) : ;;
+  *) : ;;
+esac
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__case_glob_reachability__tests__C128_fix_C128.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__case_glob_reachability__tests__C128_fix_C128.sh.snap
@@ -1,0 +1,96 @@
+---
+source: crates/shuck-linter/src/rules/correctness/case_glob_reachability.rs
+assertion_line: 367
+---
+Diagnostics:
+C128 this case pattern shadows a later pattern
+ --> <source>:7:3
+  |
+7 |   foo) : ;;
+  |
+
+C128 this case pattern shadows a later pattern
+  --> <source>:13:3
+   |
+13 |   foo*) : ;;
+   |
+
+C128 this case pattern shadows a later pattern
+  --> <source>:19:3
+   |
+19 |   *|foo*) : ;;
+   |
+
+C128 this case pattern shadows a later pattern
+  --> <source>:19:5
+   |
+19 |   *|foo*) : ;;
+   |
+
+
+Applied fixes: 3
+
+Diff:
+--- before
++++ after
+@@ -5,18 +5,15 @@
+ # Should trigger: duplicate patterns shadow later case arms.
+ case "$value" in
+   foo) : ;;
+-  foo) : ;;
+ esac
+ 
+ # Should trigger: a wildcard arm shadows a later literal.
+ case "$value" in
+-  foo*) : ;;
+   foobar) : ;;
+ esac
+ 
+ # Should trigger: earlier alternatives in the same arm can shadow later patterns.
+ case "$value" in
+-  *|foo*) : ;;
+   foo) : ;;
+ esac
+ 
+
+Fixed source:
+#!/bin/bash
+
+value=foobar
+
+# Should trigger: duplicate patterns shadow later case arms.
+case "$value" in
+  foo) : ;;
+esac
+
+# Should trigger: a wildcard arm shadows a later literal.
+case "$value" in
+  foobar) : ;;
+esac
+
+# Should trigger: earlier alternatives in the same arm can shadow later patterns.
+case "$value" in
+  foo) : ;;
+esac
+
+# Should not trigger: character classes are intentionally left out of this reachability check.
+case "$value" in
+  [ab]*) : ;;
+  afoo) : ;;
+esac
+
+# Should not trigger: continue-matching terminators keep later arms reachable.
+case "$value" in
+  foo) : ;;&
+  foo) : ;;
+esac
+
+# Should not trigger: extglob reachability is not analyzed here.
+shopt -s extglob
+case "$value" in
+  @(foo|bar)*) : ;;
+  foobar) : ;;
+esac
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__continue_outside_loop_in_function__tests__C126_fix_C126.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__continue_outside_loop_in_function__tests__C126_fix_C126.sh.snap
@@ -1,0 +1,38 @@
+---
+source: crates/shuck-linter/src/rules/correctness/continue_outside_loop_in_function.rs
+assertion_line: 194
+---
+Diagnostics:
+C126 `continue` inside a function must be inside a loop
+ --> <source>:4:3
+  |
+4 |   continue
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,7 +1,7 @@
+ #!/bin/sh
+ 
+ myfunc() {
+-  continue
++  return
+ }
+ 
+ myfunc
+
+Fixed source:
+#!/bin/sh
+
+myfunc() {
+  return
+}
+
+myfunc
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__env_prefix_expansion_only__tests__C132_fix_C132.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__env_prefix_expansion_only__tests__C132_fix_C132.sh.snap
@@ -1,0 +1,148 @@
+---
+source: crates/shuck-linter/src/rules/correctness/env_prefix_expansion_only.rs
+assertion_line: 209
+---
+Diagnostics:
+C132 this same-command expansion still sees the earlier shell value
+ --> <source>:4:51
+  |
+4 | CFLAGS="${SLKCFLAGS}" ./configure --with-optmizer=${CFLAGS}
+  |
+
+C132 this same-command expansion still sees the earlier shell value
+ --> <source>:7:12
+  |
+7 | PATH=/tmp "$PATH"/bin/tool
+  |
+
+C132 this same-command expansion still sees the earlier shell value
+  --> <source>:10:8
+   |
+10 | A=1 B="$A" C="$B" cmd
+   |
+
+C132 this same-command expansion still sees the earlier shell value
+  --> <source>:10:15
+   |
+10 | A=1 B="$A" C="$B" cmd
+   |
+
+C132 this same-command expansion still sees the earlier shell value
+  --> <source>:13:15
+   |
+13 | foo=1 export "$foo"
+   |
+
+C132 this same-command expansion still sees the earlier shell value
+  --> <source>:16:11
+   |
+16 | foo=1 bar[$foo]=x cmd
+   |
+
+C132 this same-command expansion still sees the earlier shell value
+  --> <source>:19:37
+   |
+19 | COUNTDOWN=$[ $COUNTDOWN - 1 ] echo "$COUNTDOWN"
+   |
+
+C132 this same-command expansion still sees the earlier shell value
+  --> <source>:25:15
+   |
+25 | FOO=tmp cmd >"$FOO"
+   |
+
+
+Applied fixes: 7
+
+Diff:
+--- before
++++ after
+@@ -1,28 +1,38 @@
+ #!/bin/bash
+ 
+ # Should trigger: later argument expansion still sees the old shell value.
+-CFLAGS="${SLKCFLAGS}" ./configure --with-optmizer=${CFLAGS}
++CFLAGS="${SLKCFLAGS}"
++./configure --with-optmizer=${CFLAGS}
+ 
+ # Should trigger: command name expansion still uses the old PATH.
+-PATH=/tmp "$PATH"/bin/tool
++PATH=/tmp
++"$PATH"/bin/tool
+ 
+ # Should trigger: later prefix assignments still expand before earlier ones apply.
+-A=1 B="$A" C="$B" cmd
++A=1
++B="$A"
++C="$B"
++cmd
+ 
+ # Should trigger: builtin operands do not see the same-command prefix assignment.
+-foo=1 export "$foo"
++foo=1
++export "$foo"
+ 
+ # Should trigger: assignment subscripts are expanded before the command runs.
+-foo=1 bar[$foo]=x cmd
++foo=1
++bar[$foo]=x
++cmd
+ 
+ # Should trigger: later command arguments still see the old arithmetic value.
+-COUNTDOWN=$[ $COUNTDOWN - 1 ] echo "$COUNTDOWN"
++COUNTDOWN=$[ $COUNTDOWN - 1 ]
++echo "$COUNTDOWN"
+ 
+ # Should not trigger: nested commands are out of scope.
+ foo=1 cmd "$(printf %s "$foo")"
+ 
+ # Should trigger: redirect targets are expanded before the command runs.
+-FOO=tmp cmd >"$FOO"
++FOO=tmp
++cmd >"$FOO"
+ 
+ # Should not trigger: assignment-only commands do not create the temporary command environment.
+ foo=1 bar="$foo"
+
+Fixed source:
+#!/bin/bash
+
+# Should trigger: later argument expansion still sees the old shell value.
+CFLAGS="${SLKCFLAGS}"
+./configure --with-optmizer=${CFLAGS}
+
+# Should trigger: command name expansion still uses the old PATH.
+PATH=/tmp
+"$PATH"/bin/tool
+
+# Should trigger: later prefix assignments still expand before earlier ones apply.
+A=1
+B="$A"
+C="$B"
+cmd
+
+# Should trigger: builtin operands do not see the same-command prefix assignment.
+foo=1
+export "$foo"
+
+# Should trigger: assignment subscripts are expanded before the command runs.
+foo=1
+bar[$foo]=x
+cmd
+
+# Should trigger: later command arguments still see the old arithmetic value.
+COUNTDOWN=$[ $COUNTDOWN - 1 ]
+echo "$COUNTDOWN"
+
+# Should not trigger: nested commands are out of scope.
+foo=1 cmd "$(printf %s "$foo")"
+
+# Should trigger: redirect targets are expanded before the command runs.
+FOO=tmp
+cmd >"$FOO"
+
+# Should not trigger: assignment-only commands do not create the temporary command environment.
+foo=1 bar="$foo"
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__find_or_without_grouping__tests__C103_fix_C103.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__find_or_without_grouping__tests__C103_fix_C103.sh.snap
@@ -1,0 +1,57 @@
+---
+source: crates/shuck-linter/src/rules/correctness/find_or_without_grouping.rs
+assertion_line: 248
+---
+Diagnostics:
+C103 `find` alternatives joined with `-o` should be grouped before applying actions
+ --> <source>:4:49
+  |
+4 | find . -name perllocal.pod -o -name ".packlist" -print
+  |
+
+C103 `find` alternatives joined with `-o` should be grouped before applying actions
+ --> <source>:7:39
+  |
+7 | find . -name '*.tmp' -o -name '*.bak' -delete
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/bash
+ 
+ # Invalid: `-o` alternatives are not grouped before an action.
+-find . -name perllocal.pod -o -name ".packlist" -print
++find . -name perllocal.pod -o \( -name ".packlist" -print \)
+ 
+ # Invalid: same precedence issue on another branch pair.
+-find . -name '*.tmp' -o -name '*.bak' -delete
++find . -name '*.tmp' -o \( -name '*.bak' -delete \)
+ 
+ # Valid: grouped alternatives before applying action.
+ find . \( -name perllocal.pod -o -name ".packlist" \) -print
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: `-o` alternatives are not grouped before an action.
+find . -name perllocal.pod -o \( -name ".packlist" -print \)
+
+# Invalid: same precedence issue on another branch pair.
+find . -name '*.tmp' -o \( -name '*.bak' -delete \)
+
+# Valid: grouped alternatives before applying action.
+find . \( -name perllocal.pod -o -name ".packlist" \) -print
+
+# Valid: explicit `-a` avoids implicit precedence traps.
+find . -name '*.tmp' -o -name '*.bak' -a -print
+
+# Valid: if earlier branches already include actions, this pattern is intentional.
+find . -name '*.tmp' -print -o -name '*.bak' -print
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_test_comparison__tests__C090_fix_C090.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_test_comparison__tests__C090_fix_C090.sh.snap
@@ -1,0 +1,70 @@
+---
+source: crates/shuck-linter/src/rules/correctness/glob_in_test_comparison.rs
+assertion_line: 218
+---
+Diagnostics:
+C090 glob matching on the right-hand side of `[ ... ]` won't work here
+ --> <source>:4:14
+  |
+4 | [ "$ARCH" == i?86 ]
+  |
+
+C090 glob matching on the right-hand side of `[ ... ]` won't work here
+ --> <source>:7:13
+  |
+7 | [ "$ARCH" = [[:digit:]] ]
+  |
+
+C090 glob matching on the right-hand side of `[ ... ]` won't work here
+  --> <source>:10:14
+   |
+10 | [ "$ARCH" != *.x86 ]
+   |
+
+
+Applied fixes: 3
+
+Diff:
+--- before
++++ after
+@@ -1,13 +1,13 @@
+ #!/bin/bash
+ 
+ # Invalid: `[ ]` comparisons do not treat the RHS as a glob pattern.
+-[ "$ARCH" == i?86 ]
++[ "$ARCH" == "i?86" ]
+ 
+ # Invalid: the same problem applies to `=` and wildcard classes.
+-[ "$ARCH" = [[:digit:]] ]
++[ "$ARCH" = "[[:digit:]]" ]
+ 
+ # Invalid: `!=` still compares strings literally in `[ ]`.
+-[ "$ARCH" != *.x86 ]
++[ "$ARCH" != "*.x86" ]
+ 
+ # Valid: quoting the pattern makes it a plain string literal.
+ [ "$ARCH" == "i?86" ]
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: `[ ]` comparisons do not treat the RHS as a glob pattern.
+[ "$ARCH" == "i?86" ]
+
+# Invalid: the same problem applies to `=` and wildcard classes.
+[ "$ARCH" = "[[:digit:]]" ]
+
+# Invalid: `!=` still compares strings literally in `[ ]`.
+[ "$ARCH" != "*.x86" ]
+
+# Valid: quoting the pattern makes it a plain string literal.
+[ "$ARCH" == "i?86" ]
+
+# Valid: escaping the wildcard makes it literal too.
+[ "$ARCH" == i\?86 ]
+
+# Valid: `[[ ]]` can do pattern matching directly.
+[[ "$ARCH" == i?86 ]]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_test_directory__tests__C102_fix_C102.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_in_test_directory__tests__C102_fix_C102.sh.snap
@@ -1,0 +1,77 @@
+---
+source: crates/shuck-linter/src/rules/correctness/glob_in_test_directory.rs
+assertion_line: 337
+---
+Diagnostics:
+C102 unquoted globs in file tests can match multiple paths
+ --> <source>:2:6
+  |
+2 | [ -d mtp2* ]
+  |
+
+C102 unquoted globs in file tests can match multiple paths
+ --> <source>:3:6
+  |
+3 | [ -f foo* -a -e bar* -a -L baz* ]
+  |
+
+C102 unquoted globs in file tests can match multiple paths
+ --> <source>:3:17
+  |
+3 | [ -f foo* -a -e bar* -a -L baz* ]
+  |
+
+C102 unquoted globs in file tests can match multiple paths
+ --> <source>:3:28
+  |
+3 | [ -f foo* -a -e bar* -a -L baz* ]
+  |
+
+C102 unquoted globs in file tests can match multiple paths
+ --> <source>:4:7
+  |
+4 | [[ -r qux* && -w quux* ]]
+  |
+
+C102 unquoted globs in file tests can match multiple paths
+ --> <source>:4:18
+  |
+4 | [[ -r qux* && -w quux* ]]
+  |
+
+C102 unquoted globs in file tests can match multiple paths
+ --> <source>:6:9
+  |
+6 | test -d mtp2*
+  |
+
+
+Applied fixes: 7
+
+Diff:
+--- before
++++ after
+@@ -1,7 +1,7 @@
+ #!/bin/bash
+-[ -d mtp2* ]
+-[ -f foo* -a -e bar* -a -L baz* ]
+-[[ -r qux* && -w quux* ]]
+ [ -d "mtp2*" ]
+-test -d mtp2*
++[ -f "foo*" -a -e "bar*" -a -L "baz*" ]
++[[ -r "qux*" && -w "quux*" ]]
++[ -d "mtp2*" ]
++test -d "mtp2*"
+ test -n mtp2*
+
+Fixed source:
+#!/bin/bash
+[ -d "mtp2*" ]
+[ -f "foo*" -a -e "bar*" -a -L "baz*" ]
+[[ -r "qux*" && -w "quux*" ]]
+[ -d "mtp2*" ]
+test -d "mtp2*"
+test -n mtp2*
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_with_expansion_in_loop__tests__C114_fix_C114.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__glob_with_expansion_in_loop__tests__C114_fix_C114.sh.snap
@@ -1,0 +1,65 @@
+---
+source: crates/shuck-linter/src/rules/correctness/glob_with_expansion_in_loop.rs
+assertion_line: 210
+---
+Diagnostics:
+C114 quote expansion prefixes when combining them with loop globs
+ --> <source>:2:10
+  |
+2 | for i in $CWD/file.*pattern*; do :; done
+  |
+
+C114 quote expansion prefixes when combining them with loop globs
+ --> <source>:3:10
+  |
+3 | for i in ${CWD}/file.*pattern*; do :; done
+  |
+
+C114 quote expansion prefixes when combining them with loop globs
+ --> <source>:4:10
+  |
+4 | for i in $(pwd)/file.*pattern*; do :; done
+  |
+
+C114 quote expansion prefixes when combining them with loop globs
+ --> <source>:9:10
+  |
+9 | for i in $DIR/{1..3}*.txt; do :; done
+  |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/sh
+-for i in $CWD/file.*pattern*; do :; done
+-for i in ${CWD}/file.*pattern*; do :; done
+-for i in $(pwd)/file.*pattern*; do :; done
++for i in "$CWD"/file.*pattern*; do :; done
++for i in "${CWD}"/file.*pattern*; do :; done
++for i in "$(pwd)"/file.*pattern*; do :; done
+ 
+ for i in "$CWD"/file.*pattern*; do :; done
+ for i in file.*pattern*; do :; done
+ for i in "$CWD"/*.txt; do :; done
+-for i in $DIR/{1..3}*.txt; do :; done
++for i in "$DIR"/{1..3}*.txt; do :; done
+ for i in $DIR/setjmp-aarch64/{setjmp.S,private-*.h}; do :; done
+
+Fixed source:
+#!/bin/sh
+for i in "$CWD"/file.*pattern*; do :; done
+for i in "${CWD}"/file.*pattern*; do :; done
+for i in "$(pwd)"/file.*pattern*; do :; done
+
+for i in "$CWD"/file.*pattern*; do :; done
+for i in file.*pattern*; do :; done
+for i in "$CWD"/*.txt; do :; done
+for i in "$DIR"/{1..3}*.txt; do :; done
+for i in $DIR/setjmp-aarch64/{setjmp.S,private-*.h}; do :; done
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__heredoc_closer_not_alone__tests__C144_fix_C144.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__heredoc_closer_not_alone__tests__C144_fix_C144.sh.snap
@@ -1,0 +1,31 @@
+---
+source: crates/shuck-linter/src/rules/correctness/heredoc_closer_not_alone.rs
+assertion_line: 139
+---
+Diagnostics:
+C144 this here-document closer must be on its own line
+ --> <source>:3:3
+  |
+3 | x EOF
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,3 +1,4 @@
+ #!/bin/sh
+ cat <<EOF
+ x EOF
++EOF
+
+Fixed source:
+#!/bin/sh
+cat <<EOF
+x EOF
+EOF
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__local_cross_reference__tests__C136_fix_C136.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__local_cross_reference__tests__C136_fix_C136.sh.snap
@@ -1,0 +1,40 @@
+---
+source: crates/shuck-linter/src/rules/correctness/local_cross_reference.rs
+assertion_line: 310
+---
+Diagnostics:
+C136 assignment is reused later in the same declaration
+ --> <source>:4:9
+  |
+4 |   local iface="${1}" ifvar="$(echo "${iface}" | tr - _)"
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,7 +1,8 @@
+ #!/bin/sh
+ # shellcheck disable=3043,2034,2155
+ myfunc() {
+-  local iface="${1}" ifvar="$(echo "${iface}" | tr - _)"
++  local iface="${1}"
++  local ifvar="$(echo "${iface}" | tr - _)"
+   echo "$iface $ifvar"
+ }
+ myfunc eth0
+
+Fixed source:
+#!/bin/sh
+# shellcheck disable=3043,2034,2155
+myfunc() {
+  local iface="${1}"
+  local ifvar="$(echo "${iface}" | tr - _)"
+  echo "$iface $ifvar"
+}
+myfunc eth0
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__missing_done_in_for_loop__tests__C142_fix_C142.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__missing_done_in_for_loop__tests__C142_fix_C142.sh.snap
@@ -1,0 +1,30 @@
+---
+source: crates/shuck-linter/src/rules/correctness/missing_done_in_for_loop.rs
+assertion_line: 78
+---
+Diagnostics:
+C142 this `for` loop is missing a closing `done`
+ --> <source>:4:1
+  |
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,3 +1,4 @@
+ #!/bin/sh
+ for x in a; do
+   echo "$x"
++done
+
+Fixed source:
+#!/bin/sh
+for x in a; do
+  echo "$x"
+done
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__non_shell_syntax_in_script__tests__C104_fix_C104.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__non_shell_syntax_in_script__tests__C104_fix_C104.sh.snap
@@ -1,0 +1,39 @@
+---
+source: crates/shuck-linter/src/rules/correctness/non_shell_syntax_in_script.rs
+assertion_line: 148
+---
+Diagnostics:
+C104 line looks like non-shell declaration syntax
+ --> <source>:2:1
+  |
+2 | int value;
+  |
+
+C104 line looks like non-shell declaration syntax
+ --> <source>:3:1
+  |
+3 | char *name;
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,4 +1,4 @@
+ #!/bin/sh
+-int value;
+-char *name;
++
++
+ echo int value;
+
+Fixed source:
+#!/bin/sh
+
+
+echo int value;
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__quoted_array_slice__tests__C099_fix_C099.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__quoted_array_slice__tests__C099_fix_C099.sh.snap
@@ -1,0 +1,215 @@
+---
+source: crates/shuck-linter/src/rules/correctness/quoted_array_slice.rs
+assertion_line: 308
+---
+Diagnostics:
+C099 all-elements array expansions collapse in scalar assignment values
+ --> <source>:6:8
+  |
+6 | params="$@"
+  |
+
+C099 all-elements array expansions collapse in scalar assignment values
+ --> <source>:7:8
+  |
+7 | params="${@}"
+  |
+
+C099 all-elements array expansions collapse in scalar assignment values
+ --> <source>:8:8
+  |
+8 | params=${@:5}
+  |
+
+C099 all-elements array expansions collapse in scalar assignment values
+ --> <source>:9:8
+  |
+9 | joined="${arr[@]}"
+  |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:10:10
+   |
+10 | fallback="${arr[@]:-fallback}"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:11:8
+   |
+11 | quoted="${arr[@]@Q}"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:12:8
+   |
+12 | flags+=" ${add_flags[@]}"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:13:15
+   |
+13 | targets[$key]="${items[@]}"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:14:9
+   |
+14 | CFLAGS+=" ${add_flags[@]}" make
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:15:9
+   |
+15 | escaped="\\$@"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:16:15
+   |
+16 | escaped_slice="\\${@:2}"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:17:18
+   |
+17 | declare declared="$@"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:18:17
+   |
+18 | readonly packed=${arr[@]}
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:21:8
+   |
+21 | params="${@:5}"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:22:8
+   |
+22 | joined="prefix${@:2}suffix"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:23:18
+   |
+23 | declare declared="${arr[@]:1}"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:24:17
+   |
+24 | readonly packed="${arr[@]:1:2}"
+   |
+
+C099 all-elements array expansions collapse in scalar assignment values
+  --> <source>:27:16
+   |
+27 |   local nested="${@:3}"
+   |
+
+
+Applied fixes: 18
+
+Diff:
+--- before
++++ after
+@@ -3,28 +3,28 @@
+ # shellcheck disable=2034,2154
+ 
+ # Invalid: all-elements expansions in scalar assignments collapse element boundaries.
+-params="$@"
+-params="${@}"
+-params=${@:5}
+-joined="${arr[@]}"
+-fallback="${arr[@]:-fallback}"
+-quoted="${arr[@]@Q}"
+-flags+=" ${add_flags[@]}"
+-targets[$key]="${items[@]}"
+-CFLAGS+=" ${add_flags[@]}" make
+-escaped="\\$@"
+-escaped_slice="\\${@:2}"
+-declare declared="$@"
+-readonly packed=${arr[@]}
++params="$*"
++params="${*}"
++params=${*:5}
++joined="${arr[*]}"
++fallback="${arr[*]:-fallback}"
++quoted="${arr[*]@Q}"
++flags+=" ${add_flags[*]}"
++targets[$key]="${items[*]}"
++CFLAGS+=" ${add_flags[*]}" make
++escaped="\\$*"
++escaped_slice="\\${*:2}"
++declare declared="$*"
++readonly packed=${arr[*]}
+ 
+ # Invalid: quoted all-elements array slices also collapse in scalar assignments.
+-params="${@:5}"
+-joined="prefix${@:2}suffix"
+-declare declared="${arr[@]:1}"
+-readonly packed="${arr[@]:1:2}"
++params="${*:5}"
++joined="prefix${*:2}suffix"
++declare declared="${arr[*]:1}"
++readonly packed="${arr[*]:1:2}"
+ 
+ f() {
+-  local nested="${@:3}"
++  local nested="${*:3}"
+ }
+ 
+ # Valid: star-selector slices are outside this rule.
+
+Fixed source:
+#!/bin/bash
+
+# shellcheck disable=2034,2154
+
+# Invalid: all-elements expansions in scalar assignments collapse element boundaries.
+params="$*"
+params="${*}"
+params=${*:5}
+joined="${arr[*]}"
+fallback="${arr[*]:-fallback}"
+quoted="${arr[*]@Q}"
+flags+=" ${add_flags[*]}"
+targets[$key]="${items[*]}"
+CFLAGS+=" ${add_flags[*]}" make
+escaped="\\$*"
+escaped_slice="\\${*:2}"
+declare declared="$*"
+readonly packed=${arr[*]}
+
+# Invalid: quoted all-elements array slices also collapse in scalar assignments.
+params="${*:5}"
+joined="prefix${*:2}suffix"
+declare declared="${arr[*]:1}"
+readonly packed="${arr[*]:1:2}"
+
+f() {
+  local nested="${*:3}"
+}
+
+# Valid: star-selector slices are outside this rule.
+joined="${arr[*]:1}"
+
+# Valid: replacement forms substitute the replacement word, not the element list.
+joined="${@:+fallback}"
+joined="${arr[@]:+fallback}"
+joined="\$@"
+joined="\${@:2}"
+
+# Valid: array compound assignments keep element boundaries.
+arr=("${@:2}")
+declare -a copied=("${arr[@]:1}")
+
+# Valid: comparison contexts are handled by C112.
+if [ "${arr[@]:1}" = foo ]; then :; fi
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__quoted_command_in_test__tests__C089_fix_C089.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__quoted_command_in_test__tests__C089_fix_C089.sh.snap
@@ -1,0 +1,93 @@
+---
+source: crates/shuck-linter/src/rules/correctness/quoted_command_in_test.rs
+assertion_line: 434
+---
+Diagnostics:
+C089 this test uses a quoted pipeline literal instead of command output
+ --> <source>:4:3
+  |
+4 | [ "lsmod | grep v4l2loopback" ]
+  |
+
+C089 this test uses a quoted pipeline literal instead of command output
+ --> <source>:7:6
+  |
+7 | [ -n "modprobe | grep snd" ]
+  |
+
+C089 this test uses a quoted pipeline literal instead of command output
+  --> <source>:10:5
+   |
+10 | [ ! "dmesg | grep usb" ]
+   |
+
+C089 this test uses a quoted pipeline literal instead of command output
+  --> <source>:13:13
+   |
+13 | [[ "$ok" && "lsmod | grep v4l2loopback" ]]
+   |
+
+C089 this test uses a quoted pipeline literal instead of command output
+  --> <source>:16:6
+   |
+16 | [[ ! "lsmod | grep v4l2loopback" ]]
+   |
+
+
+Applied fixes: 5
+
+Diff:
+--- before
++++ after
+@@ -1,19 +1,19 @@
+ #!/bin/bash
+ 
+ # Invalid: this treats a literal pipeline as a truthy string.
+-[ "lsmod | grep v4l2loopback" ]
++[ "$(lsmod | grep v4l2loopback)" ]
+ 
+ # Invalid: unary string tests do not execute the quoted pipeline either.
+-[ -n "modprobe | grep snd" ]
++[ -n "$(modprobe | grep snd)" ]
+ 
+ # Invalid: negation still only flips the truthiness of the quoted pipeline literal.
+-[ ! "dmesg | grep usb" ]
++[ ! "$(dmesg | grep usb)" ]
+ 
+ # Invalid: nested `[[ ]]` conditions still only see a string literal here.
+-[[ "$ok" && "lsmod | grep v4l2loopback" ]]
++[[ "$ok" && "$(lsmod | grep v4l2loopback)" ]]
+ 
+ # Invalid: negated `[[ ]]` conditions still only negate the literal string.
+-[[ ! "lsmod | grep v4l2loopback" ]]
++[[ ! "$(lsmod | grep v4l2loopback)" ]]
+ 
+ # Valid: plain quoted strings are covered by the generic constant-test rules instead.
+ [ "echo hi" ]
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: this treats a literal pipeline as a truthy string.
+[ "$(lsmod | grep v4l2loopback)" ]
+
+# Invalid: unary string tests do not execute the quoted pipeline either.
+[ -n "$(modprobe | grep snd)" ]
+
+# Invalid: negation still only flips the truthiness of the quoted pipeline literal.
+[ ! "$(dmesg | grep usb)" ]
+
+# Invalid: nested `[[ ]]` conditions still only see a string literal here.
+[[ "$ok" && "$(lsmod | grep v4l2loopback)" ]]
+
+# Invalid: negated `[[ ]]` conditions still only negate the literal string.
+[[ ! "$(lsmod | grep v4l2loopback)" ]]
+
+# Valid: plain quoted strings are covered by the generic constant-test rules instead.
+[ "echo hi" ]
+
+# Valid: explicit comparisons are outside this quoted-command rule.
+[ "cat file | grep foo" = x ]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__redirect_before_pipe__tests__C119_fix_C119.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__redirect_before_pipe__tests__C119_fix_C119.sh.snap
@@ -1,0 +1,66 @@
+---
+source: crates/shuck-linter/src/rules/correctness/redirect_before_pipe.rs
+assertion_line: 336
+---
+Diagnostics:
+C119 a stdout redirect before a pipe only affects the command on the left
+ --> <source>:4:5
+  |
+4 | cmd >/dev/null | next
+  |
+
+C119 a stdout redirect before a pipe only affects the command on the left
+ --> <source>:5:5
+  |
+5 | cmd >out | next
+  |
+
+C119 a stdout redirect before a pipe only affects the command on the left
+ --> <source>:8:12
+  |
+8 | left | mid >/dev/null | right
+  |
+
+
+Applied fixes: 3
+
+Diff:
+--- before
++++ after
+@@ -1,11 +1,11 @@
+ #!/bin/sh
+ 
+ # Should trigger: stdout is redirected before the pipe.
+-cmd >/dev/null | next
+-cmd >out | next
++cmd | next >/dev/null
++cmd | next >out
+ 
+ # Should trigger: the middle segment is the one with the redirect.
+-left | mid >/dev/null | right
++left | mid | right >/dev/null
+ 
+ # Should not trigger: stderr-only redirect.
+ 2>/dev/null | next
+
+Fixed source:
+#!/bin/sh
+
+# Should trigger: stdout is redirected before the pipe.
+cmd | next >/dev/null
+cmd | next >out
+
+# Should trigger: the middle segment is the one with the redirect.
+left | mid | right >/dev/null
+
+# Should not trigger: stderr-only redirect.
+2>/dev/null | next
+
+# Should not trigger: the redirect happens after the pipeline.
+cmd | next >/dev/null
+
+# Should not trigger: pipeall is a different operator.
+cmd >/dev/null |& next
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__set_flags_without_dashes__tests__C098_fix_C098.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__set_flags_without_dashes__tests__C098_fix_C098.sh.snap
@@ -1,0 +1,60 @@
+---
+source: crates/shuck-linter/src/rules/correctness/set_flags_without_dashes.rs
+assertion_line: 189
+---
+Diagnostics:
+C098 flags passed to `set` should start with `-` or `+`
+ --> <source>:4:5
+  |
+4 | set euox pipefail
+  |
+
+C098 flags passed to `set` should start with `-` or `+`
+ --> <source>:7:5
+  |
+7 | set foo bar
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,10 +1,10 @@
+ #!/bin/bash
+ 
+ # Invalid: set flags without a leading prefix
+-set euox pipefail
++set -- euox pipefail
+ 
+ # Invalid: positional arguments should be explicit with --
+-set foo bar
++set -- foo bar
+ 
+ # Valid: short options are prefixed
+ set -euo pipefail
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: set flags without a leading prefix
+set -- euox pipefail
+
+# Invalid: positional arguments should be explicit with --
+set -- foo bar
+
+# Valid: short options are prefixed
+set -euo pipefail
+
+# Valid: explicit positional separator
+set -- foo bar
+
+# Valid: single positional argument is unambiguous
+set foo
+
+# Valid: non-identifier positional values are not set flags
+set n-aliases.conf n-env.conf
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__string_compared_with_eq__tests__C121_fix_C121.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__string_compared_with_eq__tests__C121_fix_C121.sh.snap
@@ -1,0 +1,48 @@
+---
+source: crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
+assertion_line: 422
+---
+Diagnostics:
+C121 this numeric comparison uses text instead of a number
+ --> <source>:2:13
+  |
+2 | [[ $VER -eq "latest" ]]
+  |
+
+C121 this numeric comparison uses text instead of a number
+ --> <source>:3:4
+  |
+3 | [[ foo -ne 3 ]]
+  |
+
+C121 this numeric comparison uses text instead of a number
+ --> <source>:4:10
+  |
+4 | [[ 3 -eq bar ]]
+  |
+
+
+Applied fixes: 3
+
+Diff:
+--- before
++++ after
+@@ -1,5 +1,5 @@
+ #!/bin/bash
+-[[ $VER -eq "latest" ]]
+-[[ foo -ne 3 ]]
+-[[ 3 -eq bar ]]
++[[ $VER = "latest" ]]
++[[ "foo" != 3 ]]
++[[ 3 = "bar" ]]
+ [ $VER -eq "latest" ]
+
+Fixed source:
+#!/bin/bash
+[[ $VER = "latest" ]]
+[[ "foo" != 3 ]]
+[[ 3 = "bar" ]]
+[ $VER -eq "latest" ]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tilde_in_string_comparison__tests__C091_fix_C091.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tilde_in_string_comparison__tests__C091_fix_C091.sh.snap
@@ -1,0 +1,111 @@
+---
+source: crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
+assertion_line: 261
+---
+Diagnostics:
+C091 quoted `~/...` stays literal; use `$HOME` or an unquoted tilde
+ --> <source>:4:17
+  |
+4 | [ "$profile" = "~/.bashrc" ]
+  |
+
+C091 quoted `~/...` stays literal; use `$HOME` or an unquoted tilde
+ --> <source>:7:4
+  |
+7 | [ "~/.bash_profile" = "$profile" ]
+  |
+
+C091 quoted `~/...` stays literal; use `$HOME` or an unquoted tilde
+  --> <source>:10:19
+   |
+10 | [[ "$profile" == "~/.zshrc" ]]
+   |
+
+C091 quoted `~/...` stays literal; use `$HOME` or an unquoted tilde
+  --> <source>:13:17
+   |
+13 | [ "$profile" != '~/.config/fish/config.fish' ]
+   |
+
+C091 quoted `~/...` stays literal; use `$HOME` or an unquoted tilde
+  --> <source>:16:9
+   |
+16 | profile='~/.bash_profile'
+   |
+
+C091 quoted `~/...` stays literal; use `$HOME` or an unquoted tilde
+  --> <source>:17:16
+   |
+17 | printf '%s\n' "~/.config/powershell/profile.ps1"
+   |
+
+C091 quoted `~/...` stays literal; use `$HOME` or an unquoted tilde
+  --> <source>:18:7
+   |
+18 | [ -e "~/.cache/app" ]
+   |
+
+
+Applied fixes: 7
+
+Diff:
+--- before
++++ after
+@@ -1,21 +1,21 @@
+ #!/bin/bash
+ 
+ # Invalid: the quoted home-relative path stays literal in `[ ]`.
+-[ "$profile" = "~/.bashrc" ]
++[ "$profile" = "$HOME/.bashrc" ]
+ 
+ # Invalid: either side of the string comparison can carry the quoted `~/...`.
+-[ "~/.bash_profile" = "$profile" ]
++[ "$HOME/.bash_profile" = "$profile" ]
+ 
+ # Invalid: `[[ ]]` string comparisons have the same quoted-tilde issue.
+-[[ "$profile" == "~/.zshrc" ]]
++[[ "$profile" == "$HOME/.zshrc" ]]
+ 
+ # Invalid: single quotes still prevent tilde expansion.
+-[ "$profile" != '~/.config/fish/config.fish' ]
++[ "$profile" != "$HOME/.config/fish/config.fish" ]
+ 
+ # Invalid: assignments and command arguments have the same quoted-tilde issue.
+-profile='~/.bash_profile'
+-printf '%s\n' "~/.config/powershell/profile.ps1"
+-[ -e "~/.cache/app" ]
++profile="$HOME/.bash_profile"
++printf '%s\n' "$HOME/.config/powershell/profile.ps1"
++[ -e "$HOME/.cache/app" ]
+ 
+ # Valid: an unquoted tilde expands before the comparison.
+ [ "$profile" = ~/.bashrc ]
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: the quoted home-relative path stays literal in `[ ]`.
+[ "$profile" = "$HOME/.bashrc" ]
+
+# Invalid: either side of the string comparison can carry the quoted `~/...`.
+[ "$HOME/.bash_profile" = "$profile" ]
+
+# Invalid: `[[ ]]` string comparisons have the same quoted-tilde issue.
+[[ "$profile" == "$HOME/.zshrc" ]]
+
+# Invalid: single quotes still prevent tilde expansion.
+[ "$profile" != "$HOME/.config/fish/config.fish" ]
+
+# Invalid: assignments and command arguments have the same quoted-tilde issue.
+profile="$HOME/.bash_profile"
+printf '%s\n' "$HOME/.config/powershell/profile.ps1"
+[ -e "$HOME/.cache/app" ]
+
+# Valid: an unquoted tilde expands before the comparison.
+[ "$profile" = ~/.bashrc ]
+
+# Valid: `~user` is a different lookup and not interchangeable with `$HOME`.
+[ "$profile" = "~user/.bashrc" ]
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unicode_single_quote_in_single_quotes__tests__C137_fix_C137.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unicode_single_quote_in_single_quotes__tests__C137_fix_C137.sh.snap
@@ -1,0 +1,40 @@
+---
+source: crates/shuck-linter/src/rules/correctness/unicode_single_quote_in_single_quotes.rs
+assertion_line: 137
+---
+Diagnostics:
+C137 a unicode curly single quote appears inside a single-quoted string
+ --> <source>:3:13
+  |
+3 | echo 'hello ‘world’'
+  |
+
+C137 a unicode curly single quote appears inside a single-quoted string
+ --> <source>:3:19
+  |
+3 | echo 'hello ‘world’'
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,5 +1,5 @@
+ #!/bin/sh
+ 
+-echo 'hello ‘world’'
++echo 'hello '\''world'\'''
+ echo "hello ‘world’"
+ echo 'plain text'
+
+Fixed source:
+#!/bin/sh
+
+echo 'hello '\''world'\'''
+echo "hello ‘world’"
+echo 'plain text'
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unset_associative_array_element__tests__C108_fix_C108.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__unset_associative_array_element__tests__C108_fix_C108.sh.snap
@@ -1,0 +1,97 @@
+---
+source: crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
+assertion_line: 174
+---
+Diagnostics:
+C108 quote `unset` array-subscript operands so bracket text stays literal
+ --> <source>:7:7
+  |
+7 | unset parts["one"]
+  |
+
+C108 quote `unset` array-subscript operands so bracket text stays literal
+ --> <source>:8:7
+  |
+8 | unset parts['two']
+  |
+
+C108 quote `unset` array-subscript operands so bracket text stays literal
+  --> <source>:10:7
+   |
+10 | unset parts[$key]
+   |
+
+C108 quote `unset` array-subscript operands so bracket text stays literal
+  --> <source>:11:7
+   |
+11 | unset parts["$key"]
+   |
+
+C108 quote `unset` array-subscript operands so bracket text stays literal
+  --> <source>:20:7
+   |
+20 | unset nums[1]
+   |
+
+C108 quote `unset` array-subscript operands so bracket text stays literal
+  --> <source>:21:7
+   |
+21 | unset nums["1"]
+   |
+
+
+Applied fixes: 6
+
+Diff:
+--- before
++++ after
+@@ -4,11 +4,11 @@
+ declare -A parts
+ parts[one]=1
+ parts[two]=2
+-unset parts["one"]
+-unset parts['two']
++unset "parts[one]"
++unset "parts[two]"
+ key=two
+-unset parts[$key]
+-unset parts["$key"]
++unset "parts[${key}]"
++unset "parts[${key}]"
+ 
+ # Valid: quote the entire operand to keep it literal.
+ unset 'parts[key]'
+@@ -17,5 +17,5 @@
+ # Invalid: indexed arrays are also subject to this check.
+ declare -a nums
+ nums[1]=one
+-unset nums[1]
+-unset nums["1"]
++unset "nums[1]"
++unset "nums[1]"
+
+Fixed source:
+#!/bin/bash
+
+# Invalid: array-subscript operands in `unset` should stay literal.
+declare -A parts
+parts[one]=1
+parts[two]=2
+unset "parts[one]"
+unset "parts[two]"
+key=two
+unset "parts[${key}]"
+unset "parts[${key}]"
+
+# Valid: quote the entire operand to keep it literal.
+unset 'parts[key]'
+unset "parts[key]"
+
+# Invalid: indexed arrays are also subject to this check.
+declare -a nums
+nums[1]=one
+unset "nums[1]"
+unset "nums[1]"
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
+++ b/crates/shuck-linter/src/rules/correctness/string_compared_with_eq.rs
@@ -1,13 +1,18 @@
 use shuck_ast::{ConditionalBinaryOp, Name, Span, is_shell_variable_name, static_word_text};
 use shuck_parser::text_is_self_contained_arithmetic_expression;
 
-use crate::{Checker, ConditionalNodeFact, ConditionalOperandFact, Rule, Violation, WordQuote};
+use crate::{
+    Checker, ConditionalBinaryFact, ConditionalNodeFact, ConditionalOperandFact, Diagnostic, Edit,
+    Fix, FixAvailability, Rule, Violation, WordQuote,
+};
 
 use super::variable_reference_common::binding_defines_variable_name_at;
 
 pub struct StringComparedWithEq;
 
 impl Violation for StringComparedWithEq {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::StringComparedWithEq
     }
@@ -15,11 +20,15 @@ impl Violation for StringComparedWithEq {
     fn message(&self) -> String {
         "this numeric comparison uses text instead of a number".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("use a string comparison".to_owned())
+    }
 }
 
 pub fn string_compared_with_eq(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -30,14 +39,16 @@ pub fn string_compared_with_eq(checker: &mut Checker) {
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || StringComparedWithEq);
+    for (span, fix) in diagnostics {
+        checker.report_diagnostic_dedup(Diagnostic::new(StringComparedWithEq, span).with_fix(fix));
+    }
 }
 
 fn conditional_string_eq_spans(
     checker: &Checker<'_>,
     conditional: &crate::ConditionalFact<'_>,
     source: &str,
-) -> Vec<Span> {
+) -> Vec<(Span, Fix)> {
     conditional
         .nodes()
         .iter()
@@ -48,18 +59,7 @@ fn conditional_string_eq_spans(
                     ConditionalBinaryOp::ArithmeticEq | ConditionalBinaryOp::ArithmeticNe
                 ) =>
             {
-                let mut spans = Vec::new();
-                if let Some(span) =
-                    conditional_operand_string_value_span(checker, binary.left(), source)
-                {
-                    spans.push(span);
-                }
-                if let Some(span) =
-                    conditional_operand_string_value_span(checker, binary.right(), source)
-                {
-                    spans.push(span);
-                }
-                spans
+                string_eq_diagnostics(checker, *binary, source)
             }
             ConditionalNodeFact::BareWord(_)
             | ConditionalNodeFact::Unary(_)
@@ -69,11 +69,40 @@ fn conditional_string_eq_spans(
         .collect()
 }
 
-fn conditional_operand_string_value_span(
+fn string_eq_diagnostics(
+    checker: &Checker<'_>,
+    binary: ConditionalBinaryFact<'_>,
+    source: &str,
+) -> Vec<(Span, Fix)> {
+    let operands = [binary.left(), binary.right()]
+        .into_iter()
+        .filter_map(|operand| conditional_operand_string_value(checker, operand, source))
+        .collect::<Vec<_>>();
+    if operands.is_empty() {
+        return Vec::new();
+    }
+
+    let Some(fix) = string_eq_fix(binary, &operands) else {
+        return Vec::new();
+    };
+
+    operands
+        .into_iter()
+        .map(|operand| (operand.span, fix.clone()))
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StringOperand {
+    span: Span,
+    quote: Option<WordQuote>,
+}
+
+fn conditional_operand_string_value(
     checker: &Checker<'_>,
     operand: ConditionalOperandFact<'_>,
     source: &str,
-) -> Option<Span> {
+) -> Option<StringOperand> {
     operand
         .word()
         .zip(operand.word_classification())
@@ -91,8 +120,47 @@ fn conditional_operand_string_value_span(
                         )
                     })
                 })
-                .map(|word| word.span)
+                .map(|word| StringOperand {
+                    span: word.span,
+                    quote: operand.quote(),
+                })
         })
+}
+
+fn string_eq_fix(binary: ConditionalBinaryFact<'_>, operands: &[StringOperand]) -> Option<Fix> {
+    let operator_replacement = match binary.op() {
+        ConditionalBinaryOp::ArithmeticEq => "=",
+        ConditionalBinaryOp::ArithmeticNe => "!=",
+        ConditionalBinaryOp::RegexMatch
+        | ConditionalBinaryOp::NewerThan
+        | ConditionalBinaryOp::OlderThan
+        | ConditionalBinaryOp::SameFile
+        | ConditionalBinaryOp::ArithmeticLe
+        | ConditionalBinaryOp::ArithmeticGe
+        | ConditionalBinaryOp::ArithmeticLt
+        | ConditionalBinaryOp::ArithmeticGt
+        | ConditionalBinaryOp::And
+        | ConditionalBinaryOp::Or
+        | ConditionalBinaryOp::PatternEqShort
+        | ConditionalBinaryOp::PatternEq
+        | ConditionalBinaryOp::PatternNe
+        | ConditionalBinaryOp::LexicalBefore
+        | ConditionalBinaryOp::LexicalAfter => return None,
+    };
+
+    let mut edits = vec![Edit::replacement(
+        operator_replacement,
+        binary.operator_span(),
+    )];
+    for operand in operands
+        .iter()
+        .filter(|operand| operand.quote == Some(WordQuote::Unquoted))
+    {
+        edits.push(Edit::insertion(operand.span.start.offset, "\""));
+        edits.push(Edit::insertion(operand.span.end.offset, "\""));
+    }
+
+    Some(Fix::unsafe_edits(edits))
 }
 
 fn operand_text_looks_like_string_value(
@@ -146,9 +214,12 @@ fn looks_like_decimal_integer(text: &str) -> bool {
 mod tests {
     use std::fs;
 
-    use crate::test::test_snippet;
-    use crate::test::test_snippet_at_path;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{
+        test_path_with_fix, test_snippet, test_snippet_at_path, test_snippet_with_fix,
+    };
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
     use tempfile::tempdir;
 
     #[test]
@@ -311,5 +382,58 @@ source ./helper.sh
                 .collect::<Vec<_>>(),
             vec!["flag"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_text_numeric_comparisons() {
+        let source = "\
+#!/bin/bash
+[[ $VER -eq \"latest\" ]]
+[[ foo -ne 3 ]]
+[[ foo -eq bar ]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::StringComparedWithEq),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[[ $VER = \"latest\" ]]
+[[ \"foo\" != 3 ]]
+[[ \"foo\" = \"bar\" ]]
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_text_numeric_comparisons_unchanged() {
+        let source = "#!/bin/bash\n[[ foo -eq 3 ]]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::StringComparedWithEq),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C121.sh").as_path(),
+            &LinterSettings::for_rule(Rule::StringComparedWithEq),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C121_fix_C121.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
+++ b/crates/shuck-linter/src/rules/correctness/tilde_in_string_comparison.rs
@@ -1,10 +1,14 @@
 use shuck_ast::{Position, Span};
 
-use crate::{Checker, Rule, Violation, WordFactHostKind, WordQuote};
+use crate::{
+    Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation, WordFactHostKind, WordQuote,
+};
 
 pub struct TildeInStringComparison;
 
 impl Violation for TildeInStringComparison {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::TildeInStringComparison
     }
@@ -12,18 +16,29 @@ impl Violation for TildeInStringComparison {
     fn message(&self) -> String {
         "quoted `~/...` stays literal; use `$HOME` or an unquoted tilde".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the quoted home path with `$HOME`".to_owned())
+    }
 }
 
 pub fn tilde_in_string_comparison(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .word_facts()
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
         .filter_map(|fact| word_fact_tilde_span(fact, source))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || TildeInStringComparison);
+    for span in diagnostics {
+        checker.report_diagnostic_dedup(Diagnostic::new(TildeInStringComparison, span).with_fix(
+            Fix::unsafe_edit(Edit::replacement(
+                home_path_replacement(span.slice(source)),
+                span,
+            )),
+        ));
+    }
 }
 
 fn word_fact_tilde_span(fact: crate::WordOccurrenceRef<'_, '_>, source: &str) -> Option<Span> {
@@ -62,6 +77,19 @@ fn quoted_tilde_span_from_raw(span: Span, raw: &str) -> Option<Span> {
     Some(Span::from_positions(start, end))
 }
 
+fn home_path_replacement(raw: &str) -> String {
+    if let Some(path) = raw
+        .strip_prefix("'~/")
+        .and_then(|rest| rest.strip_suffix('\''))
+    {
+        format!("\"$HOME/{path}\"")
+    } else if let Some(path) = raw.strip_prefix("~/") {
+        format!("$HOME/{path}")
+    } else {
+        raw.to_owned()
+    }
+}
+
 fn advance_position(mut position: Position, text: &str) -> Position {
     position = position.advanced_by(text);
     position
@@ -69,8 +97,10 @@ fn advance_position(mut position: Position, text: &str) -> Position {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_quoted_home_relative_paths_in_string_comparisons() {
@@ -171,5 +201,64 @@ case \"$path\" in \"~/.cache\") : ;; esac
                 "~/.cache",
             ]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_quoted_home_paths() {
+        let source = "\
+#!/bin/bash
+[ \"$profile\" = \"~/.bashrc\" ]
+[ \"$profile\" != '~/.zshrc' ]
+profile='~/.bash_profile'
+printf '%s\n' \"~/.config/powershell/profile.ps1\"
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::TildeInStringComparison),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ \"$profile\" = \"$HOME/.bashrc\" ]
+[ \"$profile\" != \"$HOME/.zshrc\" ]
+profile=\"$HOME/.bash_profile\"
+printf '%s\n' \"$HOME/.config/powershell/profile.ps1\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn leaves_unquoted_tildes_and_user_tildes_unchanged_when_fixing() {
+        let source = "\
+#!/bin/bash
+[ \"$profile\" = ~/.bashrc ]
+[ \"$profile\" = \"~user/.bashrc\" ]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::TildeInStringComparison),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C091.sh").as_path(),
+            &LinterSettings::for_rule(Rule::TildeInStringComparison),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C091_fix_C091.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/unicode_single_quote_in_single_quotes.rs
+++ b/crates/shuck-linter/src/rules/correctness/unicode_single_quote_in_single_quotes.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct UnicodeSingleQuoteInSingleQuotes;
 
 impl Violation for UnicodeSingleQuoteInSingleQuotes {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnicodeSingleQuoteInSingleQuotes
     }
@@ -10,11 +12,15 @@ impl Violation for UnicodeSingleQuoteInSingleQuotes {
     fn message(&self) -> String {
         "a unicode curly single quote appears inside a single-quoted string".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace it with a shell-safe apostrophe".to_owned())
+    }
 }
 
 pub fn unicode_single_quote_in_single_quotes(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .single_quoted_fragments()
         .iter()
@@ -26,18 +32,28 @@ pub fn unicode_single_quote_in_single_quotes(checker: &mut Checker) {
                 }
 
                 let start = fragment.span().start.advanced_by(&text[..offset]);
-                Some(shuck_ast::Span::from_positions(start, start))
+                let span = shuck_ast::Span::from_positions(start, start);
+                let fix = Fix::unsafe_edit(Edit::replacement_at(
+                    start.offset,
+                    start.offset + char.len_utf8(),
+                    "'\\''",
+                ));
+                Some(Diagnostic::new(UnicodeSingleQuoteInSingleQuotes, span).with_fix(fix))
             })
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnicodeSingleQuoteInSingleQuotes);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_unicode_single_quotes_inside_single_quoted_strings() {
@@ -69,5 +85,56 @@ echo \"hello ‘world’\"
                 .collect::<Vec<_>>(),
             vec![(2, 13, 2, 13, '‘'), (2, 19, 2, 19, '’')]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_unicode_single_quotes() {
+        let source = "\
+#!/bin/sh
+echo 'hello ‘world’'
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnicodeSingleQuoteInSingleQuotes),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo 'hello '\\''world'\\'''
+"
+        );
+        assert_eq!(result.fixes_applied, 2);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_unicode_single_quotes_unchanged() {
+        let source = "\
+#!/bin/sh
+echo 'hello ‘world’'
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnicodeSingleQuoteInSingleQuotes),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixes_applied, 0);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C137.sh").as_path(),
+            &LinterSettings::for_rule(Rule::UnicodeSingleQuoteInSingleQuotes),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C137_fix_C137.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
+++ b/crates/shuck-linter/src/rules/correctness/unset_associative_array_element.rs
@@ -1,8 +1,11 @@
-use crate::{Checker, Rule, Violation};
+use crate::facts::surface::rewrite_word_as_single_double_quoted_string;
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct UnsetAssociativeArrayElement;
 
 impl Violation for UnsetAssociativeArrayElement {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnsetAssociativeArrayElement
     }
@@ -10,10 +13,15 @@ impl Violation for UnsetAssociativeArrayElement {
     fn message(&self) -> String {
         "quote `unset` array-subscript operands so bracket text stays literal".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the unset operand".to_owned())
+    }
 }
 
 pub fn unset_associative_array_element(checker: &mut Checker) {
-    let mut spans = Vec::new();
+    let source = checker.source();
+    let mut diagnostics = Vec::new();
 
     for fact in checker
         .facts()
@@ -26,18 +34,28 @@ pub fn unset_associative_array_element(checker: &mut Checker) {
 
         for operand in unset.operand_facts() {
             if operand.array_subscript().is_some() {
-                spans.push(operand.word().span);
+                diagnostics.push((
+                    operand.word().span,
+                    rewrite_word_as_single_double_quoted_string(operand.word(), source, None),
+                ));
             }
         }
     }
 
-    checker.report_all_dedup(spans, || UnsetAssociativeArrayElement);
+    for (span, replacement) in diagnostics {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(UnsetAssociativeArrayElement, span)
+                .with_fix(Fix::unsafe_edit(Edit::replacement(replacement, span))),
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_array_subscript_unset_operands() {
@@ -98,5 +116,62 @@ unset \"parts[key]\"
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_array_subscript_unset_operands() {
+        let source = "\
+#!/bin/bash
+unset parts[\"one\"]
+unset parts['two']
+unset parts[$key]
+unset parts[\"$key\"]
+unset parts[\\\"four\\\"]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnsetAssociativeArrayElement),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 5);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+unset \"parts[one]\"
+unset \"parts[two]\"
+unset \"parts[${key}]\"
+unset \"parts[${key}]\"
+unset \"parts[\\\"four\\\"]\"
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_unset_operands_unchanged() {
+        let source = "#!/bin/bash\nunset parts[key]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnsetAssociativeArrayElement),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C108.sh").as_path(),
+            &LinterSettings::for_rule(Rule::UnsetAssociativeArrayElement),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C108_fix_C108.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
+++ b/crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
@@ -1,14 +1,22 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct BraceVariableBeforeBracket;
 
 impl Violation for BraceVariableBeforeBracket {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::BraceVariableBeforeBracket
     }
 
     fn message(&self) -> String {
         "brace variable expansions before adjacent `[` text".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("wrap the variable expansion in braces".to_owned())
     }
 }
 
@@ -17,16 +25,57 @@ pub fn brace_variable_before_bracket(checker: &mut Checker) {
         return;
     }
 
-    checker.report_fact_slice_dedup(
-        |facts| facts.brace_variable_before_bracket_spans(),
-        || BraceVariableBeforeBracket,
-    );
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .brace_variable_before_bracket_spans()
+        .iter()
+        .copied()
+        .map(|span| {
+            let diagnostic = Diagnostic::new(BraceVariableBeforeBracket, span);
+            match brace_variable_fix(span, source) {
+                Some(fix) => diagnostic.with_fix(fix),
+                None => diagnostic,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn brace_variable_fix(span: Span, source: &str) -> Option<Fix> {
+    let offset = span.start.offset;
+    let tail = source.get(offset..)?;
+    let rest = tail.strip_prefix('$')?;
+    let mut chars = rest.char_indices();
+    let (_, first) = chars.next()?;
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return None;
+    }
+
+    let mut name_len = first.len_utf8();
+    for (index, ch) in chars {
+        if ch == '_' || ch.is_ascii_alphanumeric() {
+            name_len = index + ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    Some(Fix::safe_edits([
+        Edit::insertion(offset + '$'.len_utf8(), "{"),
+        Edit::insertion(offset + '$'.len_utf8() + name_len, "}"),
+    ]))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn reports_unbraced_variables_before_bracket_text() {
@@ -116,5 +165,44 @@ print $reply[2]
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_by_bracing_variable_expansions() {
+        let source = "\
+#!/bin/sh
+echo \"$foo[0]\"
+echo game$game[0]
+$cmd[0] arg
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::BraceVariableBeforeBracket),
+            Applicability::Safe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+echo \"${foo}[0]\"
+echo game${game}[0]
+${cmd}[0] arg
+"
+        );
+        assert_eq!(result.fixes_applied, 3);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("style").join("S077.sh").as_path(),
+            &LinterSettings::for_rule(Rule::BraceVariableBeforeBracket),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("S077_fix_S077.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
+++ b/crates/shuck-linter/src/rules/style/function_body_without_braces.rs
@@ -1,14 +1,22 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct FunctionBodyWithoutBraces;
 
 impl Violation for FunctionBodyWithoutBraces {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::FunctionBodyWithoutBraces
     }
 
     fn message(&self) -> String {
         "function body should use a brace group instead of a bare compound command".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("wrap the function body in braces".to_owned())
     }
 }
 
@@ -20,16 +28,51 @@ pub fn function_body_without_braces(checker: &mut Checker) {
         return;
     }
 
-    checker.report_fact_slice_dedup(
-        |facts| facts.function_body_without_braces_spans(),
-        || FunctionBodyWithoutBraces,
-    );
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .function_body_without_braces_spans()
+        .iter()
+        .copied()
+        .map(|span| {
+            Diagnostic::new(FunctionBodyWithoutBraces, span)
+                .with_fix(wrap_function_body_fix(span, source))
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn wrap_function_body_fix(span: Span, source: &str) -> Fix {
+    let insert_end = trim_trailing_whitespace_offset(span, source);
+    Fix::safe_edits([
+        Edit::insertion(span.start.offset, "{ "),
+        Edit::insertion(insert_end, "; }"),
+    ])
+}
+
+fn trim_trailing_whitespace_offset(span: Span, source: &str) -> usize {
+    let mut offset = span.end.offset;
+    while offset > span.start.offset {
+        let Some(ch) = source[..offset].chars().next_back() else {
+            break;
+        };
+        if !ch.is_whitespace() {
+            break;
+        }
+        offset -= ch.len_utf8();
+    }
+    offset
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_function_bodies_written_as_bare_compound_commands() {
@@ -72,5 +115,42 @@ i() (( x++ ))
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_safe_fix_by_wrapping_function_body_in_braces() {
+        let source = "\
+#!/bin/bash
+f() [[ -n \"$x\" ]]
+g() if true; then :; fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionBodyWithoutBraces),
+            Applicability::Safe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+f() { [[ -n \"$x\" ]]; }
+g() { if true; then :; fi; }
+"
+        );
+        assert_eq!(result.fixes_applied, 2);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("style").join("S041.sh").as_path(),
+            &LinterSettings::for_rule(Rule::FunctionBodyWithoutBraces),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("S041_fix_S041.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
+++ b/crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
@@ -1,8 +1,13 @@
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFactHostKind, WordQuote};
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation,
+    WordFactHostKind, WordQuote,
+};
 
 pub struct GlobAssignedToVariable;
 
 impl Violation for GlobAssignedToVariable {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::GlobAssignedToVariable
     }
@@ -10,11 +15,15 @@ impl Violation for GlobAssignedToVariable {
     fn message(&self) -> String {
         "quote assigned glob patterns so they stay literal".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the assigned glob pattern".to_owned())
+    }
 }
 
 pub fn glob_assigned_to_variable(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .expansion_word_facts(ExpansionContext::AssignmentValue)
         .chain(
@@ -25,17 +34,34 @@ pub fn glob_assigned_to_variable(checker: &mut Checker) {
         .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
         .filter(|fact| !checker.facts().is_compound_assignment_value_word(*fact))
         .filter(|fact| fact.classification().quote != WordQuote::FullyQuoted)
-        .filter(|fact| !fact.active_literal_glob_spans(source).is_empty())
-        .map(|fact| fact.span())
+        .filter_map(|fact| {
+            let glob_spans = fact.active_literal_glob_spans(source);
+            (!glob_spans.is_empty()).then(|| {
+                Diagnostic::new(GlobAssignedToVariable, fact.span())
+                    .with_fix(quote_glob_spans_fix(glob_spans, source))
+            })
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || GlobAssignedToVariable);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn quote_glob_spans_fix(spans: Vec<shuck_ast::Span>, source: &str) -> Fix {
+    let edits = spans.into_iter().map(|span| {
+        let text = span.slice(source);
+        Edit::replacement(format!("'{text}'"), span)
+    });
+    Fix::safe_edits(edits)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_assignment_values_with_unquoted_globs() {
@@ -91,5 +117,44 @@ LOCS=(\"$dir\"/*.oxt)
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_safe_fix_by_quoting_literal_glob_fragments() {
+        let source = "\
+#!/bin/bash
+LOCS=*.oxt
+LOCS=$dir/*.oxt
+readonly LOCS=foo*bar
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GlobAssignedToVariable),
+            Applicability::Safe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+LOCS='*'.oxt
+LOCS=$dir/'*'.oxt
+readonly LOCS=foo'*'bar
+"
+        );
+        assert_eq!(result.fixes_applied, 3);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("style").join("S055.sh").as_path(),
+            &LinterSettings::for_rule(Rule::GlobAssignedToVariable),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("S055_fix_S055.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct LiteralBackslashInSingleQuotes;
 
 impl Violation for LiteralBackslashInSingleQuotes {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LiteralBackslashInSingleQuotes
     }
@@ -10,23 +14,59 @@ impl Violation for LiteralBackslashInSingleQuotes {
     fn message(&self) -> String {
         "a backslash inside single quotes stays literal".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite as a double-quoted string".to_owned())
+    }
 }
 
 pub fn literal_backslash_in_single_quotes(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .single_quoted_fragments()
         .iter()
-        .filter_map(|fragment| fragment.literal_backslash_in_single_quotes_span())
+        .filter_map(|fragment| {
+            let span = fragment.literal_backslash_in_single_quotes_span()?;
+            Some(
+                Diagnostic::new(LiteralBackslashInSingleQuotes, span)
+                    .with_fix(rewrite_single_quoted_fragment_fix(fragment.span(), source)?),
+            )
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || LiteralBackslashInSingleQuotes);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn rewrite_single_quoted_fragment_fix(fragment_span: Span, source: &str) -> Option<Fix> {
+    let fragment = fragment_span.slice(source);
+    let content = fragment.strip_prefix('\'')?.strip_suffix('\'')?;
+    let mut replacement = String::from("\"");
+    for ch in content.chars() {
+        match ch {
+            '$' | '`' | '"' | '\\' => {
+                replacement.push('\\');
+                replacement.push(ch);
+            }
+            _ => replacement.push(ch),
+        }
+    }
+    replacement.push('"');
+
+    Some(Fix::safe_edit(Edit::replacement(
+        replacement,
+        fragment_span,
+    )))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics_diff};
 
     #[test]
     fn reports_single_quoted_escape_sequences_that_run_into_more_literal_text() {
@@ -68,5 +108,42 @@ printf '%s\\n' a'\\'bc
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_by_rewriting_single_quotes_as_double_quotes() {
+        let source = "\
+#!/bin/sh
+grep ^start'\\s'end file.txt
+printf '%s\\n' 'a$`\"\\\\b\\n'c
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralBackslashInSingleQuotes),
+            Applicability::Safe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+grep ^start\"\\\\s\"end file.txt
+printf '%s\\n' \"a\\$\\`\\\"\\\\\\\\b\\\\n\"c
+"
+        );
+        assert_eq!(result.fixes_applied, 2);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_safe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("style").join("S039.sh").as_path(),
+            &LinterSettings::for_rule(Rule::LiteralBackslashInSingleQuotes),
+            Applicability::Safe,
+        )?;
+
+        assert_diagnostics_diff!("S039_fix_S039.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/local_declare_combined.rs
+++ b/crates/shuck-linter/src/rules/style/local_declare_combined.rs
@@ -1,16 +1,24 @@
 use shuck_ast::DeclOperand;
 
-use crate::{Checker, DeclarationKind, Rule, ShellDialect, Violation};
+use crate::{
+    Checker, DeclarationKind, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation,
+};
 
 pub struct LocalDeclareCombined;
 
 impl Violation for LocalDeclareCombined {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LocalDeclareCombined
     }
 
     fn message(&self) -> String {
         "mix either `local` or `declare`, not both in the same statement".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete the extra declaration word".to_owned())
     }
 }
 
@@ -22,14 +30,22 @@ pub fn local_declare_combined(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|fact| declaration_combination_span(fact))
+        .map(|span| {
+            Diagnostic::new(LocalDeclareCombined, span).with_fix(Fix::unsafe_edit(Edit::deletion(
+                operand_deletion_span(span, source),
+            )))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || LocalDeclareCombined);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn declaration_combination_span(fact: crate::CommandFactRef<'_, '_>) -> Option<shuck_ast::Span> {
@@ -52,10 +68,42 @@ fn declaration_combination_span(fact: crate::CommandFactRef<'_, '_>) -> Option<s
         })
 }
 
+fn operand_deletion_span(span: shuck_ast::Span, source: &str) -> shuck_ast::Span {
+    let bytes = source.as_bytes();
+    let mut end_offset = span.end.offset;
+    while end_offset < bytes.len() && matches!(bytes[end_offset], b' ' | b'\t') {
+        end_offset += 1;
+    }
+    if end_offset > span.end.offset {
+        return shuck_ast::Span::from_positions(
+            span.start,
+            span.end.advanced_by(&source[span.end.offset..end_offset]),
+        );
+    }
+
+    let mut start_offset = span.start.offset;
+    while start_offset > 0 && matches!(bytes[start_offset - 1], b' ' | b'\t') {
+        start_offset -= 1;
+    }
+    shuck_ast::Span::from_positions(
+        shuck_ast::Position {
+            offset: start_offset,
+            line: span.start.line,
+            column: span
+                .start
+                .column
+                .saturating_sub(span.start.offset.saturating_sub(start_offset)),
+        },
+        span.end,
+    )
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
 
     #[test]
     fn reports_combined_local_and_declare_words() {
@@ -102,5 +150,62 @@ f() {
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_deleting_extra_declaration_word() {
+        let source = "\
+#!/bin/sh
+f() {
+  local declare hard_list
+  declare local other_list
+}
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LocalDeclareCombined),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+f() {
+  local hard_list
+  declare other_list
+}
+"
+        );
+        assert_eq!(result.fixes_applied, 2);
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn safe_fix_mode_leaves_combined_declarations_unchanged() {
+        let source = "\
+#!/bin/sh
+local declare x
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LocalDeclareCombined),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixes_applied, 0);
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("style").join("S066.sh").as_path(),
+            &LinterSettings::for_rule(Rule::LocalDeclareCombined),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("S066_fix_S066.sh", result);
+        Ok(())
     }
 }

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__brace_variable_before_bracket__tests__S077_fix_S077.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__brace_variable_before_bracket__tests__S077_fix_S077.sh.snap
@@ -1,0 +1,84 @@
+---
+source: crates/shuck-linter/src/rules/style/brace_variable_before_bracket.rs
+assertion_line: 205
+---
+Diagnostics:
+S077 brace variable expansions before adjacent `[` text
+ --> <source>:3:16
+  |
+3 | printf '%s\n' "$name[0]"
+  |
+
+S077 brace variable expansions before adjacent `[` text
+ --> <source>:6:11
+  |
+6 | pattern="^$key[[:space:]]*$"
+  |
+
+S077 brace variable expansions before adjacent `[` text
+ --> <source>:9:11
+  |
+9 | entry=game$game[0]
+  |
+
+S077 brace variable expansions before adjacent `[` text
+  --> <source>:12:1
+   |
+12 | $cmd[0] arg
+   |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -1,15 +1,15 @@
+ #!/bin/sh
+ # Should trigger: adjacent bracket text after an unbraced variable.
+-printf '%s\n' "$name[0]"
++printf '%s\n' "${name}[0]"
+ 
+ # Should trigger: bracket expressions after an unbraced variable in a pattern.
+-pattern="^$key[[:space:]]*$"
++pattern="^${key}[[:space:]]*$"
+ 
+ # Should trigger: literal prefixes do not change the ambiguity.
+-entry=game$game[0]
++entry=game${game}[0]
+ 
+ # Should trigger: command names are still ordinary words here.
+-$cmd[0] arg
++${cmd}[0] arg
+ 
+ # Should not trigger: braces make the boundary explicit.
+ printf '%s\n' "${name}[0]"
+
+Fixed source:
+#!/bin/sh
+# Should trigger: adjacent bracket text after an unbraced variable.
+printf '%s\n' "${name}[0]"
+
+# Should trigger: bracket expressions after an unbraced variable in a pattern.
+pattern="^${key}[[:space:]]*$"
+
+# Should trigger: literal prefixes do not change the ambiguity.
+entry=game${game}[0]
+
+# Should trigger: command names are still ordinary words here.
+${cmd}[0] arg
+
+# Should not trigger: braces make the boundary explicit.
+printf '%s\n' "${name}[0]"
+
+# Should not trigger: quote boundaries break the adjacency.
+printf '%s\n' "$name""[0]" "$name"'[0]'
+
+# Should not trigger: escaped brackets stay literal.
+printf '%s\n' "$name\[0]"
+
+# Should not trigger: positional parameters are not part of this rule.
+printf '%s\n' "$1[0]"
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__function_body_without_braces__tests__S041_fix_S041.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__function_body_without_braces__tests__S041_fix_S041.sh.snap
@@ -1,0 +1,28 @@
+---
+source: crates/shuck-linter/src/rules/style/function_body_without_braces.rs
+assertion_line: 153
+---
+Diagnostics:
+S041 function body should use a brace group instead of a bare compound command
+ --> <source>:2:5
+  |
+2 | f() [[ -n "$x" ]]
+  |
+
+
+Applied fixes: 1
+
+Diff:
+--- before
++++ after
+@@ -1,2 +1,2 @@
+ #!/bin/bash
+-f() [[ -n "$x" ]]
++f() { [[ -n "$x" ]]; }
+
+Fixed source:
+#!/bin/bash
+f() { [[ -n "$x" ]]; }
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__glob_assigned_to_variable__tests__S055_fix_S055.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__glob_assigned_to_variable__tests__S055_fix_S055.sh.snap
@@ -1,0 +1,92 @@
+---
+source: crates/shuck-linter/src/rules/style/glob_assigned_to_variable.rs
+assertion_line: 157
+---
+Diagnostics:
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:2:6
+  |
+2 | LOCS=*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:4:6
+  |
+4 | LOCS=$dir/*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:5:6
+  |
+5 | LOCS="$dir"/*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:6:6
+  |
+6 | LOCS=${dir}/*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:7:6
+  |
+7 | LOCS=$(pwd)/*.oxt
+  |
+
+S055 quote assigned glob patterns so they stay literal
+ --> <source>:9:15
+  |
+9 | readonly LOCS=foo*bar
+  |
+
+S055 quote assigned glob patterns so they stay literal
+  --> <source>:10:13
+   |
+10 | export LOCS=$dir/*.txt
+   |
+
+
+Applied fixes: 7
+
+Diff:
+--- before
++++ after
+@@ -1,13 +1,13 @@
+ #!/bin/sh
+-LOCS=*.oxt
++LOCS='*'.oxt
+ LOCS="*.oxt"
+-LOCS=$dir/*.oxt
+-LOCS="$dir"/*.oxt
+-LOCS=${dir}/*.oxt
+-LOCS=$(pwd)/*.oxt
++LOCS=$dir/'*'.oxt
++LOCS="$dir"/'*'.oxt
++LOCS=${dir}/'*'.oxt
++LOCS=$(pwd)/'*'.oxt
+ LOCS=\*.oxt
+-readonly LOCS=foo*bar
+-export LOCS=$dir/*.txt
++readonly LOCS=foo'*'bar
++export LOCS=$dir/'*'.txt
+ LOCS=(*.oxt)
+ LOCS=("$dir"/*.txt)
+ LOCS=${name#*:}
+
+Fixed source:
+#!/bin/sh
+LOCS='*'.oxt
+LOCS="*.oxt"
+LOCS=$dir/'*'.oxt
+LOCS="$dir"/'*'.oxt
+LOCS=${dir}/'*'.oxt
+LOCS=$(pwd)/'*'.oxt
+LOCS=\*.oxt
+readonly LOCS=foo'*'bar
+export LOCS=$dir/'*'.txt
+LOCS=(*.oxt)
+LOCS=("$dir"/*.txt)
+LOCS=${name#*:}
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__literal_backslash_in_single_quotes__tests__S039_fix_S039.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__literal_backslash_in_single_quotes__tests__S039_fix_S039.sh.snap
@@ -1,0 +1,65 @@
+---
+source: crates/shuck-linter/src/rules/style/literal_backslash_in_single_quotes.rs
+assertion_line: 146
+---
+Diagnostics:
+S039 a backslash inside single quotes stays literal
+ --> <source>:3:15
+  |
+3 | grep ^start'\s'end file.txt
+  |
+
+S039 a backslash inside single quotes stays literal
+ --> <source>:4:18
+  |
+4 | printf '%s\n' '\n'foo
+  |
+
+S039 a backslash inside single quotes stays literal
+ --> <source>:5:20
+  |
+5 | printf '%s\n' 'ab\n'c
+  |
+
+S039 a backslash inside single quotes stays literal
+ --> <source>:6:19
+  |
+6 | printf '%s\n' '\\n'foo
+  |
+
+
+Applied fixes: 4
+
+Diff:
+--- before
++++ after
+@@ -1,9 +1,9 @@
+ #!/bin/sh
+ 
+-grep ^start'\s'end file.txt
+-printf '%s\n' '\n'foo
+-printf '%s\n' 'ab\n'c
+-printf '%s\n' '\\n'foo
++grep ^start"\\s"end file.txt
++printf '%s\n' "\\n"foo
++printf '%s\n' "ab\\n"c
++printf '%s\n' "\\\\n"foo
+ printf '%s\n' 'foo\nbar'
+ printf '%s\n' '\x'41
+ printf '%s\n' '\0'foo
+
+Fixed source:
+#!/bin/sh
+
+grep ^start"\\s"end file.txt
+printf '%s\n' "\\n"foo
+printf '%s\n' "ab\\n"c
+printf '%s\n' "\\\\n"foo
+printf '%s\n' 'foo\nbar'
+printf '%s\n' '\x'41
+printf '%s\n' '\0'foo
+printf '%s\n' $'\n'foo
+printf '%s\n' a'\'bc
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__local_declare_combined__tests__S066_fix_S066.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__local_declare_combined__tests__S066_fix_S066.sh.snap
@@ -1,0 +1,41 @@
+---
+source: crates/shuck-linter/src/rules/style/local_declare_combined.rs
+assertion_line: 208
+---
+Diagnostics:
+S066 mix either `local` or `declare`, not both in the same statement
+ --> <source>:3:9
+  |
+3 |   local declare hard_list
+  |
+
+S066 mix either `local` or `declare`, not both in the same statement
+ --> <source>:4:11
+  |
+4 |   declare local other_list
+  |
+
+
+Applied fixes: 2
+
+Diff:
+--- before
++++ after
+@@ -1,5 +1,5 @@
+ #!/bin/sh
+ f() {
+-  local declare hard_list
+-  declare local other_list
++  local hard_list
++  declare other_list
+ }
+
+Fixed source:
+#!/bin/sh
+f() {
+  local hard_list
+  declare other_list
+}
+
+Remaining diagnostics:
+<none>


### PR DESCRIPTION
## Summary
- implement advertised autofixes for all implemented rules with non-null `fix_description`
- add focused fix tests and snapshot coverage for each new autofix
- keep rule metadata unchanged because safety/descriptions still match the implementations

## Validation
- `cargo test -p shuck-linter`
- `cargo clippy --all-targets -- -D warnings`
- targeted `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=...` for every added fix, all with `implementation_diffs=0`

Final audit: `missing advertised fix among implemented: 0`.