### PR TITLE
feat(linter): implement C160 unanchored source paths

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -65,6 +65,7 @@ struct EffectiveRuleOptions {
     c158_treat_readonly_as_documented: bool,
     c158_treat_export_as_intentional: bool,
     c159_allow_conditional_init: bool,
+    c160_allowed_anchors: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -194,6 +195,7 @@ impl EffectiveRuleOptions {
             c158_treat_readonly_as_documented: rule_options.c158.treat_readonly_as_documented,
             c158_treat_export_as_intentional: rule_options.c158.treat_export_as_intentional,
             c159_allow_conditional_init: rule_options.c159.allow_conditional_init,
+            c160_allowed_anchors: rule_options.c160.allowed_anchors.clone(),
         }
     }
 }
@@ -215,6 +217,7 @@ impl CacheKey for EffectiveRuleOptions {
         self.c158_treat_readonly_as_documented.cache_key(state);
         self.c158_treat_export_as_intentional.cache_key(state);
         self.c159_allow_conditional_init.cache_key(state);
+        self.c160_allowed_anchors.cache_key(state);
     }
 }
 
@@ -1042,6 +1045,14 @@ fn linter_rule_options_for_lint_config(lint: &LintConfig) -> shuck_linter::Linte
         .and_then(|c159| c159.allow_conditional_init)
     {
         rule_options.c159.allow_conditional_init = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.c160.as_ref())
+        .and_then(|c160| c160.allowed_anchors.as_ref())
+    {
+        rule_options.c160.allowed_anchors = value.clone();
     }
 
     rule_options

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -61,7 +61,7 @@ const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "entrypoints",
 ];
 const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] =
-    &["c001", "c063", "s084", "s085", "c158", "c159"];
+    &["c001", "c063", "s084", "s085", "c158", "c159", "c160"];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
 const CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS: &[&str] = &["report-unreached-nested-definitions"];
@@ -81,6 +81,7 @@ const CONFIG_OVERRIDE_C158_RULE_OPTION_KEYS: &[&str] = &[
     "treat-export-as-intentional",
 ];
 const CONFIG_OVERRIDE_C159_RULE_OPTION_KEYS: &[&str] = &["allow-conditional-init"];
+const CONFIG_OVERRIDE_C160_RULE_OPTION_KEYS: &[&str] = &["allowed-anchors"];
 const CONFIG_OVERRIDE_RUN_KEYS: &[&str] = &["shell", "shell-version", "shells"];
 const CONFIG_OVERRIDE_RUN_SHELL_NAMES: &[&str] =
     &["bash", "gbash", "bashkit", "zsh", "dash", "mksh", "busybox"];
@@ -341,6 +342,8 @@ pub struct LintRuleOptionsConfig {
     pub c158: Option<C158RuleOptionsConfig>,
     /// Options for rule C159.
     pub c159: Option<C159RuleOptionsConfig>,
+    /// Options for rule C160.
+    pub c160: Option<C160RuleOptionsConfig>,
 }
 
 impl LintRuleOptionsConfig {
@@ -362,6 +365,9 @@ impl LintRuleOptionsConfig {
         }
         if let Some(c159) = overrides.c159 {
             self.c159.get_or_insert_default().apply_overrides(c159);
+        }
+        if let Some(c160) = overrides.c160 {
+            self.c160.get_or_insert_default().apply_overrides(c160);
         }
     }
 }
@@ -489,6 +495,22 @@ impl C159RuleOptionsConfig {
     fn apply_overrides(&mut self, overrides: Self) {
         if overrides.allow_conditional_init.is_some() {
             self.allow_conditional_init = overrides.allow_conditional_init;
+        }
+    }
+}
+
+/// Options for rule C160.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct C160RuleOptionsConfig {
+    /// Variable anchors treated as safe roots for sourced relative paths.
+    pub allowed_anchors: Option<Vec<String>>,
+}
+
+impl C160RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.allowed_anchors.is_some() {
+            self.allowed_anchors = overrides.allowed_anchors;
         }
     }
 }
