### PR TITLE
refactor(linter): replace public lint matrix

### DIFF
--- a/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
+++ b/crates/shuck-benchmark/benches/large_corpus_hotspots.rs
@@ -6,10 +6,8 @@ use std::sync::{Arc, OnceLock};
 
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use shuck_benchmark::configure_benchmark_allocator;
-use shuck_indexer::Indexer;
 use shuck_linter::{
-    LinterSettings, Rule, RuleSet, ShellCheckCodeMap, ShellDialect,
-    lint_file_at_path_with_resolver_and_parse_result,
+    AnalysisRequest, LinterSettings, Rule, RuleSet, ShellCheckCodeMap, ShellDialect,
 };
 use shuck_parser::parser::{ParseResult, Parser};
 use shuck_semantic::SourcePathResolver;
@@ -246,17 +244,12 @@ fn lint_large_corpus_fixture_with_settings(
         .with_shell(ShellDialect::from_name(&fixture.shell))
         .with_analyzed_paths([fixture.path.clone()]);
     let parse_result = parse_large_corpus_fixture(fixture);
-    let indexer = Indexer::new(&fixture.source, &parse_result);
     let shellcheck_map = ShellCheckCodeMap::default();
-    let diagnostics = lint_file_at_path_with_resolver_and_parse_result(
-        &parse_result,
-        &fixture.source,
-        &indexer,
-        &settings,
-        &shellcheck_map,
-        Some(&fixture.path),
-        resolver,
-    );
+    let diagnostics = AnalysisRequest::from_parse_result(&parse_result, &fixture.source, &settings)
+        .with_source_path(fixture.path.as_path())
+        .with_shellcheck_map(&shellcheck_map)
+        .with_optional_source_path_resolver(resolver)
+        .lint();
 
     black_box(diagnostics.len())
 }

--- a/crates/shuck-benchmark/benches/linter.rs
+++ b/crates/shuck-benchmark/benches/linter.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 use shuck_benchmark::{benchmark_cases, configure_benchmark_allocator, parse_fixture};
 use shuck_indexer::Indexer;
 use shuck_linter::{
-    LinterFacts, LinterSemanticArtifacts, LinterSettings, RuleSet, ShellCheckCodeMap, lint_file,
+    AnalysisRequest, LinterFacts, LinterSemanticArtifacts, LinterSettings, RuleSet,
+    ShellCheckCodeMap,
 };
 use shuck_parser::parser::ParseResult;
 
@@ -36,8 +37,9 @@ fn lint_source(
     shellcheck_map: &ShellCheckCodeMap,
 ) -> usize {
     let output = parse_fixture(source);
-    let indexer = Indexer::new(source, &output);
-    let diagnostics = lint_file(&output, source, &indexer, settings, shellcheck_map, None);
+    let diagnostics = AnalysisRequest::from_parse_result(&output, source, settings)
+        .with_shellcheck_map(shellcheck_map)
+        .lint();
 
     black_box(diagnostics.len())
 }

--- a/crates/shuck-benchmark/examples/large_corpus_profile.rs
+++ b/crates/shuck-benchmark/examples/large_corpus_profile.rs
@@ -7,10 +7,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Instant;
 
-use shuck_indexer::Indexer;
 use shuck_linter::{
-    LinterSettings, RuleSelector, RuleSet, ShellCheckCodeMap, ShellDialect,
-    lint_file_at_path_with_resolver_and_parse_result,
+    AnalysisRequest, LinterSettings, RuleSelector, RuleSet, ShellCheckCodeMap, ShellDialect,
 };
 use shuck_parser::parser::Parser;
 use shuck_semantic::SourcePathResolver;
@@ -310,17 +308,12 @@ fn run_large_corpus_fixture(
         .with_shell(shell)
         .with_analyzed_paths([fixture.path.clone()]);
     let parsed = Parser::with_dialect(&source, shell.parser_dialect()).parse();
-    let indexer = Indexer::new(&source, &parsed);
     let shellcheck_map = ShellCheckCodeMap::default();
-    let diagnostics = lint_file_at_path_with_resolver_and_parse_result(
-        &parsed,
-        &source,
-        &indexer,
-        &settings,
-        &shellcheck_map,
-        Some(&fixture.path),
-        Some(resolver),
-    );
+    let diagnostics = AnalysisRequest::from_parse_result(&parsed, &source, &settings)
+        .with_source_path(fixture.path.as_path())
+        .with_shellcheck_map(&shellcheck_map)
+        .with_source_path_resolver(resolver)
+        .lint();
 
     Ok(diagnostics.len())
 }

