### PR TITLE
feat(linter): implement rule-local autofixes

### DIFF
--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -746,6 +746,9 @@ fn linebreak_before_and_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
     if source.as_bytes().get(insert_offset) != Some(&b'\n') {
         return None;
     }
+    if previous_line_has_shell_comment(source, insert_offset) {
+        return None;
+    }
 
     let operator = span.slice(source);
     let rest = source.get(span.end.offset..)?;
@@ -758,6 +761,70 @@ fn linebreak_before_and_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
         Edit::insertion(insert_offset, format!(" {operator}")),
         Edit::deletion_at(span.start.offset, span.end.offset + trailing_ws_len),
     ]))
+}
+
+fn previous_line_has_shell_comment(source: &str, line_end: usize) -> bool {
+    let line_start = source[..line_end]
+        .rfind('\n')
+        .map_or(0, |offset| offset + 1);
+    line_has_shell_comment(&source[line_start..line_end])
+}
+
+fn line_has_shell_comment(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut index = 0usize;
+    let mut comment_can_start = true;
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut double_quote_escape = false;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+
+        if in_single_quotes {
+            if byte == b'\'' {
+                in_single_quotes = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        if in_double_quotes {
+            if double_quote_escape {
+                double_quote_escape = false;
+            } else if byte == b'\\' {
+                double_quote_escape = true;
+            } else if byte == b'"' {
+                in_double_quotes = false;
+            }
+            index += 1;
+            continue;
+        }
+
+        match byte {
+            b'#' if comment_can_start => return true,
+            b'\'' => {
+                in_single_quotes = true;
+                comment_can_start = false;
+            }
+            b'"' => {
+                in_double_quotes = true;
+                comment_can_start = false;
+            }
+            b'\\' => {
+                index += 1;
+                comment_can_start = false;
+            }
+            byte if byte.is_ascii_whitespace() || is_shell_word_separator(byte as char) => {
+                comment_can_start = true;
+            }
+            _ => comment_can_start = false,
+        }
+
+        index += 1;
+    }
+
+    false
 }
 
 fn dangling_else_span(parse_diagnostics: &[ParseDiagnostic]) -> Option<Span> {
@@ -2029,6 +2096,28 @@ fi
         assert_eq!(
             apply_fixes(source, &diagnostics, Applicability::Safe).code,
             "#!/bin/bash\ntrue &&\necho x\n"
+        );
+    }
+
+    #[test]
+    fn skips_linebreak_before_and_fix_after_trailing_comment_for_s072() {
+        let source = "#!/bin/bash\ntrue # note\n&& echo x\n";
+        let recovered = Parser::new(source).parse();
+        let settings = LinterSettings::for_rule(Rule::LinebreakBeforeAnd);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            Some(&recovered),
+            &settings.rules,
+            ShellDialect::Bash,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::LinebreakBeforeAnd);
+        assert!(diagnostics[0].fix.is_none());
+        assert_eq!(
+            apply_fixes(source, &diagnostics, Applicability::Safe).code,
+            source
         );
     }
 

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -17,7 +17,8 @@ use crate::rules::portability::zsh_always_block::ZshAlwaysBlock;
 use crate::rules::portability::zsh_brace_if::ZshBraceIf;
 use crate::rules::style::linebreak_before_and::LinebreakBeforeAnd;
 use crate::{
-    Diagnostic, Edit, Fix, LinterSemanticArtifacts, Rule, RuleSet, ShellDialect, Violation,
+    Diagnostic, Edit, Fix, FixAvailability, LinterSemanticArtifacts, Rule, RuleSet, ShellDialect,
+    Violation,
 };
 
 pub struct ExtglobCase;
@@ -34,12 +35,18 @@ impl Violation for ExtglobCase {
 }
 
 impl Violation for ExtglobInCasePattern {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::ExtglobInCasePattern
     }
 
     fn message(&self) -> String {
         "extended glob alternation in a case pattern is not portable to POSIX sh".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("expand the case pattern alternatives".to_owned())
     }
 }
 
@@ -84,7 +91,9 @@ pub(crate) fn collect_parse_rule_diagnostics(
     if enabled_rules.contains(crate::Rule::LoopWithoutEnd)
         && missing_done_loop_kind == Some(MissingDoneLoopKind::NonFor)
     {
-        diagnostics.push(Diagnostic::new(LoopWithoutEnd, eof_point(file)));
+        diagnostics.push(
+            Diagnostic::new(LoopWithoutEnd, eof_point(file)).with_fix(missing_done_fix(source)),
+        );
     }
     if enabled_rules.contains(crate::Rule::MissingDoneInForLoop)
         && missing_done_loop_kind == Some(MissingDoneLoopKind::For)
@@ -107,11 +116,18 @@ pub(crate) fn collect_parse_rule_diagnostics(
     if enabled_rules.contains(crate::Rule::IfBracketGlued)
         && let Some(span) = if_bracket_glued_span(locator, parse_diagnostics)
     {
-        diagnostics.push(Diagnostic::new(IfBracketGlued, span));
+        diagnostics.push(
+            Diagnostic::new(IfBracketGlued, span)
+                .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset + 2, " "))),
+        );
     }
     if enabled_rules.contains(crate::Rule::LinebreakBeforeAnd) {
         for span in linebreak_before_and_spans(locator, parse_diagnostics) {
-            diagnostics.push(Diagnostic::new(LinebreakBeforeAnd, span));
+            let diagnostic = Diagnostic::new(LinebreakBeforeAnd, span);
+            diagnostics.push(match linebreak_before_and_fix(locator, span) {
+                Some(fix) => diagnostic.with_fix(fix),
+                None => diagnostic,
+            });
         }
     }
     if enabled_rules.contains(crate::Rule::FunctionParamsInSh)
@@ -171,12 +187,243 @@ pub(crate) fn collect_parse_rule_diagnostics(
             .unwrap_or(&[])
         {
             if part.pattern_part_index > 0 {
-                diagnostics.push(Diagnostic::new(ExtglobInCasePattern, part.span));
+                let diagnostic = Diagnostic::new(ExtglobInCasePattern, part.span);
+                diagnostics.push(match extglob_in_case_pattern_fix(source, part.span) {
+                    Some(fix) => diagnostic.with_fix(fix),
+                    None => diagnostic,
+                });
             }
         }
     }
 
     diagnostics
+}
+
+fn extglob_in_case_pattern_fix(source: &str, part_span: Span) -> Option<Fix> {
+    let group = part_span.slice(source);
+    group.strip_prefix('(')?.strip_suffix(')')?;
+    let (pattern_span, pattern_text) = simple_case_pattern_surface(source, part_span)?;
+    let alternatives = expand_case_pattern_surface_alternatives(pattern_text)?;
+    let replacement = alternatives.join("|");
+
+    Some(Fix::safe_edit(Edit::replacement(replacement, pattern_span)))
+}
+
+fn simple_case_pattern_surface(source: &str, part_span: Span) -> Option<(Span, &str)> {
+    let line_start = source[..part_span.start.offset]
+        .rfind('\n')
+        .map_or(0, |offset| offset + 1);
+    let pattern_start = simple_case_pattern_start(source, line_start, part_span.start.offset)?;
+    let prefix = &source[pattern_start..part_span.start.offset];
+    if prefix.is_empty() || prefix.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        return None;
+    }
+
+    let pattern_end = simple_case_pattern_end(source, part_span.end.offset)?;
+    let pattern_text = &source[pattern_start..pattern_end];
+    if pattern_text.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        return None;
+    }
+
+    let start = Position {
+        line: part_span.start.line,
+        column: part_span
+            .start
+            .column
+            .saturating_sub(part_span.start.offset - pattern_start),
+        offset: pattern_start,
+    };
+    let end = part_span
+        .end
+        .advanced_by(&source[part_span.end.offset..pattern_end]);
+
+    Some((Span::from_positions(start, end), pattern_text))
+}
+
+fn simple_case_pattern_start(source: &str, line_start: usize, group_start: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut index = group_start;
+    let mut depth = 0usize;
+    let mut escaped = false;
+
+    while index > line_start {
+        index -= 1;
+        let byte = bytes[index];
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if byte == b'\\' {
+            escaped = true;
+            continue;
+        }
+        match byte {
+            b')' => depth += 1,
+            b'(' => {
+                if depth > 0 {
+                    depth -= 1;
+                }
+            }
+            b'|' if depth == 0 => return Some(index + 1),
+            _ => {}
+        }
+    }
+
+    let leading_blanks = source[line_start..group_start]
+        .bytes()
+        .take_while(|byte| matches!(byte, b' ' | b'\t'))
+        .count();
+    Some(line_start + leading_blanks)
+}
+
+fn simple_case_pattern_end(source: &str, start: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut index = start;
+    let mut escaped = false;
+    let mut in_bracket = false;
+    let mut depth = 0usize;
+
+    while let Some(byte) = bytes.get(index).copied() {
+        if byte == b'\n' {
+            return None;
+        }
+        if escaped {
+            escaped = false;
+            index += 1;
+            continue;
+        }
+        if byte == b'\\' {
+            escaped = true;
+            index += 1;
+            continue;
+        }
+        if in_bracket {
+            in_bracket = byte != b']';
+            index += 1;
+            continue;
+        }
+        match byte {
+            b'[' => in_bracket = true,
+            b'(' => depth += 1,
+            b')' if depth > 0 => depth -= 1,
+            b'|' if depth == 0 => return Some(index),
+            b')' => return Some(index),
+            _ => {}
+        }
+        index += 1;
+    }
+
+    None
+}
+
+fn expand_case_pattern_surface_alternatives(text: &str) -> Option<Vec<String>> {
+    let mut expanded = vec![String::new()];
+    let mut index = 0usize;
+
+    while index < text.len() {
+        let rest = &text[index..];
+        if rest.starts_with('\\') {
+            let escaped = rest.chars().take(2).collect::<String>();
+            append_to_all(&mut expanded, &escaped);
+            index += escaped.len();
+            continue;
+        }
+        if rest.starts_with('(')
+            && let Some(close) = matching_group_close(text, index)
+            && let Some(group_alternatives) = split_case_group_alternatives(&text[index + 1..close])
+        {
+            let part_alternatives = group_alternatives
+                .iter()
+                .map(|alternative| expand_case_pattern_surface_alternatives(alternative))
+                .collect::<Option<Vec<_>>>()?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+            expanded = combine_alternatives(&expanded, &part_alternatives);
+            index = close + 1;
+            continue;
+        }
+
+        let ch = rest.chars().next()?;
+        append_to_all(&mut expanded, &rest[..ch.len_utf8()]);
+        index += ch.len_utf8();
+    }
+
+    Some(expanded)
+}
+
+fn append_to_all(alternatives: &mut [String], suffix: &str) {
+    for alternative in alternatives {
+        alternative.push_str(suffix);
+    }
+}
+
+fn combine_alternatives(prefixes: &[String], suffixes: &[String]) -> Vec<String> {
+    let mut combined = Vec::with_capacity(prefixes.len() * suffixes.len());
+    for prefix in prefixes {
+        for suffix in suffixes {
+            let mut alternative = String::with_capacity(prefix.len() + suffix.len());
+            alternative.push_str(prefix);
+            alternative.push_str(suffix);
+            combined.push(alternative);
+        }
+    }
+    combined
+}
+
+fn matching_group_close(text: &str, open: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut escaped = false;
+    for (relative, ch) in text[open..].char_indices() {
+        let index = open + relative;
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' => escaped = true,
+            '(' => depth += 1,
+            ')' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn split_case_group_alternatives(text: &str) -> Option<Vec<&str>> {
+    let mut alternatives = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0usize;
+    let mut escaped = false;
+
+    for (index, ch) in text.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' => escaped = true,
+            '(' => depth += 1,
+            ')' => depth = depth.checked_sub(1)?,
+            '|' if depth == 0 => {
+                alternatives.push(&text[start..index]);
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    alternatives.push(&text[start..]);
+
+    (alternatives.len() > 1
+        && alternatives
+            .iter()
+            .all(|alternative| !alternative.is_empty()))
+    .then_some(alternatives)
 }
 
 fn is_missing_fi_error(message: &str) -> bool {
@@ -492,6 +739,27 @@ fn leading_control_operator_span(locator: Locator<'_>, line_number: usize) -> Op
     let start = locator.position_at_offset(start_offset)?;
     let end = locator.position_at_offset(start_offset + operator.len())?;
     Some(Span::from_positions(start, end))
+}
+
+fn linebreak_before_and_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
+    let source = locator.source();
+    let line_start = line_start_offset(locator, span.start.line)?;
+    let insert_offset = line_start.checked_sub(1)?;
+    if source.as_bytes().get(insert_offset) != Some(&b'\n') {
+        return None;
+    }
+
+    let operator = span.slice(source);
+    let rest = source.get(span.end.offset..)?;
+    let trailing_ws_len = rest
+        .chars()
+        .take_while(|ch| matches!(ch, ' ' | '\t'))
+        .map(char::len_utf8)
+        .sum::<usize>();
+    Some(Fix::safe_edits([
+        Edit::insertion(insert_offset, format!(" {operator}")),
+        Edit::deletion_at(span.start.offset, span.end.offset + trailing_ws_len),
+    ]))
 }
 
 fn dangling_else_span(parse_diagnostics: &[ParseDiagnostic]) -> Option<Span> {
@@ -968,7 +1236,7 @@ mod tests {
     };
     use crate::{
         Applicability, Diagnostic, LinterSemanticArtifacts, LinterSettings, Locator, Rule, RuleSet,
-        ShellDialect,
+        ShellDialect, apply_fixes,
     };
 
     fn collect_parse_rule_diagnostics(
@@ -1132,6 +1400,14 @@ fi
         assert_eq!(diagnostics[0].rule, Rule::LoopWithoutEnd);
         assert_eq!(diagnostics[0].span.start.line, 4);
         assert_eq!(diagnostics[0].span.start.column, 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            apply_fixes(source, &diagnostics, Applicability::Unsafe).code,
+            "#!/bin/sh\nwhile true; do\n  :\ndone\n"
+        );
     }
 
     #[test]
@@ -1573,6 +1849,10 @@ fi
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::IfBracketGlued);
         assert_eq!(diagnostics[0].span.slice(source), "if[");
+        assert_eq!(
+            apply_fixes(source, &diagnostics, Applicability::Safe).code,
+            "#!/bin/sh\nif [ \"${1:-}\" = ok ]; then\n  :\nfi\n"
+        );
     }
 
     #[test]
@@ -1748,6 +2028,10 @@ fi
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::LinebreakBeforeAnd);
         assert_eq!(diagnostics[0].span.start.line, 3);
+        assert_eq!(
+            apply_fixes(source, &diagnostics, Applicability::Safe).code,
+            "#!/bin/bash\ntrue &&\necho x\n"
+        );
     }
 
     #[test]
