### PR TITLE
feat(linter): fix suspect closing quote diagnostics

### DIFF
--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -845,7 +845,6 @@ impl<'a> SurfaceFragmentSink<'a> {
     pub(super) fn collect_split_suspect_closing_quote_fragment_in_words(&mut self, words: &[Word]) {
         for (index, word) in words.iter().enumerate() {
             let has_later_words = index + 1 < words.len();
-            let replacement = rewrite_word_as_single_double_quoted_string(word, self.source, None);
             self.split_suspect_closing_quote_scratch.clear();
             collect_split_suspect_closing_quote_spans(
                 word,
@@ -853,6 +852,11 @@ impl<'a> SurfaceFragmentSink<'a> {
                 has_later_words,
                 &mut self.split_suspect_closing_quote_scratch,
             );
+            if self.split_suspect_closing_quote_scratch.is_empty() {
+                continue;
+            }
+
+            let mut replacement = None;
             for index in 0..self.split_suspect_closing_quote_scratch.len() {
                 let span = self.split_suspect_closing_quote_scratch[index];
                 if self
@@ -868,7 +872,11 @@ impl<'a> SurfaceFragmentSink<'a> {
                     .push(SuspectClosingQuoteFragmentFact {
                         span,
                         replacement_span: word.span,
-                        replacement: replacement.clone(),
+                        replacement: replacement
+                            .get_or_insert_with(|| {
+                                rewrite_word_as_single_double_quoted_string(word, self.source, None)
+                            })
+                            .clone(),
                     });
             }
         }

--- a/crates/shuck-linter/src/facts/surface.rs
+++ b/crates/shuck-linter/src/facts/surface.rs
@@ -109,14 +109,24 @@ impl CasePatternExpansionFact {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct SuspectClosingQuoteFragmentFact {
     span: Span,
+    replacement_span: Span,
+    replacement: Box<str>,
 }
 
 impl SuspectClosingQuoteFragmentFact {
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    pub fn replacement_span(&self) -> Span {
+        self.replacement_span
+    }
+
+    pub fn replacement(&self) -> &str {
+        &self.replacement
     }
 }
 
@@ -824,13 +834,18 @@ impl<'a> SurfaceFragmentSink<'a> {
                 });
             self.facts
                 .suspect_closing_quotes
-                .push(SuspectClosingQuoteFragmentFact { span: closing_span });
+                .push(SuspectClosingQuoteFragmentFact {
+                    span: closing_span,
+                    replacement_span: word.span,
+                    replacement: replacement.clone(),
+                });
         }
     }
 
     pub(super) fn collect_split_suspect_closing_quote_fragment_in_words(&mut self, words: &[Word]) {
         for (index, word) in words.iter().enumerate() {
             let has_later_words = index + 1 < words.len();
+            let replacement = rewrite_word_as_single_double_quoted_string(word, self.source, None);
             self.split_suspect_closing_quote_scratch.clear();
             collect_split_suspect_closing_quote_spans(
                 word,
@@ -850,7 +865,11 @@ impl<'a> SurfaceFragmentSink<'a> {
                 }
                 self.facts
                     .suspect_closing_quotes
-                    .push(SuspectClosingQuoteFragmentFact { span });
+                    .push(SuspectClosingQuoteFragmentFact {
+                        span,
+                        replacement_span: word.span,
+                        replacement: replacement.clone(),
+                    });
             }
         }
     }

--- a/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
+++ b/crates/shuck-linter/src/rules/style/suspect_closing_quote.rs
@@ -1,8 +1,10 @@
-use crate::{Checker, Rule, Violation};
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
 
 pub struct SuspectClosingQuote;
 
 impl Violation for SuspectClosingQuote {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
     fn rule() -> Rule {
         Rule::SuspectClosingQuote
     }
@@ -10,23 +12,33 @@ impl Violation for SuspectClosingQuote {
     fn message(&self) -> String {
         "quote is closed but the following character looks ambiguous".to_owned()
     }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("rewrite the word as one double-quoted string".to_owned())
+    }
 }
 
 pub fn suspect_closing_quote(checker: &mut Checker) {
-    let spans = checker
+    let diagnostics = checker
         .facts()
         .suspect_closing_quote_fragments()
         .iter()
-        .map(|fragment| fragment.span())
+        .map(|fragment| {
+            Diagnostic::new(SuspectClosingQuote, fragment.span()).with_fix(Fix::unsafe_edit(
+                Edit::replacement(fragment.replacement(), fragment.replacement_span()),
+            ))
+        })
         .collect::<Vec<_>>();
 
-    checker.report_all_dedup(spans, || SuspectClosingQuote);
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule};
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule};
 
     #[test]
     fn reports_suspicious_closing_quote() {
@@ -38,6 +50,20 @@ mod tests {
         assert_eq!(diagnostics[0].span.start.line, 3);
         assert_eq!(diagnostics[0].span.start.column, 7);
         assert_eq!(diagnostics[0].span.start, diagnostics[0].span.end);
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_rewrite_suspicious_split_word() {
+        let source = "#!/bin/bash\necho \"alpha\n\"_beta\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::SuspectClosingQuote),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/bash\necho \"alpha\n_beta\"\n");
+        assert!(result.fixed_diagnostics.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- split suspect-closing-quote into its own fact-backed PR
- carry replacement spans on suspect closing quote fragments
- mark the diagnostic fixable by rewriting the word as one double-quoted string

## Tests
- cargo test -p shuck-linter --lib suspect_closing_quote