### PR TITLE
feat(linter): add S078 shebang shell policy rule

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -55,7 +55,7 @@ struct EffectivePerFileShell {
 struct EffectiveRuleOptions {
     c001_treat_indirect_expansion_targets_as_used: bool,
     c063_report_unreached_nested_definitions: bool,
-    c162_treat_as_masking: Vec<String>,
+    s078_allowed_shells: Vec<String>,
     s084_require_globals: bool,
     s084_require_arguments: bool,
     s084_require_outputs: bool,
@@ -68,6 +68,7 @@ struct EffectiveRuleOptions {
     c159_allow_conditional_init: bool,
     c160_allowed_anchors: Vec<String>,
     c161_ignore_after_source: bool,
+    c162_treat_as_masking: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -187,7 +188,7 @@ impl EffectiveRuleOptions {
             c063_report_unreached_nested_definitions: rule_options
                 .c063
                 .report_unreached_nested_definitions,
-            c162_treat_as_masking: rule_options.c162.treat_as_masking.clone(),
+            s078_allowed_shells: rule_options.s078.allowed_shells.clone(),
             s084_require_globals: rule_options.s084.require_globals,
             s084_require_arguments: rule_options.s084.require_arguments,
             s084_require_outputs: rule_options.s084.require_outputs,
@@ -200,6 +201,7 @@ impl EffectiveRuleOptions {
             c159_allow_conditional_init: rule_options.c159.allow_conditional_init,
             c160_allowed_anchors: rule_options.c160.allowed_anchors.clone(),
             c161_ignore_after_source: rule_options.c161.ignore_after_source,
+            c162_treat_as_masking: rule_options.c162.treat_as_masking.clone(),
         }
     }
 }
@@ -211,7 +213,7 @@ impl CacheKey for EffectiveRuleOptions {
             .cache_key(state);
         self.c063_report_unreached_nested_definitions
             .cache_key(state);
-        self.c162_treat_as_masking.cache_key(state);
+        self.s078_allowed_shells.cache_key(state);
         self.s084_require_globals.cache_key(state);
         self.s084_require_arguments.cache_key(state);
         self.s084_require_outputs.cache_key(state);
@@ -224,6 +226,7 @@ impl CacheKey for EffectiveRuleOptions {
         self.c159_allow_conditional_init.cache_key(state);
         self.c160_allowed_anchors.cache_key(state);
         self.c161_ignore_after_source.cache_key(state);
+        self.c162_treat_as_masking.cache_key(state);
     }
 }
 
@@ -971,6 +974,14 @@ fn linter_rule_options_for_lint_config(lint: &LintConfig) -> shuck_linter::Linte
         .and_then(|c063| c063.report_unreached_nested_definitions)
     {
         rule_options.c063.report_unreached_nested_definitions = value;
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s078.as_ref())
+        .and_then(|s078| s078.allowed_shells.as_ref())
+    {
+        rule_options.s078.allowed_shells.clone_from(value);
     }
     if let Some(value) = lint
         .rule_options

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -61,11 +61,12 @@ const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "entrypoints",
 ];
 const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &[
-    "c001", "c063", "s084", "s085", "c158", "c159", "c160", "c161", "c162",
+    "c001", "c063", "s078", "s084", "s085", "c158", "c159", "c160", "c161", "c162",
 ];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
 const CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS: &[&str] = &["report-unreached-nested-definitions"];
+const CONFIG_OVERRIDE_S078_RULE_OPTION_KEYS: &[&str] = &["allowed-shells"];
 const CONFIG_OVERRIDE_S084_RULE_OPTION_KEYS: &[&str] = &[
     "require-globals",
     "require-arguments",
@@ -337,6 +338,8 @@ pub struct LintRuleOptionsConfig {
     pub c001: Option<C001RuleOptionsConfig>,
     /// Options for rule C063.
     pub c063: Option<C063RuleOptionsConfig>,
+    /// Options for rule S078.
+    pub s078: Option<S078RuleOptionsConfig>,
     /// Options for rule S084.
     pub s084: Option<S084RuleOptionsConfig>,
     /// Options for rule S085.
@@ -360,6 +363,9 @@ impl LintRuleOptionsConfig {
         }
         if let Some(c063) = overrides.c063 {
             self.c063.get_or_insert_default().apply_overrides(c063);
+        }
+        if let Some(s078) = overrides.s078 {
+            self.s078.get_or_insert_default().apply_overrides(s078);
         }
         if let Some(s084) = overrides.s084 {
             self.s084.get_or_insert_default().apply_overrides(s084);
@@ -415,6 +421,22 @@ impl C063RuleOptionsConfig {
         if overrides.report_unreached_nested_definitions.is_some() {
             self.report_unreached_nested_definitions =
                 overrides.report_unreached_nested_definitions;
+        }
+    }
+}
+
+/// Options for rule S078.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct S078RuleOptionsConfig {
+    /// Shell names accepted in shebang interpreters.
+    pub allowed_shells: Option<Vec<String>>,
+}
+
+impl S078RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.allowed_shells.is_some() {
+            self.allowed_shells = overrides.allowed_shells;
         }
     }
 }
