### PR TITLE
feat(linter): add S079 shebang form policy rule

### DIFF
--- a/crates/shuck-cli/src/commands/check/settings.rs
+++ b/crates/shuck-cli/src/commands/check/settings.rs
@@ -56,6 +56,8 @@ struct EffectiveRuleOptions {
     c001_treat_indirect_expansion_targets_as_used: bool,
     c063_report_unreached_nested_definitions: bool,
     s078_allowed_shells: Vec<String>,
+    s079_allowed_forms: Vec<String>,
+    s079_allowed_paths: Vec<String>,
     s084_require_globals: bool,
     s084_require_arguments: bool,
     s084_require_outputs: bool,
@@ -189,6 +191,8 @@ impl EffectiveRuleOptions {
                 .c063
                 .report_unreached_nested_definitions,
             s078_allowed_shells: rule_options.s078.allowed_shells.clone(),
+            s079_allowed_forms: rule_options.s079.allowed_forms.clone(),
+            s079_allowed_paths: rule_options.s079.allowed_paths.clone(),
             s084_require_globals: rule_options.s084.require_globals,
             s084_require_arguments: rule_options.s084.require_arguments,
             s084_require_outputs: rule_options.s084.require_outputs,
@@ -214,6 +218,8 @@ impl CacheKey for EffectiveRuleOptions {
         self.c063_report_unreached_nested_definitions
             .cache_key(state);
         self.s078_allowed_shells.cache_key(state);
+        self.s079_allowed_forms.cache_key(state);
+        self.s079_allowed_paths.cache_key(state);
         self.s084_require_globals.cache_key(state);
         self.s084_require_arguments.cache_key(state);
         self.s084_require_outputs.cache_key(state);
@@ -982,6 +988,22 @@ fn linter_rule_options_for_lint_config(lint: &LintConfig) -> shuck_linter::Linte
         .and_then(|s078| s078.allowed_shells.as_ref())
     {
         rule_options.s078.allowed_shells.clone_from(value);
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s079.as_ref())
+        .and_then(|s079| s079.allowed_forms.as_ref())
+    {
+        rule_options.s079.allowed_forms.clone_from(value);
+    }
+    if let Some(value) = lint
+        .rule_options
+        .as_ref()
+        .and_then(|options| options.s079.as_ref())
+        .and_then(|s079| s079.allowed_paths.as_ref())
+    {
+        rule_options.s079.allowed_paths.clone_from(value);
     }
     if let Some(value) = lint
         .rule_options

--- a/crates/shuck-config/src/lib.rs
+++ b/crates/shuck-config/src/lib.rs
@@ -61,12 +61,13 @@ const CONFIG_OVERRIDE_LINT_ZSH_PLUGIN_KEYS: &[&str] = &[
     "entrypoints",
 ];
 const CONFIG_OVERRIDE_LINT_RULE_OPTION_KEYS: &[&str] = &[
-    "c001", "c063", "s078", "s084", "s085", "c158", "c159", "c160", "c161", "c162",
+    "c001", "c063", "s078", "s079", "s084", "s085", "c158", "c159", "c160", "c161", "c162",
 ];
 const CONFIG_OVERRIDE_C001_RULE_OPTION_KEYS: &[&str] =
     &["treat-indirect-expansion-targets-as-used"];
 const CONFIG_OVERRIDE_C063_RULE_OPTION_KEYS: &[&str] = &["report-unreached-nested-definitions"];
 const CONFIG_OVERRIDE_S078_RULE_OPTION_KEYS: &[&str] = &["allowed-shells"];
+const CONFIG_OVERRIDE_S079_RULE_OPTION_KEYS: &[&str] = &["allowed-forms", "allowed-paths"];
 const CONFIG_OVERRIDE_S084_RULE_OPTION_KEYS: &[&str] = &[
     "require-globals",
     "require-arguments",
@@ -340,6 +341,8 @@ pub struct LintRuleOptionsConfig {
     pub c063: Option<C063RuleOptionsConfig>,
     /// Options for rule S078.
     pub s078: Option<S078RuleOptionsConfig>,
+    /// Options for rule S079.
+    pub s079: Option<S079RuleOptionsConfig>,
     /// Options for rule S084.
     pub s084: Option<S084RuleOptionsConfig>,
     /// Options for rule S085.
@@ -366,6 +369,9 @@ impl LintRuleOptionsConfig {
         }
         if let Some(s078) = overrides.s078 {
             self.s078.get_or_insert_default().apply_overrides(s078);
+        }
+        if let Some(s079) = overrides.s079 {
+            self.s079.get_or_insert_default().apply_overrides(s079);
         }
         if let Some(s084) = overrides.s084 {
             self.s084.get_or_insert_default().apply_overrides(s084);
@@ -437,6 +443,27 @@ impl S078RuleOptionsConfig {
     fn apply_overrides(&mut self, overrides: Self) {
         if overrides.allowed_shells.is_some() {
             self.allowed_shells = overrides.allowed_shells;
+        }
+    }
+}
+
+/// Options for rule S079.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct S079RuleOptionsConfig {
+    /// Shebang invocation forms accepted by the policy.
+    pub allowed_forms: Option<Vec<String>>,
+    /// Exact shebang command strings accepted by the policy.
+    pub allowed_paths: Option<Vec<String>>,
+}
+
+impl S079RuleOptionsConfig {
+    fn apply_overrides(&mut self, overrides: Self) {
+        if overrides.allowed_forms.is_some() {
+            self.allowed_forms = overrides.allowed_forms;
+        }
+        if overrides.allowed_paths.is_some() {
+            self.allowed_paths = overrides.allowed_paths;
         }
     }
 }
@@ -876,6 +903,27 @@ const CONFIGURATION_METADATA: [ConfigSectionMetadata; 3] = [
                             value_type: "list[string]",
                             example: r#"allowed-shells = ["bash", "zsh"]"#,
                         }],
+                        sections: &[],
+                    },
+                    ConfigSectionMetadata {
+                        key: "s079",
+                        docs: "Behavior overrides for `S079` shebang invocation form policy.",
+                        fields: &[
+                            ConfigFieldMetadata {
+                                key: "allowed-forms",
+                                docs: "Shebang invocation forms accepted for this project. Supported values are `absolute-path` and `env-lookup`.",
+                                default: r#"["env-lookup"]"#,
+                                value_type: "list[string]",
+                                example: r#"allowed-forms = ["env-lookup"]"#,
+                            },
+                            ConfigFieldMetadata {
+                                key: "allowed-paths",
+                                docs: "Exact shebang invocation strings accepted regardless of invocation form.",
+                                default: r#"["/bin/bash", "/usr/bin/env bash"]"#,
+                                value_type: "list[string]",
+                                example: r#"allowed-paths = ["/usr/bin/env bash"]"#,
+                            },
+                        ],
                         sections: &[],
                     },
                     ConfigSectionMetadata {
@@ -1687,6 +1735,9 @@ fn validate_lint_rule_options_override(value: &toml::Value) -> std::result::Resu
     if let Some(s078_value) = rule_options.get("s078") {
         validate_s078_rule_options_override(s078_value)?;
     }
+    if let Some(s079_value) = rule_options.get("s079") {
+        validate_s079_rule_options_override(s079_value)?;
+    }
     if let Some(s084_value) = rule_options.get("s084") {
         validate_s084_rule_options_override(s084_value)?;
     }
@@ -1753,6 +1804,22 @@ fn validate_s078_rule_options_override(value: &toml::Value) -> std::result::Resu
             return Err(format!(
                 "unsupported `[lint.rule-options.s078]` option `{key}`; expected one of: {}",
                 CONFIG_OVERRIDE_S078_RULE_OPTION_KEYS.join(", ")
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_s079_rule_options_override(value: &toml::Value) -> std::result::Result<(), String> {
+    let s079 = value
+        .as_table()
+        .ok_or_else(|| "`[lint.rule-options.s079]` must be a TOML table".to_owned())?;
+    for key in s079.keys() {
+        if !CONFIG_OVERRIDE_S079_RULE_OPTION_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "unsupported `[lint.rule-options.s079]` option `{key}`; expected one of: {}",
+                CONFIG_OVERRIDE_S079_RULE_OPTION_KEYS.join(", ")
             ));
         }
     }
@@ -2109,6 +2176,30 @@ mod tests {
                 .and_then(|options| options.c063.as_ref())
                 .and_then(|c063| c063.report_unreached_nested_definitions),
             Some(true)
+        );
+    }
+
+    #[test]
+    fn inline_config_overrides_validate_supported_s079_rule_option_keys() {
+        let config = parse_config_override(
+            "lint.rule-options.s079.allowed-forms = ['env-lookup']\n\
+             lint.rule-options.s079.allowed-paths = ['/usr/bin/env bash']",
+        )
+        .unwrap();
+        let s079 = config
+            .lint
+            .rule_options
+            .as_ref()
+            .and_then(|options| options.s079.as_ref())
+            .expect("expected s079 options");
+
+        assert_eq!(
+            s079.allowed_forms.as_deref(),
+            Some(&["env-lookup".to_owned()][..])
+        );
+        assert_eq!(
+            s079.allowed_paths.as_deref(),
+            Some(&["/usr/bin/env bash".to_owned()][..])
         );
     }
 
@@ -2486,6 +2577,39 @@ mod tests {
                 .and_then(|options| options.c063.as_ref())
                 .and_then(|c063| c063.report_unreached_nested_definitions),
             Some(false)
+        );
+    }
+
+    #[test]
+    fn s079_rule_option_config_arguments_allow_last_override_to_win() {
+        let tempdir = tempdir().unwrap();
+        let config = ConfigArguments::from_cli(
+            vec![
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override("lint.rule-options.s079.allowed-forms = ['env-lookup']")
+                        .unwrap(),
+                )),
+                SingleConfigArgument::SettingsOverride(Box::new(
+                    parse_config_override(
+                        "lint.rule-options.s079.allowed-forms = ['absolute-path']",
+                    )
+                    .unwrap(),
+                )),
+            ],
+            false,
+        )
+        .unwrap();
+
+        let loaded = load_project_config(tempdir.path(), &config).unwrap();
+        assert_eq!(
+            loaded
+                .lint
+                .rule_options
+                .as_ref()
+                .and_then(|options| options.s079.as_ref())
+                .and_then(|s079| s079.allowed_forms.as_ref())
+                .map(Vec::as_slice),
+            Some(&["absolute-path".to_owned()][..])
         );
     }
 

