### PR TITLE
feat(linter): implement C032 jammed test bracket

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C032.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C032.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+[! -r /etc/passwd ]
+[foo]
+[foo ]
+[[foo]]
+[[foo ]]
+if [! -r x ]; then :; fi
+case x in a)[! -r x ];; esac
+
+[ ! -r /etc/passwd ]
+[ foo]
+[[ foo]]
+if[ -r x ]; then :; fi
+echo [foo]

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -1180,6 +1180,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::MissingSpaceBeforeBracketClose) {
             rules::correctness::missing_space_before_bracket_close::missing_space_before_bracket_close(self);
         }
+        if self.is_rule_enabled(Rule::JammedTestBracket) {
+            rules::correctness::jammed_test_bracket::jammed_test_bracket(self);
+        }
         if self.is_rule_enabled(Rule::EscapedNegationInTest) {
             rules::correctness::escaped_negation_in_test::escaped_negation_in_test(self);
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -323,6 +323,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 build_glued_closing_bracket_operand_span(visit.command, self.source);
             let glued_closing_bracket_insert_offset =
                 build_glued_closing_bracket_insert_offset(visit.command, self.source);
+            let jammed_test_bracket = build_jammed_test_bracket_fact(visit.command, self.source);
             let simple_test = build_simple_test_fact(visit.command, self.source);
             let conditional_expression_visits = self
                 .semantic_artifacts
@@ -348,6 +349,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 declaration_assignment_probes: declaration_assignment_probe_range,
                 glued_closing_bracket_operand_span,
                 glued_closing_bracket_insert_offset,
+                jammed_test_bracket_span: jammed_test_bracket.map(|fact| fact.0),
+                jammed_test_bracket_insert_offset: jammed_test_bracket.map(|fact| fact.1),
                 linebreak_in_test_anchor_span: None,
                 linebreak_in_test_insert_offset: None,
                 simple_test,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -323,7 +323,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 build_glued_closing_bracket_operand_span(visit.command, self.source);
             let glued_closing_bracket_insert_offset =
                 build_glued_closing_bracket_insert_offset(visit.command, self.source);
-            let jammed_test_bracket = build_jammed_test_bracket_fact(visit.command, self.source);
             let simple_test = build_simple_test_fact(visit.command, self.source);
             let conditional_expression_visits = self
                 .semantic_artifacts
@@ -349,8 +348,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 declaration_assignment_probes: declaration_assignment_probe_range,
                 glued_closing_bracket_operand_span,
                 glued_closing_bracket_insert_offset,
-                jammed_test_bracket_span: jammed_test_bracket.map(|fact| fact.0),
-                jammed_test_bracket_insert_offset: jammed_test_bracket.map(|fact| fact.1),
                 linebreak_in_test_anchor_span: None,
                 linebreak_in_test_insert_offset: None,
                 simple_test,
@@ -984,6 +981,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 backtick_command_name_spans,
                 assignment_spacing_spans: OnceLock::new(),
                 missing_space_before_bracket_close_facts: OnceLock::new(),
+                jammed_test_bracket_facts: OnceLock::new(),
                 assignment_like_command_name_spans,
                 bare_command_name_assignment_spans,
             },

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -22,6 +22,8 @@ pub struct CommandFact<'a> {
     pub(crate) declaration_assignment_probes: IdRange<DeclarationAssignmentProbe>,
     pub(crate) glued_closing_bracket_operand_span: Option<Span>,
     pub(crate) glued_closing_bracket_insert_offset: Option<usize>,
+    pub(crate) jammed_test_bracket_span: Option<Span>,
+    pub(crate) jammed_test_bracket_insert_offset: Option<usize>,
     pub(crate) linebreak_in_test_anchor_span: Option<Span>,
     pub(crate) linebreak_in_test_insert_offset: Option<usize>,
     pub(crate) simple_test: Option<SimpleTestFact<'a>>,
