### PR TITLE
feat(linter): implement C053 spacey assign

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/correctness/C053.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C053.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+name = demo
+empty =
+joined =demo
+read = value
+test = foo
+time = 1
+FOO=1 name = value
+time FOO=1 timed = value
+
+name=value
+name= value
+export name = demo
+echo = demo
+name == demo
+name "=" demo

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -1062,6 +1062,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::AssignSpecialZero) {
             rules::correctness::assign_special_zero::assign_special_zero(self);
         }
+        if self.is_rule_enabled(Rule::SpaceyAssign) {
+            rules::correctness::spacey_assign::spacey_assign(self);
+        }
         if self.is_rule_enabled(Rule::IfsSetToLiteralBackslashN) {
             rules::correctness::ifs_set_to_literal_backslash_n::ifs_set_to_literal_backslash_n(
                 self,

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -635,6 +635,28 @@ pub(crate) fn build_assign_special_zero_spans<'a>(
         .collect()
 }
 
+#[cfg_attr(shuck_profiling, inline(never))]
+pub(crate) fn build_spacey_assignment_spans<'a>(
+    commands: &[CommandFact<'a>],
+    source: &str,
+) -> Vec<Span> {
+    commands
+        .iter()
+        .filter_map(|fact| match fact.command() {
+            Command::Simple(command) => spacey_assignment_span(command, source),
+            Command::Compound(CompoundCommand::Time(command)) => {
+                spacey_time_assignment_span(command, source)
+            }
+            Command::Builtin(_)
+            | Command::Decl(_)
+            | Command::Binary(_)
+            | Command::Compound(_)
+            | Command::Function(_)
+            | Command::AnonymousFunction(_) => None,
+        })
+        .collect()
+}
+
 pub(crate) fn collect_assignment_like_command_name_spans_in_command(
     fact: &CommandFact<'_>,
     source: &str,
@@ -703,6 +725,63 @@ fn assign_special_zero_span(word: &Word, source: &str) -> Option<Span> {
     }
 
     None
+}
+
+fn spacey_assignment_span(command: &SimpleCommand, source: &str) -> Option<Span> {
+    let target = command.name.span.slice(source);
+    if !is_shell_variable_name(target) {
+        return None;
+    }
+
+    let first_arg = command.args.first()?;
+    let first_arg_text = first_arg.span.slice(source);
+    if first_arg_text == "=" {
+        let end = command
+            .args
+            .get(1)
+            .map(|word| word.span.end)
+            .unwrap_or(first_arg.span.end);
+        return Some(Span::from_positions(command.name.span.start, end));
+    }
+
+    first_arg_text
+        .strip_prefix('=')
+        .filter(|value| !value.is_empty() && !value.starts_with('='))
+        .map(|_| Span::from_positions(command.name.span.start, first_arg.span.end))
+}
+
+fn spacey_time_assignment_span(command: &TimeCommand, source: &str) -> Option<Span> {
+    if command.posix_format {
+        return None;
+    }
+
+    let timed = command.command.as_deref()?;
+    let Command::Simple(inner) = &timed.command else {
+        return None;
+    };
+    if let Some(span) = spacey_assignment_span(inner, source) {
+        return Some(span);
+    }
+
+    let prefix = source.get(command.span.start.offset..inner.name.span.start.offset)?;
+    if prefix.trim() != "time" {
+        return None;
+    }
+
+    let operator_text = inner.name.span.slice(source);
+    if operator_text == "=" {
+        let end = inner
+            .args
+            .first()
+            .map(|word| word.span.end)
+            .unwrap_or(inner.name.span.end);
+        return Some(Span::from_positions(command.span.start, end));
+    }
+
+    operator_text
+        .strip_prefix('=')
+        .filter(|value| !value.is_empty() && !value.starts_with('='))
+        .map(|_| Span::from_positions(command.span.start, inner.name.span.end))
 }
 
 pub(crate) fn zsh_declaration_brace_assignment_target(

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -984,6 +984,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 jammed_test_bracket_facts: OnceLock::new(),
                 assignment_like_command_name_spans,
                 assign_special_zero_spans: OnceLock::new(),
+                spacey_assignment_spans: OnceLock::new(),
                 bare_command_name_assignment_spans,
             },
             words: WordFactStore {

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -80,8 +80,8 @@ use shuck_ast::{
     IdRange, ListArena, Name, ParameterExpansion, ParameterExpansionSyntax, ParameterOp, Pattern,
     PatternPart, Position, PrefixMatchKind, Redirect, RedirectKind, SelectCommand, SimpleCommand,
     SourceText, Span, StaticCommandWrapperTarget, Stmt, StmtSeq, StmtTerminator, Subscript,
-    SubscriptSelector, TextRange, TextSize, VarRef, WhileCommand, Word, WordPart, WordPartNode,
-    ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment, ZshParameterExpansion,
+    SubscriptSelector, TextRange, TextSize, TimeCommand, VarRef, WhileCommand, Word, WordPart,
+    WordPartNode, ZshExpansionOperation, ZshExpansionTarget, ZshGlobSegment, ZshParameterExpansion,
     ZshQualifiedGlob, is_shell_variable_name, static_command_name_text,
     static_command_wrapper_target_index, static_word_text, word_is_standalone_status_capture,
 };

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -51,6 +51,7 @@ pub(crate) struct CommandFactStore<'a> {
     pub(in crate::facts) jammed_test_bracket_facts: OnceLock<Vec<(Span, usize)>>,
     pub(in crate::facts) assignment_like_command_name_spans: Vec<Span>,
     pub(in crate::facts) assign_special_zero_spans: OnceLock<Vec<Span>>,
+    pub(in crate::facts) spacey_assignment_spans: OnceLock<Vec<Span>>,
     pub(in crate::facts) bare_command_name_assignment_spans: Vec<Span>,
 }
 
@@ -720,6 +721,15 @@ impl<'facts, 'a> CommandFactQueries<'facts, 'a> {
                     self.facts.source_facts.source,
                 )
             })
