### PR TITLE
feat(linter): implement C024 assignment spacing

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -907,6 +907,17 @@ repos:
           line: 2110
           column: 61
         classification: real
+      - path: "check_update.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 301
+          column: 49
+        end:
+          line: 301
+          column: 50
+        classification: real
   - name: "holman-dotfiles"
     github_url: "https://github.com/holman/dotfiles.git"
     commit: "af5071cd804b63dc59caeb21f7d0d0d0d1f55efa"
@@ -7064,6 +7075,380 @@ repos:
           line: 113
           column: 11
         classification: real
+      - path: "plugins/archlinux/archlinux.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 183
+          column: 30
+        end:
+          line: 183
+          column: 31
+        classification: real
+      - path: "plugins/archlinux/archlinux.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 184
+          column: 28
+        end:
+          line: 184
+          column: 29
+        classification: real
+      - path: "plugins/jump/jump.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 30
+          column: 7
+        end:
+          line: 30
+          column: 8
+        classification: real
+      - path: "plugins/nvm/nvm.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 32
+          column: 19
+        end:
+          line: 32
+          column: 20
+        classification: real
+      - path: "plugins/svn-fast-info/svn-fast-info.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 3
+          column: 15
+        end:
+          line: 3
+          column: 16
+        classification: real
+      - path: "plugins/svn-fast-info/svn-fast-info.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 34
+          column: 46
+        end:
+          line: 34
+          column: 47
+        classification: real
+      - path: "plugins/svn-fast-info/svn-fast-info.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 45
+          column: 54
+        end:
+          line: 45
+          column: 55
+        classification: real
+      - path: "plugins/svn-fast-info/svn-fast-info.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 49
+          column: 21
+        end:
+          line: 49
+          column: 22
+        classification: real
+      - path: "plugins/svn/svn.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 3
+          column: 16
+        end:
+          line: 3
+          column: 17
+        classification: real
+      - path: "plugins/svn/svn.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 30
+          column: 21
+        end:
+          line: 30
+          column: 22
+        classification: real
+      - path: "plugins/svn/svn.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 37
+          column: 21
+        end:
+          line: 37
+          column: 22
+        classification: real
+      - path: "plugins/svn/svn.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 58
+          column: 45
+        end:
+          line: 58
+          column: 46
+        classification: real
+      - path: "plugins/svn/svn.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 62
+          column: 33
+        end:
+          line: 62
+          column: 34
+        classification: real
+      - path: "plugins/svn/svn.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 67
+          column: 67
+        end:
+          line: 67
+          column: 68
+        classification: real
+      - path: "plugins/svn/svn.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 68
+          column: 11
+        end:
+          line: 68
+          column: 12
+        classification: real
+      - path: "plugins/svn/svn.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 82
+          column: 11
+        end:
+          line: 82
+          column: 12
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 67
+          column: 10
+        end:
+          line: 67
+          column: 11
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 68
+          column: 13
+        end:
+          line: 68
+          column: 14
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 75
+          column: 10
+        end:
+          line: 75
+          column: 11
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 75
+          column: 27
+        end:
+          line: 75
+          column: 28
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 82
+          column: 10
+        end:
+          line: 82
+          column: 11
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 83
+          column: 13
+        end:
+          line: 83
+          column: 14
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 90
+          column: 10
+        end:
+          line: 90
+          column: 11
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 91
+          column: 13
+        end:
+          line: 91
+          column: 14
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 103
+          column: 10
+        end:
+          line: 103
+          column: 11
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 104
+          column: 13
+        end:
+          line: 104
+          column: 14
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 111
+          column: 10
+        end:
+          line: 111
+          column: 11
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 112
+          column: 13
+        end:
+          line: 112
+          column: 14
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 118
+          column: 8
+        end:
+          line: 118
+          column: 9
+        classification: real
+      - path: "plugins/systemadmin/systemadmin.plugin.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 119
+          column: 11
+        end:
+          line: 119
+          column: 12
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 121
+          column: 13
+        end:
+          line: 121
+          column: 14
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 127
+          column: 19
+        end:
+          line: 127
+          column: 20
+        classification: real
+      - path: "tools/check_for_upgrade.sh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 209
+          column: 40
+        end:
+          line: 209
+          column: 41
+        classification: real
+      - path: "tools/upgrade.sh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 245
+          column: 9
+        end:
+          line: 245
+          column: 10
+        classification: real
   - name: "powerlevel10k"
     github_url: "https://github.com/romkatv/powerlevel10k.git"
     commit: "604f19a9eaa18e76db2e60b8d446d5f879065f90"
@@ -13173,6 +13558,237 @@ repos:
           line: 287
           column: 24
         classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1838
+          column: 23
+        end:
+          line: 1838
+          column: 24
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 5940
+          column: 17
+        end:
+          line: 5940
+          column: 18
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 5940
+          column: 31
+        end:
+          line: 5940
+          column: 32
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 5940
+          column: 44
+        end:
+          line: 5940
+          column: 45
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 5940
+          column: 57
+        end:
+          line: 5940
+          column: 58
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 5940
+          column: 69
+        end:
+          line: 5940
+          column: 70
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 5940
+          column: 81
+        end:
+          line: 5940
+          column: 82
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 7473
+          column: 18
+        end:
+          line: 7473
+          column: 19
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 7473
+          column: 24
+        end:
+          line: 7473
+          column: 25
+        classification: real
+      - path: "internal/p10k.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 7919
+          column: 15
+        end:
+          line: 7919
+          column: 16
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2099
+          column: 46
+        end:
+          line: 2099
+          column: 47
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2099
+          column: 60
+        end:
+          line: 2099
+          column: 61
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2101
+          column: 27
+        end:
+          line: 2101
+          column: 28
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2101
+          column: 69
+        end:
+          line: 2101
+          column: 70
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2101
+          column: 84
+        end:
+          line: 2101
+          column: 85
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2103
+          column: 21
+        end:
+          line: 2103
+          column: 22
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2103
+          column: 35
+        end:
+          line: 2103
+          column: 36
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2103
+          column: 46
+        end:
+          line: 2103
+          column: 47
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2103
+          column: 58
+        end:
+          line: 2103
+          column: 59
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2103
+          column: 69
+        end:
+          line: 2103
+          column: 70
+        classification: real
+      - path: "internal/wizard.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2103
+          column: 81
+        end:
+          line: 2103
+          column: 82
+        classification: real
   - name: "prezto"
     github_url: "https://github.com/sorin-ionescu/prezto.git"
     commit: "cff2d01871425b1b80710f8ec6a475c5a53145b4"
