### PR TITLE
feat(linter): implement C027 bare done word

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C027.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C027.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+printf '%s\n' done
+printf '%s\n' do
+command done
+x=done printf '%s\n' ok
+export x=done
+rvm 3.1.3 do rvm gemdir
+: do
+[ "$state" = done ]
+[[ $state == done ]]
+[[ $state == do ]]
+case done in ok) :;; esac
+for value in done; do :; done
+echo hi > done
+trap done EXIT
+
+echo "done" 'done' d"on"e
+echo "do" 'do' d"o"
+echo done.x done#suffix
+./do
+case "$state" in done) :;; esac
+[[ $state =~ done ]]
+echo ${state:-done}

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -511,6 +511,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::BareSlashMarker) {
             rules::correctness::bare_slash_marker::bare_slash_marker(self);
         }
+        if self.is_rule_enabled(Rule::BareDoneWord) {
+            rules::correctness::bare_done_word::bare_done_word(self);
+        }
         if self.is_rule_enabled(Rule::StatusCaptureAfterBranchTest) {
             rules::correctness::status_capture_after_branch_test::status_capture_after_branch_test(
                 self,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -871,6 +871,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         );
         let brace_variable_before_bracket_spans =
             build_brace_variable_before_bracket_spans(&word_nodes, &word_occurrences, source);
+        let bare_done_word_spans =
+            build_bare_done_word_spans(&commands, &word_nodes, &word_occurrences, source);
         let alias_definition_expansion_spans = build_alias_definition_expansion_spans(
             &commands,
             &fact_store,
@@ -992,6 +994,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 word_index,
                 array_assignment_split_word_ids,
                 brace_variable_before_bracket_spans,
+                bare_done_word_spans,
                 array_index_arithmetic_spans: arithmetic_summary.array_index_arithmetic_spans,
                 arithmetic_score_line_spans: arithmetic_summary.arithmetic_score_line_spans,
                 dollar_in_arithmetic_spans: arithmetic_summary.dollar_in_arithmetic_spans,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -871,8 +871,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         );
         let brace_variable_before_bracket_spans =
             build_brace_variable_before_bracket_spans(&word_nodes, &word_occurrences, source);
-        let bare_done_word_spans =
-            build_bare_done_word_spans(&commands, &word_nodes, &word_occurrences, source);
         let alias_definition_expansion_spans = build_alias_definition_expansion_spans(
             &commands,
             &fact_store,
@@ -994,7 +992,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 word_index,
                 array_assignment_split_word_ids,
                 brace_variable_before_bracket_spans,
-                bare_done_word_spans,
+                bare_done_word_spans: OnceLock::new(),
                 array_index_arithmetic_spans: arithmetic_summary.array_index_arithmetic_spans,
                 arithmetic_score_line_spans: arithmetic_summary.arithmetic_score_line_spans,
                 dollar_in_arithmetic_spans: arithmetic_summary.dollar_in_arithmetic_spans,

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -61,6 +61,7 @@ pub(crate) struct WordFactStore<'a> {
     pub(in crate::facts) word_index: FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     pub(in crate::facts) array_assignment_split_word_ids: Vec<WordOccurrenceId>,
     pub(in crate::facts) brace_variable_before_bracket_spans: Vec<Span>,
+    pub(in crate::facts) bare_done_word_spans: Vec<Span>,
     pub(in crate::facts) array_index_arithmetic_spans: Vec<Span>,
     pub(in crate::facts) arithmetic_score_line_spans: Vec<Span>,
     pub(in crate::facts) dollar_in_arithmetic_spans: Vec<Span>,
@@ -1097,6 +1098,10 @@ impl<'facts, 'a> WordFacts<'facts, 'a> {
 
     pub(crate) fn brace_variable_before_bracket_spans(self) -> &'facts [Span] {
         &self.facts.words.brace_variable_before_bracket_spans
+    }
+
+    pub(crate) fn bare_done_word_spans(self) -> &'facts [Span] {
+        &self.facts.words.bare_done_word_spans
     }
 
     pub(crate) fn array_index_arithmetic_spans(self) -> &'facts [Span] {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -61,7 +61,7 @@ pub(crate) struct WordFactStore<'a> {
     pub(in crate::facts) word_index: FxHashMap<FactSpan, SmallVec<[WordOccurrenceId; 2]>>,
     pub(in crate::facts) array_assignment_split_word_ids: Vec<WordOccurrenceId>,
     pub(in crate::facts) brace_variable_before_bracket_spans: Vec<Span>,
-    pub(in crate::facts) bare_done_word_spans: Vec<Span>,
+    pub(in crate::facts) bare_done_word_spans: OnceLock<Vec<Span>>,
     pub(in crate::facts) array_index_arithmetic_spans: Vec<Span>,
     pub(in crate::facts) arithmetic_score_line_spans: Vec<Span>,
     pub(in crate::facts) dollar_in_arithmetic_spans: Vec<Span>,
@@ -1101,7 +1101,14 @@ impl<'facts, 'a> WordFacts<'facts, 'a> {
     }
 
     pub(crate) fn bare_done_word_spans(self) -> &'facts [Span] {
-        &self.facts.words.bare_done_word_spans
+        self.facts.words.bare_done_word_spans.get_or_init(|| {
+            build_bare_done_word_spans(
+                &self.facts.command.commands,
+                &self.facts.words.word_nodes,
+                &self.facts.words.word_occurrences,
+                self.facts.source_facts.source,
+            )
+        })
     }
 
     pub(crate) fn array_index_arithmetic_spans(self) -> &'facts [Span] {

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -878,6 +878,163 @@ pub(crate) fn build_brace_variable_before_bracket_spans<'a>(
     spans
 }
 
