### PR TITLE
feat(linter): implement C045 diff marker line

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C045.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C045.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+--- a/sample.txt
+  --- indented.txt
+--help
+\-n foo
+-$tool foo
+
+echo --- a/sample.txt
+# --- comment.txt
+cat <<'DOC'
+--- heredoc.txt
+DOC
+"-n" foo
+'-n' foo
+command -n foo
+find . -exec chmod 755 {}\; -o -name '*.txt'

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -514,6 +514,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::CPrototypeFragment) {
             rules::correctness::c_prototype_fragment::c_prototype_fragment(self);
         }
+        if self.is_rule_enabled(Rule::DiffMarkerLine) {
+            rules::correctness::diff_marker_line::diff_marker_line(self);
+        }
         if self.is_rule_enabled(Rule::BareSlashMarker) {
             rules::correctness::bare_slash_marker::bare_slash_marker(self);
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -862,6 +862,8 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         );
         let assignment_like_command_name_spans =
             build_assignment_like_command_name_spans(&commands, self.source);
+        let escaped_dash_command_name_spans =
+            build_escaped_dash_command_name_spans(self.source, self._indexer);
         let bare_command_name_assignment_spans = build_bare_command_name_assignment_spans(
             &commands,
             &word_nodes,
@@ -1083,6 +1085,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 errexit_enabled_anywhere,
                 commented_continuation_comment_spans,
                 comment_double_quote_nesting_spans,
+                escaped_dash_command_name_spans,
                 trailing_directive_comment_spans,
                 backtick_substitution_spans,
                 backtick_escaped_parameters,

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -862,8 +862,6 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
         );
         let assignment_like_command_name_spans =
             build_assignment_like_command_name_spans(&commands, self.source);
-        let escaped_dash_command_name_spans =
-            build_escaped_dash_command_name_spans(self.source, self._indexer);
         let bare_command_name_assignment_spans = build_bare_command_name_assignment_spans(
             &commands,
             &word_nodes,
@@ -1083,9 +1081,10 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 duplicate_shebang_flag_span: shebang_header_facts.duplicate_shebang_flag_span,
                 non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
                 errexit_enabled_anywhere,
+                region_index: self._indexer.region_index(),
                 commented_continuation_comment_spans,
                 comment_double_quote_nesting_spans,
-                escaped_dash_command_name_spans,
+                escaped_dash_command_name_spans: OnceLock::new(),
                 trailing_directive_comment_spans,
                 backtick_substitution_spans,
                 backtick_escaped_parameters,

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -396,7 +396,9 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
             }
             _ => {
                 !word.has_quoted_parts()
-                    && self.literal_name().is_some_and(|name| name.starts_with('-'))
+                    && self
+                        .literal_name()
+                        .is_some_and(|name| name.starts_with('-'))
             }
         }
     }

--- a/crates/shuck-linter/src/facts/commands.rs
+++ b/crates/shuck-linter/src/facts/commands.rs
@@ -381,6 +381,37 @@ impl<'facts, 'a> CommandFactRef<'facts, 'a> {
         }
     }
 