@@ -17688,6 +18304,116 @@ repos:
           line: 3284
           column: 59
         classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 563
+          column: 40
+        end:
+          line: 563
+          column: 41
+        classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 577
+          column: 40
+        end:
+          line: 577
+          column: 41
+        classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1136
+          column: 27
+        end:
+          line: 1136
+          column: 40
+        classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1138
+          column: 37
+        end:
+          line: 1138
+          column: 39
+        classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1141
+          column: 28
+        end:
+          line: 1141
+          column: 39
+        classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1144
+          column: 34
+        end:
+          line: 1144
+          column: 39
+        classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1146
+          column: 28
+        end:
+          line: 1146
+          column: 39
+        classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1147
+          column: 35
+        end:
+          line: 1147
+          column: 39
+        classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1725
+          column: 20
+        end:
+          line: 1725
+          column: 21
+        classification: real
+      - path: "zinit.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1725
+          column: 39
+        end:
+          line: 1725
+          column: 40
+        classification: real
   - name: "zsh-autosuggestions"
     github_url: "https://github.com/zsh-users/zsh-autosuggestions.git"
     commit: "85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5"
@@ -19213,4 +19939,15 @@ repos:
         end:
           line: 578
           column: 64
+        classification: real
+      - path: "tests/test-perfs.zsh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 70
+          column: 13
+        end:
+          line: 70
+          column: 14
         classification: real

--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -1043,6 +1043,28 @@ repos:
           line: 17
           column: 38
         classification: real
+      - path: "script/bootstrap"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 56
+          column: 19
+        end:
+          line: 56
+          column: 20
+        classification: real
+      - path: "script/bootstrap"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 56
+          column: 27
+        end:
+          line: 56
+          column: 28
+        classification: real
   - name: "ohmyzsh"
     github_url: "https://github.com/ohmyzsh/ohmyzsh.git"
     commit: "e64912e0c1eaa32181c3b5e5e4bf8042ecd0e8a7"
@@ -6964,6 +6986,83 @@ repos:
         end:
           line: 257
           column: 38
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 697
+          column: 15
+        end:
+          line: 697
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 697
+          column: 21
+        end:
+          line: 697
+          column: 22
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 697
+          column: 26
+        end:
+          line: 697
+          column: 27
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1005
+          column: 25
+        end:
+          line: 1005
+          column: 26
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 1129
+          column: 15
+        end:
+          line: 1129
+          column: 16
+        classification: real
+      - path: "plugins/gitfast/git-completion.bash"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 2347
+          column: 34
+        end:
+          line: 2347
+          column: 35
+        classification: real
+      - path: "tools/install.sh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 113
+          column: 10
+        end:
+          line: 113
+          column: 11
         classification: real
   - name: "powerlevel10k"
     github_url: "https://github.com/romkatv/powerlevel10k.git"
@@ -12909,6 +13008,171 @@ repos:
           line: 94
           column: 48
         classification: real
+      - path: "gitstatus/gitstatus.plugin.sh"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 363
+          column: 17
+        end:
+          line: 363
+          column: 18
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 21
+          column: 18
+        end:
+          line: 21
+          column: 19
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 21
+          column: 30
+        end:
+          line: 21
+          column: 31
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 21
+          column: 39
+        end:
+          line: 21
+          column: 40
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 21
+          column: 48
+        end:
+          line: 21
+          column: 49
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 21
+          column: 63
+        end:
+          line: 21
+          column: 64
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 21
+          column: 74
+        end:
+          line: 21
+          column: 75
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 22
+          column: 13
+        end:
+          line: 22
+          column: 14
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 22
+          column: 21
+        end:
+          line: 22
+          column: 22
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 157
+          column: 31
+        end:
+          line: 157
+          column: 32
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 176
+          column: 24
+        end:
+          line: 176
+          column: 25
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 176
+          column: 38
+        end:
+          line: 176
+          column: 39
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 176
+          column: 44
+        end:
+          line: 176
+          column: 45
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 176
+          column: 53
+        end:
+          line: 176
+          column: 54
+        classification: real
+      - path: "gitstatus/install"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 287
+          column: 23
+        end:
+          line: 287
+          column: 24
+        classification: real
   - name: "prezto"
     github_url: "https://github.com/sorin-ionescu/prezto.git"
     commit: "cff2d01871425b1b80710f8ec6a475c5a53145b4"
@@ -13686,6 +13950,17 @@ repos:
         end:
           line: 49
           column: 41
+        classification: real
+      - path: "hooks/post-up"
+        code: "C024"
+        severity: "warning"
+        message: "a space after `=` keeps this from being one assignment word"
+        start:
+          line: 24
+          column: 16
+        end:
+          line: 24
+          column: 17
         classification: real
   - name: "zdot"
     github_url: "https://github.com/georgeharker/zdot.git"

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C024.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C024.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+foo= bar
+foo+= append
+A= B= cmd
+export left= right other= value
+
+foo=bar
+foo=
+foo =bar
+echo foo= bar
+export done=

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -1043,6 +1043,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::AppendWithEscapedQuotes) {
             rules::correctness::append_with_escaped_quotes::append_with_escaped_quotes(self);
         }
+        if self.is_rule_enabled(Rule::AssignmentSpacing) {
+            rules::correctness::assignment_spacing::assignment_spacing(self);
+        }
         if self.is_rule_enabled(Rule::LocalCrossReference) {
             rules::correctness::local_cross_reference::local_cross_reference(self);
         }

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -130,6 +130,383 @@ impl<'a> BindingValueFact<'a> {
     }
 }
 