@@ -869,6 +891,18 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                             default: "true",
                             value_type: "bool",
                             example: "allow-conditional-init = false",
+                        }],
+                        sections: &[],
+                    },
+                    ConfigSectionMetadata {
+                        key: "c160",
+                        docs: "Behavior overrides for `C160` unanchored source path analysis.",
+                        fields: &[ConfigFieldMetadata {
+                            key: "allowed-anchors",
+                            docs: "Path prefix expressions accepted as script-directory anchors for source or dot commands.",
+                            default: r#"["${BASH_SOURCE[0]%/*}", "$(dirname \"$0\")", "$(dirname \"${BASH_SOURCE[0]}\")"]"#,
+                            value_type: "list[string]",
+                            example: r#"allowed-anchors = ["$SCRIPT_DIR"]"#,
                         }],
                         sections: &[],
                     },
@@ -1558,6 +1592,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(c159_value) = rule_options.get("c159") {
         validate_c159_rule_options_override(c159_value)?;
     }
+    if let Some(c160_value) = rule_options.get("c160") {
+        validate_c160_rule_options_override(c160_value)?;
+    }
 
     Ok(())
 }
@@ -1650,6 +1687,22 @@ fn validate_c159_rule_options_override(value: &toml::Value) -> std::result::Resu
             return Err(format!(
                 "unsupported `[lint.rule-options.c159]` option `{key}`; expected one of: {}",
                 CONFIG_OVERRIDE_C159_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_c160_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let c160 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.c160]` must be a TOML table".to_owned())?;
+    for key in c160.keys() {
+        if !CONFIG_OVERRIDE_C160_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.c160]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_C160_RULE_OPTION_KEYS.join(", ")
             ));
         }
     }
@@ -1971,6 +2024,23 @@ mod tests {
     }
 
     #[test]
+    fn inline_config_overrides_validate_supported_c160_rule_option_keys() {
+        let config =
+            parse_config_override("lint.rule-options.c160.allowed-anchors = ['$SCRIPT_DIR']")
+                .unwrap();
+        assert_eq!(
+            config
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.c160.as_ref())
+                .and_then(|c160| c160.allowed_anchors.as_ref())
+                .map(Vec::as_slice),
+            Some(&["$SCRIPT_DIR".to_owned()][..])
+        );
+    }
+
+    #[test]
     fn inline_config_overrides_validate_supported_zsh_plugin_keys() {
         let config = parse_config_override(
             "lint.zsh.plugins.resolution = false\n\
@@ -2081,6 +2151,12 @@ mod tests {
     fn inline_config_overrides_reject_unknown_c159_rule_option_keys() {
         let err = parse_config_override("lint.rule-options.c159.preview = true").unwrap_err();
         assert!(err.contains("unsupported `[lint.rule-options.c159]` option `preview`"));
+    }
+
+    #[test]
+    fn inline_config_overrides_reject_unknown_c160_rule_option_keys() {
+        let err = parse_config_override("lint.rule-options.c160.preview = true").unwrap_err();
+        assert!(err.contains("unsupported `[lint.rule-options.c160]` option `preview`"));
     }
 
     #[test]
@@ -2309,6 +2385,41 @@ mod tests {
                 .and_then(|options| options.c159.as_ref())
                 .and_then(|c159| c159.allow_conditional_init),
             Some(true)
+        );
+    }
+
+    #[test]
+    fn c160_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.c160.allowed-anchors = ['$SCRIPT_DIR']",
+                    )
+                    .unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.c160.allowed-anchors = ['$REPO_ROOT']",
+                    )
+                    .unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.c160.as_ref())
+                .and_then(|c160| c160.allowed_anchors.as_ref())
+                .map(Vec::as_slice),
+            Some(&["$REPO_ROOT".to_owned()][..])
         );
     }
 

--- a/crates/shuck-linter/resources/test/fixtures/correctness/C160.sh
+++ b/crates/shuck-linter/resources/test/fixtures/correctness/C160.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+source ./lib.sh
+. ../env.sh
+source "lib/defaults.sh"
+
+source "${BASH_SOURCE[0]%/*}/anchored.sh"
+source ${BASH_SOURCE[0]%/*}"/split-anchored.sh"
+source "$(dirname "$0")/also-anchored.sh"
+source /etc/profile
+source ~alice/profile
+source "$(select_source_file)"
+source "${BASH_SOURCE[0]%/*}suffix/not-anchored.sh"
+source '${BASH_SOURCE[0]%/*}/single-quoted.sh'
+# shellcheck source=./helper.sh
+source '$(select_source_file)'
+source ~${USER}/dynamic-home.sh

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -403,6 +403,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::UntrackedSourceFile) {
             rules::correctness::untracked_source_file::untracked_source_file(self);
         }
+        if self.is_rule_enabled(Rule::UnanchoredSourcePath) {
+            rules::correctness::unanchored_source_path::unanchored_source_path(self);
+        }
     }
 
     fn check_command_facts(&mut self) {

--- a/crates/shuck-linter/src/facts/mod.rs
+++ b/crates/shuck-linter/src/facts/mod.rs
@@ -32,6 +32,7 @@ pub(crate) mod pipelines;
 mod presence;
 pub(crate) mod redirects;
 pub(crate) mod simple_tests;
+pub(crate) mod source_paths;
 pub(crate) mod statements;
 pub(crate) mod substitutions;
 pub(crate) mod surface;

--- a/crates/shuck-linter/src/facts/source_paths.rs
+++ b/crates/shuck-linter/src/facts/source_paths.rs
@@ -1,0 +1,204 @@
+use shuck_semantic::{SourceRef, SourceRefKind};
+
+pub(crate) fn source_ref_has_unanchored_path(
+    source_ref: &SourceRef,
+    source: &str,
+    allowed_anchors: &[String],
+) -> bool {
+    let raw_path = source_ref.path_span.slice(source).trim();
+    let path = strip_outer_quotes(raw_path).trim();
+    let outer_quote = outer_quote(raw_path);
+    if path.is_empty()
+        || (outer_quote != Some('\'') && starts_with_allowed_anchor(path, allowed_anchors))
+        || starts_with_absolute_anchor(path)
+        || starts_with_unquoted_home_anchor(raw_path, path)
+        || (outer_quote != Some('\'') && is_entire_command_substitution(path))
+    {
+        return false;
+    }
+
+    match &source_ref.kind {
+        SourceRefKind::Literal(path) => !path.is_empty(),
+        SourceRefKind::Directive(_) => {
+            if outer_quote == Some('\'') {
+                !path.is_empty()
+            } else {
+                directive_runtime_path_can_be_unanchored(path)
+            }
+        }
+        SourceRefKind::Dynamic | SourceRefKind::SingleVariableStaticTail { .. } => {
+            path_has_static_path_component(path)
+        }
+        SourceRefKind::DirectiveDevNull => {
+            if outer_quote == Some('\'') {
+                !path.is_empty()
+            } else {
+                directive_runtime_path_can_be_unanchored(path)
+            }
+        }
+    }
+}
+
+fn starts_with_allowed_anchor(path: &str, allowed_anchors: &[String]) -> bool {
+    allowed_anchors
+        .iter()
+        .filter(|anchor| !anchor.is_empty())
+        .any(|anchor| {
+            starts_with_anchor_boundary(path, anchor)
+                || starts_with_split_quoted_anchor(path, anchor)
+        })
+}
+
+fn starts_with_anchor_boundary(path: &str, anchor: &str) -> bool {
+    path.strip_prefix(anchor)
+        .is_some_and(anchor_suffix_is_boundary)
+}
+
+fn starts_with_split_quoted_anchor(path: &str, anchor: &str) -> bool {
+    let Some(rest) = path.strip_prefix('"') else {
+        return false;
+    };
+    let Some(after_anchor) = rest.strip_prefix(anchor) else {
+        return false;
+    };
+
+    let Some(after_quote) = after_anchor.strip_prefix('"') else {
+        return false;
+    };
+
+    anchor_suffix_is_boundary(after_quote)
+}
+
+fn anchor_suffix_is_boundary(suffix: &str) -> bool {
+    suffix.is_empty()
+        || suffix.starts_with('/')
+        || suffix
+            .strip_prefix(['"', '\''])
+            .is_some_and(|rest| rest.starts_with('/'))
+}
+
+fn starts_with_absolute_anchor(path: &str) -> bool {
+    path.starts_with('/')
+}
+
+fn starts_with_unquoted_home_anchor(raw_path: &str, path: &str) -> bool {
+    raw_path == path && unquoted_home_anchor_len(path).is_some()
+}
+
+fn unquoted_home_anchor_len(path: &str) -> Option<usize> {
+    let suffix = path.strip_prefix('~')?;
+    if suffix.is_empty() || suffix.starts_with('/') {
+        return Some(1);
+    }
+
+    let user_end = suffix.find('/').unwrap_or(suffix.len());
+    let user = &suffix[..user_end];
+    if user.is_empty()
+        || user.starts_with(['+', '-'])
+        || user.as_bytes().first().is_some_and(u8::is_ascii_digit)
+        || !user
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.'))
+    {
+        return None;
+    }
+
+    Some(1 + user_end)
+}
+
+fn path_has_static_path_component(path: &str) -> bool {
+    path.starts_with("./") || path.starts_with("../") || path.contains('/')
+}
+
+fn directive_runtime_path_can_be_unanchored(path: &str) -> bool {
+    !path_has_dynamic_expansion(path) || path_has_static_path_component(path)
+}
+
+fn path_has_dynamic_expansion(path: &str) -> bool {
+    path.contains('$') || path.contains('`')
+}
+
+fn strip_outer_quotes(text: &str) -> &str {
+    if outer_quote(text).is_some() {
+        &text[1..text.len() - 1]
+    } else {
+        text
+    }
+}
+
+fn outer_quote(text: &str) -> Option<char> {
+    let bytes = text.as_bytes();
+    if bytes.len() >= 2
+        && ((bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\''))
+    {
+        Some(bytes[0] as char)
+    } else {
+        None
+    }
+}
+
+fn is_entire_command_substitution(path: &str) -> bool {
+    is_entire_backtick_substitution(path) || is_entire_dollar_paren_substitution(path)
+}
+
+fn is_entire_backtick_substitution(path: &str) -> bool {
+    path.len() >= 2
+        && path.starts_with('`')
+        && path.ends_with('`')
+        && !path[1..path.len() - 1].contains('`')
+}
+
+fn is_entire_dollar_paren_substitution(path: &str) -> bool {
+    if !path.starts_with("$(") {
+        return false;
+    }
+
+    let mut depth = 0usize;
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+    let mut chars = path.char_indices().peekable();
+    while let Some((index, ch)) = chars.next() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+
+        if in_single_quote {
+            if ch == '\'' {
+                in_single_quote = false;
+            }
+            continue;
+        }
+
+        if in_double_quote {
+            match ch {
+                '\\' => escaped = true,
+                '"' => in_double_quote = false,
+                _ => {}
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' if depth > 0 => in_single_quote = true,
+            '"' if depth > 0 => in_double_quote = true,
+            '\\' if depth > 0 => escaped = true,
+            '$' if chars.peek().is_some_and(|(_, next)| *next == '(') => {
+                let _ = chars.next();
+                depth += 1;
+            }
+            '(' if depth > 0 => depth += 1,
+            ')' if depth > 0 => {
+                depth -= 1;
+                if depth == 0 {
+                    return index + ch.len_utf8() == path.len();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    false
+}

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -107,8 +107,8 @@ pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 /// Linter configuration and per-file ignore types.
 pub use settings::{
     AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions, C159RuleOptions,
-    CompiledPerFileIgnoreList, LinterRuleOptions, LinterSettings, PerFileIgnore, S084RuleOptions,
-    S085RuleOptions,
+    C160RuleOptions, CompiledPerFileIgnoreList, LinterRuleOptions, LinterSettings, PerFileIgnore,
+    S084RuleOptions, S085RuleOptions,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -500,6 +500,12 @@ declare_rules! {
         ImplicitGlobalInFunction
     ),
     ("C159", Category::Correctness, Severity::Warning, MutableGlobal),
+    (
+        "C160",
+        Category::Correctness,
+        Severity::Warning,
+        UnanchoredSourcePath
+    ),
     ("P001", Category::Performance, Severity::Warning, ExprArithmetic),
     ("P002", Category::Performance, Severity::Warning, GrepCountPipeline),
     ("P003", Category::Performance, Severity::Warning, SingleTestSubshell),

--- a/crates/shuck-linter/src/rules/correctness/mod.rs
+++ b/crates/shuck-linter/src/rules/correctness/mod.rs
@@ -136,6 +136,7 @@ pub mod template_brace_in_command;
 pub mod tilde_in_string_comparison;
 pub mod trap_string_expansion;
 pub mod truthy_literal_test;
+pub mod unanchored_source_path;
 pub mod unchecked_directory_change;
 pub mod unchecked_directory_change_in_function;
 pub mod undefined_variable;
@@ -309,6 +310,7 @@ mod tests {
     #[test_case(Rule::IfBracketGlued, Path::new("C157.sh"))]
     #[test_case(Rule::ImplicitGlobalInFunction, Path::new("C158.sh"))]
     #[test_case(Rule::MutableGlobal, Path::new("C159.sh"))]
+    #[test_case(Rule::UnanchoredSourcePath, Path::new("C160.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {
         let snapshot = format!("{}_{}", rule.code(), path.display());
         let (diagnostics, source) = test_path(

--- a/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C160_C160.sh.snap
+++ b/crates/shuck-linter/src/rules/correctness/snapshots/shuck_linter__rules__correctness__tests__C160_C160.sh.snap
@@ -1,0 +1,44 @@
+---
+source: crates/shuck-linter/src/rules/correctness/mod.rs
+---
+C160 source path is relative to the current directory; anchor it to the script directory
+ --> <source>:3:8
+  |
+3 | source ./lib.sh
+  |
+
+C160 source path is relative to the current directory; anchor it to the script directory
+ --> <source>:4:3
+  |
+4 | . ../env.sh
+  |
+
+C160 source path is relative to the current directory; anchor it to the script directory
+ --> <source>:5:8
+  |
+5 | source "lib/defaults.sh"
+  |
+
+C160 source path is relative to the current directory; anchor it to the script directory
+  --> <source>:13:8
+   |
+13 | source "${BASH_SOURCE[0]%/*}suffix/not-anchored.sh"
+   |
+
+C160 source path is relative to the current directory; anchor it to the script directory
+  --> <source>:14:8
+   |
+14 | source '${BASH_SOURCE[0]%/*}/single-quoted.sh'
+   |
+
+C160 source path is relative to the current directory; anchor it to the script directory
+  --> <source>:16:8
+   |
+16 | source '$(select_source_file)'
+   |
+
+C160 source path is relative to the current directory; anchor it to the script directory
+  --> <source>:17:8
+   |
+17 | source ~${USER}/dynamic-home.sh
+   |

--- a/crates/shuck-linter/src/rules/correctness/unanchored_source_path.rs
+++ b/crates/shuck-linter/src/rules/correctness/unanchored_source_path.rs
@@ -1,0 +1,345 @@
+use crate::facts::source_paths::source_ref_has_unanchored_path;
+use crate::{Checker, Rule, ShellDialect, Violation};
+
+pub struct UnanchoredSourcePath;
+
+impl Violation for UnanchoredSourcePath {
+    fn rule() -> Rule {
+        Rule::UnanchoredSourcePath
+    }
+
+    fn message(&self) -> String {
+        "source path is relative to the current directory; anchor it to the script directory"
+            .to_owned()
+    }
+}
+
+pub fn unanchored_source_path(checker: &mut Checker) {
+    if checker.shell() != ShellDialect::Bash {
+        return;
+    }
+
+    for source_ref in checker.semantic().source_refs() {
+        if source_ref_has_unanchored_path(
+            source_ref,
+            checker.source(),
+            &checker.rule_options().c160.allowed_anchors,
+        ) {
+            checker.report(UnanchoredSourcePath, source_ref.path_span);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule, ShellDialect};
+
+    #[test]
+    fn reports_literal_relative_source_paths() {
+        let source = "\
+#!/bin/bash
+source ./lib.sh
+. ../tools/env.sh
+source lib/defaults.sh
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["./lib.sh", "../tools/env.sh", "lib/defaults.sh"]
+        );
+    }
+
+    #[test]
+    fn accepts_default_script_directory_anchors() {
+        for source in [
+            "#!/bin/bash\nsource \"${BASH_SOURCE[0]%/*}/lib.sh\"\n",
+            "#!/bin/bash\nsource \"${BASH_SOURCE[0]%/*}\"/lib.sh\n",
+            "#!/bin/bash\nsource ${BASH_SOURCE[0]%/*}\"/lib.sh\"\n",
+            "#!/bin/bash\nsource ${BASH_SOURCE[0]%/*}'/lib.sh'\n",
+            "#!/bin/bash\nsource \"$(dirname \"$0\")/lib.sh\"\n",
+            "#!/bin/bash\nsource \"$(dirname \"$0\")\"/lib.sh\n",
+            "#!/bin/bash\nsource \"$(dirname \"${BASH_SOURCE[0]}\")/lib.sh\"\n",
+            "#!/bin/bash\nsource \"$(dirname \"${BASH_SOURCE[0]}\")\"/lib.sh\n",
+        ] {
+            let diagnostics = test_snippet(
+                source,
+                &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+            );
+
+            assert!(diagnostics.is_empty(), "{source}");
+        }
+    }
+
+    #[test]
+    fn accepts_absolute_home_and_whole_command_substitution_paths() {
+        for source in [
+            "#!/bin/bash\nsource /etc/profile\n",
+            "#!/bin/bash\nsource ~/.bashrc\n",
+            "#!/bin/bash\nsource ~alice/lib.sh\n",
+            "#!/bin/bash\nsource \"$(select_source_file)\"\n",
+            "#!/bin/bash\nsource \"$(printf '%s' '/tmp)')\"\n",
+            "#!/bin/bash\nsource \"$(printf \"%s\" \"/tmp)\")\"\n",
+            "#!/bin/bash\nsource `select_source_file`\n",
+        ] {
+            let diagnostics = test_snippet(
+                source,
+                &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+            );
+
+            assert!(diagnostics.is_empty(), "{source}");
+        }
+    }
+
+    #[test]
+    fn reports_dynamic_tilde_source_paths() {
+        let source = "\
+#!/bin/bash
+source ~${USER}/lib.sh
+source ~$USER/lib.sh
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["~${USER}/lib.sh", "~$USER/lib.sh"]
+        );
+    }
+
+    #[test]
+    fn reports_quoted_home_source_paths() {
+        for source in [
+            "#!/bin/bash\nsource \"~/.bashrc\"\n",
+            "#!/bin/bash\nsource '~/.bashrc'\n",
+        ] {
+            let diagnostics = test_snippet(
+                source,
+                &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+            );
+
+            assert_eq!(
+                diagnostics
+                    .iter()
+                    .map(|diagnostic| diagnostic.span.slice(source))
+                    .collect::<Vec<_>>(),
+                vec![source.lines().nth(1).unwrap().split_once(' ').unwrap().1]
+            );
+        }
+    }
+
+    #[test]
+    fn reports_dynamic_path_prefixes_with_static_path_tails() {
+        let source = "\
+#!/bin/bash
+source \"$SCRIPT_DIR/lib.sh\"
+source \"$(pwd)/lib.sh\"
+source '${BASH_SOURCE[0]%/*}/lib.sh'
+source '${BASH_SOURCE[0]%/*}'/lib.sh
+source \"${BASH_SOURCE[0]%/*}suffix/lib.sh\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "\"$SCRIPT_DIR/lib.sh\"",
+                "\"$(pwd)/lib.sh\"",
+                "'${BASH_SOURCE[0]%/*}/lib.sh'",
+                "'${BASH_SOURCE[0]%/*}'/lib.sh",
+                "\"${BASH_SOURCE[0]%/*}suffix/lib.sh\""
+            ]
+        );
+    }
+
+    #[test]
+    fn reports_single_quoted_command_substitution_text() {
+        let source = "#!/bin/bash\nsource '$(select_source_file)'\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "'$(select_source_file)'");
+    }
+
+    #[test]
+    fn custom_allowed_anchors_accept_project_specific_prefixes() {
+        let source =
+            "#!/bin/bash\nsource \"$SCRIPT_DIR/lib.sh\"\nsource \"$SCRIPT_DIR\"/other.sh\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath)
+                .with_c160_allowed_anchors(["$SCRIPT_DIR"]),
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:#?}");
+    }
+
+    #[test]
+    fn custom_allowed_anchors_require_boundaries() {
+        let source = "\
+#!/bin/bash
+source \"$SCRIPT_DIR/lib.sh\"
+source \"$SCRIPT_DIRECTORY/lib.sh\"
+source \"$SCRIPT_DIR\"suffix/lib.sh
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath)
+                .with_c160_allowed_anchors(["$SCRIPT_DIR"]),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "\"$SCRIPT_DIRECTORY/lib.sh\"",
+                "\"$SCRIPT_DIR\"suffix/lib.sh"
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_dynamic_paths_without_static_path_components() {
+        let source = "#!/bin/bash\nsource \"$helper\"\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_dynamic_paths_without_static_components_even_with_source_directive() {
+        let source = "\
+#!/bin/bash
+# shellcheck source=./helper.sh
+source \"$helper\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn reports_single_quoted_dynamic_text_even_with_source_directive() {
+        let source = "\
+#!/bin/bash
+# shellcheck source=./helper.sh
+source '$(select_source_file)'
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "'$(select_source_file)'");
+    }
+
+    #[test]
+    fn still_reports_static_runtime_paths_with_source_directives() {
+        let source = "\
+#!/bin/bash
+# shellcheck source=./helper.sh
+source ./runtime.sh
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "./runtime.sh");
+    }
+
+    #[test]
+    fn still_reports_static_runtime_paths_with_empty_source_directives() {
+        let source = "\
+#!/bin/bash
+# shellcheck source=
+source ./runtime.sh
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].span.slice(source), "./runtime.sh");
+    }
+
+    #[test]
+    fn still_reports_static_runtime_paths_with_dev_null_source_directives() {
+        let source = "\
+#!/bin/bash
+# shellcheck source=/dev/null
+source ./runtime.sh
+. ../runtime.sh
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["./runtime.sh", "../runtime.sh"]
+        );
+    }
+
+    #[test]
+    fn ignores_pure_dynamic_paths_with_dev_null_source_directives() {
+        let source = "\
+#!/bin/bash
+# shellcheck source=/dev/null
+source \"$helper\"
+";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn ignores_non_bash_shells() {
+        let source = "#!/bin/sh\n. ./lib.sh\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::UnanchoredSourcePath).with_shell(ShellDialect::Sh),
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+}

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -11,8 +11,16 @@ use shuck_semantic::{UnreachedFunctionAnalysisOptions, UnusedAssignmentAnalysisO
 use crate::ambient_contracts::ResolvedAmbientContracts;
 use crate::{Category, Rule, RuleSelector, RuleSet, Severity, ShellDialect};
 
-const DEFAULT_DISABLED_NON_STYLE_RULES: &[Rule] =
-    &[Rule::ImplicitGlobalInFunction, Rule::MutableGlobal];
+const DEFAULT_DISABLED_NON_STYLE_RULES: &[Rule] = &[
+    Rule::ImplicitGlobalInFunction,
+    Rule::MutableGlobal,
+    Rule::UnanchoredSourcePath,
+];
+const DEFAULT_C160_ALLOWED_ANCHORS: &[&str] = &[
+    "${BASH_SOURCE[0]%/*}",
+    "$(dirname \"$0\")",
+    "$(dirname \"${BASH_SOURCE[0]}\")",
+];
 
 /// Per-rule behavior overrides applied during lint analysis.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -29,6 +37,8 @@ pub struct LinterRuleOptions {
     pub c158: C158RuleOptions,
     /// Behavior overrides for `C159`.
     pub c159: C159RuleOptions,
+    /// Behavior overrides for `C160`.
+    pub c160: C160RuleOptions,
 }
 
 /// Behavior overrides for `C001` unused-assignment analysis.
