### PR TITLE
feat(linter): implement C044 bare glob command path

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C044.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C044.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+/opt/tool-*.AppImage --help
+./foo?.sh
+./[ab].sh
+$dir/*.sh
+
+"/opt/tool-*.AppImage" --help
+cmd /opt/tool-*.AppImage
+./{foo,bar}.sh
+./tool.AppImage

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -848,6 +848,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::LeadingGlobArgument) {
             rules::correctness::leading_glob_argument::leading_glob_argument(self);
         }
+        if self.is_rule_enabled(Rule::BareGlobCommandPath) {
+            rules::correctness::bare_glob_command_path::bare_glob_command_path(self);
+        }
         if self.is_rule_enabled(Rule::FindOutputToXargs) {
             rules::correctness::find_output_to_xargs::find_output_to_xargs(self);
         }

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -374,6 +374,50 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         self.fact.body_name_word()
     }
 
+    pub fn command_name_word(self) -> Option<&'a Word> {
+        match self.command() {
+            Command::Simple(command) => Some(&command.name),
+            _ => None,
+        }
+    }
+
+    pub fn command_name_word_unquoted_glob_spans(self, source: &str) -> Vec<Span> {
+        let Some(word) = self.command_name_word() else {
+            return Vec::new();
+        };
+
+        word_spans::word_unquoted_glob_pattern_spans_outside_brace_expansion(word, source)
+    }
+
+    pub fn command_name_word_active_glob_spans_outside_brace_expansion(
+        self,
+        source: &str,
+    ) -> Vec<Span> {
+        if self.has_wrapper(WrapperKind::Noglob) {
+            return Vec::new();
+        }
+
+        let Some(word) = self.command_name_word() else {
+            return Vec::new();
+        };
+
+        let behavior = self.shell_behavior();
+        word_spans::word_active_glob_pattern_spans_outside_brace_expansion(
+            word,
+            source,
+            behavior.pathname_expansion(),
+            behavior.glob_pattern(),
+        )
+    }
+
+    pub fn command_name_word_single_double_quoted_replacement(
+        self,
+        source: &str,
+    ) -> Option<Box<str>> {
+        self.command_name_word()
+            .map(|word| rewrite_word_as_single_double_quoted_string(word, source, None))
+    }
+
     pub fn suspicious_body_name_bracket_glob_spans(self, source: &str) -> Vec<Span> {
         let Some(word) = self.body_name_word() else {
             return Vec::new();

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -124,6 +124,7 @@ declare_rules! {
     ("C041", Category::Correctness, Severity::Error, CStyleComment),
     ("C042", Category::Correctness, Severity::Warning, CPrototypeFragment),
     ("C043", Category::Correctness, Severity::Warning, BadRedirectionFdOrder),
+    ("C044", Category::Correctness, Severity::Warning, BareGlobCommandPath),
     ("C046", Category::Correctness, Severity::Warning, PipeToKill),
     ("C047", Category::Correctness, Severity::Error, InvalidExitStatus),
     ("C048", Category::Correctness, Severity::Warning, CasePatternVar),
@@ -846,6 +847,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-121" => Some(Rule::CStyleComment),
         "SH-123" => Some(Rule::CPrototypeFragment),
         "SH-129" => Some(Rule::BadRedirectionFdOrder),
+        "SH-130" => Some(Rule::BareGlobCommandPath),
         "SH-141" => Some(Rule::InvalidExitStatus),
         "SH-142" => Some(Rule::CasePatternVar),
         "SH-143" => Some(Rule::TautologyChain),
@@ -1215,6 +1217,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-123"), Some(Rule::CPrototypeFragment));
         assert_eq!(code_to_rule("C043"), Some(Rule::BadRedirectionFdOrder));
         assert_eq!(code_to_rule("SH-129"), Some(Rule::BadRedirectionFdOrder));
+        assert_eq!(code_to_rule("C044"), Some(Rule::BareGlobCommandPath));
+        assert_eq!(code_to_rule("SH-130"), Some(Rule::BareGlobCommandPath));
         assert_eq!(code_to_rule("C085"), Some(Rule::StderrBeforeStdoutRedirect));
         assert_eq!(code_to_rule("C094"), Some(Rule::RedirectClobbersInput));
         assert_eq!(

--- a/crates/shuck-linter/src/rules/correctness/bare_glob_command_path.rs
+++ b/crates/shuck-linter/src/rules/correctness/bare_glob_command_path.rs
@@ -1,0 +1,157 @@
+use crate::{
+    Checker, Diagnostic, Edit, ExpansionContext, Fix, FixAvailability, Rule, ShellDialect,
+    Violation, WordFactHostKind,
+};
+
+pub struct BareGlobCommandPath;
+
+impl Violation for BareGlobCommandPath {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    fn rule() -> Rule {
+        Rule::BareGlobCommandPath
+    }
+
+    fn message(&self) -> String {
+        "quote this wildcard command path".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("quote the wildcard command path".to_owned())
+    }
+}
+
+pub fn bare_glob_command_path(checker: &mut Checker) {
+    if checker.shell() == ShellDialect::Zsh {
+        return;
+    }
+
+    let source = checker.source();
+    let diagnostics = checker
+        .facts()
+        .command_facts()
+        .structural_commands()
+        .filter(|fact| {
+            !fact
+                .command_name_word_active_glob_spans_outside_brace_expansion(source)
+                .is_empty()
+        })
+        .filter_map(|fact| {
+            let word = fact.command_name_word()?;
+            let replacement = fact.command_name_word_single_double_quoted_replacement(source)?;
+
+            Some(
+                Diagnostic::new(BareGlobCommandPath, word.span)
+                    .with_fix(Fix::unsafe_edit(Edit::replacement(replacement, word.span))),
+            )
+        })
+        .collect::<Vec<_>>();
+    let diagnostics = diagnostics
+        .into_iter()
+        .chain(
+            checker
+                .facts()
+                .words()
+                .expansion_word_facts(ExpansionContext::CommandName)
+                .filter(|fact| fact.host_kind() == WordFactHostKind::Direct)
+                .filter(|fact| {
+                    !fact
+                        .active_glob_spans_outside_brace_expansion(source)
+                        .is_empty()
+                })
+                .map(|fact| {
+                    Diagnostic::new(BareGlobCommandPath, fact.span()).with_fix(Fix::unsafe_edit(
+                        Edit::replacement(
+                            fact.single_double_quoted_replacement(source),
+                            fact.span(),
+                        ),
+                    ))
+                }),
+        )
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_wildcards_in_command_position() {
+        let source = "\
+#!/bin/sh
+/opt/tool-*.AppImage --help
+./foo?.sh
+./[ab].sh
+$dir/*.sh
+echo $($OUT/bin/python*-config --cflags)
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::BareGlobCommandPath));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "/opt/tool-*.AppImage",
+                "./foo?.sh",
+                "./[ab].sh",
+                "$dir/*.sh",
+                "$OUT/bin/python*-config"
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_quoted_words_arguments_and_brace_expansion() {
+        let source = "\
+#!/bin/bash
+\"/opt/tool-*.AppImage\" --help
+cmd /opt/tool-*.AppImage
+./{foo,bar}.sh
+$dir/{tool*,tool}.sh
+/opt/tool-star.AppImage --help
+exec ./foo?.sh
+command ./foo?.sh
+env FOO=1 ./foo?.sh
+noglob ./disabled*.sh
+";
+        let diagnostics =
+            test_snippet(source, &LinterSettings::for_rule(Rule::BareGlobCommandPath));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn skips_zsh() {
+        let source = "#!/bin/zsh\n./foo?.sh\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::BareGlobCommandPath).with_shell(ShellDialect::Zsh),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn applies_unsafe_fix_to_the_full_command_word() {
+        let source = "#!/bin/sh\n/opt/tool-*.AppImage --help\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::BareGlobCommandPath),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(
+            result.fixed_source,
+            "#!/bin/sh\n\"/opt/tool-*.AppImage\" --help\n"
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -14,6 +14,7 @@ pub mod bad_redirection_fd_order;
 pub mod bad_var_name;
 pub mod bare_closing_brace;
 pub mod bare_done_word;
+pub mod bare_glob_command_path;
 pub mod bare_slash_marker;
 pub mod broken_assoc_key;
 mod broken_test_common;
@@ -191,6 +192,7 @@ mod tests {
     #[test_case(Rule::CStyleComment, Path::new("C041.sh"))]
     #[test_case(Rule::CPrototypeFragment, Path::new("C042.sh"))]
     #[test_case(Rule::BadRedirectionFdOrder, Path::new("C043.sh"))]
+    #[test_case(Rule::BareGlobCommandPath, Path::new("C044.sh"))]
     #[test_case(Rule::PipeToKill, Path::new("C046.sh"))]
     #[test_case(Rule::InvalidExitStatus, Path::new("C047.sh"))]
     #[test_case(Rule::CasePatternVar, Path::new("C048.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C044_C044.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C044_C044.sh.snap
@@ -1,0 +1,26 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C044 quote this wildcard command path
+ --> <source>:3:1
+  |
+3 | /opt/tool-*.AppImage --help
+  |
+
+C044 quote this wildcard command path
+ --> <source>:4:1
+  |
+4 | ./foo?.sh
+  |
+
+C044 quote this wildcard command path
+ --> <source>:5:1
+  |
+5 | ./[ab].sh
+  |
+
+C044 quote this wildcard command path
+ --> <source>:6:1
+  |
+6 | $dir/*.sh
+  |

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -124,6 +124,7 @@ mod tests {
         assert_eq!(map.resolve("SC1012"), Some(Rule::LiteralControlEscape));
         assert_eq!(map.resolve("SC2238"), Some(Rule::RedirectToCommandName));
         assert_eq!(map.resolve("SC2063"), Some(Rule::LeadingGlobInGrepPattern));
+        assert_eq!(map.resolve("SC2211"), Some(Rule::BareGlobCommandPath));
         assert_eq!(map.resolve("SC3034"), Some(Rule::BashFileSlurp));
         assert_eq!(map.resolve("SC2096"), Some(Rule::DuplicateShebangFlag));
         assert_eq!(map.resolve("SC2318"), Some(Rule::LocalCrossReference));

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -1179,12 +1179,12 @@
       "ksh"
     ],
     "shellcheckCode": "SC2211",
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
-    "fixStatus": "planned",
-    "fixAvailability": "none",
+    "severity": "Warning",
+    "fixStatus": "implemented",
+    "fixAvailability": "always",
     "fixSafety": "unsafe",
     "fixDescription": "Wrap the wildcard command-path word in quotes.",
     "examples": [


### PR DESCRIPTION
## Summary
- implement C044 for unquoted glob syntax in command-name position
- cover literal command words and direct dynamic command-name expansions, including command substitutions while excluding wrapper targets
- wire the rule into registry, suppression mapping tests, fixture snapshots, and fix the packaging smoke-script fixture used by make check

## Validation
- cargo fmt --check
- cargo test -p shuck-linter bare_glob_command_path
- INSTA_UPDATE=always cargo test -p shuck-linter rule_bareglobcommandpath_path_new_c044_sh_expects
- cargo test -p shuck-linter resolves_known_codes_and_ignores_unknown_ones
- cargo test -p shuck-linter resolves_legacy_shuck_aliases
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C044
- make check