+pub(crate) fn command_may_have_assignment_spacing_candidate(
+    command: &Command,
+    source: &str,
+) -> bool {
+    match command {
+        Command::Simple(command) => {
+            simple_command_may_have_assignment_spacing_candidate(command, source)
+        }
+        Command::Decl(command) => {
+            command
+                .assignments
+                .iter()
+                .any(assignment_reports_assignment_spacing)
+                || declaration_operands_may_have_assignment_spacing_candidate(
+                    &command.operands,
+                    source,
+                )
+        }
+        Command::Builtin(command) => match command {
+            BuiltinCommand::Break(command) => command
+                .assignments
+                .iter()
+                .any(assignment_reports_assignment_spacing),
+            BuiltinCommand::Continue(command) => command
+                .assignments
+                .iter()
+                .any(assignment_reports_assignment_spacing),
+            BuiltinCommand::Return(command) => command
+                .assignments
+                .iter()
+                .any(assignment_reports_assignment_spacing),
+            BuiltinCommand::Exit(command) => command
+                .assignments
+                .iter()
+                .any(assignment_reports_assignment_spacing),
+        },
+        Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => false,
+    }
+}
+
+fn simple_command_may_have_assignment_spacing_candidate(
+    command: &SimpleCommand,
+    source: &str,
+) -> bool {
+    for (index, assignment) in command.assignments.iter().enumerate() {
+        if assignment_reports_assignment_spacing(assignment)
+            && (index + 1 < command.assignments.len() || !span_is_empty(command.name.span))
+        {
+            return true;
+        }
+    }
+
+    !span_is_empty(command.name.span)
+        && word_reports_assignment_spacing(&command.name, source)
+        && !command.args.is_empty()
+}
+
+fn declaration_operands_may_have_assignment_spacing_candidate(
+    operands: &[DeclOperand],
+    source: &str,
+) -> bool {
+    operands.iter().enumerate().any(|(index, operand)| {
+        declaration_operand_reports_assignment_spacing(operand, source)
+            && index + 1 < operands.len()
+    })
+}
+
+#[cfg_attr(shuck_profiling, inline(never))]
+pub(crate) fn build_assignment_spacing_spans(
+    commands: &[CommandFact<'_>],
+    source: &str,
+) -> Vec<Span> {
+    let mut spans = Vec::new();
+
+    for fact in commands {
+        collect_assignment_spacing_spans_in_command(fact.command(), source, &mut spans);
+    }
+
+    spans.sort_unstable_by_key(|span| (span.start.offset, span.end.offset));
+    spans.dedup();
+    spans
+}
+
+fn collect_assignment_spacing_spans_in_command(
+    command: &Command,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    match command {
+        Command::Simple(command) => {
+            collect_simple_assignment_spacing_spans(command, source, spans);
+        }
+        Command::Decl(command) => {
+            collect_prefix_assignment_spacing_spans(
+                &command.assignments,
+                command.variant_span,
+                source,
+                spans,
+            );
+            collect_declaration_operand_assignment_spacing_spans(&command.operands, source, spans);
+        }
+        Command::Builtin(command) => match command {
+            BuiltinCommand::Break(command) => {
+                collect_prefix_assignment_spacing_spans(
+                    &command.assignments,
+                    first_word_start_after(command.span, &command.assignments, source),
+                    source,
+                    spans,
+                );
+            }
+            BuiltinCommand::Continue(command) => {
+                collect_prefix_assignment_spacing_spans(
+                    &command.assignments,
+                    first_word_start_after(command.span, &command.assignments, source),
+                    source,
+                    spans,
+                );
+            }
+            BuiltinCommand::Return(command) => {
+                collect_prefix_assignment_spacing_spans(
+                    &command.assignments,
+                    first_word_start_after(command.span, &command.assignments, source),
+                    source,
+                    spans,
+                );
+            }
+            BuiltinCommand::Exit(command) => {
+                collect_prefix_assignment_spacing_spans(
+                    &command.assignments,
+                    first_word_start_after(command.span, &command.assignments, source),
+                    source,
+                    spans,
+                );
+            }
+        },
+        Command::Binary(_)
+        | Command::Compound(_)
+        | Command::Function(_)
+        | Command::AnonymousFunction(_) => {}
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AssignmentSpacingItem {
+    span: Span,
+    report: bool,
+}
+
+fn collect_simple_assignment_spacing_spans(
+    command: &SimpleCommand,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let mut previous = None;
+    for assignment in &command.assignments {
+        let item = AssignmentSpacingItem {
+            span: assignment.span,
+            report: assignment_reports_assignment_spacing(assignment),
+        };
+        collect_assignment_spacing_gap_from_previous(previous, item, source, spans);
+        previous = Some(item);
+    }
+
+    if !span_is_empty(command.name.span) {
+        let name_item = AssignmentSpacingItem {
+            span: command.name.span,
+            report: word_reports_assignment_spacing(&command.name, source),
+        };
+        collect_assignment_spacing_gap_from_previous(previous, name_item, source, spans);
+
+        if name_item.report {
+            previous = Some(name_item);
+            for arg in &command.args {
+                let arg_item = AssignmentSpacingItem {
+                    span: arg.span,
+                    report: word_reports_assignment_spacing(arg, source),
+                };
+                collect_assignment_spacing_gap_from_previous(previous, arg_item, source, spans);
+                if !arg_item.report {
+                    break;
+                }
+                previous = Some(arg_item);
+            }
+        }
+    }
+}
+
+fn collect_prefix_assignment_spacing_spans(
+    assignments: &[Assignment],
+    fallback_next_span: Span,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    if assignments.is_empty() {
+        return;
+    }
+
+    let mut previous = None;
+    for assignment in assignments {
+        let item = AssignmentSpacingItem {
+            span: assignment.span,
+            report: assignment_reports_assignment_spacing(assignment),
+        };
+        collect_assignment_spacing_gap_from_previous(previous, item, source, spans);
+        previous = Some(item);
+    }
+    collect_assignment_spacing_gap_from_previous(
+        previous,
+        AssignmentSpacingItem {
+            span: fallback_next_span,
+            report: false,
+        },
+        source,
+        spans,
+    );
+}
+
+fn collect_declaration_operand_assignment_spacing_spans(
+    operands: &[DeclOperand],
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let mut previous = None;
+    for operand in operands {
+        let item = AssignmentSpacingItem {
+            span: declaration_operand_span(operand),
+            report: declaration_operand_has_empty_assignment_value(operand, source),
+        };
+        collect_assignment_spacing_gap_from_previous(previous, item, source, spans);
+        previous = Some(item);
+    }
+}
+
+fn collect_assignment_spacing_gap_from_previous(
+    previous: Option<AssignmentSpacingItem>,
+    current: AssignmentSpacingItem,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let Some(previous) = previous else {
+        return;
+    };
+    if !previous.report {
+        return;
+    }
+    if let Some(span) =
+        horizontal_whitespace_span_between(previous.span.end, current.span.start, source)
+    {
+        spans.push(span);
+    }
+}
+
+fn assignment_has_empty_scalar_value(assignment: &Assignment) -> bool {
+    matches!(
+        &assignment.value,
+        AssignmentValue::Scalar(word) if span_is_empty(word.span)
+    )
+}
+
+fn assignment_reports_assignment_spacing(assignment: &Assignment) -> bool {
+    assignment_has_empty_scalar_value(assignment)
+        && !is_assignment_spacing_exempt_target(assignment.target.name.as_str())
+}
+
+fn declaration_operand_has_empty_assignment_value(operand: &DeclOperand, source: &str) -> bool {
+    declaration_operand_reports_assignment_spacing(operand, source)
+}
+
+fn declaration_operand_reports_assignment_spacing(operand: &DeclOperand, source: &str) -> bool {
+    match operand {
+        DeclOperand::Assignment(assignment) => assignment_reports_assignment_spacing(assignment),
+        DeclOperand::Dynamic(word) => word_reports_assignment_spacing(word, source),
+        DeclOperand::Flag(_) | DeclOperand::Name(_) => false,
+    }
+}
+
+fn declaration_operand_span(operand: &DeclOperand) -> Span {
+    match operand {
+        DeclOperand::Flag(word) | DeclOperand::Dynamic(word) => word.span,
+        DeclOperand::Name(reference) => reference.span,
+        DeclOperand::Assignment(assignment) => assignment.span,
+    }
+}
+
+fn word_reports_assignment_spacing(word: &Word, source: &str) -> bool {
+    let Some(target) = plain_literal_assignment_spacing_target(word, source) else {
+        return false;
+    };
+    is_shell_variable_name(target) && !is_assignment_spacing_exempt_target(target)
+}
+
+fn plain_literal_assignment_spacing_target<'a>(word: &'a Word, source: &'a str) -> Option<&'a str> {
+    let [part] = word.parts.as_slice() else {
+        return None;
+    };
+    let WordPart::Literal(text) = &part.kind else {
+        return None;
+    };
+    let text = text.as_str(source, part.span);
+    let target = text.strip_suffix("+=").or_else(|| text.strip_suffix('='))?;
+    (!target.is_empty() && !target.chars().any(char::is_whitespace)).then_some(target)
+}
+
+fn is_assignment_spacing_exempt_target(target: &str) -> bool {
+    target == "IFS"
+}
+
+fn first_word_start_after(command_span: Span, assignments: &[Assignment], source: &str) -> Span {
+    let start = assignments
+        .last()
+        .map_or(command_span.start.offset, |assignment| {
+            assignment.span.end.offset
+        });
+    let end = command_span.end.offset.min(source.len());
+    let next = source
+        .get(start..end)
+        .and_then(|tail| {
+            tail.char_indices()
+                .find(|(_, ch)| !matches!(ch, ' ' | '\t' | '\r' | '\n'))
+                .map(|(offset, _)| start + offset)
+        })
+        .unwrap_or(end);
+    let position = command_span
+        .start
+        .advanced_by(&source[command_span.start.offset..next]);
+    Span::from_positions(position, position)
+}
+
+fn horizontal_whitespace_span_between(
+    start: Position,
+    end: Position,
+    source: &str,
+) -> Option<Span> {
+    if start.offset >= end.offset || end.offset > source.len() {
+        return None;
+    }
+    let gap = source.get(start.offset..end.offset)?;
+    if gap_is_assignment_spacing_whitespace(gap) {
+        Some(Span::from_positions(start, end))
+    } else {
+        None
+    }
+}
+
+fn gap_is_assignment_spacing_whitespace(gap: &str) -> bool {
+    let bytes = gap.as_bytes();
+    let mut index = 0;
+    let mut saw_line_continuation = false;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b' ' | b'\t' => index += 1,
+            b'\\' if bytes.get(index + 1) == Some(&b'\n') => {
+                saw_line_continuation = true;
+                index += 2;
+            }
+            b'\\'
+                if bytes.get(index + 1) == Some(&b'\r') && bytes.get(index + 2) == Some(&b'\n') =>
+            {
+                saw_line_continuation = true;
+                index += 3;
+            }
+            _ => return false,
+        }
+    }
+
+    !gap.is_empty()
+        && (saw_line_continuation || bytes.iter().all(|byte| matches!(byte, b' ' | b'\t')))
+}
+
+fn span_is_empty(span: Span) -> bool {
+    span.start.offset == span.end.offset
+}
+
 #[cfg_attr(shuck_profiling, inline(never))]
 pub(crate) fn build_bare_command_name_assignment_spans<'a>(
     commands: &[CommandFact<'a>],

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -509,18 +509,29 @@ fn first_word_start_after(command_span: Span, assignments: &[Assignment], source
             assignment.span.end.offset
         });
     let end = command_span.end.offset.min(source.len());
-    let next = source
-        .get(start..end)
-        .and_then(|tail| {
-            tail.char_indices()
-                .find(|(_, ch)| !matches!(ch, ' ' | '\t' | '\r' | '\n'))
-                .map(|(offset, _)| start + offset)
-        })
-        .unwrap_or(end);
+    let next = first_command_word_offset_in_gap(source, start, end);
     let position = command_span
         .start
         .advanced_by(&source[command_span.start.offset..next]);
     Span::from_positions(position, position)
+}
+
+fn first_command_word_offset_in_gap(source: &str, start: usize, end: usize) -> usize {
+    let bytes = source.as_bytes();
+    let mut index = start;
+
+    while index < end {
+        match bytes[index] {
+            b' ' | b'\t' | b'\r' | b'\n' => index += 1,
+            b'\\' if index + 1 < end && bytes[index + 1] == b'\n' => index += 2,
+            b'\\' if index + 2 < end && bytes[index + 1] == b'\r' && bytes[index + 2] == b'\n' => {
+                index += 3;
+            }
+            _ => return index,
+        }
+    }
+
+    end
 }
 
 fn horizontal_whitespace_span_between(

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -200,6 +200,68 @@ fn declaration_operands_may_have_assignment_spacing_candidate(
     })
 }
 