@@ -133,6 +143,24 @@ impl Default for C159RuleOptions {
     fn default() -> Self {
         Self {
             allow_conditional_init: true,
+        }
+    }
+}
+
+/// Behavior overrides for `C160` unanchored source path analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct C160RuleOptions {
+    /// Path prefix expressions accepted as script-directory anchors.
+    pub allowed_anchors: Vec<String>,
+}
+
+impl Default for C160RuleOptions {
+    fn default() -> Self {
+        Self {
+            allowed_anchors: DEFAULT_C160_ALLOWED_ANCHORS
+                .iter()
+                .map(|anchor| (*anchor).to_owned())
+                .collect(),
         }
     }
 }
@@ -368,6 +396,15 @@ impl LinterSettings {
         self
     }
 
+    pub fn with_c160_allowed_anchors<I, S>(mut self, anchors: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.rule_options.c160.allowed_anchors = anchors.into_iter().map(Into::into).collect();
+        self
+    }
+
     pub fn per_file_ignored_rules(&self, path: Option<&Path>) -> RuleSet {
         path.map_or(RuleSet::EMPTY, |path| {
             self.per_file_ignores.ignored_rules(path)
@@ -494,6 +531,7 @@ mod tests {
         assert!(defaults.contains(Rule::RmGlobOnVariablePath));
         assert!(!defaults.contains(Rule::ImplicitGlobalInFunction));
         assert!(!defaults.contains(Rule::MutableGlobal));
+        assert!(!defaults.contains(Rule::UnanchoredSourcePath));
         assert!(!defaults.contains(Rule::AmpersandSemicolon));
     }
 

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -4291,10 +4291,10 @@
       "bash"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- Add C160 as a default-disabled Bash correctness rule for source/dot paths that are relative to the caller's current directory instead of anchored to the script directory.
- Add configurable `allowed-anchors` wiring across linter settings, config parsing, and check cache keys.
- Add focused unit coverage plus the C160 fixture/snapshot, and keep the packaging smoke script compatible with `make check`.

## Validation
- `cargo fmt --check`
- `cargo test -p shuck-linter unanchored_source_path`
- `cargo test -p shuck-linter default_rules`
- `cargo test -p shuck-config c160`
- `INSTA_UPDATE=always cargo test -p shuck-linter rule_unanchoredsourcepath_path_new_c160_sh_expects`
- `cargo test -p shuck-linter rule_unanchoredsourcepath_path_new_c160_sh_expects`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=C160`
- `make check`