+    }
+
+    pub(crate) fn spacey_assignment_spans(self) -> &'facts [Span] {
+        self.facts.command.spacey_assignment_spans.get_or_init(|| {
+            build_spacey_assignment_spans(
+                &self.facts.command.commands,
+                self.facts.source_facts.source,
+            )
+        })
     }
 
     pub(crate) fn bare_command_name_assignment_spans(self) -> &'facts [Span] {

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -137,6 +137,7 @@ declare_rules! {
     ("C050", Category::Correctness, Severity::Warning, ArithmeticRedirectionTarget),
     ("C051", Category::Correctness, Severity::Error, DuplicateRedirect),
     ("C052", Category::Correctness, Severity::Error, AssignSpecialZero),
+    ("C053", Category::Correctness, Severity::Warning, SpaceyAssign),
     ("C054", Category::Correctness, Severity::Warning, BareSlashMarker),
     ("C055", Category::Correctness, Severity::Warning, PatternWithVariable),
     ("C056", Category::Correctness, Severity::Warning, StatusCaptureAfterBranchTest),
@@ -815,6 +816,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-060" => Some(Rule::SudoRedirectionOrder),
         "SH-065" => Some(Rule::StrayClosingKeyword),
         "SH-146" => Some(Rule::AssignSpecialZero),
+        "SH-147" => Some(Rule::SpaceyAssign),
         "SH-069" => Some(Rule::ConstantComparisonTest),
         "SH-070" => Some(Rule::LoopControlOutsideLoop),
         "SH-072" => Some(Rule::LiteralUnaryStringTest),
@@ -1070,6 +1072,7 @@ mod tests {
             Some(Rule::BareCommandNameAssignment)
         );
         assert_eq!(code_to_rule("SH-146"), Some(Rule::AssignSpecialZero));
+        assert_eq!(code_to_rule("SH-147"), Some(Rule::SpaceyAssign));
         assert_eq!(code_to_rule("SH-064"), Some(Rule::GrepCountPipeline));
         assert_eq!(code_to_rule("SH-137"), Some(Rule::SingleTestSubshell));
         assert_eq!(code_to_rule("SH-164"), Some(Rule::SubshellTestGroup));

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -115,6 +115,7 @@ mod shell_quoting_reuse;
 pub mod single_quoted_literal;
 pub mod space_after_hash_bang;
 pub mod spaced_assignment;
+pub mod spacey_assign;
 pub mod status_capture_after_branch_test;
 pub mod stderr_before_stdout_redirect;
 pub mod stray_closing_keyword;
@@ -212,6 +213,7 @@ mod tests {
     #[test_case(Rule::ArithmeticRedirectionTarget, Path::new("C050.sh"))]
     #[test_case(Rule::DuplicateRedirect, Path::new("C051.sh"))]
     #[test_case(Rule::AssignSpecialZero, Path::new("C052.sh"))]
+    #[test_case(Rule::SpaceyAssign, Path::new("C053.sh"))]
     #[test_case(Rule::BareSlashMarker, Path::new("C054.sh"))]
     #[test_case(Rule::PatternWithVariable, Path::new("C055.sh"))]
     #[test_case(Rule::StatusCaptureAfterBranchTest, Path::new("C056.sh"))]

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C053_C053.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C053_C053.sh.snap
@@ -1,0 +1,57 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+assertion_line: 294
+---
+C053 assignment spacing makes this run as a command
+ --> <source>:3:1
+  |
+3 | name = demo
+  |
+
+C053 assignment spacing makes this run as a command
+ --> <source>:4:1
+  |
+4 | empty =
+  |
+
+C053 assignment spacing makes this run as a command
+ --> <source>:5:1
+  |
+5 | joined =demo
+  |
+
+C053 assignment spacing makes this run as a command
+ --> <source>:6:1
+  |
+6 | read = value
+  |
+
+C053 assignment spacing makes this run as a command
+ --> <source>:7:1
+  |
+7 | test = foo
+  |
+
+C053 assignment spacing makes this run as a command
+ --> <source>:8:1
+  |
+8 | time = 1
+  |
+
+C053 assignment spacing makes this run as a command
+ --> <source>:9:7
+  |
+9 | FOO=1 name = value
+  |
+
+C053 assignment spacing makes this run as a command
+  --> <source>:10:12
+   |
+10 | time FOO=1 timed = value
+   |
+
+C053 assignment spacing makes this run as a command
+  --> <source>:15:1
+   |
+15 | echo = demo
+   |

--- a/crates/shuck-linter/src/rules/correctness/spacey_assign.rs
+++ b/crates/shuck-linter/src/rules/correctness/spacey_assign.rs
@@ -1,0 +1,94 @@
+use crate::{Checker, Rule, ShellDialect, Violation};
+
+pub struct SpaceyAssign;
+
+impl Violation for SpaceyAssign {
+    fn rule() -> Rule {
+        Rule::SpaceyAssign
+    }
+
+    fn message(&self) -> String {
+        "assignment spacing makes this run as a command".to_owned()
+    }
+}
+
+pub fn spacey_assign(checker: &mut Checker) {
+    if checker.shell() == ShellDialect::Zsh {
+        return;
+    }
+
+    checker.report_fact_slice_dedup(
+        |facts| facts.command_facts().spacey_assignment_spans(),
+        || SpaceyAssign,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_variable_like_commands_followed_by_equals_words() {
+        let source = "\
+#!/bin/sh
+name = demo
+empty =
+joined =demo
+read = value
+test = foo
+time = 1
+FOO=1 name = value
+time timed = value
+time FOO=1 timed = value
+f() { inside = \"$value\"; }
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceyAssign));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "name = demo",
+                "empty =",
+                "joined =demo",
+                "read = value",
+                "test = foo",
+                "time = 1",
+                "name = value",
+                "timed = value",
+                "timed = value",
+                "inside = \"$value\""
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_assignments_declarations_comparisons_and_quoted_equals() {
+        let source = "\
+#!/bin/sh
+name=value
+name= value
+export name = demo
+name == demo
+name \"=\" demo
+name \\= demo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceyAssign));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn skips_zsh() {
+        let source = "\
+#!/bin/zsh
+name = demo
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::SpaceyAssign));
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -1436,10 +1436,10 @@
       "ksh"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "planned",
     "fixAvailability": "none",
     "fixSafety": "unsafe",


### PR DESCRIPTION
## Summary
- Add C053/SH-147 as a correctness rule for simple commands that look like spaced assignments, such as `name = demo`.
- Store the reusable spans in `LinterFacts` and keep the rule itself as a fact-backed filter with zsh excluded.
- Add focused unit coverage plus the C053 fixture/snapshot, and keep the packaging smoke script compatible with `make check`.

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter spacey_assign`
- `cargo test -p shuck-linter resolves_legacy_shuck_aliases`
- `INSTA_UPDATE=always cargo test -p shuck-linter rule_spaceyassign_path_new_c053_sh_expects`
- `cargo test -p shuck-linter rule_spaceyassign_path_new_c053_sh_expects`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C053`
- `make check`