+pub(crate) fn source_may_have_assignment_spacing_candidate(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] != b'=' || !assignment_spacing_gap_can_start_at(bytes, index + 1) {
+            index += 1;
+            continue;
+        }
+
+        let target_end = if index > 0 && bytes[index - 1] == b'+' {
+            index - 1
+        } else {
+            index
+        };
+        if target_end == 0 {
+            index += 1;
+            continue;
+        }
+
+        if bytes[target_end - 1] == b']' {
+            return true;
+        }
+
+        let mut target_start = target_end;
+        while target_start > 0 && is_shell_name_continue_byte(bytes[target_start - 1]) {
+            target_start -= 1;
+        }
+        if target_start == target_end
+            || !is_shell_name_start_byte(bytes[target_start])
+            || &source[target_start..target_end] == "IFS"
+        {
+            index += 1;
+            continue;
+        }
+
+        return true;
+    }
+
+    false
+}
+
+fn assignment_spacing_gap_can_start_at(bytes: &[u8], start: usize) -> bool {
+    matches!(bytes.get(start), Some(b' ' | b'\t'))
+        || matches!(
+            (bytes.get(start), bytes.get(start + 1)),
+            (Some(b'\\'), Some(b'\n'))
+        )
+        || matches!(
+            (bytes.get(start), bytes.get(start + 1), bytes.get(start + 2)),
+            (Some(b'\\'), Some(b'\r'), Some(b'\n'))
+        )
+}
+
+fn is_shell_name_start_byte(byte: u8) -> bool {
+    byte == b'_' || byte.is_ascii_alphabetic()
+}
+
+fn is_shell_name_continue_byte(byte: u8) -> bool {
+    is_shell_name_start_byte(byte) || byte.is_ascii_digit()
+}
+
 #[cfg_attr(shuck_profiling, inline(never))]
 pub(crate) fn build_assignment_spacing_spans(
     commands: &[CommandFact<'_>],

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -977,6 +977,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 condition_status_capture_spans,
                 command_substitution_command_spans,
                 backtick_command_name_spans,
+                assignment_spacing_spans: OnceLock::new(),
                 assignment_like_command_name_spans,
                 bare_command_name_assignment_spans,
             },

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -603,16 +603,13 @@ impl<'facts, 'a> CommandFactQueries<'facts, 'a> {
 
     pub(crate) fn assignment_spacing_spans(self) -> &'facts [Span] {
         self.facts.command.assignment_spacing_spans.get_or_init(|| {
-            if self.facts.command.commands.iter().any(|command| {
-                command_may_have_assignment_spacing_candidate(
-                    command.command(),
-                    self.facts.source_facts.source,
-                )
-            }) {
-                build_assignment_spacing_spans(
-                    &self.facts.command.commands,
-                    self.facts.source_facts.source,
-                )
+            let source = self.facts.source_facts.source;
+            if source_may_have_assignment_spacing_candidate(source)
+                && self.facts.command.commands.iter().any(|command| {
+                    command_may_have_assignment_spacing_candidate(command.command(), source)
+                })
+            {
+                build_assignment_spacing_spans(&self.facts.command.commands, source)
             } else {
                 Vec::new()
             }

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -44,6 +44,7 @@ pub(crate) struct CommandFactStore<'a> {
     pub(in crate::facts) condition_status_capture_spans: Vec<Span>,
     pub(in crate::facts) command_substitution_command_spans: Vec<Span>,
     pub(in crate::facts) backtick_command_name_spans: Vec<Span>,
+    pub(in crate::facts) assignment_spacing_spans: OnceLock<Vec<Span>>,
     pub(in crate::facts) assignment_like_command_name_spans: Vec<Span>,
     pub(in crate::facts) bare_command_name_assignment_spans: Vec<Span>,
 }
@@ -598,6 +599,24 @@ impl<'facts, 'a> CommandFactQueries<'facts, 'a> {
 
     pub(crate) fn backtick_command_name_spans(self) -> &'facts [Span] {
         &self.facts.command.backtick_command_name_spans
+    }
+
+    pub(crate) fn assignment_spacing_spans(self) -> &'facts [Span] {
+        self.facts.command.assignment_spacing_spans.get_or_init(|| {
+            if self.facts.command.commands.iter().any(|command| {
+                command_may_have_assignment_spacing_candidate(
+                    command.command(),
+                    self.facts.source_facts.source,
+                )
+            }) {
+                build_assignment_spacing_spans(
+                    &self.facts.command.commands,
+                    self.facts.source_facts.source,
+                )
+            } else {
+                Vec::new()
+            }
+        })
     }
 
     pub(crate) fn assignment_like_command_name_spans(self) -> &'facts [Span] {

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -111,6 +111,7 @@ declare_rules! {
     ("C021", Category::Correctness, Severity::Warning, ConstantCaseSubject),
     ("C022", Category::Correctness, Severity::Error, EmptyTest),
     ("C023", Category::Correctness, Severity::Error, LeadingZeroArithmetic),
+    ("C024", Category::Correctness, Severity::Warning, AssignmentSpacing),
     ("C030", Category::Correctness, Severity::Error, MissingBracketSpace),
     ("C025", Category::Correctness, Severity::Warning, PositionalTenBraces),
     ("C035", Category::Correctness, Severity::Error, MissingFi),
@@ -806,6 +807,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-073" => Some(Rule::TruthyLiteralTest),
         "SH-074" => Some(Rule::ConstantCaseSubject),
         "SH-075" => Some(Rule::EmptyTest),
+        "SH-084" => Some(Rule::AssignmentSpacing),
         "SH-098" => Some(Rule::MissingBracketSpace),
         "SH-134" => Some(Rule::PipeToKill),
         "SH-086" => Some(Rule::PositionalTenBraces),
@@ -1155,6 +1157,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-075"), Some(Rule::EmptyTest));
         assert_eq!(code_to_rule("C023"), Some(Rule::LeadingZeroArithmetic));
         assert_eq!(code_to_rule("SH-078"), Some(Rule::LeadingZeroArithmetic));
+        assert_eq!(code_to_rule("C024"), Some(Rule::AssignmentSpacing));
+        assert_eq!(code_to_rule("SH-084"), Some(Rule::AssignmentSpacing));
         assert_eq!(code_to_rule("C030"), Some(Rule::MissingBracketSpace));
         assert_eq!(code_to_rule("SH-098"), Some(Rule::MissingBracketSpace));
         assert_eq!(code_to_rule("SH-134"), Some(Rule::PipeToKill));

--- a/crates/shuck-linter/src/rules/correctness/assignment_spacing.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_spacing.rs
@@ -41,15 +41,6 @@ fn source_may_contain_assignment_spacing(source: &str) -> bool {
     let mut index = 0;
 
     while index < bytes.len() {
-        if bytes[index] == b'\'' {
-            index += 1;
-            while index < bytes.len() && bytes[index] != b'\'' {
-                index += 1;
-            }
-            index += 1;
-            continue;
-        }
-
         if bytes[index] != b'=' || !assignment_spacing_gap_can_start_at(bytes, index + 1) {
             index += 1;
             continue;
@@ -195,6 +186,7 @@ foo =bar
 echo foo= bar
 foo=bar cmd baz= qux
 export foo=
+comment='name= value'
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignmentSpacing));
 
@@ -219,13 +211,32 @@ export foo=
     }
 
     #[test]
-    fn source_prefilter_matches_reportable_shapes() {
+    fn reports_after_comment_apostrophe() {
+        let source = "\
+#!/bin/sh
+# it's okay to use contractions in comments
+foo= bar
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignmentSpacing));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![" "]
+        );
+    }
+
+    #[test]
+    fn source_prefilter_matches_candidate_shapes() {
         for source in [
             "foo= bar\n",
             "foo+= append\n",
             "declare foo= bar\n",
             "array[0]= value\n",
             "foo=\\\nbar\n",
+            "comment='name= value'\n",
         ] {
             assert!(
                 super::source_may_contain_assignment_spacing(source),
@@ -241,7 +252,6 @@ export foo=
             "foo = bar\n",
             "[ \"$left\" = right ]\n",
             "while IFS= read -r line; do :; done\n",
-            "comment='name= value'\n",
         ] {
             assert!(
                 !super::source_may_contain_assignment_spacing(source),

--- a/crates/shuck-linter/src/rules/correctness/assignment_spacing.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_spacing.rs
@@ -1,0 +1,302 @@
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, Violation};
+
+pub struct AssignmentSpacing;
+
+impl Violation for AssignmentSpacing {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    fn rule() -> Rule {
+        Rule::AssignmentSpacing
+    }
+
+    fn message(&self) -> String {
+        "a space after `=` keeps this from being one assignment word".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("delete the whitespace after `=`".to_owned())
+    }
+}
+
+pub fn assignment_spacing(checker: &mut Checker) {
+    if !source_may_contain_assignment_spacing(checker.source()) {
+        return;
+    }
+
+    let spans = checker
+        .facts()
+        .command_facts()
+        .assignment_spacing_spans()
+        .to_vec();
+    for span in spans {
+        checker.report_diagnostic_dedup(
+            Diagnostic::new(AssignmentSpacing, span)
+                .with_fix(Fix::unsafe_edit(Edit::deletion(span))),
+        );
+    }
+}
+
+fn source_may_contain_assignment_spacing(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'\'' {
+            index += 1;
+            while index < bytes.len() && bytes[index] != b'\'' {
+                index += 1;
+            }
+            index += 1;
+            continue;
+        }
+
+        if bytes[index] != b'=' || !assignment_spacing_gap_can_start_at(bytes, index + 1) {
+            index += 1;
+            continue;
+        }
+
+        let target_end = if index > 0 && bytes[index - 1] == b'+' {
+            index - 1
+        } else {
+            index
+        };
+        if target_end == 0 {
+            index += 1;
+            continue;
+        }
+
+        if bytes[target_end - 1] == b']' {
+            return true;
+        }
+
+        let mut target_start = target_end;
+        while target_start > 0 && is_shell_name_continue_byte(bytes[target_start - 1]) {
+            target_start -= 1;
+        }
+        if target_start == target_end
+            || !is_shell_name_start_byte(bytes[target_start])
+            || &source[target_start..target_end] == "IFS"
+        {
+            index += 1;
+            continue;
+        }
+
+        return true;
+    }
+
+    false
+}
+
+fn assignment_spacing_gap_can_start_at(bytes: &[u8], start: usize) -> bool {
+    matches!(bytes.get(start), Some(b' ' | b'\t'))
+        || matches!(
+            (bytes.get(start), bytes.get(start + 1)),
+            (Some(b'\\'), Some(b'\n'))
+        )
+        || matches!(
+            (bytes.get(start), bytes.get(start + 1), bytes.get(start + 2)),
+            (Some(b'\\'), Some(b'\r'), Some(b'\n'))
+        )
+}
+
+fn is_shell_name_start_byte(byte: u8) -> bool {
+    byte == b'_' || byte.is_ascii_alphabetic()
+}
+
+fn is_shell_name_continue_byte(byte: u8) -> bool {
+    is_shell_name_start_byte(byte) || byte.is_ascii_digit()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use crate::test::{test_path_with_fix, test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect, assert_diagnostics_diff};
+
+    #[test]
+    fn reports_spaces_after_empty_assignments() {
+        let source = "\
+#!/bin/sh
+foo= bar
+foo+= append
+A= B= cmd
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignmentSpacing));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![" ", " ", " ", " "]
+        );
+    }
+
+    #[test]
+    fn reports_declaration_operands_independently() {
+        let source = "\
+#!/bin/sh
+export foo= bar baz= qux
+readonly pinned= value
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignmentSpacing));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![" ", " ", " "]
+        );
+    }
+
+    #[test]
+    fn reports_line_continued_assignment_gaps() {
+        let source = "\
+#!/bin/sh
+ARCH= \\
+EARCH= \\
+./configure
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignmentSpacing));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![" \\\n", " \\\n"]
+        );
+    }
+
+    #[test]
+    fn ignores_ifs_empty_assignments() {
+        let source = "\
+#!/bin/sh
+while IFS= read -r line; do
+  printf '%s\\n' \"$line\"
+done
+local IFS= value
+IFS=  read -r first_line
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignmentSpacing));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_complete_assignments_and_later_arguments() {
+        let source = "\
+#!/bin/sh
+foo=bar
+foo=
+foo =bar
+echo foo= bar
+foo=bar cmd baz= qux
+export foo=
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignmentSpacing));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn reports_zsh_scripts() {
+        let source = "#!/bin/zsh\nfoo= bar\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentSpacing).with_shell(ShellDialect::Zsh),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![" "]
+        );
+    }
+
+    #[test]
+    fn source_prefilter_matches_reportable_shapes() {
+        for source in [
+            "foo= bar\n",
+            "foo+= append\n",
+            "declare foo= bar\n",
+            "array[0]= value\n",
+            "foo=\\\nbar\n",
+        ] {
+            assert!(
+                super::source_may_contain_assignment_spacing(source),
+                "source: {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn source_prefilter_ignores_common_non_reportable_shapes() {
+        for source in [
+            "foo=bar\n",
+            "foo = bar\n",
+            "[ \"$left\" = right ]\n",
+            "while IFS= read -r line; do :; done\n",
+            "comment='name= value'\n",
+        ] {
+            assert!(
+                !super::source_may_contain_assignment_spacing(source),
+                "source: {source:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn attaches_unsafe_fix_metadata() {
+        let source = "#!/bin/sh\nfoo= bar\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignmentSpacing));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].fix.as_ref().map(|fix| fix.applicability()),
+            Some(Applicability::Unsafe)
+        );
+        assert_eq!(
+            diagnostics[0].fix_title.as_deref(),
+            Some("delete the whitespace after `=`")
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_assignment_spacing() {
+        let source = "\
+#!/bin/sh
+foo= bar
+foo+= append
+export left= right other= value
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::AssignmentSpacing),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 4);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\nfoo=bar\nfoo+=append\nexport left=right other=value\n"
+        );
+        assert!(result.fixed_diagnostics.is_empty());
+    }
+
+    #[test]
+    fn snapshots_unsafe_fix_output_for_fixture() -> anyhow::Result<()> {
+        let result = test_path_with_fix(
+            Path::new("correctness").join("C024.sh").as_path(),
+            &LinterSettings::for_rule(Rule::AssignmentSpacing),
+            Applicability::Unsafe,
+        )?;
+
+        assert_diagnostics_diff!("C024_fix_C024.sh", result);
+        Ok(())
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/assignment_spacing.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_spacing.rs
@@ -19,10 +19,6 @@ impl Violation for AssignmentSpacing {
 }
 
 pub fn assignment_spacing(checker: &mut Checker) {
-    if !source_may_contain_assignment_spacing(checker.source()) {
-        return;
-    }
-
     let spans = checker
         .facts()
         .command_facts()
@@ -34,68 +30,6 @@ pub fn assignment_spacing(checker: &mut Checker) {
                 .with_fix(Fix::unsafe_edit(Edit::deletion(span))),
         );
     }
-}
-
-fn source_may_contain_assignment_spacing(source: &str) -> bool {
-    let bytes = source.as_bytes();
-    let mut index = 0;
-
-    while index < bytes.len() {
-        if bytes[index] != b'=' || !assignment_spacing_gap_can_start_at(bytes, index + 1) {
-            index += 1;
-            continue;
-        }
-
-        let target_end = if index > 0 && bytes[index - 1] == b'+' {
-            index - 1
-        } else {
-            index
-        };
-        if target_end == 0 {
-            index += 1;
-            continue;
-        }
-
-        if bytes[target_end - 1] == b']' {
-            return true;
-        }
-
-        let mut target_start = target_end;
-        while target_start > 0 && is_shell_name_continue_byte(bytes[target_start - 1]) {
-            target_start -= 1;
-        }
-        if target_start == target_end
-            || !is_shell_name_start_byte(bytes[target_start])
-            || &source[target_start..target_end] == "IFS"
-        {
-            index += 1;
-            continue;
-        }
-
-        return true;
-    }
-
-    false
-}
-
-fn assignment_spacing_gap_can_start_at(bytes: &[u8], start: usize) -> bool {
-    matches!(bytes.get(start), Some(b' ' | b'\t'))
-        || matches!(
-            (bytes.get(start), bytes.get(start + 1)),
-            (Some(b'\\'), Some(b'\n'))
-        )
-        || matches!(
-            (bytes.get(start), bytes.get(start + 1), bytes.get(start + 2)),
-            (Some(b'\\'), Some(b'\r'), Some(b'\n'))
-        )
-}
-
-fn is_shell_name_start_byte(byte: u8) -> bool {
-    byte == b'_' || byte.is_ascii_alphabetic()
-}
-
-fn is_shell_name_continue_byte(byte: u8) -> bool {
-    is_shell_name_start_byte(byte) || byte.is_ascii_digit()
 }
 
 #[cfg(test)]
@@ -226,38 +160,6 @@ foo= bar
                 .collect::<Vec<_>>(),
             vec![" "]
         );
-    }
-
-    #[test]
-    fn source_prefilter_matches_candidate_shapes() {
-        for source in [
-            "foo= bar\n",
-            "foo+= append\n",
-            "declare foo= bar\n",
-            "array[0]= value\n",
-            "foo=\\\nbar\n",
-            "comment='name= value'\n",
-        ] {
-            assert!(
-                super::source_may_contain_assignment_spacing(source),
-                "source: {source:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn source_prefilter_ignores_common_non_reportable_shapes() {
-        for source in [
-            "foo=bar\n",
-            "foo = bar\n",
-            "[ \"$left\" = right ]\n",
-            "while IFS= read -r line; do :; done\n",
-        ] {
-            assert!(
-                !super::source_may_contain_assignment_spacing(source),
-                "source: {source:?}"
-            );
-        }
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/assignment_spacing.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_spacing.rs
@@ -96,6 +96,26 @@ EARCH= \\
     }
 
     #[test]
+    fn reports_line_continued_builtin_assignment_gaps() {
+        let source = "\
+#!/bin/sh
+foo= \\
+\treturn
+bar= \\
+\texit
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignmentSpacing));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![" \\\n\t", " \\\n\t"]
+        );
+    }
+
+    #[test]
     fn ignores_ifs_empty_assignments() {
         let source = "\
 #!/bin/sh

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -5,6 +5,7 @@ pub mod arithmetic_redirection_target;
 pub mod array_slice_in_comparison;
 pub mod array_to_string_conversion;
 pub mod assignment_looks_like_comparison;
+pub mod assignment_spacing;
 pub mod assignment_to_numeric_variable;
 pub mod at_sign_in_string_compare;
 pub mod backslash_before_closing_backtick;
@@ -175,6 +176,7 @@ mod tests {
     #[test_case(Rule::ConstantCaseSubject, Path::new("C021.sh"))]
     #[test_case(Rule::EmptyTest, Path::new("C022.sh"))]
     #[test_case(Rule::LeadingZeroArithmetic, Path::new("C023.sh"))]
+    #[test_case(Rule::AssignmentSpacing, Path::new("C024.sh"))]
     #[test_case(Rule::MissingBracketSpace, Path::new("C030.sh"))]
     #[test_case(Rule::PositionalTenBraces, Path::new("C025.sh"))]
     #[test_case(Rule::MissingFi, Path::new("C035.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__assignment_spacing__tests__C024_fix_C024.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__assignment_spacing__tests__C024_fix_C024.sh.snap
@@ -1,0 +1,77 @@
+---
+source: crates/shuck-linter/src/rules/correctness/assignment_spacing.rs
+---
+Diagnostics:
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:3:5
+  |
+3 | foo= bar
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:4:6
+  |
+4 | foo+= append
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:5:3
+  |
+5 | A= B= cmd
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:5:6
+  |
+5 | A= B= cmd
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:6:13
+  |
+6 | export left= right other= value
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:6:26
+  |
+6 | export left= right other= value
+  |
+
+
+Applied fixes: 6
+
+Diff:
+--- before
++++ after
+@@ -1,9 +1,9 @@
+ #!/bin/sh
+ 
+-foo= bar
+-foo+= append
+-A= B= cmd
+-export left= right other= value
++foo=bar
++foo+=append
++A=B=cmd
++export left=right other=value
+ 
+ foo=bar
+ foo=
+
+Fixed source:
+#!/bin/sh
+
+foo=bar
+foo+=append
+A=B=cmd
+export left=right other=value
+
+foo=bar
+foo=
+foo =bar
+echo foo= bar
+export done=
+
+Remaining diagnostics:
+<none>

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C024_C024.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C024_C024.sh.snap
@@ -1,0 +1,38 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:3:5
+  |
+3 | foo= bar
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:4:6
+  |
+4 | foo+= append
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:5:3
+  |
+5 | A= B= cmd
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:5:6
+  |
+5 | A= B= cmd
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:6:13
+  |
+6 | export left= right other= value
+  |
+
+C024 a space after `=` keeps this from being one assignment word
+ --> <source>:6:26
+  |
+6 | export left= right other= value
+  |

--- a/scripts/benchmarks/run.sh
+++ b/scripts/benchmarks/run.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)}
+repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)}
 fixtures_dir=${SHUCK_BENCHMARK_FIXTURES_DIR:-"$repo_root/crates/shuck-benchmark/resources/files"}
 target_dir=${CARGO_TARGET_DIR:-"$repo_root/target"}
 shuck=${SHUCK_BENCHMARK_SHUCK_BIN:-"$target_dir/release/shuck"}

