### PR TITLE
feat(linter): implement C158 implicit globals

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -62,6 +62,8 @@ struct EffectiveRuleOptions {
     s085_non_trivial_line_threshold: usize,
     s085_non_trivial_function_count: usize,
     s085_main_name: String,
+    c158_treat_readonly_as_documented: bool,
+    c158_treat_export_as_intentional: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -188,6 +190,8 @@ impl EffectiveRuleOptions {
             s085_non_trivial_line_threshold: rule_options.s085.non_trivial_line_threshold,
             s085_non_trivial_function_count: rule_options.s085.non_trivial_function_count,
             s085_main_name: rule_options.s085.main_name.clone(),
+            c158_treat_readonly_as_documented: rule_options.c158.treat_readonly_as_documented,
+            c158_treat_export_as_intentional: rule_options.c158.treat_export_as_intentional,
         }
     }
 }
@@ -206,6 +210,8 @@ impl CacheKey for EffectiveRuleOptions {
         self.s085_non_trivial_line_threshold.cache_key(state);
         self.s085_non_trivial_function_count.cache_key(state);
         self.s085_main_name.cache_key(state);
+        self.c158_treat_readonly_as_documented.cache_key(state);
+        self.c158_treat_export_as_intentional.cache_key(state);
     }
 }
 
@@ -1009,6 +1015,22 @@ fn linter_rule_options_for_lint_config(lint: &LintConfig) -> shuck_linter::Linte
         .and_then(|s085| s085.main_name.as_ref())
     {
         rule_options.s085.main_name.clone_from(value);
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.c158.as_ref())
+        .and_then(|c158| c158.treat_readonly_as_documented)
+    {
+        rule_options.c158.treat_readonly_as_documented = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.c158.as_ref())
+        .and_then(|c158| c158.treat_export_as_intentional)
+    {
+        rule_options.c158.treat_export_as_intentional = value;
     }
 
     rule_options

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -60,7 +60,7 @@ const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "theme-loads",
     "entrypoints",
 ];
-const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &["c001", "c063", "s084", "s085"];
+const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &["c001", "c063", "s084", "s085", "c158"];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
 const CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS: &[&str] = &["report-unreached-nested-definitions"];
@@ -74,6 +74,10 @@ const CONFIG_OVERRIDE_S085_RULE_OPTION_KEYS: &[&str] = &[
     "non-trivial-line-threshold",
     "non-trivial-function-count",
     "main-name",
+];
+const CONFIG_OVERRIDE_C158_RULE_OPTION_KEYS: &[&str] = &[
+    "treat-readonly-as-documented",
+    "treat-export-as-intentional",
 ];
 const CONFIG_OVERRIDE_RUN_KEYS: &[&str] = &["shell", "shell-version", "shells"];
 const CONFIG_OVERRIDE_RUN_SHELL_NAMES: &[&str] =
@@ -331,6 +335,8 @@ pub struct LintRuleOptionsConfig {
     pub s084: Option<S084RuleOptionsConfig>,
     /// Options for rule S085.
     pub s085: Option<S085RuleOptionsConfig>,
+    /// Options for rule C158.
+    pub c158: Option<C158RuleOptionsConfig>,
 }
 
 impl LintRuleOptionsConfig {
@@ -346,6 +352,9 @@ impl LintRuleOptionsConfig {
         }
         if let Some(s085) = overrides.s085 {
             self.s085.get_or_insert_default().apply_overrides(s085);
+        }
+        if let Some(c158) = overrides.c158 {
+            self.c158.get_or_insert_default().apply_overrides(c158);
         }
     }
 }
@@ -440,6 +449,28 @@ impl S085RuleOptionsConfig {
         }
     }
 }
+
+/// Options for rule C158.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct C158RuleOptionsConfig {
+    /// Whether readonly declarations document intentional globals.
+    pub treat_readonly_as_documented: Option<bool>,
+    /// Whether exported assignments should be treated as intentional globals.
+    pub treat_export_as_intentional: Option<bool>,
+}
+
+impl C158RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.treat_readonly_as_documented.is_some() {
+            self.treat_readonly_as_documented = overrides.treat_readonly_as_documented;
+        }
+        if overrides.treat_export_as_intentional.is_some() {
+            self.treat_export_as_intentional = overrides.treat_export_as_intentional;
+        }
+    }
+}
+
 /// Partial formatter settings supplied by CLI flags or config files.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct FormatSettingsPatch {
