### PR TITLE
feat(linter): implement C159 mutable globals

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -64,6 +64,7 @@ struct EffectiveRuleOptions {
     s085_main_name: String,
     c158_treat_readonly_as_documented: bool,
     c158_treat_export_as_intentional: bool,
+    c159_allow_conditional_init: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -192,6 +193,7 @@ impl EffectiveRuleOptions {
             s085_main_name: rule_options.s085.main_name.clone(),
             c158_treat_readonly_as_documented: rule_options.c158.treat_readonly_as_documented,
             c158_treat_export_as_intentional: rule_options.c158.treat_export_as_intentional,
+            c159_allow_conditional_init: rule_options.c159.allow_conditional_init,
         }
     }
 }
@@ -212,6 +214,7 @@ impl CacheKey for EffectiveRuleOptions {
         self.s085_main_name.cache_key(state);
         self.c158_treat_readonly_as_documented.cache_key(state);
         self.c158_treat_export_as_intentional.cache_key(state);
+        self.c159_allow_conditional_init.cache_key(state);
     }
 }
 
@@ -1031,6 +1034,14 @@ fn linter_rule_options_for_lint_config(lint: &LintConfig) -> shuck_linter::Linte
         .and_then(|c158| c158.treat_export_as_intentional)
     {
         rule_options.c158.treat_export_as_intentional = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.c159.as_ref())
+        .and_then(|c159| c159.allow_conditional_init)
+    {
+        rule_options.c159.allow_conditional_init = value;
     }
 
     rule_options

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -60,7 +60,8 @@ const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "theme-loads",
     "entrypoints",
 ];
-const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &["c001", "c063", "s084", "s085", "c158"];
+const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] =
+    &["c001", "c063", "s084", "s085", "c158", "c159"];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
 const CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS: &[&str] = &["report-unreached-nested-definitions"];
@@ -79,6 +80,7 @@ const CONFIG_OVERRIDE_C158_RULE_OPTION_KEYS: &[&str] = &[
     "treat-readonly-as-documented",
     "treat-export-as-intentional",
 ];
+const CONFIG_OVERRIDE_C159_RULE_OPTION_KEYS: &[&str] = &["allow-conditional-init"];
 const CONFIG_OVERRIDE_RUN_KEYS: &[&str] = &["shell", "shell-version", "shells"];
 const CONFIG_OVERRIDE_RUN_SHELL_NAMES: &[&str] =
     &["bash", "gbash", "bashkit", "zsh", "dash", "mksh", "busybox"];
@@ -337,6 +339,8 @@ pub struct LintRuleOptionsConfig {
     pub s085: Option<S085RuleOptionsConfig>,
     /// Options for rule C158.
     pub c158: Option<C158RuleOptionsConfig>,
+    /// Options for rule C159.
+    pub c159: Option<C159RuleOptionsConfig>,
 }
 
 impl LintRuleOptionsConfig {
@@ -355,6 +359,9 @@ impl LintRuleOptionsConfig {
         }
         if let Some(c158) = overrides.c158 {
             self.c158.get_or_insert_default().apply_overrides(c158);
+        }
+        if let Some(c159) = overrides.c159 {
+            self.c159.get_or_insert_default().apply_overrides(c159);
         }
     }
 }
@@ -449,7 +456,6 @@ impl S085RuleOptionsConfig {
         }
     }
 }
-
 /// Options for rule C158.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
@@ -467,6 +473,22 @@ impl C158RuleOptionsConfig {
         }
         if overrides.treat_export_as_intentional.is_some() {
             self.treat_export_as_intentional = overrides.treat_export_as_intentional;
+        }
+    }
+}
+
+/// Options for rule C159.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct C159RuleOptionsConfig {
+    /// Whether conditional initialization should suppress later mutable-global reports.
+    pub allow_conditional_init: Option<bool>,
+}
+
+impl C159RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.allow_conditional_init.is_some() {
+            self.allow_conditional_init = overrides.allow_conditional_init;
         }
     }
 }
@@ -836,6 +858,18 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                                 example: "treat-export-as-intentional = false",
                             },
                         ],
+                        sections: &[],
+                    },
+                    ConfigSectionMetadata {
+                        key: "c159",
+                        docs: "Behavior overrides for `C159` mutable global analysis.",
+                        fields: &[ConfigFieldMetadata {
+                            key: "allow-conditional-init",
+                            docs: "Allow self-referential default initializers such as `name=${name:-value}` without treating them as global mutations.",
+                            default: "true",
+                            value_type: "bool",
+                            example: "allow-conditional-init = false",
+                        }],
                         sections: &[],
                     },
                 ],
@@ -1521,6 +1555,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(c158_value) = rule_options.get("c158") {
         validate_c158_rule_options_override(c158_value)?;
     }
+    if let Some(c159_value) = rule_options.get("c159") {
+        validate_c159_rule_options_override(c159_value)?;
+    }
 
     Ok(())
 }
@@ -1588,7 +1625,6 @@ fn validate_s085_rule_options_override(value: &toml::Value) -> std::result::Resu
 
     Ok(())
 }
-
 fn validate_c158_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
     let c158 = value
         .as_table()
@@ -1598,6 +1634,22 @@ fn validate_c158_rule_options_override(value: &toml::Value) -> std::result::Resu
             return Err(format!(
                 "unsupported `[lint.rule-options.c158]` option `{key}`; expected one of: {}",
                 CONFIG_OVERRIDE_C158_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_c159_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let c159 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.c159]` must be a TOML table".to_owned())?;
+    for key in c159.keys() {
+        if !CONFIG_OVERRIDE_C159_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.c159]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_C159_RULE_OPTION_KEYS.join(", ")
             ));
         }
     }
@@ -1904,6 +1956,21 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_c159_rule_option_keys() {
+        let config =
+            parse_config_override("lint.rule-options.c159.allow-conditional-init = false").unwrap();
+        assert_eq!(
+            config
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.c159.as_ref())
+                .and_then(|c159| c159.allow_conditional_init),
+            Some(false)
+        );
+    }
+
+    #[test]
     fn inline_config_overrides_validate_supported_zsh_plugin_keys() {
         let config = parse_config_override(
             "lint.zsh.plugins.resolution = false\n\
@@ -2008,6 +2075,12 @@ mod tests {
     fn inline_config_overrides_reject_unknown_s085_rule_option_keys() {
         let err = parse_config_override("lint.rule-options.s085.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint.rule-options.s085]` option `preview`"));
+    }
+
+    #[test]
+    fn inline_config_overrides_reject_unknown_c159_rule_option_keys() {
+        let err = parse_config_override("lint.rule-options.c159.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options.c159]` option `preview`"));
     }
 
     #[test]
@@ -2206,6 +2279,36 @@ mod tests {
                 .and_then(|options| options.c158.as_ref())
                 .and_then(|c158| c158.treat_export_as_intentional),
             Some(false)
+        );
+    }
+
+    #[test]
+    fn c159_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.c159.allow-conditional-init = false")
+                        .unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.c159.allow-conditional-init = true")
+                        .unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.c159.as_ref())
+                .and_then(|c159| c159.allow_conditional_init),
+            Some(true)
         );
     }
 

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C159.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C159.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+count=0
+count=1
+
+mode=${mode:-dev}
+mode=prod
+mode=${mode#d}${mode:-prod}
+
+refresh() {
+  count=2
+  local mode
+  mode=test
+}
+
+readonly LIMIT=5
+echo "$count" "$mode" "$LIMIT"

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -344,6 +344,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::CommaArrayElements) {
             rules::correctness::comma_array_elements::comma_array_elements(self);
         }