+    pub fn command_name_starts_with_literal_dash(self, source: &str) -> bool {
+        let Some(word) = self.command_name_word() else {
+            return false;
+        };
+        let Some(first) = word.parts.first() else {
+            return false;
+        };
+
+        match &first.kind {
+            WordPart::Literal(text) => {
+                text.as_str(source, first.span).starts_with('-')
+                    || static_word_text(word, source).is_some_and(|text| text.starts_with('-'))
+            }
+            _ => {
+                !word.has_quoted_parts()
+                    && self.literal_name().is_some_and(|name| name.starts_with('-'))
+            }
+        }
+    }
+
+    pub fn command_name_follows_escaped_semicolon(self, source: &str) -> bool {
+        let Some(word) = self.command_name_word() else {
+            return false;
+        };
+        let Some(before) = source.get(..word.span.start.offset) else {
+            return false;
+        };
+
+        before.trim_end_matches([' ', '\t']).ends_with("\\;")
+    }
+
     pub fn command_name_word_unquoted_glob_spans(self, source: &str) -> Vec<Span> {
         let Some(word) = self.command_name_word() else {
             return Vec::new();

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -363,6 +363,41 @@ pub(crate) fn build_commented_continuation_comment_spans(
         .collect()
 }
 
+pub(crate) fn build_escaped_dash_command_name_spans(source: &str, indexer: &Indexer) -> Vec<Span> {
+    let line_index = indexer.line_index();
+
+    (1..=line_index.line_count())
+        .filter_map(|line_number| {
+            let source_line = source_line(source, line_index, line_number)?;
+            let line = source_line.text;
+            let marker_start = line
+                .len()
+                .saturating_sub(line.trim_start_matches(char::is_whitespace).len());
+            let rest = &line[marker_start..];
+            if !rest.starts_with("\\-") {
+                return None;
+            }
+
+            let marker_offset = source_line.offset + marker_start;
+            let marker_text_size = TextSize::from(marker_offset as u32);
+            if indexer.region_index().is_heredoc(marker_text_size)
+                || indexer.region_index().is_quoted(marker_text_size)
+            {
+                return None;
+            }
+
+            let marker_len = rest.find(char::is_whitespace).unwrap_or(rest.len());
+            Some(line_slice_span(
+                line_number,
+                source_line.offset,
+                line,
+                marker_start,
+                marker_len,
+            ))
+        })
+        .collect()
+}
+
 pub(crate) fn build_comment_double_quote_nesting_spans(
     source: &str,
     indexer: &Indexer,

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -363,9 +363,12 @@ pub(crate) fn build_commented_continuation_comment_spans(
         .collect()
 }
 
-pub(crate) fn build_escaped_dash_command_name_spans(source: &str, indexer: &Indexer) -> Vec<Span> {
-    let line_index = indexer.line_index();
-
+pub(crate) fn build_escaped_dash_command_name_spans(
+    source: &str,
+    line_index: &LineIndex,
+    region_index: &RegionIndex,
+    command_name_offsets: &[usize],
+) -> Vec<Span> {
     (1..=line_index.line_count())
         .filter_map(|line_number| {
             let source_line = source_line(source, line_index, line_number)?;
@@ -377,16 +380,24 @@ pub(crate) fn build_escaped_dash_command_name_spans(source: &str, indexer: &Inde
             if !rest.starts_with("\\-") {
                 return None;
             }
+            if previous_line_ends_with_unescaped_continuation(source, line_index, line_number) {
+                return None;
+            }
 
             let marker_offset = source_line.offset + marker_start;
+            if command_name_offsets.binary_search(&marker_offset).is_err() {
+                return None;
+            }
+
             let marker_text_size = TextSize::from(marker_offset as u32);
-            if indexer.region_index().is_heredoc(marker_text_size)
-                || indexer.region_index().is_quoted(marker_text_size)
+            if region_index.is_heredoc(marker_text_size) || region_index.is_quoted(marker_text_size)
             {
                 return None;
             }
 
-            let marker_len = rest.find(char::is_whitespace).unwrap_or(rest.len());
+            let marker_len = rest
+                .find(escaped_dash_command_name_token_delimiter)
+                .unwrap_or(rest.len());
             Some(line_slice_span(
                 line_number,
                 source_line.offset,
@@ -396,6 +407,35 @@ pub(crate) fn build_escaped_dash_command_name_spans(source: &str, indexer: &Inde
             ))
         })
         .collect()
+}
+
+fn escaped_dash_command_name_token_delimiter(ch: char) -> bool {
+    ch.is_whitespace() || matches!(ch, ';' | '&' | '|' | '(' | ')' | '<' | '>')
+}
+
+fn previous_line_ends_with_unescaped_continuation(
+    source: &str,
+    line_index: &LineIndex,
+    line_number: usize,
+) -> bool {
+    let Some(previous_line_number) = line_number.checked_sub(1) else {
+        return false;
+    };
+    if previous_line_number == 0 {
+        return false;
+    }
+
+    let Some(previous_line) = source_line(source, line_index, previous_line_number) else {
+        return false;
+    };
+    let trimmed = previous_line.text.trim_end_matches([' ', '\t', '\r']);
+    let backslash_count = trimmed
+        .as_bytes()
+        .iter()
+        .rev()
+        .take_while(|byte| **byte == b'\\')
+        .count();
+    backslash_count % 2 == 1
 }
 
 pub(crate) fn build_comment_double_quote_nesting_spans(

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -153,6 +153,7 @@ pub(crate) struct SourceFactStore<'a> {
     pub(in crate::facts) errexit_enabled_anywhere: bool,
     pub(in crate::facts) commented_continuation_comment_spans: Vec<Span>,
     pub(in crate::facts) comment_double_quote_nesting_spans: Vec<Span>,
+    pub(in crate::facts) escaped_dash_command_name_spans: Vec<Span>,
     pub(in crate::facts) trailing_directive_comment_spans: Vec<Span>,
     pub(in crate::facts) backtick_substitution_spans: Vec<Span>,
     pub(in crate::facts) backtick_escaped_parameters: Vec<BacktickEscapedParameter>,
@@ -1020,6 +1021,10 @@ impl<'facts, 'a> SourceFacts<'facts, 'a> {
 
     pub(crate) fn comment_double_quote_nesting_spans(self) -> &'facts [Span] {
         &self.facts.source_facts.comment_double_quote_nesting_spans
+    }
+
+    pub(crate) fn escaped_dash_command_name_spans(self) -> &'facts [Span] {
+        &self.facts.source_facts.escaped_dash_command_name_spans
     }
 
     pub(crate) fn trailing_directive_comment_spans(self) -> &'facts [Span] {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -151,9 +151,10 @@ pub(crate) struct SourceFactStore<'a> {
     pub(in crate::facts) duplicate_shebang_flag_span: Option<Span>,
     pub(in crate::facts) non_absolute_shebang_span: Option<Span>,
     pub(in crate::facts) errexit_enabled_anywhere: bool,
+    pub(in crate::facts) region_index: &'a RegionIndex,
     pub(in crate::facts) commented_continuation_comment_spans: Vec<Span>,
     pub(in crate::facts) comment_double_quote_nesting_spans: Vec<Span>,
-    pub(in crate::facts) escaped_dash_command_name_spans: Vec<Span>,
+    pub(in crate::facts) escaped_dash_command_name_spans: OnceLock<Vec<Span>>,
     pub(in crate::facts) trailing_directive_comment_spans: Vec<Span>,
     pub(in crate::facts) backtick_substitution_spans: Vec<Span>,
     pub(in crate::facts) backtick_escaped_parameters: Vec<BacktickEscapedParameter>,
@@ -1024,7 +1025,27 @@ impl<'facts, 'a> SourceFacts<'facts, 'a> {
     }
 
     pub(crate) fn escaped_dash_command_name_spans(self) -> &'facts [Span] {
-        &self.facts.source_facts.escaped_dash_command_name_spans
+        self.facts
+            .source_facts
+            .escaped_dash_command_name_spans
+            .get_or_init(|| {
+                let mut command_name_offsets = self
+                    .facts
+                    .command_facts()
+                    .structural_commands()
+                    .filter_map(|command| command.command_name_word())
+                    .map(|word| word.span.start.offset)
+                    .collect::<Vec<_>>();
+                command_name_offsets.sort_unstable();
+                command_name_offsets.dedup();
+
+                build_escaped_dash_command_name_spans(
+                    self.facts.source_facts.source,
+                    self.facts.source_facts.line_index,
+                    self.facts.source_facts.region_index,
+                    &command_name_offsets,
+                )
+            })
     }
 
     pub(crate) fn trailing_directive_comment_spans(self) -> &'facts [Span] {

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -129,6 +129,7 @@ declare_rules! {
     ("C042", Category::Correctness, Severity::Warning, CPrototypeFragment),
     ("C043", Category::Correctness, Severity::Warning, BadRedirectionFdOrder),
     ("C044", Category::Correctness, Severity::Warning, BareGlobCommandPath),
+    ("C045", Category::Correctness, Severity::Warning, DiffMarkerLine),
     ("C046", Category::Correctness, Severity::Warning, PipeToKill),
     ("C047", Category::Correctness, Severity::Error, InvalidExitStatus),
     ("C048", Category::Correctness, Severity::Warning, CasePatternVar),
@@ -822,6 +823,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-098" => Some(Rule::MissingBracketSpace),
         "SH-102" => Some(Rule::JammedTestBracket),
         "SH-104" => Some(Rule::IndentedHeredocClose),
+        "SH-133" => Some(Rule::DiffMarkerLine),
         "SH-134" => Some(Rule::PipeToKill),
         "SH-086" => Some(Rule::PositionalTenBraces),
         "SH-091" => Some(Rule::BareDoneWord),
@@ -1247,6 +1249,8 @@ mod tests {
         assert_eq!(code_to_rule("SH-129"), Some(Rule::BadRedirectionFdOrder));
         assert_eq!(code_to_rule("C044"), Some(Rule::BareGlobCommandPath));
         assert_eq!(code_to_rule("SH-130"), Some(Rule::BareGlobCommandPath));
+        assert_eq!(code_to_rule("C045"), Some(Rule::DiffMarkerLine));
+        assert_eq!(code_to_rule("SH-133"), Some(Rule::DiffMarkerLine));
         assert_eq!(code_to_rule("C085"), Some(Rule::StderrBeforeStdoutRedirect));
         assert_eq!(code_to_rule("C094"), Some(Rule::RedirectClobbersInput));
         assert_eq!(

--- a/crates/shuck-linter/src/rules/correctness/diff_marker_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/diff_marker_line.rs
@@ -1,9 +1,12 @@
+use shuck_ast::Span;
+use shuck_semantic::{CommandConditionRole, CommandId};
+
 use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
 
 pub struct DiffMarkerLine;
 
 impl Violation for DiffMarkerLine {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
 
     fn rule() -> Rule {
         Rule::DiffMarkerLine
@@ -24,19 +27,19 @@ pub fn diff_marker_line(checker: &mut Checker) {
     }
 
     let source = checker.source();
-    let mut diagnostics = checker
-        .facts()
-        .command_facts()
+    let command_facts = checker.facts().command_facts();
+    let mut diagnostics = command_facts
         .structural_commands()
         .filter(|command| command.command_name_starts_with_literal_dash(source))
         .filter(|command| !command.command_name_follows_escaped_semicolon(source))
         .filter_map(|command| {
             let name = command.command_name_word()?;
-            Some(
-                Diagnostic::new(DiffMarkerLine, name.span).with_fix(Fix::unsafe_edit(
-                    Edit::insertion(name.span.start.offset, "# "),
-                )),
-            )
+            let can_fix_in_context = command_can_be_fixed_in_context(checker, command.id());
+            Some(diagnostic_for_dash_command(
+                source,
+                name.span,
+                can_fix_in_context,
+            ))
         })
         .collect::<Vec<_>>();
     diagnostics.extend(
@@ -47,14 +50,62 @@ pub fn diff_marker_line(checker: &mut Checker) {
             .iter()
             .copied()
             .map(|span| {
-                Diagnostic::new(DiffMarkerLine, span)
-                    .with_fix(Fix::unsafe_edit(Edit::insertion(span.start.offset, "# ")))
+                let can_fix_in_context = command_facts
+                    .command_for_name_word_span(span)
+                    .is_none_or(|command| command_can_be_fixed_in_context(checker, command.id()));
+                diagnostic_for_dash_command(source, span, can_fix_in_context)
             }),
     );
 
     for diagnostic in diagnostics {
         checker.report_diagnostic_dedup(diagnostic);
     }
+}
+
+fn command_can_be_fixed_in_context(checker: &Checker<'_>, command_id: CommandId) -> bool {
+    !matches!(
+        checker.semantic().command_condition_role(command_id),
+        Some(
+            CommandConditionRole::If
+                | CommandConditionRole::Elif
+                | CommandConditionRole::While
+                | CommandConditionRole::Until
+        )
+    ) && !command_satisfies_pending_operator(checker, command_id)
+}
+
+fn command_satisfies_pending_operator(checker: &Checker<'_>, command_id: CommandId) -> bool {
+    let command_facts = checker.facts().command_facts();
+    command_facts.pipelines().iter().any(|pipeline| {
+        pipeline
+            .segments()
+            .iter()
+            .skip(1)
+            .any(|segment| segment.command_id() == command_id)
+    }) || command_facts.lists().iter().any(|list| {
+        list.segments()
+            .iter()
+            .skip(1)
+            .any(|segment| segment.command_id() == command_id)
+    })
+}
+
+fn diagnostic_for_dash_command(source: &str, span: Span, can_fix_in_context: bool) -> Diagnostic {
+    let diagnostic = Diagnostic::new(DiffMarkerLine, span);
+    if can_fix_in_context && span_starts_physical_line(source, span) {
+        diagnostic.with_fix(Fix::unsafe_edit(Edit::insertion(span.start.offset, "# ")))
+    } else {
+        diagnostic
+    }
+}
+
+fn span_starts_physical_line(source: &str, span: Span) -> bool {
+    let line_start = source[..span.start.offset]
+        .rfind('\n')
+        .map_or(0, |offset| offset + 1);
+    source[line_start..span.start.offset]
+        .chars()
+        .all(|ch| matches!(ch, ' ' | '\t'))
 }
 
 #[cfg(test)]
@@ -70,6 +121,7 @@ mod tests {
   --- indented.txt
 --help
 \\-n foo
+\\-x&& echo ok
 -$tool foo
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DiffMarkerLine));
@@ -79,7 +131,7 @@ mod tests {
                 .iter()
                 .map(|diagnostic| diagnostic.span.slice(source))
                 .collect::<Vec<_>>(),
-            vec!["---", "---", "--help", "\\-n", "-$tool"]
+            vec!["---", "---", "--help", "\\-n", "\\-x", "-$tool"]
         );
     }
 
@@ -96,6 +148,11 @@ DOC
 '-n' foo
 command -n foo
 find . -exec chmod 755 {}\\; -o -name '*.txt'
+echo \\
+\\-n
+case \"$1\" in
+  \\-n) echo no ;;
+esac
 ";
         let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DiffMarkerLine));
 
@@ -122,5 +179,152 @@ find . -exec chmod 755 {}\\; -o -name '*.txt'
 
         assert_eq!(result.fixes_applied, 1);
         assert_eq!(result.fixed_source, "#!/bin/sh\n  # --- a/sample.txt\n");
+    }
+
+    #[test]
+    fn withholds_fix_for_dash_commands_inside_control_heads() {
+        let source = "#!/bin/sh\nif --help; then echo ok; fi\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DiffMarkerLine));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "--help");
+        assert!(diagnostics[0].fix.is_none());
+
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DiffMarkerLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+    }
+
+    #[test]
+    fn withholds_fix_for_dash_commands_inside_multiline_control_heads() {
+        let source = "\
+#!/bin/sh
+if
+--help
+then
+  echo ok
+fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DiffMarkerLine));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "--help");
+        assert!(diagnostics[0].fix.is_none());
+
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DiffMarkerLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+    }
+
+    #[test]
+    fn withholds_fix_for_escaped_dash_commands_inside_multiline_control_heads() {
+        let source = "\
+#!/bin/sh
+if
+\\-n;
+then
+  echo ok
+fi
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DiffMarkerLine));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "\\-n");
+        assert!(diagnostics[0].fix.is_none());
+
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DiffMarkerLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+    }
+
+    #[test]
+    fn withholds_fix_for_dash_commands_inside_loop_condition_heads() {
+        let source = "\
+#!/bin/sh
+while
+--help
+do
+  echo ok
+done
+until
+\\-n
+do
+  echo ok
+done
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DiffMarkerLine));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["--help", "\\-n"]
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_none())
+        );
+
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DiffMarkerLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
+    }
+
+    #[test]
+    fn withholds_fix_for_dash_commands_satisfying_pending_operators() {
+        let source = "\
+#!/bin/sh
+foo |
+--help
+foo &&
+\\-n
+foo ||
+--- retry
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DiffMarkerLine));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["--help", "\\-n", "---"]
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.fix.is_none())
+        );
+
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DiffMarkerLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 0);
+        assert_eq!(result.fixed_source, source);
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/diff_marker_line.rs
+++ b/crates/shuck-linter/src/rules/correctness/diff_marker_line.rs
@@ -1,0 +1,126 @@
+use crate::{Checker, Diagnostic, Edit, Fix, FixAvailability, Rule, ShellDialect, Violation};
+
+pub struct DiffMarkerLine;
+
+impl Violation for DiffMarkerLine {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    fn rule() -> Rule {
+        Rule::DiffMarkerLine
+    }
+
+    fn message(&self) -> String {
+        "this dash-prefixed command looks like leftover patch text".to_owned()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("comment out the dash-prefixed line".to_owned())
+    }
+}
+
+pub fn diff_marker_line(checker: &mut Checker) {
+    if checker.shell() == ShellDialect::Zsh {
+        return;
+    }
+
+    let source = checker.source();
+    let mut diagnostics = checker
+        .facts()
+        .command_facts()
+        .structural_commands()
+        .filter(|command| command.command_name_starts_with_literal_dash(source))
+        .filter(|command| !command.command_name_follows_escaped_semicolon(source))
+        .filter_map(|command| {
+            let name = command.command_name_word()?;
+            Some(
+                Diagnostic::new(DiffMarkerLine, name.span).with_fix(Fix::unsafe_edit(
+                    Edit::insertion(name.span.start.offset, "# "),
+                )),
+            )
+        })
+        .collect::<Vec<_>>();
+    diagnostics.extend(
+        checker
+            .facts()
+            .source_facts()
+            .escaped_dash_command_name_spans()
+            .iter()
+            .copied()
+            .map(|span| {
+                Diagnostic::new(DiffMarkerLine, span)
+                    .with_fix(Fix::unsafe_edit(Edit::insertion(span.start.offset, "# ")))
+            }),
+    );
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::{test_snippet, test_snippet_with_fix};
+    use crate::{Applicability, LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_dash_prefixed_command_names() {
+        let source = "\
+#!/bin/sh
+--- a/sample.txt
+  --- indented.txt
+--help
+\\-n foo
+-$tool foo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DiffMarkerLine));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["---", "---", "--help", "\\-n", "-$tool"]
+        );
+    }
+
+    #[test]
+    fn ignores_arguments_comments_quoted_names_and_zsh() {
+        let source = "\
+#!/bin/sh
+echo --- a/sample.txt
+# --- comment.txt
+cat <<'DOC'
+--- heredoc.txt
+DOC
+\"-n\" foo
+'-n' foo
+command -n foo
+find . -exec chmod 755 {}\\; -o -name '*.txt'
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::DiffMarkerLine));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+
+        let zsh_diagnostics = test_snippet(
+            "#!/bin/zsh\n--- a/sample.txt\n",
+            &LinterSettings::for_rule(Rule::DiffMarkerLine).with_shell(ShellDialect::Zsh),
+        );
+        assert!(
+            zsh_diagnostics.is_empty(),
+            "diagnostics: {zsh_diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn applies_unsafe_fix_before_the_command_name() {
+        let source = "#!/bin/sh\n  --- a/sample.txt\n";
+        let result = test_snippet_with_fix(
+            source,
+            &LinterSettings::for_rule(Rule::DiffMarkerLine),
+            Applicability::Unsafe,
+        );
+
+        assert_eq!(result.fixes_applied, 1);
+        assert_eq!(result.fixed_source, "#!/bin/sh\n  # --- a/sample.txt\n");
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -34,6 +34,7 @@ pub mod constant_case_subject;
 pub mod constant_comparison_test;
 pub mod continue_outside_loop_in_function;
 pub mod dangling_else;
+pub mod diff_marker_line;
 pub mod dollar_question_after_command;
 pub mod double_paren_grouping;
 pub mod duplicate_redirect;
@@ -202,6 +203,7 @@ mod tests {
     #[test_case(Rule::CPrototypeFragment, Path::new("C042.sh"))]
     #[test_case(Rule::BadRedirectionFdOrder, Path::new("C043.sh"))]
     #[test_case(Rule::BareGlobCommandPath, Path::new("C044.sh"))]
+    #[test_case(Rule::DiffMarkerLine, Path::new("C045.sh"))]
     #[test_case(Rule::PipeToKill, Path::new("C046.sh"))]
     #[test_case(Rule::InvalidExitStatus, Path::new("C047.sh"))]
     #[test_case(Rule::CasePatternVar, Path::new("C048.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C045_C045.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C045_C045.sh.snap
@@ -1,0 +1,32 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C045 this dash-prefixed command looks like leftover patch text
+ --> <source>:3:1
+  |
+3 | --- a/sample.txt
+  |
+
+C045 this dash-prefixed command looks like leftover patch text
+ --> <source>:4:3
+  |
+4 |   --- indented.txt
+  |
+
+C045 this dash-prefixed command looks like leftover patch text
+ --> <source>:5:1
+  |
+5 | --help
+  |
+
+C045 this dash-prefixed command looks like leftover patch text
+ --> <source>:6:1
+  |
+6 | \-n foo
+  |
+
+C045 this dash-prefixed command looks like leftover patch text
+ --> <source>:7:1
+  |
+7 | -$tool foo
+  |

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -126,6 +126,7 @@ mod tests {
         assert_eq!(map.resolve("SC2238"), Some(Rule::RedirectToCommandName));
         assert_eq!(map.resolve("SC2063"), Some(Rule::LeadingGlobInGrepPattern));
         assert_eq!(map.resolve("SC2211"), Some(Rule::BareGlobCommandPath));
+        assert_eq!(map.resolve("SC2215"), Some(Rule::DiffMarkerLine));
         assert_eq!(map.resolve("SC3034"), Some(Rule::BashFileSlurp));
         assert_eq!(map.resolve("SC2096"), Some(Rule::DuplicateShebangFlag));
         assert_eq!(map.resolve("SC2318"), Some(Rule::LocalCrossReference));

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -1213,7 +1213,7 @@
     "hasKnownShellcheckDivergences": false,
     "severity": "Warning",
     "fixStatus": "implemented",
-    "fixAvailability": "always",
+    "fixAvailability": "sometimes",
     "fixSafety": "unsafe",
     "fixDescription": "Prefix the patch-marker line with `# ` to turn it into a shell comment.",
     "examples": [

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -1208,12 +1208,12 @@
       "ksh"
     ],
     "shellcheckCode": "SC2215",
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
-    "fixStatus": "planned",
-    "fixAvailability": "none",
+    "severity": "Warning",
+    "fixStatus": "implemented",
+    "fixAvailability": "always",
     "fixSafety": "unsafe",
     "fixDescription": "Prefix the patch-marker line with `# ` to turn it into a shell comment.",
     "examples": [


### PR DESCRIPTION
## Summary
- implement C045 for dash-prefixed command names that look like leftover patch or option text
- add command-fact helpers plus a narrow escaped-dash line fact for parser recovery coverage
- wire the rule into registry, suppression mapping tests, fixture snapshots, and fix the packaging smoke-script fixture used by make check

## Validation
- cargo fmt --check
- cargo test -p shuck-linter diff_marker_line
- INSTA_UPDATE=always cargo test -p shuck-linter rule_diffmarkerline_path_new_c045_sh_expects
- cargo test -p shuck-linter resolves_known_codes_and_ignores_unknown_ones
- cargo test -p shuck-linter resolves_legacy_shuck_aliases
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C045
- make check