@@ -782,6 +813,27 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                                 default: r#""main""#,
                                 value_type: "string",
                                 example: r#"main-name = "run""#,
+                            },
+                        ],
+                        sections: &[],
+                    },
+                    ConfigSectionMetadata {
+                        key: "c158",
+                        docs: "Behavior overrides for `C158` implicit global assignment analysis.",
+                        fields: &[
+                            ConfigFieldMetadata {
+                                key: "treat-readonly-as-documented",
+                                docs: "Treat top-level readonly declarations as documented intentional globals.",
+                                default: "true",
+                                value_type: "bool",
+                                example: "treat-readonly-as-documented = false",
+                            },
+                            ConfigFieldMetadata {
+                                key: "treat-export-as-intentional",
+                                docs: "Treat top-level exported bindings as intentional globals.",
+                                default: "true",
+                                value_type: "bool",
+                                example: "treat-export-as-intentional = false",
                             },
                         ],
                         sections: &[],
@@ -1466,6 +1518,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(s085_value) = rule_options.get("s085") {
         validate_s085_rule_options_override(s085_value)?;
     }
+    if let Some(c158_value) = rule_options.get("c158") {
+        validate_c158_rule_options_override(c158_value)?;
+    }
 
     Ok(())
 }
@@ -1533,6 +1588,23 @@ fn validate_s085_rule_options_override(value: &toml::Value) -> std::result::Resu
 
     Ok(())
 }