--- a/crates/shuck-benchmark/src/lib.rs
+++ b/crates/shuck-benchmark/src/lib.rs
@@ -177,8 +177,7 @@ mod tests {
     use super::{TEST_FILES, benchmark_cases, parse_fixture, resources_dir};
     use serde::Deserialize;
     use shuck_formatter::{FormattedSource, ShellFormatOptions, format_file_ast, format_source};
-    use shuck_indexer::Indexer;
-    use shuck_linter::{LinterSettings, ShellCheckCodeMap, lint_file};
+    use shuck_linter::{AnalysisRequest, LinterSettings, ShellCheckCodeMap};
 
     #[derive(Debug, Deserialize)]
     struct Manifest {
@@ -262,15 +261,9 @@ mod tests {
 
         for file in TEST_FILES.iter() {
             let output = parse_fixture(file.source);
-            let indexer = Indexer::new(file.source, &output);
-            let diagnostics = lint_file(
-                &output,
-                file.source,
-                &indexer,
-                &settings,
-                &shellcheck_map,
-                None,
-            );
+            let diagnostics = AnalysisRequest::from_parse_result(&output, file.source, &settings)
+                .with_shellcheck_map(&shellcheck_map)
+                .lint();
 
             assert!(
                 diagnostics.len() < usize::MAX,

--- a/crates/shuck-cli/src/commands/check/analyze.rs
+++ b/crates/shuck-cli/src/commands/check/analyze.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Result;
-use shuck_indexer::Indexer;
 use shuck_linter::{Applicability, LinterSettings, RuleSet, ShellCheckCodeMap, ShellDialect};
 use shuck_parser::{
     Error as ParseError,
@@ -157,17 +156,11 @@ pub(super) fn collect_lint_diagnostics(
     shellcheck_map: &ShellCheckCodeMap,
     source_path: &Path,
 ) -> shuck_linter::AnalysisResult {
-    let indexer = Indexer::new(source, parse_result);
-    shuck_linter::analyze_file_at_path_with_resolver_and_parse_result_with_plugin_resolver(
-        parse_result,
-        source,
-        &indexer,
-        linter_settings,
-        shellcheck_map,
-        Some(source_path),
-        None,
-        plugin_resolver,
-    )
+    shuck_linter::AnalysisRequest::from_parse_result(parse_result, source, linter_settings)
+        .with_source_path(source_path)
+        .with_shellcheck_map(shellcheck_map)
+        .with_optional_plugin_resolver(plugin_resolver)
+        .analyze()
 }
 pub(super) fn read_shared_source(path: &Path) -> Result<Arc<str>> {
     Ok(Arc::<str>::from(fs::read_to_string(path)?))

--- a/crates/shuck-cli/src/shellcheck_compat/mod.rs
+++ b/crates/shuck-cli/src/shellcheck_compat/mod.rs
@@ -11,7 +11,6 @@ use std::process::ExitCode;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use shuck_indexer::Indexer;
 use shuck_linter::{
     LinterSettings, Rule, RuleSet, Severity, ShellCheckCodeMap, ShellCheckLevel, ShellDialect,
     rule_metadata,
@@ -931,7 +930,6 @@ fn lint_with_context(
         .unwrap_or_else(|| ShellDialect::infer(source, Some(path)));
 
     let parse_result = Parser::with_profile(source, shell.shell_profile()).parse();
-    let indexer = Indexer::new(source, &parse_result);
     let explicit = explicit_paths.into_iter().collect::<Vec<_>>();
     let resolver = CompatSourceResolver {
         cwd: canonicalize_or_clone(&std::env::current_dir().map_err(|err| {
@@ -954,24 +952,12 @@ fn lint_with_context(
         rule_options,
     };
 
-    let diagnostics = shuck_linter::lint_file_at_path_with_resolver_and_parse_result(
-        &parse_result,
-        source,
-        &indexer,
-        &settings,
-        &options.shellcheck_map,
-        Some(path),
-        Some(&resolver),
-    );
-    let analysis = shuck_linter::analyze_file_at_path_with_resolver(
-        &parse_result.file,
-        source,
-        &indexer,
-        &settings,
-        None,
-        Some(path),
-        Some(&resolver),
-    );
+    let analysis =
+        shuck_linter::AnalysisRequest::from_parse_result(&parse_result, source, &settings)
+            .with_source_path(path)
+            .with_shellcheck_map(&options.shellcheck_map)
+            .with_source_path_resolver(&resolver)
+            .analyze();
 
     let resolved_paths = analysis
         .semantic
@@ -980,7 +966,7 @@ fn lint_with_context(
         .flat_map(|source_ref| resolve_source_ref_paths(path, source_ref, &resolver))
         .collect::<BTreeSet<_>>();
 
-    Ok((diagnostics, resolved_paths))
+    Ok((analysis.diagnostics, resolved_paths))
 }
 
 fn resolve_source_ref_paths(

--- a/crates/shuck-cli/tests/large_corpus.rs
+++ b/crates/shuck-cli/tests/large_corpus.rs
@@ -3115,17 +3115,12 @@ fn lint_large_corpus_output(
     linter_settings: &shuck_linter::LinterSettings,
     source_path_resolver: Option<&(dyn shuck_semantic::SourcePathResolver + Send + Sync)>,
 ) -> Vec<shuck_linter::Diagnostic> {
-    let indexer = shuck_indexer::Indexer::new(source, parse_result);
     let shellcheck_map = shuck_linter::ShellCheckCodeMap::default();
-    shuck_linter::lint_file_at_path_with_resolver_and_parse_result(
-        parse_result,
-        source,
-        &indexer,
-        linter_settings,
-        &shellcheck_map,
-        Some(&fixture.path),
-        source_path_resolver,
-    )
+    shuck_linter::AnalysisRequest::from_parse_result(parse_result, source, linter_settings)
+        .with_source_path(fixture.path.as_path())
+        .with_shellcheck_map(&shellcheck_map)
+        .with_optional_source_path_resolver(source_path_resolver)
+        .lint()
 }
 
 fn run_shuck(

--- a/crates/shuck-indexer/src/lib.rs
+++ b/crates/shuck-indexer/src/lib.rs
@@ -31,7 +31,7 @@ pub use line_index::LineIndex;
 /// Structural region indexes over parsed shell source.
 pub use region_index::{RegionIndex, RegionKind};
 
-use shuck_ast::TextSize;
+use shuck_ast::{File, TextSize};
 use shuck_parser::parser::ParseResult;
 
 /// Pre-computed positional and structural index over a parsed shell script.
@@ -60,9 +60,17 @@ impl Indexer {
     /// source text can make line and region queries meaningless, even though the
     /// constructor defensively avoids panicking on malformed comment ranges.
     pub fn new(source: &str, output: &ParseResult) -> Self {
+        Self::for_file(source, &output.file)
+    }
+
+    /// Build all indexes from an already parsed file and the original source text.
+    ///
+    /// `source` must be the exact text used to produce `file`; ranges in the
+    /// AST are interpreted as byte offsets into that string.
+    pub fn for_file(source: &str, file: &File) -> Self {
         let line_index = LineIndex::new(source);
-        let comment_index = CommentIndex::new(source, &line_index, &output.file);
-        let region_index = RegionIndex::new(source, &output.file);
+        let comment_index = CommentIndex::new(source, &line_index, file);
+        let region_index = RegionIndex::new(source, file);
         let continuation_lines =
             collect_continuation_lines(&line_index, &comment_index, &region_index);
 

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -130,7 +130,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use shuck_ast::{Command, CompoundCommand, File, Span, Stmt, StmtSeq, TextSize};
 use shuck_indexer::Indexer;
 
-use shuck_parser::parser::{ParseResult, Parser};
+use shuck_parser::parser::ParseResult;
 use shuck_semantic::{
     CommandKind, CompoundCommandKind, FlowContext, PluginResolver, ScopeId, SemanticBuildOptions,
     SemanticCommandContext, SemanticModel, SourcePathResolver, TraversalObserver,
@@ -152,9 +152,208 @@ pub struct AnalysisResult {
     pub diagnostics: Vec<Diagnostic>,
 }
 
+/// Request object for running linter analysis.
+///
+/// Build one from a [`ParseResult`] when lint output should include parse-aware diagnostics and
+/// inline suppression directives. Build one from a parsed [`File`] only when the caller already
+/// owns parse diagnostics and wants rule diagnostics for that AST.
+pub struct AnalysisRequest<'a> {
+    input: AnalysisInput<'a>,
+    source: &'a str,
+    indexer: Indexer,
+    settings: &'a LinterSettings,
+    source_path: Option<&'a Path>,
+    source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
+    plugin_resolver: Option<&'a (dyn PluginResolver + Send + Sync)>,
+    suppressions: SuppressionRequest<'a>,
+}
+
+enum AnalysisInput<'a> {
+    File(&'a File),
+    ParseResult(&'a ParseResult),
+}
+
+enum SuppressionRequest<'a> {
+    None,
+    DefaultShellCheckMap,
+    Index(&'a SuppressionIndex),
+    Directives(&'a [SuppressionDirective]),
+    ShellCheckMap(&'a ShellCheckCodeMap),
+}
+
+impl<'a> AnalysisRequest<'a> {
+    /// Creates a request from a parsed shell file.
+    ///
+    /// This form runs rule analysis over the provided AST without parse diagnostics or
+    /// directive-derived suppressions. Use [`AnalysisRequest::from_parse_result`] for the normal
+    /// linting path where parser diagnostics and inline suppressions should be honored.
+    pub fn from_file(file: &'a File, source: &'a str, settings: &'a LinterSettings) -> Self {
+        Self {
+            input: AnalysisInput::File(file),
+            source,
+            indexer: Indexer::for_file(source, file),
+            settings,
+            source_path: None,
+            source_path_resolver: None,
+            plugin_resolver: None,
+            suppressions: SuppressionRequest::None,
+        }
+    }
+
+    /// Creates a request from a parser result.
+    ///
+    /// This form lets [`analyze`] and [`lint`] include parse-aware diagnostics from the supplied
+    /// parser result.
+    pub fn from_parse_result(
+        parse_result: &'a ParseResult,
+        source: &'a str,
+        settings: &'a LinterSettings,
+    ) -> Self {
+        Self {
+            input: AnalysisInput::ParseResult(parse_result),
+            source,
+            indexer: Indexer::new(source, parse_result),
+            settings,
+            source_path: None,
+            source_path_resolver: None,
+            plugin_resolver: None,
+            suppressions: SuppressionRequest::DefaultShellCheckMap,
+        }
+    }
+
+    /// Sets the source path used for shell inference, source resolution, and per-file ignores.
+    pub fn with_source_path(mut self, source_path: &'a Path) -> Self {
+        self.source_path = Some(source_path);
+        self
+    }
+
+    /// Sets an optional source path used for shell inference, source resolution, and per-file ignores.
+    pub fn with_optional_source_path(mut self, source_path: Option<&'a Path>) -> Self {
+        self.source_path = source_path;
+        self
+    }
+
+    /// Sets a resolver for shell sources reached from the analyzed file.
+    pub fn with_source_path_resolver(
+        mut self,
+        source_path_resolver: &'a (dyn SourcePathResolver + Send + Sync),
+    ) -> Self {
+        self.source_path_resolver = Some(source_path_resolver);
+        self
+    }
+
+    /// Sets an optional resolver for shell sources reached from the analyzed file.
+    pub fn with_optional_source_path_resolver(
+        mut self,
+        source_path_resolver: Option<&'a (dyn SourcePathResolver + Send + Sync)>,
+    ) -> Self {
+        self.source_path_resolver = source_path_resolver;
+        self
+    }
+
+    /// Sets a plugin resolver used while building semantic facts.
+    pub fn with_plugin_resolver(
+        mut self,
+        plugin_resolver: &'a (dyn PluginResolver + Send + Sync),
+    ) -> Self {
+        self.plugin_resolver = Some(plugin_resolver);
+        self
+    }
+
+    /// Sets an optional plugin resolver used while building semantic facts.
+    pub fn with_optional_plugin_resolver(
+        mut self,
+        plugin_resolver: Option<&'a (dyn PluginResolver + Send + Sync)>,
+    ) -> Self {
+        self.plugin_resolver = plugin_resolver;
+        self
+    }
+
+    /// Uses an already-built suppression index for the request.
+    pub fn with_suppression_index(mut self, suppression_index: &'a SuppressionIndex) -> Self {
+        self.suppressions = SuppressionRequest::Index(suppression_index);
+        self
+    }
+
+    /// Uses an optional already-built suppression index for the request.
+    pub fn with_optional_suppression_index(
+        mut self,
+        suppression_index: Option<&'a SuppressionIndex>,
+    ) -> Self {
+        self.suppressions = suppression_index
+            .map(SuppressionRequest::Index)
+            .unwrap_or(SuppressionRequest::None);
+        self
+    }
+
+    /// Disables directive-derived and externally supplied suppressions for this request.
+    pub fn without_suppressions(mut self) -> Self {
+        self.suppressions = SuppressionRequest::None;
+        self
+    }
+
+    /// Uses already parsed suppression directives for the request.
+    pub fn with_directives(mut self, directives: &'a [SuppressionDirective]) -> Self {
+        self.suppressions = SuppressionRequest::Directives(directives);
+        self
+    }
+
+    /// Parses suppression directives using the provided compatibility-code map.
+    pub fn with_shellcheck_map(mut self, shellcheck_map: &'a ShellCheckCodeMap) -> Self {
+        self.suppressions = SuppressionRequest::ShellCheckMap(shellcheck_map);
+        self
+    }
+
+    /// Runs semantic analysis and returns both the semantic model and diagnostics.
+    pub fn analyze(self) -> AnalysisResult {
+        analyze(self)
+    }
+
+    /// Runs linting and returns diagnostics.
+    pub fn lint(self) -> Vec<Diagnostic> {
+        lint(self)
+    }
+
+    /// Returns the positional index built for this request's source and AST.
+    pub fn indexer(&self) -> &Indexer {
+        &self.indexer
+    }
+
+    fn file(&self) -> &'a File {
+        match self.input {
+            AnalysisInput::File(file) => file,
+            AnalysisInput::ParseResult(parse_result) => &parse_result.file,
+        }
+    }
+
+    fn parse_result(&self) -> Option<&'a ParseResult> {
+        match self.input {
+            AnalysisInput::File(_) => None,
+            AnalysisInput::ParseResult(parse_result) => Some(parse_result),
+        }
+    }
+}
+
+enum AppliedSuppressionIndex<'a> {
+    None,
+    Borrowed(&'a SuppressionIndex),
+    Owned(SuppressionIndex),
+}
+
+impl AppliedSuppressionIndex<'_> {
+    fn as_ref(&self) -> Option<&SuppressionIndex> {
+        match self {
+            Self::None => None,
+            Self::Borrowed(suppression_index) => Some(suppression_index),
+            Self::Owned(suppression_index) => Some(suppression_index),
+        }
+    }
+}
+
 struct LinterAnalysisResult<'a> {
     semantic: LinterSemanticArtifacts<'a>,
     diagnostics: Vec<Diagnostic>,
+    suppression_index: AppliedSuppressionIndex<'a>,
 }
 
 /// Semantic model plus linter-private traversal artifacts needed to build facts.
@@ -170,7 +369,7 @@ pub struct LinterSemanticArtifacts<'a> {
 
 impl<'a> LinterSemanticArtifacts<'a> {
     /// Builds semantic analysis artifacts for linter fact construction.
-    pub fn build(file: &'a File, source: &'a str, indexer: &'a Indexer) -> Self {
+    pub fn build(file: &'a File, source: &'a str, indexer: &Indexer) -> Self {
         Self::build_with_options(file, source, indexer, SemanticBuildOptions::default())
     }
 
@@ -178,7 +377,7 @@ impl<'a> LinterSemanticArtifacts<'a> {
     pub fn build_with_options(
         file: &'a File,
         source: &'a str,
-        indexer: &'a Indexer,
+        indexer: &Indexer,
         options: SemanticBuildOptions<'_>,
     ) -> Self {
         let mut observer = LintTraversalObserver::default();
@@ -645,199 +844,205 @@ fn build_suppression_index_from_semantic(
     ))
 }
 
-/// Builds semantic facts and linter diagnostics for a parsed file.
-pub fn analyze_file(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-) -> AnalysisResult {
-    analyze_file_at_path(file, source, indexer, settings, suppression_index, None)
-}
-
 #[cfg(feature = "benchmarking")]
 #[doc(hidden)]
 pub use facts::benchmark::CasePatternMatcher as BenchmarkCasePatternMatcher;
 
-/// Builds semantic facts and linter diagnostics for a parsed file at an optional source path.
-pub fn analyze_file_at_path(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-) -> AnalysisResult {
-    analyze_file_at_path_with_resolver(
-        file,
-        source,
-        indexer,
-        settings,
-        suppression_index,
-        source_path,
-        None,
-    )
-}
+/// Builds semantic facts and linter diagnostics for a request.
+pub fn analyze(request: AnalysisRequest<'_>) -> AnalysisResult {
+    let shell = resolve_shell(request.settings, request.source, request.source_path);
+    let first_parse_error = request.parse_result().and_then(parse_error_position);
+    let mut result = analyze_linter(&request, shell, first_parse_error);
 
-/// Builds semantic facts and linter diagnostics with a custom source-path resolver.
-pub fn analyze_file_at_path_with_resolver(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-) -> AnalysisResult {
-    analyze_file_at_path_with_resolvers(
-        file,
-        source,
-        indexer,
-        settings,
-        suppression_index,
-        source_path,
-        source_path_resolver,
-        None,
-    )
-}
+    if let Some(parse_result) = request.parse_result() {
+        add_parse_diagnostics(&mut result, &request, parse_result, shell);
+    }
+    finalize_diagnostics(&mut result, &request);
 
-/// Builds semantic facts and linter diagnostics with custom source and plugin resolvers.
-#[allow(clippy::too_many_arguments)]
-pub fn analyze_file_at_path_with_resolvers(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
-) -> AnalysisResult {
-    let shell = resolve_shell(settings, source, source_path);
-    let first_parse_error = parse_error_position(&parse_for_lint(source, shell));
-
-    analyze_file_at_path_with_resolver_and_shell(
-        file,
-        source,
-        indexer,
-        settings,
-        suppression_index,
-        source_path,
-        source_path_resolver,
-        plugin_resolver,
-        shell,
-        first_parse_error,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn analyze_file_at_path_with_resolver_and_shell(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
-    shell: ShellDialect,
-    first_parse_error: Option<(usize, usize)>,
-) -> AnalysisResult {
-    let result = analyze_linter_file_at_path_with_resolver_and_shell(
-        file,
-        source,
-        indexer,
-        settings,
-        suppression_index,
-        source_path,
-        source_path_resolver,
-        plugin_resolver,
-        shell,
-        first_parse_error,
-    );
     AnalysisResult {
         semantic: result.semantic.into_semantic(),
         diagnostics: result.diagnostics,
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn analyze_linter_file_at_path_with_resolver_and_shell<'a>(
-    file: &'a File,
-    source: &'a str,
-    indexer: &'a Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
+/// Lints a request and returns diagnostics.
+pub fn lint(request: AnalysisRequest<'_>) -> Vec<Diagnostic> {
+    let shell = resolve_shell(request.settings, request.source, request.source_path);
+    if let Some(parse_result) = request.parse_result() {
+        let mut result = analyze_linter(&request, shell, parse_error_position(parse_result));
+        add_parse_diagnostics(&mut result, &request, parse_result, shell);
+        finalize_diagnostics(&mut result, &request);
+        return result.diagnostics;
+    }
+
+    let mut result = analyze_linter(&request, shell, None);
+    finalize_diagnostics(&mut result, &request);
+    result.diagnostics
+}
+
+fn analyze_linter<'a>(
+    request: &AnalysisRequest<'a>,
     shell: ShellDialect,
     first_parse_error: Option<(usize, usize)>,
 ) -> LinterAnalysisResult<'a> {
+    let linter_semantic_artifacts = build_linter_semantic_artifacts(request, shell);
+    let suppression_index = build_request_suppression_index(request, &linter_semantic_artifacts);
+    let checker = Checker::new(
+        request.file(),
+        request.source,
+        &linter_semantic_artifacts,
+        request.indexer(),
+        &request.settings.rules,
+        shell,
+        request.settings.ambient_shell_options,
+        request.settings.report_environment_style_names,
+        request.settings.rule_options.clone(),
+        suppression_index.as_ref(),
+        first_parse_error,
+    );
+    let diagnostics = checker.check();
+
+    LinterAnalysisResult {
+        semantic: linter_semantic_artifacts,
+        diagnostics,
+        suppression_index,
+    }
+}
+
+fn build_linter_semantic_artifacts<'a>(
+    request: &AnalysisRequest<'a>,
+    shell: ShellDialect,
+) -> LinterSemanticArtifacts<'a> {
     let mut file_entry_contract_collector =
-        settings
+        request
+            .settings
             .ambient_contracts
-            .collector(source, source_path, shell);
-    let file_entry_contract_collector_factory = settings.ambient_contracts.collector_factory();
-    let analyzed_paths_fallback =
-        source_path.map(|path| FxHashSet::from_iter([path.to_path_buf()]));
-    let analyzed_paths = settings
+            .collector(request.source, request.source_path, shell);
+    let file_entry_contract_collector_factory =
+        request.settings.ambient_contracts.collector_factory();
+    let analyzed_paths_fallback = request
+        .source_path
+        .map(|path| FxHashSet::from_iter([path.to_path_buf()]));
+    let analyzed_paths = request
+        .settings
         .analyzed_paths
         .as_deref()
         .or(analyzed_paths_fallback.as_ref());
 
     let shell_profile = shell.shell_profile();
-    let linter_semantic_artifacts = LinterSemanticArtifacts::build_with_options(
-        file,
-        source,
-        indexer,
+    LinterSemanticArtifacts::build_with_options(
+        request.file(),
+        request.source,
+        request.indexer(),
         SemanticBuildOptions {
-            source_path,
-            source_path_resolver,
-            plugin_resolver,
+            source_path: request.source_path,
+            source_path_resolver: request.source_path_resolver,
+            plugin_resolver: request.plugin_resolver,
             file_entry_contract: None,
             file_entry_contract_collector: Some(&mut file_entry_contract_collector),
             file_entry_contract_collector_factory: Some(&file_entry_contract_collector_factory),
             analyzed_paths,
             shell_profile: Some(shell_profile),
-            resolve_source_closure: settings.resolve_source_closure,
+            resolve_source_closure: request.settings.resolve_source_closure,
         },
+    )
+}
+
+fn build_request_suppression_index<'a>(
+    request: &AnalysisRequest<'a>,
+    semantic: &LinterSemanticArtifacts<'_>,
+) -> AppliedSuppressionIndex<'a> {
+    match request.suppressions {
+        SuppressionRequest::None => AppliedSuppressionIndex::None,
+        SuppressionRequest::DefaultShellCheckMap => {
+            let shellcheck_map = ShellCheckCodeMap::default();
+            let directives = parse_directives(
+                request.source,
+                request.indexer().comment_index(),
+                &shellcheck_map,
+            );
+            build_suppression_index_from_semantic(
+                &directives,
+                request.file(),
+                request.source,
+                semantic,
+            )
+            .map(AppliedSuppressionIndex::Owned)
+            .unwrap_or(AppliedSuppressionIndex::None)
+        }
+        SuppressionRequest::Index(suppression_index) => {
+            AppliedSuppressionIndex::Borrowed(suppression_index)
+        }
+        SuppressionRequest::Directives(directives) => build_suppression_index_from_semantic(
+            directives,
+            request.file(),
+            request.source,
+            semantic,
+        )
+        .map(AppliedSuppressionIndex::Owned)
+        .unwrap_or(AppliedSuppressionIndex::None),
+        SuppressionRequest::ShellCheckMap(shellcheck_map) => {
+            let directives = parse_directives(
+                request.source,
+                request.indexer().comment_index(),
+                shellcheck_map,
+            );
+            build_suppression_index_from_semantic(
+                &directives,
+                request.file(),
+                request.source,
+                semantic,
+            )
+            .map(AppliedSuppressionIndex::Owned)
+            .unwrap_or(AppliedSuppressionIndex::None)
+        }
+    }
+}
+
+fn add_parse_diagnostics(
+    result: &mut LinterAnalysisResult<'_>,
+    request: &AnalysisRequest<'_>,
+    parse_result: &ParseResult,
+    shell: ShellDialect,
+) {
+    let locator = Locator::new(request.source, request.indexer().line_index());
+    let parse_diagnostics = parse_diagnostics::collect_parse_rule_diagnostics(
+        request.file(),
+        locator,
+        Some(parse_result),
+        &result.semantic,
+        &request.settings.rules,
+        shell,
     );
-    let checker_diagnostics = {
-        let checker = Checker::new(
-            file,
-            source,
-            &linter_semantic_artifacts,
-            indexer,
-            &settings.rules,
-            shell,
-            settings.ambient_shell_options,
-            settings.report_environment_style_names,
-            settings.rule_options.clone(),
-            suppression_index,
-            first_parse_error,
-        );
-        checker.check()
-    };
-    let mut diagnostics = checker_diagnostics;
-    for diagnostic in &mut diagnostics {
-        if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
+    result.diagnostics.extend(parse_diagnostics);
+    if parse_result.is_err() {
+        sanitize_diagnostic_spans_cold(&mut result.diagnostics, locator);
+    }
+}
+
+fn finalize_diagnostics(result: &mut LinterAnalysisResult<'_>, request: &AnalysisRequest<'_>) {
+    for diagnostic in result.diagnostics.iter_mut() {
+        if let Some(&severity) = request.settings.severity_overrides.get(&diagnostic.rule) {
             diagnostic.severity = severity;
         }
     }
 
-    if let Some(suppression_index) = suppression_index {
-        filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
+    if let Some(suppression_index) = result.suppression_index.as_ref() {
+        filter_suppressed_diagnostics(
+            &mut result.diagnostics,
+            request.indexer(),
+            suppression_index,
+        );
     }
-    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
+    filter_per_file_ignored_diagnostics(
+        &mut result.diagnostics,
+        request.settings,
+        request.source_path,
+    );
 
-    diagnostics
+    result
+        .diagnostics
         .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
-    LinterAnalysisResult {
-        semantic: linter_semantic_artifacts,
-        diagnostics,
-    }
 }
 
 fn resolve_shell(
@@ -850,10 +1055,6 @@ fn resolve_shell(
     } else {
         settings.shell
     }
-}
-
-fn parse_for_lint(source: &str, shell: ShellDialect) -> ParseResult {
-    Parser::with_profile(source, shell.shell_profile()).parse()
 }
 
 fn parse_error_position(parse_result: &ParseResult) -> Option<(usize, usize)> {
@@ -870,409 +1071,6 @@ fn parse_error_position(parse_result: &ParseResult) -> Option<(usize, usize)> {
         .diagnostics
         .first()
         .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
-}
-
-/// Lints a parsed file located at an optional source path.
-pub fn lint_file_at_path(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-) -> Vec<Diagnostic> {
-    lint_file_at_path_with_resolver(
-        file,
-        source,
-        indexer,
-        settings,
-        suppression_index,
-        source_path,
-        None,
-    )
-}
-
-/// Lints a parsed file with a custom source-path resolver.
-pub fn lint_file_at_path_with_resolver(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-) -> Vec<Diagnostic> {
-    lint_file_at_path_with_resolvers(
-        file,
-        source,
-        indexer,
-        settings,
-        suppression_index,
-        source_path,
-        source_path_resolver,
-        None,
-    )
-}
-
-/// Lints a parsed file with custom source and plugin resolvers.
-#[allow(clippy::too_many_arguments)]
-pub fn lint_file_at_path_with_resolvers(
-    file: &File,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
-) -> Vec<Diagnostic> {
-    let shell = resolve_shell(settings, source, source_path);
-    let parse_result = parse_for_lint(source, shell);
-
-    let analysis = analyze_linter_file_at_path_with_resolver_and_shell(
-        file,
-        source,
-        indexer,
-        settings,
-        suppression_index,
-        source_path,
-        source_path_resolver,
-        plugin_resolver,
-        shell,
-        parse_error_position(&parse_result),
-    );
-    let mut diagnostics = analysis.diagnostics;
-
-    let locator = Locator::new(source, indexer.line_index());
-    diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
-        file,
-        locator,
-        Some(&parse_result),
-        &analysis.semantic,
-        &settings.rules,
-        shell,
-    ));
-
-    for diagnostic in &mut diagnostics {
-        if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
-            diagnostic.severity = severity;
-        }
-    }
-
-    if let Some(suppression_index) = suppression_index {
-        filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
-    }
-    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
-
-    diagnostics
-        .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
-
-    diagnostics
-}
-
-/// Lints an existing parse result while preserving parse-aware diagnostics.
-#[allow(clippy::too_many_arguments)]
-pub fn lint_file_at_path_with_resolver_and_parse_result(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    shellcheck_map: &ShellCheckCodeMap,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-) -> Vec<Diagnostic> {
-    lint_file_at_path_with_resolver_and_parse_result_with_plugin_resolver(
-        parse_result,
-        source,
-        indexer,
-        settings,
-        shellcheck_map,
-        source_path,
-        source_path_resolver,
-        None,
-    )
-}
-
-/// Lints an existing parse result while preserving parse-aware diagnostics and plugin resolution.
-#[allow(clippy::too_many_arguments)]
-pub fn lint_file_at_path_with_resolver_and_parse_result_with_plugin_resolver(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    shellcheck_map: &ShellCheckCodeMap,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
-) -> Vec<Diagnostic> {
-    let directives = parse_directives(source, indexer.comment_index(), shellcheck_map);
-    lint_file_at_path_with_resolver_and_parse_result_and_directives(
-        parse_result,
-        source,
-        indexer,
-        settings,
-        &directives,
-        source_path,
-        source_path_resolver,
-        plugin_resolver,
-    )
-}
-
-/// Analyzes an existing parse result while preserving diagnostics and semantic dependency paths.
-#[allow(clippy::too_many_arguments)]
-pub fn analyze_file_at_path_with_resolver_and_parse_result_with_plugin_resolver(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    shellcheck_map: &ShellCheckCodeMap,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
-) -> AnalysisResult {
-    let directives = parse_directives(source, indexer.comment_index(), shellcheck_map);
-    analyze_file_at_path_with_resolver_and_parse_result_and_directives(
-        parse_result,
-        source,
-        indexer,
-        settings,
-        &directives,
-        source_path,
-        source_path_resolver,
-        plugin_resolver,
-    )
-}
-
-/// Lints an existing parse result while deriving suppressions from parsed directives
-/// and semantic-collected command spans.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn lint_file_at_path_with_resolver_and_parse_result_and_directives(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    directives: &[SuppressionDirective],
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
-) -> Vec<Diagnostic> {
-    analyze_file_at_path_with_resolver_and_parse_result_and_directives(
-        parse_result,
-        source,
-        indexer,
-        settings,
-        directives,
-        source_path,
-        source_path_resolver,
-        plugin_resolver,
-    )
-    .diagnostics
-}
-
-#[allow(clippy::too_many_arguments)]
-fn analyze_file_at_path_with_resolver_and_parse_result_and_directives(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    directives: &[SuppressionDirective],
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
-) -> AnalysisResult {
-    let shell = resolve_shell(settings, source, source_path);
-    let locator = Locator::new(source, indexer.line_index());
-    let mut file_entry_contract_collector =
-        settings
-            .ambient_contracts
-            .collector(source, source_path, shell);
-    let file_entry_contract_collector_factory = settings.ambient_contracts.collector_factory();
-    let analyzed_paths_fallback =
-        source_path.map(|path| FxHashSet::from_iter([path.to_path_buf()]));
-    let analyzed_paths = settings
-        .analyzed_paths
-        .as_deref()
-        .or(analyzed_paths_fallback.as_ref());
-    let linter_semantic_artifacts = LinterSemanticArtifacts::build_with_options(
-        &parse_result.file,
-        source,
-        indexer,
-        SemanticBuildOptions {
-            source_path,
-            source_path_resolver,
-            plugin_resolver,
-            file_entry_contract: None,
-            file_entry_contract_collector: Some(&mut file_entry_contract_collector),
-            file_entry_contract_collector_factory: Some(&file_entry_contract_collector_factory),
-            analyzed_paths,
-            shell_profile: Some(shell.shell_profile()),
-            resolve_source_closure: settings.resolve_source_closure,
-        },
-    );
-    let suppression_index = build_suppression_index_from_semantic(
-        directives,
-        &parse_result.file,
-        source,
-        &linter_semantic_artifacts,
-    );
-    let checker = Checker::new(
-        &parse_result.file,
-        source,
-        &linter_semantic_artifacts,
-        indexer,
-        &settings.rules,
-        shell,
-        settings.ambient_shell_options,
-        settings.report_environment_style_names,
-        settings.rule_options.clone(),
-        suppression_index.as_ref(),
-        parse_error_position(parse_result),
-    );
-    let mut diagnostics = checker.check();
-
-    diagnostics.extend(parse_diagnostics::collect_parse_rule_diagnostics(
-        &parse_result.file,
-        locator,
-        Some(parse_result),
-        &linter_semantic_artifacts,
-        &settings.rules,
-        shell,
-    ));
-    if parse_result.is_err() {
-        sanitize_diagnostic_spans_cold(&mut diagnostics, locator);
-    }
-
-    for diagnostic in &mut diagnostics {
-        if let Some(&severity) = settings.severity_overrides.get(&diagnostic.rule) {
-            diagnostic.severity = severity;
-        }
-    }
-
-    if let Some(suppression_index) = suppression_index.as_ref() {
-        filter_suppressed_diagnostics(&mut diagnostics, indexer, suppression_index);
-    }
-    filter_per_file_ignored_diagnostics(&mut diagnostics, settings, source_path);
-
-    diagnostics
-        .sort_by_key(|diagnostic| (diagnostic.span.start.offset, diagnostic.span.end.offset));
-
-    AnalysisResult {
-        semantic: linter_semantic_artifacts.into_semantic(),
-        diagnostics,
-    }
-}
-
-/// Lints an existing parse result while parsing suppression directives inside the linter.
-///
-/// This keeps directive attachment internal while we migrate it to semantic command visits.
-#[allow(clippy::too_many_arguments)]
-pub fn lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    shellcheck_map: &ShellCheckCodeMap,
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-) -> Vec<Diagnostic> {
-    let directives = parse_directives(source, indexer.comment_index(), shellcheck_map);
-    lint_file_at_path_with_resolver_and_parse_result_and_directives(
-        parse_result,
-        source,
-        indexer,
-        settings,
-        &directives,
-        source_path,
-        source_path_resolver,
-        None,
-    )
-}
-
-/// Lints an existing parse result located at an optional source path.
-pub fn lint_file(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    shellcheck_map: &ShellCheckCodeMap,
-    source_path: Option<&Path>,
-) -> Vec<Diagnostic> {
-    lint_file_at_path_with_resolver_and_parse_result(
-        parse_result,
-        source,
-        indexer,
-        settings,
-        shellcheck_map,
-        source_path,
-        None,
-    )
-}
-
-/// Lints an existing parse result while deriving suppressions from parsed directives
-/// and semantic-collected command spans.
-pub(crate) fn lint_file_with_directives(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    directives: &[SuppressionDirective],
-    source_path: Option<&Path>,
-) -> Vec<Diagnostic> {
-    lint_file_with_directives_and_resolvers(
-        parse_result,
-        source,
-        indexer,
-        settings,
-        directives,
-        source_path,
-        None,
-        None,
-    )
-}
-
-/// Lints an existing parse result while deriving suppressions from parsed directives
-/// and allowing caller-provided source and plugin resolvers.
-#[allow(clippy::too_many_arguments)]
-pub fn lint_file_with_directives_and_resolvers(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    directives: &[SuppressionDirective],
-    source_path: Option<&Path>,
-    source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
-    plugin_resolver: Option<&(dyn PluginResolver + Send + Sync)>,
-) -> Vec<Diagnostic> {
-    lint_file_at_path_with_resolver_and_parse_result_and_directives(
-        parse_result,
-        source,
-        indexer,
-        settings,
-        directives,
-        source_path,
-        source_path_resolver,
-        plugin_resolver,
-    )
-}
-
-/// Lints an existing parse result while parsing suppression directives inside the linter.
-pub fn lint_file_with_comment_directives(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    shellcheck_map: &ShellCheckCodeMap,
-    source_path: Option<&Path>,
-) -> Vec<Diagnostic> {
-    lint_file_at_path_with_resolver_and_parse_result_with_comment_directives(
-        parse_result,
-        source,
-        indexer,
-        settings,
-        shellcheck_map,
-        source_path,
-        None,
-    )
 }
 
 fn filter_suppressed_diagnostics(
@@ -1393,7 +1191,9 @@ mod tests {
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        lint_file_with_directives(&output, source, &indexer, settings, &directives, None)
+        AnalysisRequest::from_parse_result(&output, source, settings)
+            .with_directives(&directives)
+            .lint()
     }
 
     fn lint_path(path: &Path, settings: &LinterSettings) -> Vec<Diagnostic> {
@@ -1405,14 +1205,10 @@ mod tests {
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        lint_file_with_directives(
-            &output,
-            &source,
-            &indexer,
-            settings,
-            &directives,
-            Some(path),
-        )
+        AnalysisRequest::from_parse_result(&output, &source, settings)
+            .with_source_path(path)
+            .with_directives(&directives)
+            .lint()
     }
 
     fn lint_for_rule(source: &str, rule: Rule) -> Vec<Diagnostic> {
@@ -1436,16 +1232,12 @@ mod tests {
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        lint_file_at_path_with_resolver_and_parse_result_and_directives(
-            &output,
-            &source,
-            &indexer,
-            &LinterSettings::for_rule(rule),
-            &directives,
-            Some(path),
-            source_path_resolver,
-            None,
-        )
+        let settings = LinterSettings::for_rule(rule);
+        AnalysisRequest::from_parse_result(&output, &source, &settings)
+            .with_source_path(path)
+            .with_directives(&directives)
+            .with_optional_source_path_resolver(source_path_resolver)
+            .lint()
     }
 
     fn lint_path_for_rule_with_plugin_resolver(
@@ -1463,16 +1255,12 @@ mod tests {
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        lint_file_at_path_with_resolver_and_parse_result_and_directives(
-            &output,
-            &source,
-            &indexer,
-            &LinterSettings::for_rule(rule),
-            &directives,
-            Some(path),
-            None,
-            Some(plugin_resolver),
-        )
+        let settings = LinterSettings::for_rule(rule);
+        AnalysisRequest::from_parse_result(&output, &source, &settings)
+            .with_source_path(path)
+            .with_directives(&directives)
+            .with_plugin_resolver(plugin_resolver)
+            .lint()
     }
 
     fn lint_named_source(path: &Path, source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
@@ -1483,7 +1271,10 @@ mod tests {
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        lint_file_with_directives(&output, source, &indexer, settings, &directives, Some(path))
+        AnalysisRequest::from_parse_result(&output, source, settings)
+            .with_source_path(path)
+            .with_directives(&directives)
+            .lint()
     }
 
     fn lint_named_source_with_parse_dialect(
@@ -1499,7 +1290,10 @@ mod tests {
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        lint_file_with_directives(&output, source, &indexer, settings, &directives, Some(path))
+        AnalysisRequest::from_parse_result(&output, source, settings)
+            .with_source_path(path)
+            .with_directives(&directives)
+            .lint()
     }
 
     fn runtime_prelude_source(shebang: &str) -> String {
@@ -1595,15 +1389,11 @@ mod tests {
     fn lint_file_preserves_parse_rule_diagnostics() {
         let source = "#!/bin/sh\n{ :; } always { :; }\n";
         let parse_result = Parser::new(source).parse();
-        let indexer = Indexer::new(source, &parse_result);
-        let diagnostics = lint_file(
-            &parse_result,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::ZshAlwaysBlock),
-            &ShellCheckCodeMap::default(),
-            None,
-        );
+        let settings = LinterSettings::for_rule(Rule::ZshAlwaysBlock);
+        let shellcheck_map = ShellCheckCodeMap::default();
+        let diagnostics = AnalysisRequest::from_parse_result(&parse_result, source, &settings)
+            .with_shellcheck_map(&shellcheck_map)
+            .lint();
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::ZshAlwaysBlock);
@@ -1614,14 +1404,8 @@ mod tests {
     fn analyze_file_returns_semantic_model_and_diagnostics() {
         let source = "#!/bin/bash\nvalue=ok\necho \"$value\"\n";
         let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
-        let result = analyze_file(
-            &output.file,
-            source,
-            &indexer,
-            &LinterSettings::default(),
-            None,
-        );
+        let settings = LinterSettings::default();
+        let result = AnalysisRequest::from_file(&output.file, source, &settings).analyze();
 
         assert!(result.diagnostics.is_empty());
         assert!(!result.semantic.scopes().is_empty());
@@ -2983,15 +2767,12 @@ END
 
         for (path, dialect) in cases {
             let parse_result = Parser::with_dialect(source, dialect).parse();
-            let indexer = Indexer::new(source, &parse_result);
-            let diagnostics = lint_file(
-                &parse_result,
-                source,
-                &indexer,
-                &LinterSettings::default(),
-                &ShellCheckCodeMap::default(),
-                path,
-            );
+            let settings = LinterSettings::default();
+            let shellcheck_map = ShellCheckCodeMap::default();
+            let diagnostics = AnalysisRequest::from_parse_result(&parse_result, source, &settings)
+                .with_optional_source_path(path)
+                .with_shellcheck_map(&shellcheck_map)
+                .lint();
 
             for diagnostic in diagnostics {
                 assert!(
@@ -6463,14 +6244,10 @@ foo=1
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        let diagnostics = lint_file_with_directives(
-            &output,
-            source,
-            &indexer,
-            &LinterSettings::default(),
-            &directives,
-            None,
-        );
+        let settings = LinterSettings::default();
+        let diagnostics = AnalysisRequest::from_parse_result(&output, source, &settings)
+            .with_directives(&directives)
+            .lint();
         assert!(diagnostics.is_empty());
     }
 

--- a/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
+++ b/crates/shuck-linter/src/rules/correctness/function_references_unset_param.rs
@@ -80,8 +80,7 @@ mod tests {
 
     use crate::test::test_snippet;
     use crate::{
-        LinterSettings, Rule, ShellCheckCodeMap, ShellDialect, lint_file_with_directives,
-        parse_directives,
+        AnalysisRequest, LinterSettings, Rule, ShellCheckCodeMap, ShellDialect, parse_directives,
     };
 
     #[test]
@@ -938,14 +937,10 @@ greet
             indexer.comment_index(),
             &ShellCheckCodeMap::default(),
         );
-        let diagnostics = lint_file_with_directives(
-            &parse_result,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam),
-            &directives,
-            None,
-        );
+        let settings = LinterSettings::for_rule(Rule::FunctionReferencesUnsetParam);
+        let diagnostics = AnalysisRequest::from_parse_result(&parse_result, source, &settings)
+            .with_directives(&directives)
+            .lint();
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }

--- a/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
+++ b/crates/shuck-linter/src/rules/correctness/quoted_bash_source.rs
@@ -33,8 +33,7 @@ pub fn quoted_bash_source(checker: &mut Checker) {
 #[cfg(test)]
 mod tests {
     use crate::test::test_snippet;
-    use crate::{LinterSettings, Rule, ShellDialect, lint_file_at_path};
-    use shuck_indexer::Indexer;
+    use crate::{AnalysisRequest, LinterSettings, Rule, ShellDialect};
     use shuck_parser::parser::Parser;
     use std::fs;
     use tempfile::tempdir;
@@ -712,15 +711,10 @@ TERMUX_PKG_VERSION=(\"$(. ./helper.sh; printf '%s\\n' \"$TERMUX_PKG_VERSION\")\"
 
         let source = fs::read_to_string(&main).unwrap();
         let output = Parser::new(&source).parse().unwrap();
-        let indexer = Indexer::new(&source, &output);
-        let diagnostics = lint_file_at_path(
-            &output.file,
-            &source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::QuotedBashSource),
-            None,
-            Some(&main),
-        );
+        let settings = LinterSettings::for_rule(Rule::QuotedBashSource);
+        let diagnostics = AnalysisRequest::from_file(&output.file, &source, &settings)
+            .with_source_path(main.as_path())
+            .lint();
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }

--- a/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
+++ b/crates/shuck-linter/src/rules/correctness/untracked_source_file.rs
@@ -37,13 +37,12 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
 
-    use shuck_indexer::Indexer;
     use shuck_parser::parser::Parser;
     use shuck_semantic::SourcePathResolver;
     use tempfile::tempdir;
 
     use crate::test::test_snippet_at_path;
-    use crate::{LinterSettings, Rule, ShellDialect, lint_file_at_path_with_resolver};
+    use crate::{AnalysisRequest, LinterSettings, Rule, ShellDialect};
 
     struct TestSourceResolver {
         helper: PathBuf,
@@ -225,20 +224,15 @@ source \"${scriptfolder}${known_pins_dbfile}\"
         let parse_result = Parser::with_dialect(source, shuck_parser::ShellDialect::Bash)
             .parse()
             .unwrap();
-        let indexer = Indexer::new(source, &parse_result);
         let resolver = TestSourceResolver {
             helper: helper.clone(),
         };
 
-        let diagnostics = lint_file_at_path_with_resolver(
-            &parse_result.file,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
-            None,
-            Some(&main),
-            Some(&resolver),
-        );
+        let settings = LinterSettings::for_rule(Rule::UntrackedSourceFile);
+        let diagnostics = AnalysisRequest::from_file(&parse_result.file, source, &settings)
+            .with_source_path(main.as_path())
+            .with_source_path_resolver(&resolver)
+            .lint();
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(
@@ -476,7 +470,6 @@ fi
         fs::write(&helper, "echo helper\n").unwrap();
 
         let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
 
         let main_path = main.clone();
         let helper_path = helper.clone();
@@ -488,15 +481,11 @@ fi
             }
         };
 
-        let diagnostics = lint_file_at_path_with_resolver(
-            &output.file,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
-            None,
-            Some(&main),
-            Some(&resolver),
-        );
+        let settings = LinterSettings::for_rule(Rule::UntrackedSourceFile);
+        let diagnostics = AnalysisRequest::from_file(&output.file, source, &settings)
+            .with_source_path(main.as_path())
+            .with_source_path_resolver(&resolver)
+            .lint();
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
     }
@@ -565,7 +554,6 @@ source "${script_dir}/logging.zsh"
         fs::write(&helper, "echo helper\n").unwrap();
 
         let output = Parser::new(source).parse().unwrap();
-        let indexer = Indexer::new(source, &output);
 
         let main_path = main.clone();
         let helper_path = helper.clone();
@@ -577,15 +565,11 @@ source "${script_dir}/logging.zsh"
             }
         };
 
-        let diagnostics = lint_file_at_path_with_resolver(
-            &output.file,
-            source,
-            &indexer,
-            &LinterSettings::for_rule(Rule::UntrackedSourceFile),
-            None,
-            Some(&main),
-            Some(&resolver),
-        );
+        let settings = LinterSettings::for_rule(Rule::UntrackedSourceFile);
+        let diagnostics = AnalysisRequest::from_file(&output.file, source, &settings)
+            .with_source_path(main.as_path())
+            .with_source_path_resolver(&resolver)
+            .lint();
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(

--- a/crates/shuck-linter/src/rules/style/escaped_underscore.rs
+++ b/crates/shuck-linter/src/rules/style/escaped_underscore.rs
@@ -123,29 +123,22 @@ fn is_regular_plain_word_escape_target(byte: u8) -> bool {
 mod tests {
     use std::path::Path;
 
-    use shuck_indexer::Indexer;
     use shuck_parser::parser::{Parser, ShellDialect as ParseDialect};
 
     use super::FIX_TITLE;
     use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
     use crate::{
-        Applicability, Diagnostic, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff,
-        lint_file,
+        AnalysisRequest, Applicability, Diagnostic, LinterSettings, Rule, ShellDialect,
+        assert_diagnostics_diff,
     };
 
     fn test_posix_snippet_at_path(path: &Path, source: &str) -> Vec<Diagnostic> {
         let parse_result = Parser::with_dialect(source, ParseDialect::Posix).parse();
-        let indexer = Indexer::new(source, &parse_result);
         let settings =
             LinterSettings::for_rule(Rule::EscapedUnderscore).with_shell(ShellDialect::Sh);
-        lint_file(
-            &parse_result,
-            source,
-            &indexer,
-            &settings,
-            &crate::ShellCheckCodeMap::default(),
-            Some(path),
-        )
+        AnalysisRequest::from_parse_result(&parse_result, source, &settings)
+            .with_source_path(path)
+            .lint()
     }
 
     #[test]

--- a/crates/shuck-linter/src/suppression/rewrite.rs
+++ b/crates/shuck-linter/src/suppression/rewrite.rs
@@ -12,8 +12,8 @@ use shuck_parser::{
 };
 
 use crate::{
-    Diagnostic, LinterSettings, PluginResolver, Rule, ShellDialect, SourcePathResolver,
-    lint_file_with_directives, lint_file_with_directives_and_resolvers,
+    AnalysisRequest, Diagnostic, LinterSettings, PluginResolver, Rule, ShellDialect,
+    SourcePathResolver,
 };
 
 use super::{
@@ -194,27 +194,12 @@ fn analyze_source(
     let parse_result = parse_for_lint(source, shell);
     let indexer = Indexer::new(source, &parse_result);
     let directives = parse_directives(source, indexer.comment_index(), shellcheck_map);
-    let diagnostics = if source_path_resolver.is_some() || plugin_resolver.is_some() {
-        lint_file_with_directives_and_resolvers(
-            &parse_result,
-            source,
-            &indexer,
-            settings,
-            &directives,
-            source_path,
-            source_path_resolver,
-            plugin_resolver,
-        )
-    } else {
-        lint_file_with_directives(
-            &parse_result,
-            source,
-            &indexer,
-            settings,
-            &directives,
-            source_path,
-        )
-    };
+    let diagnostics = AnalysisRequest::from_parse_result(&parse_result, source, settings)
+        .with_optional_source_path(source_path)
+        .with_directives(&directives)
+        .with_optional_source_path_resolver(source_path_resolver)
+        .with_optional_plugin_resolver(plugin_resolver)
+        .lint();
     let strict_parse_error = strict_parse_error(&parse_result);
     let parse_error = strict_parse_error
         .clone()

--- a/crates/shuck-linter/src/test.rs
+++ b/crates/shuck-linter/src/test.rs
@@ -2,12 +2,11 @@ use std::fmt::Write;
 use std::fs;
 use std::path::Path;
 
-use shuck_indexer::Indexer;
 use shuck_parser::parser::{ParseResult, Parser};
 use similar::TextDiff;
 
 use crate::{
-    Applicability, Diagnostic, LinterSettings, ShellDialect, apply_fixes, lint_file_with_directives,
+    AnalysisRequest, Applicability, Diagnostic, LinterSettings, ShellDialect, apply_fixes,
 };
 
 fn infer_shell(source: &str, settings: &LinterSettings, path: Option<&Path>) -> ShellDialect {
@@ -34,10 +33,11 @@ pub struct FixTestResult {
 /// Lint a source string directly (no file needed).
 pub fn test_snippet(source: &str, settings: &LinterSettings) -> Vec<Diagnostic> {
     let parse_result = parse_for_lint(source, settings, None);
-    let indexer = Indexer::new(source, &parse_result);
     // Fixture and rule-focused test helpers ignore inline directives by default so
     // embedded ShellCheck suppressions do not silently mask the rule under test.
-    lint_file_with_directives(&parse_result, source, &indexer, settings, &[], None)
+    AnalysisRequest::from_parse_result(&parse_result, source, settings)
+        .without_suppressions()
+        .lint()
 }
 
 /// Lint a source string while preserving an explicit path for path-sensitive rules.
@@ -47,8 +47,10 @@ pub fn test_snippet_at_path(
     settings: &LinterSettings,
 ) -> Vec<Diagnostic> {
     let parse_result = parse_for_lint(source, settings, Some(path));
-    let indexer = Indexer::new(source, &parse_result);
-    lint_file_with_directives(&parse_result, source, &indexer, settings, &[], Some(path))
+    AnalysisRequest::from_parse_result(&parse_result, source, settings)
+        .with_source_path(path)
+        .without_suppressions()
+        .lint()
 }
 
 pub fn test_snippet_with_fix(

--- a/crates/shuck-semantic/src/builder/arithmetic.rs
+++ b/crates/shuck-semantic/src/builder/arithmetic.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
+impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     pub(super) fn visit_conditional_expr(
         &mut self,
         command_span: Span,

--- a/crates/shuck-semantic/src/builder/bindings.rs
+++ b/crates/shuck-semantic/src/builder/bindings.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
+impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     pub(super) fn visit_assignment_reads_into(
         &mut self,
         assignment: &'a Assignment,
@@ -325,7 +325,7 @@ impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
 }
 
 fn assignment_source_path_template_for_binding(
-    builder: &SemanticModelBuilder<'_, '_>,
+    builder: &SemanticModelBuilder<'_, '_, '_>,
     assignment: &Assignment,
 ) -> Option<SourcePathTemplate> {
     let AssignmentValue::Scalar(word) = &assignment.value else {

--- a/crates/shuck-semantic/src/builder/declarations.rs
+++ b/crates/shuck-semantic/src/builder/declarations.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
+impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     pub(super) fn declaration_scope_and_attributes(
         &self,
         builtin: DeclarationBuiltin,

--- a/crates/shuck-semantic/src/builder/mod.rs
+++ b/crates/shuck-semantic/src/builder/mod.rs
@@ -74,10 +74,10 @@ pub(crate) struct BuildOutput {
     pub(crate) heuristic_unused_assignments: Vec<BindingId>,
 }
 
-pub(crate) struct SemanticModelBuilder<'a, 'observer> {
+pub(crate) struct SemanticModelBuilder<'a, 'idx, 'observer> {
     source: &'a str,
     file_entry_contract_collector: Option<&'observer mut dyn FileEntryContractCollector>,
-    line_index: &'a LineIndex,
+    line_index: &'idx LineIndex,
     shell_profile: ShellProfile,
     observer: &'observer mut dyn TraversalObserver<'a>,
     scopes: Vec<Scope>,
@@ -209,11 +209,11 @@ mod traversal;
 mod words;
 mod zsh_effects;
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
+impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     pub(crate) fn build(
         file: &'a File,
         source: &'a str,
-        indexer: &'a Indexer,
+        indexer: &'idx Indexer,
         observer: &'observer mut dyn TraversalObserver<'a>,
         file_entry_contract_collector: Option<&'observer mut dyn FileEntryContractCollector>,
         bash_runtime_vars_enabled: bool,

--- a/crates/shuck-semantic/src/builder/references.rs
+++ b/crates/shuck-semantic/src/builder/references.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
+impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     pub(super) fn add_reference(
         &mut self,
         name: &Name,

--- a/crates/shuck-semantic/src/builder/source_refs.rs
+++ b/crates/shuck-semantic/src/builder/source_refs.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
+impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     pub(super) fn classify_source_ref(&self, line: usize, word: &Word) -> SourceRefKind {
         if let Some(directive) = self.source_directive_for_line(line) {
             return directive;

--- a/crates/shuck-semantic/src/builder/special_builtins.rs
+++ b/crates/shuck-semantic/src/builder/special_builtins.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
+impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     pub(super) fn classify_special_simple_command(
         &mut self,
         name: &Name,

--- a/crates/shuck-semantic/src/builder/traversal.rs
+++ b/crates/shuck-semantic/src/builder/traversal.rs
@@ -1,7 +1,7 @@
 use super::zsh_effects::recorded_command_info;
 use super::*;
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
+impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     pub(super) fn flow_context(flow: FlowState) -> FlowContext {
         FlowContext {
             in_function: flow.in_function,

--- a/crates/shuck-semantic/src/builder/words.rs
+++ b/crates/shuck-semantic/src/builder/words.rs
@@ -4,7 +4,7 @@ use super::inert::{
 };
 use super::*;
 
-impl<'a, 'observer> SemanticModelBuilder<'a, 'observer> {
+impl<'a, 'idx, 'observer> SemanticModelBuilder<'a, 'idx, 'observer> {
     pub(super) fn visit_words(
         &mut self,
         words: &'a [Word],

--- a/crates/shuck-semantic/src/lib.rs
+++ b/crates/shuck-semantic/src/lib.rs
@@ -2350,7 +2350,7 @@ fn file_entry_contract_can_consume_exact_binding(binding: &Binding) -> bool {
 pub fn build_with_observer<'a>(
     file: &'a File,
     source: &'a str,
-    indexer: &'a Indexer,
+    indexer: &Indexer,
     observer: &mut dyn TraversalObserver<'a>,
 ) -> SemanticModel {
     build_with_observer_with_options(
@@ -2366,7 +2366,7 @@ pub fn build_with_observer<'a>(
 pub fn build_with_observer_with_options<'a>(
     file: &'a File,
     source: &'a str,
-    indexer: &'a Indexer,
+    indexer: &Indexer,
     observer: &mut dyn TraversalObserver<'a>,
     options: SemanticBuildOptions<'_>,
 ) -> SemanticModel {
@@ -2377,7 +2377,7 @@ pub fn build_with_observer_with_options<'a>(
 pub fn build_with_observer_at_path<'a>(
     file: &'a File,
     source: &'a str,
-    indexer: &'a Indexer,
+    indexer: &Indexer,
     observer: &mut dyn TraversalObserver<'a>,
     source_path: Option<&Path>,
 ) -> SemanticModel {
@@ -2388,7 +2388,7 @@ pub fn build_with_observer_at_path<'a>(
 pub fn build_with_observer_at_path_with_resolver<'a>(
     file: &'a File,
     source: &'a str,
-    indexer: &'a Indexer,
+    indexer: &Indexer,
     observer: &mut dyn TraversalObserver<'a>,
     source_path: Option<&Path>,
     source_path_resolver: Option<&(dyn SourcePathResolver + Send + Sync)>,
@@ -2415,7 +2415,7 @@ pub fn build_with_observer_at_path_with_resolver<'a>(
 fn build_semantic_model<'a>(
     file: &'a File,
     source: &'a str,
-    indexer: &'a Indexer,
+    indexer: &Indexer,
     observer: &mut dyn TraversalObserver<'a>,
     options: SemanticBuildOptions<'_>,
 ) -> SemanticModel {
@@ -2486,7 +2486,7 @@ fn build_semantic_model<'a>(
 pub(crate) fn build_semantic_model_base<'a, 'observer>(
     file: &'a File,
     source: &'a str,
-    indexer: &'a Indexer,
+    indexer: &Indexer,
     observer: &'observer mut dyn TraversalObserver<'a>,
     source_path: Option<&Path>,
     shell_profile: Option<ShellProfile>,

--- a/crates/shuck-server/src/lint.rs
+++ b/crates/shuck-server/src/lint.rs
@@ -5,8 +5,8 @@ use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use shuck_indexer::LineIndex;
 use shuck_linter::{
-    Applicability, Diagnostic as ShuckDiagnostic, Edit as ShuckEdit, Fix, Severity,
-    ShellCheckCodeMap, ShellDialect,
+    AnalysisRequest, Applicability, Diagnostic as ShuckDiagnostic, Edit as ShuckEdit, Fix,
+    Severity, ShellCheckCodeMap, ShellDialect,
 };
 use shuck_parser::parser::Parser;
 
@@ -187,16 +187,15 @@ fn collect_raw_diagnostics(
     path: Option<&Path>,
 ) -> RawDocumentDiagnostics {
     let parse_result = Parser::with_profile(source, shell.shell_profile()).parse();
-    let indexer = shuck_indexer::Indexer::new(source, &parse_result);
     let shellcheck_map = ShellCheckCodeMap::default();
-    let shell_diagnostics = shuck_linter::lint_file(
+    let shell_diagnostics = AnalysisRequest::from_parse_result(
         &parse_result,
         source,
-        &indexer,
         snapshot.shuck_settings().linter(),
-        &shellcheck_map,
-        path,
-    );
+    )
+    .with_optional_source_path(path)
+    .with_shellcheck_map(&shellcheck_map)
+    .lint();
     let parse_error = parse_result.is_err().then(|| {
         let shuck_parser::Error::Parse {
             message,

--- a/fuzz/fuzz_targets/formatter_validity_common.rs
+++ b/fuzz/fuzz_targets/formatter_validity_common.rs
@@ -2,8 +2,7 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use shuck_formatter::{FormattedSource, ShellDialect as FormatDialect, ShellFormatOptions};
-use shuck_indexer::Indexer;
-use shuck_linter::{Diagnostic, LinterSettings, ShellCheckCodeMap, lint_file};
+use shuck_linter::{AnalysisRequest, Diagnostic, LinterSettings, ShellCheckCodeMap};
 use shuck_parser::{ShellDialect as ParseDialect, parser::Parser};
 
 pub(crate) const FORMAT_CASES: [FormatCase; 4] = [
@@ -66,16 +65,12 @@ pub(crate) fn lint_source_strict(
             parse_result.strict_error()
         );
     }
-    let indexer = Indexer::new(source, &parse_result);
     let settings = LinterSettings::default().with_analyzed_paths([path.to_path_buf()]);
-    lint_file(
-        &parse_result,
-        source,
-        &indexer,
-        &settings,
-        &ShellCheckCodeMap::default(),
-        Some(path),
-    )
+    let shellcheck_map = ShellCheckCodeMap::default();
+    AnalysisRequest::from_parse_result(&parse_result, source, &settings)
+        .with_source_path(path)
+        .with_shellcheck_map(&shellcheck_map)
+        .lint()
 }
 
 pub(crate) fn compare_lint_counts(original: &[Diagnostic], formatted: &[Diagnostic], path: &Path) {

--- a/fuzz/fuzz_targets/linter_common.rs
+++ b/fuzz/fuzz_targets/linter_common.rs
@@ -1,8 +1,7 @@
 use std::path::Path;
 
 use shuck_ast::Span;
-use shuck_indexer::Indexer;
-use shuck_linter::{Diagnostic, LinterSettings, ShellCheckCodeMap, lint_file};
+use shuck_linter::{AnalysisRequest, Diagnostic, LinterSettings, ShellCheckCodeMap};
 use shuck_parser::{ShellDialect as ParseDialect, parser::Parser};
 
 pub(crate) const LINT_CASES: [LintCase; 4] = [
@@ -64,17 +63,13 @@ pub(crate) fn lint_source_with_recovery(
     dialect: ParseDialect,
 ) -> Vec<Diagnostic> {
     let parse_result = Parser::with_dialect(source, dialect).parse();
-    let indexer = Indexer::new(source, &parse_result);
     let settings = match path {
         Some(path) => LinterSettings::default().with_analyzed_paths([path.to_path_buf()]),
         None => LinterSettings::default(),
     };
-    lint_file(
-        &parse_result,
-        source,
-        &indexer,
-        &settings,
-        &ShellCheckCodeMap::default(),
-        path,
-    )
+    let shellcheck_map = ShellCheckCodeMap::default();
+    AnalysisRequest::from_parse_result(&parse_result, source, &settings)
+        .with_optional_source_path(path)
+        .with_shellcheck_map(&shellcheck_map)
+        .lint()
 }

--- a/specs/005-linter.md
+++ b/specs/005-linter.md
@@ -51,7 +51,7 @@ This gives each category 999 rule slots — more than enough. The scheme is exte
 crates/shuck-linter/
 ├── Cargo.toml
 └── src/
-    ├── lib.rs              # Public API: analyze_file(), lint_file(), lint_file_at_path*, LinterSettings
+    ├── lib.rs              # Public API: AnalysisRequest, analyze(), lint(), LinterSettings
     ├── registry.rs         # Rule enum, Category enum, code→rule mapping
     ├── rule_set.rs         # Bitset of enabled rules
     ├── rule_selector.rs    # Parsing user selections ("SHC", "SHC001")
@@ -586,33 +586,10 @@ The top-level entry point consumed by the CLI:
 
 ```rust
 /// Lint an existing parse result and return diagnostics.
-pub fn lint_file(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-) -> Vec<Diagnostic> {
-    let analysis = analyze_file_at_path(
-        &parse_result.file,
-        source,
-        indexer,
-        settings,
-        source_path,
-    );
-    let mut diagnostics = analysis.diagnostics;
-
-    // Add parse-aware rule diagnostics, then apply severity overrides,
-    // suppression filtering, per-file ignores, and stable ordering.
-    diagnostics.extend(collect_parse_rule_diagnostics(parse_result, source, settings));
-    for diag in &mut diagnostics {
-        if let Some(&severity) = settings.severity_overrides.get(&diag.rule) {
-            diag.severity = severity;
-        }
-    }
-    diagnostics
-}
+let diagnostics = AnalysisRequest::from_parse_result(parse_result, source, settings)
+    .with_source_path(path)
+    .with_shellcheck_map(shellcheck_map)
+    .lint();
 ```
 
 ### Data Flow (End-to-End)
@@ -622,13 +599,12 @@ How the linter fits into `shuck check`:
 ```
 Source text
     → shuck-parser::Parser::parse()       → ParseOutput (Script + Comments)
-    → shuck-indexer::Indexer::new()        → Indexer
-    → shuck-linter::lint_file()
+    → shuck-linter::AnalysisRequest::from_parse_result(...).lint()
                                              → Vec<Diagnostic>
     → CLI formats and prints diagnostics
 ```
 
-The CLI owns the pipeline. The linter is a pure function over parsed input, source text, an indexer, and settings. It performs no I/O, caching, or output formatting.
+The CLI owns the pipeline. The linter is a pure function over parsed input, source text, and settings. The request builds the positional index it needs internally, and the linter performs no I/O, caching, or output formatting.
 
 ## Alternatives Considered
 
@@ -662,8 +638,8 @@ Once implemented, verify with:
 
 - **Rule registration**: `Rule::iter().count()` returns the expected number of rules, and every rule has a unique code.
 - **Prefix selection**: `RuleSelector::from_str("C").unwrap().into_rule_set()` contains exactly the correctness rules. Same for other prefixes.
-- **Diagnostic output**: `lint_file()` on a script with a known undefined variable produces a diagnostic with `rule == Rule::UndefinedVariable`, `severity == Severity::Error`, and the correct span.
+- **Diagnostic output**: `AnalysisRequest::from_parse_result(...).lint()` on a script with a known undefined variable produces a diagnostic with `rule == Rule::UndefinedVariable`, `severity == Severity::Error`, and the correct span.
 - **Rule gating**: A `LinterSettings` with only `C001` enabled produces diagnostics only for that rule, even on a script that would trigger others.
 - **Severity override**: Setting `severity_overrides[Rule::UnquotedExpansion] = Severity::Hint` produces a diagnostic with `Severity::Hint`.
 - **Sort order**: Diagnostics are returned sorted by source position.
-- **No-op on empty rule set**: `lint_file()` with `RuleSet::EMPTY` returns an empty vec without running any checks.
+- **No-op on empty rule set**: `AnalysisRequest::from_parse_result(...).lint()` with `RuleSet::EMPTY` returns an empty vec without running any checks.

--- a/specs/006-suppressions.md
+++ b/specs/006-suppressions.md
@@ -253,42 +253,9 @@ Following ruff's post-hoc pattern, suppressions are applied **after** the checke
 
 ```rust
 /// Lint an existing parse result and return diagnostics.
-pub fn lint_file(
-    parse_result: &ParseResult,
-    source: &str,
-    indexer: &Indexer,
-    settings: &LinterSettings,
-    suppression_index: Option<&SuppressionIndex>,
-    source_path: Option<&Path>,
-) -> Vec<Diagnostic> {
-    let analysis = analyze_file_at_path(
-        &parse_result.file,
-        source,
-        indexer,
-        settings,
-        source_path,
-    );
-    let mut diagnostics = analysis.diagnostics;
-
-    // Add parse-aware rule diagnostics, then apply severity overrides.
-    diagnostics.extend(collect_parse_rule_diagnostics(parse_result, source, settings));
-    for diag in &mut diagnostics {
-        if let Some(&severity) = settings.severity_overrides.get(&diag.rule) {
-            diag.severity = severity;
-        }
-    }
-
-    // Filter suppressed diagnostics
-    if let Some(suppressions) = suppression_index {
-        diagnostics.retain(|diag| {
-            let line = indexer.line_index().line_for_offset(diag.span.start());
-            !suppressions.is_suppressed(diag.rule, line)
-        });
-    }
-
-    diagnostics.sort_by_key(|d| (d.span.start.offset, d.span.end.offset));
-    diagnostics
-}
+let diagnostics = AnalysisRequest::from_parse_result(parse_result, source, settings)
+    .with_directives(&directives)
+    .lint();
 ```
 
 The directives-aware linter entry points now build the `SuppressionIndex` from semantic-collected command spans after directive parsing. This keeps suppression scoping aligned with the semantic traversal instead of requiring a second AST walk.
@@ -303,7 +270,7 @@ Source text
     → shuck-indexer::Indexer::new()        → Indexer (includes CommentIndex)
     → parse_directives()                   → Vec<SuppressionDirective>
     → shuck-semantic::SemanticModel::new() → SemanticModel
-    → shuck-linter::lint_file_with_directives()
+    → shuck-linter::AnalysisRequest::from_parse_result(...).with_directives(...).lint()
                                              → Vec<Diagnostic>  (filtered by suppressions)
     → CLI formats and prints diagnostics
 ```

--- a/specs/007-benchmarks.md
+++ b/specs/007-benchmarks.md
@@ -218,7 +218,7 @@ criterion_group!(benches, bench_parse);
 criterion_main!(benches);
 ```
 
-The lexer, semantic, and linter benches follow the same structure, benchmarking `Lexer::new(source).collect::<Vec<_>>()`, `SemanticModel::build(...)`, and the full `lint_file()` pipeline respectively.
+The lexer, semantic, and linter benches follow the same structure, benchmarking `Lexer::new(source).collect::<Vec<_>>()`, `SemanticModel::build(...)`, and the full `AnalysisRequest::from_parse_result(...).lint()` pipeline respectively.
 
 #### Memory Allocator
 

--- a/specs/017-google-shell-style.md
+++ b/specs/017-google-shell-style.md
@@ -507,7 +507,7 @@ A `[lint] preset = "google"` switch could enable the bundle in one line. We reje
 
 ### Filesystem-aware rules in this spec
 
-The original proposal included rules that need the executable bit, the filename, and the repo path role. These would require threading a `FileMetadata` (path, mode, project root) through `lint_file` and adding filesystem stats to the linter pipeline. We deferred them: the linter is currently a pure function over source plus an indexer, and breaking that invariant in this spec would entangle the rule additions with an API change that deserves its own design pass.
+The original proposal included rules that need the executable bit, the filename, and the repo path role. These would require threading a `FileMetadata` (path, mode, project root) through `AnalysisRequest` and adding filesystem stats to the linter pipeline. We deferred them: the linter is currently a pure function over source plus an indexer, and breaking that invariant in this spec would entangle the rule additions with an API change that deserves its own design pass.
 
 ### Cross-file analysis for sourced-file effects
 

--- a/specs/018-lsp.md
+++ b/specs/018-lsp.md
@@ -337,16 +337,13 @@ fn check(query: &DocumentQuery, encoding: PositionEncoding) -> Vec<Diagnostic> {
     let dialect = settings.dialect_for(query.file_url(), query.language_id());
 
     let parsed = shuck_parser::parser::parse(source, dialect, profile);
-    let indexer = shuck_indexer::Indexer::new(&parsed.file, source);
-    let suppressions = shuck_linter::SuppressionIndex::build(source, &indexer);
-    let analysis = shuck_linter::analyze_file_at_path(
-        &parsed.file,
+    let analysis = shuck_linter::AnalysisRequest::from_parse_result(
+        &parsed,
         source,
-        &indexer,
         &settings.linter,
-        Some(&suppressions),
-        query.file_path().as_deref(),
-    );
+    )
+    .with_optional_source_path(query.file_path().as_deref())
+    .analyze();
 
     analysis.diagnostics
         .into_iter()

--- a/specs/020-zsh-plugin-resolution.md
+++ b/specs/020-zsh-plugin-resolution.md
@@ -649,8 +649,8 @@ implementable in this codebase.
 
 - build a per-file plugin resolver from `ResolvedCheckSettings` and the file's
   absolute path.
-- call a resolver-aware linter entrypoint during normal `shuck check` instead
-  of the current `lint_file(..., None)` path.
+- pass the per-file plugin resolver through `AnalysisRequest` during normal
+  `shuck check`.
 - return dependency fingerprints alongside diagnostics so cache insertion and
   watch-mode refresh both see the same dependency set.
 


### PR DESCRIPTION
## Summary
- Replace the linter public function matrix with an `AnalysisRequest` request object plus `analyze` / `lint` entrypoints.
- Make requests own their positional index, default parse-result requests to inline suppressions, and keep raw-file requests as AST-only rule analysis.
- Update CLI, server, ShellCheck compatibility, benchmark, fuzz, test helpers, and specs to use the request API directly.
- Narrow semantic-builder indexer lifetimes so request-owned indexers can feed semantic artifacts without leaking into returned models.

## Validation
- `cargo fmt`
- `cargo check -p shuck-linter -p shuck-cli -p shuck-benchmark -p shuck-server`
- `cargo test -p shuck-linter`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test -p shuck-indexer -p shuck-semantic -p shuck-cli -p shuck-server`
- `git diff --check`
