### PR TITLE
feat(linter): implement C033 indented heredoc close

### DIFF
--- a/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
+++ b/crates/shuck-cli/tests/testdata/zsh-diagnostic-corpus.yaml
@@ -7497,6 +7497,17 @@ repos:
           line: 471
           column: 29
         classification: real
+      - path: "gitstatus/build"
+        code: "C033"
+        severity: "error"
+        message: "move this here-document terminator to the start of the line"
+        start:
+          line: 449
+          column: 1
+        end:
+          line: 449
+          column: 1
+        classification: false_positive
       - path: "gitstatus/gitstatus.plugin.sh"
         code: "C086"
         severity: "warning"

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C033.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C033.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cat <<EOF
+hi
+ EOF
+  EOF
+EOF
+
+cat <<-EOF
+hi
+	EOF
+
+cat <<EOF
+hi EOF
+EOF
+
+cat <<EOF
+hi
+EOF 

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -955,6 +955,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::HeredocMissingEnd) {
             rules::correctness::heredoc_missing_end::heredoc_missing_end(self);
         }
+        if self.is_rule_enabled(Rule::IndentedHeredocClose) {
+            rules::correctness::indented_heredoc_close::indented_heredoc_close(self);
+        }
         if self.is_rule_enabled(Rule::HeredocCloserNotAlone) {
             rules::correctness::heredoc_closer_not_alone::heredoc_closer_not_alone(self);
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -36,6 +36,7 @@ pub(crate) struct HeredocFactSummary {
     pub(crate) heredoc_closer_not_alone_spans: Vec<Span>,
     pub(crate) misquoted_heredoc_close_spans: Vec<Span>,
     pub(crate) heredoc_end_space_spans: Vec<Span>,
+    pub(crate) indented_heredoc_close_facts: Vec<(Span, Span)>,
     pub(crate) echo_here_doc_spans: Vec<Span>,
     pub(crate) spaced_tabstrip_close_spans: Vec<Span>,
 }
@@ -1094,6 +1095,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 heredoc_closer_not_alone_spans: heredoc_summary.heredoc_closer_not_alone_spans,
                 misquoted_heredoc_close_spans: heredoc_summary.misquoted_heredoc_close_spans,
                 heredoc_end_space_spans: heredoc_summary.heredoc_end_space_spans,
+                indented_heredoc_close_facts: heredoc_summary.indented_heredoc_close_facts,
                 echo_here_doc_spans: heredoc_summary.echo_here_doc_spans,
                 spaced_tabstrip_close_spans: heredoc_summary.spaced_tabstrip_close_spans,
             },

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -36,7 +36,6 @@ pub(crate) struct HeredocFactSummary {
     pub(crate) heredoc_closer_not_alone_spans: Vec<Span>,
     pub(crate) misquoted_heredoc_close_spans: Vec<Span>,
     pub(crate) heredoc_end_space_spans: Vec<Span>,
-    pub(crate) indented_heredoc_close_facts: Vec<(Span, Span)>,
     pub(crate) echo_here_doc_spans: Vec<Span>,
     pub(crate) spaced_tabstrip_close_spans: Vec<Span>,
 }
@@ -1095,7 +1094,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 heredoc_closer_not_alone_spans: heredoc_summary.heredoc_closer_not_alone_spans,
                 misquoted_heredoc_close_spans: heredoc_summary.misquoted_heredoc_close_spans,
                 heredoc_end_space_spans: heredoc_summary.heredoc_end_space_spans,
-                indented_heredoc_close_facts: heredoc_summary.indented_heredoc_close_facts,
+                indented_heredoc_close_facts: OnceLock::new(),
                 echo_here_doc_spans: heredoc_summary.echo_here_doc_spans,
                 spaced_tabstrip_close_spans: heredoc_summary.spaced_tabstrip_close_spans,
             },

--- a/crates/shuck-linter/src/facts/heredocs.rs
+++ b/crates/shuck-linter/src/facts/heredocs.rs
@@ -55,6 +55,16 @@ pub(crate) fn build_heredoc_fact_summary(
                 summary.heredoc_end_space_spans.push(span);
             }
 