+
+fn validate_c158_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let c158 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.c158]` must be a TOML table".to_owned())?;
+    for key in c158.keys() {
+        if !CONFIG_OVERRIDE_C158_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.c158]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_C158_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 fn invalid_config_argument(
     cmd: &clap::Command,
     arg: Option<&clap::Arg>,
@@ -1815,6 +1887,23 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_c158_rule_option_keys() {
+        let config = parse_config_override(
+            "lint.rule-options.c158.treat-readonly-as-documented = false\n\
+             lint.rule-options.c158.treat-export-as-intentional = false",
+        )
+        .unwrap();
+        let c158 = config
+            .lint
+            .rule_options
+            .as_ref()
+            .and_then(|options| options.c158.as_ref())
+            .expect("expected c158 rule options");
+        assert_eq!(c158.treat_readonly_as_documented, Some(false));
+        assert_eq!(c158.treat_export_as_intentional, Some(false));
+    }
+
+    #[test]
     fn inline_config_overrides_validate_supported_zsh_plugin_keys() {
         let config = parse_config_override(
             "lint.zsh.plugins.resolution = false\n\
@@ -2083,6 +2172,40 @@ mod tests {
                 .and_then(|options| options.s085.as_ref())
                 .and_then(|s085| s085.main_name.as_deref()),
             Some("run")
+        );
+    }
+
+    #[test]
+    fn c158_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.c158.treat-export-as-intentional = true",
+                    )
+                    .unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.c158.treat-export-as-intentional = false",
+                    )
+                    .unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.c158.as_ref())
+                .and_then(|c158| c158.treat_export_as_intentional),
+            Some(false)
         );
     }
 

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C158.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C158.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+work() {
+  item=1
+  local scoped=1
+  scoped=2
+  declare named
+  named=value
+  for loop in a b; do
+    :
+  done
+}

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -1085,6 +1085,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::BadVarName) {
             rules::correctness::bad_var_name::bad_var_name(self);
         }
+        if self.is_rule_enabled(Rule::ImplicitGlobalInFunction) {
+            rules::correctness::implicit_global_in_function::implicit_global_in_function(self);
+        }
         if self.is_rule_enabled(Rule::CommentedContinuationLine) {
             rules::correctness::commented_continuation_line::commented_continuation_line(self);
         }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -106,8 +106,9 @@ pub use rule_set::RuleSet;
 pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 /// Linter configuration and per-file ignore types.
 pub use settings::{
-    AmbientShellOptions, C001RuleOptions, C063RuleOptions, CompiledPerFileIgnoreList,
-    LinterRuleOptions, LinterSettings, PerFileIgnore, S084RuleOptions, S085RuleOptions,
+    AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions,
+    CompiledPerFileIgnoreList, LinterRuleOptions, LinterSettings, PerFileIgnore, S084RuleOptions,
+    S085RuleOptions,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -493,6 +493,12 @@ declare_rules! {
         PossibleVariableMisspelling
     ),
     ("C157", Category::Correctness, Severity::Error, IfBracketGlued),
+    (
+        "C158",
+        Category::Correctness,
+        Severity::Warning,
+        ImplicitGlobalInFunction
+    ),
     ("P001", Category::Performance, Severity::Warning, ExprArithmetic),
     ("P002", Category::Performance, Severity::Warning, GrepCountPipeline),
     ("P003", Category::Performance, Severity::Warning, SingleTestSubshell),

--- a/crates/shuck-linter/src/rules/correctness/implicit_global_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/implicit_global_in_function.rs
@@ -212,6 +212,7 @@ fn function_local_declarations(
     semantic: &shuck_semantic::SemanticModel,
 ) -> FxHashMap<(ScopeId, Name), Vec<usize>> {
     let mut declarations = FxHashMap::<(ScopeId, Name), Vec<usize>>::default();
+
     for binding in semantic.bindings() {
         if !binding_declares_function_local(binding) {
             continue;
@@ -226,7 +227,50 @@ fn function_local_declarations(
         }
     }
 
+    for declaration in semantic.declarations() {
+        if !declaration_declares_function_global(declaration) {
+            continue;
+        }
+
+        let declaration_scope = semantic.scope_at(declaration.span.start.offset);
+        let Some(function_scope) = semantic.enclosing_function_scope(declaration_scope) else {
+            continue;
+        };
+        if declaration_scope != function_scope {
+            continue;
+        }
+
+        for (name, offset) in declaration_operand_names(declaration) {
+            declarations
+                .entry((function_scope, name.clone()))
+                .or_default()
+                .push(offset);
+        }
+    }
+
     declarations
+}
+
+fn declaration_declares_function_global(declaration: &shuck_semantic::Declaration) -> bool {
+    matches!(
+        declaration.builtin,
+        DeclarationBuiltin::Declare | DeclarationBuiltin::Typeset
+    ) && declaration_has_flag(declaration, 'g')
+}
+
+fn declaration_operand_names(
+    declaration: &shuck_semantic::Declaration,
+) -> impl Iterator<Item = (&Name, usize)> {
+    declaration
+        .operands
+        .iter()
+        .filter_map(|operand| match operand {
+            DeclarationOperand::Name { name, span } => Some((name, span.start.offset)),
+            DeclarationOperand::Assignment {
+                name, name_span, ..
+            } => Some((name, name_span.start.offset)),
+            DeclarationOperand::Flag { .. } | DeclarationOperand::DynamicWord { .. } => None,
+        })
 }
 
 fn binding_declares_function_local(binding: &Binding) -> bool {
@@ -304,6 +348,25 @@ work() {
   path=/tmp
   readonly pinned=1
   pinned=2
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn accepts_assignments_after_explicit_function_global_declarations() {
+        let source = "\
+#!/bin/bash
+work() {
+  declare -g shared
+  shared=1
+  typeset -g other=0
+  other=1
 }
 ";
         let diagnostics = test_snippet(

--- a/crates/shuck-linter/src/rules/correctness/implicit_global_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/implicit_global_in_function.rs
@@ -1,0 +1,516 @@
+use compact_str::CompactString;
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::Name;
+use shuck_semantic::{
+    Binding, BindingAttributes, BindingKind, DeclarationBuiltin, DeclarationOperand, ReferenceKind,
+    ScopeId,
+};
+
+use crate::{Checker, Diagnostic, Rule, ShellDialect, Violation};
+
+pub struct ImplicitGlobalInFunction {
+    pub name: CompactString,
+}
+
+impl Violation for ImplicitGlobalInFunction {
+    fn rule() -> Rule {
+        Rule::ImplicitGlobalInFunction
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "assignment to `{}` inside a function is not declared local",
+            self.name
+        )
+    }
+}
+
+pub fn implicit_global_in_function(checker: &mut Checker) {
+    if checker.shell() != ShellDialect::Bash {
+        return;
+    }
+
+    let semantic = checker.semantic();
+    let analysis = checker.semantic_analysis();
+    let options = &checker.rule_options().c158;
+    let documented_globals = documented_global_names(
+        semantic,
+        options.treat_readonly_as_documented,
+        options.treat_export_as_intentional,
+    );
+    let local_declarations = function_local_declarations(semantic);
+    let diagnostics = semantic
+        .bindings()
+        .iter()
+        .filter(|binding| binding_can_mutate_function_global(binding))
+        .filter(|binding| !documented_globals.contains(&binding.name))
+        .filter(|binding| !analysis.scope_runs_in_transient_context(binding.scope))
+        .filter_map(|binding| {
+            let function_scope = semantic.enclosing_function_scope(binding.scope)?;
+            let has_local_declaration = local_declarations
+                .get(&(function_scope, binding.name.clone()))
+                .is_some_and(|offsets| {
+                    offsets
+                        .iter()
+                        .any(|offset| *offset <= binding.span.start.offset)
+                });
+            (!has_local_declaration).then(|| {
+                Diagnostic::new(
+                    ImplicitGlobalInFunction {
+                        name: binding.name.as_str().into(),
+                    },
+                    binding.span,
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for diagnostic in diagnostics {
+        checker.report_diagnostic_dedup(diagnostic);
+    }
+}
+
+fn documented_global_names(
+    semantic: &shuck_semantic::SemanticModel,
+    treat_readonly_as_documented: bool,
+    treat_export_as_intentional: bool,
+) -> FxHashSet<Name> {
+    let mut documented = semantic
+        .bindings()
+        .iter()
+        .filter(|binding| binding_is_top_level_declaration_site(semantic, binding))
+        .filter(|binding| {
+            (treat_readonly_as_documented && binding_documents_readonly(binding))
+                || (treat_export_as_intentional && binding_documents_export(binding))
+        })
+        .map(|binding| binding.name.clone())
+        .collect::<FxHashSet<_>>();
+
+    let documented_attribute_names = semantic
+        .bindings()
+        .iter()
+        .filter(|binding| binding_is_file_scoped(binding, semantic))
+        .filter(|binding| {
+            (treat_readonly_as_documented && binding_documents_readonly(binding))
+                || (treat_export_as_intentional && binding_documents_export(binding))
+        })
+        .map(|binding| binding.name.clone())
+        .collect::<FxHashSet<_>>();
+
+    documented.extend(
+        semantic
+            .references()
+            .iter()
+            .filter(|reference| reference.kind == ReferenceKind::DeclarationName)
+            .filter(|reference| reference_is_top_level(semantic, reference))
+            .filter(|reference| documented_attribute_names.contains(&reference.name))
+            .filter(|reference| {
+                declaration_reference_documents_global(
+                    semantic,
+                    reference,
+                    treat_readonly_as_documented,
+                    treat_export_as_intentional,
+                )
+            })
+            .map(|reference| reference.name.clone()),
+    );
+
+    documented
+}
+
+fn declaration_reference_documents_global(
+    semantic: &shuck_semantic::SemanticModel,
+    reference: &shuck_semantic::Reference,
+    treat_readonly_as_documented: bool,
+    treat_export_as_intentional: bool,
+) -> bool {
+    semantic.declarations().iter().any(|declaration| {
+        declaration_covers_reference(declaration, reference)
+            && ((treat_readonly_as_documented && declaration_documents_readonly(declaration))
+                || (treat_export_as_intentional && declaration_documents_export(declaration)))
+    })
+}
+
+fn declaration_covers_reference(
+    declaration: &shuck_semantic::Declaration,
+    reference: &shuck_semantic::Reference,
+) -> bool {
+    declaration.operands.iter().any(|operand| match operand {
+        DeclarationOperand::Name { name, span } => {
+            name == &reference.name && *span == reference.span
+        }
+        DeclarationOperand::Assignment {
+            name_span, name, ..
+        } => name == &reference.name && *name_span == reference.span,
+        DeclarationOperand::Flag { .. } | DeclarationOperand::DynamicWord { .. } => false,
+    })
+}
+
+fn declaration_documents_readonly(declaration: &shuck_semantic::Declaration) -> bool {
+    matches!(declaration.builtin, DeclarationBuiltin::Readonly)
+        || declaration_has_flag(declaration, 'r')
+}
+
+fn declaration_documents_export(declaration: &shuck_semantic::Declaration) -> bool {
+    matches!(declaration.builtin, DeclarationBuiltin::Export)
+        || declaration_has_flag(declaration, 'x')
+}
+
+fn declaration_has_flag(declaration: &shuck_semantic::Declaration, flag: char) -> bool {
+    declaration.operands.iter().any(|operand| {
+        matches!(operand, DeclarationOperand::Flag { flag: candidate, .. } if *candidate == flag)
+    })
+}
+
+fn binding_is_top_level_declaration_site(
+    semantic: &shuck_semantic::SemanticModel,
+    binding: &Binding,
+) -> bool {
+    binding_is_file_scoped(binding, semantic) && matches!(binding.kind, BindingKind::Declaration(_))
+}
+
+fn binding_is_file_scoped(binding: &Binding, semantic: &shuck_semantic::SemanticModel) -> bool {
+    matches!(
+        semantic.scope_kind(binding.scope),
+        shuck_semantic::ScopeKind::File
+    ) && matches!(
+        semantic.scope_kind(semantic.scope_at(binding.span.start.offset)),
+        shuck_semantic::ScopeKind::File
+    )
+}
+
+fn reference_is_top_level(
+    semantic: &shuck_semantic::SemanticModel,
+    reference: &shuck_semantic::Reference,
+) -> bool {
+    matches!(
+        semantic.scope_kind(reference.scope),
+        shuck_semantic::ScopeKind::File
+    ) && matches!(
+        semantic.scope_kind(semantic.scope_at(reference.span.start.offset)),
+        shuck_semantic::ScopeKind::File
+    )
+}
+
+fn binding_documents_readonly(binding: &Binding) -> bool {
+    binding.attributes.contains(BindingAttributes::READONLY)
+        || matches!(
+            binding.kind,
+            BindingKind::Declaration(DeclarationBuiltin::Readonly)
+        )
+}
+
+fn binding_documents_export(binding: &Binding) -> bool {
+    binding.attributes.contains(BindingAttributes::EXPORTED)
+        || matches!(
+            binding.kind,
+            BindingKind::Declaration(DeclarationBuiltin::Export)
+        )
+}
+
+fn function_local_declarations(
+    semantic: &shuck_semantic::SemanticModel,
+) -> FxHashMap<(ScopeId, Name), Vec<usize>> {
+    let mut declarations = FxHashMap::<(ScopeId, Name), Vec<usize>>::default();
+    for binding in semantic.bindings() {
+        if !binding_declares_function_local(binding) {
+            continue;
+        }
+        if let Some(function_scope) = semantic.enclosing_function_scope(binding.scope)
+            && binding.scope == function_scope
+        {
+            declarations
+                .entry((function_scope, binding.name.clone()))
+                .or_default()
+                .push(binding.span.start.offset);
+        }
+    }
+
+    declarations
+}
+
+fn binding_declares_function_local(binding: &Binding) -> bool {
+    binding.attributes.contains(BindingAttributes::LOCAL)
+        || matches!(
+            binding.kind,
+            BindingKind::Declaration(
+                DeclarationBuiltin::Declare
+                    | DeclarationBuiltin::Local
+                    | DeclarationBuiltin::Readonly
+                    | DeclarationBuiltin::Typeset
+            ) | BindingKind::Nameref
+        )
+}
+
+fn binding_can_mutate_function_global(binding: &Binding) -> bool {
+    matches!(
+        binding.kind,
+        BindingKind::Assignment
+            | BindingKind::ParameterDefaultAssignment
+            | BindingKind::AppendAssignment
+            | BindingKind::ArrayAssignment
+            | BindingKind::LoopVariable
+            | BindingKind::ReadTarget
+            | BindingKind::MapfileTarget
+            | BindingKind::PrintfTarget
+            | BindingKind::GetoptsTarget
+            | BindingKind::ZparseoptsTarget
+            | BindingKind::ArithmeticAssignment
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_function_assignments_without_prior_local_declarations() {
+        let source = "\
+#!/bin/bash
+work() {
+  item=1
+  item+=2
+  for loop in a b; do
+    :
+  done
+  read -r line
+  printf -v rendered '%s' \"$item\"
+  (( total += 1 ))
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["item", "item", "loop", "line", "rendered", "total"]
+        );
+    }
+
+    #[test]
+    fn accepts_assignments_after_function_scope_declarations() {
+        let source = "\
+#!/bin/bash
+work() {
+  local item=1
+  item=2
+  declare path
+  path=/tmp
+  readonly pinned=1
+  pinned=2
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn later_local_declarations_do_not_hide_earlier_global_assignments() {
+        let source = "\
+#!/bin/bash
+work() {
+  late=1
+  local late
+  late=2
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["late"]
+        );
+    }
+
+    #[test]
+    fn treats_documented_global_bindings_as_intentional_by_default() {
+        let source = "\
+#!/bin/bash
+readonly PINNED=1
+export SHARED=old
+work() {
+  PINNED=2
+  SHARED=new
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn treats_top_level_name_only_export_and_readonly_as_documenting_existing_globals() {
+        let source = "\
+#!/bin/bash
+PINNED=old
+readonly PINNED
+SHARED=old
+export SHARED
+work() {
+  PINNED=new
+  SHARED=new
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn function_export_does_not_document_existing_file_global() {
+        let source = "\
+#!/bin/bash
+SHARED=old
+mark_exported() {
+  export SHARED
+}
+work() {
+  SHARED=new
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "SHARED");
+        assert_eq!(diagnostics[0].span.start.line, 7);
+    }
+
+    #[test]
+    fn unrelated_top_level_declare_does_not_document_function_exported_global() {
+        let source = "\
+#!/bin/bash
+SHARED=old
+mark_exported() {
+  export SHARED
+}
+declare SHARED
+work() {
+  SHARED=new
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "SHARED");
+        assert_eq!(diagnostics[0].span.start.line, 8);
+    }
+
+    #[test]
+    fn function_global_declarations_do_not_document_file_globals() {
+        let source = "\
+#!/bin/bash
+export DOCUMENTED=1
+declare_global() {
+  declare -gx SHARED=1
+}
+work() {
+  DOCUMENTED=2
+  SHARED=2
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["SHARED"]
+        );
+    }
+
+    #[test]
+    fn options_can_report_readonly_and_exported_globals() {
+        let source = "\
+#!/bin/bash
+readonly PINNED=1
+export SHARED=old
+work() {
+  PINNED=2
+  SHARED=new
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction)
+                .with_c158_treat_readonly_as_documented(false)
+                .with_c158_treat_export_as_intentional(false),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["PINNED", "SHARED"]
+        );
+    }
+
+    #[test]
+    fn ignores_other_shells_transient_scopes_and_default_settings() {
+        let sh_source = "\
+#!/bin/sh
+work() {
+  item=1
+}
+";
+        let transient_source = "\
+#!/bin/bash
+work() {
+  (item=1)
+  echo \"$(nested=1)\"
+}
+";
+
+        assert!(
+            test_snippet(
+                sh_source,
+                &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+            )
+            .is_empty()
+        );
+        assert!(
+            test_snippet(
+                transient_source,
+                &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+            )
+            .is_empty()
+        );
+        assert!(
+            test_snippet(sh_source, &LinterSettings::default())
+                .iter()
+                .all(|diagnostic| diagnostic.rule != Rule::ImplicitGlobalInFunction)
+        );
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/implicit_global_in_function.rs
+++ b/crates/shuck-linter/src/rules/correctness/implicit_global_in_function.rs
@@ -80,8 +80,12 @@ fn documented_global_names(
         .iter()
         .filter(|binding| binding_is_top_level_declaration_site(semantic, binding))
         .filter(|binding| {
-            (treat_readonly_as_documented && binding_documents_readonly(binding))
-                || (treat_export_as_intentional && binding_documents_export(binding))
+            declaration_binding_documents_global(
+                semantic,
+                binding,
+                treat_readonly_as_documented,
+                treat_export_as_intentional,
+            )
         })
         .map(|binding| binding.name.clone())
         .collect::<FxHashSet<_>>();
@@ -118,6 +122,19 @@ fn documented_global_names(
     documented
 }
 
+fn declaration_binding_documents_global(
+    semantic: &shuck_semantic::SemanticModel,
+    binding: &Binding,
+    treat_readonly_as_documented: bool,
+    treat_export_as_intentional: bool,
+) -> bool {
+    semantic.declarations().iter().any(|declaration| {
+        declaration_covers_binding(declaration, binding)
+            && ((treat_readonly_as_documented && declaration_documents_readonly(declaration))
+                || (treat_export_as_intentional && declaration_documents_export(declaration)))
+    })
+}
+
 fn declaration_reference_documents_global(
     semantic: &shuck_semantic::SemanticModel,
     reference: &shuck_semantic::Reference,
@@ -128,6 +145,22 @@ fn declaration_reference_documents_global(
         declaration_covers_reference(declaration, reference)
             && ((treat_readonly_as_documented && declaration_documents_readonly(declaration))
                 || (treat_export_as_intentional && declaration_documents_export(declaration)))
+    })
+}
+
+fn declaration_covers_binding(
+    declaration: &shuck_semantic::Declaration,
+    binding: &Binding,
+) -> bool {
+    declaration.operands.iter().any(|operand| match operand {
+        DeclarationOperand::Name { name, span } => name == &binding.name && *span == binding.span,
+        DeclarationOperand::Assignment {
+            name,
+            target_span,
+            name_span,
+            ..
+        } => name == &binding.name && (*name_span == binding.span || *target_span == binding.span),
+        DeclarationOperand::Flag { .. } | DeclarationOperand::DynamicWord { .. } => false,
     })
 }
 
@@ -152,14 +185,42 @@ fn declaration_documents_readonly(declaration: &shuck_semantic::Declaration) -> 
 }
 
 fn declaration_documents_export(declaration: &shuck_semantic::Declaration) -> bool {
+    if declaration_has_flag(declaration, 'n') || declaration_disables_flag(declaration, 'x') {
+        return false;
+    }
+
     matches!(declaration.builtin, DeclarationBuiltin::Export)
         || declaration_has_flag(declaration, 'x')
 }
 
 fn declaration_has_flag(declaration: &shuck_semantic::Declaration, flag: char) -> bool {
-    declaration.operands.iter().any(|operand| {
-        matches!(operand, DeclarationOperand::Flag { flag: candidate, .. } if *candidate == flag)
-    })
+    declaration_flag_state(declaration, flag) == Some(true)
+}
+
+fn declaration_disables_flag(declaration: &shuck_semantic::Declaration, flag: char) -> bool {
+    declaration_flag_state(declaration, flag) == Some(false)
+}
+
+fn declaration_flag_state(declaration: &shuck_semantic::Declaration, flag: char) -> Option<bool> {
+    let mut state = None;
+    for operand in &declaration.operands {
+        let DeclarationOperand::Flag { flags, .. } = operand else {
+            continue;
+        };
+        let mut chars = flags.chars();
+        let Some(polarity) = chars.next() else {
+            continue;
+        };
+        let enabled = match polarity {
+            '-' => true,
+            '+' => false,
+            _ => continue,
+        };
+        if chars.any(|candidate| candidate == flag) {
+            state = Some(enabled);
+        }
+    }
+    state
 }
 
 fn binding_is_top_level_declaration_site(
@@ -439,6 +500,26 @@ work() {
         );
 
         assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn unexport_declarations_do_not_document_globals() {
+        let source = "\
+#!/bin/bash
+SHARED=old
+export -n SHARED
+work() {
+  SHARED=new
+}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ImplicitGlobalInFunction),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "SHARED");
+        assert_eq!(diagnostics[0].span.start.line, 5);
     }
 
     #[test]

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -68,6 +68,7 @@ pub mod if_bracket_glued;
 pub mod if_dollar_command;
 pub mod if_missing_then;
 pub mod ifs_set_to_literal_backslash_n;
+pub mod implicit_global_in_function;
 pub mod indented_heredoc_close;
 pub mod indented_shebang;
 pub mod invalid_exit_status;
@@ -305,6 +306,7 @@ mod tests {
     #[test_case(Rule::SubshellSideEffect, Path::new("C155.sh"))]
     #[test_case(Rule::PossibleVariableMisspelling, Path::new("C156.sh"))]
     #[test_case(Rule::IfBracketGlued, Path::new("C157.sh"))]
+    #[test_case(Rule::ImplicitGlobalInFunction, Path::new("C158.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {
         let snapshot = format!("{}_{}", rule.code(), path.display());
         let (diagnostics, source) = test_path(

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C158_C158.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C158_C158.sh.snap
@@ -1,0 +1,14 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C158 assignment to `item` inside a function is not declared local
+ --> <source>:4:3
+  |
+4 |   item=1
+  |
+
+C158 assignment to `loop` inside a function is not declared local
+ --> <source>:9:7
+  |
+9 |   for loop in a b; do
+  |

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -11,9 +11,7 @@ use shuck_semantic::{UnreachedFunctionAnalysisOptions, UnusedAssignmentAnalysisO
 use crate::ambient_contracts::ResolvedAmbientContracts;
 use crate::{Category, Rule, RuleSelector, RuleSet, Severity, ShellDialect};
 
-// ShellCheck's optional checks currently map only to compat-only behavior
-// toggles in this repository, not to standalone implemented non-style rules.
-const DEFAULT_DISABLED_NON_STYLE_RULES: &[Rule] = &[];
+const DEFAULT_DISABLED_NON_STYLE_RULES: &[Rule] = &[Rule::ImplicitGlobalInFunction];
 
 /// Per-rule behavior overrides applied during lint analysis.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -26,6 +24,8 @@ pub struct LinterRuleOptions {
     pub s084: S084RuleOptions,
     /// Behavior overrides for `S085`.
     pub s085: S085RuleOptions,
+    /// Behavior overrides for `C158`.
+    pub c158: C158RuleOptions,
 }
 
 /// Behavior overrides for `C001` unused-assignment analysis.
@@ -98,6 +98,24 @@ impl Default for S085RuleOptions {
             non_trivial_line_threshold: 30,
             non_trivial_function_count: 2,
             main_name: "main".to_owned(),
+        }
+    }
+}
+
+/// Behavior overrides for `C158` implicit global assignment analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct C158RuleOptions {
+    /// Whether top-level readonly declarations document intentional globals.
+    pub treat_readonly_as_documented: bool,
+    /// Whether top-level exported bindings document intentional globals.
+    pub treat_export_as_intentional: bool,
+}
+
+impl Default for C158RuleOptions {
+    fn default() -> Self {
+        Self {
+            treat_readonly_as_documented: true,
+            treat_export_as_intentional: true,
         }
     }
 }
@@ -317,6 +335,17 @@ impl LinterSettings {
         self.rule_options.s085.main_name = value.into();
         self
     }
+
+    pub fn with_c158_treat_readonly_as_documented(mut self, value: bool) -> Self {
+        self.rule_options.c158.treat_readonly_as_documented = value;
+        self
+    }
+
+    pub fn with_c158_treat_export_as_intentional(mut self, value: bool) -> Self {
+        self.rule_options.c158.treat_export_as_intentional = value;
+        self
+    }
+
     pub fn per_file_ignored_rules(&self, path: Option<&Path>) -> RuleSet {
         path.map_or(RuleSet::EMPTY, |path| {
             self.per_file_ignores.ignored_rules(path)
@@ -441,6 +470,7 @@ mod tests {
         assert!(defaults.contains(Rule::UndefinedVariable));
         assert!(defaults.contains(Rule::ConstantCaseSubject));
         assert!(defaults.contains(Rule::RmGlobOnVariablePath));
+        assert!(!defaults.contains(Rule::ImplicitGlobalInFunction));
         assert!(!defaults.contains(Rule::AmpersandSemicolon));
     }
 

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -4231,10 +4231,10 @@
       "bash"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- Add C158 as a default-disabled Bash correctness rule for function-scope assignments that lack a prior local/declare/readonly declaration in that function.
- Add C158 rule options for treating top-level readonly/exported bindings as intentional globals, including config parsing and cache-key wiring.
- Add focused unit coverage plus the C158 fixture/snapshot, and keep the packaging smoke script compatible with `make check`.

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter implicit_global_in_function`
- `cargo test -p shuck-linter default_rules_include_non_style_rules`
- `cargo test -p shuck-linter default_rules_exclude_verified_default_disabled_non_style_rules`
- `cargo test -p shuck-config c158_rule_option`
- `INSTA_UPDATE=always cargo test -p shuck-linter rule_implicitglobalinfunction_path_new_c158_sh_expects`
- `cargo test -p shuck-linter rule_implicitglobalinfunction_path_new_c158_sh_expects`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C158`
- `make check`