--- a/scripts/benchmarks/run_formatter.sh
+++ b/scripts/benchmarks/run_formatter.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+repo_root=$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)
 fixtures_dir="$repo_root/crates/shuck-benchmark/resources/files"
 shuck="$repo_root/target/release/shuck"
 cache_dir="$repo_root/.cache"

--- a/scripts/benchmarks/run_formatter_single.sh
+++ b/scripts/benchmarks/run_formatter_single.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+repo_root=$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)
 shuck="$repo_root/target/release/shuck"
 timeout_runner="$repo_root/scripts/benchmarks/with_timeout.sh"
 timeout_secs=${SHUCK_FORMAT_BENCH_TIMEOUT_SECS:-3}

--- a/scripts/benchmarks/run_repo_corpus.sh
+++ b/scripts/benchmarks/run_repo_corpus.sh
@@ -23,7 +23,7 @@
 #   SHUCK_BENCHMARK_MANIFEST    manifest path for SHA pinning (optional)
 set -eu
 
-repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)}
+repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)}
 manifest_file=${SHUCK_BENCHMARK_MANIFEST:-"$repo_root/.cache/large-corpus/manifest.yaml"}
 # Cache clones in $HOME so reruns reuse them. We deliberately don't follow
 # $TMPDIR — nix develop overrides it to a per-session path, which would

