### PR TITLE
feat(linter): add K006 rm rootish target rule

### DIFF
--- a/crates/shuck-linter/resources/test/fixtures/security/K006.sh
+++ b/crates/shuck-linter/resources/test/fixtures/security/K006.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+rm -rf "$HOME"/*
+rm -rf "$HOME"/**
+rm -rf /
+rm -rf /**
+rm -rf /..
+rm -rf /../*
+rm -rf ~
+rm -rf ~/**
+rm -rf ~0
+rm -rf "$HOME"/..

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -409,6 +409,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::RmGlobOnVariablePath) {
             rules::security::rm_glob_on_variable_path::rm_glob_on_variable_path(self);
         }
+        if self.is_rule_enabled(Rule::RmRootishTarget) {
+            rules::security::rm_rootish_target::rm_rootish_target(self);
+        }
         if self.is_rule_enabled(Rule::SshLocalExpansion) {
             rules::security::ssh_local_expansion::ssh_local_expansion(self);
         }

--- a/crates/shuck-linter/src/facts/command_options/mod.rs
+++ b/crates/shuck-linter/src/facts/command_options/mod.rs
@@ -200,13 +200,25 @@ impl<'a> UnsetOperandFact<'a> {
 pub(crate) struct UnsetArraySubscriptFact;
 
 #[derive(Debug, Clone)]
-pub struct RmCommandFacts {
+pub struct RmCommandFacts<'a> {
     dangerous_path_spans: Box<[Span]>,
+    rootish_path_words: Box<[&'a Word]>,
+    rootish_path_spans: OnceLock<Box<[Span]>>,
 }
 
-impl RmCommandFacts {
+impl RmCommandFacts<'_> {
     pub fn dangerous_path_spans(&self) -> &[Span] {
         &self.dangerous_path_spans
+    }
+
+    pub fn rootish_path_spans(&self, source: &str) -> &[Span] {
+        self.rootish_path_spans.get_or_init(|| {
+            self.rootish_path_words
+                .iter()
+                .filter_map(|word| rm_path_is_rootish(word, source).then_some(word.span))
+                .collect::<Vec<_>>()
+                .into_boxed_slice()
+        })
     }
 }
 
@@ -612,7 +624,7 @@ pub struct SudoFamilyCommandFacts {
 
 #[derive(Debug, Clone, Default)]
 pub struct CommandOptionFacts<'a> {
-    rm: Option<RmCommandFacts>,
+    rm: Option<RmCommandFacts<'a>>,
     ssh: Option<SshCommandFacts>,
     read: Option<ReadCommandFacts>,
     su: Option<SuCommandFacts>,
@@ -648,7 +660,7 @@ impl<'facts, 'a> CommandOptionFactsRef<'facts, 'a> {
         Self { inner }
     }
 
-    pub fn rm(self) -> Option<&'facts RmCommandFacts> {
+    pub fn rm(self) -> Option<&'facts RmCommandFacts<'a>> {
         self.inner.and_then(CommandOptionFacts::rm)
     }
 
@@ -748,7 +760,7 @@ impl<'facts, 'a> CommandOptionFactsRef<'facts, 'a> {
 }
 
 impl<'a> CommandOptionFacts<'a> {
-    pub fn rm(&self) -> Option<&RmCommandFacts> {
+    pub fn rm(&self) -> Option<&RmCommandFacts<'a>> {
         self.rm.as_ref()
     }
 
@@ -1055,7 +1067,7 @@ fn is_tr_option(text: &str) -> bool {
             .all(|byte| matches!(byte, b'c' | b'C' | b'd' | b's' | b't'))
 }
 
-fn parse_rm_command(args: &[&Word], source: &str) -> Option<RmCommandFacts> {
+fn parse_rm_command<'a>(args: &[&'a Word], source: &str) -> Option<RmCommandFacts<'a>> {
     let mut index = 0usize;
     let mut recursive = false;
 
@@ -1091,9 +1103,16 @@ fn parse_rm_command(args: &[&Word], source: &str) -> Option<RmCommandFacts> {
         .iter()
         .flat_map(|word| std::iter::repeat_n(word.span, rm_path_danger_count(word, source)))
         .collect::<Vec<_>>();
+    let rootish_path_words = args[index..]
+        .iter()
+        .copied()
+        .filter(|word| rm_path_may_be_rootish(word, source))
+        .collect::<Vec<_>>();
 
-    (!dangerous_path_spans.is_empty()).then_some(RmCommandFacts {
+    (!dangerous_path_spans.is_empty() || !rootish_path_words.is_empty()).then_some(RmCommandFacts {
         dangerous_path_spans: dangerous_path_spans.into_boxed_slice(),
+        rootish_path_words: rootish_path_words.into_boxed_slice(),
+        rootish_path_spans: OnceLock::new(),
     })
 }
 
@@ -1131,7 +1150,9 @@ fn rm_path_danger_count(word: &Word, source: &str) -> usize {
 
 #[derive(Debug, Default)]
 struct RmPathSegment {
-    has_unsafe_param: bool,
+    unsafe_param_count: usize,
+    unsafe_home_param_count: usize,
+    home_param_count: usize,
     has_literal_text: bool,
     has_other_dynamic: bool,
     text: String,
@@ -1169,23 +1190,36 @@ fn append_rm_path_part(
             current_rm_path_segment(segments).has_other_dynamic = true;
         }
         WordPart::DoubleQuoted { parts, .. } => append_rm_path_segments(segments, parts, source),
-        WordPart::Variable(_) => {
-            current_rm_path_segment(segments).has_unsafe_param = true;
+        WordPart::Variable(name) => {
+            mark_rm_path_unsafe_parameter(segments, name.as_str() == "HOME");
         }
         WordPart::Parameter(parameter) => {
-            if rm_path_parameter_expansion_is_unsafe(parameter) {
-                current_rm_path_segment(segments).has_unsafe_param = true;
+            if rm_path_parameter_expansion_is_guarded_home_access(parameter) {
+                mark_rm_path_home_parameter(segments);
+            } else if rm_path_parameter_expansion_is_unsafe(parameter) {
+                mark_rm_path_unsafe_parameter(
+                    segments,
+                    rm_path_parameter_expansion_is_home_access(parameter, source),
+                );
             } else {
                 current_rm_path_segment(segments).has_other_dynamic = true;
             }
         }
         WordPart::ParameterExpansion {
+            reference,
             operator,
             colon_variant: _,
             ..
         } => {
-            if rm_path_parameter_op_is_unsafe(operator) {
-                current_rm_path_segment(segments).has_unsafe_param = true;
+            let is_guarded_home = rm_path_parameter_op_is_guarded_home_access(reference, operator);
+            if is_guarded_home {
+                mark_rm_path_home_parameter(segments);
+            } else if rm_path_parameter_op_is_unsafe(operator) {
+                mark_rm_path_unsafe_parameter(
+                    segments,
+                    rm_var_ref_is_home(reference)
+                        && rm_path_parameter_op_preserves_home_root(operator, source),
+                );
             } else {
                 current_rm_path_segment(segments).has_other_dynamic = true;
             }
@@ -1208,6 +1242,19 @@ fn append_rm_path_part(
     }
 }
 
+fn mark_rm_path_unsafe_parameter(segments: &mut [RmPathSegment], is_home: bool) {
+    let segment = current_rm_path_segment(segments);
+    segment.unsafe_param_count += 1;
+    if is_home {
+        segment.unsafe_home_param_count += 1;
+        segment.home_param_count += 1;
+    }
+}
+
+fn mark_rm_path_home_parameter(segments: &mut [RmPathSegment]) {
+    current_rm_path_segment(segments).home_param_count += 1;
+}
+
 fn rm_path_parameter_expansion_is_unsafe(parameter: &ParameterExpansion) -> bool {
     match &parameter.syntax {
         ParameterExpansionSyntax::Bourne(syntax) => match syntax {
@@ -1220,8 +1267,13 @@ fn rm_path_parameter_expansion_is_unsafe(parameter: &ParameterExpansion) -> bool
             } => operator
                 .as_deref()
                 .is_none_or(rm_path_parameter_op_is_unsafe),
-            BourneParameterExpansion::Operation { operator, .. } => {
+            BourneParameterExpansion::Operation {
+                reference,
+                operator,
+                ..
+            } => {
                 rm_path_parameter_op_is_unsafe(operator)
+                    && !rm_path_parameter_op_is_guarded_home_access(reference, operator)
             }
             BourneParameterExpansion::Length { .. }
             | BourneParameterExpansion::Indices { .. }
@@ -1231,6 +1283,55 @@ fn rm_path_parameter_expansion_is_unsafe(parameter: &ParameterExpansion) -> bool
         },
         ParameterExpansionSyntax::Zsh(_) => false,
     }
+}
+
+fn rm_path_parameter_expansion_is_home_access(
+    parameter: &ParameterExpansion,
+    source: &str,
+) -> bool {
+    match &parameter.syntax {
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Access { reference }) => {
+            rm_var_ref_is_home(reference)
+        }
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+            reference,
+            operator,
+            ..
+        }) => {
+            rm_path_parameter_op_is_guarded_home_access(reference, operator)
+                || rm_var_ref_is_home(reference)
+                    && rm_path_parameter_op_preserves_home_root(operator, source)
+        }
+        ParameterExpansionSyntax::Bourne(_) | ParameterExpansionSyntax::Zsh(_) => false,
+    }
+}
+
+fn rm_path_parameter_expansion_is_guarded_home_access(parameter: &ParameterExpansion) -> bool {
+    matches!(
+        &parameter.syntax,
+        ParameterExpansionSyntax::Bourne(BourneParameterExpansion::Operation {
+            reference,
+            operator,
+            ..
+        }) if rm_path_parameter_op_is_guarded_home_access(reference, operator)
+    )
+}
+
+fn rm_path_parameter_op_preserves_home_root(operator: &ParameterOp, source: &str) -> bool {
+    match operator {
+        ParameterOp::RemoveSuffixShort { pattern } | ParameterOp::RemoveSuffixLong { pattern } => {
+            matches!(pattern.render(source).as_str(), "" | "/")
+        }
+        _ => false,
+    }
+}
+
+fn rm_var_ref_is_home(reference: &VarRef) -> bool {
+    reference.name.as_str() == "HOME" && reference.subscript.is_none()
+}
+
+fn rm_path_parameter_op_is_guarded_home_access(reference: &VarRef, operator: &ParameterOp) -> bool {
+    rm_var_ref_is_home(reference) && matches!(operator, ParameterOp::Error)
 }
 
 fn rm_path_parameter_op_is_unsafe(operator: &ParameterOp) -> bool {
@@ -1261,10 +1362,22 @@ fn current_rm_path_segment(segments: &mut [RmPathSegment]) -> &mut RmPathSegment
 }
 
 fn rm_path_segment_is_empty(segment: &RmPathSegment) -> bool {
-    !segment.has_unsafe_param
+    segment.unsafe_param_count == 0
         && !segment.has_literal_text
         && !segment.has_other_dynamic
         && segment.text.is_empty()
+}
+
+fn rm_path_segment_is_root_equivalent_tail(
+    segment: &RmPathSegment,
+    dotdot_is_root_equivalent: bool,
+) -> bool {
+    rm_path_segment_is_empty(segment)
+        || (segment.unsafe_param_count == 0 && !segment.has_other_dynamic && segment.text == ".")
+        || (dotdot_is_root_equivalent
+            && segment.unsafe_param_count == 0
+            && !segment.has_other_dynamic
+            && segment.text == "..")
 }
 
 fn rm_path_has_absolute_root(segments: &[RmPathSegment]) -> bool {
@@ -1276,7 +1389,113 @@ fn rm_word_has_explicit_trailing_separator(word: &Word, source: &str) -> bool {
 }
 
 fn rm_path_segment_is_pure_unsafe_parameter(segment: &RmPathSegment) -> bool {
-    segment.has_unsafe_param && !segment.has_literal_text && !segment.has_other_dynamic
+    segment.unsafe_param_count > 0 && !segment.has_literal_text && !segment.has_other_dynamic
+}
+
+fn rm_path_is_rootish(word: &Word, source: &str) -> bool {
+    let segments = rm_path_segments(word, source);
+    if segments.is_empty() {
+        return false;
+    }
+    let has_unquoted_glob = rm_word_has_unquoted_glob_pattern(word, source);
+
+    if rm_path_has_absolute_root(&segments) {
+        return rm_path_tail_is_rootish(&segments[1..], has_unquoted_glob, true);
+    }
+
+    let Some((root, tail)) = segments.split_first() else {
+        return false;
+    };
+
+    (rm_path_segment_is_home_parameter_root(root)
+        || rm_path_segment_is_unquoted_home_tilde(root, word, source))
+        && rm_path_tail_is_rootish(tail, has_unquoted_glob, false)
+}
+
+fn rm_path_may_be_rootish(word: &Word, source: &str) -> bool {
+    let text = word.span.slice(source);
+    text.contains('/') || text.contains('~') || text.contains("HOME") || text.contains('*')
+}
+
+fn rm_word_has_unquoted_glob_pattern(word: &Word, source: &str) -> bool {
+    !word_spans::word_unquoted_glob_pattern_spans(word, source).is_empty()
+}
+
+fn rm_path_segment_is_home_parameter_root(segment: &RmPathSegment) -> bool {
+    segment.home_param_count == 1
+        && segment.unsafe_param_count == segment.unsafe_home_param_count
+        && !segment.has_literal_text
+        && !segment.has_other_dynamic
+        && segment.text.is_empty()
+}
+
+fn rm_path_segment_is_unquoted_home_tilde(
+    segment: &RmPathSegment,
+    word: &Word,
+    source: &str,
+) -> bool {
+    word.span.slice(source).starts_with('~')
+        && segment.unsafe_param_count == 0
+        && !segment.has_other_dynamic
+        && rm_tilde_prefix_is_home_root(&segment.text)
+}
+
+fn rm_tilde_prefix_is_home_root(text: &str) -> bool {
+    let Some(suffix) = text.strip_prefix('~') else {
+        return false;
+    };
+
+    if suffix.starts_with(['+', '-']) {
+        return false;
+    }
+
+    if suffix.as_bytes().first().is_some_and(u8::is_ascii_digit) {
+        return false;
+    }
+
+    !suffix.contains(['*', '?', '[', ']', '{', '}'])
+}
+
+fn rm_path_tail_is_rootish(
+    segments: &[RmPathSegment],
+    has_unquoted_glob: bool,
+    dotdot_is_root_equivalent: bool,
+) -> bool {
+    let canonical_segments = canonicalize_rm_path_tail(segments);
+    let mut meaningful_segments = canonical_segments.iter().copied().filter(|segment| {
+        !rm_path_segment_is_root_equivalent_tail(segment, dotdot_is_root_equivalent)
+    });
+
+    match (meaningful_segments.next(), meaningful_segments.next()) {
+        (None, _) => true,
+        (Some(segment), None) => rm_path_segment_is_rootish_wildcard(segment, has_unquoted_glob),
+        (Some(_), Some(_)) => false,
+    }
+}
+
+fn canonicalize_rm_path_tail(segments: &[RmPathSegment]) -> Vec<&RmPathSegment> {
+    let mut stack = Vec::<&RmPathSegment>::new();
+
+    for segment in segments {
+        if rm_path_segment_is_static_text(segment, ".") || rm_path_segment_is_empty(segment) {
+            continue;
+        }
+
+        stack.push(segment);
+    }
+
+    stack
+}
+
+fn rm_path_segment_is_static_text(segment: &RmPathSegment, text: &str) -> bool {
+    segment.unsafe_param_count == 0 && !segment.has_other_dynamic && segment.text == text
+}
+
+fn rm_path_segment_is_rootish_wildcard(segment: &RmPathSegment, has_unquoted_glob: bool) -> bool {
+    has_unquoted_glob
+        && segment.unsafe_param_count == 0
+        && !segment.has_other_dynamic
+        && matches!(segment.text.as_str(), "*" | "**" | ".*")
 }
 
 fn rm_path_tail_text(segments: &[RmPathSegment]) -> String {
@@ -1291,7 +1510,7 @@ const RM_PURE_DYNAMIC_TAIL_COMPONENT: &str = "\u{1f}";
 const RM_MIXED_DYNAMIC_TAIL_PREFIX: &str = "\u{1e}";
 
 fn rm_path_segment_tail_pattern(segment: &RmPathSegment) -> String {
-    if segment.has_unsafe_param || segment.has_other_dynamic {
+    if segment.unsafe_param_count > 0 || segment.has_other_dynamic {
         if segment.text.is_empty() {
             RM_PURE_DYNAMIC_TAIL_COMPONENT.to_owned()
         } else {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -3505,6 +3505,86 @@ rm -rf /usr/share/*
 }
 
 #[test]
+fn rm_command_facts_track_rootish_targets() {
+    let source = "\
+#!/bin/sh
+dir=/tmp
+rm -rf /
+rm -rf /*
+rm -rf /**
+rm -rf /./
+rm -rf /./*
+rm -rf /..
+rm -rf /../*
+rm -rf \"$HOME\"
+rm -rf \"${HOME}\"/*
+rm -rf \"${HOME:?}\"
+rm -rf \"${HOME:?}\"/*
+rm -rf \"$HOME\"/.
+rm -rf \"$HOME\"/./*
+rm -rf ~
+rm -rf ~/*
+rm -rf ~/**
+rm -rf ~/.
+rm -rf ~/./*
+rm -rf ~root/*
+rm -f \"$HOME\"/*
+rm -rf \"$HOME\"/.cache
+rm -rf \"${HOME%/*}\"
+rm -rf \"${HOME%%/*}\"
+rm -rf \"$HOME\"/..
+rm -rf \"$HOME\"/../*
+rm -rf ~/..
+rm -rf ~/../*
+rm -rf ~0
+rm -rf ~1/*
+rm -rf ~/Downloads/*
+rm -rf /tmp/*
+rm -rf /tmp/../*
+rm -rf ~/tmp/../*
+rm -rf ~root/tmp/../*
+rm -rf \"$dir\"/*
+rm -rf \"~\"/*
+rm -rf \"$HOME\"/\"*\"
+";
+
+    with_facts(source, None, |_, facts| {
+        let rm_spans = facts
+            .commands()
+            .iter()
+            .filter_map(|fact| fact.options().rm())
+            .flat_map(|rm| rm.rootish_path_spans(source).iter().copied())
+            .map(|span| span.slice(source))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            rm_spans,
+            vec![
+                "/",
+                "/*",
+                "/**",
+                "/./",
+                "/./*",
+                "/..",
+                "/../*",
+                "\"$HOME\"",
+                "\"${HOME}\"/*",
+                "\"${HOME:?}\"",
+                "\"${HOME:?}\"/*",
+                "\"$HOME\"/.",
+                "\"$HOME\"/./*",
+                "~",
+                "~/*",
+                "~/**",
+                "~/.",
+                "~/./*",
+                "~root/*"
+            ]
+        );
+    });
+}
+
+#[test]
 fn builds_redirect_facts_with_cached_target_analysis() {
     let source = "#!/bin/bash\necho hi 2>&3 >/dev/null >> \"$((i++))\"\necho hi > \"$((i + 1))\"\n";
 

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -569,6 +569,7 @@ declare_rules! {
     ("K002", Category::Security, Severity::Warning, SshLocalExpansion),
     ("K003", Category::Security, Severity::Warning, EvalOnArray),
     ("K004", Category::Security, Severity::Warning, FindExecDirWithShell),
+    ("K006", Category::Security, Severity::Warning, RmRootishTarget),
     ("S001", Category::Style, Severity::Warning, UnquotedExpansion),
     ("S002", Category::Style, Severity::Warning, ReadWithoutRaw),
     ("S003", Category::Style, Severity::Warning, LoopFromCommandOutput),
@@ -790,6 +791,7 @@ pub fn code_to_rule(code: &str) -> Option<Rule> {
         "SH-044" => Some(Rule::RmGlobOnVariablePath),
         "SH-047" => Some(Rule::SshLocalExpansion),
         "SH-151" => Some(Rule::EvalOnArray),
+        "SH-324" => Some(Rule::RmRootishTarget),
         "SH-045" => Some(Rule::ChainedTestBranches),
         "C079" => Some(Rule::ChainedTestBranches),
         "SH-201" => Some(Rule::ChainedTestBranches),
@@ -1132,6 +1134,7 @@ mod tests {
         assert_eq!(code_to_rule("SH-043"), Some(Rule::QuotedBashRegex));
         assert_eq!(code_to_rule("SH-044"), Some(Rule::RmGlobOnVariablePath));
         assert_eq!(code_to_rule("SH-047"), Some(Rule::SshLocalExpansion));
+        assert_eq!(code_to_rule("SH-324"), Some(Rule::RmRootishTarget));
         assert_eq!(code_to_rule("SH-045"), Some(Rule::ChainedTestBranches));
         assert_eq!(code_to_rule("C079"), Some(Rule::ChainedTestBranches));
         assert_eq!(code_to_rule("SH-201"), Some(Rule::ChainedTestBranches));

--- a/crates/shuck-linter/src/rules/security/mod.rs
+++ b/crates/shuck-linter/src/rules/security/mod.rs
@@ -1,6 +1,7 @@
 pub mod eval_on_array;
 pub mod find_execdir_with_shell;
 pub mod rm_glob_on_variable_path;
+pub mod rm_rootish_target;
 pub mod ssh_local_expansion;
 
 #[cfg(test)]
@@ -14,6 +15,7 @@ mod tests {
 
     #[test_case(Rule::FindExecDirWithShell, Path::new("K004.sh"))]
     #[test_case(Rule::RmGlobOnVariablePath, Path::new("K001.sh"))]
+    #[test_case(Rule::RmRootishTarget, Path::new("K006.sh"))]
     #[test_case(Rule::SshLocalExpansion, Path::new("K002.sh"))]
     #[test_case(Rule::EvalOnArray, Path::new("K003.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {

--- a/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
+++ b/crates/shuck-linter/src/rules/security/rm_glob_on_variable_path.rs
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn ignores_guarded_parameter_segments_that_shellcheck_accepts() {
-        let source = "#!/bin/bash\ndir=/tmp\nrm -rf \"$dir/${dev:-does_not_exist}\"\nrm -rf \"${NVM_DIR}/${TEST_VERSION:?}\" .nvmrc\nrm -rf \"${foo:-\"$bar/baz\"}/$1\"/\n";
+        let source = "#!/bin/bash\ndir=/tmp\nrepo=demo\nrm -rf \"$dir/${dev:-does_not_exist}\"\nrm -rf \"${NVM_DIR}/${TEST_VERSION:?}\" .nvmrc\nrm -rf \"${HOME:?}/${repo}\"\nrm -rf \"${foo:-\"$bar/baz\"}/$1\"/\n";
         let diagnostics = test_snippet(
             source,
             &LinterSettings::for_rule(Rule::RmGlobOnVariablePath),

--- a/crates/shuck-linter/src/rules/security/rm_rootish_target.rs
+++ b/crates/shuck-linter/src/rules/security/rm_rootish_target.rs
@@ -1,0 +1,76 @@
+use crate::{Checker, Rule, Violation};
+
+pub struct RmRootishTarget;
+
+impl Violation for RmRootishTarget {
+    fn rule() -> Rule {
+        Rule::RmRootishTarget
+    }
+
+    fn message(&self) -> String {
+        "recursive `rm` targets a root-like directory".to_owned()
+    }
+}
+
+pub fn rm_rootish_target(checker: &mut Checker) {
+    let spans = checker
+        .facts()
+        .command_facts()
+        .structural_commands()
+        .filter(|fact| fact.effective_name_is("rm"))
+        .filter_map(|fact| fact.options().rm())
+        .flat_map(|rm| rm.rootish_path_spans(checker.source()).iter().copied())
+        .collect::<Vec<_>>();
+
+    checker.report_all(spans, || RmRootishTarget);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_recursive_rm_on_root_or_home_roots() {
+        let source = "#!/bin/sh\nrm -rf /\nrm -rf /*\nrm -rf /**\nrm -rf /./\nrm -rf /./*\nrm -rf /..\nrm -rf /../*\nrm -rf \"$HOME\"\nrm -rf \"${HOME}\"/*\nrm -rf \"${HOME}\"/**\nrm -rf \"$HOME\"/.\nrm -rf \"$HOME\"/./*\nrm -rf \"${HOME:?}\"\nrm -rf \"${HOME:?}\"/*\nrm -rf \"${HOME:?}\"/.\nrm -rf ~\nrm -rf ~/*\nrm -rf ~/**\nrm -rf ~/.\nrm -rf ~/./*\nrm -rf ~root/*\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RmRootishTarget));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec![
+                "/",
+                "/*",
+                "/**",
+                "/./",
+                "/./*",
+                "/..",
+                "/../*",
+                "\"$HOME\"",
+                "\"${HOME}\"/*",
+                "\"${HOME}\"/**",
+                "\"$HOME\"/.",
+                "\"$HOME\"/./*",
+                "\"${HOME:?}\"",
+                "\"${HOME:?}\"/*",
+                "\"${HOME:?}\"/.",
+                "~",
+                "~/*",
+                "~/**",
+                "~/.",
+                "~/./*",
+                "~root/*"
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_non_recursive_and_bounded_rm_targets() {
+        let source = "#!/bin/sh\ndir=/tmp\nrm -f \"$HOME\"/*\nrm -rf \"$HOME\"/.cache\nrm -rf \"${HOME%/*}\"\nrm -rf \"${HOME%%/*}\"\nrm -rf \"$HOME\"/..\nrm -rf \"$HOME\"/../*\nrm -rf ~/..\nrm -rf ~/../*\nrm -rf ~0\nrm -rf ~1/*\nrm -rf ~/Downloads/*\nrm -rf /tmp/*\nrm -rf /tmp/../*\nrm -rf ~/tmp/../*\nrm -rf ~root/tmp/../*\nrm -rf \"$dir\"/*\nrm -rf \"~\"/*\nrm -rf \"$HOME\"/\"*\"\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::RmRootishTarget));
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+}

--- a/crates/shuck-linter/src/rules/security/snapshots/shuck_linter__rules__security__tests__K006_K006.sh.snap
+++ b/crates/shuck-linter/src/rules/security/snapshots/shuck_linter__rules__security__tests__K006_K006.sh.snap
@@ -1,0 +1,50 @@
+---
+source: crates/shuck-linter/src/rules/security/mod.rs
+---
+K006 recursive `rm` targets a root-like directory
+ --> <source>:2:8
+  |
+2 | rm -rf "$HOME"/*
+  |
+
+K006 recursive `rm` targets a root-like directory
+ --> <source>:3:8
+  |
+3 | rm -rf "$HOME"/**
+  |
+
+K006 recursive `rm` targets a root-like directory
+ --> <source>:4:8
+  |
+4 | rm -rf /
+  |
+
+K006 recursive `rm` targets a root-like directory
+ --> <source>:5:8
+  |
+5 | rm -rf /**
+  |
+
+K006 recursive `rm` targets a root-like directory
+ --> <source>:6:8
+  |
+6 | rm -rf /..
+  |
+
+K006 recursive `rm` targets a root-like directory
+ --> <source>:7:8
+  |
+7 | rm -rf /../*
+  |
+
+K006 recursive `rm` targets a root-like directory
+ --> <source>:8:8
+  |
+8 | rm -rf ~
+  |
+
+K006 recursive `rm` targets a root-like directory
+ --> <source>:9:8
+  |
+9 | rm -rf ~/**
+  |

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -9800,10 +9800,10 @@
       "ksh"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary

- Adds K006 to detect recursive `rm` targets that point at filesystem root or home-root forms such as `$HOME` and `~`.
- Extends existing `rm` command facts with rootish target spans so the rule stays fact-based.
- Adds focused rule/fact coverage, a security fixture snapshot, and the existing script-lint cleanup needed for `make check` from current `main`.

## Validation

- `cargo test -p shuck-linter rm_rootish_target`
- `cargo test -p shuck-linter rm_command_facts_track_rootish_targets`
- `cargo test -p shuck-linter rules::security::tests::rules::rule_rmrootishtarget_path_new_k006_sh_expects`
- `cargo test -p shuck-linter registry::tests::resolves_legacy_shuck_aliases`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=K006`
- `make test`
- `make check`