@@ -2003,6 +2287,54 @@ fi
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::ExtglobInCasePattern);
         assert_eq!(diagnostics[0].span.slice(source), "(a|b)");
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Safe)
+        );
+        assert_eq!(
+            apply_fixes(source, &diagnostics, Applicability::Safe).code,
+            concat!(
+                "#!/bin/sh\n",
+                "case \"$x\" in\n",
+                "  foo_a_*|foo_b_*) echo match ;;\n",
+                "esac\n",
+            )
+        );
+    }
+
+    #[test]
+    fn expands_multiple_embedded_case_groups_with_one_fix() {
+        let source = concat!(
+            "#!/bin/sh\n",
+            "case \"$x\" in\n",
+            "  foo_(a|b)_(c|d)) echo match ;;\n",
+            "esac\n",
+        );
+        let recovered = Parser::new(source).parse();
+        let settings = LinterSettings::for_rule(Rule::ExtglobInCasePattern);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            Some(&recovered),
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert_eq!(diagnostics.len(), 2);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_some())
+        );
+        assert_eq!(
+            apply_fixes(source, &diagnostics, Applicability::Safe).code,
+            concat!(
+                "#!/bin/sh\n",
+                "case \"$x\" in\n",
+                "  foo_a_c|foo_a_d|foo_b_c|foo_b_d) echo match ;;\n",
+                "esac\n",
+            )
+        );
     }
 
     #[test]

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -260,9 +260,7 @@ fn simple_case_pattern_start(source: &str, line_start: usize, group_start: usize
         match byte {
             b')' => depth += 1,
             b'(' => {
-                if depth > 0 {
-                    depth -= 1;
-                }
+                depth = depth.saturating_sub(1);
             }
             b'|' if depth == 0 => return Some(index + 1),
             _ => {}

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -245,6 +245,7 @@ fn simple_case_pattern_start(source: &str, line_start: usize, group_start: usize
     let mut index = group_start;
     let mut depth = 0usize;
     let mut escaped = false;
+    let mut in_bracket = false;
 
     while index > line_start {
         index -= 1;
@@ -257,7 +258,12 @@ fn simple_case_pattern_start(source: &str, line_start: usize, group_start: usize
             escaped = true;
             continue;
         }
+        if in_bracket {
+            in_bracket = byte != b'[';
+            continue;
+        }
         match byte {
+            b']' => in_bracket = true,
             b')' => depth += 1,
             b'(' => {
                 depth = depth.saturating_sub(1);
@@ -2419,6 +2425,37 @@ fi
                 "#!/bin/sh\n",
                 "case \"$x\" in\n",
                 "  foo_a_c|foo_a_d|foo_b_c|foo_b_d) echo match ;;\n",
+                "esac\n",
+            )
+        );
+    }
+
+    #[test]
+    fn expands_embedded_case_group_after_bracket_class_pipe() {
+        let source = concat!(
+            "#!/bin/sh\n",
+            "case \"$x\" in\n",
+            "  foo_[a|b](c|d)) echo match ;;\n",
+            "esac\n",
+        );
+        let recovered = Parser::new(source).parse();
+        let settings = LinterSettings::for_rule(Rule::ExtglobInCasePattern);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            Some(&recovered),
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::ExtglobInCasePattern);
+        assert_eq!(
+            apply_fixes(source, &diagnostics, Applicability::Safe).code,
+            concat!(
+                "#!/bin/sh\n",
+                "case \"$x\" in\n",
+                "  foo_[a|b]c|foo_[a|b]d) echo match ;;\n",
                 "esac\n",
             )
         );

--- a/crates/shuck-linter/src/parse_diagnostics.rs
+++ b/crates/shuck-linter/src/parse_diagnostics.rs
@@ -378,14 +378,20 @@ fn combine_alternatives(prefixes: &[String], suffixes: &[String]) -> Vec<String>
 fn matching_group_close(text: &str, open: usize) -> Option<usize> {
     let mut depth = 0usize;
     let mut escaped = false;
+    let mut in_bracket = false;
     for (relative, ch) in text[open..].char_indices() {
         let index = open + relative;
         if escaped {
             escaped = false;
             continue;
         }
+        if in_bracket {
+            in_bracket = ch != ']';
+            continue;
+        }
         match ch {
             '\\' => escaped = true,
+            '[' => in_bracket = true,
             '(' => depth += 1,
             ')' => {
                 depth = depth.checked_sub(1)?;
@@ -404,14 +410,20 @@ fn split_case_group_alternatives(text: &str) -> Option<Vec<&str>> {
     let mut start = 0usize;
     let mut depth = 0usize;
     let mut escaped = false;
+    let mut in_bracket = false;
 
     for (index, ch) in text.char_indices() {
         if escaped {
             escaped = false;
             continue;
         }
+        if in_bracket {
+            in_bracket = ch != ']';
+            continue;
+        }
         match ch {
             '\\' => escaped = true,
+            '[' => in_bracket = true,
             '(' => depth += 1,
             ')' => depth = depth.checked_sub(1)?,
             '|' if depth == 0 => {
@@ -2456,6 +2468,37 @@ fi
                 "#!/bin/sh\n",
                 "case \"$x\" in\n",
                 "  foo_[a|b]c|foo_[a|b]d) echo match ;;\n",
+                "esac\n",
+            )
+        );
+    }
+
+    #[test]
+    fn expands_case_group_alternatives_around_bracket_class_pipe() {
+        let source = concat!(
+            "#!/bin/sh\n",
+            "case \"$x\" in\n",
+            "  foo_([a|b]|c)) echo match ;;\n",
+            "esac\n",
+        );
+        let recovered = Parser::new(source).parse();
+        let settings = LinterSettings::for_rule(Rule::ExtglobInCasePattern);
+        let diagnostics = collect_parse_rule_diagnostics(
+            &recovered.file,
+            source,
+            Some(&recovered),
+            &settings.rules,
+            ShellDialect::Sh,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::ExtglobInCasePattern);
+        assert_eq!(
+            apply_fixes(source, &diagnostics, Applicability::Safe).code,
+            concat!(
+                "#!/bin/sh\n",
+                "case \"$x\" in\n",
+                "  foo_[a|b]|foo_c) echo match ;;\n",
                 "esac\n",
             )
         );

--- a/crates/shuck-linter/src/rules/correctness/heredoc_missing_end.rs
+++ b/crates/shuck-linter/src/rules/correctness/heredoc_missing_end.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct HeredocMissingEnd;
 
 impl Violation for HeredocMissingEnd {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::HeredocMissingEnd
     }
@@ -10,19 +14,66 @@ impl Violation for HeredocMissingEnd {
     fn message(&self) -> String {
         "this here-document is missing its closing marker".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("append the missing heredoc closing marker".to_owned())
+    }
 }
 
 pub fn heredoc_missing_end(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.heredoc_missing_end_spans(),
-        || HeredocMissingEnd,
-    );
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .heredoc_missing_end_spans()
+        .iter()
+        .copied()
+        .map(|span| {
+            let diagnostic = Diagnostic::new(HeredocMissingEnd, span);
+            match heredoc_closer_fix(span, source) {
+                Some(fix) => diagnostic.with_fix(fix),
+                None => diagnostic,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn heredoc_closer_fix(span: Span, source: &str) -> Option<Fix> {
+    let marker = heredoc_marker_from_redirect_span(span, source)?;
+    if marker.is_empty() {
+        return None;
+    }
+    let prefix = if source.is_empty() || source.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    Some(Fix::safe_edit(Edit::insertion(
+        source.len(),
+        format!("{prefix}{marker}\n"),
+    )))
+}
+
+fn heredoc_marker_from_redirect_span(span: Span, source: &str) -> Option<String> {
+    let text = span.slice(source).trim();
+    let marker = text
+        .strip_prefix("<<-")
+        .or_else(|| text.strip_prefix("<<"))?
+        .trim();
+    Some(
+        marker
+            .trim_matches(|ch| matches!(ch, '\'' | '"' | '\\'))
+            .to_owned(),
+    )
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_heredoc_without_a_closing_marker() {
@@ -36,6 +87,20 @@ line
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
         assert_eq!(diagnostics[0].span.slice(source), "<<MARK");
+    }
+
+    #[test]
+    fn applies_safe_fix_by_appending_missing_heredoc_marker() {
+        let source = "#!/bin/sh\ncat <<MARK\nline\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::HeredocMissingEnd),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\ncat <<MARK\nline\nMARK\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/if_bracket_glued.rs
+++ b/crates/shuck-linter/src/rules/correctness/if_bracket_glued.rs
@@ -1,13 +1,19 @@
-use crate::{Rule, Violation};
+use crate::{FixAvailability, Rule, Violation};
 
 pub struct IfBracketGlued;
 
 impl Violation for IfBracketGlued {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::IfBracketGlued
     }
 
     fn message(&self) -> String {
         "this `if` keyword is glued to a `[` test".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("insert a space after `if`".to_owned())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
@@ -40,20 +40,38 @@ pub fn if_dollar_command(checker: &mut Checker) {
 fn if_dollar_command_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
     let text = span.slice(source);
     let body = text.strip_prefix("$(")?.strip_suffix(')')?;
+    let close_cleanup = command_substitution_close_cleanup(span, source);
     Some((
         span,
         Fix::unsafe_edit(Edit::replacement_at(
             span.start.offset,
-            command_substitution_replacement_end(span, source),
-            body,
+            close_cleanup.end,
+            close_cleanup.replacement_body(body),
         )),
     ))
 }
 
-fn command_substitution_replacement_end(span: Span, source: &str) -> usize {
+struct CloseCleanup<'a> {
+    end: usize,
+    list_operator: Option<&'a str>,
+}
+
+impl CloseCleanup<'_> {
+    fn replacement_body(&self, body: &str) -> String {
+        match self.list_operator {
+            Some(operator) => body_with_trailing_list_operator(body, operator),
+            None => body.to_owned(),
+        }
+    }
+}
+
+fn command_substitution_close_cleanup<'a>(span: Span, source: &'a str) -> CloseCleanup<'a> {
     let close_start = span.end.offset.saturating_sub(1);
     if !offset_is_indented_line_start(source, close_start) {
-        return span.end.offset;
+        return CloseCleanup {
+            end: span.end.offset,
+            list_operator: None,
+        };
     }
 
     let mut end = span.end.offset;
@@ -64,11 +82,14 @@ fn command_substitution_replacement_end(span: Span, source: &str) -> usize {
     {
         end += 1;
     }
-    if source.as_bytes().get(end) != Some(&b';') {
-        return span.end.offset;
-    }
+    let Some((operator, operator_len)) = close_cleanup_operator(source, end) else {
+        return CloseCleanup {
+            end: span.end.offset,
+            list_operator: None,
+        };
+    };
 
-    end += 1;
+    end += operator_len;
     while source
         .as_bytes()
         .get(end)
@@ -76,7 +97,33 @@ fn command_substitution_replacement_end(span: Span, source: &str) -> usize {
     {
         end += 1;
     }
-    end
+
+    CloseCleanup {
+        end,
+        list_operator: (operator != ";").then_some(operator),
+    }
+}
+
+fn close_cleanup_operator(source: &str, offset: usize) -> Option<(&str, usize)> {
+    let rest = source.get(offset..)?;
+    if rest.starts_with(';') {
+        Some((";", 1))
+    } else if rest.starts_with("&&") {
+        Some(("&&", 2))
+    } else if rest.starts_with("||") {
+        Some(("||", 2))
+    } else {
+        None
+    }
+}
+
+fn body_with_trailing_list_operator(body: &str, operator: &str) -> String {
+    let trimmed = body.trim_end_matches([' ', '\t']);
+    if let Some(without_newline) = trimmed.strip_suffix('\n') {
+        format!("{without_newline} {operator} ")
+    } else {
+        format!("{trimmed} {operator} ")
+    }
 }
 
 fn offset_is_indented_line_start(source: &str, offset: usize) -> bool {
@@ -199,6 +246,38 @@ fi
                 "#!/bin/bash\n",
                 "if \n",
                 "  false\n",
+                "then\n",
+                "  :\n",
+                "fi\n",
+            )
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_multiline_command_substitution_condition_with_list_operator() {
+        let source = "\
+#!/bin/bash
+if $(
+  false
+)&& echo x
+then
+  :
+fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::IfDollarCommand),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            concat!(
+                "#!/bin/bash\n",
+                "if \n",
+                "  false && echo x\n",
                 "then\n",
                 "  :\n",
                 "fi\n",

--- a/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
@@ -40,7 +40,50 @@ pub fn if_dollar_command(checker: &mut Checker) {
 fn if_dollar_command_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
     let text = span.slice(source);
     let body = text.strip_prefix("$(")?.strip_suffix(')')?;
-    Some((span, Fix::unsafe_edit(Edit::replacement(body, span))))
+    Some((
+        span,
+        Fix::unsafe_edit(Edit::replacement_at(
+            span.start.offset,
+            command_substitution_replacement_end(span, source),
+            body,
+        )),
+    ))
+}
+
+fn command_substitution_replacement_end(span: Span, source: &str) -> usize {
+    let close_start = span.end.offset.saturating_sub(1);
+    if !offset_is_indented_line_start(source, close_start) {
+        return span.end.offset;
+    }
+
+    let mut end = span.end.offset;
+    while source
+        .as_bytes()
+        .get(end)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        end += 1;
+    }
+    if source.as_bytes().get(end) != Some(&b';') {
+        return span.end.offset;
+    }
+
+    end += 1;
+    while source
+        .as_bytes()
+        .get(end)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        end += 1;
+    }
+    end
+}
+
+fn offset_is_indented_line_start(source: &str, offset: usize) -> bool {
+    let line_start = source[..offset].rfind('\n').map_or(0, |offset| offset + 1);
+    source[line_start..offset]
+        .bytes()
+        .all(|byte| matches!(byte, b' ' | b'\t'))
 }
 
 #[cfg(test)]
@@ -129,6 +172,37 @@ if `printf '%s' ok`; then :; fi
         assert_eq!(
             result.fixed_source,
             "#!/bin/bash\nif false; then echo ok; fi\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_multiline_command_substitution_condition() {
+        let source = "\
+#!/bin/bash
+if $(
+  false
+); then
+  :
+fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::IfDollarCommand),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            concat!(
+                "#!/bin/bash\n",
+                "if \n",
+                "  false\n",
+                "then\n",
+                "  :\n",
+                "fi\n",
+            )
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
+++ b/crates/shuck-linter/src/rules/correctness/if_dollar_command.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct IfDollarCommand;
 
 impl Violation for IfDollarCommand {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::IfDollarCommand
     }
@@ -11,19 +15,38 @@ impl Violation for IfDollarCommand {
         "use the command's exit status directly instead of executing the output from `$(...)`"
             .to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the command substitution wrapper".to_owned())
+    }
 }
 
 pub fn if_dollar_command(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.command_substitution_command_spans(),
-        || IfDollarCommand,
-    );
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .command_substitution_command_spans()
+        .iter()
+        .copied()
+        .filter_map(|span| if_dollar_command_fix(span, source))
+        .map(|(span, fix)| Diagnostic::new(IfDollarCommand, span).with_fix(fix))
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn if_dollar_command_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let text = span.slice(source);
+    let body = text.strip_prefix("$(")?.strip_suffix(')')?;
+    Some((span, Fix::unsafe_edit(Edit::replacement(body, span))))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_command_substitution_condition_commands() {
@@ -91,5 +114,22 @@ if `printf '%s' ok`; then :; fi
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::IfDollarCommand));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_unwrapping_command_substitution_condition() {
+        let source = "#!/bin/bash\nif $(false); then echo ok; fi\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::IfDollarCommand),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\nif false; then echo ok; fi\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/loop_without_end.rs
+++ b/crates/shuck-linter/src/rules/correctness/loop_without_end.rs
@@ -1,13 +1,19 @@
-use crate::{Rule, Violation};
+use crate::{FixAvailability, Rule, Violation};
 
 pub struct LoopWithoutEnd;
 
 impl Violation for LoopWithoutEnd {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LoopWithoutEnd
     }
 
     fn message(&self) -> String {
         "this loop is missing a closing `done`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("append a closing `done`".to_owned())
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
+++ b/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct MisquotedHeredocClose;
 
 impl Violation for MisquotedHeredocClose {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::MisquotedHeredocClose
     }
@@ -10,19 +14,60 @@ impl Violation for MisquotedHeredocClose {
     fn message(&self) -> String {
         "this here-document closing marker is only a near match".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("append the unquoted heredoc closing marker".to_owned())
+    }
 }
 
 pub fn misquoted_heredoc_close(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.misquoted_heredoc_close_spans(),
-        || MisquotedHeredocClose,
-    );
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .misquoted_heredoc_close_spans()
+        .iter()
+        .copied()
+        .filter_map(|span| {
+            let fix = heredoc_closer_fix(span, source)?;
+            Some(Diagnostic::new(MisquotedHeredocClose, span).with_fix(fix))
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn heredoc_closer_fix(span: Span, source: &str) -> Option<Fix> {
+    let marker = heredoc_marker_from_redirect_span(span, source)?;
+    let prefix = if source.is_empty() || source.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    Some(Fix::safe_edit(Edit::insertion(
+        source.len(),
+        format!("{prefix}{marker}\n"),
+    )))
+}
+
+fn heredoc_marker_from_redirect_span(span: Span, source: &str) -> Option<String> {
+    let text = span.slice(source).trim();
+    let marker = text
+        .strip_prefix("<<-")
+        .or_else(|| text.strip_prefix("<<"))?
+        .trim();
+    Some(
+        marker
+            .trim_matches(|ch| matches!(ch, '\'' | '"' | '\\'))
+            .to_owned(),
+    )
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_quoted_close_match_for_quoted_delimiter() {
@@ -39,6 +84,23 @@ x
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn applies_safe_fix_by_appending_unquoted_heredoc_marker() {
+        let source = "#!/bin/bash\ncat <<'BLOCK'\nx\n'BLOCK'\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MisquotedHeredocClose),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\ncat <<'BLOCK'\nx\n'BLOCK'\nBLOCK\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
+++ b/crates/shuck-linter/src/rules/correctness/misquoted_heredoc_close.rs
@@ -27,9 +27,12 @@ pub fn misquoted_heredoc_close(checker: &mut Checker) {
         .misquoted_heredoc_close_spans()
         .iter()
         .copied()
-        .filter_map(|span| {
-            let fix = heredoc_closer_fix(span, source)?;
-            Some(Diagnostic::new(MisquotedHeredocClose, span).with_fix(fix))
+        .map(|span| {
+            let diagnostic = Diagnostic::new(MisquotedHeredocClose, span);
+            match heredoc_closer_fix(span, source) {
+                Some(fix) => diagnostic.with_fix(fix),
+                None => diagnostic,
+            }
         })
         .collect::<Vec<_>>();
 
@@ -53,6 +56,7 @@ fn heredoc_closer_fix(span: Span, source: &str) -> Option<Fix> {
 
 fn heredoc_marker_from_redirect_span(span: Span, source: &str) -> Option<String> {
     let text = span.slice(source).trim();
+    let text = text.trim_start_matches(|ch: char| ch.is_ascii_digit());
     let marker = text
         .strip_prefix("<<-")
         .or_else(|| text.strip_prefix("<<"))?
@@ -99,6 +103,23 @@ x
         assert_eq!(
             result.fixed_source,
             "#!/bin/bash\ncat <<'BLOCK'\nx\n'BLOCK'\nBLOCK\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_fd_prefixed_heredoc_redirects() {
+        let source = "#!/bin/bash\ncat 3<<'BLOCK'\nx\n'BLOCK'\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MisquotedHeredocClose),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\ncat 3<<'BLOCK'\nx\n'BLOCK'\nBLOCK\n"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
@@ -1,10 +1,12 @@
-use shuck_ast::{DeclOperand, static_word_text};
+use shuck_ast::{DeclOperand, Span, static_word_text};
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SpacedAssignment;
 
 impl Violation for SpacedAssignment {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SpacedAssignment
     }
@@ -12,39 +14,63 @@ impl Violation for SpacedAssignment {
     fn message(&self) -> String {
         "remove spaces around `=` in this assignment".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove spaces around the assignment operator".to_owned())
+    }
 }
 
 pub fn spaced_assignment(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .structural_commands()
         .filter_map(|fact| fact.declaration())
-        .flat_map(|declaration| {
-            declaration
-                .operands
-                .windows(2)
-                .filter_map(|pair| spaced_assignment_span(pair, source))
-        })
+        .flat_map(|declaration| spaced_assignment_diagnostics(&declaration.operands, source))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || SpacedAssignment);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
-fn spaced_assignment_span(pair: &[DeclOperand], source: &str) -> Option<shuck_ast::Span> {
-    let [DeclOperand::Name(_), DeclOperand::Dynamic(word)] = pair else {
-        return None;
-    };
+fn spaced_assignment_diagnostics(operands: &[DeclOperand], source: &str) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    for (index, pair) in operands.windows(2).enumerate() {
+        let [DeclOperand::Name(name), DeclOperand::Dynamic(word)] = pair else {
+            continue;
+        };
+        if !static_word_text(word, source).is_some_and(|text| text.starts_with('=')) {
+            continue;
+        }
 
-    static_word_text(word, source)?
-        .starts_with('=')
-        .then_some(word.span)
+        let mut edits = vec![Edit::deletion_at(
+            name.span.end.offset,
+            word.span.start.offset,
+        )];
+        if word.span.slice(source) == "="
+            && let Some(next) = operands.get(index + 2).and_then(decl_operand_span)
+        {
+            edits.push(Edit::deletion_at(word.span.end.offset, next.start.offset));
+        }
+        diagnostics
+            .push(Diagnostic::new(SpacedAssignment, word.span).with_fix(Fix::unsafe_edits(edits)));
+    }
+    diagnostics
+}
+
+fn decl_operand_span(operand: &DeclOperand) -> Option<Span> {
+    match operand {
+        DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => Some(word.span),
+        DeclOperand::Name(name) => Some(name.span),
+        DeclOperand::Assignment(assignment) => Some(assignment.span),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn anchors_on_the_stray_equals_word() {
@@ -75,5 +101,22 @@ foo= bar
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpacedAssignment));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_removing_declaration_assignment_spaces() {
+        let source = "#!/bin/sh\nexport foo =bar\nreadonly bar = baz\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SpacedAssignment),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nexport foo=bar\nreadonly bar=baz\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/spaced_assignment.rs
@@ -26,7 +26,7 @@ pub fn spaced_assignment(checker: &mut Checker) {
         .facts()
         .structural_commands()
         .filter_map(|fact| fact.declaration())
-        .flat_map(|declaration| spaced_assignment_diagnostics(&declaration.operands, source))
+        .flat_map(|declaration| spaced_assignment_diagnostics(declaration.operands, source))
         .collect::<Vec<_>>();
 
     for diagnostic in diagnostics {

--- a/crates/shuck-linter/src/rules/correctness/subst_with_redirect.rs
+++ b/crates/shuck-linter/src/rules/correctness/subst_with_redirect.rs
@@ -1,9 +1,11 @@
-use crate::{Checker, CommandSubstitutionKind, FixAvailability, Rule, Violation};
+use crate::{
+    Checker, CommandSubstitutionKind, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation,
+};
 
 pub struct SubstWithRedirect;
 
 impl Violation for SubstWithRedirect {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::None;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     fn rule() -> Rule {
         Rule::SubstWithRedirect
@@ -14,7 +16,7 @@ impl Violation for SubstWithRedirect {
     }
 
     fn fix_title(&self) -> Option<String> {
-        None
+        Some("delete the stdout redirect from the substitution".to_owned())
     }
 }
 
@@ -36,7 +38,10 @@ pub fn subst_with_redirect(checker: &mut Checker) {
         .collect::<Vec<_>>();
 
     for span in redirect_spans {
-        checker.report_diagnostic_dedup(crate::Diagnostic::new(SubstWithRedirect, span));
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(SubstWithRedirect, span)
+                .with_fix(Fix::unsafe_edit(Edit::deletion(span))),
+        );
     }
 }
 
@@ -44,8 +49,8 @@ pub fn subst_with_redirect(checker: &mut Checker) {
 mod tests {
     use std::path::Path;
 
-    use crate::test::{test_path, test_snippet};
-    use crate::{LinterSettings, Rule, assert_diagnostics};
+    use crate::test::{test_path, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, assert_diagnostics};
 
     #[test]
     fn reports_first_redirect_for_rerouted_substitutions() {
@@ -123,5 +128,19 @@ out=$(printf hi >&\"2\")
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "> out.txt");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_deleting_substitution_stdout_redirect() {
+        let source = "#!/bin/sh\nout=$(printf hi > out.txt)\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SubstWithRedirect),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\nout=$(printf hi )\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
@@ -1,9 +1,16 @@
 use crate::facts::word_spans;
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFactHostKind};
+use shuck_ast::Span;
+
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation,
+    WordFactHostKind,
+};
 
 pub struct SuspiciousBracketGlob;
 
 impl Violation for SuspiciousBracketGlob {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SuspiciousBracketGlob
     }
@@ -11,11 +18,15 @@ impl Violation for SuspiciousBracketGlob {
     fn message(&self) -> String {
         "bracket globs only match one character at a time; quote word-like ones".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the bracket-glob text".to_owned())
+    }
 }
 
 pub fn suspicious_bracket_glob(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -49,9 +60,19 @@ pub fn suspicious_bracket_glob(checker: &mut Checker) {
                 .filter(|fact| supports_suspicious_bracket_glob_context(fact.expansion_context()))
                 .flat_map(|fact| fact.suspicious_bracket_glob_spans(source)),
         )
+        .map(|span| {
+            Diagnostic::new(SuspiciousBracketGlob, span)
+                .with_fix(Fix::unsafe_edit(single_quote_span_edit(span, source)))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || SuspiciousBracketGlob);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn single_quote_span_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("'{}'", span.slice(source)), span)
 }
 
 fn supports_suspicious_bracket_glob_context(context: Option<ExpansionContext>) -> bool {
@@ -77,8 +98,8 @@ fn bare_bracket_test_name(text: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_suspicious_bracket_globs_across_shell_contexts() {
@@ -119,6 +140,20 @@ case $x in [appname]) : ;; esac
                 "[appname]"
             ]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_single_quoting_bracket_glob_text() {
+        let source = "#!/bin/bash\necho [appname]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SuspiciousBracketGlob),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/bash\necho '[appname]'\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
+++ b/crates/shuck-linter/src/rules/correctness/suspicious_bracket_glob.rs
@@ -72,7 +72,36 @@ pub fn suspicious_bracket_glob(checker: &mut Checker) {
 }
 
 fn single_quote_span_edit(span: Span, source: &str) -> Edit {
-    Edit::replacement(format!("'{}'", span.slice(source)), span)
+    Edit::replacement(shell_single_quoted_literal(span.slice(source)), span)
+}
+
+fn shell_single_quoted_literal(text: &str) -> String {
+    let content = unescape_single_quote_shell_escapes(text);
+    let mut quoted = String::with_capacity(content.len() + 2);
+    quoted.push('\'');
+    for ch in content.chars() {
+        if ch == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(ch);
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
+fn unescape_single_quote_shell_escapes(text: &str) -> String {
+    let mut unescaped = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' && chars.peek() == Some(&'\'') {
+            unescaped.push('\'');
+            chars.next();
+        } else {
+            unescaped.push(ch);
+        }
+    }
+    unescaped
 }
 
 fn supports_suspicious_bracket_glob_context(context: Option<ExpansionContext>) -> bool {
@@ -153,6 +182,20 @@ case $x in [appname]) : ;; esac
 
         assert_eq!(result.fixes_applied, 1);
         assert_eq!(result.fixed_source, "#!/bin/bash\necho '[appname]'\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_with_escaped_apostrophe_in_bracket_glob_text() {
+        let source = "#!/bin/bash\necho [a\\'a]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SuspiciousBracketGlob),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/bash\necho '[a'\\''a]'\n");
         assert!(result.fixed_diagnostics.is_empty());
     }
 

--- a/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
+++ b/crates/shuck-linter/src/rules/correctness/unreachable_after_exit.rs
@@ -1,4 +1,7 @@
-use crate::{Checker, CommandFact, CommandFacts, ListFact, Rule, Violation, WrapperKind};
+use crate::{
+    Checker, CommandFact, CommandFacts, Diagnostic, Edit, Fix, FixAvailability, ListFact, Rule,
+    Violation, WrapperKind,
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Command as AstCommand, Name, Span};
 use shuck_semantic::{
@@ -8,12 +11,18 @@ use shuck_semantic::{
 pub struct UnreachableAfterExit;
 
 impl Violation for UnreachableAfterExit {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnreachableAfterExit
     }
 
     fn message(&self) -> String {
         "code is unreachable".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete the unreachable code".to_owned())
     }
 }
 
@@ -44,7 +53,10 @@ pub fn unreachable_after_exit(checker: &mut Checker) {
         .into_iter()
         .map(|span| trim_trailing_terminator(span, source))
     {
-        checker.report(UnreachableAfterExit, span);
+        checker.report_diagnostic(
+            Diagnostic::new(UnreachableAfterExit, span)
+                .with_fix(Fix::safe_edit(Edit::deletion(span))),
+        );
     }
 }
 
@@ -384,4 +396,24 @@ fn trim_trailing_terminator(span: Span, source: &str) -> Span {
         .trim_end_matches(';')
         .trim_end_matches(char::is_whitespace);
     Span::from_positions(span.start, span.start.advanced_by(trimmed))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet_with_fix;
+    use crate::{Applicability, LinterSettings, Rule};
+
+    #[test]
+    fn applies_safe_fix_by_deleting_unreachable_command() {
+        let source = "#!/bin/sh\nexit 0\necho unreachable\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnreachableAfterExit),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert!(result.fixed_diagnostics.is_empty());
+        assert!(!result.fixed_source.contains("echo unreachable"));
+    }
 }

--- a/crates/shuck-linter/src/rules/correctness/unused_heredoc.rs
+++ b/crates/shuck-linter/src/rules/correctness/unused_heredoc.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Locator, Rule, Violation};
 
 pub struct UnusedHeredoc;
 
 impl Violation for UnusedHeredoc {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::UnusedHeredoc
     }
@@ -10,16 +14,127 @@ impl Violation for UnusedHeredoc {
     fn message(&self) -> String {
         "this here-document has no command to consume it".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the unused here-document".to_owned())
+    }
 }
 
 pub fn unused_heredoc(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(|facts| facts.unused_heredoc_spans(), || UnusedHeredoc);
+    let locator = checker.locator();
+    let spans = checker.facts().unused_heredoc_spans().to_vec();
+    for span in spans {
+        let mut diagnostic = Diagnostic::new(UnusedHeredoc, span);
+        if let Some(fix) = unused_heredoc_fix(locator, span) {
+            diagnostic = diagnostic.with_fix(fix);
+        }
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn unused_heredoc_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
+    let source = locator.source();
+    let marker = heredoc_marker_from_redirect_span(span, source)?;
+    if marker.name.is_empty() {
+        return None;
+    }
+
+    let line_range = locator.line_range(span.start.line)?;
+    let line_start = usize::from(line_range.start());
+    let raw_line_end = usize::from(line_range.end());
+    let line_end = trim_cr_end(source, raw_line_end);
+    let header_delete_start = preceding_space_start(source, span.start.offset, line_start);
+    let body_start = locator
+        .line_index()
+        .line_start(span.start.line + 1)
+        .map(usize::from)
+        .unwrap_or(source.len());
+    let body_end = heredoc_body_end(locator, span.start.line + 1, &marker)?;
+
+    let prefix_is_blank = source
+        .get(line_start..header_delete_start)
+        .is_some_and(|prefix| prefix.trim().is_empty());
+    let suffix_is_blank = source
+        .get(span.end.offset..line_end)
+        .is_some_and(|suffix| suffix.trim().is_empty());
+    if prefix_is_blank && suffix_is_blank {
+        return Some(Fix::unsafe_edit(Edit::deletion_at(line_start, body_end)));
+    }
+
+    Some(Fix::unsafe_edits([
+        Edit::deletion_at(header_delete_start, span.end.offset),
+        Edit::deletion_at(body_start, body_end),
+    ]))
+}
+
+struct HeredocMarker {
+    name: String,
+    strip_tabs: bool,
+}
+
+fn heredoc_marker_from_redirect_span(span: Span, source: &str) -> Option<HeredocMarker> {
+    let text = span.slice(source).trim();
+    let operator_start = text.find("<<")?;
+    let mut marker = &text[operator_start + 2..];
+    let strip_tabs = marker.starts_with('-');
+    if strip_tabs {
+        marker = &marker[1..];
+    }
+    let name = marker
+        .trim()
+        .trim_matches(|ch| matches!(ch, '\'' | '"' | '\\'))
+        .to_owned();
+    Some(HeredocMarker { name, strip_tabs })
+}
+
+fn heredoc_body_end(
+    locator: Locator<'_>,
+    mut line_number: usize,
+    marker: &HeredocMarker,
+) -> Option<usize> {
+    let source = locator.source();
+    loop {
+        let line_range = locator.line_range(line_number)?;
+        let line_start = usize::from(line_range.start());
+        let line_end = trim_cr_end(source, usize::from(line_range.end()));
+        let line = source.get(line_start..line_end)?;
+        let candidate = if marker.strip_tabs {
+            line.trim_start_matches('\t')
+        } else {
+            line
+        };
+        if candidate == marker.name {
+            return Some(
+                locator
+                    .line_index()
+                    .line_start(line_number + 1)
+                    .map(usize::from)
+                    .unwrap_or(source.len()),
+            );
+        }
+        line_number += 1;
+    }
+}
+
+fn preceding_space_start(source: &str, mut offset: usize, floor: usize) -> usize {
+    while offset > floor && matches!(source.as_bytes().get(offset - 1), Some(b' ' | b'\t')) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn trim_cr_end(source: &str, offset: usize) -> usize {
+    if offset > 0 && matches!(source.as_bytes().get(offset - 1), Some(b'\r')) {
+        offset - 1
+    } else {
+        offset
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_heredocs_without_a_consuming_command() {
@@ -74,5 +189,28 @@ EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnusedHeredoc));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_delete_unused_heredoc_redirect_and_body() {
+        let source = "\
+#!/bin/sh
+<<EOF
+alpha
+EOF
+
+x=1 <<EOF
+beta
+EOF
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnusedHeredoc),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(result.fixed_source, "#!/bin/sh\n\nx=1\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -88,7 +88,7 @@ fn grep_count_pipeline_fix(
 ) -> Option<Fix> {
     let grep_name = grep.body_name_word()?;
     let wc_span = wc.span_in_source(source);
-    let delete_start = preceding_space_start(source, operator_span.start.offset);
+    let delete_start = pipeline_delete_start(source, operator_span.start.offset);
     Some(Fix::unsafe_edits([
         Edit::insertion(grep_name.span.end.offset, " -c"),
         Edit::deletion_at(delete_start, wc_span.end.offset),
@@ -125,6 +125,24 @@ fn wc_uses_line_count(fact: CommandFactRef<'_, '_>, source: &str) -> bool {
             text == "-l" || text == "--lines" || (text.starts_with('-') && text[1..].contains('l'))
         })
     })
+}
+
+fn pipeline_delete_start(source: &str, operator_start: usize) -> usize {
+    let offset = preceding_space_start(source, operator_start);
+    line_continuation_delete_start(source, offset).unwrap_or(offset)
+}
+
+fn line_continuation_delete_start(source: &str, offset: usize) -> Option<usize> {
+    if offset == 0 || source.as_bytes().get(offset - 1) != Some(&b'\n') {
+        return None;
+    }
+
+    let backslash = offset.checked_sub(2)?;
+    if source.as_bytes().get(backslash) != Some(&b'\\') {
+        return None;
+    }
+
+    Some(preceding_space_start(source, backslash))
 }
 
 fn preceding_space_start(source: &str, mut offset: usize) -> usize {
@@ -182,6 +200,30 @@ grep foo file | grep bar | wc -l
 grep -c foo file
 grep -c foo file 2>/dev/null
 grep foo file | grep -c bar
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_multiline_continued_grep_wc_pipeline() {
+        let source = "\
+#!/bin/sh
+grep foo file \\
+  | wc -l
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GrepCountPipeline),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+grep -c foo file
 "
         );
         assert!(result.fixed_diagnostics.is_empty());

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -7,7 +7,7 @@ use crate::{
 pub struct GrepCountPipeline;
 
 impl Violation for GrepCountPipeline {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
 
     fn rule() -> Rule {
         Rule::GrepCountPipeline

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -31,15 +31,17 @@ pub fn grep_count_pipeline(checker: &mut Checker) {
         .collect::<Vec<_>>();
 
     for report in reports {
-        checker.report_diagnostic_dedup(
-            Diagnostic::new(GrepCountPipeline, report.diagnostic_span).with_fix(report.fix),
-        );
+        let diagnostic = Diagnostic::new(GrepCountPipeline, report.diagnostic_span);
+        checker.report_diagnostic_dedup(match report.fix {
+            Some(fix) => diagnostic.with_fix(fix),
+            None => diagnostic,
+        });
     }
 }
 
 struct GrepCountPipelineReport {
     diagnostic_span: Span,
-    fix: Fix,
+    fix: Option<Fix>,
 }
 
 fn unsafe_grep_count_pipeline_reports(
@@ -68,13 +70,17 @@ fn unsafe_grep_count_pipeline_reports(
                 return None;
             }
 
-            if !wc_uses_only_line_count(right, checker.source()) {
+            if !wc_uses_line_count(right, checker.source()) {
                 return None;
             }
 
             Some(GrepCountPipelineReport {
                 diagnostic_span: command_body_span(left)?,
-                fix: grep_count_pipeline_fix(checker.source(), left, right, operator.span())?,
+                fix: wc_uses_only_line_count(right, checker.source())
+                    .then(|| {
+                        grep_count_pipeline_fix(checker.source(), left, right, operator.span())
+                    })
+                    .flatten(),
             })
         })
         .collect()
@@ -117,6 +123,14 @@ fn command_body_span(fact: CommandFactRef<'_, '_>) -> Option<Span> {
 
 fn is_raw_utility_named(fact: CommandFactRef<'_, '_>, name: &str) -> bool {
     fact.literal_name() == Some(name) && fact.wrappers().is_empty()
+}
+
+fn wc_uses_line_count(fact: CommandFactRef<'_, '_>, source: &str) -> bool {
+    fact.body_args().iter().any(|word| {
+        static_word_text(word, source).is_some_and(|text| {
+            text == "-l" || text == "--lines" || (text.starts_with('-') && text[1..].contains('l'))
+        })
+    })
 }
 
 fn wc_uses_only_line_count(fact: CommandFactRef<'_, '_>, source: &str) -> bool {
@@ -242,8 +256,15 @@ grep foo file | wc -cl
 grep foo file | wc -l other.txt
 grep foo file | wc -l > count
 ";
-        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GrepCountPipeline));
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GrepCountPipeline),
+            Applicability::Unsafe,
+        );
 
-        assert!(diagnostics.is_empty());
+        assert_eq!(result.diagnostics.len(), 3);
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 3);
     }
 }

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -1,10 +1,14 @@
 use shuck_ast::{Span, static_word_text};
 
-use crate::{Checker, CommandFactRef, PipelineFact, Rule, Violation};
+use crate::{
+    Checker, CommandFactRef, Diagnostic, Edit, Fix, FixAvailability, PipelineFact, Rule, Violation,
+};
 
 pub struct GrepCountPipeline;
 
 impl Violation for GrepCountPipeline {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::GrepCountPipeline
     }
@@ -12,27 +16,41 @@ impl Violation for GrepCountPipeline {
     fn message(&self) -> String {
         "use `grep -c` instead of piping `grep` into `wc -l`".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace the pipeline with `grep -c`".to_owned())
+    }
 }
 
 pub fn grep_count_pipeline(checker: &mut Checker) {
-    let spans = checker
+    let reports = checker
         .facts()
         .pipelines()
         .iter()
-        .flat_map(|pipeline| unsafe_grep_count_pipeline_spans(checker, pipeline))
+        .flat_map(|pipeline| unsafe_grep_count_pipeline_reports(checker, pipeline))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || GrepCountPipeline);
+    for report in reports {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(GrepCountPipeline, report.diagnostic_span).with_fix(report.fix),
+        );
+    }
 }
 
-fn unsafe_grep_count_pipeline_spans(
+struct GrepCountPipelineReport {
+    diagnostic_span: Span,
+    fix: Fix,
+}
+
+fn unsafe_grep_count_pipeline_reports(
     checker: &Checker<'_>,
     pipeline: &PipelineFact<'_>,
-) -> Vec<Span> {
+) -> Vec<GrepCountPipelineReport> {
     pipeline
         .segments()
         .windows(2)
-        .filter_map(|pair| {
+        .zip(pipeline.operators())
+        .filter_map(|(pair, operator)| {
             let left_segment = &pair[0];
             let right_segment = &pair[1];
             let left = checker.facts().command(left_segment.command_id());
@@ -54,9 +72,27 @@ fn unsafe_grep_count_pipeline_spans(
                 return None;
             }
 
-            command_body_span(left)
+            Some(GrepCountPipelineReport {
+                diagnostic_span: command_body_span(left)?,
+                fix: grep_count_pipeline_fix(checker.source(), left, right, operator.span())?,
+            })
         })
         .collect()
+}
+
+fn grep_count_pipeline_fix(
+    source: &str,
+    grep: CommandFactRef<'_, '_>,
+    wc: CommandFactRef<'_, '_>,
+    operator_span: Span,
+) -> Option<Fix> {
+    let grep_name = grep.body_name_word()?;
+    let wc_span = wc.span_in_source(source);
+    let delete_start = preceding_space_start(source, operator_span.start.offset);
+    Some(Fix::unsafe_edits([
+        Edit::insertion(grep_name.span.end.offset, " -c"),
+        Edit::deletion_at(delete_start, wc_span.end.offset),
+    ]))
 }
 
 fn command_body_span(fact: CommandFactRef<'_, '_>) -> Option<Span> {
@@ -91,10 +127,17 @@ fn wc_uses_line_count(fact: CommandFactRef<'_, '_>, source: &str) -> bool {
     })
 }
 
+fn preceding_space_start(source: &str, mut offset: usize) -> usize {
+    while offset > 0 && matches!(source.as_bytes().get(offset - 1), Some(b' ' | b'\t')) {
+        offset -= 1;
+    }
+    offset
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn anchors_on_the_grep_pipeline_segment() {
@@ -115,5 +158,32 @@ grep foo file | grep bar | wc -l
                 .collect::<Vec<_>>(),
             vec!["grep foo file", "grep foo file 2>/dev/null", "grep bar",]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_replace_grep_wc_pipeline_with_grep_count() {
+        let source = "\
+#!/bin/sh
+grep foo file | wc -l
+grep foo file 2>/dev/null | wc --lines
+grep foo file | grep bar | wc -l
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::GrepCountPipeline),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+grep -c foo file
+grep -c foo file 2>/dev/null
+grep foo file | grep -c bar
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
+++ b/crates/shuck-linter/src/rules/performance/grep_count_pipeline.rs
@@ -68,7 +68,7 @@ fn unsafe_grep_count_pipeline_reports(
                 return None;
             }
 
-            if !wc_uses_line_count(right, checker.source()) {
+            if !wc_uses_only_line_count(right, checker.source()) {
                 return None;
             }
 
@@ -119,12 +119,17 @@ fn is_raw_utility_named(fact: CommandFactRef<'_, '_>, name: &str) -> bool {
     fact.literal_name() == Some(name) && fact.wrappers().is_empty()
 }
 
-fn wc_uses_line_count(fact: CommandFactRef<'_, '_>, source: &str) -> bool {
-    fact.body_args().iter().any(|word| {
-        static_word_text(word, source).is_some_and(|text| {
-            text == "-l" || text == "--lines" || (text.starts_with('-') && text[1..].contains('l'))
-        })
-    })
+fn wc_uses_only_line_count(fact: CommandFactRef<'_, '_>, source: &str) -> bool {
+    if !fact.redirect_facts().is_empty() {
+        return false;
+    }
+
+    let mut args = fact.body_args().iter();
+    let Some(arg) = args.next() else {
+        return false;
+    };
+    args.next().is_none()
+        && static_word_text(arg, source).is_some_and(|text| text == "-l" || text == "--lines")
 }
 
 fn pipeline_delete_start(source: &str, operator_start: usize) -> usize {
@@ -227,5 +232,18 @@ grep -c foo file
 "
         );
         assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_wc_invocations_with_extra_count_modes_or_operands() {
+        let source = "\
+#!/bin/sh
+grep foo file | wc -cl
+grep foo file | wc -l other.txt
+grep foo file | wc -l > count
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::GrepCountPipeline));
+
+        assert!(diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
+++ b/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
@@ -38,7 +38,7 @@ fn remove_outer_parens_fix(source: &str, span: Span) -> Fix {
             opening_paren_delete_start(source, span.start.offset),
             span.start.offset + 1,
         ),
-        Edit::deletion_at(close_start, closing_paren_delete_end(source, close_start)),
+        closing_paren_edit(source, close_start),
     ])
 }
 
@@ -59,9 +59,9 @@ fn opening_paren_delete_start(source: &str, open_start: usize) -> usize {
     start
 }
 
-fn closing_paren_delete_end(source: &str, close_start: usize) -> usize {
+fn closing_paren_edit(source: &str, close_start: usize) -> Edit {
     if !offset_is_indented_line_start(source, close_start) {
-        return close_start + 1;
+        return Edit::deletion_at(close_start, close_start + 1);
     }
 
     let mut end = close_start + 1;
@@ -72,11 +72,11 @@ fn closing_paren_delete_end(source: &str, close_start: usize) -> usize {
     {
         end += 1;
     }
-    if source.as_bytes().get(end) != Some(&b';') {
-        return close_start + 1;
-    }
+    let Some((operator, operator_len)) = close_cleanup_operator(source, end) else {
+        return Edit::deletion_at(close_start, close_start + 1);
+    };
 
-    end += 1;
+    end += operator_len;
     while source
         .as_bytes()
         .get(end)
@@ -84,7 +84,26 @@ fn closing_paren_delete_end(source: &str, close_start: usize) -> usize {
     {
         end += 1;
     }
-    end
+
+    if operator == ";" {
+        Edit::deletion_at(close_start, end)
+    } else {
+        let line_break = source[..close_start].rfind('\n').unwrap_or(close_start);
+        Edit::replacement_at(line_break, end, format!(" {operator} "))
+    }
+}
+
+fn close_cleanup_operator(source: &str, offset: usize) -> Option<(&str, usize)> {
+    let rest = source.get(offset..)?;
+    if rest.starts_with(';') {
+        Some((";", 1))
+    } else if rest.starts_with("&&") {
+        Some(("&&", 2))
+    } else if rest.starts_with("||") {
+        Some(("||", 2))
+    } else {
+        None
+    }
 }
 
 fn offset_is_indented_line_start(source: &str, offset: usize) -> bool {
@@ -181,5 +200,28 @@ fi
 "
         );
         assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn closing_paren_edit_joins_multiline_list_operator() {
+        let source = "\
+#!/bin/sh
+if (
+  test -f a
+)&& echo y
+then
+  :
+fi
+";
+        let close_start = source.find(")&&").expect("expected close paren");
+        let edit = super::closing_paren_edit(source, close_start);
+        let line_break = source.find("\n)&&").expect("expected close line break");
+        let echo_start = source
+            .find("echo y")
+            .expect("expected command after operator");
+
+        assert_eq!(usize::from(edit.range().start()), line_break);
+        assert_eq!(usize::from(edit.range().end()), echo_start);
+        assert_eq!(edit.content(), " && ");
     }
 }

--- a/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
+++ b/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SingleTestSubshell;
 
 impl Violation for SingleTestSubshell {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SingleTestSubshell
     }
@@ -10,19 +14,32 @@ impl Violation for SingleTestSubshell {
     fn message(&self) -> String {
         "drop the subshell around this single test condition".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the subshell parentheses".to_owned())
+    }
 }
 
 pub fn single_test_subshell(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.single_test_subshell_spans(),
-        || SingleTestSubshell,
-    );
+    let spans = checker.facts().single_test_subshell_spans().to_vec();
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(SingleTestSubshell, span).with_fix(remove_outer_parens_fix(span)),
+        );
+    }
+}
+
+fn remove_outer_parens_fix(span: Span) -> Fix {
+    Fix::unsafe_edits([
+        Edit::deletion_at(span.start.offset, span.start.offset + 1),
+        Edit::deletion_at(span.end.offset.saturating_sub(1), span.end.offset),
+    ])
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn anchors_on_the_condition_subshell() {
@@ -58,5 +75,22 @@ until ! (command test -f /etc/passwd); do :; done
                 "(command test -f /etc/passwd)",
             ]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_remove_subshell_parentheses() {
+        let source = "#!/bin/sh\nif (test -f /etc/passwd); then :; fi\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SingleTestSubshell),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nif test -f /etc/passwd; then :; fi\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
+++ b/crates/shuck-linter/src/rules/performance/single_test_subshell.rs
@@ -21,19 +21,77 @@ impl Violation for SingleTestSubshell {
 }
 
 pub fn single_test_subshell(checker: &mut Checker) {
+    let source = checker.source();
     let spans = checker.facts().single_test_subshell_spans().to_vec();
     for span in spans {
         checker.report_diagnostic_dedup(
-            Diagnostic::new(SingleTestSubshell, span).with_fix(remove_outer_parens_fix(span)),
+            Diagnostic::new(SingleTestSubshell, span)
+                .with_fix(remove_outer_parens_fix(source, span)),
         );
     }
 }
 
-fn remove_outer_parens_fix(span: Span) -> Fix {
+fn remove_outer_parens_fix(source: &str, span: Span) -> Fix {
+    let close_start = span.end.offset.saturating_sub(1);
     Fix::unsafe_edits([
-        Edit::deletion_at(span.start.offset, span.start.offset + 1),
-        Edit::deletion_at(span.end.offset.saturating_sub(1), span.end.offset),
+        Edit::deletion_at(
+            opening_paren_delete_start(source, span.start.offset),
+            span.start.offset + 1,
+        ),
+        Edit::deletion_at(close_start, closing_paren_delete_end(source, close_start)),
     ])
+}
+
+fn opening_paren_delete_start(source: &str, open_start: usize) -> usize {
+    if source.as_bytes().get(open_start + 1) != Some(&b'\n') {
+        return open_start;
+    }
+
+    let mut start = open_start;
+    while start > 0
+        && source
+            .as_bytes()
+            .get(start - 1)
+            .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        start -= 1;
+    }
+    start
+}
+
+fn closing_paren_delete_end(source: &str, close_start: usize) -> usize {
+    if !offset_is_indented_line_start(source, close_start) {
+        return close_start + 1;
+    }
+
+    let mut end = close_start + 1;
+    while source
+        .as_bytes()
+        .get(end)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        end += 1;
+    }
+    if source.as_bytes().get(end) != Some(&b';') {
+        return close_start + 1;
+    }
+
+    end += 1;
+    while source
+        .as_bytes()
+        .get(end)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        end += 1;
+    }
+    end
+}
+
+fn offset_is_indented_line_start(source: &str, offset: usize) -> bool {
+    let line_start = source[..offset].rfind('\n').map_or(0, |offset| offset + 1);
+    source[line_start..offset]
+        .bytes()
+        .all(|byte| matches!(byte, b' ' | b'\t'))
 }
 
 #[cfg(test)]
@@ -90,6 +148,37 @@ until ! (command test -f /etc/passwd); do :; done
         assert_eq!(
             result.fixed_source,
             "#!/bin/sh\nif test -f /etc/passwd; then :; fi\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_multiline_condition_subshell() {
+        let source = "\
+#!/bin/sh
+if (
+  test -f /etc/passwd
+); then
+  :
+fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SingleTestSubshell),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+if
+  test -f /etc/passwd
+then
+  :
+fi
+"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
+++ b/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
@@ -21,6 +21,7 @@ impl Violation for SubshellTestGroup {
 }
 
 pub fn subshell_test_group(checker: &mut Checker) {
+    let source = checker.source();
     let single_test_spans = checker.facts().single_test_subshell_spans();
     let spans = checker
         .facts()
@@ -31,16 +32,30 @@ pub fn subshell_test_group(checker: &mut Checker) {
         .collect::<Vec<_>>();
     for span in spans {
         checker.report_diagnostic_dedup(
-            Diagnostic::new(SubshellTestGroup, span).with_fix(brace_group_fix(span)),
+            Diagnostic::new(SubshellTestGroup, span).with_fix(brace_group_fix(source, span)),
         );
     }
 }
 
-fn brace_group_fix(span: Span) -> Fix {
+fn brace_group_fix(source: &str, span: Span) -> Fix {
+    let close_start = span.end.offset.saturating_sub(1);
+    let close_replacement = if offset_is_indented_line_start(source, close_start) {
+        "}"
+    } else {
+        "; }"
+    };
+
     Fix::unsafe_edits([
         Edit::replacement_at(span.start.offset, span.start.offset + 1, "{"),
-        Edit::replacement_at(span.end.offset.saturating_sub(1), span.end.offset, "; }"),
+        Edit::replacement_at(close_start, span.end.offset, close_replacement),
     ])
+}
+
+fn offset_is_indented_line_start(source: &str, offset: usize) -> bool {
+    let line_start = source[..offset].rfind('\n').map_or(0, |offset| offset + 1);
+    source[line_start..offset]
+        .bytes()
+        .all(|byte| matches!(byte, b' ' | b'\t'))
 }
 
 #[cfg(test)]
@@ -93,6 +108,39 @@ if ( [ \"$b\" = jpeg ] || [ \"$b\" = jpg ] ); then echo ok; fi
         assert_eq!(
             result.fixed_source,
             "#!/bin/sh\na=1\nb=jpg\nif [ -n \"$a\" ] && { [ \"$b\" = jpeg ] || [ \"$b\" = jpg ] ; }; then echo ok; fi\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_multiline_subshell_group() {
+        let source = "\
+#!/bin/sh
+if (
+  [ -f a ]
+  [ -f b ]
+); then
+  echo ok
+fi
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellTestGroup),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+if {
+  [ -f a ]
+  [ -f b ]
+}; then
+  echo ok
+fi
+"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
+++ b/crates/shuck-linter/src/rules/performance/subshell_test_group.rs
@@ -1,14 +1,22 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SubshellTestGroup;
 
 impl Violation for SubshellTestGroup {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SubshellTestGroup
     }
 
     fn message(&self) -> String {
         "use braces to group these tests instead of a subshell".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace the subshell with a brace group".to_owned())
     }
 }
 
@@ -21,13 +29,24 @@ pub fn subshell_test_group(checker: &mut Checker) {
         .copied()
         .filter(|span| !single_test_spans.contains(span))
         .collect::<Vec<_>>();
-    checker.report_all_dedup(spans, || SubshellTestGroup);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(SubshellTestGroup, span).with_fix(brace_group_fix(span)),
+        );
+    }
+}
+
+fn brace_group_fix(span: Span) -> Fix {
+    Fix::unsafe_edits([
+        Edit::replacement_at(span.start.offset, span.start.offset + 1, "{"),
+        Edit::replacement_at(span.end.offset.saturating_sub(1), span.end.offset, "; }"),
+    ])
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn anchors_on_the_grouping_subshell() {
@@ -59,5 +78,22 @@ if ( [ \"$b\" = jpeg ] || [ \"$b\" = jpg ] ); then echo ok; fi
                 "( [ \"$b\" = jpeg ] ; [ \"$b\" = jpg ] )",
             ]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_replace_subshell_group_with_braces() {
+        let source = "#!/bin/sh\na=1\nb=jpg\nif [ -n \"$a\" ] && ( [ \"$b\" = jpeg ] || [ \"$b\" = jpg ] ); then echo ok; fi\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SubshellTestGroup),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\na=1\nb=jpg\nif [ -n \"$a\" ] && { [ \"$b\" = jpeg ] || [ \"$b\" = jpg ] ; }; then echo ok; fi\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/ampersand_redirect_in_sh.rs
@@ -1,16 +1,24 @@
 use shuck_ast::{RedirectKind, Span, static_word_text};
 
-use crate::{Checker, RedirectFact, Rule, ShellDialect, Violation};
+use crate::{
+    Checker, Diagnostic, Edit, Fix, FixAvailability, RedirectFact, Rule, ShellDialect, Violation,
+};
 
 pub struct AmpersandRedirectInSh;
 
 impl Violation for AmpersandRedirectInSh {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::AmpersandRedirectInSh
     }
 
     fn message(&self) -> String {
         "combined `>&` redirection is not portable in `sh`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("expand the combined stdout/stderr redirect".to_owned())
     }
 }
 
@@ -19,15 +27,20 @@ pub fn ampersand_redirect_in_sh(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .flat_map(|fact| fact.redirect_facts().iter())
         .filter_map(|redirect| combined_ampersand_redirect_span(redirect, checker.source()))
+        .filter_map(|span| ampersand_redirect_in_sh_fix(span, source))
+        .map(|(span, fix)| Diagnostic::new(AmpersandRedirectInSh, span).with_fix(fix))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || AmpersandRedirectInSh);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn combined_ampersand_redirect_span(redirect: &RedirectFact<'_>, source: &str) -> Option<Span> {
@@ -70,10 +83,23 @@ fn combined_ampersand_redirect_span(redirect: &RedirectFact<'_>, source: &str) -
     Some(redirect_data.span)
 }
 
+fn ampersand_redirect_in_sh_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let text = span.slice(source);
+    let operator_index = text.find(">&")?;
+    let target = text[operator_index + 2..].trim_start();
+    if target.is_empty() {
+        return None;
+    }
+    Some((
+        span,
+        Fix::safe_edit(Edit::replacement(format!("> {target} 2>&1"), span)),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_ampersand_redirect_in_sh() {
@@ -127,5 +153,22 @@ echo test >& /dev/null
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_ampersand_redirects_in_sh() {
+        let source = "#!/bin/sh\necho test >& /dev/null\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AmpersandRedirectInSh),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\necho test > /dev/null 2>&1\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
@@ -51,7 +51,10 @@ pub fn base_prefix_in_arithmetic(checker: &mut Checker) {
 
 fn base_prefix_fix(span: Span, source: &str) -> Option<Fix> {
     let text = span.slice(source);
-    let (_, digits) = text.split_once('#')?;
+    let (base, digits) = text.split_once('#')?;
+    if base != "10" {
+        return None;
+    }
     if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
         return None;
     }
@@ -106,6 +109,20 @@ echo ${foo:-$((10#1))}
         assert_eq!(result.fixes_applied, 1);
         assert_eq!(result.fixed_source, "#!/bin/sh\necho $((123))\n");
         assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn skips_unsafe_fix_for_non_decimal_base_prefixes() {
+        let source = "#!/bin/sh\necho $((2#10 + 16#10))\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::BasePrefixInArithmetic),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 2);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/portability/base_prefix_in_arithmetic.rs
@@ -1,14 +1,25 @@
-use crate::{ArithmeticLiteralKind, Checker, Rule, ShellDialect, Violation};
+use shuck_ast::Span;
+
+use crate::{
+    ArithmeticLiteralKind, Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect,
+    Violation,
+};
 
 pub struct BasePrefixInArithmetic;
 
 impl Violation for BasePrefixInArithmetic {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::BasePrefixInArithmetic
     }
 
     fn message(&self) -> String {
         "base prefixes like `10#` are not portable in `sh` arithmetic".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace the explicit-base literal with decimal digits".to_owned())
     }
 }
 
@@ -17,21 +28,46 @@ pub fn base_prefix_in_arithmetic(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .arithmetic_literal_facts()
         .iter()
         .filter_map(|fact| {
             (fact.kind() == ArithmeticLiteralKind::ExplicitBasePrefix).then_some(fact.span())
         })
+        .map(|span| {
+            let diagnostic = Diagnostic::new(BasePrefixInArithmetic, span);
+            match base_prefix_fix(span, source) {
+                Some(fix) => diagnostic.with_fix(fix),
+                None => diagnostic,
+            }
+        })
         .collect::<Vec<_>>();
-    checker.report_all_dedup(spans, || BasePrefixInArithmetic);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn base_prefix_fix(span: Span, source: &str) -> Option<Fix> {
+    let text = span.slice(source);
+    let (_, digits) = text.split_once('#')?;
+    if digits.is_empty() || !digits.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let normalized = digits.trim_start_matches('0');
+    let normalized = if normalized.is_empty() {
+        "0"
+    } else {
+        normalized
+    };
+    Some(Fix::unsafe_edit(Edit::replacement(normalized, span)))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_base_prefixes_in_sh() {
@@ -56,6 +92,20 @@ echo ${foo:-$((10#1))}
                 .collect::<Vec<_>>(),
             vec!["10#123", "10#", "10#1", "10#1", "10#1"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_literal_decimal_base_prefixes() {
+        let source = "#!/bin/sh\necho $((10#00123))\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::BasePrefixInArithmetic),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\necho $((123))\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
@@ -1,16 +1,22 @@
 use shuck_ast::{Command, CompoundCommand, Span};
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct CStyleForInSh;
 
 impl Violation for CStyleForInSh {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::CStyleForInSh
     }
 
     fn message(&self) -> String {
         "C-style `for ((...))` loops are not portable in `sh` scripts".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite as a portable while loop".to_owned())
     }
 }
 
@@ -19,13 +25,24 @@ pub fn c_style_for_in_sh(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|fact| match fact.command() {
-            Command::Compound(CompoundCommand::ArithmeticFor(_)) => {
-                Some(keyword_span(fact.span_in_source(checker.source()), "for"))
+            Command::Compound(CompoundCommand::ArithmeticFor(command)) => {
+                let span = keyword_span(fact.span_in_source(checker.source()), "for");
+                let diagnostic = Diagnostic::new(CStyleForInSh, span);
+                Some(
+                    match c_style_for_fix(
+                        command,
+                        fact.span_in_source(checker.source()),
+                        checker.source(),
+                    ) {
+                        Some(fix) => diagnostic.with_fix(fix),
+                        None => diagnostic,
+                    },
+                )
             }
             Command::Simple(_)
             | Command::Builtin(_)
@@ -37,17 +54,113 @@ pub fn c_style_for_in_sh(checker: &mut Checker) {
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || CStyleForInSh);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 fn keyword_span(span: Span, keyword: &str) -> Span {
     Span::from_positions(span.start, span.start.advanced_by(keyword))
 }
 
+fn c_style_for_fix(
+    command: &shuck_ast::ArithmeticForCommand,
+    replacement_span: Span,
+    source: &str,
+) -> Option<Fix> {
+    let init = command.init_span.map(|span| span.slice(source).trim());
+    let condition = command
+        .condition_span
+        .map(|span| span.slice(source).trim())
+        .filter(|condition| !condition.is_empty())
+        .unwrap_or("1");
+    let step = command.step_span.map(|span| span.slice(source).trim());
+    let body = command.body.span.slice(source).trim_end();
+    if body.is_empty() {
+        return None;
+    }
+
+    let indent = line_indent_before(source, replacement_span.start.offset);
+    let child_indent = format!("{indent}  ");
+    let mut replacement = String::new();
+    if let Some(init) = init.filter(|init| !init.is_empty()) {
+        replacement.push_str(&format!("{indent}: \"$(({init}))\"\n"));
+    }
+    replacement.push_str(&format!(
+        "{indent}while [ \"$(({condition}))\" -ne 0 ]; do\n"
+    ));
+    push_indented_body(&mut replacement, body, &child_indent);
+    if let Some(step) = step.filter(|step| !step.is_empty()) {
+        replacement.push_str(&format!(
+            "{child_indent}: \"$(({}))\"\n",
+            portable_arithmetic_update(step)
+        ));
+    }
+    replacement.push_str(&format!("{indent}done"));
+
+    Some(Fix::unsafe_edit(Edit::replacement(
+        replacement,
+        replacement_span,
+    )))
+}
+
+fn push_indented_body(replacement: &mut String, body: &str, child_indent: &str) {
+    for line in body.lines() {
+        if line.trim().is_empty() {
+            replacement.push('\n');
+        } else {
+            replacement.push_str(child_indent);
+            replacement.push_str(line.trim_start());
+            replacement.push('\n');
+        }
+    }
+}
+
+fn portable_arithmetic_update(expression: &str) -> String {
+    if let Some(name) = expression
+        .strip_suffix("++")
+        .filter(|name| is_arithmetic_name(name))
+    {
+        return format!("{name} = {name} + 1");
+    }
+    if let Some(name) = expression
+        .strip_suffix("--")
+        .filter(|name| is_arithmetic_name(name))
+    {
+        return format!("{name} = {name} - 1");
+    }
+    if let Some(name) = expression
+        .strip_prefix("++")
+        .filter(|name| is_arithmetic_name(name))
+    {
+        return format!("{name} = {name} + 1");
+    }
+    if let Some(name) = expression
+        .strip_prefix("--")
+        .filter(|name| is_arithmetic_name(name))
+    {
+        return format!("{name} = {name} - 1");
+    }
+    expression.to_owned()
+}
+
+fn is_arithmetic_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+fn line_indent_before(source: &str, offset: usize) -> &str {
+    let line_start = source[..offset].rfind('\n').map_or(0, |offset| offset + 1);
+    &source[line_start..offset]
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_for_keyword_only() {
@@ -67,5 +180,34 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_rewrite_c_style_for_loop() {
+        let source = "\
+#!/bin/sh
+for ((i = 0; i < 3; i++)); do
+  echo \"$i\"
+done
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForInSh),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+: \"$((i = 0))\"
+while [ \"$((i < 3))\" -ne 0 ]; do
+  echo \"$i\"
+  : \"$((i = i + 1))\"
+done
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_in_sh.rs
@@ -154,7 +154,12 @@ fn is_arithmetic_name(name: &str) -> bool {
 
 fn line_indent_before(source: &str, offset: usize) -> &str {
     let line_start = source[..offset].rfind('\n').map_or(0, |offset| offset + 1);
-    &source[line_start..offset]
+    let line_prefix = &source[line_start..offset];
+    let indent_len = line_prefix
+        .bytes()
+        .take_while(|byte| matches!(byte, b' ' | b'\t'))
+        .count();
+    &line_prefix[..indent_len]
 }
 
 #[cfg(test)]
@@ -207,6 +212,24 @@ while [ \"$((i < 3))\" -ne 0 ]; do
   : \"$((i = i + 1))\"
 done
 "
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_without_copying_inline_prefix_as_indent() {
+        let source =
+            "#!/bin/sh\nif ready; then for ((i = 0; i < 1; i++)); do echo \"$i\"; done; fi\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForInSh),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nif ready; then : \"$((i = 0))\"\nwhile [ \"$((i < 1))\" -ne 0 ]; do\n  echo \"$i\";\n  : \"$((i = i + 1))\"\ndone; fi\n"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/portability/conditional_portability.rs
+++ b/crates/shuck-linter/src/rules/portability/conditional_portability.rs
@@ -1,4 +1,6 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct DoubleBracketInSh;
 pub struct TestEqualityOperator;
@@ -27,12 +29,18 @@ impl Violation for DoubleBracketInSh {
 }
 
 impl Violation for TestEqualityOperator {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::TestEqualityOperator
     }
 
     fn message(&self) -> String {
         "use `=` instead of `==` in POSIX test expressions".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace `==` with `=`".to_owned())
     }
 }
 
@@ -57,12 +65,18 @@ impl Violation for ExtglobInSh {
 }
 
 impl Violation for CaretNegationInBracket {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::CaretNegationInBracket
     }
 
     fn message(&self) -> String {
         "caret negation in bracket expressions is not portable to POSIX sh".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace `^` with `!` in the bracket expression".to_owned())
     }
 }
 
@@ -127,12 +141,18 @@ impl Violation for VTestInSh {
 }
 
 impl Violation for ATestInSh {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::ATestInSh
     }
 
     fn message(&self) -> String {
         "use `-e` instead of `-a` for file-existence checks in POSIX sh".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace `-a` with `-e`".to_owned())
     }
 }
 
@@ -194,18 +214,8 @@ cached_portability_rule!(
     double_bracket_in_sh,
     DoubleBracketInSh
 );
-cached_portability_rule!(
-    test_equality_operator,
-    test_equality_operator,
-    TestEqualityOperator
-);
 cached_portability_rule!(if_elif_bash_test, if_elif_bash_test, IfElifBashTest);
 cached_portability_rule!(extglob_in_sh, extglob_in_sh, ExtglobInSh);
-cached_portability_rule!(
-    caret_negation_in_bracket,
-    caret_negation_in_bracket,
-    CaretNegationInBracket
-);
 cached_portability_rule!(
     array_subscript_test,
     array_subscript_test,
@@ -242,7 +252,6 @@ cached_portability_rule!(
 );
 cached_portability_rule!(regex_match_in_sh, regex_match_in_sh, RegexMatchInSh);
 cached_portability_rule!(v_test_in_sh, v_test_in_sh, VTestInSh);
-cached_portability_rule!(a_test_in_sh, a_test_in_sh, ATestInSh);
 cached_portability_rule!(option_test_in_sh, option_test_in_sh, OptionTestInSh);
 cached_portability_rule!(
     sticky_bit_test_in_sh,
@@ -255,10 +264,84 @@ cached_portability_rule!(
     OwnershipTestInSh
 );
 
+pub fn test_equality_operator(checker: &mut Checker) {
+    if !is_posix_sh_shell(checker.shell()) {
+        return;
+    }
+
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .conditional_portability()
+        .test_equality_operator()
+        .iter()
+        .copied()
+        .map(|span| {
+            let diagnostic = Diagnostic::new(TestEqualityOperator, span);
+            if span.slice(source) == "==" {
+                diagnostic.with_fix(Fix::safe_edit(Edit::replacement("=", span)))
+            } else {
+                diagnostic
+            }
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+pub fn caret_negation_in_bracket(checker: &mut Checker) {
+    if !is_posix_sh_shell(checker.shell()) {
+        return;
+    }
+
+    let diagnostics = checker
+        .facts()
+        .conditional_portability()
+        .caret_negation_in_bracket()
+        .iter()
+        .copied()
+        .map(|span| {
+            Diagnostic::new(CaretNegationInBracket, span)
+                .with_fix(Fix::safe_edit(caret_negation_fix(span)))
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn caret_negation_fix(span: Span) -> Edit {
+    Edit::replacement_at(span.start.offset + 1, span.start.offset + 2, "!")
+}
+
+pub fn a_test_in_sh(checker: &mut Checker) {
+    if !is_posix_sh_shell(checker.shell()) {
+        return;
+    }
+
+    let diagnostics = checker
+        .facts()
+        .conditional_portability()
+        .a_test_in_sh()
+        .iter()
+        .copied()
+        .map(|span| {
+            Diagnostic::new(ATestInSh, span).with_fix(Fix::safe_edit(Edit::replacement("-e", span)))
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_at_extglob_in_posix_shells() {
@@ -341,6 +424,20 @@ esac
                 .iter()
                 .all(|diagnostic| diagnostic.rule == Rule::CaretNegationInBracket)
         );
+    }
+
+    #[test]
+    fn applies_safe_fix_to_caret_negation_in_brackets() {
+        let source = "#!/bin/sh\necho [^a]*\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CaretNegationInBracket),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\necho [!a]*\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]
@@ -487,5 +584,33 @@ fi
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_test_equality_operator_when_span_is_exact() {
+        let source = "#!/bin/sh\n[ \"$x\" == value ]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::TestEqualityOperator),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\n[ \"$x\" = value ]\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_a_file_test_operator() {
+        let source = "#!/bin/sh\n[[ -a file ]]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ATestInSh),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\n[[ -e file ]]\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/portability/errexit_trap_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/errexit_trap_in_sh.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct ErrexitTrapInSh;
 
 impl Violation for ErrexitTrapInSh {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::ErrexitTrapInSh
     }
 
     fn message(&self) -> String {
         "`set` trap inheritance flags are not portable in `sh` scripts".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the trap inheritance flag".to_owned())
     }
 }
 
@@ -32,13 +38,34 @@ pub fn errexit_trap_in_sh(checker: &mut Checker) {
         })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || ErrexitTrapInSh);
+    for span in spans {
+        checker.report_diagnostic(
+            Diagnostic::new(ErrexitTrapInSh, span)
+                .with_fix(errexit_trap_fix(checker.source(), span)),
+        );
+    }
+}
+
+fn errexit_trap_fix(source: &str, span: shuck_ast::Span) -> Fix {
+    let text = span.slice(source);
+    let mut chars = text.chars();
+    let Some(sign @ ('-' | '+')) = chars.next() else {
+        return Fix::unsafe_edit(Edit::deletion(span));
+    };
+    let retained = chars
+        .filter(|ch| !matches!(ch, 'E' | 'T'))
+        .collect::<String>();
+    if retained.is_empty() {
+        Fix::unsafe_edit(Edit::deletion(span))
+    } else {
+        Fix::unsafe_edit(Edit::replacement(format!("{sign}{retained}"), span))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_nonportable_trap_inheritance_flags_in_sh() {
@@ -90,5 +117,19 @@ set -E -T -- +E +T
                 .collect::<Vec<_>>(),
             vec!["-E", "-T"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_remove_nonportable_trap_flags() {
+        let source = "#!/bin/sh\nset -E\nset -eE\nset -ET\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ErrexitTrapInSh),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(result.fixed_source, "#!/bin/sh\nset \nset -e\nset \n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/portability/errexit_trap_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/errexit_trap_in_sh.rs
@@ -29,24 +29,29 @@ pub fn errexit_trap_in_sh(checker: &mut Checker) {
         .iter()
         .filter(|fact| fact.effective_name_is("set"))
         .flat_map(|fact| {
-            fact.options().set().into_iter().flat_map(|set| {
+            let command_span = fact.span_in_source(checker.source());
+            fact.options().set().into_iter().flat_map(move |set| {
                 set.errtrace_flag_spans()
                     .iter()
                     .chain(set.functrace_flag_spans().iter())
                     .copied()
+                    .map(move |span| (command_span, span))
             })
         })
         .collect::<Vec<_>>();
 
-    for span in spans {
+    for (command_span, span) in spans {
         checker.report_diagnostic(
-            Diagnostic::new(ErrexitTrapInSh, span)
-                .with_fix(errexit_trap_fix(checker.source(), span)),
+            Diagnostic::new(ErrexitTrapInSh, span).with_fix(errexit_trap_fix(
+                checker.source(),
+                command_span,
+                span,
+            )),
         );
     }
 }
 
-fn errexit_trap_fix(source: &str, span: shuck_ast::Span) -> Fix {
+fn errexit_trap_fix(source: &str, command_span: shuck_ast::Span, span: shuck_ast::Span) -> Fix {
     let text = span.slice(source);
     let mut chars = text.chars();
     let Some(sign @ ('-' | '+')) = chars.next() else {
@@ -56,10 +61,47 @@ fn errexit_trap_fix(source: &str, span: shuck_ast::Span) -> Fix {
         .filter(|ch| !matches!(ch, 'E' | 'T'))
         .collect::<String>();
     if retained.is_empty() {
-        Fix::unsafe_edit(Edit::deletion(span))
+        if command_is_empty_set_after_removing_span(source, command_span, span) {
+            Fix::unsafe_edit(Edit::replacement(
+                empty_set_replacement(source, command_span),
+                command_span,
+            ))
+        } else {
+            Fix::unsafe_edit(Edit::deletion(span))
+        }
     } else {
         Fix::unsafe_edit(Edit::replacement(format!("{sign}{retained}"), span))
     }
+}
+
+fn empty_set_replacement(source: &str, command_span: shuck_ast::Span) -> &'static str {
+    if command_span.slice(source).trim_end().ends_with(';') {
+        ":;"
+    } else {
+        ":"
+    }
+}
+
+fn command_is_empty_set_after_removing_span(
+    source: &str,
+    command_span: shuck_ast::Span,
+    span: shuck_ast::Span,
+) -> bool {
+    let command = command_span.slice(source);
+    let remove_start = span.start.offset.saturating_sub(command_span.start.offset);
+    let remove_end = span.end.offset.saturating_sub(command_span.start.offset);
+    let mut remaining = String::with_capacity(command.len());
+    remaining.push_str(&command[..remove_start]);
+    remaining.push_str(&command[remove_end..]);
+    let remaining = remaining.trim();
+    if remaining == "set" {
+        return true;
+    }
+    remaining.strip_prefix("set").is_some_and(|suffix| {
+        suffix
+            .bytes()
+            .all(|byte| matches!(byte, b' ' | b'\t' | b';'))
+    })
 }
 
 #[cfg(test)]
@@ -129,7 +171,21 @@ set -E -T -- +E +T
         );
 
         assert_eq!(result.fixes_applied, 3);
-        assert_eq!(result.fixed_source, "#!/bin/sh\nset \nset -e\nset \n");
+        assert_eq!(result.fixed_source, "#!/bin/sh\n:\nset -e\n:\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_without_leaving_bare_set_commands() {
+        let source = "#!/bin/sh\nif ok; then set -E; fi\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ErrexitTrapInSh),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\nif ok; then :; fi\n");
         assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/portability/hyphenated_function_name.rs
+++ b/crates/shuck-linter/src/rules/portability/hyphenated_function_name.rs
@@ -1,16 +1,22 @@
 use shuck_ast::Span;
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct HyphenatedFunctionName;
 
 impl Violation for HyphenatedFunctionName {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::HyphenatedFunctionName
     }
 
     fn message(&self) -> String {
         "function names cannot contain hyphens in `sh` scripts".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rename the function with underscores".to_owned())
     }
 }
 
@@ -20,7 +26,7 @@ pub fn hyphenated_function_name(checker: &mut Checker) {
     }
 
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .function_headers()
         .iter()
@@ -31,19 +37,78 @@ pub fn hyphenated_function_name(checker: &mut Checker) {
                     .as_ref()
                     .map(|name| name.as_str())
                     .unwrap_or_else(|| entry.word.span.slice(source));
-                name.contains('-')
-                    .then_some(header.function_span_in_source(source))
+                name.contains('-').then(|| {
+                    let replacement = name.replace('-', "_");
+                    let diagnostic_span = header.function_span_in_source(source);
+                    Diagnostic::new(HyphenatedFunctionName, diagnostic_span).with_fix(
+                        Fix::unsafe_edits(rename_function_edits(
+                            checker,
+                            name,
+                            &replacement,
+                            entry.word.span,
+                            header.binding_id(),
+                        )),
+                    )
+                })
             })
         })
-        .collect::<Vec<Span>>();
+        .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || HyphenatedFunctionName);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn rename_function_edits(
+    checker: &Checker<'_>,
+    old_name: &str,
+    new_name: &str,
+    definition_span: Span,
+    binding_id: Option<shuck_semantic::BindingId>,
+) -> Vec<Edit> {
+    let mut edits = vec![Edit::replacement(new_name, definition_span)];
+    let Some(binding_id) = binding_id else {
+        return edits;
+    };
+
+    for command in checker.facts().commands() {
+        if command.effective_or_literal_name() != Some(old_name) {
+            continue;
+        }
+        let Some(name_span) = command.body_word_span() else {
+            continue;
+        };
+        if name_span == definition_span {
+            continue;
+        }
+        if checker
+            .semantic_analysis()
+            .visible_function_binding_at_call(&shuck_ast::Name::from(old_name), name_span)
+            == Some(binding_id)
+        {
+            edits.push(Edit::replacement(new_name, name_span));
+        }
+    }
+
+    edits.sort_by_key(|edit| {
+        (
+            usize::from(edit.range().start()),
+            usize::from(edit.range().end()),
+        )
+    });
+    edits.dedup_by_key(|edit| {
+        (
+            usize::from(edit.range().start()),
+            usize::from(edit.range().end()),
+        )
+    });
+    edits
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet_at_path;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet_at_path, test_snippet_at_path_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_hyphenated_function_names_in_sh() {
@@ -110,6 +175,36 @@ termux_run_build-package() { :; }
                 .collect::<Vec<_>>(),
             vec!["my-func() { :; }", "termux_run_build-package() { :; }"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_rename_function_and_call_sites() {
+        let source = "\
+#!/bin/sh
+my-func() { :; }
+my-func
+other-func() { my-func; }
+other-func
+";
+        let result = test_snippet_at_path_with_fix(
+            std::path::Path::new("/tmp/project/main.sh"),
+            source,
+            &LinterSettings::for_rule(Rule::HyphenatedFunctionName),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+my_func() { :; }
+my_func
+other_func() { my_func; }
+other_func
+"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/portability/legacy_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/legacy_arithmetic_in_sh.rs
@@ -1,14 +1,22 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct LegacyArithmeticInSh;
 
 impl Violation for LegacyArithmeticInSh {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LegacyArithmeticInSh
     }
 
     fn message(&self) -> String {
         "legacy `$[...]` arithmetic is not portable in `sh` scripts".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite as `$((...))`".to_owned())
     }
 }
 
@@ -17,20 +25,33 @@ pub fn legacy_arithmetic_in_sh(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .legacy_arithmetic_fragments()
         .iter()
-        .map(|fragment| fragment.span())
+        .filter_map(|fragment| legacy_arithmetic_fix(fragment.span(), source))
+        .map(|(span, fix)| Diagnostic::new(LegacyArithmeticInSh, span).with_fix(fix))
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || LegacyArithmeticInSh);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
+}
+
+fn legacy_arithmetic_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let text = span.slice(source);
+    let body = text.strip_prefix("$[")?.strip_suffix(']')?;
+    Some((
+        span,
+        Fix::safe_edit(Edit::replacement(format!("$(({body}))"), span)),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_legacy_arithmetic_fragment() {
@@ -65,5 +86,19 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_legacy_arithmetic_in_sh() {
+        let source = "#!/bin/sh\ni=$[$i+1]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LegacyArithmeticInSh),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\ni=$(($i+1))\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/portability/pipe_stderr_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/pipe_stderr_in_sh.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct PipeStderrInSh;
 
 impl Violation for PipeStderrInSh {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::PipeStderrInSh
     }
 
     fn message(&self) -> String {
         "the `|&` pipeline operator is not portable in `sh`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("expand `|&` to `2>&1 |`".to_owned())
     }
 }
 
@@ -17,22 +23,28 @@ pub fn pipe_stderr_in_sh(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .pipelines()
         .iter()
         .flat_map(|pipeline| pipeline.operators().iter())
         .filter(|operator| operator.op() == shuck_ast::BinaryOp::PipeAll)
         .map(|operator| operator.span())
+        .map(|span| {
+            Diagnostic::new(PipeStderrInSh, span)
+                .with_fix(Fix::safe_edit(Edit::replacement("2>&1 |", span)))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || PipeStderrInSh);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_pipe_stderr_in_sh() {
@@ -59,5 +71,22 @@ echo test |& grep -q foo
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::PipeStderrInSh));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_pipe_stderr_operator() {
+        let source = "#!/bin/sh\necho test |& grep -q foo\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::PipeStderrInSh),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\necho test 2>&1 | grep -q foo\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/portability/pipe_stderr_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/pipe_stderr_in_sh.rs
@@ -31,14 +31,34 @@ pub fn pipe_stderr_in_sh(checker: &mut Checker) {
         .filter(|operator| operator.op() == shuck_ast::BinaryOp::PipeAll)
         .map(|operator| operator.span())
         .map(|span| {
-            Diagnostic::new(PipeStderrInSh, span)
-                .with_fix(Fix::safe_edit(Edit::replacement("2>&1 |", span)))
+            Diagnostic::new(PipeStderrInSh, span).with_fix(Fix::safe_edit(Edit::replacement(
+                pipe_all_replacement(checker.source(), span),
+                span,
+            )))
         })
         .collect::<Vec<_>>();
 
     for diagnostic in diagnostics {
         checker.report_diagnostic_dedup(diagnostic);
     }
+}
+
+fn pipe_all_replacement(source: &str, span: shuck_ast::Span) -> String {
+    let leading = span.start.offset > 0
+        && source
+            .as_bytes()
+            .get(span.start.offset - 1)
+            .is_some_and(|byte| !byte.is_ascii_whitespace());
+    let trailing = source
+        .as_bytes()
+        .get(span.end.offset)
+        .is_some_and(|byte| !byte.is_ascii_whitespace());
+
+    format!(
+        "{}2>&1 |{}",
+        if leading { " " } else { "" },
+        if trailing { " " } else { "" }
+    )
 }
 
 #[cfg(test)]
@@ -86,6 +106,33 @@ echo test |& grep -q foo
         assert_eq!(
             result.fixed_source,
             "#!/bin/sh\necho test 2>&1 | grep -q foo\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_compact_pipe_stderr_operator() {
+        let source = "\
+#!/bin/sh
+first|&next
+left |&right
+left|& right
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::PipeStderrInSh),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+first 2>&1 | next
+left 2>&1 | right
+left 2>&1 | right
+"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/source_inside_function_in_sh.rs
@@ -1,19 +1,27 @@
 use shuck_ast::Span;
 use shuck_semantic::{SourceRef, SourceRefKind};
 
-use crate::{Checker, CommandFactRef, Rule, ShellDialect, Violation};
+use crate::{
+    Checker, CommandFactRef, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation,
+};
 
 use super::source_common::source_anchor_span_for_command_fact;
 
 pub struct SourceInsideFunctionInSh;
 
 impl Violation for SourceInsideFunctionInSh {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SourceInsideFunctionInSh
     }
 
     fn message(&self) -> String {
         "`source` inside a function is not portable in `sh` scripts".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace `source` with `.`".to_owned())
     }
 }
 
@@ -22,7 +30,7 @@ pub fn source_inside_function_in_sh(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let diagnostics = checker
         .semantic()
         .source_refs()
         .iter()
@@ -34,9 +42,18 @@ pub fn source_inside_function_in_sh(checker: &mut Checker) {
         })
         .filter_map(|source_ref| source_command_for_ref(checker, source_ref))
         .filter(|command| inside_function(checker, command.span()))
-        .map(|command| source_anchor_span_for_command_fact(command, checker.source()))
+        .filter_map(|command| {
+            let diagnostic_span = source_anchor_span_for_command_fact(command, checker.source());
+            let fix_span = command.body_name_word()?.span;
+            Some(
+                Diagnostic::new(SourceInsideFunctionInSh, diagnostic_span)
+                    .with_fix(Fix::unsafe_edit(Edit::replacement(".", fix_span))),
+            )
+        })
         .collect::<Vec<_>>();
-    checker.report_all(spans, || SourceInsideFunctionInSh);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 fn source_command_for_ref<'checker, 'ast>(
@@ -59,4 +76,39 @@ fn inside_function(checker: &Checker<'_>, span: Span) -> bool {
         .semantic_analysis()
         .enclosing_function_scope_at(span.start.offset)
         .is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
+
+    #[test]
+    fn reports_source_inside_function_in_sh() {
+        let source = "#!/bin/sh\nf() {\n  # shellcheck source=/dev/null\n  source ./lib.sh\n}\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::SourceInsideFunctionInSh),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "source ./lib.sh");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_source_inside_function_in_sh() {
+        let source = "#!/bin/sh\nf() {\n  # shellcheck source=/dev/null\n  source ./lib.sh\n}\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SourceInsideFunctionInSh),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nf() {\n  # shellcheck source=/dev/null\n  . ./lib.sh\n}\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
 }

--- a/crates/shuck-linter/src/rules/style/arithmetic_score_line.rs
+++ b/crates/shuck-linter/src/rules/style/arithmetic_score_line.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct ArithmeticScoreLine;
 
 impl Violation for ArithmeticScoreLine {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::ArithmeticScoreLine
     }
@@ -10,19 +14,38 @@ impl Violation for ArithmeticScoreLine {
     fn message(&self) -> String {
         "avoid extra parentheses in arithmetic assignments".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the extra arithmetic parentheses".to_owned())
+    }
 }
 
 pub fn arithmetic_score_line(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.arithmetic_score_line_spans(),
-        || ArithmeticScoreLine,
-    );
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .arithmetic_score_line_spans()
+        .iter()
+        .copied()
+        .filter_map(|span| arithmetic_score_line_fix(span, source))
+        .map(|(span, fix)| Diagnostic::new(ArithmeticScoreLine, span).with_fix(fix))
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn arithmetic_score_line_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let text = span.slice(source);
+    let body = text.strip_prefix('(')?.strip_suffix(')')?;
+    Some((span, Fix::safe_edit(Edit::replacement(body, span))))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_redundant_parentheses_in_assignment_arithmetic() {
@@ -41,5 +64,19 @@ mod tests {
             test_snippet(source, &LinterSettings::for_rule(Rule::ArithmeticScoreLine));
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_safe_fix_to_redundant_arithmetic_parentheses() {
+        let source = "#!/bin/bash\nscore=$(( (1 + 2) ))\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ArithmeticScoreLine),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/bash\nscore=$(( 1 + 2 ))\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/array_index_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/array_index_arithmetic.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct ArrayIndexArithmetic;
 
 impl Violation for ArrayIndexArithmetic {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::ArrayIndexArithmetic
     }
@@ -10,19 +14,33 @@ impl Violation for ArrayIndexArithmetic {
     fn message(&self) -> String {
         "remove the `$((...))` wrapper from array subscripts".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the arithmetic expansion wrapper".to_owned())
+    }
 }
 
 pub fn array_index_arithmetic(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.array_index_arithmetic_spans(),
-        || ArrayIndexArithmetic,
-    );
+    let source = checker.source();
+    checker.report_fact_diagnostics_dedup(|facts, report| {
+        for span in facts.array_index_arithmetic_spans().iter().copied() {
+            if let Some(fix) = array_index_arithmetic_fix(span, source) {
+                report(Diagnostic::new(ArrayIndexArithmetic, span).with_fix(fix));
+            }
+        }
+    });
+}
+
+fn array_index_arithmetic_fix(span: Span, source: &str) -> Option<Fix> {
+    let text = span.slice(source);
+    let body = text.strip_prefix("$((")?.strip_suffix("))")?;
+    Some(Fix::safe_edit(Edit::replacement(body, span)))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_arithmetic_expansions_inside_assignment_subscripts() {
@@ -61,6 +79,20 @@ mod tests {
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_safe_fix_to_array_index_arithmetic_wrapper() {
+        let source = "#!/bin/bash\narr[$((1+1))]=x\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ArrayIndexArithmetic),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/bash\narr[1+1]=x\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
+++ b/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
@@ -59,16 +59,23 @@ fn let_command_fix(source: &str, fact: crate::facts::CommandFactRef<'_, '_>) -> 
     let last_arg = args.last()?;
     let operands = args
         .iter()
-        .map(|word| {
-            word.quoted_content_span_in_source(source).map_or_else(
-                || word.span.slice(source).to_owned(),
-                |span| span.slice(source).to_owned(),
-            )
-        })
+        .map(|word| let_operand_text(source, word))
+        .filter(|operand| operand != "--")
         .collect::<Vec<_>>();
+    if operands.is_empty() {
+        return None;
+    }
+
     let replacement = format!("(( {} ))", operands.join(", "));
     let span = Span::from_positions(name.span.start, last_arg.span.end);
     Some(Fix::unsafe_edit(Edit::replacement(replacement, span)))
+}
+
+fn let_operand_text(source: &str, word: &shuck_ast::Word) -> String {
+    word.quoted_content_span_in_source(source).map_or_else(
+        || word.span.slice(source).to_owned(),
+        |span| span.slice(source).to_owned(),
+    )
 }
 
 fn let_command_span(source: &str, fact: crate::facts::CommandFactRef<'_, '_>) -> Option<Span> {
@@ -168,5 +175,33 @@ mod tests {
             "#!/usr/bin/env bash\n(( count+=1, total %= RANGE ))\n"
         );
         assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_without_option_sentinel_operand() {
+        let source = "#!/usr/bin/env bash\nlet -- i=1\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AvoidLetBuiltin),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/usr/bin/env bash\n(( i=1 ))\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn skips_unsafe_fix_for_only_option_sentinel_operand() {
+        let source = "#!/usr/bin/env bash\nlet --\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AvoidLetBuiltin),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
     }
 }

--- a/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
+++ b/crates/shuck-linter/src/rules/style/avoid_let_builtin.rs
@@ -1,16 +1,22 @@
 use shuck_ast::Span;
 
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct AvoidLetBuiltin;
 
 impl Violation for AvoidLetBuiltin {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::AvoidLetBuiltin
     }
 
     fn message(&self) -> String {
         "prefer arithmetic expansion instead of `let`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite `let` as an arithmetic command".to_owned())
     }
 }
 
@@ -19,15 +25,50 @@ pub fn avoid_let_builtin(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let source = checker.source();
+    let reports = checker
         .facts()
         .commands()
         .iter()
         .filter(|fact| fact.wrappers().is_empty() && fact.effective_name_is("let"))
-        .filter_map(|fact| let_command_span(checker.source(), fact))
+        .filter_map(|fact| {
+            Some(LetCommandReport {
+                diagnostic_span: let_command_span(source, fact)?,
+                fix: let_command_fix(source, fact),
+            })
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || AvoidLetBuiltin);
+    for report in reports {
+        let mut diagnostic = Diagnostic::new(AvoidLetBuiltin, report.diagnostic_span);
+        if let Some(fix) = report.fix {
+            diagnostic = diagnostic.with_fix(fix);
+        }
+        checker.report_diagnostic(diagnostic);
+    }
+}
+
+struct LetCommandReport {
+    diagnostic_span: Span,
+    fix: Option<Fix>,
+}
+
+fn let_command_fix(source: &str, fact: crate::facts::CommandFactRef<'_, '_>) -> Option<Fix> {
+    let name = fact.body_name_word()?;
+    let args = fact.body_args();
+    let last_arg = args.last()?;
+    let operands = args
+        .iter()
+        .map(|word| {
+            word.quoted_content_span_in_source(source).map_or_else(
+                || word.span.slice(source).to_owned(),
+                |span| span.slice(source).to_owned(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let replacement = format!("(( {} ))", operands.join(", "));
+    let span = Span::from_positions(name.span.start, last_arg.span.end);
+    Some(Fix::unsafe_edit(Edit::replacement(replacement, span)))
 }
 
 fn let_command_span(source: &str, fact: crate::facts::CommandFactRef<'_, '_>) -> Option<Span> {
@@ -68,8 +109,8 @@ fn let_argument_end(source: &str, word: &shuck_ast::Word) -> shuck_ast::Position
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_let_builtin_in_bash() {
@@ -110,5 +151,22 @@ mod tests {
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AvoidLetBuiltin));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_rewrite_let_builtin() {
+        let source = "#!/usr/bin/env bash\nlet count+=1 \"total %= RANGE\"\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AvoidLetBuiltin),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/usr/bin/env bash\n(( count+=1, total %= RANGE ))\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
+++ b/crates/shuck-linter/src/rules/style/bare_command_name_assignment.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct BareCommandNameAssignment;
 
 impl Violation for BareCommandNameAssignment {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::BareCommandNameAssignment
     }
@@ -11,19 +15,51 @@ impl Violation for BareCommandNameAssignment {
         "bare command-like text in an assignment should be quoted or captured with `$(...)`"
             .to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the assignment value".to_owned())
+    }
 }
 
 pub fn bare_command_name_assignment(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.bare_command_name_assignment_spans(),
-        || BareCommandNameAssignment,
-    );
+    let source = checker.source();
+    checker.report_fact_diagnostics_dedup(|facts, report| {
+        for span in facts.bare_command_name_assignment_spans().iter().copied() {
+            let diagnostic = Diagnostic::new(BareCommandNameAssignment, span);
+            report(match quote_assignment_value_fix(span, source) {
+                Some(fix) => diagnostic.with_fix(fix),
+                None => diagnostic,
+            });
+        }
+    });
+}
+
+fn quote_assignment_value_fix(span: Span, source: &str) -> Option<Fix> {
+    let line = source
+        .get(span.start.offset..)?
+        .split_inclusive('\n')
+        .next()?;
+    let eq_relative = line.find('=')?;
+    let value_start = span.start.offset + eq_relative + 1;
+    let value_text = source.get(value_start..)?;
+    let value_len = value_text
+        .chars()
+        .take_while(|ch| !ch.is_whitespace() && *ch != ';')
+        .map(char::len_utf8)
+        .sum::<usize>();
+    if value_len == 0 {
+        return None;
+    }
+    Some(Fix::safe_edits([
+        Edit::insertion(value_start, "\""),
+        Edit::insertion(value_start + value_len, "\""),
+    ]))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_plain_assignments_and_single_assignment_command_prefixes() {
@@ -77,6 +113,20 @@ f() {
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_by_quoting_literal_assignment_value() {
+        let source = "#!/bin/sh\ntool=grep\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::BareCommandNameAssignment),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\ntool=\"grep\"\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/command_output_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/command_output_array_split.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CommandOutputArraySplit;
 
 impl Violation for CommandOutputArraySplit {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::CommandOutputArraySplit
     }
@@ -10,10 +14,15 @@ impl Violation for CommandOutputArraySplit {
     fn message(&self) -> String {
         "avoid splitting command output directly into arrays; use mapfile or read -a".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the command substitution in the array assignment".to_owned())
+    }
 }
 
 pub fn command_output_array_split(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .array_assignment_split_word_facts()
         .flat_map(|fact| {
@@ -21,17 +30,27 @@ pub fn command_output_array_split(checker: &mut Checker) {
                 .iter()
                 .copied()
         })
+        .map(|span| {
+            Diagnostic::new(CommandOutputArraySplit, span)
+                .with_fix(Fix::unsafe_edit(double_quote_span_edit(span, source)))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || CommandOutputArraySplit);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn double_quote_span_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("\"{}\"", span.slice(source)), span)
 }
 
 #[cfg(test)]
 mod tests {
     use std::path::Path;
 
-    use crate::test::{test_snippet, test_snippet_at_path};
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_at_path, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_unquoted_command_substitutions_in_array_assignments() {
@@ -59,6 +78,23 @@ arr+=($(printf '%s\\n' tail))
                 "$(printf '%s\\n' tail)"
             ]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_quoting_command_substitution_in_array_assignment() {
+        let source = "#!/bin/bash\narr=($(printf '%s\\n' a b))\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CommandOutputArraySplit),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\narr=(\"$(printf '%s\\n' a b)\")\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/default_value_in_colon_assign.rs
+++ b/crates/shuck-linter/src/rules/style/default_value_in_colon_assign.rs
@@ -1,10 +1,13 @@
 use rustc_hash::FxHashSet;
+use shuck_ast::Span;
 
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation};
 
 pub struct DefaultValueInColonAssign;
 
 impl Violation for DefaultValueInColonAssign {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::DefaultValueInColonAssign
     }
@@ -12,6 +15,10 @@ impl Violation for DefaultValueInColonAssign {
     fn message(&self) -> String {
         "quote default-assignment expansions passed to ':' to avoid splitting and globbing"
             .to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the default-assignment expansion".to_owned())
     }
 }
 
@@ -24,20 +31,31 @@ pub fn default_value_in_colon_assign(checker: &mut Checker) {
         .map(|fact| fact.id())
         .collect::<FxHashSet<_>>();
 
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .expansion_word_facts(ExpansionContext::CommandArgument)
         .filter(|fact| colon_command_ids.contains(&fact.command_id()))
         .flat_map(|fact| fact.unquoted_assign_default_spans())
+        .map(|span| {
+            Diagnostic::new(DefaultValueInColonAssign, span)
+                .with_fix(Fix::safe_edit(double_quote_span_edit(span, source)))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || DefaultValueInColonAssign);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn double_quote_span_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("\"{}\"", span.slice(source)), span)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_unquoted_assign_default_expansions_passed_to_colon() {
@@ -86,5 +104,19 @@ printf '%s\\n' ${x:=fallback}
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_by_quoting_default_assignment_expansion() {
+        let source = "#!/bin/bash\n: ${x:=fallback}\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DefaultValueInColonAssign),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/bash\n: \"${x:=fallback}\"\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
+++ b/crates/shuck-linter/src/rules/style/dollar_in_arithmetic.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct DollarInArithmetic;
 
 impl Violation for DollarInArithmetic {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::DollarInArithmetic
     }
@@ -10,19 +14,45 @@ impl Violation for DollarInArithmetic {
     fn message(&self) -> String {
         "omit the `$` prefix inside arithmetic".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the redundant arithmetic `$`".to_owned())
+    }
 }
 
 pub fn dollar_in_arithmetic(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.dollar_in_arithmetic_spans(),
-        || DollarInArithmetic,
-    );
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .dollar_in_arithmetic_spans()
+        .iter()
+        .copied()
+        .filter_map(|span| dollar_in_arithmetic_fix(span, source))
+        .map(|(span, fix)| Diagnostic::new(DollarInArithmetic, span).with_fix(fix))
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn dollar_in_arithmetic_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let text = span.slice(source);
+    let replacement = if let Some(body) = text
+        .strip_prefix("${")
+        .and_then(|text| text.strip_suffix('}'))
+    {
+        body
+    } else {
+        text.strip_prefix('$')?
+    };
+    Some((span, Fix::safe_edit(Edit::replacement(replacement, span))))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_dollar_prefixed_arithmetic_variables_in_assignments() {
@@ -49,6 +79,23 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "${x}");
+    }
+
+    #[test]
+    fn applies_safe_fix_to_dollar_prefixed_arithmetic_variables() {
+        let source = "#!/bin/bash\nx=1\nprintf '%s\\n' \"$(( $x + ${x} ))\"\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DollarInArithmetic),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\nx=1\nprintf '%s\\n' \"$(( x + x ))\"\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
+++ b/crates/shuck-linter/src/rules/style/double_quote_nesting.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation};
 
 pub struct DoubleQuoteNesting;
 
 impl Violation for DoubleQuoteNesting {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::DoubleQuoteNesting
     }
 
     fn message(&self) -> String {
         "a double-quoted expansion is nested between reopened double-quoted text".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("merge the reopened double quotes".to_owned())
     }
 }
 
@@ -21,7 +27,7 @@ fn span_is_strictly_inside(span: &shuck_ast::Span, host: &shuck_ast::Span) -> bo
 
 pub fn double_quote_nesting(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .expansion_word_facts(ExpansionContext::CommandName)
         .chain(
@@ -62,23 +68,34 @@ pub fn double_quote_nesting(checker: &mut Checker) {
                         .iter()
                         .any(|host| span_is_strictly_inside(span, host))
                 })
+                .map(move |diagnostic_span| {
+                    Diagnostic::new(DoubleQuoteNesting, diagnostic_span).with_fix(Fix::safe_edit(
+                        Edit::replacement(
+                            fact.single_double_quoted_replacement(source),
+                            fact.span(),
+                        ),
+                    ))
+                })
         })
         .chain(
             checker
                 .facts()
                 .comment_double_quote_nesting_spans()
                 .iter()
-                .copied(),
+                .copied()
+                .map(|span| Diagnostic::new(DoubleQuoteNesting, span)),
         )
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || DoubleQuoteNesting);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_unquoted_scalar_expansions_between_double_quoted_segments() {
@@ -110,6 +127,23 @@ value=\"\n-DLZ4_HOME=\"${TERMUX_PREFIX}\"\n-DPROTOBUF_HOME=\"$(printf '%s' proto
                 "$(printf '%s' proto)"
             ]
         );
+    }
+
+    #[test]
+    fn applies_safe_fix_to_merge_reopened_double_quoted_segments() {
+        let source = "#!/bin/bash\necho \"$PIDFILE exists, skipping \"$INTERVAL\" run\"\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DoubleQuoteNesting),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\necho \"${PIDFILE} exists, skipping ${INTERVAL} run\"\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/echo_here_doc.rs
+++ b/crates/shuck-linter/src/rules/style/echo_here_doc.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Locator, Rule, Violation};
 
 pub struct EchoHereDoc;
 
 impl Violation for EchoHereDoc {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::EchoHereDoc
     }
@@ -10,16 +14,116 @@ impl Violation for EchoHereDoc {
     fn message(&self) -> String {
         "here-document input on `echo` is ignored".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the ignored here-document".to_owned())
+    }
 }
 
 pub fn echo_here_doc(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(|facts| facts.echo_here_doc_spans(), || EchoHereDoc);
+    let locator = checker.locator();
+    let spans = checker.facts().echo_here_doc_spans().to_vec();
+    for span in spans {
+        let mut diagnostic = Diagnostic::new(EchoHereDoc, span);
+        if let Some(fix) = echo_here_doc_fix(locator, span) {
+            diagnostic = diagnostic.with_fix(fix);
+        }
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn echo_here_doc_fix(locator: Locator<'_>, span: Span) -> Option<Fix> {
+    let source = locator.source();
+    let span_text = span.slice(source);
+    let operator_offset = span_text.find("<<")?;
+    let redirect_start = span.start.offset + operator_offset;
+    let marker = heredoc_marker_from_redirect_text(&span_text[operator_offset..])?;
+    if marker.name.is_empty() {
+        return None;
+    }
+
+    let line_range = locator.line_range(span.start.line)?;
+    let line_start = usize::from(line_range.start());
+    let header_delete_start = preceding_space_start(source, redirect_start, line_start);
+    let body_start = locator
+        .line_index()
+        .line_start(span.start.line + 1)
+        .map(usize::from)
+        .unwrap_or(source.len());
+    let body_end = heredoc_body_end(locator, span.start.line + 1, &marker)?;
+
+    Some(Fix::unsafe_edits([
+        Edit::deletion_at(header_delete_start, span.end.offset),
+        Edit::deletion_at(body_start, body_end),
+    ]))
+}
+
+struct HeredocMarker {
+    name: String,
+    strip_tabs: bool,
+}
+
+fn heredoc_marker_from_redirect_text(text: &str) -> Option<HeredocMarker> {
+    let mut marker = text.strip_prefix("<<")?;
+    let strip_tabs = marker.starts_with('-');
+    if strip_tabs {
+        marker = &marker[1..];
+    }
+    let name = marker
+        .trim()
+        .trim_matches(|ch| matches!(ch, '\'' | '"' | '\\'))
+        .to_owned();
+    Some(HeredocMarker { name, strip_tabs })
+}
+
+fn heredoc_body_end(
+    locator: Locator<'_>,
+    mut line_number: usize,
+    marker: &HeredocMarker,
+) -> Option<usize> {
+    let source = locator.source();
+    loop {
+        let line_range = locator.line_range(line_number)?;
+        let line_start = usize::from(line_range.start());
+        let line_end = trim_cr_end(source, usize::from(line_range.end()));
+        let line = source.get(line_start..line_end)?;
+        let candidate = if marker.strip_tabs {
+            line.trim_start_matches('\t')
+        } else {
+            line
+        };
+        if candidate == marker.name {
+            return Some(
+                locator
+                    .line_index()
+                    .line_start(line_number + 1)
+                    .map(usize::from)
+                    .unwrap_or(source.len()),
+            );
+        }
+        line_number += 1;
+    }
+}
+
+fn preceding_space_start(source: &str, mut offset: usize, floor: usize) -> usize {
+    while offset > floor && matches!(source.as_bytes().get(offset - 1), Some(b' ' | b'\t')) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn trim_cr_end(source: &str, offset: usize) -> usize {
+    if offset > 0 && matches!(source.as_bytes().get(offset - 1), Some(b'\r')) {
+        offset - 1
+    } else {
+        offset
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_heredoc_attached_to_echo() {
@@ -62,5 +166,19 @@ EOF
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::EchoHereDoc));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_delete_echo_heredoc_redirect_and_body() {
+        let source = "#!/bin/sh\necho <<EOF\nhi\nEOF\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::EchoHereDoc),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\necho\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/echoed_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/echoed_command_substitution.rs
@@ -1,11 +1,15 @@
+use shuck_ast::Span;
+
 use crate::{
-    Checker, CommandSubstitutionKind, ExpansionContext, Rule, SubstitutionHostKind, Violation,
-    WordFactContext,
+    Checker, CommandSubstitutionKind, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability,
+    Rule, SubstitutionHostKind, Violation, WordFactContext,
 };
 
 pub struct EchoedCommandSubstitution;
 
 impl Violation for EchoedCommandSubstitution {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::EchoedCommandSubstitution
     }
@@ -13,15 +17,21 @@ impl Violation for EchoedCommandSubstitution {
     fn message(&self) -> String {
         "call the command directly instead of echoing its substitution".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the echo wrapper".to_owned())
+    }
 }
 
 pub fn echoed_command_substitution(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let reports = checker
         .facts()
         .commands()
         .iter()
         .filter(|fact| fact.effective_name_is("echo"))
         .filter_map(|fact| {
+            let name = fact.body_name_word()?;
             let [word] = fact.body_args() else {
                 return None;
             };
@@ -47,17 +57,58 @@ pub fn echoed_command_substitution(checker: &mut Checker) {
                                     && !substitution.unquoted_in_host()))
                     })
                 })
-                .map(|_| word.span)
+                .map(|_| EchoedCommandSubstitutionReport {
+                    diagnostic_span: word.span,
+                    fix_span: Span::from_positions(name.span.start, word.span.end),
+                })
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || EchoedCommandSubstitution);
+    for report in reports {
+        let mut diagnostic = Diagnostic::new(EchoedCommandSubstitution, report.diagnostic_span);
+        if let Some(fix) =
+            echoed_command_substitution_fix(source, report.diagnostic_span, report.fix_span)
+        {
+            diagnostic = diagnostic.with_fix(fix);
+        }
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+struct EchoedCommandSubstitutionReport {
+    diagnostic_span: Span,
+    fix_span: Span,
+}
+
+fn echoed_command_substitution_fix(
+    source: &str,
+    diagnostic_span: Span,
+    fix_span: Span,
+) -> Option<Fix> {
+    let text = diagnostic_span.slice(source);
+    let body = command_substitution_body(text)?;
+    Some(Fix::unsafe_edit(Edit::replacement(body, fix_span)))
+}
+
+fn command_substitution_body(text: &str) -> Option<&str> {
+    let unquoted = text
+        .strip_prefix('"')
+        .and_then(|inner| inner.strip_suffix('"'))
+        .unwrap_or(text);
+    unquoted
+        .strip_prefix("$(")
+        .and_then(|inner| inner.strip_suffix(')'))
+        .or_else(|| {
+            unquoted
+                .strip_prefix('`')
+                .and_then(|inner| inner.strip_suffix('`'))
+        })
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn only_reports_plain_command_substitutions() {
@@ -144,5 +195,22 @@ value=$(echo $(printf '%s\n' one; printf '%s\n' two) | tr -d ' ')
                 .collect::<Vec<_>>(),
             vec!["$(basename $filename .fuzz)"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_remove_echo_wrapper() {
+        let source = "#!/bin/sh\necho \"$(date)\"\necho $(basename \"$path\" .txt)\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::EchoedCommandSubstitution),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\ndate\nbasename \"$path\" .txt\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
+++ b/crates/shuck-linter/src/rules/style/heredoc_end_space.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct HeredocEndSpace;
 
 impl Violation for HeredocEndSpace {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::HeredocEndSpace
     }
@@ -10,16 +14,48 @@ impl Violation for HeredocEndSpace {
     fn message(&self) -> String {
         "remove trailing whitespace after this here-document terminator".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete the trailing heredoc terminator whitespace".to_owned())
+    }
 }
 
 pub fn heredoc_end_space(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(|facts| facts.heredoc_end_space_spans(), || HeredocEndSpace);
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .heredoc_end_space_spans()
+        .iter()
+        .copied()
+        .filter_map(|span| heredoc_end_space_fix(span, source))
+        .map(|(span, fix)| Diagnostic::new(HeredocEndSpace, span).with_fix(fix))
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn heredoc_end_space_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let start = span.start.offset;
+    let rest = source.get(start..)?;
+    let len = rest
+        .chars()
+        .take_while(|ch| matches!(ch, ' ' | '\t'))
+        .map(char::len_utf8)
+        .sum::<usize>();
+    (len > 0).then(|| {
+        (
+            span,
+            Fix::unsafe_edit(Edit::deletion_at(start, start + len)),
+        )
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_trailing_space_after_heredoc_terminator() {
@@ -79,6 +115,20 @@ cat <<-EOF
         assert_eq!(diagnostics[0].span.end.line, 4);
         assert_eq!(diagnostics[0].span.end.column, 4);
         assert_eq!(diagnostics[0].span.slice(source), "");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_deleting_trailing_heredoc_terminator_space() {
+        let source = "#!/bin/sh\ncat <<EOF\nok\nEOF  \t\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::HeredocEndSpace),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\ncat <<EOF\nok\nEOF\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/legacy_arithmetic_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/legacy_arithmetic_expansion.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct LegacyArithmeticExpansion;
 
 impl Violation for LegacyArithmeticExpansion {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LegacyArithmeticExpansion
     }
@@ -10,23 +14,40 @@ impl Violation for LegacyArithmeticExpansion {
     fn message(&self) -> String {
         "prefer `$((...))` over legacy `$[...]` arithmetic expansion".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite as `$((...))`".to_owned())
+    }
 }
 
 pub fn legacy_arithmetic_expansion(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .legacy_arithmetic_fragments()
         .iter()
-        .map(|fragment| fragment.span())
+        .filter_map(|fragment| legacy_arithmetic_fix(fragment.span(), source))
+        .map(|(span, fix)| Diagnostic::new(LegacyArithmeticExpansion, span).with_fix(fix))
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || LegacyArithmeticExpansion);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn legacy_arithmetic_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let text = span.slice(source);
+    let body = text.strip_prefix("$[")?.strip_suffix(']')?;
+    Some((
+        span,
+        Fix::safe_edit(Edit::replacement(format!("$(({body}))"), span)),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn anchors_on_each_legacy_arithmetic_fragment() {
@@ -60,5 +81,19 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["$[$[1 + 2] + 3]", "$[1 + 2]"]
         );
+    }
+
+    #[test]
+    fn applies_safe_fix_to_legacy_arithmetic_fragments() {
+        let source = "#!/bin/bash\necho $[1 + 2]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LegacyArithmeticExpansion),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/bash\necho $((1 + 2))\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/linebreak_before_and.rs
+++ b/crates/shuck-linter/src/rules/style/linebreak_before_and.rs
@@ -1,14 +1,20 @@
-use crate::{Rule, Violation};
+use crate::{FixAvailability, Rule, Violation};
 
 pub struct LinebreakBeforeAnd;
 
 impl Violation for LinebreakBeforeAnd {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LinebreakBeforeAnd
     }
 
     fn message(&self) -> String {
         "control operator starts a new line instead of ending the previous one".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("move the control operator to the previous line".to_owned())
     }
 }
 

--- a/crates/shuck-linter/src/rules/style/literal_backslash.rs
+++ b/crates/shuck-linter/src/rules/style/literal_backslash.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, ExpansionContext, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation};
 
 pub struct LiteralBackslash;
 
 impl Violation for LiteralBackslash {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LiteralBackslash
     }
@@ -10,12 +12,16 @@ impl Violation for LiteralBackslash {
     fn message(&self) -> String {
         "a backslash before a normal letter is literal".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the literal backslash".to_owned())
+    }
 }
 
 pub fn literal_backslash(checker: &mut Checker) {
     let source = checker.source();
     let facts = checker.facts();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .word_facts()
         .iter()
@@ -24,9 +30,17 @@ pub fn literal_backslash(checker: &mut Checker) {
         .filter(|fact| !is_command_name_word(facts, *fact))
         .filter(|fact| !is_unalias_argument(facts, *fact))
         .filter_map(|fact| fact.standalone_literal_backslash_span(source))
+        .map(|span| {
+            Diagnostic::new(LiteralBackslash, span).with_fix(Fix::safe_edit(Edit::deletion_at(
+                span.start.offset,
+                span.start.offset + 1,
+            )))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || LiteralBackslash);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn is_relevant_word_context(context: Option<ExpansionContext>) -> bool {
@@ -62,8 +76,8 @@ fn is_unalias_argument<'a>(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_literal_backslashes_before_normal_letters() {
@@ -92,5 +106,19 @@ echo '\\q'
                 .collect::<Vec<_>>(),
             vec!["", ""]
         );
+    }
+
+    #[test]
+    fn applies_safe_fix_to_literal_backslash_words() {
+        let source = "#!/bin/sh\necho \\q\nprintf '%s\\n' \\w\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralBackslash),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(result.fixed_source, "#!/bin/sh\necho q\nprintf '%s\\n' w\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/literal_braces.rs
+++ b/crates/shuck-linter/src/rules/style/literal_braces.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct LiteralBraces;
 
 impl Violation for LiteralBraces {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::LiteralBraces
     }
@@ -10,16 +12,27 @@ impl Violation for LiteralBraces {
     fn message(&self) -> String {
         "literal braces may be interpreted as brace syntax".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("escape the literal brace".to_owned())
+    }
 }
 
 pub fn literal_braces(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(|facts| facts.literal_brace_spans(), || LiteralBraces);
+    checker.report_fact_diagnostics_dedup(|facts, report| {
+        for span in facts.literal_brace_spans().iter().copied() {
+            report(
+                Diagnostic::new(LiteralBraces, span)
+                    .with_fix(Fix::safe_edit(Edit::insertion(span.start.offset, "\\"))),
+            );
+        }
+    });
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_literal_unquoted_brace_pair_edges() {
@@ -29,6 +42,20 @@ mod tests {
         assert_eq!(diagnostics.len(), 2);
         assert_eq!(diagnostics[0].span.start.column, 11);
         assert_eq!(diagnostics[1].span.start.column, 13);
+    }
+
+    #[test]
+    fn applies_safe_fix_to_literal_braces() {
+        let source = "#!/bin/bash\necho HEAD@{1}\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::LiteralBraces),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(result.fixed_source, "#!/bin/bash\necho HEAD@\\{1\\}\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
+++ b/crates/shuck-linter/src/rules/style/mixed_quote_word.rs
@@ -1,8 +1,15 @@
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFactHostKind};
+use shuck_ast::Span;
+
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation,
+    WordFactHostKind,
+};
 
 pub struct MixedQuoteWord;
 
 impl Violation for MixedQuoteWord {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::MixedQuoteWord
     }
@@ -10,11 +17,16 @@ impl Violation for MixedQuoteWord {
     fn message(&self) -> String {
         "avoid mixing bare fragments between reopened double-quoted text".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the word as one double-quoted string".to_owned())
+    }
 }
 
 pub fn mixed_quote_word(checker: &mut Checker) {
     let facts = checker.facts();
-    let spans = [
+    let source = checker.source();
+    let reports = [
         ExpansionContext::CommandName,
         ExpansionContext::CommandArgument,
         ExpansionContext::AssignmentValue,
@@ -27,19 +39,38 @@ pub fn mixed_quote_word(checker: &mut Checker) {
     .chain(facts.case_subject_facts())
     .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
     .flat_map(|fact| {
+        let replacement_span = fact.span();
+        let replacement = fact.single_double_quoted_replacement(source);
         fact.unquoted_literal_between_double_quoted_segments_spans()
             .iter()
             .copied()
+            .map(move |diagnostic_span| MixedQuoteWordReport {
+                diagnostic_span,
+                replacement_span,
+                replacement: replacement.clone(),
+            })
     })
     .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || MixedQuoteWord);
+    for report in reports {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(MixedQuoteWord, report.diagnostic_span).with_fix(Fix::safe_edit(
+                Edit::replacement(report.replacement, report.replacement_span),
+            )),
+        );
+    }
+}
+
+struct MixedQuoteWordReport {
+    diagnostic_span: Span,
+    replacement_span: Span,
+    replacement: Box<str>,
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_bare_fragments_between_reopened_double_quotes() {
@@ -61,6 +92,23 @@ case x in \"foo\"bar\"baz\") : ;; esac
                 .collect::<Vec<_>>(),
             vec!["middle", "-", "bar", "bar", "bar", "bar"]
         );
+    }
+
+    #[test]
+    fn applies_safe_fix_to_rewrite_mixed_quote_words() {
+        let source = "#!/bin/bash\nprintf '%s\\n' \"left \"middle\" right\" \"foo\"-\"bar\"\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::MixedQuoteWord),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\nprintf '%s\\n' \"left middle right\" \"foo-bar\"\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
+++ b/crates/shuck-linter/src/rules/style/quoted_dollar_star_loop.rs
@@ -1,9 +1,13 @@
 use crate::facts::word_spans;
-use crate::{Checker, Rule, Violation, WordQuote};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation, WordQuote};
 
 pub struct QuotedDollarStarLoop;
 
 impl Violation for QuotedDollarStarLoop {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::QuotedDollarStarLoop
     }
@@ -11,10 +15,14 @@ impl Violation for QuotedDollarStarLoop {
     fn message(&self) -> String {
         "fully quoted loop-list expansions collapse into one value".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the loop-list quotes".to_owned())
+    }
 }
 
 pub fn quoted_dollar_star_loop(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .for_headers()
         .iter()
@@ -37,15 +45,32 @@ pub fn quoted_dollar_star_loop(checker: &mut Checker) {
                 || !word_spans::word_quoted_star_splat_spans(word.word()).is_empty())
             .then_some(word.span())
         })
+        .filter_map(quoted_loop_word_fix)
+        .map(|(span, fix)| Diagnostic::new(QuotedDollarStarLoop, span).with_fix(fix))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || QuotedDollarStarLoop);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn quoted_loop_word_fix(span: Span) -> Option<(Span, Fix)> {
+    if span.end.offset < span.start.offset + 2 {
+        return None;
+    }
+    Some((
+        span,
+        Fix::unsafe_edits([
+            Edit::deletion_at(span.start.offset, span.start.offset + 1),
+            Edit::deletion_at(span.end.offset - 1, span.end.offset),
+        ]),
+    ))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_fully_quoted_loop_list_expansions() {
@@ -100,6 +125,23 @@ done
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_unquoting_single_loop_list_word() {
+        let source = "#!/bin/bash\nfor item in \"$*\"; do :; done\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::QuotedDollarStarLoop),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\nfor item in $*; do :; done\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/read_without_raw.rs
+++ b/crates/shuck-linter/src/rules/style/read_without_raw.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct ReadWithoutRaw;
 
 impl Violation for ReadWithoutRaw {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::ReadWithoutRaw
     }
@@ -10,10 +12,14 @@ impl Violation for ReadWithoutRaw {
     fn message(&self) -> String {
         "use `read -r` to keep backslashes literal".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("add `-r` to `read`".to_owned())
+    }
 }
 
 pub fn read_without_raw(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -24,15 +30,21 @@ pub fn read_without_raw(checker: &mut Checker) {
                 .is_some_and(|read| !read.uses_raw_input)
         })
         .filter_map(|fact| fact.body_name_word().map(|word| word.span))
+        .map(|span| {
+            Diagnostic::new(ReadWithoutRaw, span)
+                .with_fix(Fix::unsafe_edit(Edit::insertion(span.end.offset, " -r")))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all(spans, || ReadWithoutRaw);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_plain_reads_and_nested_reads_without_raw_input() {
@@ -68,5 +80,19 @@ builtin read -r line
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_adding_raw_read_flag() {
+        let source = "#!/bin/sh\nread line\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::ReadWithoutRaw),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\nread -r line\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/single_quote_backslash.rs
+++ b/crates/shuck-linter/src/rules/style/single_quote_backslash.rs
@@ -1,10 +1,12 @@
 use shuck_ast::Span;
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SingleQuoteBackslash;
 
 impl Violation for SingleQuoteBackslash {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SingleQuoteBackslash
     }
@@ -12,18 +14,29 @@ impl Violation for SingleQuoteBackslash {
     fn message(&self) -> String {
         "a backslash at the end of a single-quoted string is literal".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("move the trailing backslash outside the quotes".to_owned())
+    }
 }
 
 pub fn single_quote_backslash(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .single_quoted_fragments()
         .iter()
         .filter_map(|fragment| single_quoted_fragment_backslash_span(fragment.span(), source))
+        .map(|span| {
+            Diagnostic::new(SingleQuoteBackslash, span).with_fix(Fix::safe_edit(
+                Edit::replacement_at(span.start.offset, span.start.offset + 2, "'\\\\"),
+            ))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || SingleQuoteBackslash);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn single_quoted_fragment_backslash_span(span: Span, source: &str) -> Option<Span> {
@@ -39,8 +52,8 @@ fn single_quoted_fragment_backslash_span(span: Span, source: &str) -> Option<Spa
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_backslash_at_end_of_single_quoted_string() {
@@ -76,5 +89,19 @@ printf '%s\\n' \"${dest_dir//\\'/\\'\\\\\\'\\'}\"
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_trailing_single_quote_backslash() {
+        let source = "#!/bin/sh\nprintf '%s\\n' 'foo\\'\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SingleQuoteBackslash),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\nprintf '%s\\n' 'foo'\\\\\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/spaced_tabstrip_close.rs
+++ b/crates/shuck-linter/src/rules/style/spaced_tabstrip_close.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SpacedTabstripClose;
 
 impl Violation for SpacedTabstripClose {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SpacedTabstripClose
     }
@@ -10,19 +14,48 @@ impl Violation for SpacedTabstripClose {
     fn message(&self) -> String {
         "this `<<-` closer must be indented with tabs only".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete spaces before the tab-stripped heredoc closer".to_owned())
+    }
 }
 
 pub fn spaced_tabstrip_close(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.spaced_tabstrip_close_spans(),
-        || SpacedTabstripClose,
-    );
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .spaced_tabstrip_close_spans()
+        .iter()
+        .copied()
+        .filter_map(|span| spaced_tabstrip_close_fix(span, source))
+        .map(|(span, fix)| Diagnostic::new(SpacedTabstripClose, span).with_fix(fix))
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn spaced_tabstrip_close_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let start = span.start.offset;
+    let line = source.get(start..)?.split_inclusive('\n').next()?;
+    let mut edits = Vec::new();
+    let mut offset = start;
+    for ch in line.chars() {
+        match ch {
+            ' ' => edits.push(Edit::deletion_at(offset, offset + 1)),
+            '\t' => {}
+            _ => break,
+        }
+        offset += ch.len_utf8();
+    }
+    (!edits.is_empty()).then(|| (span, Fix::unsafe_edits(edits)))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_space_indented_tabstrip_close_candidate() {
@@ -56,6 +89,20 @@ END
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 4);
         assert_eq!(diagnostics[0].span.start.column, 1);
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_deleting_spaces_before_tabstrip_close() {
+        let source = "#!/bin/sh\ncat <<-END\nx\n\t END\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SpacedTabstripClose),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\ncat <<-END\nx\n\tEND\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/trailing_directive.rs
+++ b/crates/shuck-linter/src/rules/style/trailing_directive.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Locator, Rule, Violation};
 
 pub struct TrailingDirective;
 
 impl Violation for TrailingDirective {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::TrailingDirective
     }
@@ -10,19 +12,68 @@ impl Violation for TrailingDirective {
     fn message(&self) -> String {
         "directive after code is ignored".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("move the directive before the command".to_owned())
+    }
 }
 
 pub fn trailing_directive(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.trailing_directive_comment_spans(),
-        || TrailingDirective,
-    );
+    let locator = checker.locator();
+    let spans = checker.facts().trailing_directive_comment_spans().to_vec();
+    for span in spans {
+        let mut diagnostic = Diagnostic::new(TrailingDirective, span);
+        if let Some(fix) = trailing_directive_fix(locator, span) {
+            diagnostic = diagnostic.with_fix(fix);
+        }
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn trailing_directive_fix(locator: Locator<'_>, span: shuck_ast::Span) -> Option<Fix> {
+    let source = locator.source();
+    let line_range = locator.line_range(span.start.line)?;
+    let line_start = usize::from(line_range.start());
+    let raw_line_end = usize::from(line_range.end());
+    let line_end = source
+        .get(..raw_line_end)
+        .filter(|_| raw_line_end > 0 && source.as_bytes()[raw_line_end - 1] == b'\r')
+        .map_or(raw_line_end, |_| raw_line_end - 1);
+    let comment_start = span.start.offset;
+    if comment_start < line_start || comment_start >= line_end {
+        return None;
+    }
+
+    let line = source.get(line_start..line_end)?;
+    let indent_len = line
+        .bytes()
+        .take_while(|byte| matches!(byte, b' ' | b'\t'))
+        .count();
+    let indent = &line[..indent_len];
+    let comment_text = source.get(comment_start..line_end)?;
+    let newline = if raw_line_end > line_end {
+        "\r\n"
+    } else {
+        "\n"
+    };
+
+    let mut delete_start = comment_start;
+    while delete_start > line_start
+        && matches!(source.as_bytes().get(delete_start - 1), Some(b' ' | b'\t'))
+    {
+        delete_start -= 1;
+    }
+
+    Some(Fix::safe_edits([
+        Edit::insertion(line_start, format!("{indent}{comment_text}{newline}")),
+        Edit::deletion_at(delete_start, line_end),
+    ]))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_inline_disable_directive() {
@@ -170,5 +221,22 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.start.line, 2);
+    }
+
+    #[test]
+    fn applies_safe_fix_to_move_directive_before_command() {
+        let source = "#!/bin/sh\n  : # shellcheck disable=2034\nfoo=1\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::TrailingDirective),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\n  # shellcheck disable=2034\n  :\nfoo=1\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_array_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_expansion.rs
@@ -1,8 +1,15 @@
-use crate::{Checker, ExpansionContext, Rule, ShellDialect, Violation};
+use shuck_ast::Span;
+
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, ShellDialect,
+    Violation,
+};
 
 pub struct UnquotedArrayExpansion;
 
 impl Violation for UnquotedArrayExpansion {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedArrayExpansion
     }
@@ -10,9 +17,14 @@ impl Violation for UnquotedArrayExpansion {
     fn message(&self) -> String {
         "quote array expansions to preserve element boundaries".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the array expansion".to_owned())
+    }
 }
 
 pub fn unquoted_array_expansion(checker: &mut Checker) {
+    let source = checker.source();
     let mut spans = [
         ExpansionContext::CommandName,
         ExpansionContext::CommandArgument,
@@ -42,13 +54,22 @@ pub fn unquoted_array_expansion(checker: &mut Checker) {
         );
     }
 
-    checker.report_all_dedup(spans, || UnquotedArrayExpansion);
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(UnquotedArrayExpansion, span)
+                .with_fix(Fix::unsafe_edit(double_quote_span_edit(span, source))),
+        );
+    }
+}
+
+fn double_quote_span_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("\"{}\"", span.slice(source)), span)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_inner_array_expansion_spans() {
@@ -68,6 +89,23 @@ printf '%s\\n' prefix${arr[@]}suffix ${arr[0]} ${names[*]}
                 .collect::<Vec<_>>(),
             vec!["${arr[@]}"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_quoting_array_expansions() {
+        let source = "#!/bin/bash\nprintf '%s\\n' ${arr[@]} $@\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedArrayExpansion),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\nprintf '%s\\n' \"${arr[@]}\" \"$@\"\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_array_split.rs
@@ -1,10 +1,12 @@
 use shuck_ast::Span;
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct UnquotedArraySplit;
 
 impl Violation for UnquotedArraySplit {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedArraySplit
     }
@@ -12,11 +14,15 @@ impl Violation for UnquotedArraySplit {
     fn message(&self) -> String {
         "quote array assignment expansions to avoid accidental splitting".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the array-assignment expansion".to_owned())
+    }
 }
 
 pub fn unquoted_array_split(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .array_assignment_split_word_facts()
         .flat_map(|fact| {
@@ -42,9 +48,15 @@ pub fn unquoted_array_split(checker: &mut Checker) {
                 .map(|(_, part_span)| part_span)
                 .collect::<Vec<_>>()
         })
+        .map(|span| {
+            Diagnostic::new(UnquotedArraySplit, span)
+                .with_fix(Fix::unsafe_edit(double_quote_span_edit(span, source)))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnquotedArraySplit);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn span_contains(outer: Span, inner: Span) -> bool {
@@ -55,10 +67,14 @@ fn is_excluded_special_parameter_span(span: Span, source: &str) -> bool {
     matches!(span.slice(source), "$!" | "$?" | "$$" | "$#" | "$-")
 }
 
+fn double_quote_span_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("\"{}\"", span.slice(source)), span)
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn reports_unquoted_expansions_in_array_assignments() {
@@ -90,6 +106,23 @@ arr+=($tail)
                 "$tail"
             ]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_quoting_array_assignment_expansions() {
+        let source = "#!/bin/bash\narr=($x ${items[@]})\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedArraySplit),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\narr=(\"$x\" \"${items[@]}\")\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_command_substitution.rs
@@ -1,16 +1,23 @@
 use crate::{
-    Checker, ExpansionContext, Rule, ShellDialect, Violation, WordFactHostKind, WordOccurrenceRef,
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, ShellDialect,
+    Violation, WordFactHostKind, WordOccurrenceRef,
 };
 
 pub struct UnquotedCommandSubstitution;
 
 impl Violation for UnquotedCommandSubstitution {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedCommandSubstitution
     }
 
     fn message(&self) -> String {
         "quote command substitutions in arguments to avoid word splitting".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the command substitution".to_owned())
     }
 }
 
@@ -40,7 +47,8 @@ pub fn unquoted_command_substitution(checker: &mut Checker) {
         .filter(|fact| !fact.body_has_commands())
         .map(|fact| fact.span())
         .collect::<Vec<_>>();
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .word_facts()
         .iter()
@@ -61,9 +69,16 @@ pub fn unquoted_command_substitution(checker: &mut Checker) {
                 })
                 .collect::<Vec<_>>()
         })
+        .map(|span| {
+            Diagnostic::new(UnquotedCommandSubstitution, span).with_fix(Fix::unsafe_edit(
+                Edit::replacement(format!("\"{}\"", span.slice(source)), span),
+            ))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnquotedCommandSubstitution);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn should_report_unquoted_command_substitution(
@@ -110,8 +125,8 @@ fn should_report_unquoted_command_substitution(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_inner_command_substitution_spans() {
@@ -128,6 +143,23 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["$(date)", "$(uname)"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_quoting_command_substitutions() {
+        let source = "#!/bin/bash\nprintf '%s\\n' $(printf arg)\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedCommandSubstitution),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\nprintf '%s\\n' \"$(printf arg)\"\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_dollar_star.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_dollar_star.rs
@@ -1,8 +1,15 @@
-use crate::{Checker, ExpansionContext, Rule, Violation, WordOccurrenceRef};
+use shuck_ast::Span;
+
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation,
+    WordOccurrenceRef,
+};
 
 pub struct UnquotedDollarStar;
 
 impl Violation for UnquotedDollarStar {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedDollarStar
     }
@@ -10,10 +17,15 @@ impl Violation for UnquotedDollarStar {
     fn message(&self) -> String {
         "quote star-splat expansions to preserve argument boundaries".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the star-splat expansion".to_owned())
+    }
 }
 
 pub fn unquoted_dollar_star(checker: &mut Checker) {
-    let spans = [
+    let source = checker.source();
+    let diagnostics = [
         ExpansionContext::CommandName,
         ExpansionContext::CommandArgument,
         ExpansionContext::ForList,
@@ -23,19 +35,29 @@ pub fn unquoted_dollar_star(checker: &mut Checker) {
     .flat_map(|context| checker.facts().expansion_word_facts(context))
     .filter(|fact| !fact.has_literal_affixes())
     .flat_map(unquoted_star_splat_spans)
+    .map(|span| {
+        Diagnostic::new(UnquotedDollarStar, span)
+            .with_fix(Fix::unsafe_edit(double_quote_span_edit(span, source)))
+    })
     .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnquotedDollarStar);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn unquoted_star_splat_spans(fact: WordOccurrenceRef<'_, '_>) -> Vec<shuck_ast::Span> {
     fact.unquoted_star_splat_spans()
 }
 
+fn double_quote_span_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("\"{}\"", span.slice(source)), span)
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_unquoted_star_splats_in_command_and_loop_list_contexts() {
@@ -90,5 +112,22 @@ if [[ $* == foo ]]; then :; fi
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedDollarStar));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_quoting_star_splats() {
+        let source = "#!/bin/bash\nprintf '%s\\n' $* ${arr[*]}\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedDollarStar),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\nprintf '%s\\n' \"$*\" \"${arr[*]}\"\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_expansion.rs
@@ -5,18 +5,25 @@ use shuck_ast::Span;
 
 use self::safe_value::{S001QuoteExposure, SafeValueIndex, SafeValueQuery};
 use crate::{
-    Checker, ExpansionContext, FactSpan, Locator, Rule, ShellDialect, Violation, WordOccurrenceRef,
+    Checker, Diagnostic, Edit, ExpansionContext, FactSpan, Fix, FixAvailability, Locator, Rule,
+    ShellDialect, Violation, WordOccurrenceRef,
 };
 
 pub struct UnquotedExpansion;
 
 impl Violation for UnquotedExpansion {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedExpansion
     }
 
     fn message(&self) -> String {
         "quote parameter expansions to avoid word splitting and globbing".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the parameter expansion".to_owned())
     }
 }
 
@@ -84,7 +91,12 @@ pub fn unquoted_expansion(checker: &mut Checker) {
         }
     }
     for span in spans {
-        checker.report_dedup(UnquotedExpansion, span);
+        checker.report_diagnostic_dedup(Diagnostic::new(UnquotedExpansion, span).with_fix(
+            Fix::unsafe_edit(Edit::replacement(
+                format!("\"{}\"", span.slice(source)),
+                span,
+            )),
+        ));
     }
 }
 

--- a/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_path_in_mkdir.rs
@@ -1,10 +1,16 @@
+use shuck_ast::Span;
 use shuck_ast::static_word_text;
 
-use crate::{Checker, CommandFactRef, ExpansionContext, Rule, Violation, WordFactContext};
+use crate::{
+    Checker, CommandFactRef, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule,
+    Violation, WordFactContext,
+};
 
 pub struct UnquotedPathInMkdir;
 
 impl Violation for UnquotedPathInMkdir {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedPathInMkdir
     }
@@ -12,12 +18,16 @@ impl Violation for UnquotedPathInMkdir {
     fn message(&self) -> String {
         "quote mkdir path expansions".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the mkdir path expansion".to_owned())
+    }
 }
 
 pub fn unquoted_path_in_mkdir(checker: &mut Checker) {
     let source = checker.source();
 
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -30,9 +40,15 @@ pub fn unquoted_path_in_mkdir(checker: &mut Checker) {
             )
         })
         .flat_map(|fact| fact.unquoted_scalar_expansion_spans().iter().copied())
+        .map(|span| {
+            Diagnostic::new(UnquotedPathInMkdir, span)
+                .with_fix(Fix::unsafe_edit(double_quote_span_edit(span, source)))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnquotedPathInMkdir);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn mkdir_path_operand_spans(command: CommandFactRef<'_, '_>, source: &str) -> Vec<shuck_ast::Span> {
@@ -101,10 +117,14 @@ fn is_mkdir_option(_span: shuck_ast::Span, text: &str, expects_mode_operand: &mu
     false
 }
 
+fn double_quote_span_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("\"{}\"", span.slice(source)), span)
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_unquoted_path_expansions_in_mkdir_operands() {
@@ -126,6 +146,20 @@ command mkdir $other
                 .collect::<Vec<_>>(),
             vec!["$dir", "$PKG", "$leaf", "${root}", "$other"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_quoting_mkdir_path_expansion() {
+        let source = "#!/bin/sh\nmkdir $dir\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedPathInMkdir),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\nmkdir \"$dir\"\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_tr_class.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_tr_class.rs
@@ -1,10 +1,16 @@
+use shuck_ast::Span;
 use shuck_ast::static_word_text;
 
-use crate::{Checker, ExpansionContext, Rule, Violation, WordFactContext, WordQuote};
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, Violation,
+    WordFactContext, WordQuote,
+};
 
 pub struct UnquotedTrClass;
 
 impl Violation for UnquotedTrClass {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedTrClass
     }
@@ -12,10 +18,15 @@ impl Violation for UnquotedTrClass {
     fn message(&self) -> String {
         "quote `tr` character class operands".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the `tr` character class".to_owned())
+    }
 }
 
 pub fn unquoted_tr_class(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -33,9 +44,15 @@ pub fn unquoted_tr_class(checker: &mut Checker) {
                 is_unquoted_tr_class(text.as_ref()).then_some(word.span)
             })
         })
+        .map(|span| {
+            Diagnostic::new(UnquotedTrClass, span)
+                .with_fix(Fix::unsafe_edit(single_quote_span_edit(span, source)))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnquotedTrClass);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn is_unquoted_tr_class(text: &str) -> bool {
@@ -47,10 +64,14 @@ fn is_unquoted_tr_class(text: &str) -> bool {
     !inner.is_empty() && inner.bytes().all(|byte| byte.is_ascii_lowercase())
 }
 
+fn single_quote_span_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("'{}'", span.slice(source)), span)
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_unquoted_tr_class_operands() {
@@ -93,5 +114,22 @@ printf '%s\\n' '[:lower:]'
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedTrClass));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_quoting_tr_character_classes() {
+        let source = "#!/bin/sh\ntr [:upper:] [:lower:]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedTrClass),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\ntr '[:upper:]' '[:lower:]'\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/unquoted_tr_range.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_tr_range.rs
@@ -1,10 +1,12 @@
-use shuck_ast::static_word_text;
+use shuck_ast::{Span, static_word_text};
 
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct UnquotedTrRange;
 
 impl Violation for UnquotedTrRange {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedTrRange
     }
@@ -12,10 +14,15 @@ impl Violation for UnquotedTrRange {
     fn message(&self) -> String {
         "quote `tr` character class and range operands".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the outer brackets from the `tr` set".to_owned())
+    }
 }
 
 pub fn unquoted_tr_range(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -26,9 +33,13 @@ pub fn unquoted_tr_range(checker: &mut Checker) {
                 is_bracketed_tr_set(text.as_ref()).then_some(word.span)
             })
         })
+        .filter_map(|span| unquoted_tr_range_fix(span, source))
+        .map(|(span, fix)| Diagnostic::new(UnquotedTrRange, span).with_fix(fix))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnquotedTrRange);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 fn is_bracketed_tr_set(text: &str) -> bool {
@@ -50,10 +61,27 @@ fn is_bracketed_tr_set(text: &str) -> bool {
         .any(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
 }
 
+fn unquoted_tr_range_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let text = span.slice(source);
+    let (prefix, body, suffix) =
+        if let Some(inner) = text.strip_prefix("'").and_then(|t| t.strip_suffix("'")) {
+            ("'", inner, "'")
+        } else if let Some(inner) = text.strip_prefix('"').and_then(|t| t.strip_suffix('"')) {
+            ("\"", inner, "\"")
+        } else {
+            ("", text, "")
+        };
+    let body = body.strip_prefix('[')?.strip_suffix(']')?;
+    Some((
+        span,
+        Fix::unsafe_edit(Edit::replacement(format!("{prefix}{body}{suffix}"), span)),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_bracketed_tr_operands() {
@@ -102,6 +130,20 @@ command tr x y
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::UnquotedTrRange));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_removing_outer_tr_range_brackets() {
+        let source = "#!/bin/sh\ntr '[A-Z]' [a-z]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedTrRange),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(result.fixed_source, "#!/bin/sh\ntr 'A-Z' a-z\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_variable_in_test.rs
@@ -1,12 +1,16 @@
+use shuck_ast::Span;
 use shuck_ast::static_word_text;
 
 use crate::{
-    Checker, ExpansionContext, Rule, SimpleTestShape, SimpleTestSyntax, Violation, WordFactContext,
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, SimpleTestShape,
+    SimpleTestSyntax, Violation, WordFactContext,
 };
 
 pub struct UnquotedVariableInTest;
 
 impl Violation for UnquotedVariableInTest {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedVariableInTest
     }
@@ -14,51 +18,57 @@ impl Violation for UnquotedVariableInTest {
     fn message(&self) -> String {
         "quote variable expansions in -n tests".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the variable expansion in the test".to_owned())
+    }
 }
 
 pub fn unquoted_variable_in_test(checker: &mut Checker) {
     let source = checker.source();
-    checker.report_fact_spans_dedup(
-        |facts, report| {
-            for fact in facts.commands() {
-                let Some(simple_test) = fact.simple_test() else {
-                    continue;
-                };
-                if simple_test.syntax() != SimpleTestSyntax::Bracket {
-                    continue;
-                }
-                if simple_test.shape() != SimpleTestShape::Unary
-                    || simple_test.operands().len() != 2
-                {
-                    continue;
-                }
-
-                let operator = simple_test.operands()[0];
-                if static_word_text(operator, source).as_deref() != Some("-n") {
-                    continue;
-                }
-
-                let operand = simple_test.operands()[1];
-                let Some(word_fact) = facts.word_fact(
-                    operand.span,
-                    WordFactContext::Expansion(ExpansionContext::CommandArgument),
-                ) else {
-                    continue;
-                };
-
-                for span in word_fact.unquoted_scalar_expansion_spans().iter().copied() {
-                    report(span);
-                }
+    checker.report_fact_diagnostics_dedup(|facts, report| {
+        for fact in facts.commands() {
+            let Some(simple_test) = fact.simple_test() else {
+                continue;
+            };
+            if simple_test.syntax() != SimpleTestSyntax::Bracket {
+                continue;
             }
-        },
-        || UnquotedVariableInTest,
-    );
+            if simple_test.shape() != SimpleTestShape::Unary || simple_test.operands().len() != 2 {
+                continue;
+            }
+
+            let operator = simple_test.operands()[0];
+            if static_word_text(operator, source).as_deref() != Some("-n") {
+                continue;
+            }
+
+            let operand = simple_test.operands()[1];
+            let Some(word_fact) = facts.word_fact(
+                operand.span,
+                WordFactContext::Expansion(ExpansionContext::CommandArgument),
+            ) else {
+                continue;
+            };
+
+            for span in word_fact.unquoted_scalar_expansion_spans().iter().copied() {
+                report(
+                    Diagnostic::new(UnquotedVariableInTest, span)
+                        .with_fix(Fix::unsafe_edit(double_quote_span_edit(span, source))),
+                );
+            }
+        }
+    });
+}
+
+fn double_quote_span_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("\"{}\"", span.slice(source)), span)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_unquoted_scalar_expansions_in_n_tests() {
@@ -81,6 +91,20 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["$foo", "$baz", "${bar}", "${qux:-fallback}"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_quoting_variable_in_n_test() {
+        let source = "#!/bin/sh\n[ -n $foo ]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedVariableInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\n[ -n \"$foo\" ]\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/unquoted_word_between_quotes.rs
+++ b/crates/shuck-linter/src/rules/style/unquoted_word_between_quotes.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct UnquotedWordBetweenQuotes;
 
 impl Violation for UnquotedWordBetweenQuotes {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::UnquotedWordBetweenQuotes
     }
@@ -10,24 +14,38 @@ impl Violation for UnquotedWordBetweenQuotes {
     fn message(&self) -> String {
         "an unquoted word follows single-quoted text".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the literal word segment".to_owned())
+    }
 }
 
 pub fn unquoted_word_between_quotes(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .word_facts()
         .iter()
         .flat_map(|fact| fact.unquoted_word_after_single_quoted_segment_spans(source))
+        .map(|span| {
+            Diagnostic::new(UnquotedWordBetweenQuotes, span)
+                .with_fix(Fix::safe_edit(quote_literal_segment_edit(span, source)))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || UnquotedWordBetweenQuotes);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn quote_literal_segment_edit(span: Span, source: &str) -> Edit {
+    Edit::replacement(format!("'{}'", span.slice(source)), span)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_unquoted_words_after_single_quoted_segments() {
@@ -75,5 +93,22 @@ sed -i 's/^\\(\\[binaries\\]\\)$/\\1\\nexe_wrapper = '\\''exe_wrapper'\\''/g' \\
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_by_quoting_middle_literal_segment() {
+        let source = "#!/bin/bash\nprintf '%s\\n' 'foo'Default'baz'\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::UnquotedWordBetweenQuotes),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\nprintf '%s\\n' 'foo''Default''baz'\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/x_prefix_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/x_prefix_in_test.rs
@@ -1,13 +1,15 @@
 use shuck_ast::Span;
 
 use crate::{
-    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Rule, SimpleTestSyntax, Violation,
-    leading_literal_word_prefix,
+    Checker, ConditionalNodeFact, ConditionalOperatorFamily, Diagnostic, Edit, Fix,
+    FixAvailability, Rule, SimpleTestSyntax, Violation, leading_literal_word_prefix,
 };
 
 pub struct XPrefixInTest;
 
 impl Violation for XPrefixInTest {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::XPrefixInTest
     }
@@ -15,30 +17,48 @@ impl Violation for XPrefixInTest {
     fn message(&self) -> String {
         "this comparison uses the legacy x-prefix idiom".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove the x-prefix comparison padding".to_owned())
+    }
 }
 
 pub fn x_prefix_in_test(checker: &mut Checker) {
     let source = checker.source();
-    let spans = checker
+    let reports = checker
         .facts()
         .commands()
         .iter()
         .flat_map(|fact| {
-            let mut spans = Vec::new();
+            let mut reports = Vec::new();
             if let Some(simple_test) = fact.simple_test() {
-                spans.extend(simple_test_spans(simple_test, source));
+                reports.extend(simple_test_reports(simple_test, source));
             }
             if let Some(conditional) = fact.conditional() {
-                spans.extend(conditional_spans(conditional, source));
+                reports.extend(conditional_reports(conditional, source));
             }
-            spans
+            reports
         })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || XPrefixInTest);
+    for report in reports {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(XPrefixInTest, report.diagnostic_span)
+                .with_fix(x_prefix_fix(source, &report)),
+        );
+    }
 }
 
-fn simple_test_spans(simple_test: &crate::SimpleTestFact<'_>, source: &str) -> Vec<Span> {
+struct XPrefixComparisonReport {
+    diagnostic_span: Span,
+    left_span: Span,
+    right_span: Span,
+}
+
+fn simple_test_reports(
+    simple_test: &crate::SimpleTestFact<'_>,
+    source: &str,
+) -> Vec<XPrefixComparisonReport> {
     if simple_test.syntax() != SimpleTestSyntax::Test
         && simple_test.syntax() != SimpleTestSyntax::Bracket
     {
@@ -49,13 +69,21 @@ fn simple_test_spans(simple_test: &crate::SimpleTestFact<'_>, source: &str) -> V
         .string_binary_expression_words(source)
         .into_iter()
         .filter_map(|(left, _operator, right)| {
-            (word_has_x_prefix(left, source) && word_has_x_prefix(right, source))
-                .then_some(left.span)
+            (word_has_x_prefix(left, source) && word_has_x_prefix(right, source)).then_some(
+                XPrefixComparisonReport {
+                    diagnostic_span: left.span,
+                    left_span: left.span,
+                    right_span: right.span,
+                },
+            )
         })
         .collect()
 }
 
-fn conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &str) -> Vec<Span> {
+fn conditional_reports(
+    conditional: &crate::ConditionalFact<'_>,
+    source: &str,
+) -> Vec<XPrefixComparisonReport> {
     conditional
         .nodes()
         .iter()
@@ -66,9 +94,12 @@ fn conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &str) -> 
                 if conditional_operand_has_x_prefix(binary.left(), source)
                     && conditional_operand_has_x_prefix(binary.right(), source)
                 {
-                    binary.left().word().map(|word| word.span).or_else(|| {
-                        let span = binary.left().expression().span();
-                        Some(span)
+                    let left_span = conditional_operand_span(binary.left());
+                    let right_span = conditional_operand_span(binary.right());
+                    Some(XPrefixComparisonReport {
+                        diagnostic_span: left_span,
+                        left_span,
+                        right_span,
                     })
                 } else {
                     None
@@ -80,6 +111,13 @@ fn conditional_spans(conditional: &crate::ConditionalFact<'_>, source: &str) -> 
             | ConditionalNodeFact::Other(_) => None,
         })
         .collect()
+}
+
+fn conditional_operand_span(operand: crate::ConditionalOperandFact<'_>) -> Span {
+    operand
+        .word()
+        .map(|word| word.span)
+        .unwrap_or_else(|| operand.expression().span())
 }
 
 fn conditional_operand_has_x_prefix(
@@ -100,10 +138,42 @@ fn has_legacy_x_prefix(text: &str) -> bool {
     matches!(text.as_bytes().first(), Some(b'x' | b'X'))
 }
 
+fn x_prefix_fix(source: &str, report: &XPrefixComparisonReport) -> Fix {
+    Fix::unsafe_edits([
+        Edit::replacement(
+            x_prefix_operand_replacement(source, report.left_span),
+            report.left_span,
+        ),
+        Edit::replacement(
+            x_prefix_operand_replacement(source, report.right_span),
+            report.right_span,
+        ),
+    ])
+}
+
+fn x_prefix_operand_replacement(source: &str, span: Span) -> String {
+    let text = span.slice(source);
+    let body = strip_simple_quotes(text).unwrap_or(text);
+    let without_prefix = body
+        .char_indices()
+        .nth(1)
+        .map_or("", |(offset, _)| &body[offset..]);
+    format!("\"{}\"", without_prefix.replace('"', "\\\""))
+}
+
+fn strip_simple_quotes(text: &str) -> Option<&str> {
+    text.strip_prefix('"')
+        .and_then(|inner| inner.strip_suffix('"'))
+        .or_else(|| {
+            text.strip_prefix('\'')
+                .and_then(|inner| inner.strip_suffix('\''))
+        })
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_x_prefix_comparisons_in_simple_tests_and_conditionals() {
@@ -164,5 +234,22 @@ test \"x$browser\" != \"x\"
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::XPrefixInTest));
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_remove_x_prefixes_from_both_operands() {
+        let source = "#!/bin/bash\n[ \"x$browser\" = \"x\" ]\n[[ X = Xbar ]]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::XPrefixInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\n[ \"$browser\" = \"\" ]\n[[ \"\" = \"bar\" ]]\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/style/x_prefix_in_test.rs
+++ b/crates/shuck-linter/src/rules/style/x_prefix_in_test.rs
@@ -42,10 +42,11 @@ pub fn x_prefix_in_test(checker: &mut Checker) {
         .collect::<Vec<_>>();
 
     for report in reports {
-        checker.report_diagnostic_dedup(
-            Diagnostic::new(XPrefixInTest, report.diagnostic_span)
-                .with_fix(x_prefix_fix(source, &report)),
-        );
+        let diagnostic = Diagnostic::new(XPrefixInTest, report.diagnostic_span);
+        checker.report_diagnostic_dedup(match x_prefix_fix(source, &report) {
+            Some(fix) => diagnostic.with_fix(fix),
+            None => diagnostic,
+        });
     }
 }
 
@@ -138,35 +139,54 @@ fn has_legacy_x_prefix(text: &str) -> bool {
     matches!(text.as_bytes().first(), Some(b'x' | b'X'))
 }
 
-fn x_prefix_fix(source: &str, report: &XPrefixComparisonReport) -> Fix {
-    Fix::unsafe_edits([
+fn x_prefix_fix(source: &str, report: &XPrefixComparisonReport) -> Option<Fix> {
+    Some(Fix::unsafe_edits([
         Edit::replacement(
-            x_prefix_operand_replacement(source, report.left_span),
+            x_prefix_operand_replacement(source, report.left_span)?,
             report.left_span,
         ),
         Edit::replacement(
-            x_prefix_operand_replacement(source, report.right_span),
+            x_prefix_operand_replacement(source, report.right_span)?,
             report.right_span,
         ),
-    ])
+    ]))
 }
 
-fn x_prefix_operand_replacement(source: &str, span: Span) -> String {
+fn x_prefix_operand_replacement(source: &str, span: Span) -> Option<String> {
     let text = span.slice(source);
-    let body = strip_simple_quotes(text).unwrap_or(text);
+    let (body, quote_style) = strip_simple_quotes(text).unwrap_or((text, QuoteStyle::Unquoted));
+    if quote_style == QuoteStyle::Unquoted && text.bytes().any(|byte| matches!(byte, b'\'' | b'"'))
+    {
+        return None;
+    }
+
     let without_prefix = body
         .char_indices()
         .nth(1)
         .map_or("", |(offset, _)| &body[offset..]);
-    format!("\"{}\"", without_prefix.replace('"', "\\\""))
+    Some(match quote_style {
+        QuoteStyle::Single => format!("'{without_prefix}'"),
+        QuoteStyle::Double | QuoteStyle::Unquoted => {
+            format!("\"{}\"", without_prefix.replace('"', "\\\""))
+        }
+    })
 }
 
-fn strip_simple_quotes(text: &str) -> Option<&str> {
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum QuoteStyle {
+    Single,
+    Double,
+    Unquoted,
+}
+
+fn strip_simple_quotes(text: &str) -> Option<(&str, QuoteStyle)> {
     text.strip_prefix('"')
         .and_then(|inner| inner.strip_suffix('"'))
+        .map(|inner| (inner, QuoteStyle::Double))
         .or_else(|| {
             text.strip_prefix('\'')
                 .and_then(|inner| inner.strip_suffix('\''))
+                .map(|inner| (inner, QuoteStyle::Single))
         })
 }
 
@@ -249,6 +269,23 @@ test \"x$browser\" != \"x\"
         assert_eq!(
             result.fixed_source,
             "#!/bin/bash\n[ \"$browser\" = \"\" ]\n[[ \"\" = \"bar\" ]]\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_unsafe_fix_without_expanding_single_quoted_operands() {
+        let source = "#!/bin/bash\n[ 'x$HOME' = 'x' ]\n[ 'x$(cmd)' = 'x' ]\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::XPrefixInTest),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\n[ '$HOME' = '' ]\n[ '$(cmd)' = '' ]\n"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }

--- a/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
+++ b/crates/shuck-linter/src/rules/style/xargs_with_inline_replace.rs
@@ -1,14 +1,22 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct XargsWithInlineReplace;
 
 impl Violation for XargsWithInlineReplace {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::XargsWithInlineReplace
     }
 
     fn message(&self) -> String {
         "replace deprecated `xargs -i` with `xargs -I{}`".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite `xargs -i` as `xargs -I`".to_owned())
     }
 }
 
@@ -20,7 +28,8 @@ pub fn xargs_with_inline_replace(checker: &mut Checker) {
         return;
     }
 
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
@@ -34,17 +43,33 @@ pub fn xargs_with_inline_replace(checker: &mut Checker) {
                     !option.uses_default_replacement()
                         || !xargs.has_sc2267_default_replace_silent_shape()
                 })
-                .map(|option| option.span())
+                .filter_map(|option| xargs_inline_replace_fix(option.span(), source))
         })
+        .map(|(span, fix)| Diagnostic::new(XargsWithInlineReplace, span).with_fix(fix))
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || XargsWithInlineReplace);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn xargs_inline_replace_fix(span: Span, source: &str) -> Option<(Span, Fix)> {
+    let text = span.slice(source);
+    let index = text.find('i')?;
+    let mut replacement = String::with_capacity(text.len() + 2);
+    replacement.push_str(&text[..index]);
+    replacement.push('I');
+    replacement.push_str(&text[index + 1..]);
+    if index + 1 == text.len() {
+        replacement.push_str("{}");
+    }
+    Some((span, Fix::safe_edit(Edit::replacement(replacement, span))))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_inline_replace_xargs_flags() {
@@ -135,5 +160,22 @@ find . -type d -name CVS | xargs --null rm -rf
         );
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn applies_safe_fix_to_inline_replace_options() {
+        let source = "#!/bin/sh\nxargs -i echo {}\nxargs -0iX rm -rf X\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::XargsWithInlineReplace),
+            Applicability::Safe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nxargs -I{} echo {}\nxargs -0IX rm -rf X\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- keep the original batch PR focused on autofixes that do not require new linter facts
- split every fact-backed rule into a separate PR for review
- preserve the prior rule-local autofix implementations and parse diagnostic fixes on this branch

Fact-backed splits opened separately:
- #1001 SSH local expansion
- #1002 C-style arithmetic
- #1003 star glob removal
- #1004 redundant return status
- #1005 command substitution in alias
- #1006 function in alias
- #1007 suspect closing quote

## Tests
- cargo test -p shuck-linter