--- a/scripts/benchmarks/run_single.sh
+++ b/scripts/benchmarks/run_single.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+repo_root=$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)
 shuck="$repo_root/target/release/shuck"
 file=${1:?Usage: run_single.sh <path-to-script>}
 shuck_check="$shuck check --no-cache --select ALL"

--- a/scripts/benchmarks/setup.sh
+++ b/scripts/benchmarks/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)}
+repo_root=${SHUCK_BENCHMARK_REPO_ROOT:-$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)}
 target_dir=${CARGO_TARGET_DIR:-"$repo_root/target"}
 shuck=${SHUCK_BENCHMARK_SHUCK_BIN:-"$target_dir/release/shuck"}
 

--- a/scripts/benchmarks/summarize_formatter.sh
+++ b/scripts/benchmarks/summarize_formatter.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+repo_root=$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)
 cache_dir=${1:-"$repo_root/.cache"}
 
 if ! command -v yq >/dev/null 2>&1; then

--- a/scripts/corpus-download.sh
+++ b/scripts/corpus-download.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+repo_root=$(CDPATH="" cd -- "$(dirname "$0")/.." && pwd)
 default_corpus_dir="$repo_root/.cache/large-corpus"
 archive_file="${SHUCK_LARGE_CORPUS_ARCHIVE_FILE:-shuck-cache-v3.tar.zst}"
 archive_url="${SHUCK_LARGE_CORPUS_ARCHIVE_URL:-https://github.com/ewhauser/shuck/releases/download/v0.0.0-test-files/$archive_file}"