@@ -103,6 +105,14 @@ impl<'a> CommandFact<'a> {
 
     pub fn glued_closing_bracket_insert_offset(&self) -> Option<usize> {
         self.glued_closing_bracket_insert_offset
+    }
+
+    pub fn jammed_test_bracket_span(&self) -> Option<Span> {
+        self.jammed_test_bracket_span
+    }
+
+    pub fn jammed_test_bracket_insert_offset(&self) -> Option<usize> {
+        self.jammed_test_bracket_insert_offset
     }
 
     pub fn linebreak_in_test_anchor_span(&self) -> Option<Span> {
@@ -312,6 +322,14 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
 
     pub fn glued_closing_bracket_insert_offset(self) -> Option<usize> {
         self.fact.glued_closing_bracket_insert_offset()
+    }
+
+    pub fn jammed_test_bracket_span(self) -> Option<Span> {
+        self.fact.jammed_test_bracket_span()
+    }
+
+    pub fn jammed_test_bracket_insert_offset(self) -> Option<usize> {
+        self.fact.jammed_test_bracket_insert_offset()
     }
 
     pub fn linebreak_in_test_anchor_span(self) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -22,8 +22,6 @@ pub struct CommandFact<'a> {
     pub(crate) declaration_assignment_probes: IdRange<DeclarationAssignmentProbe>,
     pub(crate) glued_closing_bracket_operand_span: Option<Span>,
     pub(crate) glued_closing_bracket_insert_offset: Option<usize>,
-    pub(crate) jammed_test_bracket_span: Option<Span>,
-    pub(crate) jammed_test_bracket_insert_offset: Option<usize>,
     pub(crate) linebreak_in_test_anchor_span: Option<Span>,
     pub(crate) linebreak_in_test_insert_offset: Option<usize>,
     pub(crate) simple_test: Option<SimpleTestFact<'a>>,
@@ -105,14 +103,6 @@ impl<'a> CommandFact<'a> {
 
     pub fn glued_closing_bracket_insert_offset(&self) -> Option<usize> {
         self.glued_closing_bracket_insert_offset
-    }
-
-    pub fn jammed_test_bracket_span(&self) -> Option<Span> {
-        self.jammed_test_bracket_span
-    }
-
-    pub fn jammed_test_bracket_insert_offset(&self) -> Option<usize> {
-        self.jammed_test_bracket_insert_offset
     }
 
     pub fn linebreak_in_test_anchor_span(&self) -> Option<Span> {
@@ -322,14 +312,6 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
 
     pub fn glued_closing_bracket_insert_offset(self) -> Option<usize> {
         self.fact.glued_closing_bracket_insert_offset()
-    }
-
-    pub fn jammed_test_bracket_span(self) -> Option<Span> {
-        self.fact.jammed_test_bracket_span()
-    }
-
-    pub fn jammed_test_bracket_insert_offset(self) -> Option<usize> {
-        self.fact.jammed_test_bracket_insert_offset()
     }
 
     pub fn linebreak_in_test_anchor_span(self) -> Option<Span> {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -48,6 +48,7 @@ pub(crate) struct CommandFactStore<'a> {
     pub(in crate::facts) backtick_command_name_spans: Vec<Span>,
     pub(in crate::facts) assignment_spacing_spans: OnceLock<Vec<Span>>,
     pub(in crate::facts) missing_space_before_bracket_close_facts: OnceLock<Vec<(Span, usize)>>,
+    pub(in crate::facts) jammed_test_bracket_facts: OnceLock<Vec<(Span, usize)>>,
     pub(in crate::facts) assignment_like_command_name_spans: Vec<Span>,
     pub(in crate::facts) bare_command_name_assignment_spans: Vec<Span>,
 }
@@ -676,6 +677,25 @@ impl<'facts, 'a> CommandFactQueries<'facts, 'a> {
                             command.command(),
                             self.facts.source_facts.source,
                             locator,
+                        )
+                    })
+                    .collect()
+            })
+    }
+
+    pub(crate) fn jammed_test_bracket_facts(self) -> &'facts [(Span, usize)] {
+        self.facts
+            .command
+            .jammed_test_bracket_facts
+            .get_or_init(|| {
+                self.facts
+                    .command
+                    .commands
+                    .iter()
+                    .filter_map(|command| {
+                        build_jammed_test_bracket_fact(
+                            command.command(),
+                            self.facts.source_facts.source,
                         )
                     })
                     .collect()

--- a/crates/shuck-linter/src/facts/simple_tests.rs
+++ b/crates/shuck-linter/src/facts/simple_tests.rs
@@ -468,6 +468,37 @@ fn unescaped_final_closing_bracket_len(text: &str) -> Option<usize> {
         .then_some(1)
 }
 
+pub(crate) fn build_jammed_test_bracket_fact(
+    command: &Command,
+    source: &str,
+) -> Option<(Span, usize)> {
+    let Command::Simple(command) = command else {
+        return None;
+    };
+    let name_text = command.name.span.slice(source);
+    let bracket_len = if name_text.starts_with("[[") {
+        "[[".len()
+    } else if name_text.starts_with('[') {
+        "[".len()
+    } else {
+        return None;
+    };
+    if name_text.len() == bracket_len {
+        return None;
+    }
+
+    let start = command.name.span.start;
+    let end = Position {
+        offset: start.offset + bracket_len,
+        line: start.line,
+        column: start.column + bracket_len,
+    };
+    Some((
+        Span::from_positions(start, end),
+        command.name.span.start.offset + bracket_len,
+    ))
+}
+
 pub(crate) fn build_glued_closing_bracket_operand_word<'a>(
     command: &'a Command,
     source: &str,

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -114,6 +114,7 @@ declare_rules! {
     ("C024", Category::Correctness, Severity::Warning, AssignmentSpacing),
     ("C030", Category::Correctness, Severity::Error, MissingBracketSpace),
     ("C031", Category::Correctness, Severity::Error, MissingSpaceBeforeBracketClose),
+    ("C032", Category::Correctness, Severity::Error, JammedTestBracket),
     ("C025", Category::Correctness, Severity::Warning, PositionalTenBraces),
     ("C027", Category::Correctness, Severity::Warning, BareDoneWord),
     ("C035", Category::Correctness, Severity::Error, MissingFi),
@@ -817,6 +818,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-075" => Some(Rule::EmptyTest),
         "SH-084" => Some(Rule::AssignmentSpacing),
         "SH-098" => Some(Rule::MissingBracketSpace),
+        "SH-102" => Some(Rule::JammedTestBracket),
         "SH-134" => Some(Rule::PipeToKill),
         "SH-086" => Some(Rule::PositionalTenBraces),
         "SH-091" => Some(Rule::BareDoneWord),
@@ -1183,6 +1185,8 @@ mod tests {
             code_to_rule("SH-100"),
             Some(Rule::MissingSpaceBeforeBracketClose)
         );
+        assert_eq!(code_to_rule("C032"), Some(Rule::JammedTestBracket));
+        assert_eq!(code_to_rule("SH-102"), Some(Rule::JammedTestBracket));
         assert_eq!(code_to_rule("SH-134"), Some(Rule::PipeToKill));
         assert_eq!(code_to_rule("SH-086"), Some(Rule::PositionalTenBraces));
         assert_eq!(code_to_rule("C027"), Some(Rule::BareDoneWord));

--- a/crates/shuck-linter/src/rules/correctness/jammed_test_bracket.rs
+++ b/crates/shuck-linter/src/rules/correctness/jammed_test_bracket.rs
@@ -27,13 +27,10 @@ pub fn jammed_test_bracket(checker: &mut Checker) {
 
     let diagnostics = checker
         .facts()
-        .commands()
+        .command_facts()
+        .jammed_test_bracket_facts()
         .iter()
-        .filter_map(|fact| {
-            let span = fact.jammed_test_bracket_span()?;
-            let insert_offset = fact.jammed_test_bracket_insert_offset()?;
-            Some(diagnostic_for_jammed_test_bracket(span, insert_offset))
-        })
+        .map(|(span, insert_offset)| diagnostic_for_jammed_test_bracket(*span, *insert_offset))
         .collect::<Vec<_>>();
 
     for diagnostic in diagnostics {

--- a/crates/shuck-linter/src/rules/correctness/jammed_test_bracket.rs
+++ b/crates/shuck-linter/src/rules/correctness/jammed_test_bracket.rs
@@ -1,0 +1,140 @@
+use shuck_ast::Span;
+
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
+
+pub struct JammedTestBracket;
+
+impl Violation for JammedTestBracket {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    fn rule() -> Rule {
+        Rule::JammedTestBracket
+    }
+
+    fn message(&self) -> String {
+        "put a space after the opening test bracket".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("insert a space after the opening bracket".to_owned())
+    }
+}
+
+pub fn jammed_test_bracket(checker: &mut Checker) {
+    if checker.shell() == ShellDialect::Zsh {
+        return;
+    }
+
+    let diagnostics = checker
+        .facts()
+        .commands()
+        .iter()
+        .filter_map(|fact| {
+            let span = fact.jammed_test_bracket_span()?;
+            let insert_offset = fact.jammed_test_bracket_insert_offset()?;
+            Some(diagnostic_for_jammed_test_bracket(span, insert_offset))
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn diagnostic_for_jammed_test_bracket(span: Span, insert_offset: usize) -> crate::Diagnostic {
+    crate::Diagnostic::new(JammedTestBracket, span)
+        .with_fix(Fix::unsafe_edit(Edit::insertion(insert_offset, " ")))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_opening_test_brackets_glued_to_operands() {
+        let source = "\
+#!/bin/bash
+[! -r /etc/passwd ]
+[foo]
+[foo ]
+[[foo]]
+[[foo ]]
+if [! -r x ]; then :; fi
+case x in a)[! -r x ];; esac
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::JammedTestBracket));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| {
+                    (
+                        diagnostic.span.start.line,
+                        diagnostic.span.start.column,
+                        diagnostic.span.end.column,
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                (2, 1, 2),
+                (3, 1, 2),
+                (4, 1, 2),
+                (5, 1, 3),
+                (6, 1, 3),
+                (7, 4, 5),
+                (8, 13, 14)
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_spaced_tests_and_other_glued_words() {
+        let source = "\
+#!/bin/bash
+[ ! -r /etc/passwd ]
+[ foo]
+[[ foo]]
+if[ -r x ]; then :; fi
+echo [foo]
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::JammedTestBracket));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn skips_zsh() {
+        let source = "#!/bin/zsh\n[foo]\n[[foo]]\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::JammedTestBracket).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_after_the_opening_bracket() {
+        let source = "\
+#!/bin/bash
+[! -r /etc/passwd ]
+[[foo]]
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::JammedTestBracket),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 2);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/bash
+[ ! -r /etc/passwd ]
+[[ foo]]
+"
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -68,6 +68,7 @@ pub mod if_missing_then;
 pub mod ifs_set_to_literal_backslash_n;
 pub mod indented_shebang;
 pub mod invalid_exit_status;
+pub mod jammed_test_bracket;
 pub mod leading_glob_argument;
 pub mod leading_zero_arithmetic;
 pub mod line_oriented_input;
@@ -184,6 +185,7 @@ mod tests {
     #[test_case(Rule::AssignmentSpacing, Path::new("C024.sh"))]
     #[test_case(Rule::MissingBracketSpace, Path::new("C030.sh"))]
     #[test_case(Rule::MissingSpaceBeforeBracketClose, Path::new("C031.sh"))]
+    #[test_case(Rule::JammedTestBracket, Path::new("C032.sh"))]
     #[test_case(Rule::PositionalTenBraces, Path::new("C025.sh"))]
     #[test_case(Rule::BareDoneWord, Path::new("C027.sh"))]
     #[test_case(Rule::MissingFi, Path::new("C035.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C032_C032.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C032_C032.sh.snap
@@ -1,0 +1,45 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 288
+---
+C032 put a space after the opening test bracket
+ --> <source>:3:1
+  |
+3 | [! -r /etc/passwd ]
+  |
+
+C032 put a space after the opening test bracket
+ --> <source>:4:1
+  |
+4 | [foo]
+  |
+
+C032 put a space after the opening test bracket
+ --> <source>:5:1
+  |
+5 | [foo ]
+  |
+
+C032 put a space after the opening test bracket
+ --> <source>:6:1
+  |
+6 | [[foo]]
+  |
+
+C032 put a space after the opening test bracket
+ --> <source>:7:1
+  |
+7 | [[foo ]]
+  |
+
+C032 put a space after the opening test bracket
+ --> <source>:8:4
+  |
+8 | if [! -r x ]; then :; fi
+  |
+
+C032 put a space after the opening test bracket
+ --> <source>:9:13
+  |
+9 | case x in a)[! -r x ];; esac
+  |

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -831,12 +831,12 @@
       "ksh"
     ],
     "shellcheckCode": "SC1035",
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
-    "fixStatus": "planned",
-    "fixAvailability": "none",
+    "severity": "Error",
+    "fixStatus": "implemented",
+    "fixAvailability": "always",
     "fixSafety": "unsafe",
     "fixDescription": "Insert a space after `[` so the test starts as `[ ! ... ]`.",
     "examples": [


### PR DESCRIPTION
## Summary
- add C032 detection for opening test brackets glued to operands
- store reusable jammed-bracket facts on command facts
- add unsafe insertion fix coverage and fixture/snapshot tests
- fix the packaging smoke script self-lint case needed for make check

## Testing
- cargo test -p shuck-linter jammed_test_bracket
- cargo test -p shuck-linter rule_jammedtestbracket_path_new_c032_sh_expects
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C032
- make check