### PR TITLE
feat(linter): fix ssh local expansion diagnostics

### DIFF
--- a/crates/shuck-linter/src/facts/command_options/mod.rs
+++ b/crates/shuck-linter/src/facts/command_options/mod.rs
@@ -212,10 +212,15 @@ impl RmCommandFacts {
 
 #[derive(Debug, Clone)]
 pub struct SshCommandFacts {
+    remote_command_arg_span: Span,
     local_expansion_spans: Box<[Span]>,
 }
 
 impl SshCommandFacts {
+    pub fn remote_command_arg_span(&self) -> Span {
+        self.remote_command_arg_span
+    }
+
     pub fn local_expansion_spans(&self) -> &[Span] {
         &self.local_expansion_spans
     }

--- a/crates/shuck-linter/src/facts/command_options/shell_invocation.rs
+++ b/crates/shuck-linter/src/facts/command_options/shell_invocation.rs
@@ -22,6 +22,7 @@ pub(super) fn parse_ssh_command(args: &[&Word], source: &str) -> Option<SshComma
         .collect::<Vec<_>>();
 
     (!local_expansion_spans.is_empty()).then_some(SshCommandFacts {
+        remote_command_arg_span: last_remote_arg.span,
         local_expansion_spans: local_expansion_spans.into_boxed_slice(),
     })
 }

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -633,11 +633,25 @@ ssh host cmd '-t' \"$USER\"
             Some(1)
         );
         assert_eq!(
+            ssh_commands[0]
+                .options()
+                .ssh()
+                .map(|ssh| ssh.remote_command_arg_span().slice(source)),
+            Some("\"echo $HOME\"")
+        );
+        assert_eq!(
             ssh_commands[1]
                 .options()
                 .ssh()
                 .map(|ssh| ssh.local_expansion_spans().len()),
             Some(1)
+        );
+        assert_eq!(
+            ssh_commands[1]
+                .options()
+                .ssh()
+                .map(|ssh| ssh.remote_command_arg_span().slice(source)),
+            Some("\"echo $USER\"")
         );
         assert!(ssh_commands[2].options().ssh().is_none());
         assert!(ssh_commands[3].options().ssh().is_none());

--- a/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
+++ b/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
@@ -1,8 +1,12 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SshLocalExpansion;
 
 impl Violation for SshLocalExpansion {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SshLocalExpansion
     }
@@ -10,24 +14,51 @@ impl Violation for SshLocalExpansion {
     fn message(&self) -> String {
         "ssh command text is expanded locally before the remote shell sees it".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("single-quote the remote command".to_owned())
+    }
 }
 
 pub fn ssh_local_expansion(checker: &mut Checker) {
-    let spans = checker
+    let source = checker.source();
+    let diagnostics = checker
         .facts()
         .commands()
         .iter()
         .filter_map(|fact| fact.options().ssh())
-        .flat_map(|fact| fact.local_expansion_spans().iter().copied())
+        .flat_map(|fact| {
+            fact.local_expansion_spans().iter().copied().map(|span| {
+                Diagnostic::new(SshLocalExpansion, span)
+                    .with_fix(remote_command_fix(source, fact.remote_command_arg_span()))
+            })
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || SshLocalExpansion);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn remote_command_fix(source: &str, span: Span) -> Fix {
+    let replacement = single_quoted_remote_command(span.slice(source)).unwrap_or_else(|| {
+        format!(
+            "'{}'",
+            span.slice(source).trim_matches('"').replace('\'', "'\\''")
+        )
+    });
+    Fix::unsafe_edit(Edit::replacement(replacement, span))
+}
+
+fn single_quoted_remote_command(text: &str) -> Option<String> {
+    let body = text.strip_prefix('"')?.strip_suffix('"')?;
+    Some(format!("'{}'", body.replace('\'', "'\\''")))
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn ignores_expansions_in_destination_arguments() {
@@ -119,5 +150,22 @@ URL=$(ssh \"$host\" url \"$REPO\")
 
         assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
         assert_eq!(diagnostics[0].span.slice(source), "$REPO");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_single_quote_remote_command_argument() {
+        let source = "#!/bin/sh\nssh \"$host\" \"echo $HOME\"\nssh host \"printf '%s\\n' $USER\"\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SshLocalExpansion),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nssh \"$host\" 'echo $HOME'\nssh host 'printf '\\''%s\\n'\\'' $USER'\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 }

--- a/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
+++ b/crates/shuck-linter/src/rules/security/ssh_local_expansion.rs
@@ -52,7 +52,30 @@ fn remote_command_fix(source: &str, span: Span) -> Fix {
 
 fn single_quoted_remote_command(text: &str) -> Option<String> {
     let body = text.strip_prefix('"')?.strip_suffix('"')?;
+    let body = decode_double_quoted_body(body);
     Some(format!("'{}'", body.replace('\'', "'\\''")))
+}
+
+fn decode_double_quoted_body(body: &str) -> String {
+    let mut decoded = String::with_capacity(body.len());
+    let mut chars = body.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            decoded.push(ch);
+            continue;
+        }
+
+        match chars.next() {
+            Some(ch @ ('$' | '`' | '"' | '\\')) => decoded.push(ch),
+            Some('\n') => {}
+            Some(ch) => {
+                decoded.push('\\');
+                decoded.push(ch);
+            }
+            None => decoded.push('\\'),
+        }
+    }
+    decoded
 }
 
 #[cfg(test)]
@@ -165,6 +188,23 @@ URL=$(ssh \"$host\" url \"$REPO\")
         assert_eq!(
             result.fixed_source,
             "#!/bin/sh\nssh \"$host\" 'echo $HOME'\nssh host 'printf '\\''%s\\n'\\'' $USER'\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn decodes_double_quote_escapes_when_fixing_remote_command() {
+        let source = "#!/bin/sh\nssh host \"printf \\\"%s\\\" $USER \\$HOME \\\\tmp\"\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SshLocalExpansion),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nssh host 'printf \"%s\" $USER $HOME \\tmp'\n"
         );
         assert!(result.fixed_diagnostics.is_empty());
     }


### PR DESCRIPTION
Splits the SSH local expansion autofix out of the larger planned-autofix branch.\n\nThis adds the remote command argument span to SSH command facts so K001 can replace the whole remote command argument with a single-quoted form.\n\nValidation:\n- cargo test -p shuck-linter --lib ssh_local_expansion\n- cargo test -p shuck-linter --lib ssh_command_facts_match_shellcheck_command_shape