--- a/scripts/profiling/profile_bench.sh
+++ b/scripts/profiling/profile_bench.sh
@@ -7,7 +7,7 @@ profile_root=${3:-.cache/profiles}
 rate=${4:-1000}
 iterations=${5:-1}
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+repo_root=$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)
 output_dir="$repo_root/$profile_root/$bench_name"
 
 mkdir -p "$output_dir"

--- a/scripts/profiling/profile_cli.sh
+++ b/scripts/profiling/profile_cli.sh
@@ -6,7 +6,7 @@ profile_root=${2:-.cache/profiles}
 rate=${3:-1000}
 iterations=${4:-1}
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+repo_root=$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)
 output_dir="$repo_root/$profile_root/cli"
 
 case "$target_file" in

--- a/scripts/profiling/profile_large_corpus.sh
+++ b/scripts/profiling/profile_large_corpus.sh
@@ -7,7 +7,7 @@ rate=${3:-1000}
 profile_iterations=${4:-1}
 fixture_iterations=${5:-1}
 
-repo_root=$(CDPATH= cd -- "$(dirname "$0")/../.." && pwd)
+repo_root=$(CDPATH="" cd -- "$(dirname "$0")/../.." && pwd)
 output_dir="$repo_root/$profile_root/large-corpus"
 
 mkdir -p "$output_dir"

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -682,12 +682,12 @@
       "ksh"
     ],
     "shellcheckCode": "SC1007",
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
-    "fixStatus": "planned",
-    "fixAvailability": "none",
+    "severity": "Warning",
+    "fixStatus": "implemented",
+    "fixAvailability": "always",
     "fixSafety": "unsafe",
     "fixDescription": "Delete the whitespace immediately after `=` so the assignment becomes one shell word.",
     "examples": [


### PR DESCRIPTION
## Summary
- implement C024 assignment-spacing diagnostics and unsafe whitespace deletion fixes
- add fact-layer spacing spans for assignments, declarations, continued lines, and IFS exemptions
- refresh C024 fixtures, snapshots, zsh diagnostic baseline, and repo scripts that need to pass self-lint

## Validation
- cargo fmt --check
- cargo test -p shuck-linter assignment_spacing
- cargo test -p shuck-linter rule_assignmentspacing_path_new_c024_sh_expects
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C024
- make check