+pub(crate) fn build_bare_done_word_spans(
+    commands: &[CommandFact<'_>],
+    nodes: &[WordNode<'_>],
+    occurrences: &[WordOccurrence],
+    source: &str,
+) -> Vec<Span> {
+    let mut spans = occurrences
+        .iter()
+        .filter(|fact| bare_done_word_context_reports(fact.context, fact.host_kind))
+        .filter(|fact| {
+            let analysis = occurrence_analysis(nodes, fact);
+            analysis.quote == WordQuote::Unquoted
+                && analysis.literalness == WordLiteralness::FixedLiteral
+        })
+        .filter(|fact| {
+            occurrence_static_text(nodes, fact, source)
+                .as_deref()
+                .is_some_and(is_bare_loop_keyword_text)
+        })
+        .map(|fact| {
+            let position = occurrence_span(nodes, fact).start;
+            Span::from_positions(position, position)
+        })
+        .collect::<Vec<_>>();
+    collect_bare_done_word_conditional_spans(commands, source, &mut spans);
+    sort_and_dedup_spans(&mut spans);
+    spans
+}
+
+fn collect_bare_done_word_conditional_spans(
+    commands: &[CommandFact<'_>],
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    for command in commands {
+        let Some(conditional) = command.conditional() else {
+            continue;
+        };
+
+        for node in conditional.nodes() {
+            match node {
+                ConditionalNodeFact::BareWord(fact) => {
+                    collect_bare_done_word_conditional_operand(fact.operand(), source, spans);
+                }
+                ConditionalNodeFact::Unary(fact) => {
+                    collect_bare_done_word_conditional_operand(fact.operand(), source, spans);
+                }
+                ConditionalNodeFact::Binary(fact) => {
+                    collect_bare_done_word_conditional_operand(fact.left(), source, spans);
+                    if fact.operator_family() != ConditionalOperatorFamily::Regex {
+                        collect_bare_done_word_conditional_operand(fact.right(), source, spans);
+                    }
+                }
+                ConditionalNodeFact::Other(_) => {}
+            }
+        }
+    }
+}
+
+fn collect_bare_done_word_conditional_operand(
+    operand: ConditionalOperandFact<'_>,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    if let ConditionalExpr::Pattern(pattern) = operand.expression() {
+        collect_bare_done_word_conditional_pattern(pattern, source, spans);
+        return;
+    }
+
+    let Some(word) = operand.word() else {
+        return;
+    };
+    collect_bare_done_word_if_static(word, operand.word_classification(), source, spans);
+}
+
+fn collect_bare_done_word_conditional_pattern(
+    pattern: &Pattern,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let [part] = pattern.parts.as_slice() else {
+        return;
+    };
+
+    match &part.kind {
+        PatternPart::Literal(text) if is_bare_loop_keyword_text(text.as_str(source, part.span)) => {
+            let position = part.span.start;
+            spans.push(Span::from_positions(position, position));
+        }
+        PatternPart::Word(word) => {
+            collect_bare_done_word_if_static(word, Some(classify_word(word, source)), source, spans);
+        }
+        PatternPart::Literal(_)
+        | PatternPart::AnyString
+        | PatternPart::AnyChar
+        | PatternPart::CharClass(_)
+        | PatternPart::Group { .. } => {}
+    }
+}
+
+fn collect_bare_done_word_if_static(
+    word: &Word,
+    classification: Option<WordClassification>,
+    source: &str,
+    spans: &mut Vec<Span>,
+) {
+    let Some(classification) = classification else {
+        return;
+    };
+    if classification.quote != WordQuote::Unquoted
+        || classification.literalness != WordLiteralness::FixedLiteral
+    {
+        return;
+    }
+    if !static_word_text(word, source)
+        .as_deref()
+        .is_some_and(is_bare_loop_keyword_text)
+    {
+        return;
+    }
+
+    let position = word.span.start;
+    spans.push(Span::from_positions(position, position));
+}
+
+fn is_bare_loop_keyword_text(text: &str) -> bool {
+    matches!(text, "do" | "done")
+}
+
+fn bare_done_word_context_reports(context: WordFactContext, host_kind: WordFactHostKind) -> bool {
+    match context {
+        WordFactContext::CaseSubject => true,
+        WordFactContext::Expansion(context) => match context {
+            ExpansionContext::CommandName => host_kind == WordFactHostKind::CommandWrapperTarget,
+            ExpansionContext::CommandArgument
+            | ExpansionContext::AssignmentValue
+            | ExpansionContext::DeclarationAssignmentValue
+            | ExpansionContext::RedirectTarget(_)
+            | ExpansionContext::DescriptorDupTarget(_)
+            | ExpansionContext::HereString
+            | ExpansionContext::ForList
+            | ExpansionContext::SelectList
+            | ExpansionContext::ConditionalPattern
+            | ExpansionContext::StringTestOperand
+            | ExpansionContext::TrapAction => matches!(
+                host_kind,
+                WordFactHostKind::Direct | WordFactHostKind::CommandWrapperTarget
+            ),
+            ExpansionContext::CasePattern
+            | ExpansionContext::RegexOperand
+            | ExpansionContext::ConditionalVarRefSubscript
+            | ExpansionContext::ParameterPattern => false,
+        },
+        WordFactContext::ArithmeticCommand | WordFactContext::ParameterOperand => false,
+    }
+}
+
 pub(crate) fn contains_template_placeholder_text_in_word(text: &str) -> bool {
     let Some(start) = text.find("{{") else {
         return false;

--- a/crates/shuck-linter/src/facts/words/occurrence.rs
+++ b/crates/shuck-linter/src/facts/words/occurrence.rs
@@ -895,7 +895,7 @@ pub(crate) fn build_bare_done_word_spans(
         .filter(|fact| {
             occurrence_static_text(nodes, fact, source)
                 .as_deref()
-                .is_some_and(is_bare_loop_keyword_text)
+                .is_some_and(|text| bare_loop_keyword_text_reports(fact.context, text))
         })
         .map(|fact| {
             let position = occurrence_span(nodes, fact).start;
@@ -1007,17 +1007,28 @@ fn is_bare_loop_keyword_text(text: &str) -> bool {
     matches!(text, "do" | "done")
 }
 
+fn bare_loop_keyword_text_reports(context: WordFactContext, text: &str) -> bool {
+    match text {
+        "done" => true,
+        "do" => !matches!(
+            context,
+            WordFactContext::Expansion(ExpansionContext::ForList | ExpansionContext::SelectList)
+        ),
+        _ => false,
+    }
+}
+
 fn bare_done_word_context_reports(context: WordFactContext, host_kind: WordFactHostKind) -> bool {
     match context {
         WordFactContext::CaseSubject => true,
         WordFactContext::Expansion(context) => match context {
             ExpansionContext::CommandName => host_kind == WordFactHostKind::CommandWrapperTarget,
             ExpansionContext::CommandArgument
-            | ExpansionContext::AssignmentValue
-            | ExpansionContext::DeclarationAssignmentValue
             | ExpansionContext::RedirectTarget(_)
             | ExpansionContext::DescriptorDupTarget(_)
             | ExpansionContext::HereString
+            | ExpansionContext::AssignmentValue
+            | ExpansionContext::DeclarationAssignmentValue
             | ExpansionContext::ForList
             | ExpansionContext::SelectList
             | ExpansionContext::ConditionalPattern

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -114,6 +114,7 @@ declare_rules! {
     ("C024", Category::Correctness, Severity::Warning, AssignmentSpacing),
     ("C030", Category::Correctness, Severity::Error, MissingBracketSpace),
     ("C025", Category::Correctness, Severity::Warning, PositionalTenBraces),
+    ("C027", Category::Correctness, Severity::Warning, BareDoneWord),
     ("C035", Category::Correctness, Severity::Error, MissingFi),
     ("C036", Category::Correctness, Severity::Error, BrokenTestEnd),
     ("C037", Category::Correctness, Severity::Error, BrokenTestParse),
@@ -811,6 +812,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-098" => Some(Rule::MissingBracketSpace),
         "SH-134" => Some(Rule::PipeToKill),
         "SH-086" => Some(Rule::PositionalTenBraces),
+        "SH-091" => Some(Rule::BareDoneWord),
         "SH-106" => Some(Rule::MissingFi),
         "SH-107" => Some(Rule::FunctionParamsInSh),
         "SH-109" => Some(Rule::BrokenTestEnd),
@@ -1163,6 +1165,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-098"), Some(Rule::MissingBracketSpace));
         assert_eq!(code_to_rule("SH-134"), Some(Rule::PipeToKill));
         assert_eq!(code_to_rule("SH-086"), Some(Rule::PositionalTenBraces));
+        assert_eq!(code_to_rule("C027"), Some(Rule::BareDoneWord));
+        assert_eq!(code_to_rule("SH-091"), Some(Rule::BareDoneWord));
         assert_eq!(code_to_rule("C035"), Some(Rule::MissingFi));
         assert_eq!(code_to_rule("SH-106"), Some(Rule::MissingFi));
         assert_eq!(code_to_rule("C036"), Some(Rule::BrokenTestEnd));

--- a/crates/shuck-linter/src/rules/correctness/bare_done_word.rs
+++ b/crates/shuck-linter/src/rules/correctness/bare_done_word.rs
@@ -1,0 +1,112 @@
+use crate::{Checker, Rule, ShellDialect, Violation};
+
+pub struct BareDoneWord;
+
+impl Violation for BareDoneWord {
+    fn rule() -> Rule {
+        Rule::BareDoneWord
+    }
+
+    fn message(&self) -> String {
+        "put a separator before this loop keyword, or quote it as literal text".to_owned()
+    }
+}
+
+pub fn bare_done_word(checker: &mut Checker) {
+    if checker.shell() == ShellDialect::Zsh {
+        return;
+    }
+
+    let spans = checker.facts().words().bare_done_word_spans().to_vec();
+    checker.report_all_dedup(spans, || BareDoneWord);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_bare_done_words_in_command_like_positions() {
+        let source = "\
+#!/bin/sh
+printf '%s\\n' done
+printf '%s\\n' do
+command done
+x=done printf '%s\\n' ok
+export x=done
+rvm 3.1.3 do rvm gemdir
+: do
+echo hi > done
+trap done EXIT
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BareDoneWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .collect::<Vec<_>>(),
+            vec![
+                (2, 15),
+                (3, 15),
+                (4, 9),
+                (5, 3),
+                (6, 10),
+                (7, 11),
+                (8, 3),
+                (9, 11),
+                (10, 6)
+            ]
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.span.start == diagnostic.span.end)
+        );
+    }
+
+    #[test]
+    fn reports_bare_done_words_in_tests_and_lists() {
+        let source = "\
+#!/bin/sh
+[ \"$state\" = done ]
+[[ $state == done ]]
+[[ $state == do ]]
+case done in ok) :;; esac
+for value in done; do :; done
+select value in done; do :; done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BareDoneWord));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .collect::<Vec<_>>(),
+            vec![(2, 14), (3, 14), (4, 14), (5, 6), (6, 14), (7, 17)]
+        );
+    }
+
+    #[test]
+    fn ignores_literal_done_when_the_syntax_is_not_command_like() {
+        let source = "\
+#!/bin/sh
+echo \"done\" 'done' d\"on\"e
+echo \"do\" 'do' d\"o\"
+echo done.x done#suffix
+./do
+case \"$state\" in done) :;; esac
+[[ $state =~ done ]]
+echo ${state:-done}
+echo ${state%done}
+array[done]=value
+echo ${array[done]}
+cat <<done
+done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BareDoneWord));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/bare_done_word.rs
+++ b/crates/shuck-linter/src/rules/correctness/bare_done_word.rs
@@ -76,6 +76,8 @@ trap done EXIT
 case done in ok) :;; esac
 for value in done; do :; done
 select value in done; do :; done
+for value in do; do :; done
+select value in do; do :; done
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BareDoneWord));
 
@@ -94,16 +96,23 @@ select value in done; do :; done
 #!/bin/sh
 echo \"done\" 'done' d\"on\"e
 echo \"do\" 'do' d\"o\"
-echo done.x done#suffix
+echo done.x do.x done#suffix do#suffix
 ./do
-case \"$state\" in done) :;; esac
+case \"$state\" in done | do) :;; esac
 [[ $state =~ done ]]
+[[ $state =~ do ]]
 echo ${state:-done}
+echo ${state:-do}
 echo ${state%done}
+echo ${state%do}
 array[done]=value
+array[do]=value
 echo ${array[done]}
-cat <<done
-done
+echo ${array[do]}
+for value in do; do :; done
+select value in do; do :; done
+cat <<do
+do
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::BareDoneWord));
 

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -13,6 +13,7 @@ pub mod backtick_in_command_position;
 pub mod bad_redirection_fd_order;
 pub mod bad_var_name;
 pub mod bare_closing_brace;
+pub mod bare_done_word;
 pub mod bare_slash_marker;
 pub mod broken_assoc_key;
 mod broken_test_common;
@@ -179,6 +180,7 @@ mod tests {
     #[test_case(Rule::AssignmentSpacing, Path::new("C024.sh"))]
     #[test_case(Rule::MissingBracketSpace, Path::new("C030.sh"))]
     #[test_case(Rule::PositionalTenBraces, Path::new("C025.sh"))]
+    #[test_case(Rule::BareDoneWord, Path::new("C027.sh"))]
     #[test_case(Rule::MissingFi, Path::new("C035.sh"))]
     #[test_case(Rule::BrokenTestEnd, Path::new("C036.sh"))]
     #[test_case(Rule::BrokenTestParse, Path::new("C037.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C027_C027.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C027_C027.sh.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/shuck-linter/src/rules/correctness/mod.rs
-assertion_line: 288
 ---
 C027 put a separator before this loop keyword, or quote it as literal text
  --> <source>:3:15

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C027_C027.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C027_C027.sh.snap
@@ -1,0 +1,87 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 288
+---
+C027 put a separator before this loop keyword, or quote it as literal text
+ --> <source>:3:15
+  |
+3 | printf '%s\n' done
+  |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+ --> <source>:4:15
+  |
+4 | printf '%s\n' do
+  |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+ --> <source>:5:9
+  |
+5 | command done
+  |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+ --> <source>:6:3
+  |
+6 | x=done printf '%s\n' ok
+  |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+ --> <source>:7:10
+  |
+7 | export x=done
+  |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+ --> <source>:8:11
+  |
+8 | rvm 3.1.3 do rvm gemdir
+  |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+ --> <source>:9:3
+  |
+9 | : do
+  |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+  --> <source>:10:14
+   |
+10 | [ "$state" = done ]
+   |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+  --> <source>:11:14
+   |
+11 | [[ $state == done ]]
+   |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+  --> <source>:12:14
+   |
+12 | [[ $state == do ]]
+   |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+  --> <source>:13:6
+   |
+13 | case done in ok) :;; esac
+   |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+  --> <source>:14:14
+   |
+14 | for value in done; do :; done
+   |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+  --> <source>:15:11
+   |
+15 | echo hi > done
+   |
+
+C027 put a separator before this loop keyword, or quote it as literal text
+  --> <source>:16:6
+   |
+16 | trap done EXIT
+   |

--- a/docs/rules/C027.yaml
+++ b/docs/rules/C027.yaml
@@ -10,8 +10,8 @@ shells:
   - bash
   - dash
   - ksh
-description: A loop-closing `done` is missing a separator before it.
-rationale: "Insert a semicolon or newline before `done`, or quote it if it is meant literally."
+description: A loop keyword is missing a separator before it.
+rationale: "Insert a semicolon or newline before the loop keyword, or quote it if it is meant literally."
 safe_fix: false
 fix_description: null
 source:
@@ -24,3 +24,8 @@ examples:
       #!/bin/sh
       printf '%s
       ' done
+  - kind: invalid
+    source: shell-checks/examples/091.sh
+    code: |
+      #!/bin/sh
+      rvm 3.1.3 do rvm gemdir

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -731,8 +731,8 @@
     "name": "bare-done-word",
     "category": "Correctness",
     "categoryPrefix": "C",
-    "description": "A loop-closing `done` is missing a separator before it.",
-    "rationale": "Insert a semicolon or newline before `done`, or quote it if it is meant literally.",
+    "description": "A loop keyword is missing a separator before it.",
+    "rationale": "Insert a semicolon or newline before the loop keyword, or quote it if it is meant literally.",
     "shells": [
       "sh",
       "bash",
@@ -752,6 +752,10 @@
       {
         "kind": "invalid",
         "code": "#!/bin/sh\nprintf '%s\n' done"
+      },
+      {
+        "kind": "invalid",
+        "code": "#!/bin/sh\nrvm 3.1.3 do rvm gemdir"
       }
     ]
   },

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -740,10 +740,10 @@
       "ksh"
     ],
     "shellcheckCode": "SC1010",
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- add C027 detection for bare loop delimiter words in command-like positions
- keep rule logic as a fact-layer span index consumed by the correctness rule
- add C027 fixture/snapshot coverage and fix the packaging smoke script self-lint case

## Testing
- cargo test -p shuck-linter bare_done_word
- cargo test -p shuck-linter rule_baredoneword_path_new_c027_sh_expects
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C027
- make check