### PR TITLE
feat(linter): fix alias expansion diagnostics

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -884,6 +884,14 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             &word_index,
             source,
         );
+        let alias_definition_expansion_facts = build_alias_definition_expansion_facts(
+            &commands,
+            &fact_store,
+            &word_nodes,
+            &word_occurrences,
+            &word_index,
+            source,
+        );
         let innermost_command_ids_by_offset = build_innermost_command_ids_by_offset(
             &commands,
             commands
@@ -994,6 +1002,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             case_cli_reachable_function_scopes,
             function_in_alias_spans,
             alias_definition_expansion_spans,
+            alias_definition_expansion_facts,
             function_body_without_braces_spans,
             function_parameter_fallback_spans,
             redundant_return_status_spans,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -55,6 +55,7 @@ pub struct LinterFacts<'a> {
     case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
     function_in_alias_spans: Vec<Span>,
     alias_definition_expansion_spans: Vec<Span>,
+    alias_definition_expansion_facts: Vec<AliasDefinitionExpansionFact>,
     function_body_without_braces_spans: Vec<Span>,
     function_parameter_fallback_spans: Vec<Span>,
     redundant_return_status_spans: Vec<Span>,
@@ -701,6 +702,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn alias_definition_expansion_spans(&self) -> &[Span] {
         &self.alias_definition_expansion_spans
+    }
+
+    pub fn alias_definition_expansion_facts(&self) -> &[AliasDefinitionExpansionFact] {
+        &self.alias_definition_expansion_facts
     }
 
     pub fn function_body_without_braces_spans(&self) -> &[Span] {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -10,6 +10,39 @@ pub(super) fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
+pub(super) fn build_alias_definition_expansion_facts(
+    commands: &[CommandFact<'_>],
+    fact_store: &FactStore<'_>,
+    nodes: &[WordNode<'_>],
+    occurrences: &[WordOccurrence],
+    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+    source: &str,
+) -> Vec<AliasDefinitionExpansionFact> {
+    let mut facts = commands
+        .iter()
+        .filter(|fact| fact.effective_name_is("alias"))
+        .flat_map(|fact| alias_definition_word_groups_for_command(fact, source).into_iter())
+        .filter_map(|definition_words| {
+            let span = alias_definition_first_active_expansion_span(
+                definition_words,
+                fact_store,
+                nodes,
+                occurrences,
+                word_index,
+            )?;
+            Some(AliasDefinitionExpansionFact::new(
+                span,
+                alias_definition_span(definition_words)?,
+                alias_definition_single_quoted_replacement(definition_words, source)?,
+            ))
+        })
+        .collect::<Vec<_>>();
+    facts.sort_by_key(|fact| (fact.span().start.offset, fact.span().end.offset));
+    facts.dedup_by_key(|fact| FactSpan::new(fact.span()));
+    facts
+}
+
+#[cfg_attr(shuck_profiling, inline(never))]
 pub(super) fn build_alias_definition_expansion_spans(
     commands: &[CommandFact<'_>],
     fact_store: &FactStore<'_>,
@@ -23,32 +56,121 @@ pub(super) fn build_alias_definition_expansion_spans(
         .filter(|fact| fact.effective_name_is("alias"))
         .flat_map(|fact| alias_definition_word_groups_for_command(fact, source).into_iter())
         .filter_map(|definition_words| {
-            definition_words
-                .iter()
-                .flat_map(|candidate| {
-                    word_index
-                        .get(&FactSpan::new(candidate.span))
-                        .into_iter()
-                        .flat_map(|indices| indices.iter().copied())
-                        .map(|id| &occurrences[id.index()])
-                        .filter(move |fact| {
-                            fact.context
-                                == WordFactContext::Expansion(ExpansionContext::CommandArgument)
-                                && occurrence_span(nodes, fact) == candidate.span
-                        })
-                })
-                .flat_map(|fact| {
-                    let derived = word_node_derived(&nodes[fact.node_id.index()]);
-                    fact_store
-                        .word_spans(derived.active_expansion_spans)
-                        .iter()
-                        .copied()
-                })
-                .min_by_key(|span| (span.start.offset, span.end.offset))
+            alias_definition_first_active_expansion_span(
+                definition_words,
+                fact_store,
+                nodes,
+                occurrences,
+                word_index,
+            )
         })
         .collect::<Vec<_>>();
-    sort_and_dedup_spans(&mut spans);
+    spans.sort_by_key(|span| (span.start.offset, span.end.offset));
+    spans.dedup_by_key(|span| FactSpan::new(*span));
     spans
+}
+
+fn alias_definition_first_active_expansion_span(
+    definition_words: &[&Word],
+    fact_store: &FactStore<'_>,
+    nodes: &[WordNode<'_>],
+    occurrences: &[WordOccurrence],
+    word_index: &FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
+) -> Option<Span> {
+    definition_words
+        .iter()
+        .flat_map(|candidate| {
+            word_index
+                .get(&FactSpan::new(candidate.span))
+                .into_iter()
+                .flat_map(|indices| indices.iter().copied())
+                .map(|id| &occurrences[id.index()])
+                .filter(move |fact| {
+                    fact.context == WordFactContext::Expansion(ExpansionContext::CommandArgument)
+                        && occurrence_span(nodes, fact) == candidate.span
+                })
+        })
+        .flat_map(|fact| {
+            let derived = word_node_derived(&nodes[fact.node_id.index()]);
+            fact_store
+                .word_spans(derived.active_expansion_spans)
+                .iter()
+                .copied()
+        })
+        .min_by_key(|span| (span.start.offset, span.end.offset))
+}
+
+#[derive(Debug, Clone)]
+pub struct AliasDefinitionExpansionFact {
+    span: Span,
+    replacement_span: Span,
+    replacement: Box<str>,
+}
+
+impl AliasDefinitionExpansionFact {
+    fn new(span: Span, replacement_span: Span, replacement: Box<str>) -> Self {
+        Self {
+            span,
+            replacement_span,
+            replacement,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn replacement_span(&self) -> Span {
+        self.replacement_span
+    }
+
+    pub fn replacement(&self) -> &str {
+        &self.replacement
+    }
+}
+
+fn alias_definition_span(words: &[&Word]) -> Option<Span> {
+    Some(Span::from_positions(
+        words.first()?.span.start,
+        words.last()?.span.end,
+    ))
+}
+
+fn alias_definition_single_quoted_replacement(words: &[&Word], source: &str) -> Option<Box<str>> {
+    let span = alias_definition_span(words)?;
+    let equals_offset = alias_definition_equals_offset(words, source)?;
+    let name = source.get(span.start.offset..equals_offset)?;
+    if !literal_alias_name_is_fixable(name) {
+        return None;
+    }
+    let value = source.get(equals_offset + 1..span.end.offset)?;
+    let body = strip_simple_alias_value_quotes(value).unwrap_or(value);
+    Some(format!("{name}='{}'", body.replace('\'', "'\\''")).into_boxed_str())
+}
+
+fn alias_definition_equals_offset(words: &[&Word], source: &str) -> Option<usize> {
+    words.iter().find_map(|word| {
+        word_chars_outside_expansions(word, source)
+            .find_map(|(offset, ch)| (ch == '=').then_some(word.span.start.offset + offset))
+    })
+}
+
+fn literal_alias_name_is_fixable(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+}
+
+fn strip_simple_alias_value_quotes(value: &str) -> Option<&str> {
+    value
+        .strip_prefix('"')
+        .and_then(|inner| inner.strip_suffix('"'))
+        .or_else(|| {
+            value
+                .strip_prefix('\'')
+                .and_then(|inner| inner.strip_suffix('\''))
+        })
 }
 
 pub(super) fn alias_definition_word_groups_for_command<'a>(

--- a/crates/shuck-linter/src/rules/style/command_substitution_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/command_substitution_in_alias.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct CommandSubstitutionInAlias;
 
 impl Violation for CommandSubstitutionInAlias {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::CommandSubstitutionInAlias
     }
@@ -10,19 +12,48 @@ impl Violation for CommandSubstitutionInAlias {
     fn message(&self) -> String {
         "avoid expansions in alias definitions".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("single-quote the alias definition".to_owned())
+    }
 }
 
 pub fn command_substitution_in_alias(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.alias_definition_expansion_spans(),
-        || CommandSubstitutionInAlias,
-    );
+    let fixable_spans = checker
+        .facts()
+        .alias_definition_expansion_facts()
+        .iter()
+        .map(|fact| fact.span())
+        .collect::<Vec<_>>();
+    let diagnostics = checker
+        .facts()
+        .alias_definition_expansion_facts()
+        .iter()
+        .map(|fact| {
+            Diagnostic::new(CommandSubstitutionInAlias, fact.span()).with_fix(Fix::unsafe_edit(
+                Edit::replacement(fact.replacement(), fact.replacement_span()),
+            ))
+        })
+        .chain(
+            checker
+                .facts()
+                .alias_definition_expansion_spans()
+                .iter()
+                .copied()
+                .filter(|span| !fixable_spans.contains(span))
+                .map(|span| Diagnostic::new(CommandSubstitutionInAlias, span)),
+        )
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_active_expansions_inside_alias_definitions() {
@@ -57,6 +88,23 @@ alias plain=printf
                 "{a,b}",
             ]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_single_quote_literal_alias_values() {
+        let source = "#!/bin/bash\nalias home=$HOME\nalias icloud=\"cd '$HOME'\"\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::CommandSubstitutionInAlias),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/bash\nalias home='$HOME'\nalias icloud='cd '\\''$HOME'\\'''\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- split command-substitution-in-alias into its own fact-backed PR
- add alias definition expansion fix facts that keep the existing diagnostic spans reusable
- mark fixable alias definitions with an unsafe single-quote replacement

## Tests
- cargo test -p shuck-linter --lib command_substitution_in_alias