--- a/crates/shuck-linter/resources/test/fixtures/style/S079.sh
+++ b/crates/shuck-linter/resources/test/fixtures/style/S079.sh
@@ -1,0 +1,5 @@
+#!/usr/local/bin/bash
+echo hello
+
+#!/usr/bin/env bash
+echo ok

--- a/crates/shuck-linter/src/checker.rs
+++ b/crates/shuck-linter/src/checker.rs
@@ -1280,6 +1280,9 @@ impl<'a> Checker<'a> {
         if self.is_rule_enabled(Rule::ShebangShellPolicy) {
             rules::style::shebang_shell_policy::shebang_shell_policy(self);
         }
+        if self.is_rule_enabled(Rule::ShebangFormPolicy) {
+            rules::style::shebang_form_policy::shebang_form_policy(self);
+        }
         if self.is_rule_enabled(Rule::NonAbsoluteShebang) {
             rules::correctness::non_absolute_shebang::non_absolute_shebang(self);
         }

--- a/crates/shuck-linter/src/facts/builder.rs
+++ b/crates/shuck-linter/src/facts/builder.rs
@@ -1085,6 +1085,7 @@ impl<'a, 'analysis> LinterFactsBuilder<'a, 'analysis> {
                 duplicate_shebang_flag_span: shebang_header_facts.duplicate_shebang_flag_span,
                 non_absolute_shebang_span: shebang_header_facts.non_absolute_shebang_span,
                 shebang_interpreter: OnceLock::new(),
+                shebang_invocation: OnceLock::new(),
                 errexit_enabled_anywhere,
                 region_index: self._indexer.region_index(),
                 commented_continuation_comment_spans,

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -213,6 +213,7 @@ pub(crate) fn build_shebang_invocation_fact(
     let first_line = source_line(source, line_index, 1)?;
     let first_line_text = first_line.text.trim_end_matches('\r');
     first_line_text
+        .trim_start()
         .strip_prefix("#!")
         .map(str::trim)
         .filter(|text| !text.is_empty())

--- a/crates/shuck-linter/src/facts/comments.rs
+++ b/crates/shuck-linter/src/facts/comments.rs
@@ -31,6 +31,34 @@ impl ShebangInterpreterFact {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShebangInvocationFact {
+    text: String,
+    span: Span,
+    form: ShebangInvocationForm,
+}
+
+impl ShebangInvocationFact {
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub fn span(&self) -> Span {
+        self.span
+    }
+
+    pub fn form(&self) -> ShebangInvocationForm {
+        self.form
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ShebangInvocationForm {
+    AbsolutePath,
+    EnvLookup,
+    Other,
+}
+
 #[cfg_attr(shuck_profiling, inline(never))]
 pub(crate) fn build_shebang_header_facts(locator: Locator<'_>) -> ShebangHeaderFacts {
     let source = locator.source();
@@ -178,6 +206,23 @@ pub(crate) fn build_shebang_interpreter_fact(
         })
 }
 
+pub(crate) fn build_shebang_invocation_fact(
+    source: &str,
+    line_index: &LineIndex,
+) -> Option<ShebangInvocationFact> {
+    let first_line = source_line(source, line_index, 1)?;
+    let first_line_text = first_line.text.trim_end_matches('\r');
+    first_line_text
+        .strip_prefix("#!")
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(|text| ShebangInvocationFact {
+            text: text.to_owned(),
+            span: line_span(1, first_line.offset, first_line_text),
+            form: shebang_invocation_form(text),
+        })
+}
+
 pub(crate) fn source_line_is_header_like(line: &str) -> bool {
     let trimmed = line.trim_start();
     trimmed.is_empty() || trimmed.starts_with('#')
@@ -261,6 +306,27 @@ pub(crate) fn line_with_ending_span(
 
 pub(crate) fn parse_shebang_words(shebang: &str) -> Vec<&str> {
     shebang.split_whitespace().collect()
+}
+
+fn shebang_invocation_form(text: &str) -> ShebangInvocationForm {
+    let Some(first_word) = text.split_whitespace().next() else {
+        return ShebangInvocationForm::Other;
+    };
+
+    let Some(name) = std::path::Path::new(first_word)
+        .file_name()
+        .and_then(|name| name.to_str())
+    else {
+        return ShebangInvocationForm::Other;
+    };
+
+    if name == "env" {
+        ShebangInvocationForm::EnvLookup
+    } else if first_word.starts_with('/') {
+        ShebangInvocationForm::AbsolutePath
+    } else {
+        ShebangInvocationForm::Other
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/shuck-linter/src/facts/model.rs
+++ b/crates/shuck-linter/src/facts/model.rs
@@ -155,6 +155,7 @@ pub(crate) struct SourceFactStore<'a> {
     pub(in crate::facts) duplicate_shebang_flag_span: Option<Span>,
     pub(in crate::facts) non_absolute_shebang_span: Option<Span>,
     pub(in crate::facts) shebang_interpreter: OnceLock<Option<ShebangInterpreterFact>>,
+    pub(in crate::facts) shebang_invocation: OnceLock<Option<ShebangInvocationFact>>,
     pub(in crate::facts) errexit_enabled_anywhere: bool,
     pub(in crate::facts) region_index: &'a RegionIndex,
     pub(in crate::facts) commented_continuation_comment_spans: Vec<Span>,
@@ -1085,6 +1086,19 @@ impl<'facts, 'a> SourceFacts<'facts, 'a> {
                     self.facts.source_facts.source,
                     self.facts.source_facts.line_index,
                 ))
+            })
+            .as_ref()
+    }
+
+    pub(crate) fn shebang_invocation(self) -> Option<&'facts ShebangInvocationFact> {
+        self.facts
+            .source_facts
+            .shebang_invocation
+            .get_or_init(|| {
+                build_shebang_invocation_fact(
+                    self.facts.source_facts.source,
+                    self.facts.source_facts.line_index,
+                )
             })
             .as_ref()
     }

--- a/crates/shuck-linter/src/lib.rs
+++ b/crates/shuck-linter/src/lib.rs
@@ -108,8 +108,8 @@ pub(crate) use rules::common::word::conditional_binary_op_is_string_match;
 pub use settings::{
     AmbientShellOptions, C001RuleOptions, C063RuleOptions, C158RuleOptions, C159RuleOptions,
     C160RuleOptions, C161RuleOptions, C162RuleOptions, CompiledPerFileIgnoreList,
-    LinterRuleOptions, LinterSettings, PerFileIgnore, S078RuleOptions, S084RuleOptions,
-    S085RuleOptions,
+    LinterRuleOptions, LinterSettings, PerFileIgnore, S078RuleOptions, S079RuleOptions,
+    S084RuleOptions, S085RuleOptions,
 };
 /// Shell dialect selection used by the linter.
 pub use shell::ShellDialect;

--- a/crates/shuck-linter/src/registry.rs
+++ b/crates/shuck-linter/src/registry.rs
@@ -713,6 +713,7 @@ declare_rules! {
     ("S074", Category::Style, Severity::Warning, AmpersandSemicolon),
     ("S075", Category::Style, Severity::Warning, CombineAppends),
     ("S078", Category::Style, Severity::Warning, ShebangShellPolicy),
+    ("S079", Category::Style, Severity::Warning, ShebangFormPolicy),
     ("S084", Category::Style, Severity::Warning, FunctionDocContent),
     ("S085", Category::Style, Severity::Warning, MissingMainEntrypoint),
 }

--- a/crates/shuck-linter/src/rules/style/mod.rs
+++ b/crates/shuck-linter/src/rules/style/mod.rs
@@ -56,6 +56,7 @@ pub mod quoted_dollar_star_loop;
 pub mod read_without_raw;
 pub mod redundant_return_status;
 pub mod redundant_spaces_in_echo;
+pub mod shebang_form_policy;
 pub mod shebang_shell_policy;
 pub mod single_iteration_loop;
 pub mod single_quote_backslash;
@@ -170,6 +171,7 @@ mod tests {
     #[test_case(Rule::AmpersandSemicolon, Path::new("S074.sh"))]
     #[test_case(Rule::CombineAppends, Path::new("S075.sh"))]
     #[test_case(Rule::ShebangShellPolicy, Path::new("S078.sh"))]
+    #[test_case(Rule::ShebangFormPolicy, Path::new("S079.sh"))]
     #[test_case(Rule::FunctionDocContent, Path::new("S084.sh"))]
     #[test_case(Rule::MissingMainEntrypoint, Path::new("S085.sh"))]
     fn rules(rule: Rule, path: &Path) -> anyhow::Result<()> {

--- a/crates/shuck-linter/src/rules/style/shebang_form_policy.rs
+++ b/crates/shuck-linter/src/rules/style/shebang_form_policy.rs
@@ -65,6 +65,20 @@ mod tests {
     }
 
     #[test]
+    fn reports_indented_shebangs_outside_the_allowed_form_policy() {
+        let source = "  #!/usr/local/bin/bash\necho hello\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ShebangFormPolicy));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["  #!/usr/local/bin/bash"]
+        );
+    }
+
+    #[test]
     fn accepts_default_env_form_and_default_exact_paths() {
         for source in [
             "#!/usr/bin/env bash\necho hello\n",

--- a/crates/shuck-linter/src/rules/style/shebang_form_policy.rs
+++ b/crates/shuck-linter/src/rules/style/shebang_form_policy.rs
@@ -1,0 +1,115 @@
+use crate::facts::ShebangInvocationForm;
+use crate::{Checker, Rule, Violation};
+
+pub struct ShebangFormPolicy;
+
+impl Violation for ShebangFormPolicy {
+    fn rule() -> Rule {
+        Rule::ShebangFormPolicy
+    }
+
+    fn message(&self) -> String {
+        "shebang invocation form is outside the configured policy".to_owned()
+    }
+}
+
+pub fn shebang_form_policy(checker: &mut Checker) {
+    let Some(shebang) = checker.facts().source_facts().shebang_invocation() else {
+        return;
+    };
+
+    let options = &checker.rule_options().s079;
+    if !allowed_path_matches(shebang.text(), &options.allowed_paths)
+        && !allowed_form_matches(shebang.form(), &options.allowed_forms)
+    {
+        checker.report(ShebangFormPolicy, shebang.span());
+    }
+}
+
+fn allowed_path_matches(text: &str, allowed_paths: &[String]) -> bool {
+    let text = text.trim();
+    allowed_paths.iter().any(|allowed| allowed.trim() == text)
+}
+
+fn allowed_form_matches(form: ShebangInvocationForm, allowed_forms: &[String]) -> bool {
+    allowed_forms
+        .iter()
+        .any(|allowed| allowed_form_name_matches(form, allowed))
+}
+
+fn allowed_form_name_matches(form: ShebangInvocationForm, allowed: &str) -> bool {
+    match allowed.trim().to_ascii_lowercase().as_str() {
+        "absolute-path" => form == ShebangInvocationForm::AbsolutePath,
+        "env-lookup" => form == ShebangInvocationForm::EnvLookup,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::test_snippet;
+    use crate::{LinterSettings, Rule};
+
+    #[test]
+    fn reports_disallowed_absolute_path_forms() {
+        let source = "#!/usr/local/bin/bash\necho hello\n";
+        let diagnostics = test_snippet(source, &LinterSettings::for_rule(Rule::ShebangFormPolicy));
+
+        assert_eq!(
+            diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.span.slice(source))
+                .collect::<Vec<_>>(),
+            vec!["#!/usr/local/bin/bash"]
+        );
+    }
+
+    #[test]
+    fn accepts_default_env_form_and_default_exact_paths() {
+        for source in [
+            "#!/usr/bin/env bash\necho hello\n",
+            "#!/bin/bash\necho hello\n",
+        ] {
+            let diagnostics =
+                test_snippet(source, &LinterSettings::for_rule(Rule::ShebangFormPolicy));
+
+            assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        }
+    }
+
+    #[test]
+    fn accepts_configured_absolute_path_forms() {
+        let source = "#!/usr/local/bin/bash\necho hello\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ShebangFormPolicy)
+                .with_s079_allowed_forms(["absolute-path"])
+                .with_s079_allowed_paths(std::iter::empty::<&str>()),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn accepts_configured_exact_paths_without_matching_form() {
+        let source = "#!/opt/project/bash\necho hello\n";
+        let diagnostics = test_snippet(
+            source,
+            &LinterSettings::for_rule(Rule::ShebangFormPolicy)
+                .with_s079_allowed_forms(["env-lookup"])
+                .with_s079_allowed_paths(["/opt/project/bash"]),
+        );
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+    }
+
+    #[test]
+    fn ignores_files_without_a_parseable_shebang_invocation() {
+        for source in ["echo hello\n", "# !/usr/local/bin/bash\necho hello\n"] {
+            let diagnostics =
+                test_snippet(source, &LinterSettings::for_rule(Rule::ShebangFormPolicy));
+
+            assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        }
+    }
+}

--- a/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S079_S079.sh.snap
+++ b/crates/shuck-linter/src/rules/style/snapshots/shuck_linter__rules__style__tests__S079_S079.sh.snap
@@ -1,0 +1,8 @@
+---
+source: crates/shuck-linter/src/rules/style/mod.rs
+---
+S079 shebang invocation form is outside the configured policy
+ --> <source>:1:1
+  |
+1 | #!/usr/local/bin/bash
+  |

--- a/crates/shuck-linter/src/settings.rs
+++ b/crates/shuck-linter/src/settings.rs
@@ -33,6 +33,8 @@ pub struct LinterRuleOptions {
     pub c063: C063RuleOptions,
     /// Behavior overrides for `S078`.
     pub s078: S078RuleOptions,
+    /// Behavior overrides for `S079`.
+    pub s079: S079RuleOptions,
     /// Behavior overrides for `S084`.
     pub s084: S084RuleOptions,
     /// Behavior overrides for `S085`.
@@ -94,6 +96,24 @@ impl Default for S078RuleOptions {
     fn default() -> Self {
         Self {
             allowed_shells: vec!["bash".to_owned()],
+        }
+    }
+}
+
+/// Behavior overrides for `S079` shebang invocation form policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S079RuleOptions {
+    /// Invocation forms accepted for shebangs in this project.
+    pub allowed_forms: Vec<String>,
+    /// Exact shebang invocation strings that are accepted regardless of form.
+    pub allowed_paths: Vec<String>,
+}
+
+impl Default for S079RuleOptions {
+    fn default() -> Self {
+        Self {
+            allowed_forms: vec!["env-lookup".to_owned()],
+            allowed_paths: vec!["/bin/bash".to_owned(), "/usr/bin/env bash".to_owned()],
         }
     }
 }
@@ -482,6 +502,22 @@ impl LinterSettings {
         S: Into<String>,
     {
         self.rule_options.c162.treat_as_masking = forms.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_s079_allowed_forms(
+        mut self,
+        allowed_forms: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.rule_options.s079.allowed_forms = allowed_forms.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn with_s079_allowed_paths(
+        mut self,
+        allowed_paths: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.rule_options.s079.allowed_paths = allowed_paths.into_iter().map(Into::into).collect();
         self
     }
 

--- a/website/app/lib/rules-data.generated.json
+++ b/website/app/lib/rules-data.generated.json
@@ -6526,10 +6526,10 @@
       "bash"
     ],
     "shellcheckCode": null,
-    "implemented": false,
-    "status": "planned",
+    "implemented": true,
+    "status": "implemented",
     "hasKnownShellcheckDivergences": false,
-    "severity": null,
+    "severity": "Warning",
     "fixStatus": "none",
     "fixAvailability": "none",
     "fixSafety": null,


### PR DESCRIPTION
## Summary
- add the S079 shebang invocation form policy rule
- expose reusable shebang invocation facts for rule filtering
- add S079 config, cache-key, registry, fixture, and snapshot coverage

## Validation
- cargo test -p shuck-linter shebang_form_policy -- --nocapture
- cargo test -p shuck-config s079_rule_option -- --nocapture
- INSTA_UPDATE=always cargo test -p shuck-linter rules::style::tests::rules::rule_shebangformpolicy_path_new_s079_sh_expects -- --nocapture
- make test-large-corpus SHUCK_LARGE_CORPUS_RULES=S079
- make test
- make check