### PR TITLE
feat(linter): fix c-style arithmetic diagnostics

### DIFF
--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1853,8 +1853,9 @@ fn arithmetic_postfix_update_operand_span(operator_span: Span, source: &str) -> 
 
 fn scan_arithmetic_lvalue_end(source: &str, start: usize) -> Option<usize> {
     let mut end = scan_identifier_end(source, start)?;
-    if source[end..].starts_with('[') {
-        end = scan_balanced_bracket_end(source, end)?;
+    let subscript_start = skip_horizontal_space_forward(source, end);
+    if source[subscript_start..].starts_with('[') {
+        end = scan_balanced_bracket_end(source, subscript_start)?;
     }
     Some(end)
 }
@@ -1865,7 +1866,8 @@ fn scan_arithmetic_lvalue_start(source: &str, end: usize) -> Option<usize> {
     }
     let mut start = if source[..end].ends_with(']') {
         let open = scan_balanced_bracket_start(source, end - 1)?;
-        scan_identifier_start(source, open)?
+        let identifier_end = skip_horizontal_space_backward(source, open);
+        scan_identifier_start(source, identifier_end)?
     } else {
         scan_identifier_start(source, end)?
     };
@@ -1873,6 +1875,25 @@ fn scan_arithmetic_lvalue_start(source: &str, end: usize) -> Option<usize> {
         start = scan_identifier_start(source, end)?;
     }
     Some(start)
+}
+
+fn skip_horizontal_space_forward(source: &str, mut offset: usize) -> usize {
+    let bytes = source.as_bytes();
+    while bytes
+        .get(offset)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+    {
+        offset += 1;
+    }
+    offset
+}
+
+fn skip_horizontal_space_backward(source: &str, mut offset: usize) -> usize {
+    let bytes = source.as_bytes();
+    while offset > 0 && matches!(bytes[offset - 1], b' ' | b'\t') {
+        offset -= 1;
+    }
+    offset
 }
 
 fn scan_identifier_end(source: &str, start: usize) -> Option<usize> {

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1743,19 +1743,41 @@ fn collect_arithmetic_lvalue_update_operator_spans(
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
+enum ArithmeticUpdateOperatorKind {
+    Increment,
+    Decrement,
+}
+
+impl ArithmeticUpdateOperatorKind {
+    fn replacement_operator(self) -> &'static str {
+        match self {
+            Self::Increment => "+",
+            Self::Decrement => "-",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 pub struct ArithmeticUpdateOperatorFixFact {
     diagnostic_span: Span,
     replacement_span: Span,
-    replacement: Box<str>,
+    operand_span: Span,
+    operator: ArithmeticUpdateOperatorKind,
 }
 
 impl ArithmeticUpdateOperatorFixFact {
-    fn new(diagnostic_span: Span, replacement_span: Span, replacement: Box<str>) -> Self {
+    fn new(
+        diagnostic_span: Span,
+        replacement_span: Span,
+        operand_span: Span,
+        operator: ArithmeticUpdateOperatorKind,
+    ) -> Self {
         Self {
             diagnostic_span,
             replacement_span,
-            replacement,
+            operand_span,
+            operator,
         }
     }
 
@@ -1767,8 +1789,10 @@ impl ArithmeticUpdateOperatorFixFact {
         self.replacement_span
     }
 
-    pub fn replacement(&self) -> &str {
-        &self.replacement
+    pub fn replacement(&self, source: &str) -> String {
+        let operand = self.operand_span.slice(source);
+        let operator = self.operator.replacement_operator();
+        format!("({operand} = {operand} {operator} 1)")
     }
 }
 
@@ -1789,26 +1813,26 @@ fn arithmetic_update_operator_fix_fact(
 ) -> Option<ArithmeticUpdateOperatorFixFact> {
     let operator = diagnostic_span.slice(source);
     let operator = match operator {
-        "++" => "+",
-        "--" => "-",
+        "++" => ArithmeticUpdateOperatorKind::Increment,
+        "--" => ArithmeticUpdateOperatorKind::Decrement,
         _ => return None,
     };
 
     if let Some(operand_span) = arithmetic_prefix_update_operand_span(diagnostic_span, source) {
-        let operand = operand_span.slice(source);
         return Some(ArithmeticUpdateOperatorFixFact::new(
             diagnostic_span,
             Span::from_positions(diagnostic_span.start, operand_span.end),
-            format!("({operand} = {operand} {operator} 1)").into_boxed_str(),
+            operand_span,
+            operator,
         ));
     }
 
     let operand_span = arithmetic_postfix_update_operand_span(diagnostic_span, source)?;
-    let operand = operand_span.slice(source);
     Some(ArithmeticUpdateOperatorFixFact::new(
         diagnostic_span,
         Span::from_positions(operand_span.start, diagnostic_span.end),
-        format!("({operand} = {operand} {operator} 1)").into_boxed_str(),
+        operand_span,
+        operator,
     ))
 }
 

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1743,6 +1743,197 @@ fn collect_arithmetic_lvalue_update_operator_spans(
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct ArithmeticUpdateOperatorFixFact {
+    diagnostic_span: Span,
+    replacement_span: Span,
+    replacement: Box<str>,
+}
+
+impl ArithmeticUpdateOperatorFixFact {
+    fn new(diagnostic_span: Span, replacement_span: Span, replacement: Box<str>) -> Self {
+        Self {
+            diagnostic_span,
+            replacement_span,
+            replacement,
+        }
+    }
+
+    pub fn diagnostic_span(&self) -> Span {
+        self.diagnostic_span
+    }
+
+    pub fn replacement_span(&self) -> Span {
+        self.replacement_span
+    }
+
+    pub fn replacement(&self) -> &str {
+        &self.replacement
+    }
+}
+
+fn build_arithmetic_update_operator_fix_facts(
+    spans: &[Span],
+    source: &str,
+) -> Vec<ArithmeticUpdateOperatorFixFact> {
+    spans
+        .iter()
+        .copied()
+        .filter_map(|span| arithmetic_update_operator_fix_fact(span, source))
+        .collect()
+}
+
+fn arithmetic_update_operator_fix_fact(
+    diagnostic_span: Span,
+    source: &str,
+) -> Option<ArithmeticUpdateOperatorFixFact> {
+    let operator = diagnostic_span.slice(source);
+    let operator = match operator {
+        "++" => "+",
+        "--" => "-",
+        _ => return None,
+    };
+
+    if let Some(operand_span) = arithmetic_prefix_update_operand_span(diagnostic_span, source) {
+        let operand = operand_span.slice(source);
+        return Some(ArithmeticUpdateOperatorFixFact::new(
+            diagnostic_span,
+            Span::from_positions(diagnostic_span.start, operand_span.end),
+            format!("({operand} = {operand} {operator} 1)").into_boxed_str(),
+        ));
+    }
+
+    let operand_span = arithmetic_postfix_update_operand_span(diagnostic_span, source)?;
+    let operand = operand_span.slice(source);
+    Some(ArithmeticUpdateOperatorFixFact::new(
+        diagnostic_span,
+        Span::from_positions(operand_span.start, diagnostic_span.end),
+        format!("({operand} = {operand} {operator} 1)").into_boxed_str(),
+    ))
+}
+
+fn arithmetic_prefix_update_operand_span(operator_span: Span, source: &str) -> Option<Span> {
+    let start = operator_span.end.offset;
+    let end = scan_arithmetic_lvalue_end(source, start)?;
+    (end > start).then(|| Span::from_positions(operator_span.end, operator_span.end.advanced_by(&source[start..end])))
+}
+
+fn arithmetic_postfix_update_operand_span(operator_span: Span, source: &str) -> Option<Span> {
+    let end = operator_span.start.offset;
+    let start = scan_arithmetic_lvalue_start(source, end)?;
+    (start < end).then(|| {
+        let start_position = position_at_offset_on_same_line(operator_span.start, start);
+        Span::from_positions(start_position, operator_span.start)
+    })
+}
+
+fn scan_arithmetic_lvalue_end(source: &str, start: usize) -> Option<usize> {
+    let mut end = scan_identifier_end(source, start)?;
+    if source[end..].starts_with('[') {
+        end = scan_balanced_bracket_end(source, end)?;
+    }
+    Some(end)
+}
+
+fn scan_arithmetic_lvalue_start(source: &str, end: usize) -> Option<usize> {
+    if end == 0 {
+        return None;
+    }
+    let mut start = if source[..end].ends_with(']') {
+        let open = scan_balanced_bracket_start(source, end - 1)?;
+        scan_identifier_start(source, open)?
+    } else {
+        scan_identifier_start(source, end)?
+    };
+    if start == end {
+        start = scan_identifier_start(source, end)?;
+    }
+    Some(start)
+}
+
+fn scan_identifier_end(source: &str, start: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let first = *bytes.get(start)?;
+    if !is_arithmetic_identifier_start(first) {
+        return None;
+    }
+    let mut end = start + 1;
+    while bytes
+        .get(end)
+        .is_some_and(|byte| is_arithmetic_identifier_continue(*byte))
+    {
+        end += 1;
+    }
+    Some(end)
+}
+
+fn scan_identifier_start(source: &str, end: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut start = end;
+    while start > 0 && is_arithmetic_identifier_continue(bytes[start - 1]) {
+        start -= 1;
+    }
+    (start < end && is_arithmetic_identifier_start(bytes[start])).then_some(start)
+}
+
+fn scan_balanced_bracket_end(source: &str, open: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut depth = 0usize;
+    let mut index = open;
+    while let Some(byte) = bytes.get(index).copied() {
+        match byte {
+            b'[' => depth += 1,
+            b']' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(index + 1);
+                }
+            }
+            b'\n' => return None,
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
+fn scan_balanced_bracket_start(source: &str, close: usize) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let mut depth = 0usize;
+    let mut index = close + 1;
+    while index > 0 {
+        index -= 1;
+        match bytes[index] {
+            b']' => depth += 1,
+            b'[' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            b'\n' => return None,
+            _ => {}
+        }
+    }
+    None
+}
+
+fn is_arithmetic_identifier_start(byte: u8) -> bool {
+    byte == b'_' || byte.is_ascii_alphabetic()
+}
+
+fn is_arithmetic_identifier_continue(byte: u8) -> bool {
+    is_arithmetic_identifier_start(byte) || byte.is_ascii_digit()
+}
+
+fn position_at_offset_on_same_line(anchor: Position, offset: usize) -> Position {
+    Position {
+        line: anchor.line,
+        column: anchor.column.saturating_sub(anchor.offset - offset),
+        offset,
+    }
+}
+
 fn find_operator_span(expression_span: Span, source: &str, operator: &str, first: bool) -> Span {
     let expression = expression_span.slice(source);
     let offset = if first {

--- a/crates/shuck-linter/src/facts/arithmetic.rs
+++ b/crates/shuck-linter/src/facts/arithmetic.rs
@@ -1934,6 +1934,7 @@ fn scan_balanced_bracket_end(source: &str, open: usize) -> Option<usize> {
                     return Some(index + 1);
                 }
             }
+            b'\'' | b'"' | b'`' | b'$' => return None,
             b'\n' => return None,
             _ => {}
         }
@@ -1956,6 +1957,7 @@ fn scan_balanced_bracket_start(source: &str, close: usize) -> Option<usize> {
                     return Some(index);
                 }
             }
+            b'\'' | b'"' | b'`' | b'$' => return None,
             b'\n' => return None,
             _ => {}
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -482,6 +482,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         arithmetic_update_operator_spans
             .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
         arithmetic_update_operator_spans.dedup();
+        let arithmetic_update_operator_fix_facts =
+            build_arithmetic_update_operator_fix_facts(&arithmetic_update_operator_spans, self.source);
         arithmetic_literal_spans.sort_unstable_by_key(|(span, kind)| {
             (span.start.offset, span.end.offset, *kind)
         });
@@ -1065,6 +1067,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             positional_parameter_operator_spans,
             double_paren_grouping_spans,
             arithmetic_update_operator_spans,
+            arithmetic_update_operator_fix_facts,
             arithmetic_literal_facts,
             escape_scan_matches,
             echo_backslash_escape_word_spans,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -483,7 +483,14 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             .sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
         arithmetic_update_operator_spans.dedup();
         let arithmetic_update_operator_fix_facts =
-            build_arithmetic_update_operator_fix_facts(&arithmetic_update_operator_spans, self.source);
+            if matches!(self.shell, ShellDialect::Sh | ShellDialect::Dash) {
+                build_arithmetic_update_operator_fix_facts(
+                    &arithmetic_update_operator_spans,
+                    self.source,
+                )
+            } else {
+                Vec::new()
+            };
         arithmetic_literal_spans.sort_unstable_by_key(|(span, kind)| {
             (span.start.offset, span.end.offset, *kind)
         });

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -122,6 +122,7 @@ pub struct LinterFacts<'a> {
     positional_parameter_operator_spans: Vec<Span>,
     double_paren_grouping_spans: Vec<Span>,
     arithmetic_update_operator_spans: Vec<Span>,
+    arithmetic_update_operator_fix_facts: Vec<ArithmeticUpdateOperatorFixFact>,
     arithmetic_literal_facts: Vec<ArithmeticLiteralFact>,
     escape_scan_matches: Vec<EscapeScanMatch>,
     echo_backslash_escape_word_spans: Vec<Span>,
@@ -958,6 +959,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn arithmetic_update_operator_spans(&self) -> &[Span] {
         &self.arithmetic_update_operator_spans
+    }
+
+    pub fn arithmetic_update_operator_fix_facts(&self) -> &[ArithmeticUpdateOperatorFixFact] {
+        &self.arithmetic_update_operator_fix_facts
     }
 
     pub fn arithmetic_literal_facts(&self) -> &[ArithmeticLiteralFact] {

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -1,14 +1,20 @@
-use crate::{Checker, Rule, ShellDialect, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct CStyleForArithmeticInSh;
 
 impl Violation for CStyleForArithmeticInSh {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::CStyleForArithmeticInSh
     }
 
     fn message(&self) -> String {
         "arithmetic `++` and `--` operators are not portable in `sh` scripts".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the arithmetic update explicitly".to_owned())
     }
 }
 
@@ -17,16 +23,26 @@ pub fn c_style_for_arithmetic_in_sh(checker: &mut Checker) {
         return;
     }
 
-    checker.report_fact_slice(
-        |facts| facts.arithmetic_update_operator_spans(),
-        || CStyleForArithmeticInSh,
-    );
+    checker.report_fact_diagnostics(|facts, report| {
+        let fix_facts = facts.arithmetic_update_operator_fix_facts();
+        for span in facts.arithmetic_update_operator_spans().iter().copied() {
+            let diagnostic = Diagnostic::new(CStyleForArithmeticInSh, span);
+            let diagnostic = match fix_facts.iter().find(|fact| fact.diagnostic_span() == span) {
+                Some(fact) => diagnostic.with_fix(Fix::unsafe_edit(Edit::replacement(
+                    fact.replacement(),
+                    fact.replacement_span(),
+                ))),
+                None => diagnostic,
+            };
+            report(diagnostic);
+        }
+    });
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
 
     #[test]
     fn anchors_on_update_operators_inside_c_style_for() {
@@ -60,6 +76,23 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["++", "--"]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_arithmetic_update_operators() {
+        let source = "#!/bin/sh\n((++i))\necho \"$((j--))\"\narr[i++]=x\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 3);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\n(((i = i + 1)))\necho \"$(((j = j - 1)))\"\narr[(i = i + 1)]=x\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -122,6 +122,21 @@ mod tests {
     }
 
     #[test]
+    fn leaves_complex_subscript_update_operators_unfixed() {
+        let source = "#!/bin/sh\n((++arr[$(printf ']')]))\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+        assert_eq!(result.fixed_diagnostics.len(), 1);
+        assert_eq!(result.fixed_diagnostics[0].span.slice(source), "++");
+    }
+
+    #[test]
     fn anchors_on_update_operators_inside_arithmetic_expansions() {
         let source = "#!/bin/sh\necho \"$((++i)) $((j--))\"\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -105,6 +105,23 @@ mod tests {
     }
 
     #[test]
+    fn applies_unsafe_fix_to_spaced_array_subscript_updates() {
+        let source = "#!/bin/sh\n((++arr [i]))\n((arr [j]--))\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CStyleForArithmeticInSh),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\n(((arr [i] = arr [i] + 1)))\n(((arr [j] = arr [j] - 1)))\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
     fn anchors_on_update_operators_inside_arithmetic_expansions() {
         let source = "#!/bin/sh\necho \"$((++i)) $((j--))\"\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
+++ b/crates/shuck-linter/src/rules/portability/c_style_for_arithmetic_in_sh.rs
@@ -23,16 +23,25 @@ pub fn c_style_for_arithmetic_in_sh(checker: &mut Checker) {
         return;
     }
 
+    let source = checker.source();
     checker.report_fact_diagnostics(|facts, report| {
-        let fix_facts = facts.arithmetic_update_operator_fix_facts();
+        let mut fix_facts = facts
+            .arithmetic_update_operator_fix_facts()
+            .iter()
+            .peekable();
         for span in facts.arithmetic_update_operator_spans().iter().copied() {
             let diagnostic = Diagnostic::new(CStyleForArithmeticInSh, span);
-            let diagnostic = match fix_facts.iter().find(|fact| fact.diagnostic_span() == span) {
-                Some(fact) => diagnostic.with_fix(Fix::unsafe_edit(Edit::replacement(
-                    fact.replacement(),
+            let diagnostic = if fix_facts
+                .peek()
+                .is_some_and(|fact| fact.diagnostic_span() == span)
+            {
+                let fact = fix_facts.next().expect("peeked arithmetic fix fact");
+                diagnostic.with_fix(Fix::unsafe_edit(Edit::replacement(
+                    fact.replacement(source),
                     fact.replacement_span(),
-                ))),
-                None => diagnostic,
+                )))
+            } else {
+                diagnostic
             };
             report(diagnostic);
         }


### PR DESCRIPTION
## Summary
- split the C-style arithmetic autofix out of the larger autofix batch
- add arithmetic update operator fix facts for portable explicit rewrites
- mark the X062 diagnostic fixable when a safe replacement span can be derived

## Tests
- cargo test -p shuck-linter --lib c_style_for_arithmetic_in_sh