### PR TITLE
feat(linter): implement C052 assign special zero

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C052.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C052.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+0=demo
+f() { 0=demo; }
+0=demo env
++0=demo
+
+export 0=demo
+command 0=demo
+0+=demo
+00=demo
+"0=demo"

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -1059,6 +1059,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::PlusPrefixInAssignment) {
             rules::correctness::plus_prefix_in_assignment::plus_prefix_in_assignment(self);
         }
+        if self.is_rule_enabled(Rule::AssignSpecialZero) {
+            rules::correctness::assign_special_zero::assign_special_zero(self);
+        }
         if self.is_rule_enabled(Rule::IfsSetToLiteralBackslashN) {
             rules::correctness::ifs_set_to_literal_backslash_n::ifs_set_to_literal_backslash_n(
                 self,

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -616,6 +616,25 @@ pub(crate) fn build_assignment_like_command_name_spans<'a>(
     spans
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
+pub(crate) fn build_assign_special_zero_spans<'a>(
+    commands: &[CommandFact<'a>],
+    source: &str,
+) -> Vec<Span> {
+    commands
+        .iter()
+        .filter_map(|fact| match fact.command() {
+            Command::Simple(command) => assign_special_zero_span(&command.name, source),
+            Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Binary(_)
+            | Command::Compound(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => None,
+        })
+        .collect()
+}
+
 pub(crate) fn collect_assignment_like_command_name_spans_in_command(
     fact: &CommandFact<'_>,
     source: &str,
@@ -668,6 +687,22 @@ pub(crate) fn assignment_like_command_name_span(word: &Word, source: &str) -> Op
     } else {
         (!is_shell_variable_name(target)).then_some(word.span)
     }
+}
+
+fn assign_special_zero_span(word: &Word, source: &str) -> Option<Span> {
+    let text = word.span.slice(source);
+    if text.starts_with("0=") {
+        return Some(word.span);
+    }
+
+    if text.starts_with("+0=") {
+        return Some(Span::from_positions(
+            word.span.start.advanced_by("+"),
+            word.span.end,
+        ));
+    }
+
+    None
 }
 
 pub(crate) fn zsh_declaration_brace_assignment_target(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -983,6 +983,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 missing_space_before_bracket_close_facts: OnceLock::new(),
                 jammed_test_bracket_facts: OnceLock::new(),
                 assignment_like_command_name_spans,
+                assign_special_zero_spans: OnceLock::new(),
                 bare_command_name_assignment_spans,
             },
             words: WordFactStore {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -50,6 +50,7 @@ pub(crate) struct CommandFactStore<'a> {
     pub(in crate::facts) missing_space_before_bracket_close_facts: OnceLock<Vec<(Span, usize)>>,
     pub(in crate::facts) jammed_test_bracket_facts: OnceLock<Vec<(Span, usize)>>,
     pub(in crate::facts) assignment_like_command_name_spans: Vec<Span>,
+    pub(in crate::facts) assign_special_zero_spans: OnceLock<Vec<Span>>,
     pub(in crate::facts) bare_command_name_assignment_spans: Vec<Span>,
 }
 
@@ -707,6 +708,18 @@ impl<'facts, 'a> CommandFactQueries<'facts, 'a> {
 
     pub(crate) fn assignment_like_command_name_spans(self) -> &'facts [Span] {
         &self.facts.command.assignment_like_command_name_spans
+    }
+
+    pub(crate) fn assign_special_zero_spans(self) -> &'facts [Span] {
+        self.facts
+            .command
+            .assign_special_zero_spans
+            .get_or_init(|| {
+                build_assign_special_zero_spans(
+                    &self.facts.command.commands,
+                    self.facts.source_facts.source,
+                )
+            })
     }
 
     pub(crate) fn bare_command_name_assignment_spans(self) -> &'facts [Span] {

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -136,6 +136,7 @@ declare_rules! {
     ("C049", Category::Correctness, Severity::Warning, TautologyChain),
     ("C050", Category::Correctness, Severity::Warning, ArithmeticRedirectionTarget),
     ("C051", Category::Correctness, Severity::Error, DuplicateRedirect),
+    ("C052", Category::Correctness, Severity::Error, AssignSpecialZero),
     ("C054", Category::Correctness, Severity::Warning, BareSlashMarker),
     ("C055", Category::Correctness, Severity::Warning, PatternWithVariable),
     ("C056", Category::Correctness, Severity::Warning, StatusCaptureAfterBranchTest),
@@ -813,6 +814,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-052" => Some(Rule::LocalTopLevel),
         "SH-060" => Some(Rule::SudoRedirectionOrder),
         "SH-065" => Some(Rule::StrayClosingKeyword),
+        "SH-146" => Some(Rule::AssignSpecialZero),
         "SH-069" => Some(Rule::ConstantComparisonTest),
         "SH-070" => Some(Rule::LoopControlOutsideLoop),
         "SH-072" => Some(Rule::LiteralUnaryStringTest),
@@ -1067,6 +1069,7 @@ mod tests {
             code_to_rule("SH-128"),
             Some(Rule::BareCommandNameAssignment)
         );
+        assert_eq!(code_to_rule("SH-146"), Some(Rule::AssignSpecialZero));
         assert_eq!(code_to_rule("SH-064"), Some(Rule::GrepCountPipeline));
         assert_eq!(code_to_rule("SH-137"), Some(Rule::SingleTestSubshell));
         assert_eq!(code_to_rule("SH-164"), Some(Rule::SubshellTestGroup));

--- a/crates/shuck-linter/src/rules/correctness/assign_special_zero.rs
+++ b/crates/shuck-linter/src/rules/correctness/assign_special_zero.rs
@@ -1,0 +1,79 @@
+use crate::{Checker, Rule, ShellDialect, Violation};
+
+pub struct AssignSpecialZero;
+
+impl Violation for AssignSpecialZero {
+    fn rule() -> Rule {
+        Rule::AssignSpecialZero
+    }
+
+    fn message(&self) -> String {
+        "the positional zero parameter cannot be assigned".to_owned()
+    }
+}
+
+pub fn assign_special_zero(checker: &mut Checker) {
+    if checker.shell() != ShellDialect::Sh {
+        return;
+    }
+
+    checker.report_fact_slice_dedup(
+        |facts| facts.command_facts().assign_special_zero_spans(),
+        || AssignSpecialZero,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_sh_command_names_that_assign_positional_zero() {
+        let source = "\
+#!/bin/sh
+0=demo
+f() { 0=demo; }
+0=demo env
++0=demo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignSpecialZero));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["0=demo", "0=demo", "0=demo", "0=demo"]
+        );
+    }
+
+    #[test]
+    fn ignores_other_shells_and_unknown_shell() {
+        for source in ["#!/bin/bash\n0=demo\n", "#!/bin/dash\n0=demo\n", "0=demo\n"] {
+            let diagnostics =
+                test_snippet(source, &LinterSettings::for_rule(Rule::AssignSpecialZero));
+            assert!(diagnostics.is_empty());
+        }
+    }
+
+    #[test]
+    fn ignores_declarations_wrappers_and_other_zero_like_words() {
+        let source = "\
+#!/bin/sh
+export 0=demo
+readonly 0=demo
+command 0=demo
+env 0=demo true
+a[0]=demo
+00=demo
+1=demo
+0+=demo
+\"0=demo\"
+echo \"$0\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::AssignSpecialZero));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
+++ b/crates/shuck-linter/src/rules/correctness/assignment_to_numeric_variable.rs
@@ -20,20 +20,31 @@ pub fn assignment_to_numeric_variable(checker: &mut Checker) {
     }
 
     let source = checker.source();
+    let suppress_assign_special_zero_overlap =
+        checker.shell() == ShellDialect::Sh && checker.is_rule_enabled(Rule::AssignSpecialZero);
     let spans = checker
         .facts()
         .commands()
         .iter()
-        .flat_map(|fact| command_assignment_spans(fact, source))
+        .flat_map(|fact| {
+            command_assignment_spans(checker, fact, source, suppress_assign_special_zero_overlap)
+        })
         .collect::<Vec<_>>();
 
     checker.report_all_dedup(spans, || AssignmentToNumericVariable);
 }
 
-fn command_assignment_spans(fact: crate::facts::CommandFactRef<'_, '_>, source: &str) -> Vec<Span> {
+fn command_assignment_spans(
+    checker: &Checker<'_>,
+    fact: crate::facts::CommandFactRef<'_, '_>,
+    source: &str,
+    suppress_assign_special_zero_overlap: bool,
+) -> Vec<Span> {
     let mut spans = Vec::new();
 
-    if let Some(span) = command_numeric_assignment_span(fact, source) {
+    if let Some(span) =
+        command_numeric_assignment_span(checker, fact, source, suppress_assign_special_zero_overlap)
+    {
         spans.push(span);
     }
 
@@ -57,11 +68,19 @@ fn command_assignment_spans(fact: crate::facts::CommandFactRef<'_, '_>, source: 
 }
 
 fn command_numeric_assignment_span(
+    checker: &Checker<'_>,
     fact: crate::facts::CommandFactRef<'_, '_>,
     source: &str,
+    suppress_assign_special_zero_overlap: bool,
 ) -> Option<Span> {
     let text = fact.span().slice(source);
     let first_word = text.split_whitespace().next()?;
+    if suppress_assign_special_zero_overlap
+        && first_word.starts_with("0=")
+        && !checker.is_suppressed_at(Rule::AssignSpecialZero, fact.span())
+    {
+        return None;
+    }
     numeric_assignment_target_span(first_word, fact.span().start)
 }
 
@@ -79,8 +98,11 @@ fn numeric_assignment_target_span(text: &str, start: Position) -> Option<Span> {
 mod tests {
     use std::path::Path;
 
+    use shuck_parser::parser::Parser;
+
+    use crate::suppression::parse_directives;
     use crate::test::{test_snippet, test_snippet_at_path};
-    use crate::{LinterSettings, Rule, ShellDialect};
+    use crate::{AnalysisRequest, Indexer, LinterSettings, Rule, ShellCheckCodeMap, ShellDialect};
 
     #[test]
     fn anchors_on_numeric_assignment_targets() {
@@ -154,5 +176,59 @@ a2=1
         );
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn defers_plain_zero_assignment_to_assign_special_zero_when_enabled() {
+        let source = "\
+#!/bin/sh
+0=demo
+0+=demo
++0=demo
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rules([
+                Rule::AssignmentToNumericVariable,
+                Rule::AssignSpecialZero,
+            ]),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| (diagnostic.rule, diagnostic.span.slice(source)))
+                .collect::<Vec<_>>(),
+            vec![
+                (Rule::AssignSpecialZero, "0=demo"),
+                (Rule::AssignmentToNumericVariable, "0"),
+                (Rule::AssignSpecialZero, "0=demo"),
+            ]
+        );
+    }
+
+    #[test]
+    fn reports_numeric_assignment_when_assign_special_zero_is_suppressed() {
+        let source = "\
+#!/bin/sh
+# shellcheck disable=SC2280
+0=demo
+";
+        let parse_result = Parser::new(source).parse().unwrap();
+        let indexer = Indexer::new(source, &parse_result);
+        let directives = parse_directives(
+            source,
+            indexer.comment_index(),
+            &ShellCheckCodeMap::default(),
+        );
+        let settings =
+            LinterSettings::for_rules([Rule::AssignmentToNumericVariable, Rule::AssignSpecialZero]);
+        let diagnostics = AnalysisRequest::from_parse_result(&parse_result, source, &settings)
+            .with_directives(&directives)
+            .lint();
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::AssignmentToNumericVariable);
+        assert_eq!(diagnostics[0].span.slice(source), "0");
     }
 }

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -4,6 +4,7 @@ pub mod append_with_escaped_quotes;
 pub mod arithmetic_redirection_target;
 pub mod array_slice_in_comparison;
 pub mod array_to_string_conversion;
+pub mod assign_special_zero;
 pub mod assignment_looks_like_comparison;
 pub mod assignment_spacing;
 pub mod assignment_to_numeric_variable;
@@ -210,6 +211,7 @@ mod tests {
     #[test_case(Rule::TautologyChain, Path::new("C049.sh"))]
     #[test_case(Rule::ArithmeticRedirectionTarget, Path::new("C050.sh"))]
     #[test_case(Rule::DuplicateRedirect, Path::new("C051.sh"))]
+    #[test_case(Rule::AssignSpecialZero, Path::new("C052.sh"))]
     #[test_case(Rule::BareSlashMarker, Path::new("C054.sh"))]
     #[test_case(Rule::PatternWithVariable, Path::new("C055.sh"))]
     #[test_case(Rule::StatusCaptureAfterBranchTest, Path::new("C056.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -1,4 +1,6 @@
-use crate::{Checker, Rule, Violation};
+use shuck_ast::Span;
+
+use crate::{Checker, Rule, ShellDialect, Violation};
 
 pub struct PlusPrefixInAssignment;
 
@@ -13,10 +15,37 @@ impl Violation for PlusPrefixInAssignment {
 }
 
 pub fn plus_prefix_in_assignment(checker: &mut Checker) {
-    checker.report_fact_slice_dedup(
-        |facts| facts.command_facts().assignment_like_command_name_spans(),
-        || PlusPrefixInAssignment,
-    );
+    let source = checker.source();
+    let suppress_assign_special_zero_overlap =
+        checker.shell() == ShellDialect::Sh && checker.is_rule_enabled(Rule::AssignSpecialZero);
+    let spans = checker
+        .facts()
+        .command_facts()
+        .assignment_like_command_name_spans()
+        .iter()
+        .copied()
+        .filter(|span| {
+            !is_assign_special_zero_overlap(
+                checker,
+                source,
+                *span,
+                suppress_assign_special_zero_overlap,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    checker.report_all_dedup(spans, || PlusPrefixInAssignment);
+}
+
+fn is_assign_special_zero_overlap(
+    checker: &Checker<'_>,
+    source: &str,
+    span: Span,
+    suppress_assign_special_zero_overlap: bool,
+) -> bool {
+    suppress_assign_special_zero_overlap
+        && span.slice(source).starts_with("0=")
+        && !checker.is_suppressed_at(Rule::AssignSpecialZero, span)
 }
 
 #[cfg(test)]
@@ -83,6 +112,19 @@ network.wan.proto='dhcp'
                 "@VAR@=$(. /etc/profile >/dev/null 2>&1; echo \"${@VAR@}\")"
             ]
         );
+    }
+
+    #[test]
+    fn defers_plain_zero_assignment_to_assign_special_zero_when_enabled() {
+        let source = "#!/bin/sh\n0=demo\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rules([Rule::PlusPrefixInAssignment, Rule::AssignSpecialZero]),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::AssignSpecialZero);
+        assert_eq!(diagnostics[0].span.slice(source), "0=demo");
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
+++ b/crates/shuck-linter/src/rules/correctness/plus_prefix_in_assignment.rs
@@ -15,9 +15,13 @@ impl Violation for PlusPrefixInAssignment {
 }
 
 pub fn plus_prefix_in_assignment(checker: &mut Checker) {
-    let source = checker.source();
     let suppress_assign_special_zero_overlap =
         checker.shell() == ShellDialect::Sh && checker.is_rule_enabled(Rule::AssignSpecialZero);
+    let assign_special_zero_spans = if suppress_assign_special_zero_overlap {
+        checker.facts().command_facts().assign_special_zero_spans()
+    } else {
+        &[]
+    };
     let spans = checker
         .facts()
         .command_facts()
@@ -27,7 +31,7 @@ pub fn plus_prefix_in_assignment(checker: &mut Checker) {
         .filter(|span| {
             !is_assign_special_zero_overlap(
                 checker,
-                source,
+                assign_special_zero_spans,
                 *span,
                 suppress_assign_special_zero_overlap,
             )
@@ -39,12 +43,12 @@ pub fn plus_prefix_in_assignment(checker: &mut Checker) {
 
 fn is_assign_special_zero_overlap(
     checker: &Checker<'_>,
-    source: &str,
+    assign_special_zero_spans: &[Span],
     span: Span,
     suppress_assign_special_zero_overlap: bool,
 ) -> bool {
     suppress_assign_special_zero_overlap
-        && span.slice(source).starts_with("0=")
+        && assign_special_zero_spans.contains(&span)
         && !checker.is_suppressed_at(Rule::AssignSpecialZero, span)
 }
 
@@ -124,6 +128,19 @@ network.wan.proto='dhcp'
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].rule, Rule::AssignSpecialZero);
+        assert_eq!(diagnostics[0].span.slice(source), "0=demo");
+    }
+
+    #[test]
+    fn keeps_declaration_zero_operands_with_assign_special_zero_enabled() {
+        let source = "#!/bin/sh\nexport 0=demo\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rules([Rule::PlusPrefixInAssignment, Rule::AssignSpecialZero]),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].rule, Rule::PlusPrefixInAssignment);
         assert_eq!(diagnostics[0].span.slice(source), "0=demo");
     }
 

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C052_C052.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C052_C052.sh.snap
@@ -1,0 +1,26 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C052 the positional zero parameter cannot be assigned
+ --> <source>:3:1
+  |
+3 | 0=demo
+  |
+
+C052 the positional zero parameter cannot be assigned
+ --> <source>:4:7
+  |
+4 | f() { 0=demo; }
+  |
+
+C052 the positional zero parameter cannot be assigned
+ --> <source>:5:1
+  |
+5 | 0=demo env
+  |
+
+C052 the positional zero parameter cannot be assigned
+ --> <source>:6:2
+  |
+6 | +0=demo
+  |

--- a/crates/shuck-linter/src/suppression/shellcheck_map.rs
+++ b/crates/shuck-linter/src/suppression/shellcheck_map.rs
@@ -137,6 +137,7 @@ mod tests {
             map.resolve("SC1087"),
             Some(Rule::BraceVariableBeforeBracket)
         );
+        assert_eq!(map.resolve("SC2280"), Some(Rule::AssignSpecialZero));
         assert_eq!(map.resolve("SC2317"), Some(Rule::UnreachableAfterExit));
         assert_eq!(map.resolve("SC7777"), None);
     }

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -1407,10 +1407,10 @@
       "sh"
     ],
     "shellcheckCode": "SC2280",
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Error",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- Add C052/SH-146 as a correctness error for `sh` scripts when a simple command name assigns `0=...`.
- Store the C052 spans in `LinterFacts` and consume them from a fact-backed rule; wire registry, legacy alias, and SC2280 suppression mapping.
- Add focused unit coverage plus the C052 fixture/snapshot, and keep the packaging smoke script compatible with `make check`.

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter assign_special_zero`
- `cargo test -p shuck-linter resolves_known_codes_and_ignores_unknown_ones`
- `cargo test -p shuck-linter resolves_legacy_shuck_aliases`
- `INSTA_UPDATE=always cargo test -p shuck-linter rule_assignspecialzero_path_new_c052_sh_expects`
- `cargo test -p shuck-linter rule_assignspecialzero_path_new_c052_sh_expects`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C052`
- `make check`