@@ -475,6 +497,7 @@ impl S085RuleOptionsConfig {
         }
     }
 }
+
 /// Options for rule C158.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
@@ -840,6 +863,18 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                             default: "false",
                             value_type: "bool",
                             example: "report-unreached-nested-definitions = true",
+                        }],
+                        sections: &[],
+                    },
+                    ConfigSectionMetadata {
+                        key: "s078",
+                        docs: "Behavior overrides for `S078` shebang shell policy.",
+                        fields: &[ConfigFieldMetadata {
+                            key: "allowed-shells",
+                            docs: "Interpreter names accepted in shebangs for this project.",
+                            default: r#"["bash"]"#,
+                            value_type: "list[string]",
+                            example: r#"allowed-shells = ["bash", "zsh"]"#,
                         }],
                         sections: &[],
                     },
@@ -1649,6 +1684,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(c063_value) = rule_options.get("c063") {
         validate_c063_rule_options_override(c063_value)?;
     }
+    if let Some(s078_value) = rule_options.get("s078") {
+        validate_s078_rule_options_override(s078_value)?;
+    }
     if let Some(s084_value) = rule_options.get("s084") {
         validate_s084_rule_options_override(s084_value)?;
     }
@@ -1706,6 +1744,22 @@ fn validate_c063_rule_options_override(value: &toml::Value) -> std::result::Resu
     Ok(())
 }
 