+        if self.is_rule_enabled(Rule::MutableGlobal) {
+            rules::correctness::mutable_global::mutable_global(self);
+        }
     }
 
     fn check_references(&mut self) {

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -205,9 +205,89 @@ impl<'name, 'uses, 'a> SelfParameterExpansionUseVisitor<'name, 'uses, 'a> {
         let name = self.name;
         let semantic = self.semantic;
         let source = self.source;
-        visit_command_substitution_candidate_words(body, semantic, source, &mut |word| {
-            collect_self_parameter_expansion_uses_in_word(word, name, semantic, source, self.uses);
-        });
+        semantic
+            .command_topology()
+            .body(body)
+            .for_each_command_visit(true, |_, visit| {
+                collect_command_self_parameter_uses(
+                    visit.command,
+                    name,
+                    semantic,
+                    source,
+                    self.uses,
+                );
+                CommandTopologyTraversal::Descend
+            });
+    }
+}
+
+fn collect_command_self_parameter_uses<'a>(
+    command: &'a Command,
+    name: &Name,
+    semantic: &'a LinterSemanticArtifacts<'a>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    visit_command_substitution_loop_header_words(command, &mut |word| {
+        collect_self_parameter_expansion_uses_in_word(word, name, semantic, source, uses);
+    });
+    visit_command_argument_words_for_substitutions(command, source, &mut |word| {
+        collect_self_parameter_expansion_uses_in_word(word, name, semantic, source, uses);
+    });
+    for assignment in command_assignments(command) {
+        collect_assignment_value_self_parameter_uses(
+            &assignment.value,
+            name,
+            semantic,
+            source,
+            uses,
+        );
+    }
+    for operand in declaration_operands(command) {
+        if let DeclOperand::Assignment(assignment) = operand {
+            collect_assignment_value_self_parameter_uses(
+                &assignment.value,
+                name,
+                semantic,
+                source,
+                uses,
+            );
+        }
+    }
+}
+
+fn collect_assignment_value_self_parameter_uses<'a>(
+    value: &'a AssignmentValue,
+    name: &Name,
+    semantic: &'a LinterSemanticArtifacts<'a>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    match value {
+        AssignmentValue::Scalar(word) => {
+            collect_self_parameter_expansion_uses_in_word(word, name, semantic, source, uses);
+        }
+        AssignmentValue::Compound(array) => {
+            for element in &array.elements {
+                match element {
+                    ArrayElem::Sequential(word) => {
+                        collect_self_parameter_expansion_uses_in_word(
+                            word, name, semantic, source, uses,
+                        );
+                    }
+                    ArrayElem::Keyed { key, value } | ArrayElem::KeyedAppend { key, value } => {
+                        visit_subscript_words(Some(key), source, &mut |word| {
+                            collect_self_parameter_expansion_uses_in_word(
+                                word, name, semantic, source, uses,
+                            );
+                        });
+                        collect_self_parameter_expansion_uses_in_word(
+                            value, name, semantic, source, uses,
+                        );
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -40,6 +40,7 @@ impl DeclarationAssignmentProbe {
 pub struct BindingValueFact<'a> {
     kind: BindingValueKind<'a>,
     standalone_status_or_pid_capture: bool,
+    uses_only_self_default_parameter_expansions: bool,
     conditional_assignment_shortcut: bool,
     one_sided_short_circuit_assignment: bool,
     zsh_selectorless_subscript_value_base_names: Box<[Name]>,
@@ -52,10 +53,17 @@ pub(crate) enum BindingValueKind<'a> {
 }
 
 impl<'a> BindingValueFact<'a> {
-    fn scalar(word: &'a Word, source: &str) -> Self {
+    fn scalar(
+        word: &'a Word,
+        target_name: &Name,
+        semantic: &'a LinterSemanticArtifacts<'a>,
+        source: &str,
+    ) -> Self {
         Self::scalar_with_status_or_pid_capture(
             word,
             word_is_standalone_status_or_pid_capture(word),
+            target_name,
+            semantic,
             source,
         )
     }
@@ -63,11 +71,20 @@ impl<'a> BindingValueFact<'a> {
     fn scalar_with_status_or_pid_capture(
         word: &'a Word,
         standalone_status_or_pid_capture: bool,
+        target_name: &Name,
+        semantic: &'a LinterSemanticArtifacts<'a>,
         source: &str,
     ) -> Self {
         Self {
             kind: BindingValueKind::Scalar(word),
             standalone_status_or_pid_capture,
+            uses_only_self_default_parameter_expansions:
+                word_uses_only_self_default_parameter_expansions(
+                    word,
+                    target_name,
+                    semantic,
+                    source,
+                ),
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
             zsh_selectorless_subscript_value_base_names:
@@ -79,6 +96,7 @@ impl<'a> BindingValueFact<'a> {
         Self {
             kind: BindingValueKind::Loop(words),
             standalone_status_or_pid_capture: false,
+            uses_only_self_default_parameter_expansions: false,
             conditional_assignment_shortcut: false,
             one_sided_short_circuit_assignment: false,
             zsh_selectorless_subscript_value_base_names: Box::default(),
@@ -111,6 +129,10 @@ impl<'a> BindingValueFact<'a> {
         self.standalone_status_or_pid_capture
     }
 
+    pub fn uses_only_self_default_parameter_expansions(&self) -> bool {
+        self.uses_only_self_default_parameter_expansions
+    }
+
     pub fn zsh_selectorless_subscript_value(&self) -> bool {
         !self.zsh_selectorless_subscript_value_base_names.is_empty()
     }
@@ -127,6 +149,245 @@ impl<'a> BindingValueFact<'a> {
 
     fn mark_one_sided_short_circuit_assignment(&mut self) {
         self.one_sided_short_circuit_assignment = true;
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct SelfParameterExpansionUses {
+    default_operator: bool,
+    other_read: bool,
+}
+
+fn word_uses_only_self_default_parameter_expansions<'a>(
+    word: &'a Word,
+    name: &Name,
+    semantic: &'a LinterSemanticArtifacts<'a>,
+    source: &str,
+) -> bool {
+    let mut uses = SelfParameterExpansionUses::default();
+    collect_self_parameter_expansion_uses_in_word(word, name, semantic, source, &mut uses);
+    uses.default_operator && !uses.other_read
+}
+
+fn collect_self_parameter_expansion_uses_in_word<'a>(
+    word: &'a Word,
+    name: &Name,
+    semantic: &'a LinterSemanticArtifacts<'a>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    let mut visitor = SelfParameterExpansionUseVisitor {
+        name,
+        semantic,
+        source,
+        uses,
+    };
+    walk_word_subtree(
+        word,
+        WordTraversalContext {
+            source,
+            locator: None,
+            shell_dialect: shuck_semantic::ShellDialect::Bash,
+        },
+        &mut visitor,
+    );
+}
+
+struct SelfParameterExpansionUseVisitor<'name, 'uses, 'a> {
+    name: &'name Name,
+    semantic: &'a LinterSemanticArtifacts<'a>,
+    source: &'a str,
+    uses: &'uses mut SelfParameterExpansionUses,
+}
+
+impl<'name, 'uses, 'a> SelfParameterExpansionUseVisitor<'name, 'uses, 'a> {
+    fn collect_command_body(&mut self, body: &'a StmtSeq) {
+        let name = self.name;
+        let semantic = self.semantic;
+        let source = self.source;
+        visit_command_substitution_candidate_words(body, semantic, source, &mut |word| {
+            collect_self_parameter_expansion_uses_in_word(word, name, semantic, source, self.uses);
+        });
+    }
+}
+
+impl<'name, 'uses, 'a> WordSubtreeVisitor<'a>
+    for SelfParameterExpansionUseVisitor<'name, 'uses, 'a>
+{
+    fn visit_part(&mut self, part: &'a WordPartNode, _state: WordTraversalState<'a>) {
+        match &part.kind {
+            WordPart::Literal(_)
+            | WordPart::ZshQualifiedGlob(_)
+            | WordPart::SingleQuoted { .. }
+            | WordPart::CommandSubstitution { .. }
+            | WordPart::ArithmeticExpansion { .. } => {}
+            WordPart::ProcessSubstitution { body, .. } => self.collect_command_body(body),
+            WordPart::DoubleQuoted { .. } => {}
+            WordPart::Variable(name) => record_name_read(name, self.name, self.uses),
+            WordPart::Parameter(parameter) => collect_parameter_expansion_self_uses(
+                parameter,
+                self.name,
+                self.semantic,
+                self.source,
+                self.uses,
+            ),
+            WordPart::ParameterExpansion {
+                reference,
+                operator,
+                ..
+            } => record_parameter_operation_use(
+                reference,
+                operator,
+                self.name,
+                self.semantic,
+                self.source,
+                self.uses,
+            ),
+            WordPart::Length(reference)
+            | WordPart::ArrayAccess(reference)
+            | WordPart::ArrayLength(reference)
+            | WordPart::ArrayIndices(reference)
+            | WordPart::Substring { reference, .. }
+            | WordPart::ArraySlice { reference, .. }
+            | WordPart::Transformation { reference, .. } => {
+                record_var_ref_read(reference, self.name, self.semantic, self.source, self.uses)
+            }
+            WordPart::IndirectExpansion { reference, .. } => {
+                record_var_ref_read(reference, self.name, self.semantic, self.source, self.uses)
+            }
+            WordPart::PrefixMatch { .. } => {}
+        }
+    }
+
+    fn visit_command_substitution(
+        &mut self,
+        part: &'a WordPartNode,
+        _state: WordTraversalState<'a>,
+    ) {
+        if let WordPart::CommandSubstitution { body, .. } = &part.kind {
+            self.collect_command_body(body);
+        }
+    }
+}
+
+fn collect_parameter_expansion_self_uses(
+    parameter: &ParameterExpansion,
+    name: &Name,
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(syntax) => {
+            collect_bourne_parameter_expansion_self_uses(syntax, name, semantic, source, uses);
+        }
+        ParameterExpansionSyntax::Zsh(syntax) => {
+            collect_zsh_parameter_expansion_self_uses(syntax, name, semantic, source, uses);
+        }
+    }
+}
+
+fn collect_bourne_parameter_expansion_self_uses(
+    syntax: &BourneParameterExpansion,
+    name: &Name,
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    match syntax {
+        BourneParameterExpansion::Access { reference }
+        | BourneParameterExpansion::Length { reference }
+        | BourneParameterExpansion::Indices { reference }
+        | BourneParameterExpansion::Transformation { reference, .. } => {
+            record_var_ref_read(reference, name, semantic, source, uses);
+        }
+        BourneParameterExpansion::Operation {
+            reference,
+            operator,
+            ..
+        } => record_parameter_operation_use(reference, operator, name, semantic, source, uses),
+        BourneParameterExpansion::Indirect { reference, .. } => {
+            record_var_ref_read(reference, name, semantic, source, uses);
+        }
+        BourneParameterExpansion::Slice { reference, .. } => {
+            record_var_ref_read(reference, name, semantic, source, uses);
+        }
+        BourneParameterExpansion::PrefixMatch { .. } => {}
+    }
+}
+
+fn collect_zsh_parameter_expansion_self_uses(
+    syntax: &ZshParameterExpansion,
+    name: &Name,
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    match &syntax.target {
+        ZshExpansionTarget::Reference(reference) => match &syntax.operation {
+            Some(ZshExpansionOperation::Defaulting {
+                kind:
+                    shuck_ast::ZshDefaultingOp::UseDefault | shuck_ast::ZshDefaultingOp::AssignDefault,
+                ..
+            }) => record_parameter_default_use(reference, name, semantic, source, uses),
+            _ => record_var_ref_read(reference, name, semantic, source, uses),
+        },
+        ZshExpansionTarget::Nested(parameter) => {
+            collect_parameter_expansion_self_uses(parameter, name, semantic, source, uses);
+        }
+        ZshExpansionTarget::Word(_) | ZshExpansionTarget::Empty => {}
+    }
+}
+
+fn record_parameter_operation_use(
+    reference: &VarRef,
+    operator: &ParameterOp,
+    name: &Name,
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    if matches!(
+        operator,
+        ParameterOp::UseDefault | ParameterOp::AssignDefault
+    ) {
+        record_parameter_default_use(reference, name, semantic, source, uses);
+    } else {
+        record_var_ref_read(reference, name, semantic, source, uses);
+    }
+}
+
+fn record_parameter_default_use(
+    reference: &VarRef,
+    name: &Name,
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    if reference.name.as_str() == name.as_str() {
+        uses.default_operator = true;
+    }
+    visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
+        collect_self_parameter_expansion_uses_in_word(word, name, semantic, source, uses);
+    });
+}
+
+fn record_var_ref_read(
+    reference: &VarRef,
+    name: &Name,
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    record_name_read(&reference.name, name, uses);
+    visit_var_ref_subscript_words_with_source(reference, source, &mut |word| {
+        collect_self_parameter_expansion_uses_in_word(word, name, semantic, source, uses);
+    });
+}
+
+fn record_name_read(name: &Name, target_name: &Name, uses: &mut SelfParameterExpansionUses) {
+    if name.as_str() == target_name.as_str() {
+        uses.other_read = true;
     }
 }
 
@@ -3280,6 +3541,7 @@ pub(crate) fn advance_escaped_char_boundary(text: &str, start: usize) -> usize {
 
 pub(crate) fn collect_binding_values<'a>(
     command: &'a Command,
+    semantic_artifacts: &'a LinterSemanticArtifacts<'a>,
     semantic: &SemanticModel,
     source: &str,
     binding_values: &mut FxHashMap<BindingId, BindingValueFact<'a>>,
@@ -3301,7 +3563,10 @@ pub(crate) fn collect_binding_values<'a>(
         if let Some(binding_id) =
             binding_value_definition_id_for_span(semantic, assignment.target.name_span)
         {
-            binding_values.insert(binding_id, BindingValueFact::scalar(word, source));
+            binding_values.insert(
+                binding_id,
+                BindingValueFact::scalar(word, &assignment.target.name, semantic_artifacts, source),
+            );
         }
     }
 
@@ -3315,7 +3580,10 @@ pub(crate) fn collect_binding_values<'a>(
         if let Some(binding_id) =
             binding_value_definition_id_for_span(semantic, assignment.target.name_span)
         {
-            binding_values.insert(binding_id, BindingValueFact::scalar(word, source));
+            binding_values.insert(
+                binding_id,
+                BindingValueFact::scalar(word, &assignment.target.name, semantic_artifacts, source),
+            );
         }
     }
 
@@ -3338,11 +3606,14 @@ pub(crate) fn collect_binding_values<'a>(
             let standalone_status_or_pid_capture =
                 word_span_is_standalone_status_or_pid_capture(word, *value_span);
             if let Some(binding_id) = binding_value_definition_id_for_span(semantic, *name_span) {
+                let binding_name = &semantic.binding(binding_id).name;
                 binding_values.insert(
                     binding_id,
                     BindingValueFact::scalar_with_status_or_pid_capture(
                         word,
                         standalone_status_or_pid_capture,
+                        binding_name,
+                        semantic_artifacts,
                         source,
                     ),
                 );

--- a/crates/shuck-linter/src/facts/assignments.rs
+++ b/crates/shuck-linter/src/facts/assignments.rs
@@ -219,8 +219,30 @@ impl<'name, 'uses, 'a> WordSubtreeVisitor<'a>
             WordPart::Literal(_)
             | WordPart::ZshQualifiedGlob(_)
             | WordPart::SingleQuoted { .. }
-            | WordPart::CommandSubstitution { .. }
-            | WordPart::ArithmeticExpansion { .. } => {}
+            | WordPart::CommandSubstitution { .. } => {}
+            WordPart::ArithmeticExpansion {
+                expression_ast,
+                expression_word_ast,
+                ..
+            } => {
+                if let Some(expression) = expression_ast {
+                    collect_arithmetic_expression_self_uses(
+                        expression,
+                        self.name,
+                        self.semantic,
+                        self.source,
+                        self.uses,
+                    );
+                } else {
+                    collect_self_parameter_expansion_uses_in_word(
+                        expression_word_ast,
+                        self.name,
+                        self.semantic,
+                        self.source,
+                        self.uses,
+                    );
+                }
+            }
             WordPart::ProcessSubstitution { body, .. } => self.collect_command_body(body),
             WordPart::DoubleQuoted { .. } => {}
             WordPart::Variable(name) => record_name_read(name, self.name, self.uses),
@@ -266,6 +288,71 @@ impl<'name, 'uses, 'a> WordSubtreeVisitor<'a>
     ) {
         if let WordPart::CommandSubstitution { body, .. } = &part.kind {
             self.collect_command_body(body);
+        }
+    }
+}
+
+fn collect_arithmetic_expression_self_uses(
+    expression: &ArithmeticExprNode,
+    name: &Name,
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    match &expression.kind {
+        ArithmeticExpr::Number(_) => {}
+        ArithmeticExpr::Variable(variable) => record_name_read(variable, name, uses),
+        ArithmeticExpr::Indexed {
+            name: variable,
+            index,
+        } => {
+            record_name_read(variable, name, uses);
+            collect_arithmetic_expression_self_uses(index, name, semantic, source, uses);
+        }
+        ArithmeticExpr::ShellWord(word) => {
+            collect_self_parameter_expansion_uses_in_word(word, name, semantic, source, uses);
+        }
+        ArithmeticExpr::Parenthesized { expression } => {
+            collect_arithmetic_expression_self_uses(expression, name, semantic, source, uses);
+        }
+        ArithmeticExpr::Unary { expr, .. } | ArithmeticExpr::Postfix { expr, .. } => {
+            collect_arithmetic_expression_self_uses(expr, name, semantic, source, uses);
+        }
+        ArithmeticExpr::Binary { left, right, .. } => {
+            collect_arithmetic_expression_self_uses(left, name, semantic, source, uses);
+            collect_arithmetic_expression_self_uses(right, name, semantic, source, uses);
+        }
+        ArithmeticExpr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_arithmetic_expression_self_uses(condition, name, semantic, source, uses);
+            collect_arithmetic_expression_self_uses(then_expr, name, semantic, source, uses);
+            collect_arithmetic_expression_self_uses(else_expr, name, semantic, source, uses);
+        }
+        ArithmeticExpr::Assignment { target, value, .. } => {
+            collect_arithmetic_lvalue_self_uses(target, name, semantic, source, uses);
+            collect_arithmetic_expression_self_uses(value, name, semantic, source, uses);
+        }
+    }
+}
+
+fn collect_arithmetic_lvalue_self_uses(
+    target: &ArithmeticLvalue,
+    name: &Name,
+    semantic: &LinterSemanticArtifacts<'_>,
+    source: &str,
+    uses: &mut SelfParameterExpansionUses,
+) {
+    match target {
+        ArithmeticLvalue::Variable(variable) => record_name_read(variable, name, uses),
+        ArithmeticLvalue::Indexed {
+            name: variable,
+            index,
+        } => {
+            record_name_read(variable, name, uses);
+            collect_arithmetic_expression_self_uses(index, name, semantic, source, uses);
         }
     }
 }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -180,6 +180,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
             }
             collect_binding_values(
                 visit.command,
+                self.semantic_artifacts,
                 self.semantic,
                 self.source,
                 &mut binding_values,

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -106,7 +106,7 @@ pub use rule_set::RuleSet;
 pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 /// Linter configuration and per-file ignore types.
 pub use settings::{
-    AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions,
+    AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions, C159RuleOptions,
     CompiledPerFileIgnoreList, LinterRuleOptions, LinterSettings, PerFileIgnore, S084RuleOptions,
     S085RuleOptions,
 };

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -499,6 +499,7 @@ declare_rules! {
         Severity::Warning,
         ImplicitGlobalInFunction
     ),
+    ("C159", Category::Correctness, Severity::Warning, MutableGlobal),
     ("P001", Category::Performance, Severity::Warning, ExprArithmetic),
     ("P002", Category::Performance, Severity::Warning, GrepCountPipeline),
     ("P003", Category::Performance, Severity::Warning, SingleTestSubshell),

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -90,6 +90,7 @@ pub mod missing_fi;
 pub mod missing_semicolon_before_brace;
 pub mod missing_space_before_bracket_close;
 pub mod mixed_and_or_in_condition;
+pub mod mutable_global;
 pub mod nested_parameter_expansion;
 pub mod non_absolute_shebang;
 pub mod non_shell_syntax_in_script;
@@ -307,6 +308,7 @@ mod tests {
     #[test_case(Rule::PossibleVariableMisspelling, Path::new("C156.sh"))]
     #[test_case(Rule::IfBracketGlued, Path::new("C157.sh"))]
     #[test_case(Rule::ImplicitGlobalInFunction, Path::new("C158.sh"))]
+    #[test_case(Rule::MutableGlobal, Path::new("C159.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {
         let snapshot = format!("{}_{}", rule.code(), path.display());
         let (diagnostics, source) = test_path(

--- a/crates/shuck-linter/src/rules/correctness/mutable_global.rs
+++ b/crates/shuck-linter/src/rules/correctness/mutable_global.rs
@@ -437,6 +437,20 @@ path=${path:-/tmp}${other:-$path}
     }
 
     #[test]
+    fn reports_arithmetic_self_reads_after_conditional_defaults() {
+        let source = "\
+#!/bin/bash
+mode=dev
+mode=${mode:-prod}$((mode + 1))
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "mode");
+        assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
     fn ignores_default_operators_in_trailing_comments() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/mutable_global.rs
+++ b/crates/shuck-linter/src/rules/correctness/mutable_global.rs
@@ -84,7 +84,7 @@ pub fn mutable_global(checker: &mut Checker) {
             if write.kind == GlobalWriteKind::File && write.binding_id == first_file_write {
                 continue;
             }
-            if allow_conditional_init && is_conditional_default_init(binding, checker.source()) {
+            if allow_conditional_init && is_conditional_default_init(binding, checker) {
                 continue;
             }
             if reported.insert(write.binding_id) {
@@ -227,7 +227,7 @@ fn is_mutable_global_write_candidate(binding: &Binding) -> bool {
     }
 }
 
-fn is_conditional_default_init(binding: &Binding, source: &str) -> bool {
+fn is_conditional_default_init(binding: &Binding, checker: &Checker<'_>) -> bool {
     if matches!(binding.kind, BindingKind::ParameterDefaultAssignment) {
         return true;
     }
@@ -236,234 +236,11 @@ fn is_conditional_default_init(binding: &Binding, source: &str) -> bool {
         .attributes
         .contains(BindingAttributes::SELF_REFERENTIAL_READ)
         && matches!(binding.origin, BindingOrigin::Assignment { .. })
-        && assignment_value_uses_self_default_operator(binding, source)
-}
-
-fn assignment_value_uses_self_default_operator(binding: &Binding, source: &str) -> bool {
-    let Some(value) = source
-        .get(binding.span.end.offset..)
-        .and_then(|remainder| remainder.strip_prefix('='))
-    else {
-        return false;
-    };
-    let value_word = assignment_value_word(value);
-    let value_word = assignment_value_without_trailing_comment(value_word);
-    value_uses_only_self_default_parameter_expansions(value_word, binding.name.as_str())
-}
-
-fn assignment_value_word(value: &str) -> &str {
-    let bytes = value.as_bytes();
-    let mut index = 0usize;
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\n' | b'\r' | b';' => return &value[..index],
-            b'\'' => index = skip_single_quoted_assignment_value(bytes, index + 1),
-            b'"' => index = skip_double_quoted_assignment_value(bytes, index + 1),
-            b'`' => index = skip_backtick_assignment_value(bytes, index + 1),
-            b'\\' => index = (index + 2).min(bytes.len()),
-            b'$' => index = skip_dollar_assignment_expansion(bytes, index),
-            _ => index += 1,
-        }
-    }
-
-    value
-}
-
-fn assignment_value_without_trailing_comment(value: &str) -> &str {
-    let mut escaped = false;
-    let mut in_single_quote = false;
-    let mut in_double_quote = false;
-    let mut comment_can_start = false;
-
-    for (index, ch) in value.char_indices() {
-        if escaped {
-            escaped = false;
-            comment_can_start = false;
-            continue;
-        }
-
-        if in_single_quote {
-            if ch == '\'' {
-                in_single_quote = false;
-            }
-            continue;
-        }
-
-        if in_double_quote {
-            match ch {
-                '\\' => escaped = true,
-                '"' => in_double_quote = false,
-                _ => {}
-            }
-            continue;
-        }
-
-        match ch {
-            '#' if comment_can_start => return &value[..index],
-            '\\' => {
-                escaped = true;
-                comment_can_start = false;
-            }
-            '\'' => {
-                in_single_quote = true;
-                comment_can_start = false;
-            }
-            '"' => {
-                in_double_quote = true;
-                comment_can_start = false;
-            }
-            ' ' | '\t' => comment_can_start = true,
-            _ => comment_can_start = false,
-        }
-    }
-
-    value
-}
-
-fn skip_single_quoted_assignment_value(bytes: &[u8], mut index: usize) -> usize {
-    while index < bytes.len() {
-        if bytes[index] == b'\'' {
-            return index + 1;
-        }
-        index += 1;
-    }
-    bytes.len()
-}
-
-fn skip_double_quoted_assignment_value(bytes: &[u8], mut index: usize) -> usize {
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\\' => index = (index + 2).min(bytes.len()),
-            b'"' => return index + 1,
-            _ => index += 1,
-        }
-    }
-    bytes.len()
-}
-
-fn skip_backtick_assignment_value(bytes: &[u8], mut index: usize) -> usize {
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\\' => index = (index + 2).min(bytes.len()),
-            b'`' => return index + 1,
-            _ => index += 1,
-        }
-    }
-    bytes.len()
-}
-
-fn skip_dollar_assignment_expansion(bytes: &[u8], index: usize) -> usize {
-    let Some(next) = bytes.get(index + 1).copied() else {
-        return bytes.len();
-    };
-
-    match next {
-        b'{' => skip_balanced_assignment_value(bytes, index + 2, b'{', b'}'),
-        b'(' => skip_balanced_assignment_value(bytes, index + 2, b'(', b')'),
-        b'[' => skip_balanced_assignment_value(bytes, index + 2, b'[', b']'),
-        _ => index + 1,
-    }
-}
-
-fn skip_balanced_assignment_value(bytes: &[u8], mut index: usize, open: u8, close: u8) -> usize {
-    let mut depth = 1usize;
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\'' => index = skip_single_quoted_assignment_value(bytes, index + 1),
-            b'"' => index = skip_double_quoted_assignment_value(bytes, index + 1),
-            b'`' => index = skip_backtick_assignment_value(bytes, index + 1),
-            b'\\' => index = (index + 2).min(bytes.len()),
-            b'$' => index = skip_dollar_assignment_expansion(bytes, index),
-            byte if byte == open => {
-                depth += 1;
-                index += 1;
-            }
-            byte if byte == close => {
-                depth -= 1;
-                index += 1;
-                if depth == 0 {
-                    return index;
-                }
-            }
-            _ => index += 1,
-        }
-    }
-    bytes.len()
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-struct SelfParameterExpansionUses {
-    default_operator: bool,
-    other_read: bool,
-}
-
-fn value_uses_only_self_default_parameter_expansions(value: &str, name: &str) -> bool {
-    let uses = self_parameter_expansion_uses(value, name);
-    uses.default_operator && !uses.other_read
-}
-
-fn self_parameter_expansion_uses(value: &str, name: &str) -> SelfParameterExpansionUses {
-    let bytes = value.as_bytes();
-    let name_bytes = name.as_bytes();
-    let mut uses = SelfParameterExpansionUses::default();
-    let mut index = 0usize;
-
-    while index < bytes.len() {
-        match bytes[index] {
-            b'\'' => index = skip_single_quoted_assignment_value(bytes, index + 1),
-            b'\\' => index = (index + 2).min(bytes.len()),
-            b'$' => {
-                if bytes.get(index + 1) == Some(&b'{') {
-                    let name_start = index + 2;
-                    let name_end = name_start + name_bytes.len();
-                    if bytes
-                        .get(name_start..name_end)
-                        .is_some_and(|candidate| candidate == name_bytes)
-                        && braced_parameter_name_has_boundary(bytes, name_end)
-                    {
-                        if braced_parameter_tail_starts_default_operator(&bytes[name_end..]) {
-                            uses.default_operator = true;
-                        } else {
-                            uses.other_read = true;
-                        }
-                    }
-                } else {
-                    let name_start = index + 1;
-                    let name_end = name_start + name_bytes.len();
-                    if bytes
-                        .get(name_start..name_end)
-                        .is_some_and(|candidate| candidate == name_bytes)
-                        && bare_parameter_name_has_boundary(bytes, name_end)
-                    {
-                        uses.other_read = true;
-                    }
-                }
-                index += 1;
-            }
-            _ => index += 1,
-        }
-    }
-
-    uses
-}
-
-fn braced_parameter_name_has_boundary(bytes: &[u8], index: usize) -> bool {
-    !bytes
-        .get(index)
-        .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
-}
-
-fn bare_parameter_name_has_boundary(bytes: &[u8], index: usize) -> bool {
-    !bytes
-        .get(index)
-        .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
-}
-
-fn braced_parameter_tail_starts_default_operator(tail: &[u8]) -> bool {
-    matches!(
-        tail,
-        [b':', b'-', ..] | [b':', b'=', ..] | [b'-', ..] | [b'=', ..]
-    )
+        && checker
+            .facts()
+            .assignments()
+            .binding_value(binding.id)
+            .is_some_and(|value| value.uses_only_self_default_parameter_expansions())
 }
 
 fn report_span_for_binding(binding: &Binding) -> Span {

--- a/crates/shuck-linter/src/rules/correctness/mutable_global.rs
+++ b/crates/shuck-linter/src/rules/correctness/mutable_global.rs
@@ -451,6 +451,20 @@ mode=${mode:-prod}$((mode + 1))
     }
 
     #[test]
+    fn reports_substitution_assignment_self_reads_after_conditional_defaults() {
+        let source = "\
+#!/bin/bash
+mode=dev
+mode=${mode:-prod}$(mode=$mode; printf x)
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "mode");
+        assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
     fn ignores_default_operators_in_trailing_comments() {
         let source = "\
 #!/bin/bash

--- a/crates/shuck-linter/src/rules/correctness/mutable_global.rs
+++ b/crates/shuck-linter/src/rules/correctness/mutable_global.rs
@@ -1,0 +1,748 @@
+use compact_str::CompactString;
+use rustc_hash::{FxHashMap, FxHashSet};
+use shuck_ast::{Name, Span};
+use shuck_semantic::{
+    Binding, BindingAttributes, BindingId, BindingKind, BindingOrigin, DeclarationBuiltin, ScopeId,
+    ScopeKind,
+};
+
+use crate::{Checker, Rule, ShellDialect, Violation};
+
+pub struct MutableGlobal {
+    pub name: CompactString,
+}
+
+impl Violation for MutableGlobal {
+    fn rule() -> Rule {
+        Rule::MutableGlobal
+    }
+
+    fn message(&self) -> String {
+        format!(
+            "global variable `{}` is written more than once; make it readonly or keep later writes local",
+            self.name
+        )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GlobalWriteKind {
+    File,
+    Function,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GlobalWrite {
+    binding_id: BindingId,
+    kind: GlobalWriteKind,
+}
+
+pub fn mutable_global(checker: &mut Checker) {
+    if checker.shell() != ShellDialect::Bash {
+        return;
+    }
+
+    let semantic = checker.semantic();
+    let mut writes_by_name = FxHashMap::<Name, Vec<GlobalWrite>>::default();
+
+    for binding in semantic.bindings() {
+        if !is_mutable_global_write_candidate(binding) {
+            continue;
+        }
+
+        let Some(kind) = global_write_kind(checker, binding) else {
+            continue;
+        };
+
+        writes_by_name
+            .entry(binding.name.clone())
+            .or_default()
+            .push(GlobalWrite {
+                binding_id: binding.id,
+                kind,
+            });
+    }
+
+    let allow_conditional_init = checker.rule_options().c159.allow_conditional_init;
+    let mut reported = FxHashSet::<BindingId>::default();
+    let mut reportable_bindings = Vec::new();
+
+    for writes in writes_by_name.values_mut() {
+        writes.sort_unstable_by_key(|write| semantic.binding(write.binding_id).span.start.offset);
+
+        let Some(first_file_write) = writes
+            .iter()
+            .find(|write| write.kind == GlobalWriteKind::File)
+            .map(|write| write.binding_id)
+        else {
+            continue;
+        };
+
+        for write in writes.iter().copied() {
+            let binding = semantic.binding(write.binding_id);
+
+            if write.kind == GlobalWriteKind::File && write.binding_id == first_file_write {
+                continue;
+            }
+            if allow_conditional_init && is_conditional_default_init(binding, checker.source()) {
+                continue;
+            }
+            if reported.insert(write.binding_id) {
+                reportable_bindings.push(write.binding_id);
+            }
+        }
+    }
+
+    reportable_bindings
+        .sort_unstable_by_key(|binding_id| semantic.binding(*binding_id).span.start.offset);
+
+    for binding_id in reportable_bindings {
+        let binding = semantic.binding(binding_id);
+        checker.report(
+            MutableGlobal {
+                name: binding.name.as_str().into(),
+            },
+            report_span_for_binding(binding),
+        );
+    }
+}
+
+fn global_write_kind(checker: &Checker<'_>, binding: &Binding) -> Option<GlobalWriteKind> {
+    let semantic = checker.semantic();
+
+    if matches!(semantic.scope_kind(binding.scope), ScopeKind::File) {
+        return Some(GlobalWriteKind::File);
+    }
+
+    if checker
+        .semantic_analysis()
+        .scope_runs_in_transient_context(binding.scope)
+    {
+        return None;
+    }
+
+    let function_scope =
+        semantic.enclosing_function_scope_without_transient_boundary(binding.scope)?;
+    if binding.attributes.contains(BindingAttributes::LOCAL)
+        || has_prior_function_declaration(checker, binding, function_scope)
+    {
+        return None;
+    }
+
+    Some(GlobalWriteKind::Function)
+}
+
+fn has_prior_function_declaration(
+    checker: &Checker<'_>,
+    binding: &Binding,
+    function_scope: ScopeId,
+) -> bool {
+    let semantic = checker.semantic();
+    semantic
+        .bindings_for(&binding.name)
+        .iter()
+        .copied()
+        .any(|id| {
+            let candidate = semantic.binding(id);
+            candidate.scope == function_scope
+                && candidate.span.start.offset < binding.span.start.offset
+                && is_function_local_declaration(candidate)
+                && declaration_runs_before_binding(checker, candidate, binding, function_scope)
+        })
+}
+
+fn declaration_runs_before_binding(
+    checker: &Checker<'_>,
+    declaration: &Binding,
+    binding: &Binding,
+    function_scope: ScopeId,
+) -> bool {
+    let analysis = checker.semantic_analysis();
+    let declaration_blocks = analysis.reachable_blocks_for_binding(declaration.id);
+    let binding_blocks = analysis.reachable_blocks_for_binding(binding.id);
+    if declaration_blocks.is_empty() {
+        return false;
+    }
+    if binding_blocks.is_empty() {
+        return true;
+    }
+
+    let declaration_blocks = declaration_blocks.into_iter().collect::<FxHashSet<_>>();
+    let uncovered_binding_blocks = binding_blocks
+        .into_iter()
+        .filter(|block| !declaration_blocks.contains(block))
+        .collect::<Vec<_>>();
+    if uncovered_binding_blocks.is_empty() {
+        return true;
+    }
+
+    let Some(entry_block) = analysis.cfg().scope_entry(function_scope) else {
+        return true;
+    };
+
+    !analysis.blocks_have_path_avoiding(
+        &[entry_block],
+        &uncovered_binding_blocks,
+        &declaration_blocks,
+    )
+}
+
+fn is_function_local_declaration(binding: &Binding) -> bool {
+    binding.attributes.contains(BindingAttributes::LOCAL)
+        || matches!(
+            binding.kind,
+            BindingKind::Declaration(
+                DeclarationBuiltin::Declare
+                    | DeclarationBuiltin::Local
+                    | DeclarationBuiltin::Readonly
+                    | DeclarationBuiltin::Typeset
+            ) | BindingKind::Nameref
+        )
+}
+
+fn is_mutable_global_write_candidate(binding: &Binding) -> bool {
+    if binding
+        .attributes
+        .intersects(BindingAttributes::READONLY | BindingAttributes::LOCAL)
+    {
+        return false;
+    }
+
+    match binding.kind {
+        BindingKind::Assignment
+        | BindingKind::AppendAssignment
+        | BindingKind::ArrayAssignment
+        | BindingKind::LoopVariable
+        | BindingKind::ReadTarget
+        | BindingKind::MapfileTarget
+        | BindingKind::PrintfTarget
+        | BindingKind::GetoptsTarget
+        | BindingKind::ZparseoptsTarget
+        | BindingKind::ArithmeticAssignment
+        | BindingKind::ParameterDefaultAssignment => true,
+        BindingKind::Declaration(_) => binding
+            .attributes
+            .contains(BindingAttributes::DECLARATION_INITIALIZED),
+        BindingKind::FunctionDefinition | BindingKind::Imported | BindingKind::Nameref => false,
+    }
+}
+
+fn is_conditional_default_init(binding: &Binding, source: &str) -> bool {
+    if matches!(binding.kind, BindingKind::ParameterDefaultAssignment) {
+        return true;
+    }
+
+    binding
+        .attributes
+        .contains(BindingAttributes::SELF_REFERENTIAL_READ)
+        && matches!(binding.origin, BindingOrigin::Assignment { .. })
+        && assignment_value_uses_self_default_operator(binding, source)
+}
+
+fn assignment_value_uses_self_default_operator(binding: &Binding, source: &str) -> bool {
+    let Some(value) = source
+        .get(binding.span.end.offset..)
+        .and_then(|remainder| remainder.strip_prefix('='))
+    else {
+        return false;
+    };
+    let value_word = assignment_value_word(value);
+    let value_word = assignment_value_without_trailing_comment(value_word);
+    value_uses_only_self_default_parameter_expansions(value_word, binding.name.as_str())
+}
+
+fn assignment_value_word(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\n' | b'\r' | b';' => return &value[..index],
+            b'\'' => index = skip_single_quoted_assignment_value(bytes, index + 1),
+            b'"' => index = skip_double_quoted_assignment_value(bytes, index + 1),
+            b'`' => index = skip_backtick_assignment_value(bytes, index + 1),
+            b'\\' => index = (index + 2).min(bytes.len()),
+            b'$' => index = skip_dollar_assignment_expansion(bytes, index),
+            _ => index += 1,
+        }
+    }
+
+    value
+}
+
+fn assignment_value_without_trailing_comment(value: &str) -> &str {
+    let mut escaped = false;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut comment_can_start = false;
+
+    for (index, ch) in value.char_indices() {
+        if escaped {
+            escaped = false;
+            comment_can_start = false;
+            continue;
+        }
+
+        if in_single_quote {
+            if ch == '\'' {
+                in_single_quote = false;
+            }
+            continue;
+        }
+
+        if in_double_quote {
+            match ch {
+                '\\' => escaped = true,
+                '"' => in_double_quote = false,
+                _ => {}
+            }
+            continue;
+        }
+
+        match ch {
+            '#' if comment_can_start => return &value[..index],
+            '\\' => {
+                escaped = true;
+                comment_can_start = false;
+            }
+            '\'' => {
+                in_single_quote = true;
+                comment_can_start = false;
+            }
+            '"' => {
+                in_double_quote = true;
+                comment_can_start = false;
+            }
+            ' ' | '\t' => comment_can_start = true,
+            _ => comment_can_start = false,
+        }
+    }
+
+    value
+}
+
+fn skip_single_quoted_assignment_value(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        if bytes[index] == b'\'' {
+            return index + 1;
+        }
+        index += 1;
+    }
+    bytes.len()
+}
+
+fn skip_double_quoted_assignment_value(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => index = (index + 2).min(bytes.len()),
+            b'"' => return index + 1,
+            _ => index += 1,
+        }
+    }
+    bytes.len()
+}
+
+fn skip_backtick_assignment_value(bytes: &[u8], mut index: usize) -> usize {
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\\' => index = (index + 2).min(bytes.len()),
+            b'`' => return index + 1,
+            _ => index += 1,
+        }
+    }
+    bytes.len()
+}
+
+fn skip_dollar_assignment_expansion(bytes: &[u8], index: usize) -> usize {
+    let Some(next) = bytes.get(index + 1).copied() else {
+        return bytes.len();
+    };
+
+    match next {
+        b'{' => skip_balanced_assignment_value(bytes, index + 2, b'{', b'}'),
+        b'(' => skip_balanced_assignment_value(bytes, index + 2, b'(', b')'),
+        b'[' => skip_balanced_assignment_value(bytes, index + 2, b'[', b']'),
+        _ => index + 1,
+    }
+}
+
+fn skip_balanced_assignment_value(bytes: &[u8], mut index: usize, open: u8, close: u8) -> usize {
+    let mut depth = 1usize;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' => index = skip_single_quoted_assignment_value(bytes, index + 1),
+            b'"' => index = skip_double_quoted_assignment_value(bytes, index + 1),
+            b'`' => index = skip_backtick_assignment_value(bytes, index + 1),
+            b'\\' => index = (index + 2).min(bytes.len()),
+            b'$' => index = skip_dollar_assignment_expansion(bytes, index),
+            byte if byte == open => {
+                depth += 1;
+                index += 1;
+            }
+            byte if byte == close => {
+                depth -= 1;
+                index += 1;
+                if depth == 0 {
+                    return index;
+                }
+            }
+            _ => index += 1,
+        }
+    }
+    bytes.len()
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct SelfParameterExpansionUses {
+    default_operator: bool,
+    other_read: bool,
+}
+
+fn value_uses_only_self_default_parameter_expansions(value: &str, name: &str) -> bool {
+    let uses = self_parameter_expansion_uses(value, name);
+    uses.default_operator && !uses.other_read
+}
+
+fn self_parameter_expansion_uses(value: &str, name: &str) -> SelfParameterExpansionUses {
+    let bytes = value.as_bytes();
+    let name_bytes = name.as_bytes();
+    let mut uses = SelfParameterExpansionUses::default();
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'\'' => index = skip_single_quoted_assignment_value(bytes, index + 1),
+            b'\\' => index = (index + 2).min(bytes.len()),
+            b'$' => {
+                if bytes.get(index + 1) == Some(&b'{') {
+                    let name_start = index + 2;
+                    let name_end = name_start + name_bytes.len();
+                    if bytes
+                        .get(name_start..name_end)
+                        .is_some_and(|candidate| candidate == name_bytes)
+                        && braced_parameter_name_has_boundary(bytes, name_end)
+                    {
+                        if braced_parameter_tail_starts_default_operator(&bytes[name_end..]) {
+                            uses.default_operator = true;
+                        } else {
+                            uses.other_read = true;
+                        }
+                    }
+                } else {
+                    let name_start = index + 1;
+                    let name_end = name_start + name_bytes.len();
+                    if bytes
+                        .get(name_start..name_end)
+                        .is_some_and(|candidate| candidate == name_bytes)
+                        && bare_parameter_name_has_boundary(bytes, name_end)
+                    {
+                        uses.other_read = true;
+                    }
+                }
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    uses
+}
+
+fn braced_parameter_name_has_boundary(bytes: &[u8], index: usize) -> bool {
+    !bytes
+        .get(index)
+        .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+}
+
+fn bare_parameter_name_has_boundary(bytes: &[u8], index: usize) -> bool {
+    !bytes
+        .get(index)
+        .is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+}
+
+fn braced_parameter_tail_starts_default_operator(tail: &[u8]) -> bool {
+    matches!(
+        tail,
+        [b':', b'-', ..] | [b':', b'=', ..] | [b'-', ..] | [b'=', ..]
+    )
+}
+
+fn report_span_for_binding(binding: &Binding) -> Span {
+    match binding.origin {
+        BindingOrigin::LoopVariable {
+            definition_span, ..
+        }
+        | BindingOrigin::Assignment {
+            definition_span, ..
+        }
+        | BindingOrigin::ParameterDefaultAssignment { definition_span }
+        | BindingOrigin::Imported { definition_span }
+        | BindingOrigin::FunctionDefinition { definition_span }
+        | BindingOrigin::BuiltinTarget {
+            definition_span, ..
+        }
+        | BindingOrigin::Declaration { definition_span }
+        | BindingOrigin::Nameref { definition_span } => definition_span,
+        BindingOrigin::ArithmeticAssignment { target_span, .. } => target_span,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_repeated_top_level_assignments_and_function_reassignments() {
+        let source = "\
+#!/bin/bash
+count=0
+count=1
+refresh() {
+  count=2
+}
+refresh
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["count", "count"]
+        );
+    }
+
+    #[test]
+    fn ignores_single_top_level_assignments() {
+        let source = "#!/bin/bash\ncount=0\necho \"$count\"\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_readonly_globals() {
+        let source = "\
+#!/bin/bash
+readonly COUNT=0
+declare -r NAME=demo
+show() {
+  echo \"$COUNT\" \"$NAME\"
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_function_local_shadowing() {
+        let source = "\
+#!/bin/bash
+value=0
+update() {
+  local value
+  value=1
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_function_assignment_when_prior_local_declaration_is_not_guaranteed() {
+        let source = "\
+#!/bin/bash
+value=0
+update() {
+  if [[ $make_local ]]; then
+    local value
+  fi
+  value=1
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "value");
+        assert_eq!(diagnostics[0].span.start.line, 7);
+    }
+
+    #[test]
+    fn reports_function_assignment_when_prior_local_declaration_is_unreachable() {
+        let source = "\
+#!/bin/bash
+value=0
+update() {
+  if [[ $stop ]]; then
+    return
+    local value
+  fi
+  value=1
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "value");
+        assert_eq!(diagnostics[0].span.start.line, 8);
+    }
+
+    #[test]
+    fn ignores_branch_local_assignment_after_branch_local_declaration() {
+        let source = "\
+#!/bin/bash
+value=0
+update() {
+  if [[ $make_local ]]; then
+    local value
+    value=1
+  fi
+}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn allows_conditional_default_initializers_by_default() {
+        let source = "\
+#!/bin/bash
+mode=dev
+mode=${mode:-prod}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_self_referential_parameter_rewrites() {
+        let source = "\
+#!/bin/bash
+mode=dev
+mode=${mode#dev}
+path=${path:-/tmp}
+path=${path%/}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["mode", "path"]
+        );
+    }
+
+    #[test]
+    fn reports_mixed_self_default_and_rewrite_assignments() {
+        let source = "\
+#!/bin/bash
+mode=dev
+mode=${mode#d}${mode:-prod}
+path=old
+path=${path:-/tmp}${other:-$path}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["mode", "path"]
+        );
+    }
+
+    #[test]
+    fn ignores_default_operators_in_trailing_comments() {
+        let source = "\
+#!/bin/bash
+mode=dev
+mode=${mode#dev} # ${mode:-prod}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "mode");
+        assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
+    fn allows_conditional_default_initializers_after_quoted_or_substitution_semicolons() {
+        let source = "\
+#!/bin/bash
+mode=dev
+mode=\"x;${mode:-prod}\"
+path=old
+path=\"$(printf '%s;' value)${path:-/tmp}\"
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn still_ignores_default_operators_after_real_assignment_terminators() {
+        let source = "\
+#!/bin/bash
+mode=dev
+mode=${mode#dev}; echo ${mode:-prod}
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "mode");
+        assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
+    fn option_can_report_conditional_default_initializers() {
+        let source = "\
+#!/bin/bash
+mode=dev
+mode=${mode:-prod}
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MutableGlobal).with_c159_allow_conditional_init(false),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "mode");
+    }
+
+    #[test]
+    fn later_assignment_after_conditional_baseline_is_reported() {
+        let source = "\
+#!/bin/bash
+mode=${mode:-dev}
+mode=prod
+";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::MutableGlobal));
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "mode");
+        assert_eq!(diagnostics[0].span.start.line, 3);
+    }
+
+    #[test]
+    fn ignores_other_shells() {
+        let source = "\
+#!/bin/sh
+count=0
+count=1
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::MutableGlobal).with_shell(ShellDialect::Sh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C159_C159.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C159_C159.sh.snap
@@ -1,0 +1,26 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C159 global variable `count` is written more than once; make it readonly or keep later writes local
+ --> <source>:4:1
+  |
+4 | count=1
+  |
+
+C159 global variable `mode` is written more than once; make it readonly or keep later writes local
+ --> <source>:7:1
+  |
+7 | mode=prod
+  |
+
+C159 global variable `mode` is written more than once; make it readonly or keep later writes local
+ --> <source>:8:1
+  |
+8 | mode=${mode#d}${mode:-prod}
+  |
+
+C159 global variable `count` is written more than once; make it readonly or keep later writes local
+  --> <source>:11:3
+   |
+11 |   count=2
+   |

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -11,7 +11,8 @@ use shuck_semantic::{UnreachedFunctionAnalysisOptions, UnusedAssignmentAnalysisO
 use crate::ambient_contracts::ResolvedAmbientContracts;
 use crate::{Category, Rule, RuleSelector, RuleSet, Severity, ShellDialect};
 
-const DEFAULT_DISABLED_NON_STYLE_RULES: &[Rule] = &[Rule::ImplicitGlobalInFunction];
+const DEFAULT_DISABLED_NON_STYLE_RULES: &[Rule] =
+    &[Rule::ImplicitGlobalInFunction, Rule::MutableGlobal];
 
 /// Per-rule behavior overrides applied during lint analysis.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -26,6 +27,8 @@ pub struct LinterRuleOptions {
     pub s085: S085RuleOptions,
     /// Behavior overrides for `C158`.
     pub c158: C158RuleOptions,
+    /// Behavior overrides for `C159`.
+    pub c159: C159RuleOptions,
 }
 
 /// Behavior overrides for `C001` unused-assignment analysis.
@@ -101,7 +104,6 @@ impl Default for S085RuleOptions {
         }
     }
 }
-
 /// Behavior overrides for `C158` implicit global assignment analysis.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct C158RuleOptions {
@@ -119,6 +121,22 @@ impl Default for C158RuleOptions {
         }
     }
 }
+
+/// Behavior overrides for `C159` mutable-global analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct C159RuleOptions {
+    /// Whether self-referential default initializers such as `name=${name:-value}` are allowed.
+    pub allow_conditional_init: bool,
+}
+
+impl Default for C159RuleOptions {
+    fn default() -> Self {
+        Self {
+            allow_conditional_init: true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinterSettings {
     pub rules: RuleSet,
@@ -335,7 +353,6 @@ impl LinterSettings {
         self.rule_options.s085.main_name = value.into();
         self
     }
-
     pub fn with_c158_treat_readonly_as_documented(mut self, value: bool) -> Self {
         self.rule_options.c158.treat_readonly_as_documented = value;
         self
@@ -343,6 +360,11 @@ impl LinterSettings {
 
     pub fn with_c158_treat_export_as_intentional(mut self, value: bool) -> Self {
         self.rule_options.c158.treat_export_as_intentional = value;
+        self
+    }
+
+    pub fn with_c159_allow_conditional_init(mut self, value: bool) -> Self {
+        self.rule_options.c159.allow_conditional_init = value;
         self
     }
 
@@ -471,6 +493,7 @@ mod tests {
         assert!(defaults.contains(Rule::ConstantCaseSubject));
         assert!(defaults.contains(Rule::RmGlobOnVariablePath));
         assert!(!defaults.contains(Rule::ImplicitGlobalInFunction));
+        assert!(!defaults.contains(Rule::MutableGlobal));
         assert!(!defaults.contains(Rule::AmpersandSemicolon));
     }
 

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -4261,10 +4261,10 @@
       "bash"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- Add C159 as a default-disabled Bash correctness rule for mutable globals written more than once at file scope or written from functions after a file-scope assignment.
- Add the `allow-conditional-init` option across linter settings, config parsing, and check cache keys.
- Add unit coverage plus the C159 fixture/snapshot, and keep the packaging smoke script compatible with `make check`.

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter mutable_global`
- `cargo test -p shuck-linter default_rules`
- `cargo test -p shuck-config c159`
- `INSTA_UPDATE=always cargo test -p shuck-linter rule_mutableglobal_path_new_c159_sh_expects`
- `cargo test -p shuck-linter rule_mutableglobal_path_new_c159_sh_expects`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C159`
- `make check`