+            if !redirect_uses_tab_stripping_heredoc(redirect, heredoc, source) {
+                summary
+                    .indented_heredoc_close_facts
+                    .extend(indented_heredoc_close_facts(
+                        heredoc.body.span,
+                        delimiter,
+                        locator,
+                    ));
+            }
+
             if redirect.kind == RedirectKind::HereDocStrip {
                 summary
                     .spaced_tabstrip_close_spans
@@ -94,6 +104,28 @@ pub(crate) fn build_heredoc_fact_summary(
 
 pub(crate) fn is_heredoc_redirect_kind(kind: RedirectKind) -> bool {
     matches!(kind, RedirectKind::HereDoc | RedirectKind::HereDocStrip)
+}
+
+fn redirect_uses_tab_stripping_heredoc(
+    redirect: &Redirect,
+    heredoc: &shuck_ast::Heredoc,
+    source: &str,
+) -> bool {
+    redirect.kind == RedirectKind::HereDocStrip
+        || heredoc.delimiter.strip_tabs
+        || redirect.span.slice(source).contains("<<-")
+        || heredoc_delimiter_line_contains_tabstrip_operator(heredoc, source)
+}
+
+fn heredoc_delimiter_line_contains_tabstrip_operator(
+    heredoc: &shuck_ast::Heredoc,
+    source: &str,
+) -> bool {
+    let delimiter_start = heredoc.delimiter.span.start.offset;
+    let line_start = source[..delimiter_start]
+        .rfind('\n')
+        .map_or(0, |offset| offset + '\n'.len_utf8());
+    source[line_start..delimiter_start].contains("<<-")
 }
 
 pub(crate) fn heredoc_closer_not_alone_span(
@@ -183,6 +215,34 @@ pub(crate) fn spaced_tabstrip_close_spans(
     }
 
     spans
+}
+
+fn indented_heredoc_close_facts(
+    body_span: Span,
+    delimiter: &str,
+    locator: Locator<'_>,
+) -> Vec<(Span, Span)> {
+    let source = locator.source();
+    let mut facts = Vec::new();
+    let mut line_start_offset = body_span.start.offset;
+    for raw_line in body_span.slice(source).split_inclusive('\n') {
+        let line_without_newline = raw_line.trim_end_matches('\n').trim_end_matches('\r');
+        let trimmed = line_without_newline.trim_start_matches([' ', '\t']);
+        let indent_len = line_without_newline.len() - trimmed.len();
+        if indent_len > 0
+            && trimmed == delimiter
+            && let Some(start) = locator.position_at_offset(line_start_offset)
+            && let Some(indent_end) = locator.position_at_offset(line_start_offset + indent_len)
+        {
+            facts.push((
+                Span::from_positions(start, start),
+                Span::from_positions(start, indent_end),
+            ));
+        }
+        line_start_offset += raw_line.len();
+    }
+
+    facts
 }
 
 pub(crate) fn normalized_heredoc_line(raw_line: &str, strip_tabs: bool) -> (&str, usize) {

--- a/crates/shuck-linter/src/facts/heredocs.rs
+++ b/crates/shuck-linter/src/facts/heredocs.rs
@@ -55,16 +55,6 @@ pub(crate) fn build_heredoc_fact_summary(
                 summary.heredoc_end_space_spans.push(span);
             }
 
-            if !redirect_uses_tab_stripping_heredoc(redirect, heredoc, source) {
-                summary
-                    .indented_heredoc_close_facts
-                    .extend(indented_heredoc_close_facts(
-                        heredoc.body.span,
-                        delimiter,
-                        locator,
-                    ));
-            }
-
             if redirect.kind == RedirectKind::HereDocStrip {
                 summary
                     .spaced_tabstrip_close_spans
@@ -106,26 +96,37 @@ pub(crate) fn is_heredoc_redirect_kind(kind: RedirectKind) -> bool {
     matches!(kind, RedirectKind::HereDoc | RedirectKind::HereDocStrip)
 }
 
-fn redirect_uses_tab_stripping_heredoc(
-    redirect: &Redirect,
-    heredoc: &shuck_ast::Heredoc,
-    source: &str,
-) -> bool {
+fn redirect_uses_tab_stripping_heredoc(redirect: &Redirect) -> bool {
     redirect.kind == RedirectKind::HereDocStrip
-        || heredoc.delimiter.strip_tabs
-        || redirect.span.slice(source).contains("<<-")
-        || heredoc_delimiter_line_contains_tabstrip_operator(heredoc, source)
 }
 
-fn heredoc_delimiter_line_contains_tabstrip_operator(
-    heredoc: &shuck_ast::Heredoc,
-    source: &str,
-) -> bool {
-    let delimiter_start = heredoc.delimiter.span.start.offset;
-    let line_start = source[..delimiter_start]
-        .rfind('\n')
-        .map_or(0, |offset| offset + '\n'.len_utf8());
-    source[line_start..delimiter_start].contains("<<-")
+pub(crate) fn build_indented_heredoc_close_facts(
+    commands: &[CommandFact<'_>],
+    locator: Locator<'_>,
+) -> Vec<(Span, Span)> {
+    let mut facts = Vec::new();
+
+    for command in commands {
+        for redirect in command.redirects() {
+            if !is_heredoc_redirect_kind(redirect.kind) {
+                continue;
+            }
+            let Some(heredoc) = redirect.heredoc() else {
+                continue;
+            };
+            let delimiter = heredoc.delimiter.cooked.as_str();
+            if delimiter.is_empty() || redirect_uses_tab_stripping_heredoc(redirect) {
+                continue;
+            }
+            facts.extend(indented_heredoc_close_facts(
+                heredoc.body.span,
+                delimiter,
+                locator,
+            ));
+        }
+    }
+
+    facts
 }
 
 pub(crate) fn heredoc_closer_not_alone_span(

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -164,7 +164,7 @@ pub(crate) struct SourceFactStore<'a> {
     pub(in crate::facts) heredoc_closer_not_alone_spans: Vec<Span>,
     pub(in crate::facts) misquoted_heredoc_close_spans: Vec<Span>,
     pub(in crate::facts) heredoc_end_space_spans: Vec<Span>,
-    pub(in crate::facts) indented_heredoc_close_facts: Vec<(Span, Span)>,
+    pub(in crate::facts) indented_heredoc_close_facts: OnceLock<Vec<(Span, Span)>>,
     pub(in crate::facts) echo_here_doc_spans: Vec<Span>,
     pub(in crate::facts) spaced_tabstrip_close_spans: Vec<Span>,
 }
@@ -1073,7 +1073,16 @@ impl<'facts, 'a> SourceFacts<'facts, 'a> {
     }
 
     pub(crate) fn indented_heredoc_close_facts(self) -> &'facts [(Span, Span)] {
-        &self.facts.source_facts.indented_heredoc_close_facts
+        self.facts
+            .source_facts
+            .indented_heredoc_close_facts
+            .get_or_init(|| {
+                let locator = Locator::new(
+                    self.facts.source_facts.source,
+                    self.facts.source_facts.line_index,
+                );
+                build_indented_heredoc_close_facts(&self.facts.command.commands, locator)
+            })
     }
 
     pub(crate) fn echo_here_doc_spans(self) -> &'facts [Span] {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -164,6 +164,7 @@ pub(crate) struct SourceFactStore<'a> {
     pub(in crate::facts) heredoc_closer_not_alone_spans: Vec<Span>,
     pub(in crate::facts) misquoted_heredoc_close_spans: Vec<Span>,
     pub(in crate::facts) heredoc_end_space_spans: Vec<Span>,
+    pub(in crate::facts) indented_heredoc_close_facts: Vec<(Span, Span)>,
     pub(in crate::facts) echo_here_doc_spans: Vec<Span>,
     pub(in crate::facts) spaced_tabstrip_close_spans: Vec<Span>,
 }
@@ -1069,6 +1070,10 @@ impl<'facts, 'a> SourceFacts<'facts, 'a> {
 
     pub(crate) fn heredoc_end_space_spans(self) -> &'facts [Span] {
         &self.facts.source_facts.heredoc_end_space_spans
+    }
+
+    pub(crate) fn indented_heredoc_close_facts(self) -> &'facts [(Span, Span)] {
+        &self.facts.source_facts.indented_heredoc_close_facts
     }
 
     pub(crate) fn echo_here_doc_spans(self) -> &'facts [Span] {

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -115,6 +115,7 @@ declare_rules! {
     ("C030", Category::Correctness, Severity::Error, MissingBracketSpace),
     ("C031", Category::Correctness, Severity::Error, MissingSpaceBeforeBracketClose),
     ("C032", Category::Correctness, Severity::Error, JammedTestBracket),
+    ("C033", Category::Correctness, Severity::Error, IndentedHeredocClose),
     ("C025", Category::Correctness, Severity::Warning, PositionalTenBraces),
     ("C027", Category::Correctness, Severity::Warning, BareDoneWord),
     ("C035", Category::Correctness, Severity::Error, MissingFi),
@@ -819,6 +820,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-084" => Some(Rule::AssignmentSpacing),
         "SH-098" => Some(Rule::MissingBracketSpace),
         "SH-102" => Some(Rule::JammedTestBracket),
+        "SH-104" => Some(Rule::IndentedHeredocClose),
         "SH-134" => Some(Rule::PipeToKill),
         "SH-086" => Some(Rule::PositionalTenBraces),
         "SH-091" => Some(Rule::BareDoneWord),
@@ -1187,6 +1189,8 @@ mod tests {
         );
         assert_eq!(code_to_rule("C032"), Some(Rule::JammedTestBracket));
         assert_eq!(code_to_rule("SH-102"), Some(Rule::JammedTestBracket));
+        assert_eq!(code_to_rule("C033"), Some(Rule::IndentedHeredocClose));
+        assert_eq!(code_to_rule("SH-104"), Some(Rule::IndentedHeredocClose));
         assert_eq!(code_to_rule("SH-134"), Some(Rule::PipeToKill));
         assert_eq!(code_to_rule("SH-086"), Some(Rule::PositionalTenBraces));
         assert_eq!(code_to_rule("C027"), Some(Rule::BareDoneWord));

--- a/crates/shuck-linter/src/rules/correctness/indented_heredoc_close.rs
+++ b/crates/shuck-linter/src/rules/correctness/indented_heredoc_close.rs
@@ -95,6 +95,41 @@ EOF
     }
 
     #[test]
+    fn reports_plain_heredocs_after_literal_tabstrip_text() {
+        let source = "\
+#!/bin/sh
+cat \"<<-\" <<EOF
+hi
+ EOF
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::IndentedHeredocClose),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 4);
+    }
+
+    #[test]
+    fn reports_plain_heredocs_with_quoted_tabstrip_like_delimiters() {
+        let source = "\
+#!/bin/sh
+cat <<'<<-'
+hi
+ <<-
+<<-
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::IndentedHeredocClose),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.start.line, 4);
+    }
+
+    #[test]
     fn skips_zsh() {
         let source = "#!/bin/zsh\ncat <<EOF\nhi\n EOF\n";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/indented_heredoc_close.rs
+++ b/crates/shuck-linter/src/rules/correctness/indented_heredoc_close.rs
@@ -1,0 +1,133 @@
+use shuck_ast::Span;
+
+use crate::{Checker, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
+
+pub struct IndentedHeredocClose;
+
+impl Violation for IndentedHeredocClose {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    fn rule() -> Rule {
+        Rule::IndentedHeredocClose
+    }
+
+    fn message(&self) -> String {
+        "move this here-document terminator to the start of the line".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("remove indentation before the here-document terminator".to_owned())
+    }
+}
+
+pub fn indented_heredoc_close(checker: &mut Checker) {
+    if checker.shell() == ShellDialect::Zsh {
+        return;
+    }
+
+    let diagnostics = checker
+        .facts()
+        .source_facts()
+        .indented_heredoc_close_facts()
+        .iter()
+        .map(|&(span, indent_span)| diagnostic_for_indented_heredoc_close(span, indent_span))
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn diagnostic_for_indented_heredoc_close(span: Span, indent_span: Span) -> crate::Diagnostic {
+    crate::Diagnostic::new(IndentedHeredocClose, span)
+        .with_fix(Fix::unsafe_edit(Edit::deletion(indent_span)))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_indented_plain_heredoc_terminators() {
+        let source = "\
+#!/bin/sh
+cat <<EOF
+hi
+ EOF
+  EOF
+EOF
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::IndentedHeredocClose),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.span.start.line, diagnostic.span.start.column))
+                .collect::<Vec<_>>(),
+            vec![(4, 1), (5, 1)]
+        );
+    }
+
+    #[test]
+    fn ignores_tab_stripped_and_non_terminator_lines() {
+        let source = "\
+#!/bin/sh
+cat <<-EOF
+hi
+\tEOF
+cat <<EOF
+hi EOF
+EOF
+cat <<EOF
+hi
+EOF 
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::IndentedHeredocClose),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn skips_zsh() {
+        let source = "#!/bin/zsh\ncat <<EOF\nhi\n EOF\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::IndentedHeredocClose).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_by_deleting_indentation() {
+        let source = "\
+#!/bin/sh
+cat <<EOF
+hi
+ EOF
+";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::IndentedHeredocClose),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "\
+#!/bin/sh
+cat <<EOF
+hi
+EOF
+"
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -66,6 +66,7 @@ pub mod if_bracket_glued;
 pub mod if_dollar_command;
 pub mod if_missing_then;
 pub mod ifs_set_to_literal_backslash_n;
+pub mod indented_heredoc_close;
 pub mod indented_shebang;
 pub mod invalid_exit_status;
 pub mod jammed_test_bracket;
@@ -186,6 +187,7 @@ mod tests {
     #[test_case(Rule::MissingBracketSpace, Path::new("C030.sh"))]
     #[test_case(Rule::MissingSpaceBeforeBracketClose, Path::new("C031.sh"))]
     #[test_case(Rule::JammedTestBracket, Path::new("C032.sh"))]
+    #[test_case(Rule::IndentedHeredocClose, Path::new("C033.sh"))]
     #[test_case(Rule::PositionalTenBraces, Path::new("C025.sh"))]
     #[test_case(Rule::BareDoneWord, Path::new("C027.sh"))]
     #[test_case(Rule::MissingFi, Path::new("C035.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C033_C033.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C033_C033.sh.snap
@@ -1,0 +1,15 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 288
+---
+C033 move this here-document terminator to the start of the line
+ --> <source>:5:1
+  |
+5 |  EOF
+  |
+
+C033 move this here-document terminator to the start of the line
+ --> <source>:6:1
+  |
+6 |   EOF
+  |

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -860,12 +860,12 @@
       "ksh"
     ],
     "shellcheckCode": "SC1039",
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
-    "fixStatus": "planned",
-    "fixAvailability": "none",
+    "severity": "Error",
+    "fixStatus": "implemented",
+    "fixAvailability": "always",
     "fixSafety": "unsafe",
     "fixDescription": "Remove the leading indentation from the reported here-doc terminator line so it starts at column 1.",
     "examples": [


### PR DESCRIPTION
## Summary
- add C033 as a fact-backed correctness rule for indented plain here-document terminators
- provide an unsafe fix that deletes the leading indentation before the reported terminator
- add C033 fixture/snapshot coverage and update the zsh diagnostic corpus baseline for the generated-script false positive

## Validation
- cargo fmt --check
- cargo test -p shuck-linter indented_heredoc_close
- cargo test -p shuck-linter rule_indentedheredocclose_path_new_c033_sh_expects
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C033
- make check