+fn validate_s078_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let s078 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.s078]` must be a TOML table".to_owned())?;
+    for key in s078.keys() {
+        if !CONFIG_OVERRIDE_S078_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.s078]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_S078_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 fn validate_s084_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
     let s084 = value
         .as_table()
@@ -1737,6 +1791,7 @@ fn validate_s085_rule_options_override(value: &toml::Value) -> std::result::Resu
 
     Ok(())
 }
+
 fn validate_c158_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
     let c158 = value
         .as_table()
@@ -2096,6 +2151,23 @@ mod tests {
         assert_eq!(s085.non_trivial_line_threshold, Some(20));
         assert_eq!(s085.non_trivial_function_count, Some(3));
         assert_eq!(s085.main_name.as_deref(), Some("run"));
+    }
+
+    #[test]
+    fn inline_config_overrides_validate_supported_s078_rule_option_keys() {
+        let config =
+            parse_config_override("lint.rule-options.s078.allowed-shells = ['bash', 'zsh']")
+                .unwrap();
+        assert_eq!(
+            config
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.s078.as_ref())
+                .and_then(|s078| s078.allowed_shells.as_ref())
+                .map(Vec::as_slice),
+            Some(&["bash".to_owned(), "zsh".to_owned()][..])
+        );
     }
 
     #[test]
@@ -2471,6 +2543,37 @@ mod tests {
                 .and_then(|options| options.s085.as_ref())
                 .and_then(|s085| s085.main_name.as_deref()),
             Some("run")
+        );
+    }
+
+    #[test]
+    fn s078_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.s078.allowed-shells = ['bash']")
+                        .unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.s078.allowed-shells = ['zsh']")
+                        .unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.s078.as_ref())
+                .and_then(|s078| s078.allowed_shells.as_ref())
+                .map(Vec::as_slice),
+            Some(&["zsh".to_owned()][..])
         );
     }
 

--- a/crates/shuck-linter/resources/test/fixtures/style/S078.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S078.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+echo hello
+
+#!/usr/bin/env bash
+echo ok

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -1277,6 +1277,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::DuplicateShebangFlag) {
             rules::style::duplicate_shebang_flag::duplicate_shebang_flag(self);
         }
+        if self.is_rule_enabled(Rule::ShebangShellPolicy) {
+            rules::style::shebang_shell_policy::shebang_shell_policy(self);
+        }
         if self.is_rule_enabled(Rule::NonAbsoluteShebang) {
             rules::correctness::non_absolute_shebang::non_absolute_shebang(self);
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -1084,6 +1084,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 missing_shebang_line_span: shebang_header_facts.missing_shebang_line_span,
                 duplicate_shebang_flag_span: shebang_header_facts.duplicate_shebang_flag_span,
                 non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
+                shebang_interpreter: OnceLock::new(),
                 errexit_enabled_anywhere,
                 region_index: self._indexer.region_index(),
                 commented_continuation_comment_spans,

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct ShebangHeaderFacts {
     pub(crate) indented_shebang_span: Option<Span>,
     pub(crate) indented_shebang_indent_span: Option<Span>,
@@ -13,6 +13,22 @@ pub(crate) struct ShebangHeaderFacts {
     pub(crate) duplicate_shebang_flag_span: Option<Span>,
     pub(crate) non_absolute_shebang_span: Option<Span>,
     pub(crate) enables_errexit: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShebangInterpreterFact {
+    interpreter: String,
+    span: Span,
+}
+
+impl ShebangInterpreterFact {
+    pub fn interpreter(&self) -> &str {
+        &self.interpreter
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
+    }
 }
 
 #[cfg_attr(shuck_profiling, inline(never))]
@@ -143,6 +159,23 @@ pub(crate) fn build_shebang_header_facts(locator: Locator<'_>) -> ShebangHeaderF
         non_absolute_shebang_span,
         enables_errexit,
     }
+}
+
+pub(crate) fn build_shebang_interpreter_fact(
+    locator: Locator<'_>,
+) -> Option<ShebangInterpreterFact> {
+    let source = locator.source();
+    let line_index = locator.line_index();
+    let first_line = source_line(source, line_index, 1)?;
+    let first_line_text = first_line.text.trim_end_matches('\r');
+    let shebang_text = first_line_text.trim_start();
+    shebang_text
+        .strip_prefix("#!")
+        .and_then(|_| shuck_parser::shebang::interpreter_name(shebang_text))
+        .map(|interpreter| ShebangInterpreterFact {
+            interpreter: interpreter.to_owned(),
+            span: line_span(1, first_line.offset, first_line_text),
+        })
 }
 
 pub(crate) fn source_line_is_header_like(line: &str) -> bool {

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -154,6 +154,7 @@ pub(crate) struct SourceFactStore<'a> {
     pub(in crate::facts) missing_shebang_line_span: Option<Span>,
     pub(in crate::facts) duplicate_shebang_flag_span: Option<Span>,
     pub(in crate::facts) non_absolute_shebang_span: Option<Span>,
+    pub(in crate::facts) shebang_interpreter: OnceLock<Option<ShebangInterpreterFact>>,
     pub(in crate::facts) errexit_enabled_anywhere: bool,
     pub(in crate::facts) region_index: &'a RegionIndex,
     pub(in crate::facts) commented_continuation_comment_spans: Vec<Span>,
@@ -1073,6 +1074,19 @@ impl<'facts, 'a> SourceFacts<'facts, 'a> {
 
     pub(crate) fn non_absolute_shebang_span(self) -> Option<Span> {
         self.facts.source_facts.non_absolute_shebang_span
+    }
+
+    pub(crate) fn shebang_interpreter(self) -> Option<&'facts ShebangInterpreterFact> {
+        self.facts
+            .source_facts
+            .shebang_interpreter
+            .get_or_init(|| {
+                build_shebang_interpreter_fact(Locator::new(
+                    self.facts.source_facts.source,
+                    self.facts.source_facts.line_index,
+                ))
+            })
+            .as_ref()
     }
 
     pub(crate) fn errexit_enabled_anywhere(self) -> bool {

--- a/crates/shuck-linter/src/facts/tests/commands.rs
+++ b/crates/shuck-linter/src/facts/tests/commands.rs
@@ -3040,6 +3040,17 @@ fn does_not_treat_long_shebang_options_as_errexit() {
 }
 
 #[test]
+fn does_not_treat_indented_shebang_options_as_errexit() {
+    let source = "  #!/bin/bash -e\ncd /tmp\n";
+    let output = Parser::new(source).parse().unwrap();
+    let indexer = Indexer::new(source, &output);
+    let semantic = LinterSemanticArtifacts::build(&output.file, source, &indexer);
+    let facts = LinterFacts::build(&output.file, source, &semantic, &indexer);
+
+    assert!(!facts.source_facts().errexit_enabled_anywhere());
+}
+
+#[test]
 fn keeps_read_raw_input_when_option_flags_are_dynamic() {
     let source = "#!/bin/bash\nbuiltin read -${_read_char_flag} 1 -s -r anykey\n";
     let output = Parser::new(source).parse().unwrap();

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -108,7 +108,8 @@ pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 pub use settings::{
     AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions, C159RuleOptions,
     C160RuleOptions, C161RuleOptions, C162RuleOptions, CompiledPerFileIgnoreList,
-    LinterRuleOptions, LinterSettings, PerFileIgnore, S084RuleOptions, S085RuleOptions,
+    LinterRuleOptions, LinterSettings, PerFileIgnore, S078RuleOptions, S084RuleOptions,
+    S085RuleOptions,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -712,6 +712,7 @@ declare_rules! {
     ("S073", Category::Style, Severity::Warning, SpacedTabstripClose),
     ("S074", Category::Style, Severity::Warning, AmpersandSemicolon),
     ("S075", Category::Style, Severity::Warning, CombineAppends),
+    ("S078", Category::Style, Severity::Warning, ShebangShellPolicy),
     ("S084", Category::Style, Severity::Warning, FunctionDocContent),
     ("S085", Category::Style, Severity::Warning, MissingMainEntrypoint),
 }

--- a/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
+++ b/crates/shuck-linter/src/rules/correctness/unchecked_directory_change.rs
@@ -127,7 +127,8 @@ cd /tmp && pwd
 ";
         let diagnostics = test_snippet(
             source,
-            &LinterSettings::for_rule(Rule::UncheckedDirectoryChange),
+            &LinterSettings::for_rule(Rule::UncheckedDirectoryChange)
+                .with_shell(ShellDialect::Bash),
         );
 
         assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -56,6 +56,7 @@ pub mod quoted_dollar_star_loop;
 pub mod read_without_raw;
 pub mod redundant_return_status;
 pub mod redundant_spaces_in_echo;
+pub mod shebang_shell_policy;
 pub mod single_iteration_loop;
 pub mod single_quote_backslash;
 pub mod spaced_tabstrip_close;
@@ -168,6 +169,7 @@ mod tests {
     #[test_case(Rule::SpacedTabstripClose, Path::new("S073.sh"))]
     #[test_case(Rule::AmpersandSemicolon, Path::new("S074.sh"))]
     #[test_case(Rule::CombineAppends, Path::new("S075.sh"))]
+    #[test_case(Rule::ShebangShellPolicy, Path::new("S078.sh"))]
     #[test_case(Rule::FunctionDocContent, Path::new("S084.sh"))]
     #[test_case(Rule::MissingMainEntrypoint, Path::new("S085.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {

--- a/crates/shuck-linter/src/rules/style/shebang_shell_policy.rs
+++ b/crates/shuck-linter/src/rules/style/shebang_shell_policy.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+
+use crate::{Checker, Rule, Violation};
+
+pub struct ShebangShellPolicy;
+
+impl Violation for ShebangShellPolicy {
+    fn rule() -> Rule {
+        Rule::ShebangShellPolicy
+    }
+
+    fn message(&self) -> String {
+        "shebang interpreter is outside the configured shell policy".to_owned()
+    }
+}
+
+pub fn shebang_shell_policy(checker: &mut Checker) {
+    let Some(shebang) = checker.facts().source_facts().shebang_interpreter() else {
+        return;
+    };
+
+    if !interpreter_is_allowed(
+        shebang.interpreter(),
+        &checker.rule_options().s078.allowed_shells,
+    ) {
+        checker.report(ShebangShellPolicy, shebang.span());
+    }
+}
+
+fn interpreter_is_allowed(interpreter: &str, allowed_shells: &[String]) -> bool {
+    let interpreter = normalize_shell_name(interpreter);
+    allowed_shells
+        .iter()
+        .map(|allowed| normalize_shell_name(allowed))
+        .any(|allowed| allowed == interpreter)
+}
+
+fn normalize_shell_name(shell: &str) -> String {
+    Path::new(shell)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(shell)
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_shebangs_outside_the_allowed_shell_policy() {
+        let source = "#!/bin/sh\necho hello\n  #!/bin/dash\necho again\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ShebangShellPolicy));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["#!/bin/sh"]
+        );
+    }
+
+    #[test]
+    fn reports_indented_shebangs_outside_the_allowed_shell_policy() {
+        let source = "  #!/bin/sh\necho hello\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ShebangShellPolicy));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["  #!/bin/sh"]
+        );
+    }
+
+    #[test]
+    fn accepts_configured_shell_names_and_env_shebangs() {
+        for source in [
+            "#!/usr/bin/env bash\necho hello\n",
+            "#!/usr/bin/env -S /bin/zsh -f\necho hello\n",
+            "#!/opt/homebrew/bin/zsh\necho hello\n",
+        ] {
+            let diagnostics = test_snippet(
+                source,
+                &LinterSettings::for_rule(Rule::ShebangShellPolicy)
+                    .with_s078_allowed_shells(["bash", "zsh"]),
+            );
+
+            assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        }
+    }
+
+    #[test]
+    fn ignores_files_without_a_parseable_shebang_interpreter() {
+        for source in ["echo hello\n", "# !/bin/sh\necho hello\n"] {
+            let diagnostics =
+                test_snippet(source, &LinterSettings::for_rule(Rule::ShebangShellPolicy));
+
+            assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        }
+    }
+}

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S078_S078.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S078_S078.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+---
+S078 shebang interpreter is outside the configured shell policy
+ --> <source>:1:1
+  |
+1 | #!/bin/sh
+  |

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -31,6 +31,8 @@ pub struct LinterRuleOptions {
     pub c001: C001RuleOptions,
     /// Behavior overrides for `C063`.
     pub c063: C063RuleOptions,
+    /// Behavior overrides for `S078`.
+    pub s078: S078RuleOptions,
     /// Behavior overrides for `S084`.
     pub s084: S084RuleOptions,
     /// Behavior overrides for `S085`.
@@ -80,6 +82,22 @@ impl C063RuleOptions {
         }
     }
 }
+
+/// Behavior overrides for `S078` shebang shell policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S078RuleOptions {
+    /// Interpreter names accepted in shebangs for this project.
+    pub allowed_shells: Vec<String>,
+}
+
+impl Default for S078RuleOptions {
+    fn default() -> Self {
+        Self {
+            allowed_shells: vec!["bash".to_owned()],
+        }
+    }
+}
+
 /// Behavior overrides for `S084` function documentation content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct S084RuleOptions {
@@ -120,6 +138,7 @@ impl Default for S085RuleOptions {
         }
     }
 }
+
 /// Behavior overrides for `C158` implicit global assignment analysis.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct C158RuleOptions {
@@ -418,6 +437,16 @@ impl LinterSettings {
         self.rule_options.s085.main_name = value.into();
         self
     }
+
+    pub fn with_s078_allowed_shells(
+        mut self,
+        allowed_shells: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.rule_options.s078.allowed_shells =
+            allowed_shells.into_iter().map(Into::into).collect();
+        self
+    }
+
     pub fn with_c158_treat_readonly_as_documented(mut self, value: bool) -> Self {
         self.rule_options.c158.treat_readonly_as_documented = value;
         self

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -6496,10 +6496,10 @@
       "bash"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- add S078 shebang shell policy diagnostics using a reusable shebang interpreter fact
- add `lint.rule-options.s078.allowed-shells` config plumbing and cache-key coverage
- wire the rule into style registry, checker dispatch, fixture, and snapshot
- keep the packaging smoke-test fixture script clean under script linting

## Validation
- `cargo test -p shuck-linter shebang_shell_policy -- --nocapture`
- `cargo test -p shuck-config s078_rule_option -- --nocapture`
- `INSTA_UPDATE=always cargo test -p shuck-linter rules::style::tests::rules::rule_shebangshellpolicy_path_new_s078_sh_expects -- --nocapture`
- `make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S078`
- `make test`
- `make check`