### PR TITLE
feat(linter): fix function alias diagnostics

### DIFF
--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -577,7 +577,11 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         sort_and_dedup_spans(&mut condition_status_capture_spans);
         sort_and_dedup_spans(&mut command_substitution_command_spans);
         sort_and_dedup_case_pattern_expansions(&mut case_pattern_expansions);
-        let function_in_alias_spans = build_function_in_alias_spans(&commands, self.source);
+        let function_in_alias_facts = build_function_in_alias_facts(&commands, self.source);
+        let function_in_alias_spans = function_in_alias_facts
+            .iter()
+            .map(FunctionInAliasFact::span)
+            .collect::<Vec<_>>();
         let function_parameter_fallback_spans = build_function_parameter_fallback_spans(
             &commands,
             &command_fact_indices_by_id,
@@ -993,6 +997,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             function_definition_command_ids_by_scope,
             case_cli_reachable_function_scopes,
             function_in_alias_spans,
+            function_in_alias_facts,
             alias_definition_expansion_spans,
             function_body_without_braces_spans,
             function_parameter_fallback_spans,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -578,10 +578,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         sort_and_dedup_spans(&mut command_substitution_command_spans);
         sort_and_dedup_case_pattern_expansions(&mut case_pattern_expansions);
         let function_in_alias_facts = build_function_in_alias_facts(&commands, self.source);
-        let function_in_alias_spans = function_in_alias_facts
-            .iter()
-            .map(FunctionInAliasFact::span)
-            .collect::<Vec<_>>();
+        let function_in_alias_spans = build_function_in_alias_spans(&commands, self.source);
         let function_parameter_fallback_spans = build_function_parameter_fallback_spans(
             &commands,
             &command_fact_indices_by_id,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -54,6 +54,7 @@ pub struct LinterFacts<'a> {
     function_definition_command_ids_by_scope: FxHashMap<ScopeId, CommandId>,
     case_cli_reachable_function_scopes: FxHashSet<ScopeId>,
     function_in_alias_spans: Vec<Span>,
+    function_in_alias_facts: Vec<FunctionInAliasFact>,
     alias_definition_expansion_spans: Vec<Span>,
     function_body_without_braces_spans: Vec<Span>,
     function_parameter_fallback_spans: Vec<Span>,
@@ -697,6 +698,10 @@ impl<'a> LinterFacts<'a> {
 
     pub fn function_in_alias_spans(&self) -> &[Span] {
         &self.function_in_alias_spans
+    }
+
+    pub fn function_in_alias_facts(&self) -> &[FunctionInAliasFact] {
+        &self.function_in_alias_facts
     }
 
     pub fn alias_definition_expansion_spans(&self) -> &[Span] {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -1,12 +1,54 @@
-pub(super) fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
-    let mut spans = commands
+pub(super) fn build_function_in_alias_facts(
+    commands: &[CommandFact<'_>],
+    source: &str,
+) -> Vec<FunctionInAliasFact> {
+    let mut facts = commands
         .iter()
         .filter(|fact| fact.effective_name_is("alias"))
-        .flat_map(|fact| alias_definition_word_groups_for_command(fact, source).into_iter())
-        .filter_map(|definition_words| function_in_alias_definition_span(definition_words, source))
+        .flat_map(|fact| {
+            let name_start = fact
+                .body_name_word()
+                .map(|word| word.span.start)
+                .unwrap_or_else(|| fact.body_span().start);
+            alias_definition_word_groups_for_command(fact, source)
+                .into_iter()
+                .filter_map(move |definition_words| {
+                    function_in_alias_definition_fact(definition_words, source, name_start)
+                })
+        })
         .collect::<Vec<_>>();
-    sort_and_dedup_spans(&mut spans);
-    spans
+    facts.sort_by_key(|fact| (fact.span().start.offset, fact.span().end.offset));
+    facts.dedup_by_key(|fact| FactSpan::new(fact.span()));
+    facts
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionInAliasFact {
+    span: Span,
+    replacement_span: Span,
+    replacement: Box<str>,
+}
+
+impl FunctionInAliasFact {
+    fn new(span: Span, replacement_span: Span, replacement: Box<str>) -> Self {
+        Self {
+            span,
+            replacement_span,
+            replacement,
+        }
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn replacement_span(&self) -> Span {
+        self.replacement_span
+    }
+
+    pub fn replacement(&self) -> &str {
+        &self.replacement
+    }
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
@@ -117,12 +159,31 @@ pub(super) fn word_chars_outside_expansions<'a>(
     })
 }
 
-pub(super) fn function_in_alias_definition_span(words: &[&Word], source: &str) -> Option<Span> {
+fn function_in_alias_definition_fact(
+    words: &[&Word],
+    source: &str,
+    replacement_start: Position,
+) -> Option<FunctionInAliasFact> {
     let definition = static_alias_definition_text(words, source)?;
-    let (_, value) = definition.split_once('=').unwrap_or(("", &definition));
-    let end = words.last()?.span.end;
-    contains_positional_parameter_reference(value)
-        .then(|| Span::from_positions(words[0].span.start, end))
+    let (name, value) = definition.split_once('=')?;
+    if !literal_alias_name_is_fixable(name) || !contains_positional_parameter_reference(value) {
+        return None;
+    }
+
+    let span = Span::from_positions(words.first()?.span.start, words.last()?.span.end);
+    let replacement_span = Span::from_positions(replacement_start, span.end);
+    Some(FunctionInAliasFact::new(
+        span,
+        replacement_span,
+        format!("{name}() {{ {}; }}", value.trim()).into_boxed_str(),
+    ))
+}
+
+fn literal_alias_name_is_fixable(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
 }
 
 pub(super) fn static_alias_definition_text(words: &[&Word], source: &str) -> Option<String> {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -5,16 +5,21 @@ pub(super) fn build_function_in_alias_facts(
     let mut facts = commands
         .iter()
         .filter(|fact| fact.effective_name_is("alias"))
-        .flat_map(|fact| {
+        .filter_map(|fact| {
             let name_start = fact
                 .body_name_word()
                 .map(|word| word.span.start)
                 .unwrap_or_else(|| fact.body_span().start);
-            alias_definition_word_groups_for_command(fact, source)
-                .into_iter()
-                .filter_map(move |definition_words| {
-                    function_in_alias_definition_fact(definition_words, source, name_start)
-                })
+            let body_args = fact.body_args();
+            let definition_words = alias_definition_word_groups_for_command(fact, source);
+            let [definition_words] = definition_words.as_slice() else {
+                return None;
+            };
+            if definition_words.len() != body_args.len() {
+                return None;
+            }
+
+            function_in_alias_definition_fact(definition_words, source, name_start)
         })
         .collect::<Vec<_>>();
     facts.sort_by_key(|fact| (fact.span().start.offset, fact.span().end.offset));
@@ -204,10 +209,7 @@ fn function_in_alias_definition_span(words: &[&Word], source: &str) -> Option<Sp
 }
 
 fn literal_alias_name_is_fixable(name: &str) -> bool {
-    !name.is_empty()
-        && name
-            .chars()
-            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+    is_shell_variable_name(name)
 }
 
 pub(super) fn static_alias_definition_text(words: &[&Word], source: &str) -> Option<String> {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -283,7 +283,7 @@ fn contains_unquoted_comment_start(text: &str) -> bool {
                 in_double_quotes = true;
                 comment_can_start = false;
             }
-            ' ' | '\t' => comment_can_start = true,
+            ' ' | '\t' | '\n' | '\r' => comment_can_start = true,
             '|' | '&' | ';' | '(' | ')' | '<' | '>' => comment_can_start = true,
             _ => comment_can_start = false,
         }

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -198,7 +198,7 @@ fn function_in_alias_definition_fact(
     Some(FunctionInAliasFact::new(
         span,
         replacement_span,
-        function_in_alias_replacement(name, value),
+        function_in_alias_replacement(name, value)?,
     ))
 }
 
@@ -219,14 +219,38 @@ fn literal_alias_name_is_fixable(name: &str) -> bool {
     is_shell_variable_name(name) && !is_shell_reserved_word(name) && !is_posix_special_builtin(name)
 }
 
-fn function_in_alias_replacement(name: &str, value: &str) -> Box<str> {
+fn function_in_alias_replacement(name: &str, value: &str) -> Option<Box<str>> {
     let value = value.trim();
+    if ends_with_incomplete_command_operator(value) {
+        return None;
+    }
     let terminator = if ends_with_unescaped_command_terminator(value) {
         ""
     } else {
         ";"
     };
-    format!("{name}() {{ {value}{terminator} }}").into_boxed_str()
+    Some(format!("{name}() {{ {value}{terminator} }}").into_boxed_str())
+}
+
+fn ends_with_incomplete_command_operator(text: &str) -> bool {
+    let bytes = text.trim_end().as_bytes();
+    [
+        b"&&".as_slice(),
+        b"||",
+        b"|&",
+        b"<<<",
+        b"<<",
+        b">>",
+        b"<>",
+        b">&",
+        b"<&",
+        b">|",
+        b"|",
+        b">",
+        b"<",
+    ]
+    .iter()
+    .any(|suffix| ends_with_unescaped_suffix(bytes, suffix))
 }
 
 fn ends_with_unescaped_command_terminator(text: &str) -> bool {
@@ -243,13 +267,14 @@ fn ends_with_unescaped_command_terminator(text: &str) -> bool {
         return false;
     }
 
-    before_last
-        .iter()
-        .rev()
-        .take_while(|&&byte| byte == b'\\')
-        .count()
-        % 2
-        == 0
+    !byte_is_escaped(bytes, bytes.len() - 1)
+}
+
+fn ends_with_unescaped_suffix(bytes: &[u8], suffix: &[u8]) -> bool {
+    bytes
+        .len()
+        .checked_sub(suffix.len())
+        .is_some_and(|start| bytes[start..] == *suffix && !byte_is_escaped(bytes, start))
 }
 
 fn is_shell_reserved_word(name: &str) -> bool {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -186,7 +186,10 @@ fn function_in_alias_definition_fact(
 ) -> Option<FunctionInAliasFact> {
     let definition = static_alias_definition_text(words, source)?;
     let (name, value) = definition.split_once('=')?;
-    if !literal_alias_name_is_fixable(name) || !contains_positional_parameter_reference(value) {
+    if !literal_alias_name_is_fixable(name)
+        || !contains_positional_parameter_reference(value)
+        || contains_unquoted_comment_start(value)
+    {
         return None;
     }
 
@@ -236,6 +239,57 @@ fn is_shell_reserved_word(name: &str) -> bool {
             | "select"
             | "coproc"
     )
+}
+
+fn contains_unquoted_comment_start(text: &str) -> bool {
+    let mut escaped = false;
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut comment_can_start = true;
+
+    for ch in text.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if in_single_quotes {
+            if ch == '\'' {
+                in_single_quotes = false;
+            }
+            continue;
+        }
+
+        if in_double_quotes {
+            match ch {
+                '\\' => escaped = true,
+                '"' => in_double_quotes = false,
+                _ => {}
+            }
+            continue;
+        }
+
+        match ch {
+            '#' if comment_can_start => return true,
+            '\\' => {
+                escaped = true;
+                comment_can_start = false;
+            }
+            '\'' => {
+                in_single_quotes = true;
+                comment_can_start = false;
+            }
+            '"' => {
+                in_double_quotes = true;
+                comment_can_start = false;
+            }
+            ' ' | '\t' => comment_can_start = true,
+            '|' | '&' | ';' | '(' | ')' | '<' | '>' => comment_can_start = true,
+            _ => comment_can_start = false,
+        }
+    }
+
+    false
 }
 
 pub(super) fn static_alias_definition_text(words: &[&Word], source: &str) -> Option<String> {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -4,7 +4,7 @@ pub(super) fn build_function_in_alias_facts(
 ) -> Vec<FunctionInAliasFact> {
     let mut facts = commands
         .iter()
-        .filter(|fact| fact.effective_name_is("alias"))
+        .filter(|fact| fact.wrappers().is_empty() && fact.effective_name_is("alias"))
         .filter_map(|fact| {
             let name_start = fact
                 .body_name_word()
@@ -209,7 +209,29 @@ fn function_in_alias_definition_span(words: &[&Word], source: &str) -> Option<Sp
 }
 
 fn literal_alias_name_is_fixable(name: &str) -> bool {
-    is_shell_variable_name(name)
+    is_shell_variable_name(name) && !is_shell_reserved_word(name)
+}
+
+fn is_shell_reserved_word(name: &str) -> bool {
+    matches!(
+        name,
+        "if" | "then"
+            | "else"
+            | "elif"
+            | "fi"
+            | "do"
+            | "done"
+            | "case"
+            | "esac"
+            | "for"
+            | "in"
+            | "while"
+            | "until"
+            | "time"
+            | "function"
+            | "select"
+            | "coproc"
+    )
 }
 
 pub(super) fn static_alias_definition_text(words: &[&Word], source: &str) -> Option<String> {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -4,12 +4,16 @@ pub(super) fn build_function_in_alias_facts(
 ) -> Vec<FunctionInAliasFact> {
     let mut facts = commands
         .iter()
-        .filter(|fact| fact.wrappers().is_empty() && fact.effective_name_is("alias"))
         .filter_map(|fact| {
-            let name_start = fact
-                .body_name_word()
-                .map(|word| word.span.start)
-                .unwrap_or_else(|| fact.body_span().start);
+            if !fact.wrappers().is_empty() || !fact.effective_name_is("alias") {
+                return None;
+            }
+            let name_word = fact.body_name_word()?;
+            let name_start = name_word.span.start;
+            if name_start != fact.span().start {
+                return None;
+            }
+
             let body_args = fact.body_args();
             let definition_words = alias_definition_word_groups_for_command(fact, source);
             let [definition_words] = definition_words.as_slice() else {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -22,6 +22,17 @@ pub(super) fn build_function_in_alias_facts(
     facts
 }
 
+pub(super) fn build_function_in_alias_spans(commands: &[CommandFact<'_>], source: &str) -> Vec<Span> {
+    let mut spans = commands
+        .iter()
+        .filter(|fact| fact.effective_name_is("alias"))
+        .flat_map(|fact| alias_definition_word_groups_for_command(fact, source).into_iter())
+        .filter_map(|definition_words| function_in_alias_definition_span(definition_words, source))
+        .collect::<Vec<_>>();
+    sort_and_dedup_spans(&mut spans);
+    spans
+}
+
 #[derive(Debug, Clone)]
 pub struct FunctionInAliasFact {
     span: Span,
@@ -176,6 +187,19 @@ fn function_in_alias_definition_fact(
         span,
         replacement_span,
         format!("{name}() {{ {}; }}", value.trim()).into_boxed_str(),
+    ))
+}
+
+fn function_in_alias_definition_span(words: &[&Word], source: &str) -> Option<Span> {
+    let definition = static_alias_definition_text(words, source)?;
+    let (_, value) = definition.split_once('=').unwrap_or(("", &definition));
+    if !contains_positional_parameter_reference(value) {
+        return None;
+    }
+
+    Some(Span::from_positions(
+        words.first()?.span.start,
+        words.last()?.span.end,
     ))
 }
 

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -198,7 +198,7 @@ fn function_in_alias_definition_fact(
     Some(FunctionInAliasFact::new(
         span,
         replacement_span,
-        format!("{name}() {{ {}; }}", value.trim()).into_boxed_str(),
+        function_in_alias_replacement(name, value),
     ))
 }
 
@@ -217,6 +217,39 @@ fn function_in_alias_definition_span(words: &[&Word], source: &str) -> Option<Sp
 
 fn literal_alias_name_is_fixable(name: &str) -> bool {
     is_shell_variable_name(name) && !is_shell_reserved_word(name) && !is_posix_special_builtin(name)
+}
+
+fn function_in_alias_replacement(name: &str, value: &str) -> Box<str> {
+    let value = value.trim();
+    let terminator = if ends_with_unescaped_command_terminator(value) {
+        ""
+    } else {
+        ";"
+    };
+    format!("{name}() {{ {value}{terminator} }}").into_boxed_str()
+}
+
+fn ends_with_unescaped_command_terminator(text: &str) -> bool {
+    let bytes = text.trim_end().as_bytes();
+    let Some((&last, before_last)) = bytes.split_last() else {
+        return false;
+    };
+
+    if !matches!(last, b';' | b'&') {
+        return false;
+    }
+
+    if last == b'&' && before_last.last() == Some(&b'&') {
+        return false;
+    }
+
+    before_last
+        .iter()
+        .rev()
+        .take_while(|&&byte| byte == b'\\')
+        .count()
+        % 2
+        == 0
 }
 
 fn is_shell_reserved_word(name: &str) -> bool {

--- a/crates/shuck-linter/src/facts/words/command_facts.rs
+++ b/crates/shuck-linter/src/facts/words/command_facts.rs
@@ -216,7 +216,7 @@ fn function_in_alias_definition_span(words: &[&Word], source: &str) -> Option<Sp
 }
 
 fn literal_alias_name_is_fixable(name: &str) -> bool {
-    is_shell_variable_name(name) && !is_shell_reserved_word(name)
+    is_shell_variable_name(name) && !is_shell_reserved_word(name) && !is_posix_special_builtin(name)
 }
 
 fn is_shell_reserved_word(name: &str) -> bool {
@@ -241,6 +241,26 @@ fn is_shell_reserved_word(name: &str) -> bool {
     )
 }
 
+fn is_posix_special_builtin(name: &str) -> bool {
+    matches!(
+        name,
+        ":" | "."
+            | "break"
+            | "continue"
+            | "eval"
+            | "exec"
+            | "exit"
+            | "export"
+            | "readonly"
+            | "return"
+            | "set"
+            | "shift"
+            | "times"
+            | "trap"
+            | "unset"
+    )
+}
+
 fn contains_unquoted_comment_start(text: &str) -> bool {
     let mut escaped = false;
     let mut in_single_quotes = false;
@@ -249,6 +269,9 @@ fn contains_unquoted_comment_start(text: &str) -> bool {
 
     for ch in text.chars() {
         if escaped {
+            if ch == '\n' || ch == '\r' {
+                comment_can_start = true;
+            }
             escaped = false;
             continue;
         }

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -163,6 +163,16 @@ alias function='echo $1'
     }
 
     #[test]
+    fn leaves_assignment_prefixed_alias_commands_unfixed() {
+        let source = "#!/bin/sh\nFOO=bar alias greet='echo $1'\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "greet='echo $1'");
+        assert!(diagnostics[0].fix.is_none());
+    }
+
+    #[test]
     fn ignores_aliases_without_static_positional_parameters() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -183,6 +183,16 @@ alias function='echo $1'
     }
 
     #[test]
+    fn leaves_multiline_comment_alias_bodies_unfixed() {
+        let source = "#!/bin/sh\nalias greet='echo $1\n# note'\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "greet='echo $1\n# note'");
+        assert!(diagnostics[0].fix.is_none());
+    }
+
+    #[test]
     fn ignores_aliases_without_static_positional_parameters() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct FunctionInAlias;
 
 impl Violation for FunctionInAlias {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+
     fn rule() -> Rule {
         Rule::FunctionInAlias
     }
@@ -10,16 +12,48 @@ impl Violation for FunctionInAlias {
     fn message(&self) -> String {
         "avoid positional parameters in alias definitions".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("replace the alias with a function".to_owned())
+    }
 }
 
 pub fn function_in_alias(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(|facts| facts.function_in_alias_spans(), || FunctionInAlias);
+    let fixable_spans = checker
+        .facts()
+        .function_in_alias_facts()
+        .iter()
+        .map(|fact| fact.span())
+        .collect::<Vec<_>>();
+    let diagnostics = checker
+        .facts()
+        .function_in_alias_facts()
+        .iter()
+        .map(|fact| {
+            Diagnostic::new(FunctionInAlias, fact.span()).with_fix(Fix::unsafe_edit(
+                Edit::replacement(fact.replacement(), fact.replacement_span()),
+            ))
+        })
+        .chain(
+            checker
+                .facts()
+                .function_in_alias_spans()
+                .iter()
+                .copied()
+                .filter(|span| !fixable_spans.contains(span))
+                .map(|span| Diagnostic::new(FunctionInAlias, span)),
+        )
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_positional_parameters_embedded_in_alias_definitions() {
@@ -44,6 +78,23 @@ alias escaped_then_pos='echo \\$$1'
                 "escaped_then_pos='echo \\$$1'",
             ]
         );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_replace_alias_with_function() {
+        let source = "#!/bin/sh\nalias greet='printf \"%s\\n\" \"$1\"'\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionInAlias),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\ngreet() { printf \"%s\\n\" \"$1\"; }\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -108,6 +108,9 @@ alias 9foo='echo $1'
 alias if='echo $1'
 alias for='echo $1'
 alias function='echo $1'
+alias export='echo $1'
+alias readonly='echo $1'
+alias unset='echo $1'
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
 
@@ -124,6 +127,9 @@ alias function='echo $1'
                 "if='echo $1'",
                 "for='echo $1'",
                 "function='echo $1'",
+                "export='echo $1'",
+                "readonly='echo $1'",
+                "unset='echo $1'",
             ]
         );
         assert!(
@@ -189,6 +195,19 @@ alias function='echo $1'
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].span.slice(source), "greet='echo $1\n# note'");
+        assert!(diagnostics[0].fix.is_none());
+    }
+
+    #[test]
+    fn leaves_escaped_newline_comment_alias_bodies_unfixed() {
+        let source = "#!/bin/sh\nalias greet='echo $1 \\\n# note'\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].span.slice(source),
+            "greet='echo $1 \\\n# note'"
+        );
         assert!(diagnostics[0].fix.is_none());
     }
 

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -173,6 +173,16 @@ alias function='echo $1'
     }
 
     #[test]
+    fn leaves_comment_alias_bodies_unfixed() {
+        let source = "#!/bin/sh\nalias greet='echo $1 # note'\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "greet='echo $1 # note'");
+        assert!(diagnostics[0].fix.is_none());
+    }
+
+    #[test]
     fn ignores_aliases_without_static_positional_parameters() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -98,6 +98,16 @@ alias escaped_then_pos='echo \\$$1'
     }
 
     #[test]
+    fn reports_non_fixable_alias_names_without_fix() {
+        let source = "#!/bin/sh\nalias foo+bar='echo $1'\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "foo+bar='echo $1'");
+        assert!(diagnostics[0].fix.is_none());
+    }
+
+    #[test]
     fn ignores_aliases_without_static_positional_parameters() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -105,6 +105,9 @@ alias foo+bar='echo $1'
 alias foo-bar='echo $1'
 alias foo.bar='echo $1'
 alias 9foo='echo $1'
+alias if='echo $1'
+alias for='echo $1'
+alias function='echo $1'
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
 
@@ -118,6 +121,9 @@ alias 9foo='echo $1'
                 "foo-bar='echo $1'",
                 "foo.bar='echo $1'",
                 "9foo='echo $1'",
+                "if='echo $1'",
+                "for='echo $1'",
+                "function='echo $1'",
             ]
         );
         assert!(
@@ -144,6 +150,16 @@ alias 9foo='echo $1'
                 .iter()
                 .all(|diagnostic| diagnostic.fix.is_none())
         );
+    }
+
+    #[test]
+    fn leaves_wrapped_alias_commands_unfixed() {
+        let source = "#!/bin/sh\nbuiltin alias greet='echo $1'\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "greet='echo $1'");
+        assert!(diagnostics[0].fix.is_none());
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -98,6 +98,20 @@ alias escaped_then_pos='echo \\$$1'
     }
 
     #[test]
+    fn applies_unsafe_fix_without_double_terminating_alias_semicolon() {
+        let source = "#!/bin/sh\nalias greet='echo $1;'\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::FunctionInAlias),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\ngreet() { echo $1; }\n");
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
     fn reports_non_fixable_alias_names_without_fix() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -226,6 +226,29 @@ alias unset='echo $1'
     }
 
     #[test]
+    fn leaves_incomplete_operator_alias_bodies_unfixed() {
+        let source = "\
+#!/bin/sh
+alias greet='echo \"$1\" &&'
+alias pipe='printf \"%s\\n\" \"$1\" |'
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["greet='echo \"$1\" &&'", "pipe='printf \"%s\\n\" \"$1\" |'",]
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_none())
+        );
+    }
+
+    #[test]
     fn ignores_aliases_without_static_positional_parameters() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/style/function_in_alias.rs
+++ b/crates/shuck-linter/src/rules/style/function_in_alias.rs
@@ -99,12 +99,51 @@ alias escaped_then_pos='echo \\$$1'
 
     #[test]
     fn reports_non_fixable_alias_names_without_fix() {
-        let source = "#!/bin/sh\nalias foo+bar='echo $1'\n";
+        let source = "\
+#!/bin/sh
+alias foo+bar='echo $1'
+alias foo-bar='echo $1'
+alias foo.bar='echo $1'
+alias 9foo='echo $1'
+";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
 
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].span.slice(source), "foo+bar='echo $1'");
-        assert!(diagnostics[0].fix.is_none());
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "foo+bar='echo $1'",
+                "foo-bar='echo $1'",
+                "foo.bar='echo $1'",
+                "9foo='echo $1'",
+            ]
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_none())
+        );
+    }
+
+    #[test]
+    fn leaves_multi_definition_alias_commands_unfixed() {
+        let source = "#!/bin/sh\nalias first='echo $1' second='echo $2'\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::FunctionInAlias));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["first='echo $1'", "second='echo $2'"]
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_none())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- split function-in-alias into its own fact-backed PR
- add function-in-alias fix facts while preserving the existing span fact surface
- mark fixable aliases with an unsafe function replacement

## Tests
- cargo test -p shuck-linter --lib function_in_alias